### PR TITLE
config entry: hardcode proxy-defaults name as global

### DIFF
--- a/.changelog/14833.txt
+++ b/.changelog/14833.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: always use name "global" for proxy-defaults config entries
+```

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -273,7 +273,7 @@ type ProxyConfigEntry struct {
 }
 
 func (p *ProxyConfigEntry) GetKind() string            { return p.Kind }
-func (p *ProxyConfigEntry) GetName() string            { return p.Name }
+func (p *ProxyConfigEntry) GetName() string            { return ProxyConfigGlobal }
 func (p *ProxyConfigEntry) GetPartition() string       { return p.Partition }
 func (p *ProxyConfigEntry) GetNamespace() string       { return p.Namespace }
 func (p *ProxyConfigEntry) GetMeta() map[string]string { return p.Meta }

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -147,6 +147,25 @@ http {
 
 		require.True(t, proxy.HTTP.SanitizeXForwardedClientCert)
 	})
+
+	// Test that if name isn't set (which isn't required for proxy-defaults because the name defaults to
+	// "global"), the CLI response still says "config entry written proxy-defaults/global".
+	t.Run("proxy defaults config entry without name set", func(t *testing.T) {
+		stdin := new(bytes.Buffer)
+		stdin.WriteString(`
+kind = "proxy-defaults"
+`)
+
+		ui := cli.NewMockUi()
+		c := New(ui)
+		c.testStdin = stdin
+
+		code := c.Run([]string{"-http-addr=" + a.HTTPAddr(), "-"})
+		require.Empty(t, ui.ErrorWriter.String())
+		require.Contains(t, ui.OutputWriter.String(),
+			`Config entry written: proxy-defaults/global`)
+		require.Equal(t, 0, code)
+	})
 }
 
 func requireContainsLower(t *testing.T, haystack, needle string) {


### PR DESCRIPTION
proxy-defaults can only have the name global. Because of this, we support not even setting the name in the config file:

```
kind = "proxy-defaults"
```

Previously, writing this would result in the output:

```
Config entry written: proxy-defaults/
```

Now it will output:

```
Config entry written: proxy-defaults/global
```

This change follows what was done for the new Mesh config entry.

Fixes https://github.com/hashicorp/consul/issues/10809