### PR TITLE
fix(api): missing peer name in query option

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -111,6 +111,9 @@ type QueryOptions struct {
 	// by the Config
 	Datacenter string
 
+	// Providing a peer name in the query option
+	Peer string
+
 	// AllowStale allows any Consul server (non-leader) to service
 	// a read. This allows for lower latency and higher throughput
 	AllowStale bool
@@ -811,6 +814,9 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	}
 	if q.Datacenter != "" {
 		r.params.Set("dc", q.Datacenter)
+	}
+	if q.Peer != "" {
+		r.params.Set("peer", q.Peer)
 	}
 	if q.AllowStale {
 		r.params.Set("stale", "")

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -763,6 +763,7 @@ func TestAPI_SetQueryOptions(t *testing.T) {
 		Namespace:         "operator",
 		Partition:         "asdf",
 		Datacenter:        "foo",
+		Peer:              "dc10",
 		AllowStale:        true,
 		RequireConsistent: true,
 		WaitIndex:         1000,
@@ -777,6 +778,9 @@ func TestAPI_SetQueryOptions(t *testing.T) {
 		t.Fatalf("bad: %v", r.params)
 	}
 	if r.params.Get("partition") != "asdf" {
+		t.Fatalf("bad: %v", r.params)
+	}
+	if r.params.Get("peer") != "dc10" {
 		t.Fatalf("bad: %v", r.params)
 	}
 	if r.params.Get("dc") != "foo" {


### PR DESCRIPTION
### Description
When using API to query a service imported by a peering, we need to set the `peer` in query option, which is missing in the current implementation. This PR fixes this issue.

### Testing & Reproduction steps

```go
cli.Health().Service("foo", "", false, &api.QueryOptions{
    Peer: "dc-abc",
})
```

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
