### PR TITLE
[OSS] chore(ci): update backport-assistant to use gh automerge

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -16,11 +16,11 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.2.5
+    container: hashicorpdev/backport-assistant:0.3.0
     steps:
       - name: Run Backport Assistant for stable-website
         run: |
-          backport-assistant backport -merge-method=squash -automerge
+          backport-assistant backport -merge-method=squash -gh-automerge
         env:
           BACKPORT_LABEL_REGEXP: "type/docs-(?P<target>cherrypick)"
           BACKPORT_TARGET_TEMPLATE: "stable-website"
@@ -41,13 +41,13 @@ jobs:
           # set BACKPORT_TARGET_TEMPLATE for backport-assistant
           # trims backport/ from the beginning with parameter substitution
           export BACKPORT_TARGET_TEMPLATE="release/${latest_backport_label#backport/}.x"
-          backport-assistant backport -merge-method=squash -automerge
+          backport-assistant backport -merge-method=squash -gh-automerge
         env:
           BACKPORT_LABEL_REGEXP: "type/docs-(?P<target>cherrypick)"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Run Backport Assistant for release branches
         run: |
-          backport-assistant backport -merge-method=squash -automerge
+          backport-assistant backport -merge-method=squash -gh-automerge
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"


### PR DESCRIPTION
### Description
This change upgrades `backport-assistant` to use the new GitHub Automerge feature. Instead of merging directly into release branches without running tests, this will leverage the GitHub feature to make sure all of the required tests pass before merging. This will hopefully stabilize failures we've been seeing when changes get backported with failures.

### Testing & Reproduction steps
N/A

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [ ] ~not a security concern~
