### PR TITLE
ci: Fix changelog-checker GHA workflow

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -25,11 +25,9 @@ jobs:
           fetch-depth: 0 # by default the checkout action doesn't checkout all branches
       - name: Check for changelog entry in diff
         run: |
-          pull_request_base_main=$(expr "${{ github.event.pull_request.base.ref }}" = "main")
-
           # check if there is a diff in the .changelog directory
           # for PRs against the main branch, the changelog file name should match the PR number
-          if [ pull_request_base_main ]; then
+          if [ "${{ github.event.pull_request.base.ref }}" = "${{ github.event.repository.default_branch }}" ]; then
             enforce_matching_pull_request_number="matching this PR number "
             changelog_file_path=".changelog/${{ github.event.pull_request.number }}.txt"
           else


### PR DESCRIPTION
### Description
I was recently working on some manual backports for 1.11 in #14828 and others and the `changelog-checker` workflow was failing despite having added a proper changelog entry. When I looked into it, it seems that there is some broken shell code in the action that is making it fail for the case where the base is not the default branch. In my case, the base branch was `release/1.11.x`.

Some history: it looks like back in #10844, there was a bit of a refactor/update to the checker logic that added this default branch case. I guess we just missed the bug in the code review.

In any case, this should fix it!

### Testing & Reproduction steps
I tested this by pulling the body of the checker out into a shell script and manually running it with the arguments for my pull request. The contents of the script are here in case you want to try it yourself: https://gist.github.com/eculver/ff83d81e09e5e030f817cf6212c6951f

It should exit 0 on a successful run and output (along with some other debug output)
```
Found .changelog entry in PR!
```
