### PR TITLE
fix flaky integration test

### DIFF
--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
@@ -26,28 +26,11 @@ load helpers
   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s1 HEALTHY 1
 }
 
-@test "s1 proxy should have been configured with max_connections in services" {
-  CLUSTER_THRESHOLD=$(get_envoy_cluster_config 127.0.0.1:20000 s1.default.primary | jq '.circuit_breakers.thresholds[0]')
-  echo $CLUSTER_THRESHOLD
-
-  MAX_CONNS=$(echo $CLUSTER_THRESHOLD | jq --raw-output '.max_connections')
-  MAX_PENDING_REQS=$(echo $CLUSTER_THRESHOLD | jq --raw-output '.max_pending_requests')
-  MAX_REQS=$(echo $CLUSTER_THRESHOLD | jq --raw-output '.max_requests')
-
-  echo "MAX_CONNS = $MAX_CONNS"
-  echo "MAX_PENDING_REQS = $MAX_PENDING_REQS"
-  echo "MAX_REQS = $MAX_REQS"
-
-  [ "$MAX_CONNS" = "100" ]
-  [ "$MAX_PENDING_REQS" = "200" ]
-  [ "$MAX_REQS" = "300" ]
-}
-
 @test "ingress-gateway should have healthy endpoints for s2" {
   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s2 HEALTHY 1
 }
 
-@test "s2 proxy should have been configured with max_connections using defaults" {
+@test "s2 proxy should have been configured with connection threshold from defaults" {
   CLUSTER_THRESHOLD=$(get_envoy_cluster_config 127.0.0.1:20000 s2.default.primary | jq '.circuit_breakers.thresholds[0]')
   echo $CLUSTER_THRESHOLD
 

--- a/test/integration/connect/envoy/case-ingress-gateway-simple/config_entries.hcl
+++ b/test/integration/connect/envoy/case-ingress-gateway-simple/config_entries.hcl
@@ -2,7 +2,11 @@ config_entries {
   bootstrap {
     kind = "ingress-gateway"
     name = "ingress-gateway"
-
+    Defaults {
+      MaxConnections = 10
+      MaxPendingRequests = 20
+      MaxConcurrentRequests = 30
+    }
     listeners = [
       {
         port     = 9999
@@ -10,6 +14,8 @@ config_entries {
         services = [
           {
             name = "s1"
+            MaxConnections = 100
+            MaxPendingRequests = 200
           }
         ]
       }

--- a/test/integration/connect/envoy/case-ingress-gateway-simple/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-simple/verify.bats
@@ -19,7 +19,24 @@ load helpers
 }
 
 @test "ingress-gateway should have healthy endpoints for s1" {
-   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s1 HEALTHY 1
+  assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s1 HEALTHY 1
+}
+
+@test "s1 proxy should have been configured with connection threshold from defaults and service" {
+  CLUSTER_THRESHOLD=$(get_envoy_cluster_config 127.0.0.1:20000 s1.default.primary | jq '.circuit_breakers.thresholds[0]')
+  echo $CLUSTER_THRESHOLD
+
+  MAX_CONNS=$(echo $CLUSTER_THRESHOLD | jq --raw-output '.max_connections')
+  MAX_PENDING_REQS=$(echo $CLUSTER_THRESHOLD | jq --raw-output '.max_pending_requests')
+  MAX_REQS=$(echo $CLUSTER_THRESHOLD | jq --raw-output '.max_requests')
+
+  echo "MAX_CONNS = $MAX_CONNS"
+  echo "MAX_PENDING_REQS = $MAX_PENDING_REQS"
+  echo "MAX_REQS = $MAX_REQS"
+
+  [ "$MAX_CONNS" = "100" ]
+  [ "$MAX_PENDING_REQS" = "200" ]
+  [ "$MAX_REQS" = "30" ]
 }
 
 @test "ingress should be able to connect to s1 via configured port" {


### PR DESCRIPTION
### Description
Fix flaky test because when a service is configured in two listeners in an ingress-gateway config entry; it randomly pick the service config from one of the listeners.

This PR moves test for setting non-default connection threshold to `integration/connect/envoy/case-ingress-gateway-simple` to avoid the non-deterministic results.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
