### PR TITLE
ui: Allow managed-runtime badge to be dynamic

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
@@ -1,67 +1,64 @@
-<li
-  class="dcs"
-  data-test-datacenter-menu
->
+<li class='dcs' data-test-datacenter-menu>
   {{#if (gt @dcs.length 1)}}
     <DisclosureMenu
-      aria-label="Datacenter"
+      aria-label='Datacenter'
       @items={{sort-by 'Primary:desc' 'Local:desc' 'Name:asc' @dcs}}
       data-test-datacenter-disclosure-menu
-    as |disclosure|>
-      <disclosure.Action
-        {{on 'click' disclosure.toggle}}
-      >
+      as |disclosure|
+    >
+      <disclosure.Action {{on 'click' disclosure.toggle}}>
         {{@dc.Name}}
       </disclosure.Action>
       <disclosure.Menu as |panel|>
         <DataSource
           @src={{uri '/*/*/*/datacenters'}}
-          @onchange={{action (mut @dcs) value="data"}}
+          @onchange={{action (mut @dcs) value='data'}}
         />
-          <p class="dcs-message">
-            Datacenters shown in this dropdown are available through WAN Federation.
-          </p>
-          <panel.Menu as |menu|>
-            <menu.Separator>
-              DATACENTERS
-            </menu.Separator>
-            {{#each menu.items as |item|}}
-              <menu.Item
-                data-test-dc-item
-                aria-current={{if (eq @dc.Name item.Name) 'true'}}
-                class={{class-map
-                  (array 'is-local' item.Local)
-                  (array 'is-primary' item.Primary)
-                }}
-              >
-                <menu.Action
-                  {{on 'click' disclosure.close}}
-                  @href={{href-to '.' params=(hash
+        <p class='dcs-message'>
+          Datacenters shown in this dropdown are available through WAN Federation.
+        </p>
+        <panel.Menu as |menu|>
+          <menu.Separator>
+            DATACENTERS
+          </menu.Separator>
+          {{#each menu.items as |item|}}
+            <menu.Item
+              data-test-dc-item
+              aria-current={{if (eq @dc.Name item.Name) 'true'}}
+              class={{class-map (array 'is-local' item.Local) (array 'is-primary' item.Primary)}}
+            >
+              <menu.Action
+                {{on 'click' disclosure.close}}
+                @href={{href-to
+                  '.'
+                  params=(hash
                     dc=item.Name
                     partition=undefined
                     nspace=(if (gt @nspace.length 0) @nspace undefined)
-                  )}}
-                >
-                  {{item.Name}}
+                  )
+                }}
+              >
+                {{item.Name}}
                 {{#if item.Primary}}
                   <span>Primary</span>
                 {{/if}}
                 {{#if item.Local}}
                   <span>Local</span>
                 {{/if}}
-                </menu.Action>
-              </menu.Item>
-            {{/each}}
-          </panel.Menu>
+              </menu.Action>
+            </menu.Item>
+          {{/each}}
+        </panel.Menu>
       </disclosure.Menu>
     </DisclosureMenu>
   {{else}}
-    <div class="dc-name" data-test-datacenter-single>
+    <div class='dc-name' data-test-datacenter-single>
       {{@dcs.firstObject.Name}}
-      {{#if (env 'CONSUL_HCP_MANAGED_RUNTIME')}}
-        <span>Self-managed</span>
-      {{/if}}
+      {{#let (env 'CONSUL_HCP_MANAGED_RUNTIME') as |managedRuntime|}}
+        {{#if managedRuntime}}
+          <span>{{capitalize managedRuntime}}</span>
+        {{/if}}
+      {{/let}}
     </div>
   {{/if}}
 </li>
-


### PR DESCRIPTION
### Description
Allow the `managed-runtime`-badge to display dynamic values. Before this change, we hard-coded the text to always display `Self-managed`. This change will make the badge dynamic by using the value that is set as the `HCPEnabledRuntime`-option as the text for the badge.

I did not add a test for this behavior, as it is nearly impossible to add a test for configuration options in only one test with the current setup of environment-variables.

<img width="404" alt="Screenshot 2022-10-04 at 10 46 40" src="https://user-images.githubusercontent.com/242299/193776016-cb43e098-d77f-4cca-a0df-ab8e01dda544.png">

### Testing & Reproduction steps
* add `HCPManagedRuntime` to the `operatorConfig` in `/config/environment.js` and set its value to the text you want the badge to display. In production, this will be taken care of by the server, for development this is the easiest way to change this option.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
