### PR TITLE
Rename `PeerName` to `Peer` on prepared queries and exported services

### DIFF
--- a/.changelog/14854.txt
+++ b/.changelog/14854.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+peering: Rename `PeerName` to `Peer` on prepared queries and exported services.
+```

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -3334,19 +3334,19 @@ func TestInternal_ExportedPeeredServices_ACLEnforcement(t *testing.T) {
 			{
 				Name: "web",
 				Consumers: []structs.ServiceConsumer{
-					{PeerName: "peer-1"},
+					{Peer: "peer-1"},
 				},
 			},
 			{
 				Name: "db",
 				Consumers: []structs.ServiceConsumer{
-					{PeerName: "peer-2"},
+					{Peer: "peer-2"},
 				},
 			},
 			{
 				Name: "api",
 				Consumers: []structs.ServiceConsumer{
-					{PeerName: "peer-1"},
+					{Peer: "peer-1"},
 				},
 			},
 		},
@@ -3405,7 +3405,7 @@ func TestInternal_ExportedPeeredServices_ACLEnforcement(t *testing.T) {
 				`
 			service "web" { policy = "read" }
 			service "api" { policy = "read" }
-			service "db"  { policy = "deny" }	
+			service "db"  { policy = "deny" }
 			`),
 			expect: map[string]structs.ServiceList{
 				"peer-1": {
@@ -3514,19 +3514,19 @@ func TestInternal_ExportedServicesForPeer_ACLEnforcement(t *testing.T) {
 			{
 				Name: "web",
 				Consumers: []structs.ServiceConsumer{
-					{PeerName: "peer-1"},
+					{Peer: "peer-1"},
 				},
 			},
 			{
 				Name: "db",
 				Consumers: []structs.ServiceConsumer{
-					{PeerName: "peer-2"},
+					{Peer: "peer-2"},
 				},
 			},
 			{
 				Name: "api",
 				Consumers: []structs.ServiceConsumer{
-					{PeerName: "peer-1"},
+					{Peer: "peer-1"},
 				},
 			},
 		},

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -257,7 +257,7 @@ func TestLeader_PeeringSync_Lifecycle_UnexportWhileDown(t *testing.T) {
 				Services: []structs.ExportedService{
 					{
 						Name:      "foo",
-						Consumers: []structs.ServiceConsumer{{PeerName: "my-peer-dialer"}},
+						Consumers: []structs.ServiceConsumer{{Peer: "my-peer-dialer"}},
 					},
 				},
 			},
@@ -1014,7 +1014,7 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 						Name: structs.WildcardSpecifier,
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "my-peer-s2",
+								Peer: "my-peer-s2",
 							},
 						},
 					},
@@ -1042,7 +1042,7 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 						Name: "a-service",
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "my-peer-s2",
+								Peer: "my-peer-s2",
 							},
 						},
 					},
@@ -1050,7 +1050,7 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 						Name: "b-service",
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "my-peer-s2",
+								Peer: "my-peer-s2",
 							},
 						},
 					},
@@ -1069,7 +1069,7 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 						Name: "a-service",
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "my-peer-s2",
+								Peer: "my-peer-s2",
 							},
 						},
 					},
@@ -1088,7 +1088,7 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 						Name: "a-service",
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "my-peer-s2",
+								Peer: "my-peer-s2",
 							},
 						},
 					},
@@ -1096,7 +1096,7 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 						Name: "c-service",
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "my-peer-s2",
+								Peer: "my-peer-s2",
 							},
 						},
 					},

--- a/agent/consul/prepared_query/walk_test.go
+++ b/agent/consul/prepared_query/walk_test.go
@@ -42,7 +42,7 @@ func TestWalk_ServiceQuery(t *testing.T) {
 		".Tags[0]:tag1",
 		".Tags[1]:tag2",
 		".Tags[2]:tag3",
-		".PeerName:",
+		".Peer:",
 	}
 	expected = append(expected, entMetaWalkFields...)
 	sort.Strings(expected)

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -540,7 +540,7 @@ func (p *PreparedQuery) execute(query *structs.PreparedQuery,
 		f = state.CheckConnectServiceNodes
 	}
 
-	_, nodes, err := f(nil, query.Service.Service, &query.Service.EnterpriseMeta, query.Service.PeerName)
+	_, nodes, err := f(nil, query.Service.Service, &query.Service.EnterpriseMeta, query.Service.Peer)
 	if err != nil {
 		return err
 	}
@@ -571,7 +571,7 @@ func (p *PreparedQuery) execute(query *structs.PreparedQuery,
 	reply.DNS = query.DNS
 
 	// Stamp the result with its this datacenter or peer.
-	if peerName := query.Service.PeerName; peerName != "" {
+	if peerName := query.Service.Peer; peerName != "" {
 		reply.PeerName = peerName
 		reply.Datacenter = ""
 	} else {
@@ -756,7 +756,7 @@ func queryFailover(q queryServer, query *structs.PreparedQuery,
 			}
 		}
 
-		if target.PeerName != "" {
+		if target.Peer != "" {
 			targets = append(targets, target)
 		}
 	}
@@ -777,9 +777,9 @@ func queryFailover(q queryServer, query *structs.PreparedQuery,
 
 		// Reset PeerName because it may have been set by a previous failover
 		// target.
-		query.Service.PeerName = target.PeerName
+		query.Service.Peer = target.Peer
 		dc := target.Datacenter
-		if target.PeerName != "" {
+		if target.Peer != "" {
 			dc = q.GetLocalDC()
 		}
 
@@ -798,7 +798,7 @@ func queryFailover(q queryServer, query *structs.PreparedQuery,
 		if err = q.ExecuteRemote(remote, reply); err != nil {
 			q.GetLogger().Warn("Failed querying for service in datacenter",
 				"service", query.Service.Service,
-				"peerName", query.Service.PeerName,
+				"peerName", query.Service.Peer,
 				"datacenter", dc,
 				"error", err,
 			)

--- a/agent/consul/state/config_entry_oss_test.go
+++ b/agent/consul/state/config_entry_oss_test.go
@@ -63,7 +63,7 @@ func TestStore_peersForService(t *testing.T) {
 						Name: "not-" + queryName,
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "zip",
+								Peer: "zip",
 							},
 						},
 					},
@@ -80,7 +80,7 @@ func TestStore_peersForService(t *testing.T) {
 						Name: "not-" + queryName,
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "zip",
+								Peer: "zip",
 							},
 						},
 					},
@@ -88,10 +88,10 @@ func TestStore_peersForService(t *testing.T) {
 						Name: structs.WildcardSpecifier,
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "bar",
+								Peer: "bar",
 							},
 							{
-								PeerName: "baz",
+								Peer: "baz",
 							},
 						},
 					},
@@ -108,7 +108,7 @@ func TestStore_peersForService(t *testing.T) {
 						Name: queryName,
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "baz",
+								Peer: "baz",
 							},
 						},
 					},
@@ -116,7 +116,7 @@ func TestStore_peersForService(t *testing.T) {
 						Name: structs.WildcardSpecifier,
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "zip",
+								Peer: "zip",
 							},
 						},
 					},

--- a/agent/consul/state/config_entry_test.go
+++ b/agent/consul/state/config_entry_test.go
@@ -1569,7 +1569,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 				Name: "default",
 				Services: []structs.ExportedService{{
 					Name:      "main",
-					Consumers: []structs.ServiceConsumer{{PeerName: "my-peer"}},
+					Consumers: []structs.ServiceConsumer{{Peer: "my-peer"}},
 				}},
 			},
 			expectErr: `contains cross-datacenter resolver redirect`,
@@ -1588,7 +1588,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 				Name: "default",
 				Services: []structs.ExportedService{{
 					Name:      "*",
-					Consumers: []structs.ServiceConsumer{{PeerName: "my-peer"}},
+					Consumers: []structs.ServiceConsumer{{Peer: "my-peer"}},
 				}},
 			},
 			expectErr: `contains cross-datacenter resolver redirect`,
@@ -1609,7 +1609,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 				Name: "default",
 				Services: []structs.ExportedService{{
 					Name:      "main",
-					Consumers: []structs.ServiceConsumer{{PeerName: "my-peer"}},
+					Consumers: []structs.ServiceConsumer{{Peer: "my-peer"}},
 				}},
 			},
 			expectErr: `contains cross-datacenter failover`,
@@ -1630,7 +1630,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 				Name: "default",
 				Services: []structs.ExportedService{{
 					Name:      "*",
-					Consumers: []structs.ServiceConsumer{{PeerName: "my-peer"}},
+					Consumers: []structs.ServiceConsumer{{Peer: "my-peer"}},
 				}},
 			},
 			expectErr: `contains cross-datacenter failover`,
@@ -1641,7 +1641,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					Name: "default",
 					Services: []structs.ExportedService{{
 						Name:      "main",
-						Consumers: []structs.ServiceConsumer{{PeerName: "my-peer"}},
+						Consumers: []structs.ServiceConsumer{{Peer: "my-peer"}},
 					}},
 				},
 			},

--- a/agent/consul/state/peering.go
+++ b/agent/consul/state/peering.go
@@ -794,7 +794,7 @@ func exportedServicesForPeerTxn(
 				// Service was covered by a wildcard that was already accounted for
 				continue
 			}
-			if consumer.PeerName != peering.Name {
+			if consumer.Peer != peering.Name {
 				continue
 			}
 			sawPeer = true
@@ -940,7 +940,7 @@ func listServicesExportedToAnyPeerByConfigEntry(
 
 		sawPeer := false
 		for _, consumer := range svc.Consumers {
-			if consumer.PeerName == "" {
+			if consumer.Peer == "" {
 				continue
 			}
 			sawPeer = true
@@ -1312,8 +1312,8 @@ func peersForServiceTxn(
 	}
 
 	for _, c := range entry.Services[targetIdx].Consumers {
-		if c.PeerName != "" {
-			results = append(results, c.PeerName)
+		if c.Peer != "" {
+			results = append(results, c.Peer)
 		}
 	}
 	return idx, results, nil

--- a/agent/consul/state/peering_test.go
+++ b/agent/consul/state/peering_test.go
@@ -1686,19 +1686,19 @@ func TestStateStore_ExportedServicesForPeer(t *testing.T) {
 				{
 					Name: "mysql",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-peering"},
+						{Peer: "my-peering"},
 					},
 				},
 				{
 					Name: "redis",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-peering"},
+						{Peer: "my-peering"},
 					},
 				},
 				{
 					Name: "mongo",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-other-peering"},
+						{Peer: "my-other-peering"},
 					},
 				},
 			},
@@ -1758,7 +1758,7 @@ func TestStateStore_ExportedServicesForPeer(t *testing.T) {
 				{
 					Name: "*",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-peering"},
+						{Peer: "my-peering"},
 					},
 				},
 			},
@@ -2046,10 +2046,10 @@ func TestStateStore_PeeringsForService(t *testing.T) {
 						Name: "foo",
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "peer1",
+								Peer: "peer1",
 							},
 							{
-								PeerName: "peer2",
+								Peer: "peer2",
 							},
 						},
 					},
@@ -2090,7 +2090,7 @@ func TestStateStore_PeeringsForService(t *testing.T) {
 						Name: "foo",
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "peer1",
+								Peer: "peer1",
 							},
 						},
 					},
@@ -2098,7 +2098,7 @@ func TestStateStore_PeeringsForService(t *testing.T) {
 						Name: "bar",
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "peer2",
+								Peer: "peer2",
 							},
 						},
 					},
@@ -2148,10 +2148,10 @@ func TestStateStore_PeeringsForService(t *testing.T) {
 						Name: "*",
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "peer1",
+								Peer: "peer1",
 							},
 							{
-								PeerName: "peer2",
+								Peer: "peer2",
 							},
 						},
 					},
@@ -2159,7 +2159,7 @@ func TestStateStore_PeeringsForService(t *testing.T) {
 						Name: "bar",
 						Consumers: []structs.ServiceConsumer{
 							{
-								PeerName: "peer3",
+								Peer: "peer3",
 							},
 						},
 					},
@@ -2261,7 +2261,7 @@ func TestStore_TrustBundleListByService(t *testing.T) {
 					Name: "foo",
 					Consumers: []structs.ServiceConsumer{
 						{
-							PeerName: "peer1",
+							Peer: "peer1",
 						},
 					},
 				},
@@ -2318,7 +2318,7 @@ func TestStore_TrustBundleListByService(t *testing.T) {
 					Name: "foo",
 					Consumers: []structs.ServiceConsumer{
 						{
-							PeerName: "peer1",
+							Peer: "peer1",
 						},
 					},
 				},
@@ -2371,10 +2371,10 @@ func TestStore_TrustBundleListByService(t *testing.T) {
 					Name: "foo",
 					Consumers: []structs.ServiceConsumer{
 						{
-							PeerName: "peer1",
+							Peer: "peer1",
 						},
 						{
-							PeerName: "peer2",
+							Peer: "peer2",
 						},
 					},
 				},

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -864,14 +864,14 @@ func TestStreamResources_Server_ServiceUpdates(t *testing.T) {
 				{
 					Name: "mysql",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-peering"},
+						{Peer: "my-peering"},
 					},
 				},
 				{
 					// Mongo does not get pushed because it does not have instances registered.
 					Name: "mongo",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-peering"},
+						{Peer: "my-peering"},
 					},
 				},
 			},
@@ -1035,7 +1035,7 @@ func TestStreamResources_Server_ServiceUpdates(t *testing.T) {
 					Name: "mongo",
 					Consumers: []structs.ServiceConsumer{
 						{
-							PeerName: "my-peering",
+							Peer: "my-peering",
 						},
 					},
 				},

--- a/agent/grpc-external/services/peerstream/subscription_manager_test.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager_test.go
@@ -80,13 +80,13 @@ func TestSubscriptionManager_RegisterDeregister(t *testing.T) {
 				{
 					Name: "mysql",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-peering"},
+						{Peer: "my-peering"},
 					},
 				},
 				{
 					Name: "mongo",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-other-peering"},
+						{Peer: "my-other-peering"},
 					},
 				},
 			},
@@ -429,7 +429,7 @@ func TestSubscriptionManager_RegisterDeregister(t *testing.T) {
 				{
 					Name: "mongo",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-other-peering"},
+						{Peer: "my-other-peering"},
 					},
 				},
 			},
@@ -506,19 +506,19 @@ func TestSubscriptionManager_InitialSnapshot(t *testing.T) {
 				{
 					Name: "mysql",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-peering"},
+						{Peer: "my-peering"},
 					},
 				},
 				{
 					Name: "mongo",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-peering"},
+						{Peer: "my-peering"},
 					},
 				},
 				{
 					Name: "chain",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "my-peering"},
+						{Peer: "my-peering"},
 					},
 				},
 			},

--- a/agent/proxycfg-glue/exported_peered_services_test.go
+++ b/agent/proxycfg-glue/exported_peered_services_test.go
@@ -36,13 +36,13 @@ func TestServerExportedPeeredServices(t *testing.T) {
 			{
 				Name: "web",
 				Consumers: []structs.ServiceConsumer{
-					{PeerName: "peer-1"},
+					{Peer: "peer-1"},
 				},
 			},
 			{
 				Name: "db",
 				Consumers: []structs.ServiceConsumer{
-					{PeerName: "peer-2"},
+					{Peer: "peer-2"},
 				},
 			},
 		},
@@ -78,20 +78,20 @@ func TestServerExportedPeeredServices(t *testing.T) {
 				{
 					Name: "web",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "peer-1"},
+						{Peer: "peer-1"},
 					},
 				},
 				{
 					Name: "db",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "peer-2"},
+						{Peer: "peer-2"},
 					},
 				},
 				{
 					Name: "api",
 					Consumers: []structs.ServiceConsumer{
-						{PeerName: "peer-1"},
-						{PeerName: "peer-3"},
+						{Peer: "peer-1"},
+						{Peer: "peer-3"},
 					},
 				},
 			},

--- a/agent/proxycfg-glue/trust_bundle_test.go
+++ b/agent/proxycfg-glue/trust_bundle_test.go
@@ -144,7 +144,7 @@ func TestServerTrustBundleList(t *testing.T) {
 					{
 						Name: serviceName,
 						Consumers: []structs.ServiceConsumer{
-							{PeerName: them},
+							{Peer: them},
 						},
 					},
 				},
@@ -249,7 +249,7 @@ func TestServerTrustBundleList_ACLEnforcement(t *testing.T) {
 					{
 						Name: serviceName,
 						Consumers: []structs.ServiceConsumer{
-							{PeerName: them},
+							{Peer: them},
 						},
 					},
 				},

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -1059,10 +1059,10 @@ func TestPeeringService_TrustBundleListByService(t *testing.T) {
 				Name: "api",
 				Consumers: []structs.ServiceConsumer{
 					{
-						PeerName: "foo",
+						Peer: "foo",
 					},
 					{
-						PeerName: "bar",
+						Peer: "bar",
 					},
 				},
 			},
@@ -1070,7 +1070,7 @@ func TestPeeringService_TrustBundleListByService(t *testing.T) {
 				Name: "web",
 				Consumers: []structs.ServiceConsumer{
 					{
-						PeerName: "baz",
+						Peer: "baz",
 					},
 				},
 			},
@@ -1264,7 +1264,7 @@ func TestPeeringService_TrustBundleListByService_ACLEnforcement(t *testing.T) {
 				Name: "api",
 				Consumers: []structs.ServiceConsumer{
 					{
-						PeerName: "foo",
+						Peer: "foo",
 					},
 				},
 			},

--- a/agent/structs/config_entry_export_oss_test.go
+++ b/agent/structs/config_entry_export_oss_test.go
@@ -17,7 +17,7 @@ func TestExportedServicesConfigEntry_OSS(t *testing.T) {
 						Name: "web",
 						Consumers: []ServiceConsumer{
 							{
-								PeerName: "bar",
+								Peer: "bar",
 							},
 						},
 					},
@@ -31,7 +31,7 @@ func TestExportedServicesConfigEntry_OSS(t *testing.T) {
 						Namespace: "",
 						Consumers: []ServiceConsumer{
 							{
-								PeerName: "bar",
+								Peer: "bar",
 							},
 						},
 					},

--- a/agent/structs/config_entry_exports.go
+++ b/agent/structs/config_entry_exports.go
@@ -35,14 +35,14 @@ type ExportedService struct {
 }
 
 // ServiceConsumer represents a downstream consumer of the service to be exported.
-// At most one of Partition or PeerName must be specified.
+// At most one of Partition or Peer must be specified.
 type ServiceConsumer struct {
 	// Partition is the admin partition to export the service to.
-	// Deprecated: PeerName should be used for both remote peers and local partitions.
+	// Deprecated: Peer should be used for both remote peers and local partitions.
 	Partition string `json:",omitempty"`
 
-	// PeerName is the name of the peer to export the service to.
-	PeerName string `json:",omitempty" alias:"peer_name"`
+	// Peer is the name of the peer to export the service to.
+	Peer string `json:",omitempty" alias:"peer_name"`
 }
 
 func (e *ExportedServicesConfigEntry) ToMap() map[string]map[string][]string {
@@ -130,13 +130,13 @@ func (e *ExportedServicesConfigEntry) Validate() error {
 			return fmt.Errorf("Services[%d]: must have at least one consumer", i)
 		}
 		for j, consumer := range svc.Consumers {
-			if consumer.PeerName != "" && consumer.Partition != "" {
-				return fmt.Errorf("Services[%d].Consumers[%d]: must define at most one of PeerName or Partition", i, j)
+			if consumer.Peer != "" && consumer.Partition != "" {
+				return fmt.Errorf("Services[%d].Consumers[%d]: must define at most one of Peer or Partition", i, j)
 			}
 			if consumer.Partition == WildcardSpecifier {
 				return fmt.Errorf("Services[%d].Consumers[%d]: exporting to all partitions (wildcard) is not supported", i, j)
 			}
-			if consumer.PeerName == WildcardSpecifier {
+			if consumer.Peer == WildcardSpecifier {
 				return fmt.Errorf("Services[%d].Consumers[%d]: exporting to all peers (wildcard) is not supported", i, j)
 			}
 		}

--- a/agent/structs/config_entry_exports_test.go
+++ b/agent/structs/config_entry_exports_test.go
@@ -60,10 +60,10 @@ func TestExportedServicesConfigEntry(t *testing.T) {
 						Name: "web",
 						Consumers: []ServiceConsumer{
 							{
-								PeerName: "foo",
+								Peer: "foo",
 							},
 							{
-								PeerName: "*",
+								Peer: "*",
 							},
 						},
 					},
@@ -80,13 +80,13 @@ func TestExportedServicesConfigEntry(t *testing.T) {
 						Consumers: []ServiceConsumer{
 							{
 								Partition: "foo",
-								PeerName:  "bar",
+								Peer:      "bar",
 							},
 						},
 					},
 				},
 			},
-			validateErr: `Services[0].Consumers[0]: must define at most one of PeerName or Partition`,
+			validateErr: `Services[0].Consumers[0]: must define at most one of Peer or Partition`,
 		},
 	}
 

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1951,7 +1951,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 								Partition = "baz"
 							},
 							{
-								PeerName = "flarm"
+								Peer = "flarm"
 							}
 						]
 					},
@@ -1984,7 +1984,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 								Partition: "baz",
 							},
 							{
-								PeerName: "flarm",
+								Peer: "flarm",
 							},
 						},
 					},

--- a/agent/structs/prepared_query.go
+++ b/agent/structs/prepared_query.go
@@ -42,8 +42,8 @@ func (f *QueryFailoverOptions) AsTargets() []QueryFailoverTarget {
 }
 
 type QueryFailoverTarget struct {
-	// PeerName specifies a peer to try during failover.
-	PeerName string
+	// Peer specifies a peer to try during failover.
+	Peer string
 
 	// Datacenter specifies a datacenter to try during failover.
 	Datacenter string
@@ -105,9 +105,9 @@ type ServiceQuery struct {
 	// should be directly next to their services so this isn't an issue.
 	Connect bool
 
-	// If not empty, PeerName represents the peer that the service
+	// If not empty, Peer represents the peer that the service
 	// was imported from.
-	PeerName string
+	Peer string
 
 	// EnterpriseMeta is the embedded enterprise metadata
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -779,7 +779,7 @@ func TestUIExportedServices(t *testing.T) {
 					Name: "api",
 					Consumers: []structs.ServiceConsumer{
 						{
-							PeerName: "peer1",
+							Peer: "peer1",
 						},
 					},
 				},

--- a/api/config_entry_exports.go
+++ b/api/config_entry_exports.go
@@ -50,8 +50,8 @@ type ServiceConsumer struct {
 	// Deprecated: PeerName should be used for both remote peers and local partitions.
 	Partition string `json:",omitempty"`
 
-	// PeerName is the name of the peer to export the service to.
-	PeerName string `json:",omitempty" alias:"peer_name"`
+	// Peer is the name of the peer to export the service to.
+	Peer string `json:",omitempty" alias:"peer_name"`
 }
 
 func (e *ExportedServicesConfigEntry) GetKind() string            { return ExportedServices }

--- a/api/config_entry_exports_test.go
+++ b/api/config_entry_exports_test.go
@@ -51,7 +51,7 @@ func TestAPI_ConfigEntries_ExportedServices(t *testing.T) {
 					Namespace: defaultNamespace,
 					Consumers: []ServiceConsumer{
 						{
-							PeerName: "alpha",
+							Peer: "alpha",
 						},
 					},
 				},

--- a/api/prepared_query.go
+++ b/api/prepared_query.go
@@ -21,8 +21,8 @@ type QueryFailoverOptions struct {
 type QueryDatacenterOptions = QueryFailoverOptions
 
 type QueryFailoverTarget struct {
-	// PeerName specifies a peer to try during failover.
-	PeerName string
+	// Peer specifies a peer to try during failover.
+	Peer string
 
 	// Datacenter specifies a datacenter to try during failover.
 	Datacenter string

--- a/command/helpers/helpers_test.go
+++ b/command/helpers/helpers_test.go
@@ -715,7 +715,7 @@ func TestParseConfigEntry(t *testing.T) {
 				},
 				"destination": {
 					"addresses": [
-						"10.0.0.0", 
+						"10.0.0.0",
 						"10.0.0.1"
 					],
 					"port": 443
@@ -741,7 +741,7 @@ func TestParseConfigEntry(t *testing.T) {
 				},
 				"Destination": {
 					"Addresses": [
-						"10.0.0.0", 
+						"10.0.0.0",
 						"10.0.0.1"
 					],
 					"Port": 443
@@ -2911,7 +2911,7 @@ func TestParseConfigEntry(t *testing.T) {
 								Partition = "baz"
 							},
 							{
-								PeerName = "flarm"
+								Peer = "flarm"
 							}
 						]
 					},
@@ -2982,7 +2982,7 @@ func TestParseConfigEntry(t *testing.T) {
 								"Partition": "baz"
 							},
 							{
-								"PeerName": "flarm"
+								"Peer": "flarm"
 							}
 						]
 					},
@@ -3016,7 +3016,7 @@ func TestParseConfigEntry(t *testing.T) {
 								Partition: "baz",
 							},
 							{
-								PeerName: "flarm",
+								Peer: "flarm",
 							},
 						},
 					},

--- a/test/integration/connect/envoy/case-cfg-resolver-cluster-peering-failover/alpha/config_entries.hcl
+++ b/test/integration/connect/envoy/case-cfg-resolver-cluster-peering-failover/alpha/config_entries.hcl
@@ -16,7 +16,7 @@ config_entries {
           name = "s2"
           consumers = [
             {
-              peer_name = "alpha-to-primary"
+              peer = "alpha-to-primary"
             }
           ]
         }

--- a/test/integration/connect/envoy/case-cross-peers-http-router/alpha/config_entries.hcl
+++ b/test/integration/connect/envoy/case-cross-peers-http-router/alpha/config_entries.hcl
@@ -29,7 +29,7 @@ config_entries {
           name = "s2"
           consumers = [
             {
-              peer_name = "alpha-to-primary"
+              peer = "alpha-to-primary"
             }
           ]
         }

--- a/test/integration/connect/envoy/case-cross-peers-http/alpha/config_entries.hcl
+++ b/test/integration/connect/envoy/case-cross-peers-http/alpha/config_entries.hcl
@@ -16,7 +16,7 @@ config_entries {
           name = "s2"
           consumers = [
             {
-              peer_name = "alpha-to-primary"
+              peer = "alpha-to-primary"
             }
           ]
         }

--- a/test/integration/connect/envoy/case-cross-peers-resolver-redirect-tcp/alpha/config_entries.hcl
+++ b/test/integration/connect/envoy/case-cross-peers-resolver-redirect-tcp/alpha/config_entries.hcl
@@ -23,7 +23,7 @@ config_entries {
           name = "s2"
           consumers = [
             {
-              peer_name = "alpha-to-primary"
+              peer = "alpha-to-primary"
             }
           ]
         }

--- a/test/integration/connect/envoy/case-cross-peers/alpha/config_entries.hcl
+++ b/test/integration/connect/envoy/case-cross-peers/alpha/config_entries.hcl
@@ -16,7 +16,7 @@ config_entries {
           name = "s2"
           consumers = [
             {
-              peer_name = "alpha-to-primary"
+              peer = "alpha-to-primary"
             }
           ]
         }

--- a/website/content/api-docs/query.mdx
+++ b/website/content/api-docs/query.mdx
@@ -207,7 +207,7 @@ The table below shows this endpoint's support for
       service instances in the local datacenter.
       This option cannot be used with `NearestN` or `Datacenters`.
 
-      - `PeerName` `(string: "")` - Specifies a [cluster peer](/docs/connect/cluster-peering) to use for
+      - `Peer` `(string: "")` - Specifies a [cluster peer](/docs/connect/cluster-peering) to use for
         failover.
 
       - `Datacenter` `(string: "")` - Specifies a WAN federated datacenter to forward the

--- a/website/content/docs/connect/config-entries/exported-services.mdx
+++ b/website/content/docs/connect/config-entries/exported-services.mdx
@@ -46,7 +46,7 @@ Services = [
     Name = "<name of service to export>"
     Consumers = [
       {
-        PeerName = "<name of the peered cluster that dials the exported service>"
+        Peer = "<name of the peered cluster that dials the exported service>"
       }
     ]
   }
@@ -73,7 +73,7 @@ spec:
     "Name": "<name of service to export>",
     "Consumers": [
       {
-        "PeerName": "<name of the peered cluster that dials the exported service>"
+        "Peer": "<name of the peered cluster that dials the exported service>"
       }
     ]
   }
@@ -96,7 +96,7 @@ Services = [
     Namespace = "<namespace in the partition containing the service to export>"
     Consumers = [
       {
-        PeerName = "<name of the peered cluster that dials the exported service>"
+        Peer = "<name of the peered cluster that dials the exported service>"
       }
     ]
   }
@@ -126,7 +126,7 @@ spec:
     "Namespace": "<namespace in the partition containing the service to export>"
     "Consumers": [
       {
-        "PeerName": "<name of the peered cluster that dials the exported service>"
+        "Peer": "<name of the peered cluster that dials the exported service>"
       }
     ]
   }
@@ -215,8 +215,8 @@ The `Services` parameter contains a list of one or more parameters that specify 
 The `Consumers` parameter contains a list of one or more parameters that specify the destination cluster for
 an exported service. Each item in the `Consumers` list must contain exactly one of the following parameters:
 
-- `PeerName`: Specifies the name of the peered cluster to export the service to.
-A asterisk wildcard (`*`) cannot be specified as the `PeerName`. Added in Consul 1.13.0.
+- `Peer`: Specifies the name of the peered cluster to export the service to.
+A asterisk wildcard (`*`) cannot be specified as the `Peer`. Added in Consul 1.13.0.
 - `Partition`: <EnterpriseAlert inline /> Specifies an admin partition in the datacenter to export the service to.
 A asterisk wildcard (`*`) cannot be specified as the `Partition`.
 
@@ -242,7 +242,7 @@ Services = [
     Name      = "payments"
     Consumers = [
         {
-            PeerName  = "web-shop"
+            Peer  = "web-shop"
         },
     ]
   },
@@ -250,7 +250,7 @@ Services = [
     Name      = "refunds"
     Consumers = [
         {
-            PeerName = "web-shop"
+            Peer = "web-shop"
         }
     ]
   }
@@ -280,7 +280,7 @@ spec:
       "Name": "payments",
       "Consumers": [
         {
-          "PeerName": "web-shop"
+          "Peer": "web-shop"
         },
       ],
     },
@@ -288,7 +288,7 @@ spec:
       "Name": "refunds",
       "Consumers": [
         {
-          "PeerName": "web-shop"
+          "Peer": "web-shop"
         }
       ]
     }
@@ -315,7 +315,7 @@ Services = [
     Namespace = "billing"
     Consumers = [
         {
-            PeerName  = "web-shop"
+            Peer  = "web-shop"
         },
     ]
   },
@@ -324,7 +324,7 @@ Services = [
     Namespace = "billing"
     Consumers = [
         {
-            PeerName = "web-shop"
+            Peer = "web-shop"
         }
     ]
   }
@@ -358,7 +358,7 @@ spec:
       "Namespace": "billing"
       "Consumers": [
         {
-          "PeerName": "web-shop"
+          "Peer": "web-shop"
         },
       ],
     },
@@ -367,7 +367,7 @@ spec:
       "Namespace": "billing",
       "Consumers": [
         {
-          "PeerName": "web-shop"
+          "Peer": "web-shop"
         }
       ]
     }
@@ -475,10 +475,10 @@ Services = [
     Name      = "*"
     Consumers = [
         {
-            PeerName  = "monitoring"
+            Peer  = "monitoring"
         },
         {
-            PeerName  = "platform"
+            Peer  = "platform"
         }
     ]
   }
@@ -507,10 +507,10 @@ spec:
       "Namespace": "*"
       "Consumers": [
         {
-          "PeerName": "monitoring"
+          "Peer": "monitoring"
         },
         {
-          "PeerName": "platform"
+          "Peer": "platform"
         }
       ]
     }
@@ -537,10 +537,10 @@ Services = [
     Namespace = "*"
     Consumers = [
         {
-            PeerName = "monitoring"
+            Peer = "monitoring"
         },
         {
-            PeerName = "platform"
+            Peer = "platform"
         }
     ]
   }
@@ -571,10 +571,10 @@ spec:
       "Namespace": "*"
       "Consumers": [
         {
-          "PeerName": "monitoring"
+          "Peer": "monitoring"
         },
         {
-          "PeerName": "platform"
+          "Peer": "platform"
         }
       ]
     }


### PR DESCRIPTION
### PR Checklist

* [X] updated test coverage
* [ ] external facing docs updated
* [X] not a security concern
