### PR TITLE
docs: Windows VM tutorial link fix

### DIFF
--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -176,7 +176,7 @@ The [Advanced Configuration](#advanced-configuration) section describes addition
 
 ### Bootstrap Envoy on Windows VMs
 
-> Complete the [Connect Services on Windows Workloads to Consul Service Mesh tutorial](https://learn.hashicorp.com/tutorials/consul/consul-on-windows-workloads?utm_source=docs) to learn how to deploy Consul and use its service mesh on Windows VMs.
+> Complete the [Connect Services on Windows Workloads to Consul Service Mesh tutorial](https://learn.hashicorp.com/tutorials/consul/developer-mesh/consul-windows-workloads?utm_source=docs) to learn how to deploy Consul and use its service mesh on Windows VMs.
 
 If you are running Consul on a Windows VM, attempting to bootstrap Envoy with the `consul connect envoy` command returns the following output:
 


### PR DESCRIPTION
Updated link address for Windows on VM tutorial to fix broken link