### PR TITLE
Merge central config for GetEnvoyBootstrapParams

### DIFF
--- a/.changelog/14869.txt
+++ b/.changelog/14869.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+grpc: Merge proxy-defaults and service-defaults in GetEnvoyBootstrapParams response.
+```

--- a/agent/configentry/merge_service_config.go
+++ b/agent/configentry/merge_service_config.go
@@ -1,4 +1,4 @@
-package consul
+package configentry
 
 import (
 	"fmt"
@@ -8,18 +8,21 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/copystructure"
 
-	"github.com/hashicorp/consul/agent/configentry"
-	"github.com/hashicorp/consul/agent/consul/state"
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-// mergeNodeServiceWithCentralConfig merges a service instance (NodeService) with the
+type StateStore interface {
+	ReadResolvedServiceConfigEntries(memdb.WatchSet, string, *acl.EnterpriseMeta, []structs.ServiceID, structs.ProxyMode) (uint64, *ResolvedServiceConfigSet, error)
+}
+
+// MergeNodeServiceWithCentralConfig merges a service instance (NodeService) with the
 // proxy-defaults/global and service-defaults/:service config entries.
 // This common helper is used by the blocking query function of different RPC endpoints
 // that need to return a fully resolved service defintion.
-func mergeNodeServiceWithCentralConfig(
+func MergeNodeServiceWithCentralConfig(
 	ws memdb.WatchSet,
-	state *state.Store,
+	state StateStore,
 	args *structs.ServiceSpecificRequest,
 	ns *structs.NodeService,
 	logger hclog.Logger) (uint64, *structs.NodeService, error) {
@@ -67,7 +70,7 @@ func mergeNodeServiceWithCentralConfig(
 			ns.ID, err)
 	}
 
-	defaults, err := configentry.ComputeResolvedServiceConfig(
+	defaults, err := ComputeResolvedServiceConfig(
 		configReq,
 		upstreams,
 		false,

--- a/agent/configentry/merge_service_config_test.go
+++ b/agent/configentry/merge_service_config_test.go
@@ -1,4 +1,4 @@
-package consul
+package configentry
 
 import (
 	"testing"

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/acl/resolver"
+	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/ipaddr"
@@ -752,7 +753,7 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 					mergedsn := sn
 					ns := sn.ToNodeService()
 					if ns.IsSidecarProxy() || ns.IsGateway() {
-						cfgIndex, mergedns, err := mergeNodeServiceWithCentralConfig(ws, state, args, ns, c.logger)
+						cfgIndex, mergedns, err := configentry.MergeNodeServiceWithCentralConfig(ws, state, args, ns, c.logger)
 						if err != nil {
 							return err
 						}
@@ -960,7 +961,7 @@ func (c *Catalog) NodeServiceList(args *structs.NodeSpecificRequest, reply *stru
 							Datacenter:   args.Datacenter,
 							QueryOptions: args.QueryOptions,
 						}
-						cfgIndex, mergedns, err = mergeNodeServiceWithCentralConfig(ws, state, &serviceSpecificReq, ns, c.logger)
+						cfgIndex, mergedns, err = configentry.MergeNodeServiceWithCentralConfig(ws, state, &serviceSpecificReq, ns, c.logger)
 						if err != nil {
 							return err
 						}

--- a/agent/consul/health_endpoint.go
+++ b/agent/consul/health_endpoint.go
@@ -11,6 +11,7 @@ import (
 	hashstructure_v2 "github.com/mitchellh/hashstructure/v2"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 )
@@ -256,7 +257,7 @@ func (h *Health) ServiceNodes(args *structs.ServiceSpecificRequest, reply *struc
 				for _, node := range resolvedNodes {
 					ns := node.Service
 					if ns.IsSidecarProxy() || ns.IsGateway() {
-						cfgIndex, mergedns, err := mergeNodeServiceWithCentralConfig(ws, state, args, ns, h.logger)
+						cfgIndex, mergedns, err := configentry.MergeNodeServiceWithCentralConfig(ws, state, args, ns, h.logger)
 						if err != nil {
 							return err
 						}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -732,7 +732,6 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server) (*Ser
 		Logger:                            logger.Named("grpc-api.dataplane"),
 		ACLResolver:                       s.ACLResolver,
 		Datacenter:                        s.config.Datacenter,
-		MergeNodeServiceWithCentralConfig: mergeNodeServiceWithCentralConfig,
 	}).Register(s.externalGRPCServer)
 
 	serverdiscovery.NewServer(serverdiscovery.Config{

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -728,10 +728,10 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server) (*Ser
 	s.externalConnectCAServer.Register(s.externalGRPCServer)
 
 	dataplane.NewServer(dataplane.Config{
-		GetStore:                          func() dataplane.StateStore { return s.FSM().State() },
-		Logger:                            logger.Named("grpc-api.dataplane"),
-		ACLResolver:                       s.ACLResolver,
-		Datacenter:                        s.config.Datacenter,
+		GetStore:    func() dataplane.StateStore { return s.FSM().State() },
+		Logger:      logger.Named("grpc-api.dataplane"),
+		ACLResolver: s.ACLResolver,
+		Datacenter:  s.config.Datacenter,
 	}).Register(s.externalGRPCServer)
 
 	serverdiscovery.NewServer(serverdiscovery.Config{

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -728,10 +728,11 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server) (*Ser
 	s.externalConnectCAServer.Register(s.externalGRPCServer)
 
 	dataplane.NewServer(dataplane.Config{
-		GetStore:    func() dataplane.StateStore { return s.FSM().State() },
-		Logger:      logger.Named("grpc-api.dataplane"),
-		ACLResolver: s.ACLResolver,
-		Datacenter:  s.config.Datacenter,
+		GetStore:                          func() dataplane.StateStore { return s.FSM().State() },
+		Logger:                            logger.Named("grpc-api.dataplane"),
+		ACLResolver:                       s.ACLResolver,
+		Datacenter:                        s.config.Datacenter,
+		MergeNodeServiceWithCentralConfig: mergeNodeServiceWithCentralConfig,
 	}).Register(s.externalGRPCServer)
 
 	serverdiscovery.NewServer(serverdiscovery.Config{

--- a/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
+++ b/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
@@ -89,7 +89,7 @@ func (s *Server) GetEnvoyBootstrapParams(ctx context.Context, req *pbdataplane.G
 	)
 	if err != nil {
 		logger.Error("Error merging with central config", "error", err)
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Error merging central config: %v", err))
+		return nil, status.Errorf(codes.Unknown, "Error merging central config: %v", err)
 	}
 
 	bootstrapConfig, err := structpb.NewStruct(ns.Proxy.Config)

--- a/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
+++ b/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
@@ -3,16 +3,17 @@ package dataplane
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	acl "github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/state"
 	external "github.com/hashicorp/consul/agent/grpc-external"
-	structs "github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/proto-public/pbdataplane"
 )
 
@@ -73,7 +74,24 @@ func (s *Server) GetEnvoyBootstrapParams(ctx context.Context, req *pbdataplane.G
 		NodeId:      string(svc.ID),
 	}
 
-	bootstrapConfig, err := structpb.NewStruct(svc.ServiceProxy.Config)
+	// This is awkward because it's designed for different requests, but
+	// this fakes the ServiceSpecificRequest so that we can reuse code.
+	_, ns, err := s.MergeNodeServiceWithCentralConfig(
+		nil,
+		store.(*state.Store),
+		&structs.ServiceSpecificRequest{
+			Datacenter:   s.Datacenter,
+			QueryOptions: options,
+		},
+		svc.ToNodeService(),
+		logger,
+	)
+	if err != nil {
+		logger.Error("Error merging with central config", "error", err)
+		return nil, status.Error(codes.Unknown, fmt.Sprintf("Error merging central config: %v", err))
+	}
+
+	bootstrapConfig, err := structpb.NewStruct(ns.Proxy.Config)
 	if err != nil {
 		logger.Error("Error creating the envoy boostrap params config", "error", err)
 		return nil, status.Error(codes.Unknown, "Error creating the envoy boostrap params config")

--- a/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
+++ b/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
@@ -78,7 +78,7 @@ func (s *Server) GetEnvoyBootstrapParams(ctx context.Context, req *pbdataplane.G
 	// this fakes the ServiceSpecificRequest so that we can reuse code.
 	_, ns, err := configentry.MergeNodeServiceWithCentralConfig(
 		nil,
-		store.(configentry.StateStore),
+		store,
 		&structs.ServiceSpecificRequest{
 			Datacenter:   s.Datacenter,
 			QueryOptions: options,

--- a/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
+++ b/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
@@ -3,7 +3,6 @@ package dataplane
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"google.golang.org/grpc/codes"

--- a/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
+++ b/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/consul/state"
 	external "github.com/hashicorp/consul/agent/grpc-external"
 	"github.com/hashicorp/consul/agent/structs"
@@ -76,9 +77,9 @@ func (s *Server) GetEnvoyBootstrapParams(ctx context.Context, req *pbdataplane.G
 
 	// This is awkward because it's designed for different requests, but
 	// this fakes the ServiceSpecificRequest so that we can reuse code.
-	_, ns, err := s.MergeNodeServiceWithCentralConfig(
+	_, ns, err := configentry.MergeNodeServiceWithCentralConfig(
 		nil,
-		store.(*state.Store),
+		store.(configentry.StateStore),
 		&structs.ServiceSpecificRequest{
 			Datacenter:   s.Datacenter,
 			QueryOptions: options,

--- a/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params_test.go
+++ b/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params_test.go
@@ -2,32 +2,48 @@ package dataplane
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	mock "github.com/stretchr/testify/mock"
+	"github.com/hashicorp/go-memdb"
+	"github.com/imdario/mergo"
+	"github.com/mitchellh/copystructure"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	acl "github.com/hashicorp/consul/acl"
-	resolver "github.com/hashicorp/consul/acl/resolver"
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/acl/resolver"
+	"github.com/hashicorp/consul/agent/configentry"
+	"github.com/hashicorp/consul/agent/consul/state"
 	external "github.com/hashicorp/consul/agent/grpc-external"
 	"github.com/hashicorp/consul/agent/grpc-external/testutils"
-	structs "github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/proto-public/pbdataplane"
 	"github.com/hashicorp/consul/types"
 )
 
 const (
 	testToken        = "acl-token-get-envoy-bootstrap-params"
+	testServiceName  = "web"
 	proxyServiceID   = "web-proxy"
 	nodeName         = "foo"
 	nodeID           = "2980b72b-bd9d-9d7b-d4f9-951bf7508d95"
 	proxyConfigKey   = "envoy_dogstatsd_url"
 	proxyConfigValue = "udp://127.0.0.1:8125"
 	serverDC         = "dc1"
+
+	protocolKey       = "protocol"
+	connectTimeoutKey = "local_connect_timeout_ms"
+	requestTimeoutKey = "local_request_timeout_ms"
+
+	proxyDefaultsProtocol         = "http"
+	proxyDefaultsRequestTimeout   = 1111
+	serviceDefaultsProtocol       = "tcp"
+	serviceDefaultsConnectTimeout = 4444
 )
 
 func testRegisterRequestProxy(t *testing.T) *structs.RegisterRequest {
@@ -43,7 +59,7 @@ func testRegisterRequestProxy(t *testing.T) *structs.RegisterRequest {
 			Address: "127.0.0.2",
 			Port:    2222,
 			Proxy: structs.ConnectProxyConfig{
-				DestinationServiceName: "web",
+				DestinationServiceName: testServiceName,
 				Config: map[string]interface{}{
 					proxyConfigKey: proxyConfigValue,
 				},
@@ -63,17 +79,56 @@ func testRegisterIngressGateway(t *testing.T) *structs.RegisterRequest {
 	return registerReq
 }
 
+func testProxyDefaults(t *testing.T) structs.ConfigEntry {
+	return &structs.ProxyConfigEntry{
+		Kind: structs.ProxyDefaults,
+		Name: structs.ProxyConfigGlobal,
+		Config: map[string]interface{}{
+			protocolKey:       proxyDefaultsProtocol,
+			requestTimeoutKey: proxyDefaultsRequestTimeout,
+		},
+	}
+}
+
+func testServiceDefaults(t *testing.T) structs.ConfigEntry {
+	return &structs.ServiceConfigEntry{
+		Kind:                  structs.ServiceDefaults,
+		Name:                  testServiceName,
+		Protocol:              serviceDefaultsProtocol,
+		LocalConnectTimeoutMs: serviceDefaultsConnectTimeout,
+	}
+}
+
+func requireConfigField(t *testing.T, resp *pbdataplane.GetEnvoyBootstrapParamsResponse, key string, value interface{}) {
+	require.Contains(t, resp.Config.Fields, key)
+	require.Equal(t, value, resp.Config.Fields[key])
+}
+
 func TestGetEnvoyBootstrapParams_Success(t *testing.T) {
 	type testCase struct {
-		name        string
-		registerReq *structs.RegisterRequest
-		nodeID      bool
+		name            string
+		registerReq     *structs.RegisterRequest
+		nodeID          bool
+		proxyDefaults   structs.ConfigEntry
+		serviceDefaults structs.ConfigEntry
 	}
 
 	run := func(t *testing.T, tc testCase) {
 		store := testutils.TestStateStore(t, nil)
-		err := store.EnsureRegistration(1, tc.registerReq)
+		idx := uint64(1)
+		err := store.EnsureRegistration(idx, tc.registerReq)
 		require.NoError(t, err)
+
+		if tc.proxyDefaults != nil {
+			idx++
+			err := store.EnsureConfigEntry(idx, tc.proxyDefaults)
+			require.NoError(t, err)
+		}
+		if tc.serviceDefaults != nil {
+			idx++
+			err := store.EnsureConfigEntry(idx, tc.serviceDefaults)
+			require.NoError(t, err)
+		}
 
 		aclResolver := &MockACLResolver{}
 		aclResolver.On("ResolveTokenAndDefaultMeta", testToken, mock.Anything, mock.Anything).
@@ -84,10 +139,11 @@ func TestGetEnvoyBootstrapParams_Success(t *testing.T) {
 		require.NoError(t, err)
 
 		server := NewServer(Config{
-			GetStore:    func() StateStore { return store },
-			Logger:      hclog.NewNullLogger(),
-			ACLResolver: aclResolver,
-			Datacenter:  serverDC,
+			GetStore:                          func() StateStore { return store },
+			Logger:                            hclog.NewNullLogger(),
+			ACLResolver:                       aclResolver,
+			Datacenter:                        serverDC,
+			MergeNodeServiceWithCentralConfig: testMergeNodeServiceWithCentralConfig,
 		})
 		client := testClient(t, server)
 
@@ -109,20 +165,33 @@ func TestGetEnvoyBootstrapParams_Success(t *testing.T) {
 		require.Equal(t, serverDC, resp.Datacenter)
 		require.Equal(t, tc.registerReq.EnterpriseMeta.PartitionOrDefault(), resp.Partition)
 		require.Equal(t, tc.registerReq.EnterpriseMeta.NamespaceOrDefault(), resp.Namespace)
-		require.Contains(t, resp.Config.Fields, proxyConfigKey)
-		require.Equal(t, structpb.NewStringValue(proxyConfigValue), resp.Config.Fields[proxyConfigKey])
+		requireConfigField(t, resp, proxyConfigKey, structpb.NewStringValue(proxyConfigValue))
 		require.Equal(t, convertToResponseServiceKind(tc.registerReq.Service.Kind), resp.ServiceKind)
 		require.Equal(t, tc.registerReq.Node, resp.NodeName)
 		require.Equal(t, string(tc.registerReq.ID), resp.NodeId)
+
+		if tc.serviceDefaults != nil && tc.proxyDefaults != nil {
+			// service-defaults take precedence over proxy-defaults
+			requireConfigField(t, resp, protocolKey, structpb.NewStringValue(serviceDefaultsProtocol))
+			requireConfigField(t, resp, connectTimeoutKey, structpb.NewNumberValue(serviceDefaultsConnectTimeout))
+			requireConfigField(t, resp, requestTimeoutKey, structpb.NewNumberValue(proxyDefaultsRequestTimeout))
+		} else if tc.serviceDefaults != nil {
+			requireConfigField(t, resp, protocolKey, structpb.NewStringValue(serviceDefaultsProtocol))
+			requireConfigField(t, resp, connectTimeoutKey, structpb.NewNumberValue(serviceDefaultsConnectTimeout))
+		} else if tc.proxyDefaults != nil {
+			requireConfigField(t, resp, protocolKey, structpb.NewStringValue(proxyDefaultsProtocol))
+			requireConfigField(t, resp, requestTimeoutKey, structpb.NewNumberValue(proxyDefaultsRequestTimeout))
+		}
+
 	}
 
 	testCases := []testCase{
 		{
-			name:        "lookup service side car proxy by node name",
+			name:        "lookup service sidecar proxy by node name",
 			registerReq: testRegisterRequestProxy(t),
 		},
 		{
-			name:        "lookup service side car proxy by node ID",
+			name:        "lookup service sidecar proxy by node ID",
 			registerReq: testRegisterRequestProxy(t),
 			nodeID:      true,
 		},
@@ -134,6 +203,21 @@ func TestGetEnvoyBootstrapParams_Success(t *testing.T) {
 			name:        "lookup ingress gw service by node ID",
 			registerReq: testRegisterIngressGateway(t),
 			nodeID:      true,
+		},
+		{
+			name:          "merge proxy defaults for sidecar proxy",
+			registerReq:   testRegisterRequestProxy(t),
+			proxyDefaults: testProxyDefaults(t),
+		},
+		{
+			name:            "merge service defaults for sidecar proxy",
+			registerReq:     testRegisterRequestProxy(t),
+			serviceDefaults: testServiceDefaults(t),
+		},
+		{
+			name:            "merge proxy defaults and service defaults for sidecar proxy",
+			registerReq:     testRegisterRequestProxy(t),
+			serviceDefaults: testServiceDefaults(t),
 		},
 	}
 
@@ -279,4 +363,186 @@ func TestGetEnvoyBootstrapParams_PermissionDenied(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, codes.PermissionDenied.String(), status.Code(err).String())
 	require.Nil(t, resp)
+}
+
+// Copied implementation from agent/consul/merge_service_config.go to avoid import cycle.
+func testMergeNodeServiceWithCentralConfig(
+	ws memdb.WatchSet,
+	state *state.Store,
+	args *structs.ServiceSpecificRequest,
+	ns *structs.NodeService,
+	logger hclog.Logger) (uint64, *structs.NodeService, error) {
+
+	serviceName := ns.Service
+	var upstreams []structs.ServiceID
+	if ns.IsSidecarProxy() {
+		// This is a sidecar proxy, ignore the proxy service's config since we are
+		// managed by the target service config.
+		serviceName = ns.Proxy.DestinationServiceName
+
+		// Also if we have any upstreams defined, add them to the defaults lookup request
+		// so we can learn about their configs.
+		for _, us := range ns.Proxy.Upstreams {
+			if us.DestinationType == "" || us.DestinationType == structs.UpstreamDestTypeService {
+				sid := us.DestinationID()
+				sid.EnterpriseMeta.Merge(&ns.EnterpriseMeta)
+				upstreams = append(upstreams, sid)
+			}
+		}
+	}
+
+	configReq := &structs.ServiceConfigRequest{
+		Name:           serviceName,
+		Datacenter:     args.Datacenter,
+		QueryOptions:   args.QueryOptions,
+		MeshGateway:    ns.Proxy.MeshGateway,
+		Mode:           ns.Proxy.Mode,
+		UpstreamIDs:    upstreams,
+		EnterpriseMeta: ns.EnterpriseMeta,
+	}
+
+	// prefer using this vs directly calling the ConfigEntry.ResolveServiceConfig RPC
+	// so as to pass down the same watch set to also watch on changes to
+	// proxy-defaults/global and service-defaults.
+	cfgIndex, configEntries, err := state.ReadResolvedServiceConfigEntries(
+		ws,
+		configReq.Name,
+		&configReq.EnterpriseMeta,
+		upstreams,
+		configReq.Mode,
+	)
+	if err != nil {
+		return 0, nil, fmt.Errorf("Failure looking up service config entries for %s: %v",
+			ns.ID, err)
+	}
+
+	defaults, err := configentry.ComputeResolvedServiceConfig(
+		configReq,
+		upstreams,
+		false,
+		configEntries,
+		logger,
+	)
+	if err != nil {
+		return 0, nil, fmt.Errorf("Failure computing service defaults for %s: %v",
+			ns.ID, err)
+	}
+
+	mergedns, err := testMergeServiceConfig(defaults, ns)
+	if err != nil {
+		return 0, nil, fmt.Errorf("Failure merging service definition with config entry defaults for %s: %v",
+			ns.ID, err)
+	}
+
+	return cfgIndex, mergedns, nil
+}
+
+// Copied implementation from agent/consul/merge_service_config.go to avoid import cycle.
+func testMergeServiceConfig(defaults *structs.ServiceConfigResponse, service *structs.NodeService) (*structs.NodeService, error) {
+	if defaults == nil {
+		return service, nil
+	}
+
+	// We don't want to change s.registration in place since it is our source of
+	// truth about what was actually registered before defaults applied. So copy
+	// it first.
+	nsRaw, err := copystructure.Copy(service)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge proxy defaults
+	ns := nsRaw.(*structs.NodeService)
+
+	if err := mergo.Merge(&ns.Proxy.Config, defaults.ProxyConfig); err != nil {
+		return nil, err
+	}
+	if err := mergo.Merge(&ns.Proxy.Expose, defaults.Expose); err != nil {
+		return nil, err
+	}
+
+	if ns.Proxy.MeshGateway.Mode == structs.MeshGatewayModeDefault {
+		ns.Proxy.MeshGateway.Mode = defaults.MeshGateway.Mode
+	}
+	if ns.Proxy.Mode == structs.ProxyModeDefault {
+		ns.Proxy.Mode = defaults.Mode
+	}
+	if ns.Proxy.TransparentProxy.OutboundListenerPort == 0 {
+		ns.Proxy.TransparentProxy.OutboundListenerPort = defaults.TransparentProxy.OutboundListenerPort
+	}
+	if !ns.Proxy.TransparentProxy.DialedDirectly {
+		ns.Proxy.TransparentProxy.DialedDirectly = defaults.TransparentProxy.DialedDirectly
+	}
+
+	// remoteUpstreams contains synthetic Upstreams generated from central config (service-defaults.UpstreamConfigs).
+	remoteUpstreams := make(map[structs.ServiceID]structs.Upstream)
+
+	for _, us := range defaults.UpstreamIDConfigs {
+		parsed, err := structs.ParseUpstreamConfigNoDefaults(us.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse upstream config map for %s: %v", us.Upstream.String(), err)
+		}
+
+		remoteUpstreams[us.Upstream] = structs.Upstream{
+			DestinationNamespace: us.Upstream.NamespaceOrDefault(),
+			DestinationPartition: us.Upstream.PartitionOrDefault(),
+			DestinationName:      us.Upstream.ID,
+			Config:               us.Config,
+			MeshGateway:          parsed.MeshGateway,
+			CentrallyConfigured:  true,
+		}
+	}
+
+	// localUpstreams stores the upstreams seen from the local registration so that we can merge in the synthetic entries.
+	// In transparent proxy mode ns.Proxy.Upstreams will likely be empty because users do not need to define upstreams explicitly.
+	// So to store upstream-specific flags from central config, we add entries to ns.Proxy.Upstream with those values.
+	localUpstreams := make(map[structs.ServiceID]struct{})
+
+	// Merge upstream defaults into the local registration
+	for i := range ns.Proxy.Upstreams {
+		// Get a pointer not a value copy of the upstream struct
+		us := &ns.Proxy.Upstreams[i]
+		if us.DestinationType != "" && us.DestinationType != structs.UpstreamDestTypeService {
+			continue
+		}
+		localUpstreams[us.DestinationID()] = struct{}{}
+
+		remoteCfg, ok := remoteUpstreams[us.DestinationID()]
+		if !ok {
+			// No config defaults to merge
+			continue
+		}
+
+		// The local upstream config mode has the highest precedence, so only overwrite when it's set to the default
+		if us.MeshGateway.Mode == structs.MeshGatewayModeDefault {
+			us.MeshGateway.Mode = remoteCfg.MeshGateway.Mode
+		}
+
+		// Merge in everything else that is read from the map
+		if err := mergo.Merge(&us.Config, remoteCfg.Config); err != nil {
+			return nil, err
+		}
+
+		// Delete the mesh gateway key from opaque config since this is the value that was resolved from
+		// the servers and NOT the final merged value for this upstream.
+		// Note that we use the "mesh_gateway" key and not other variants like "MeshGateway" because
+		// UpstreamConfig.MergeInto and ResolveServiceConfig only use "mesh_gateway".
+		delete(us.Config, "mesh_gateway")
+	}
+
+	// Ensure upstreams present in central config are represented in the local configuration.
+	// This does not apply outside of transparent mode because in that situation every possible upstream already exists
+	// inside of ns.Proxy.Upstreams.
+	if ns.Proxy.Mode == structs.ProxyModeTransparent {
+		for id, remote := range remoteUpstreams {
+			if _, ok := localUpstreams[id]; ok {
+				// Remote upstream is already present locally
+				continue
+			}
+
+			ns.Proxy.Upstreams = append(ns.Proxy.Upstreams, remote)
+		}
+	}
+
+	return ns, err
 }

--- a/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params_test.go
+++ b/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params_test.go
@@ -2,13 +2,9 @@ package dataplane
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
-	"github.com/imdario/mergo"
-	"github.com/mitchellh/copystructure"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -17,8 +13,6 @@ import (
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/acl/resolver"
-	"github.com/hashicorp/consul/agent/configentry"
-	"github.com/hashicorp/consul/agent/consul/state"
 	external "github.com/hashicorp/consul/agent/grpc-external"
 	"github.com/hashicorp/consul/agent/grpc-external/testutils"
 	"github.com/hashicorp/consul/agent/structs"
@@ -139,11 +133,10 @@ func TestGetEnvoyBootstrapParams_Success(t *testing.T) {
 		require.NoError(t, err)
 
 		server := NewServer(Config{
-			GetStore:                          func() StateStore { return store },
-			Logger:                            hclog.NewNullLogger(),
-			ACLResolver:                       aclResolver,
-			Datacenter:                        serverDC,
-			MergeNodeServiceWithCentralConfig: testMergeNodeServiceWithCentralConfig,
+			GetStore:    func() StateStore { return store },
+			Logger:      hclog.NewNullLogger(),
+			ACLResolver: aclResolver,
+			Datacenter:  serverDC,
 		})
 		client := testClient(t, server)
 
@@ -363,186 +356,4 @@ func TestGetEnvoyBootstrapParams_PermissionDenied(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, codes.PermissionDenied.String(), status.Code(err).String())
 	require.Nil(t, resp)
-}
-
-// Copied implementation from agent/consul/merge_service_config.go to avoid import cycle.
-func testMergeNodeServiceWithCentralConfig(
-	ws memdb.WatchSet,
-	state *state.Store,
-	args *structs.ServiceSpecificRequest,
-	ns *structs.NodeService,
-	logger hclog.Logger) (uint64, *structs.NodeService, error) {
-
-	serviceName := ns.Service
-	var upstreams []structs.ServiceID
-	if ns.IsSidecarProxy() {
-		// This is a sidecar proxy, ignore the proxy service's config since we are
-		// managed by the target service config.
-		serviceName = ns.Proxy.DestinationServiceName
-
-		// Also if we have any upstreams defined, add them to the defaults lookup request
-		// so we can learn about their configs.
-		for _, us := range ns.Proxy.Upstreams {
-			if us.DestinationType == "" || us.DestinationType == structs.UpstreamDestTypeService {
-				sid := us.DestinationID()
-				sid.EnterpriseMeta.Merge(&ns.EnterpriseMeta)
-				upstreams = append(upstreams, sid)
-			}
-		}
-	}
-
-	configReq := &structs.ServiceConfigRequest{
-		Name:           serviceName,
-		Datacenter:     args.Datacenter,
-		QueryOptions:   args.QueryOptions,
-		MeshGateway:    ns.Proxy.MeshGateway,
-		Mode:           ns.Proxy.Mode,
-		UpstreamIDs:    upstreams,
-		EnterpriseMeta: ns.EnterpriseMeta,
-	}
-
-	// prefer using this vs directly calling the ConfigEntry.ResolveServiceConfig RPC
-	// so as to pass down the same watch set to also watch on changes to
-	// proxy-defaults/global and service-defaults.
-	cfgIndex, configEntries, err := state.ReadResolvedServiceConfigEntries(
-		ws,
-		configReq.Name,
-		&configReq.EnterpriseMeta,
-		upstreams,
-		configReq.Mode,
-	)
-	if err != nil {
-		return 0, nil, fmt.Errorf("Failure looking up service config entries for %s: %v",
-			ns.ID, err)
-	}
-
-	defaults, err := configentry.ComputeResolvedServiceConfig(
-		configReq,
-		upstreams,
-		false,
-		configEntries,
-		logger,
-	)
-	if err != nil {
-		return 0, nil, fmt.Errorf("Failure computing service defaults for %s: %v",
-			ns.ID, err)
-	}
-
-	mergedns, err := testMergeServiceConfig(defaults, ns)
-	if err != nil {
-		return 0, nil, fmt.Errorf("Failure merging service definition with config entry defaults for %s: %v",
-			ns.ID, err)
-	}
-
-	return cfgIndex, mergedns, nil
-}
-
-// Copied implementation from agent/consul/merge_service_config.go to avoid import cycle.
-func testMergeServiceConfig(defaults *structs.ServiceConfigResponse, service *structs.NodeService) (*structs.NodeService, error) {
-	if defaults == nil {
-		return service, nil
-	}
-
-	// We don't want to change s.registration in place since it is our source of
-	// truth about what was actually registered before defaults applied. So copy
-	// it first.
-	nsRaw, err := copystructure.Copy(service)
-	if err != nil {
-		return nil, err
-	}
-
-	// Merge proxy defaults
-	ns := nsRaw.(*structs.NodeService)
-
-	if err := mergo.Merge(&ns.Proxy.Config, defaults.ProxyConfig); err != nil {
-		return nil, err
-	}
-	if err := mergo.Merge(&ns.Proxy.Expose, defaults.Expose); err != nil {
-		return nil, err
-	}
-
-	if ns.Proxy.MeshGateway.Mode == structs.MeshGatewayModeDefault {
-		ns.Proxy.MeshGateway.Mode = defaults.MeshGateway.Mode
-	}
-	if ns.Proxy.Mode == structs.ProxyModeDefault {
-		ns.Proxy.Mode = defaults.Mode
-	}
-	if ns.Proxy.TransparentProxy.OutboundListenerPort == 0 {
-		ns.Proxy.TransparentProxy.OutboundListenerPort = defaults.TransparentProxy.OutboundListenerPort
-	}
-	if !ns.Proxy.TransparentProxy.DialedDirectly {
-		ns.Proxy.TransparentProxy.DialedDirectly = defaults.TransparentProxy.DialedDirectly
-	}
-
-	// remoteUpstreams contains synthetic Upstreams generated from central config (service-defaults.UpstreamConfigs).
-	remoteUpstreams := make(map[structs.ServiceID]structs.Upstream)
-
-	for _, us := range defaults.UpstreamIDConfigs {
-		parsed, err := structs.ParseUpstreamConfigNoDefaults(us.Config)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse upstream config map for %s: %v", us.Upstream.String(), err)
-		}
-
-		remoteUpstreams[us.Upstream] = structs.Upstream{
-			DestinationNamespace: us.Upstream.NamespaceOrDefault(),
-			DestinationPartition: us.Upstream.PartitionOrDefault(),
-			DestinationName:      us.Upstream.ID,
-			Config:               us.Config,
-			MeshGateway:          parsed.MeshGateway,
-			CentrallyConfigured:  true,
-		}
-	}
-
-	// localUpstreams stores the upstreams seen from the local registration so that we can merge in the synthetic entries.
-	// In transparent proxy mode ns.Proxy.Upstreams will likely be empty because users do not need to define upstreams explicitly.
-	// So to store upstream-specific flags from central config, we add entries to ns.Proxy.Upstream with those values.
-	localUpstreams := make(map[structs.ServiceID]struct{})
-
-	// Merge upstream defaults into the local registration
-	for i := range ns.Proxy.Upstreams {
-		// Get a pointer not a value copy of the upstream struct
-		us := &ns.Proxy.Upstreams[i]
-		if us.DestinationType != "" && us.DestinationType != structs.UpstreamDestTypeService {
-			continue
-		}
-		localUpstreams[us.DestinationID()] = struct{}{}
-
-		remoteCfg, ok := remoteUpstreams[us.DestinationID()]
-		if !ok {
-			// No config defaults to merge
-			continue
-		}
-
-		// The local upstream config mode has the highest precedence, so only overwrite when it's set to the default
-		if us.MeshGateway.Mode == structs.MeshGatewayModeDefault {
-			us.MeshGateway.Mode = remoteCfg.MeshGateway.Mode
-		}
-
-		// Merge in everything else that is read from the map
-		if err := mergo.Merge(&us.Config, remoteCfg.Config); err != nil {
-			return nil, err
-		}
-
-		// Delete the mesh gateway key from opaque config since this is the value that was resolved from
-		// the servers and NOT the final merged value for this upstream.
-		// Note that we use the "mesh_gateway" key and not other variants like "MeshGateway" because
-		// UpstreamConfig.MergeInto and ResolveServiceConfig only use "mesh_gateway".
-		delete(us.Config, "mesh_gateway")
-	}
-
-	// Ensure upstreams present in central config are represented in the local configuration.
-	// This does not apply outside of transparent mode because in that situation every possible upstream already exists
-	// inside of ns.Proxy.Upstreams.
-	if ns.Proxy.Mode == structs.ProxyModeTransparent {
-		for id, remote := range remoteUpstreams {
-			if _, ok := localUpstreams[id]; ok {
-				// Remote upstream is already present locally
-				continue
-			}
-
-			ns.Proxy.Upstreams = append(ns.Proxy.Upstreams, remote)
-		}
-	}
-
-	return ns, err
 }

--- a/agent/grpc-external/services/dataplane/server.go
+++ b/agent/grpc-external/services/dataplane/server.go
@@ -4,9 +4,11 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/acl/resolver"
+	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/proto-public/pbdataplane"
 )
@@ -25,6 +27,7 @@ type Config struct {
 
 type StateStore interface {
 	ServiceNode(string, string, string, *acl.EnterpriseMeta, string) (uint64, *structs.ServiceNode, error)
+	ReadResolvedServiceConfigEntries(memdb.WatchSet, string, *acl.EnterpriseMeta, []structs.ServiceID, structs.ProxyMode) (uint64, *configentry.ResolvedServiceConfigSet, error)
 }
 
 //go:generate mockery --name ACLResolver --inpackage

--- a/agent/grpc-external/services/dataplane/server.go
+++ b/agent/grpc-external/services/dataplane/server.go
@@ -4,9 +4,11 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/acl/resolver"
+	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/proto-public/pbdataplane"
 )
@@ -20,7 +22,8 @@ type Config struct {
 	Logger      hclog.Logger
 	ACLResolver ACLResolver
 	// Datacenter of the Consul server this gRPC server is hosted on
-	Datacenter string
+	Datacenter                        string
+	MergeNodeServiceWithCentralConfig func(memdb.WatchSet, *state.Store, *structs.ServiceSpecificRequest, *structs.NodeService, hclog.Logger) (uint64, *structs.NodeService, error)
 }
 
 type StateStore interface {

--- a/agent/grpc-external/services/dataplane/server.go
+++ b/agent/grpc-external/services/dataplane/server.go
@@ -4,11 +4,9 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/acl/resolver"
-	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/proto-public/pbdataplane"
 )
@@ -22,8 +20,7 @@ type Config struct {
 	Logger      hclog.Logger
 	ACLResolver ACLResolver
 	// Datacenter of the Consul server this gRPC server is hosted on
-	Datacenter                        string
-	MergeNodeServiceWithCentralConfig func(memdb.WatchSet, *state.Store, *structs.ServiceSpecificRequest, *structs.NodeService, hclog.Logger) (uint64, *structs.NodeService, error)
+	Datacenter string
 }
 
 type StateStore interface {

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
-	"github.com/hashicorp/consul/agent/consul"
+	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -145,7 +145,7 @@ func (w *serviceConfigWatch) register(ctx context.Context) error {
 
 	// Merge the local registration with the central defaults and update this service
 	// in the local state.
-	merged, err := consul.MergeServiceConfig(serviceDefaults, w.registration.Service)
+	merged, err := configentry.MergeServiceConfig(serviceDefaults, w.registration.Service)
 	if err != nil {
 		return err
 	}
@@ -275,7 +275,7 @@ func (w *serviceConfigWatch) handleUpdate(ctx context.Context, event cache.Updat
 
 	// Merge the local registration with the central defaults and update this service
 	// in the local state.
-	merged, err := consul.MergeServiceConfig(serviceDefaults, w.registration.Service)
+	merged, err := configentry.MergeServiceConfig(serviceDefaults, w.registration.Service)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

This fixes GetEnvoyBootstrapParams to merge in proxy-defaults and service-defaults.

### Testing & Reproduction steps
* Steps to reproduce: [Gist link](https://gist.github.com/pglass/d768358a85390abf90b98c6b33c10d54)
* A script to test: Run `consul agent -dev` and then run [`check.sh` here](https://gist.github.com/pglass/e68ecbcadfaa8b08d4d2da7c65b3c436#file-check-sh) and you should see [this output](https://gist.github.com/pglass/e68ecbcadfaa8b08d4d2da7c65b3c436#file-output-txt)
* Added unit tests

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
