### PR TITLE
Update CAPIGW comparison docs

### DIFF
--- a/website/content/docs/consul-vs-other/api-gateway-compare.mdx
+++ b/website/content/docs/consul-vs-other/api-gateway-compare.mdx
@@ -9,7 +9,7 @@ description: >-
 
 **Examples**: Kong Gateway, Apigee, Mulesoft, Gravitee 
 
-The [Consul API Gateway documentation](/docs/api-gateway) is an implementation of the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/). Traditionally, API Gateways are used for two things: _Client Traffic Management_ and _API Lifecycle Management_.
+The Consul API Gateway ([documentation](/docs/api-gateway)) is an implementation of the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/). Traditionally, API Gateways are used for two things: _Client Traffic Management_ and _API Lifecycle Management_.
 
 Client traffic management refers to an API gateway's role in controlling the point of entry for public traffic into a given environment, also known as _managing north-south traffic_. The Consul API Gateway is deployed alongside Consul service mesh and is responsible for routing inbound client requests to the mesh based on defined routes. For a full list of supported traffic management features, refer to the [Consul API Gateway documentation](/docs/api-gateway).   
 

--- a/website/content/docs/consul-vs-other/api-gateway-compare.mdx
+++ b/website/content/docs/consul-vs-other/api-gateway-compare.mdx
@@ -9,7 +9,7 @@ description: >-
 
 **Examples**: Kong Gateway, Apigee, Mulesoft, Gravitee 
 
-The [Consul API Gateway](/docs/api-gateway) is an implementation of the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/). Traditionally, API gateways are used for two things: _Client Traffic Management_ and _API Lifecycle Management_.
+The [Consul API Gateway](/docs/api-gateway) is an implementation of the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/). Traditionally, API gateways are used for two things: _client traffic management_ and _API lifecycle management_.
 
 Client traffic management refers to an API gateway's role in controlling the point of entry for public traffic into a given environment, also known as _managing north-south traffic_. The Consul API Gateway is deployed alongside Consul service mesh and is responsible for routing inbound client requests to the mesh based on defined routes. For a full list of supported traffic management features, refer to the [Consul API Gateway documentation](/docs/api-gateway).   
 

--- a/website/content/docs/consul-vs-other/api-gateway-compare.mdx
+++ b/website/content/docs/consul-vs-other/api-gateway-compare.mdx
@@ -9,8 +9,8 @@ description: >-
 
 **Examples**: Kong Gateway, Apigee, Mulesoft, Gravitee 
 
-The Consul API Gateway ([documentation](/docs/api-gateway)) is an implementation of the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/). Traditionally, API Gateways are used for two things: _Client Traffic Management_ and _API Lifecycle Management_.
+The Consul API Gateway ([documentation](/docs/api-gateway)) is an implementation of the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/). Traditionally, API gateways are used for two things: _Client Traffic Management_ and _API Lifecycle Management_.
 
 Client traffic management refers to an API gateway's role in controlling the point of entry for public traffic into a given environment, also known as _managing north-south traffic_. The Consul API Gateway is deployed alongside Consul service mesh and is responsible for routing inbound client requests to the mesh based on defined routes. For a full list of supported traffic management features, refer to the [Consul API Gateway documentation](/docs/api-gateway).   
 
-API lifecycle management refers to how application developers use an API Gateway to deploy, iterate, and manage versions of an API. At this time, the Consul API Gateway does not support API lifecycle management.
+API lifecycle management refers to how application developers use an API gateway to deploy, iterate, and manage versions of an API. At this time, the Consul API Gateway does not support API lifecycle management.

--- a/website/content/docs/consul-vs-other/api-gateway-compare.mdx
+++ b/website/content/docs/consul-vs-other/api-gateway-compare.mdx
@@ -9,7 +9,7 @@ description: >-
 
 **Examples**: Kong Gateway, Apigee, Mulesoft, Gravitee 
 
-The Consul API Gateway ([documentation](/docs/api-gateway)) is an implementation of the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/). Traditionally, API gateways are used for two things: _Client Traffic Management_ and _API Lifecycle Management_.
+The [Consul API Gateway](/docs/api-gateway) is an implementation of the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/). Traditionally, API gateways are used for two things: _Client Traffic Management_ and _API Lifecycle Management_.
 
 Client traffic management refers to an API gateway's role in controlling the point of entry for public traffic into a given environment, also known as _managing north-south traffic_. The Consul API Gateway is deployed alongside Consul service mesh and is responsible for routing inbound client requests to the mesh based on defined routes. For a full list of supported traffic management features, refer to the [Consul API Gateway documentation](/docs/api-gateway).   
 


### PR DESCRIPTION
### Description
- The doc currently reads as if "Consul API Gateway documentation is an implementation..." which doesn't make sense.
- We should be using consistent casing when referring to the Consul API Gateway product vs. any API gateway

### Testing & Reproduction steps
:eyes:

### Links
[Existing doc](https://developer.hashicorp.com/consul/docs/consul-vs-other/api-gateway-compare)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
