### PR TITLE
fix: missing UDP field in checkType

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1562,6 +1562,7 @@ func (b *builder) checkVal(v *CheckDefinition) *structs.CheckDefinition {
 		Body:                           stringVal(v.Body),
 		DisableRedirects:               boolVal(v.DisableRedirects),
 		TCP:                            stringVal(v.TCP),
+		UDP:                            stringVal(v.UDP),
 		Interval:                       b.durationVal(fmt.Sprintf("check[%s].interval", id), v.Interval),
 		DockerContainerID:              stringVal(v.DockerContainerID),
 		Shell:                          stringVal(v.Shell),

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -326,6 +326,24 @@ func TestBuilder_ServiceVal_MultiError(t *testing.T) {
 	require.Contains(t, b.err.Error(), "cannot have both socket path")
 }
 
+func TestBuilder_ServiceVal_with_Check(t *testing.T) {
+	b := builder{}
+	svc := b.serviceVal(&ServiceDefinition{
+		Name: strPtr("unbound"),
+		ID:   strPtr("unbound"),
+		Port: intPtr(12345),
+		Checks: []CheckDefinition{
+			{
+				Interval: strPtr("5s"),
+				UDP:      strPtr("localhost:53"),
+			},
+		},
+	})
+	require.NoError(t, b.err)
+	require.Equal(t, 1, len(svc.Checks))
+	require.Equal(t, "localhost:53", svc.Checks[0].UDP)
+}
+
 func intPtr(v int) *int {
 	return &v
 }


### PR DESCRIPTION
### Description
Fix missing UDP field in builder, when the build parses the service definition file.

### Testing & Reproduction steps
Refer to #14864

### Links
Fix #14864

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
