### PR TITLE
Fix connect secondary CA initialization

### DIFF
--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -222,7 +222,13 @@ func (c *ConsulProvider) GenerateIntermediateCSR() (string, error) {
 		return "", err
 	}
 
-	csr, err := connect.CreateCACSR(c.spiffeID, signer)
+	uid, err := connect.CompactUID()
+	if err != nil {
+		return "", err
+	}
+	cn := connect.CACN("consul", uid, c.clusterID, c.isPrimary)
+
+	csr, err := connect.CreateCACSR(c.spiffeID, cn, signer)
 	if err != nil {
 		return "", err
 	}

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -425,6 +425,9 @@ func testSignIntermediateCrossDC(t *testing.T, provider1, provider2 Provider) {
 	// Sign the CSR with provider1.
 	intermediatePEM, err := provider1.SignIntermediate(csr)
 	require.NoError(t, err)
+	intermediateCert, err := connect.ParseCert(intermediatePEM)
+	require.NoError(t, err)
+	require.NotEmpty(t, intermediateCert.Subject.CommonName)
 	root, err := provider1.GenerateRoot()
 	require.NoError(t, err)
 	rootPEM := root.PEM
@@ -451,6 +454,8 @@ func testSignIntermediateCrossDC(t *testing.T, provider1, provider2 Provider) {
 	require.NoError(t, err)
 	requireNotEncoded(t, cert.SubjectKeyId)
 	requireNotEncoded(t, cert.AuthorityKeyId)
+	require.NotEmpty(t, cert.Issuer.CommonName)
+	require.Equal(t, cert.Issuer.CommonName, intermediateCert.Subject.CommonName)
 
 	// Check that the leaf signed by the new cert can be verified using the
 	// returned cert chain (signed intermediate + remote root).

--- a/agent/connect/csr.go
+++ b/agent/connect/csr.go
@@ -91,13 +91,31 @@ func CreateCSR(uri CertURI, privateKey crypto.Signer,
 
 // CreateCSR returns a CA CSR to sign the given service along with the PEM-encoded
 // private key for this certificate.
-func CreateCACSR(uri CertURI, privateKey crypto.Signer) (string, error) {
+func CreateCACSR(uri CertURI, commonName string, privateKey crypto.Signer) (string, error) {
 	ext, err := CreateCAExtension()
 	if err != nil {
 		return "", err
 	}
+	template := &x509.CertificateRequest{
+		URIs:               []*url.URL{uri.URI()},
+		SignatureAlgorithm: SigAlgoForKey(privateKey),
+		ExtraExtensions:    []pkix.Extension{ext},
+		Subject:            pkix.Name{CommonName: commonName},
+	}
 
-	return CreateCSR(uri, privateKey, nil, nil, ext)
+	// Create the CSR itself
+	var csrBuf bytes.Buffer
+	bs, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)
+	if err != nil {
+		return "", err
+	}
+
+	err = pem.Encode(&csrBuf, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: bs})
+	if err != nil {
+		return "", err
+	}
+
+	return csrBuf.String(), nil
 }
 
 // CreateCAExtension creates a pkix.Extension for the x509 Basic Constraints

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -767,7 +767,7 @@ func shouldPersistNewRootAndConfig(newActiveRoot *structs.CARoot, oldConfig, new
 	if newConfig == nil {
 		return false
 	}
-	return newConfig.Provider == oldConfig.Provider && reflect.DeepEqual(newConfig.Config, oldConfig.Config)
+	return newConfig.Provider != oldConfig.Provider || !reflect.DeepEqual(newConfig.Config, oldConfig.Config)
 }
 
 func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) {


### PR DESCRIPTION
### Description
During a new datacenter opening using consul 1.12.5, we faced multiple issues with connect as CA wouldn't initialize.
This datacenter is a secondary one, initializing its CA from another one, using internal consul provider.

Investigations showed that our primary datacenter was exposing an empty `ExternalTrustDomain` when calling `/v1/connect/ca/roots endpoint`, which is used in turn to set cluster ID of secondary datacenter, and would make CA appear uninitialized.

Observations also showed that `/v1/connect/ca/configuration` was not updating secondary CA configuration due to a logic inversion when moving condition into a function.

Finally, leaf certificates generated by connect were not valid, because intermediate certificate of secondary CA had no Subject Common Name, and in turn leaf certificates had no Issuer Common Name, which violates RFC 5280.

### Testing & Reproduction steps
* Root CA state realignment issue can be observed by adding a new field in structs.CARoot structure, and filling it in newCARoot function, without this patch the `/v1/connect/ca/roots` endpoint will show this new field as empty. I also added a test to ensure no unnecessary update is done.
* For intermediate certificate Subject Common Name, I believe commit is self-explanatory and I added a test to prevent future regressions.
* Secondary CA configuration logic issue also looks self-explanatory at reading original change in https://github.com/hashicorp/consul/pull/12298


### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
