### PR TITLE
ui: Remove node name from agentless service instance

### DIFF
--- a/.changelog/14903.txt
+++ b/.changelog/14903.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: Removed reference to node name on service instance page when using agentless 
+```

--- a/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
@@ -151,10 +151,12 @@ as |item|}}
               <dt>Service Name</dt>
               <dd><a href="{{href-to 'dc.services.show' item.Service.Service}}">{{item.Service.Service}}</a></dd>
             </dl>
-            <dl>
-              <dt>Node Name</dt>
-              <dd><a href="{{href-to 'dc.nodes.show' item.Node.Node}}">{{item.Node.Node}}</a></dd>
-            </dl>
+            {{#unless item.Node.Meta.synthetic-node}}
+              <dl>
+                <dt>Node Name</dt>
+                <dd><a data-test-service-instance-node-name href="{{href-to 'dc.nodes.show' item.Node.Node}}">{{item.Node.Node}}</a></dd>
+              </dl>
+            {{/unless}}
             {{#if item.Service.PeerName}}
               <dl>
                 <dt>Peer Name</dt>

--- a/ui/packages/consul-ui/mock-api/v1/health/service/_
+++ b/ui/packages/consul-ui/mock-api/v1/health/service/_
@@ -18,6 +18,16 @@
         const proxy = service.indexOf('-proxy')
         const sidecar = service.indexOf('-sidecar-proxy')
         const id = (proxy !== -1 ? service.slice(0, -6) + '-with-id-proxy' : service + '-with-id');
+        const externalSource = fake.helpers.randomize([
+            'consul-api-gateway',
+            'vault',
+            'nomad',
+            'terraform',
+            'kubernetes',
+            'aws',
+            'lambda',
+            ''
+          ]);
         let kind = '';
         switch(true) {
           case service.endsWith('-mesh-gateway'):
@@ -42,7 +52,10 @@
             "Address":"${ip}",
             "Datacenter":"dc1",
             "TaggedAddresses":{"lan":"${ip}","wan":"${ip}"},
-            "Meta":{"${service}-network-segment":""},
+            "Meta":{
+              "${service}-network-segment":"",
+              "synthetic-node":${externalSource === 'kubernetes' ? "true" : "false"}
+            },
 ${typeof location.search.peer !== 'undefined' ? `
             "PeerName": "${location.search.peer}",
 ` : ``}
@@ -87,16 +100,7 @@ ${typeof location.search.partition !== 'undefined' ? `
 ${ fake.random.number({min: 1, max: 10}) > 2 ? `
             "Meta": {
               "consul-dashboard-url": "${fake.internet.protocol()}://${fake.internet.domainName()}/?id={{Service}}",
-              "external-source": "${fake.helpers.randomize([
-                'consul-api-gateway',
-                'vault',
-                'nomad',
-                'terraform',
-                'kubernetes',
-                'aws',
-                'lambda',
-                ''
-              ])}"
+              "external-source": "${externalSource}"
             },
 ` : `
             "Meta": null,

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/instances/show.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/instances/show.feature
@@ -2,7 +2,7 @@
 Feature: dc / services / instances / show: Show Service Instance
   Background:
     Given 1 datacenter model with the value "dc1"
-    And 2 instance models from yaml
+    And 3 instance models from yaml
     ---
     - Service:
         ID: service-0-with-id
@@ -45,6 +45,15 @@ Feature: dc / services / instances / show: Show Service Instance
           ServiceID: ""
           Output: Output of check
           Status: critical
+    - Service:
+        ID: service-2-with-id
+        Meta:
+          external-source: kubernetes
+          synthetic-node: true
+      Node:
+        Node: node-2
+        Meta:
+          synthetic-node: true
     ---
   Scenario: A Service instance has no Proxy
     Given 1 proxy model from yaml
@@ -62,6 +71,7 @@ Feature: dc / services / instances / show: Show Service Instance
     ---
     Then the url should be /dc1/services/service-0/instances/another-node/service-1-with-id/health-checks
     Then I see externalSource like "nomad"
+    And I see the text "another-node" in "[data-test-service-instance-node-name]"
 
     And I don't see upstreams on the tabs
     And I see healthChecksIsSelected on the tabs
@@ -115,3 +125,14 @@ Feature: dc / services / instances / show: Show Service Instance
     ---
     Then the url should be /dc1/services/service-0/instances/node-0/service-0-with-id/health-checks
     And I don't see proxy on the tabs
+  Scenario: A Service instance with a synthetic node does not display the node name
+    When I visit the instance page for yaml
+    ---
+      dc: dc1
+      service: service-2
+      node: node-2
+      id: service-2-with-id
+    ---
+    Then the url should be /dc1/services/service-2/instances/node-2/service-2-with-id/health-checks
+    Then I see externalSource like "kubernetes"
+    And I don't see the text "node-2" in "[data-test-service-instance-node-name]"


### PR DESCRIPTION
### Description
Removes the reference to node name in the service instance header if it has the `synthetic-node: true` meta. I've set the mock-api to set `synthetic-node: true` on all service instances that have kubernetes as an external source.

### Screenshots
<img width="1840" alt="Screen Shot 2022-10-06 at 8 25 28 AM" src="https://user-images.githubusercontent.com/5448834/194339625-1aad6af9-cdc4-4c77-b11f-1dfcc85e38a6.png">
<img width="1840" alt="Screen Shot 2022-10-06 at 8 07 36 AM" src="https://user-images.githubusercontent.com/5448834/194339632-a99259ef-709c-48d8-a5b1-7403f144211c.png">
<img width="1840" alt="Screen Shot 2022-10-06 at 8 07 26 AM" src="https://user-images.githubusercontent.com/5448834/194339637-90c010c8-ebf8-4ed6-a71b-579b7b7c62c3.png">


### Links
- [Design](https://www.figma.com/file/S20gHKN9SoKfkabNjWKVuE/Agentless?node-id=101%3A11447)
- [NET-949](https://hashicorp.atlassian.net/browse/NET-949)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
