### PR TITLE
Fix outdated support email address

### DIFF
--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -105,13 +105,11 @@ Visit [consul.io/trial](https://www.hashicorp.com/products/consul/trial) for a f
 
 ## Q: How can I renew a license?
 
-Contact your organization's HashiCorp account team or email support-softwaredelivery@hashicorp.com
-for information on how to renew your organization's enterprise license.
+Contact your organization's [HashiCorp account team](https://support.hashicorp.com/hc/en-us) for information on how to renew your organization's enterprise license.
 
 ## Q: I'm an existing enterprise customer but don't have my license, how can I get it?
 
-Contact your organization's HashiCorp account team or email support-softwaredelivery@hashicorp.com
-for information on how to renew your organization's enterprise license.
+Contact your organization's [HashiCorp account team](https://support.hashicorp.com/hc/en-us) for information on how to renew your organization's enterprise license.
 
 ## Q: Are the license files locked to a specific cluster?
 
@@ -161,7 +159,7 @@ Once you have the license then create a Kubernetes secret containing the license
 
 ### VM
 
-1. Acquire a valid Consul Enterprise license. If you are an existing HashiCorp enterprise customer you may contact your organization's customer success manager (CSM) or email support-softwaredelivery@hashicorp.com for information on how to get your organization's enterprise license.
+1. Acquire a valid Consul Enterprise license. If you are an existing HashiCorp enterprise customer you may contact your organization's [customer success manager](https://support.hashicorp.com/hc/en-us) (CSM) for information on how to get your organization's enterprise license.
 1. Store the license in a secure location on disk.
 1. Set up the necessary configuration so that when Consul Enterprise reboots it will have the required license. This could be via the client agent configuration file or an environment variable.
    Visit the [Enterprise License Tutorial](https://learn.hashicorp.com/tutorials/consul/hashicorp-enterprise-license?utm_source=docs) for detailed steps on how to install the license key.
@@ -169,7 +167,7 @@ Once you have the license then create a Kubernetes secret containing the license
 
 ### Kubernetes
 
-1. Acquire a valid Consul Enterprise license. If you are an existing HashiCorp enterprise customer you may contact your organization's customer success manager (CSM) or email support-softwaredelivery@hashicorp.com for information on how to get your organization's enterprise license.
+1. Acquire a valid Consul Enterprise license. If you are an existing HashiCorp enterprise customer you may contact your organization's [customer success manager](https://support.hashicorp.com/hc/en-us) (CSM) for information on how to get your organization's enterprise license.
 1. Set up the necessary configuration so that when Consul Enterprise reboots it will have the required license. This could be via the client agent configuration file or an environment variable.
    Visit the [Enterprise License Tutorial](https://learn.hashicorp.com/tutorials/consul/hashicorp-enterprise-license?utm_source=docs) for detailed steps on how to install the license key.
 1. Proceed with the `helm` [upgrade instructions](/docs/k8s/upgrade)


### PR DESCRIPTION
The software delivery support email address is no longer valid. This replaces it with a link to the official support website.

### Description
The email address `support-softwaredelivery@hashicorp.com` is no longer valid. This removes it.

### Testing & Reproduction steps
* Visit https://www.consul.io/docs/enterprise/license/faq#q-how-can-i-renew-a-license
* It should link to the HashiCorp support website instead of the software delivery email address.

### Links
Relevant [FAQ page](https://www.consul.io/docs/enterprise/license/faq#q-how-can-i-renew-a-license).

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
