### PR TITLE
cache: prevent goroutine leak in agent cache

### DIFF
--- a/.changelog/14908.txt
+++ b/.changelog/14908.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cache: prevent goroutine leak in agent cache
+```

--- a/agent/cache/cache_test.go
+++ b/agent/cache/cache_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/lib/ttlcache"
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
 
 // Test a basic Get with no indexes (and therefore no blocking queries).
@@ -1750,12 +1751,22 @@ func TestCache_RefreshLifeCycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, true, result)
 
+	waitUntilFetching := func(expectValue bool) {
+		retry.Run(t, func(t *retry.R) {
+			c.entriesLock.Lock()
+			defer c.entriesLock.Unlock()
+			entry, ok := c.entries[key]
+			require.True(t, ok)
+			if expectValue {
+				require.True(t, entry.Fetching)
+			} else {
+				require.False(t, entry.Fetching)
+			}
+		})
+	}
+
 	// ensure that the entry is fetching again
-	c.entriesLock.Lock()
-	entry, ok := c.entries[key]
-	require.True(t, ok)
-	require.True(t, entry.Fetching)
-	c.entriesLock.Unlock()
+	waitUntilFetching(true)
 
 	requestChan := make(chan error)
 
@@ -1789,11 +1800,7 @@ func TestCache_RefreshLifeCycle(t *testing.T) {
 	}
 
 	// ensure that the entry is fetching again
-	c.entriesLock.Lock()
-	entry, ok = c.entries[key]
-	require.True(t, ok)
-	require.True(t, entry.Fetching)
-	c.entriesLock.Unlock()
+	waitUntilFetching(true)
 
 	// background a call that will wait for a newer version - will result in an acl not found error
 	go getError(5)
@@ -1814,11 +1821,7 @@ func TestCache_RefreshLifeCycle(t *testing.T) {
 
 	// ensure that the ACL not found error killed off the background refresh
 	// but didn't remove it from the cache
-	c.entriesLock.Lock()
-	entry, ok = c.entries[key]
-	require.True(t, ok)
-	require.False(t, entry.Fetching)
-	c.entriesLock.Unlock()
+	waitUntilFetching(false)
 }
 
 type fakeType struct {


### PR DESCRIPTION
### Description

There is a bug in the error handling code for the Agent cache subsystem discovered by @boxofrad :

1. `NotifyCallback` calls `notifyBlockingQuery` which calls `getWithIndex` in a loop (which backs off on-error up to 1 minute)
2. `getWithIndex` calls `fetch` if there’s no valid entry in the cache
3. `fetch` starts a goroutine which calls `Fetch` on the cache-type, waits for a while (again with backoff up to 1 minute for errors) and then calls `fetch` to trigger a refresh

The end result being that every 1 minute `notifyBlockingQuery` spawns an ancestry of goroutines that essentially lives forever.

This PR ensures that the goroutine started by `fetch` cancels any prior goroutine spawned by the same line for the same key.

In isolated testing where a cache type was tweaked to indefinitely error, this patch prevented goroutine counts from skyrocketing.