### PR TITLE
Fixes broken URLs in Dataplane docs

### DIFF
--- a/website/content/docs/connect/dataplane/index.mdx
+++ b/website/content/docs/connect/dataplane/index.mdx
@@ -33,8 +33,8 @@ Consul Dataplane manages Envoy proxies and leaves responsibility for other funct
 
 To get started with Consul Dataplane, use the following reference resources:
 
-- For `consul-dataplane` commands and usage examples, including required flags for startup, refer to the [`consul-dataplane` CLI reference](/consul/docs/dataplane/consul-dataplane).
-- For Helm chart information, refer to the [Helm Chart reference](/consul/docs/k8s/helm).
+- For `consul-dataplane` commands and usage examples, including required flags for startup, refer to the [`consul-dataplane` CLI reference](/docs/connect/dataplane/consul-dataplane).
+- For Helm chart information, refer to the [Helm Chart reference](/docs/k8s/helm).
 - For Envoy, Consul, and Consul Dataplane version compatibility, refer to the [Envoy compatibility matrix](/docs/connect/proxies/envoy).
 
 ### Installation


### PR DESCRIPTION
### Description
The URLs were pointing to the wrong paths.

### Testing & Reproduction steps
* Manual testing: I opened the URLs https://www.consul.io/docs/connect/dataplane/consul-dataplane and https://www.consul.io/docs/k8s/helm

### PR Checklist

* [n/a] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
