### PR TITLE
bug: fix goroutine leaks caused by incorrect usage of `WatchCh`

### DIFF
--- a/.changelog/14916.txt
+++ b/.changelog/14916.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: fix goroutine/memory leaks in the xDS subsystem (these were present regardless of whether or not xDS was in-use)
+```

--- a/agent/consul/xdscapacity/capacity.go
+++ b/agent/consul/xdscapacity/capacity.go
@@ -79,7 +79,7 @@ func NewController(cfg Config) *Controller {
 func (c *Controller) Run(ctx context.Context) {
 	defer close(c.doneCh)
 
-	ws, numProxies, err := c.countProxies(ctx)
+	watchCh, numProxies, err := c.countProxies(ctx)
 	if err != nil {
 		return
 	}
@@ -90,8 +90,8 @@ func (c *Controller) Run(ctx context.Context) {
 		case s := <-c.serverCh:
 			numServers = s
 			c.updateMaxSessions(numServers, numProxies)
-		case <-ws.WatchCh(ctx):
-			ws, numProxies, err = c.countProxies(ctx)
+		case <-watchCh:
+			watchCh, numProxies, err = c.countProxies(ctx)
 			if err != nil {
 				return
 			}
@@ -170,7 +170,7 @@ func (c *Controller) updateMaxSessions(numServers, numProxies uint32) {
 
 // countProxies counts the number of registered proxy services, retrying on
 // error until the given context is cancelled.
-func (c *Controller) countProxies(ctx context.Context) (memdb.WatchSet, uint32, error) {
+func (c *Controller) countProxies(ctx context.Context) (<-chan error, uint32, error) {
 	retryWaiter := &retry.Waiter{
 		MinFailures: 1,
 		MinWait:     1 * time.Second,
@@ -200,7 +200,7 @@ func (c *Controller) countProxies(ctx context.Context) (memdb.WatchSet, uint32, 
 				count += uint32(kindCount)
 			}
 		}
-		return ws, count, nil
+		return ws.WatchCh(ctx), count, nil
 	}
 }
 


### PR DESCRIPTION
### Description
[memdb's `WatchCh` method](https://pkg.go.dev/github.com/hashicorp/go-memdb#WatchSet.WatchCh) creates a goroutine that will publish to the returned channel when the watchset is triggered or the given context is canceled. Although this is called out in its godoc comment, it's not obvious that this method creates a goroutine who's lifecycle you need to manage.

In the xDS capacity controller, we were calling `WatchCh` on each iteration of the control loop, meaning the number of goroutines would grow on each autopilot event until there was catalog churn.

In the catalog config source, we were calling `WatchCh` with the background context, meaning that the goroutine would keep running after the sync loop had terminated.
