### PR TITLE
Ensure lines were modified

### DIFF
--- a/.github/scripts/metrics_checker.sh
+++ b/.github/scripts/metrics_checker.sh
@@ -6,7 +6,7 @@ set -uo pipefail
 ### It is still up to the reviewer to make sure that any tests added are needed and meaningful.
 
 # search for any "new" or modified metric emissions
-metrics_modified=$(git --no-pager diff origin/main...HEAD | grep -i "SetGauge\|EmitKey\|IncrCounter\|AddSample\|MeasureSince\|UpdateFilter")
+metrics_modified=$(git --no-pager diff origin/main...HEAD | grep -i "SetGauge\|EmitKey\|IncrCounter\|AddSample\|MeasureSince\|UpdateFilter" | grep "^[+-]")
 # search for PR body or title metric references
 metrics_in_pr_body=$(echo "${PR_BODY-""}" | grep -i "metric")
 metrics_in_pr_title=$(echo "${PR_TITLE-""}" | grep -i "metric")
@@ -15,7 +15,7 @@ metrics_in_pr_title=$(echo "${PR_TITLE-""}" | grep -i "metric")
 if [ "$metrics_modified" ] || [ "$metrics_in_pr_body" ] || [ "$metrics_in_pr_title" ]; then
   # need to check if there are modifications to metrics_test
   test_files_regex="*_test.go"
-  modified_metrics_test_files=$(git --no-pager diff HEAD "$(git merge-base HEAD "origin/main")" -- "$test_files_regex" | grep -i "metric")
+  modified_metrics_test_files=$(git --no-pager diff HEAD "$(git merge-base HEAD "origin/main")" -- "$test_files_regex" | grep -i "metric" | grep "^[+-]")
   if [ "$modified_metrics_test_files" ]; then
     # 1 happy path: metrics_test has been modified bc we modified metrics behavior
     echo "PR seems to modify metrics behavior. It seems it may have added tests to the metrics as well."


### PR DESCRIPTION
### Description
It's possible that the output of the diff contains surrounding lines that were not modified. This change filters further to lines that were added or removed.

I'm not great with grep, so if there's a nicer way to handle this let me know!

### Testing & Reproduction steps
* Tested manually
