### PR TITLE
tests: Fix flaky upgrade/compatibility test

### DIFF
--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -41,7 +41,7 @@ func TestTargetServersWithLatestGAClients(t *testing.T) {
 
 	go func() {
 		service, q, err := client.Health().Service(serviceName, "", false, &api.QueryOptions{WaitIndex: index})
-		if err == nil && q.QueryBackend != api.QueryBackendBlockingQuery {
+		if err == nil && q.QueryBackend != api.QueryBackendStreaming {
 			err = fmt.Errorf("invalid backend for this test %s", q.QueryBackend)
 		}
 		if err != nil {

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -41,7 +41,7 @@ func TestTargetServersWithLatestGAClients(t *testing.T) {
 
 	go func() {
 		service, q, err := client.Health().Service(serviceName, "", false, &api.QueryOptions{WaitIndex: index})
-		if err == nil && q.QueryBackend != api.QueryBackendStreaming {
+		if err == nil && q.QueryBackend != api.QueryBackendBlockingQuery {
 			err = fmt.Errorf("invalid backend for this test %s", q.QueryBackend)
 		}
 		if err != nil {
@@ -117,7 +117,7 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 	errCh := make(chan error)
 	go func() {
 		service, q, err := client.Health().Service(serviceName, "", false, &api.QueryOptions{WaitIndex: index})
-		if err == nil && q.QueryBackend != api.QueryBackendStreaming {
+		if err == nil && q.QueryBackend != api.QueryBackendBlockingQuery {
 			err = fmt.Errorf("invalid backend for this test %s", q.QueryBackend)
 		}
 		if err != nil {

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -153,8 +153,7 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 				HCL: `node_name="` + utils.RandName("consul-server") + `"
 					log_level="TRACE"
 					bootstrap_expect=3
-					server=true
-					rpc { enable_streaming=false }`,
+					server=true`,
 				Cmd:     []string{"agent", "-client=0.0.0.0"},
 				Version: *utils.TargetImage,
 			})
@@ -164,8 +163,7 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 		node.Config{
 			HCL: `node_name="` + utils.RandName("consul-server") + `"
 					log_level="TRACE"
-					server=true
-					rpc { enable_streaming=false }`,
+					server=true`,
 			Cmd:     []string{"agent", "-client=0.0.0.0"},
 			Version: *utils.LatestImage,
 		})


### PR DESCRIPTION
### Description
In #13658 (1.13+), we accidentally introduced a backwards incompatibility in our subscription/streaming API. Specifically, we 
[removed a field from the `SubscribeRequest` ](https://github.com/hashicorp/consul/pull/13658/commits/c7f491d174bb18c469f9fce4ee8cfad31bd78de5#diff-b23e1b89cf62b2990d0dcfcb707064c0e50fb8d1ba3e8d996807f0d05630276bL28) that gets sent for health requests. This is fine when all clients and servers are on the same version, but in the rare case where clients are on newer versions than the servers, it means that the requests they generate won't be compatible with the servers they are talking to. 

Ideally, we would remediate this issue in 1.13 and restore the compatibility, but that doesn't help us right now for the 1.12 tests which are really flaky. What makes them so flaky is the fact the test cases specifically target these mixed modes, in both directions, and the clients that are being used are always using the latest version; if the server that the client used in the test happens to be one of the older servers, the test will fail. Depending on the test case, this can be as much at 2/3rds of the time. 

My plan is to fix this here so that 1.12 builds are much less flaky and then also patch 1.13 to restore the compatibility and then remove the code again in our 1.14 since users should no longer hit this issue at that point since they shouldn't be doing 1.12->1.14 upgrades.

### Testing & Reproduction steps
- Run a test with `-count=3` and you will most likely see a failure. With this fix, you never see the failure.

### Links
- https://github.com/hashicorp/consul/pull/13658