### PR TITLE
docs: fix missing agent caching method

### DIFF
--- a/website/content/api-docs/catalog.mdx
+++ b/website/content/api-docs/catalog.mdx
@@ -270,7 +270,7 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
-| `NO`             | `none`            | `none`        | `none`       |
+| `NO`             | `none`            | `simple`      | `none`       |
 
 The corresponding CLI command is [`consul catalog datacenters`](/commands/catalog/datacenters).
 
@@ -401,7 +401,7 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required   |
 | ---------------- | ----------------- | ------------- | -------------- |
-| `YES`            | `all`             | `none`        | `service:read` |
+| `YES`            | `all`             | `simple`      | `service:read` |
 
 The corresponding CLI command is [`consul catalog services`](/commands/catalog/services).
 


### PR DESCRIPTION
### Description
Some APIs supporting simple agent caching misses description in the API doc. This PR fixes

* [List datacenters](https://github.com/hashicorp/consul/blob/58c8a10b98d125531f9ca3b677eeb95f816382b9/agent/catalog_endpoint.go#L191-L200)
* [List catalog services](https://github.com/hashicorp/consul/blob/58c8a10b98d125531f9ca3b677eeb95f816382b9/agent/catalog_endpoint.go#L268-L284)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] not a security concern
