### PR TITLE
Fix alias check leak

### DIFF
--- a/.changelog/14935.txt
+++ b/.changelog/14935.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: avoid leaking the alias check runner goroutine when the check is de-registered
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3263,7 +3263,10 @@ func (a *Agent) cancelCheckMonitors(checkID structs.CheckID) {
 		check.Stop()
 		delete(a.checkH2PINGs, checkID)
 	}
-
+	if check, ok := a.checkAliases[checkID]; ok {
+		check.Stop()
+		delete(a.checkAliases, checkID)
+	}
 }
 
 // updateTTLCheck is used to update the status of a TTL check via the Agent API.


### PR DESCRIPTION
### Description
Preivously when alias check was removed it would not be stopped nor cleaned up from the associated aliasChecks map.

This means that any time an alias check was deregistered we would leak a goroutine for CheckAlias.run() because the stopCh would never be closed.

This issue comes up then the `sidecar_service` stanza is used, as documented [here](https://www.consul.io/docs/connect/registration/sidecar-service#register-a-service-mesh-proxy-in-a-service-registration). When services are registered this way without custom health checks it leads to adding an alias check, which makes the sidecar service reflect the health of the underlying service.

The issue can lead to large goroutine counts in service mesh deployments on platforms where the client agent is mostly static but proxy services come and go regularly.

### Testing & Reproduction steps
* Noticed leak in a goroutine profile, which had over a thousand goroutines in `CheckAlias.run()` but there were only about a dozen services.
* Confirmed behavior with the unit test added, which initially failed.

### PR Checklist

* [x] updated test coverage
* [ ] ~external facing docs updated~
* [x] not a security concern
