### PR TITLE
adding configuration option cloud.scada_address

### DIFF
--- a/.changelog/14936.txt
+++ b/.changelog/14936.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Added configuration option cloud.scada_address.
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -2459,6 +2459,7 @@ func (b *builder) cloudConfigVal(v *CloudConfigRaw) (val hcpconfig.CloudConfig) 
 	val.ClientSecret = stringVal(v.ClientSecret)
 	val.AuthURL = stringVal(v.AuthURL)
 	val.Hostname = stringVal(v.Hostname)
+	val.ScadaAddress = stringVal(v.ScadaAddress)
 
 	return val
 }

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -866,6 +866,7 @@ type CloudConfigRaw struct {
 	ClientSecret *string `mapstructure:"client_secret"`
 	Hostname     *string `mapstructure:"hostname"`
 	AuthURL      *string `mapstructure:"auth_url"`
+	ScadaAddress *string `mapstructure:"scada_address"`
 }
 
 type TLSProtocolConfig struct {

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5996,6 +5996,7 @@ func TestLoad_FullConfig(t *testing.T) {
 			ClientSecret: "lCSMHOpB",
 			Hostname:     "DH4bh7aC",
 			AuthURL:      "332nCdR2",
+			ScadaAddress: "aoeusth232",
 		},
 		DNSAddrs:                         []net.Addr{tcpAddr("93.95.95.81:7001"), udpAddr("93.95.95.81:7001")},
 		DNSARecordLimit:                  29907,

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -129,7 +129,8 @@
         "ClientID": "id",
         "ClientSecret": "hidden",
         "Hostname": "",
-        "ResourceID": "cluster1"
+        "ResourceID": "cluster1",
+        "ScadaAddress": ""
     },
     "ConfigEntryBootstrap": [],
     "ConnectCAConfig": {},

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -207,6 +207,7 @@ cloud {
     client_secret = "lCSMHOpB"
     hostname = "DH4bh7aC"
     auth_url = "332nCdR2"
+    scada_address = "aoeusth232"
 }
 connect {
     ca_provider = "consul"

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -208,7 +208,8 @@
     "client_id": "6WvsDZCP",
     "client_secret":  "lCSMHOpB",
     "hostname":  "DH4bh7aC",
-    "auth_url": "332nCdR2"
+    "auth_url": "332nCdR2",
+    "scada_address": "aoeusth232"
   },
   "connect": {
     "ca_provider": "consul",

--- a/agent/hcp/config/config.go
+++ b/agent/hcp/config/config.go
@@ -13,6 +13,7 @@ type CloudConfig struct {
 	ClientSecret string
 	Hostname     string
 	AuthURL      string
+	ScadaAddress string
 }
 
 func (c *CloudConfig) HCPConfig(opts ...hcpcfg.HCPConfigOption) (hcpcfg.HCPConfig, error) {
@@ -24,6 +25,9 @@ func (c *CloudConfig) HCPConfig(opts ...hcpcfg.HCPConfigOption) (hcpcfg.HCPConfi
 	}
 	if c.Hostname != "" {
 		opts = append(opts, hcpcfg.WithAPI(c.Hostname, &tls.Config{}))
+	}
+	if c.ScadaAddress != "" {
+		opts = append(opts, hcpcfg.WithSCADA(c.ScadaAddress, &tls.Config{}))
 	}
 	opts = append(opts, hcpcfg.FromEnv())
 	return hcpcfg.NewHCPConfig(opts...)


### PR DESCRIPTION
### Description

When adding the `cloud` configuration stanza in https://github.com/hashicorp/consul/pull/14723, we forget to add `scada_address`. This is required when targeting other scada scada servers than the hcp sdk default ones. 

This addition doesn't have documentation because the other cloud configuration don't have that either.

### Testing & Reproduction steps

I tested this by building consul and using the configuration option.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern

## Adding a Simple Config Field for Client Agents
 - [x] Add the field to the Config struct (or an appropriate sub-struct) in
   `agent/config/config.go`.
 - [x] Add the field to the actual RuntimeConfig struct in
   `agent/config/runtime.go`.
 - [x] Add an appropriate parser/setter in `agent/config/builder.go` to
   translate.
 - [x] Add the new field with a random value to both the JSON and HCL files in
   `agent/config/testdata/full-config.*`, which should cause the test to fail.
   Then update the expected value in `TestLoad_FullConfig` in
   `agent/config/runtime_test.go` to make the test pass again.
 - [x] Run `go test -run TestRuntimeConfig_Sanitize ./agent/config -update` to update
   the expected value for `TestRuntimeConfig_Sanitize`. Look at `git diff` to
   make sure the value changed as you expect.
 - [x] **If** your new config field needed some validation as it's only valid in
   some cases or with some values (often true).
      - [ ] Add validation to Validate in `agent/config/builder.go`.
      - [ ] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
        `agent/config/runtime_test.go`.
 - [x] **If** your new config field needs a non-zero-value default.
      - [ ] Add that to `DefaultSource` in `agent/config/defaults.go`.
      - [ ] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
        `agent/config/runtime_test.go`.
      - [ ] If the config needs to be defaulted for the test server used in unit tests,
            also add it to `DefaultConfig()` in `agent/consul/defaults.go`.
 - [x] **If** your config should take effect on a reload/HUP.
      - [ ] Add necessary code to to trigger a safe (locked or atomic) update to
        any state the feature needs changing. This needs to be added to one or
        more of the following places:
         - `ReloadConfig` in `agent/agent.go` if it needs to affect the local
           client state or another client agent component.
         - `ReloadConfig` in `agent/consul/client.go` if it needs to affect
           state for client agent's RPC client.
      - [ ] Add a test to `agent/agent_test.go` similar to others with prefix
        `TestAgent_reloadConfig*`.
 - [x] Add documentation to `website/content/docs/agent/config/config-files.mdx`.