### PR TITLE
ui: Update peer repository to latest API changes

### DIFF
--- a/ui/packages/consul-ui/app/models/peer.js
+++ b/ui/packages/consul-ui/app/models/peer.js
@@ -16,7 +16,17 @@ export default class Peer extends Model {
   @attr('string') Name;
   @attr('string') State;
   @attr('string') ID;
-  @attr('number') ImportedServiceCount;
-  @attr('number') ExportedServiceCount;
+  @attr() ImportedServices;
+  @attr() ExportedServices;
+  @attr('date') LastHeartbeat;
+  @attr('date') LastReceive;
+  @attr('date') LastSend;
   @attr() PeerServerAddresses;
+
+  get ImportedServiceCount() {
+    return this.ImportedServices.length;
+  }
+  get ExportedServiceCount() {
+    return this.ExportedServices.length;
+  }
 }

--- a/ui/packages/consul-ui/app/models/peer.js
+++ b/ui/packages/consul-ui/app/models/peer.js
@@ -1,4 +1,5 @@
 import Model, { attr } from '@ember-data/model';
+import { nullValue } from 'consul-ui/decorators/replace';
 
 export const schema = {
   State: {
@@ -16,8 +17,8 @@ export default class Peer extends Model {
   @attr('string') Name;
   @attr('string') State;
   @attr('string') ID;
-  @attr() ImportedServices;
-  @attr() ExportedServices;
+  @nullValue([]) @attr() ImportedServices;
+  @nullValue([]) @attr() ExportedServices;
   @attr('date') LastHeartbeat;
   @attr('date') LastReceive;
   @attr('date') LastSend;

--- a/ui/packages/consul-ui/app/services/repository/peer.js
+++ b/ui/packages/consul-ui/app/services/repository/peer.js
@@ -55,7 +55,7 @@ export default class PeerService extends RepositoryService {
         },
         body: body.map((item) => {
           return cache(
-            normalizePeerPayload(item),
+            normalizePeerPayload(item, dc, partition),
             (uri) => uri`peer:///${partition}/${ns}/${dc}/peer/${item.Name}`
           );
         }),
@@ -92,7 +92,7 @@ export default class PeerService extends RepositoryService {
           uri: uri,
         },
         body: cache(
-          normalizePeerPayload(body),
+          normalizePeerPayload(body, dc, partition),
           (uri) => uri`peer:///${partition}/${ns}/${dc}/peer/${body.Name}`
         ),
       };

--- a/ui/packages/consul-ui/app/services/repository/peer.js
+++ b/ui/packages/consul-ui/app/services/repository/peer.js
@@ -1,6 +1,22 @@
 import RepositoryService from 'consul-ui/services/repository';
 import dataSource from 'consul-ui/decorators/data-source';
 
+function normalizePeerPayload(peerPayload, dc, partition) {
+  const {
+    StreamStatus: { LastHeartbeat, LastReceive, LastSend, ImportedServices, ExportedServices },
+  } = peerPayload;
+
+  return {
+    ...peerPayload,
+    LastHeartbeat,
+    LastReceive,
+    LastSend,
+    ImportedServices,
+    ExportedServices,
+    Datacenter: dc,
+    Partition: partition,
+  };
+}
 export default class PeerService extends RepositoryService {
   getModelName() {
     return 'peer';
@@ -39,11 +55,7 @@ export default class PeerService extends RepositoryService {
         },
         body: body.map((item) => {
           return cache(
-            {
-              ...item,
-              Datacenter: dc,
-              Partition: partition,
-            },
+            normalizePeerPayload(item),
             (uri) => uri`peer:///${partition}/${ns}/${dc}/peer/${item.Name}`
           );
         }),
@@ -80,11 +92,7 @@ export default class PeerService extends RepositoryService {
           uri: uri,
         },
         body: cache(
-          {
-            ...body,
-            Datacenter: dc,
-            Partition: partition,
-          },
+          normalizePeerPayload(body),
           (uri) => uri`peer:///${partition}/${ns}/${dc}/peer/${body.Name}`
         ),
       };

--- a/ui/packages/consul-ui/mock-api/v1/peerings
+++ b/ui/packages/consul-ui/mock-api/v1/peerings
@@ -18,8 +18,13 @@
       'TERMINATED',
       'UNDEFINED'
     ])}",
-    "ImportedServiceCount": ${fake.random.number({min: 0, max: 4000})},
-    "ExportedServiceCount": ${fake.random.number({min: 0, max: 4000})},
+    "StreamStatus": {
+      "LastHeartbeat": "${fake.date.past(10).toISOString()}",
+      "LastReceive": "${fake.date.past(10).toISOString()}",
+      "LastSend": "${fake.date.past(10).toISOString()}",
+      "ExportedServices": ["${`export-service-${i}`}"],
+      "ImportedServices": ["${`import-service-${i}`}"]
+    },
     "PeerID": "${id}",
     "PeerServerName": "${fake.internet.domainName()}",
     "PeerServerAddresses": [


### PR DESCRIPTION
### Description
Update to latest peer-API changes. This makes the `StreamStatus`-data available to the peer-model. I'm normalizing the data in the repository layer because the peering repository works around the serializer layer.

### Testing & Reproduction steps
* build docker image from latest `main`
* start a consul cluster setup that you can create peerings in. you can use [docker-compose](https://github.com/LevelbossMike/consul-setup)
* use `yarn start:consul` to run against this cluster and see that the UI behaves as it did before.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
