### PR TITLE
ui: make terminated peers removable

### DIFF
--- a/ui/packages/consul-ui/app/abilities/peer.js
+++ b/ui/packages/consul-ui/app/abilities/peer.js
@@ -11,7 +11,7 @@ export default class PeerAbility extends BaseAbility {
     return this.canDelete;
   }
   get canDelete() {
-    return !['DELETING', 'TERMINATED'].includes(this.item.State) && super.canDelete;
+    return !['DELETING'].includes(this.item.State) && super.canDelete;
   }
 
   get canUse() {


### PR DESCRIPTION
### Description
Make terminated peers deletable. The only reason this wasn't possible before was because we had an ability prohibiting deleting a peer with the `TERMINATED`-state. Now that the API supports this, we can remove that check.

This PR depends on https://github.com/hashicorp/consul/pull/14937

<img width="801" alt="Screenshot 2022-10-11 at 15 13 50" src="https://user-images.githubusercontent.com/242299/195100657-e387d5cf-9e36-40d1-abb5-4d2de27eca94.png">

### Testing & Reproduction steps
* same as https://github.com/hashicorp/consul/pull/14937
* go to the dialer side of a peering, delete it, and then look at the receiver side and see that the peering can be deleted.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
