### PR TITLE
fix(peering): add missing grpc_tls_port for server address reconciliation

### DIFF
--- a/agent/consul/autopilotevents/ready_servers_events.go
+++ b/agent/consul/autopilotevents/ready_servers_events.go
@@ -310,6 +310,14 @@ func (r *ReadyServersEventPublisher) getGRPCPort(srv *autopilot.ServerState) int
 	if err != nil || ns == nil || ns.Meta == nil {
 		return 0
 	}
+
+	if str, ok := ns.Meta["grpc_tls_port"]; ok {
+		grpcPort, err := strconv.Atoi(str)
+		if err == nil {
+			return grpcPort
+		}
+	}
+
 	if str, ok := ns.Meta["grpc_port"]; ok {
 		grpcPort, err := strconv.Atoi(str)
 		if err == nil {


### PR DESCRIPTION
### Description
The peering acceptor server will use grpc_tls = 8502 in its config. In this case, the address won't be replicated to the dialing cluster.

### Testing & Reproduction steps

1. Establish peering between 2 clusters.
2. Add a new server to the acceptor cluster
3. Wait for some time, the server doesn't appear in the read peering response.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
