### PR TITLE
Fixed broken links referring to tutorials running a local agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ by contacting us at security@hashicorp.com.
 
 A few quick start guides are available on the Consul website:
 
-* **Standalone binary install:** https://learn.hashicorp.com/tutorials/consul/get-started-install
+* **Standalone binary install:** https://learn.hashicorp.com/collections/consul/get-started-vms
 * **Minikube install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-minikube
 * **Kind install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-kind
 * **Kubernetes install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-deployment-guide

--- a/website/content/docs/agent/config/index.mdx
+++ b/website/content/docs/agent/config/index.mdx
@@ -38,8 +38,8 @@ documented below in the
 configuration reload.
 
 You can test the following configuration options by following the
-[Getting Started](https://learn.hashicorp.com/tutorials/consul/get-started-install?utm_source=docs)
-tutorials to install a local agent.
+[Getting Started](https://learn.hashicorp.com/collections/consul/get-started-vms?utm_source=docs)
+tutorials to install an agent in a VM.
 
 ## Ports Used
 

--- a/website/content/docs/agent/index.mdx
+++ b/website/content/docs/agent/index.mdx
@@ -94,8 +94,8 @@ Consul ships with a `-dev` flag that configures the agent to run in server mode 
 The `-dev` flag is provided for learning purposes only.
 We strongly advise against using it for production environments.
 
--> **Getting Started Tutorials**: You can test a local agent by following the
-[Getting Started tutorials](https://learn.hashicorp.com/tutorials/consul/get-started-install?utm_source=docs).
+-> **Getting Started Tutorials**: You can test a local agent in a VM by following the
+[Getting Started tutorials](https://learn.hashicorp.com/collections/consul/get-started-vms?utm_source=docs).
 
 When starting Consul with the `-dev` flag, the only additional information Consul needs to run is the location of a directory for storing agent state data.
 You can specify the location with the `-data-dir` flag or define the location in an external file and point the file with the `-config-file` flag.

--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -19,7 +19,7 @@ Downloading a precompiled binary is easiest, and we provide downloads over TLS
 along with SHA256 sums to verify the binary. We also distribute a PGP signature
 with the SHA256 sums that can be verified.
 
-The [Getting Started guides](https://learn.hashicorp.com/tutorials/consul/get-started-install?utm_source=docs) provide a quick walkthrough of installing and using Consul on your local machine.
+The [Getting Started guides](https://learn.hashicorp.com/collections/consul/get-started-vms?utm_source=docs) provide a quick walkthrough of installing and using Consul on a VM.
 
 ## Precompiled Binaries
 

--- a/website/content/docs/nia/usage/requirements.mdx
+++ b/website/content/docs/nia/usage/requirements.mdx
@@ -25,7 +25,7 @@ Below are several steps towards a minimum Consul setup required for running CTS.
 
 CTS is a daemon that runs alongside Consul, similar to other Consul ecosystem tools like Consul Template. CTS is not included with the Consul binary and needs to be installed separately.
 
-To install a local Consul agent, refer to the [Getting Started: Install Consul Tutorial](https://learn.hashicorp.com/tutorials/consul/get-started-install).
+To install a local Consul agent, refer to the [Getting Started: Install Consul Tutorial](https://learn.hashicorp.com/collections/consul/get-started-vms?utm_source=docs).
 
 For information on compatible Consul versions, refer to the [Consul compatibility matrix](/docs/nia/compatibility#consul).
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -58,7 +58,7 @@
       },
       {
         "title": "Learn Consul on VMs",
-        "href": "https://learn.hashicorp.com/tutorials/consul/get-started-install"
+        "href": "https://learn.hashicorp.com/collections/consul/get-started-vms"
       },
       {
         "title": "Manual Bootstrap",


### PR DESCRIPTION
### Description
Links referring to tutorials running Consul as a local agent are broken.

### Testing & Reproduction steps
1. Click link such as "Learn Consul on VMs" which points towards broken link (https://learn.hashicorp.com/tutorials/consul/get-started-install)
2. See that the link is broken resulting in 404 error being displayed to user.

### Links
Replaced broken links to point to https://learn.hashicorp.com/collections/consul/get-started-vms

### PR Checklist

* [ x] updated test coverage
* [ x] external facing docs updated
* [x ] not a security concern
