### PR TITLE
xds: properly merge central config for "agentless" services

### DIFF
--- a/.changelog/14962.txt
+++ b/.changelog/14962.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: Central service configuration (proxy-defaults and service-defaults) is now correctly applied to Consul Dataplane proxies
+```

--- a/agent/proxycfg-sources/catalog/config_source.go
+++ b/agent/proxycfg-sources/catalog/config_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-memdb"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
@@ -117,7 +118,6 @@ func (m *ConfigSource) startSync(closeCh <-chan chan struct{}, proxyID proxycfg.
 		ws.Add(store.AbandonCh())
 
 		_, ns, err := store.NodeService(ws, proxyID.NodeName, proxyID.ID, &proxyID.EnterpriseMeta, structs.DefaultPeerKeyword)
-
 		switch {
 		case err != nil:
 			logger.Error("failed to read service from state store", "error", err.Error())
@@ -130,14 +130,29 @@ func (m *ConfigSource) startSync(closeCh <-chan chan struct{}, proxyID proxycfg.
 			err := errors.New("service must be a sidecar proxy or gateway")
 			logger.Error(err.Error())
 			return nil, err
-		default:
-			err := m.Manager.Register(proxyID, ns, source, proxyID.Token, false)
-			if err != nil {
-				logger.Error("failed to register service", "error", err.Error())
-				return nil, err
-			}
-			return ws, nil
 		}
+
+		_, ns, err = configentry.MergeNodeServiceWithCentralConfig(
+			ws,
+			store,
+			// TODO(agentless): it doesn't seem like we actually *need* any of the
+			// values on this request struct - we should try to remove the parameter
+			// in case that changes in the future as this call-site isn't passing them.
+			&structs.ServiceSpecificRequest{},
+			ns,
+			logger,
+		)
+		if err != nil {
+			logger.Error("failed to merge with central config", "error", err.Error())
+			return nil, err
+		}
+
+		if err = m.Manager.Register(proxyID, ns, source, proxyID.Token, false); err != nil {
+			logger.Error("failed to register service", "error", err.Error())
+			return nil, err
+		}
+
+		return ws, nil
 	}
 
 	syncLoop := func(ws memdb.WatchSet) {
@@ -250,6 +265,7 @@ type ConfigManager interface {
 
 type Store interface {
 	NodeService(ws memdb.WatchSet, nodeName string, serviceID string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, *structs.NodeService, error)
+	ReadResolvedServiceConfigEntries(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, upstreamIDs []structs.ServiceID, proxyMode structs.ProxyMode) (uint64, *configentry.ResolvedServiceConfigSet, error)
 	AbandonCh() <-chan struct{}
 }
 


### PR DESCRIPTION
### Description
Fixes an omission in the 1.14 beta, where central service configuration (i.e. the `proxy-defaults` and `service-defaults` config entries) was not applied to the generated xDS resources.

### Testing & Reproduction steps
1. Start a dev server
1. Register a node, service, and sidecar proxy via the catalog API
1. Run `consul-dataplane` with the proxy service's ID
1. Create a `proxy-defaults` config entry which sets the default protocol to HTTP
1. Observe in the Envoy admin server's `config_dump` page that the public listener has an `HttpConnectionManager` filter
1. Create a `service-defaults` entry which overrides the protcol to TCP
1. Observe that the `HttpConnectionManager` filter is gone
