### PR TITLE
ui: Always sort consul-gateway to bottom sources list

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
@@ -134,7 +134,14 @@
         <BlockSlot @name='options'>
           {{#let components.Option as |Option|}}
             {{#if (gt @sources.length 0)}}
-              {{#each @sources as |source|}}
+              <Option
+                class='consul'
+                @value='consul'
+                @selected={{includes 'consul' @filter.source.value}}
+              >
+                {{t 'common.brand.consul'}}
+              </Option>
+              {{#each this.sortedSources as |source|}}
                 <Option
                   class={{source}}
                   @value={{source}}
@@ -143,13 +150,6 @@
                   {{t (concat 'common.brand.' source)}}
                 </Option>
               {{/each}}
-              <Option
-                class='consul'
-                @value='consul'
-                @selected={{includes 'consul' @filter.source.value}}
-              >
-                {{t 'common.brand.consul'}}
-              </Option>
             {{/if}}
           {{/let}}
         </BlockSlot>

--- a/ui/packages/consul-ui/app/components/consul/service/search-bar/index.js
+++ b/ui/packages/consul-ui/app/components/consul/service/search-bar/index.js
@@ -8,4 +8,14 @@ export default class ConsulServiceSearchBar extends Component {
       return ['passing', 'warning', 'critical', 'empty'];
     }
   }
+
+  get sortedSources() {
+    const sources = this.args.sources || [];
+
+    if (sources.includes('consul-api-gateway')) {
+      return [...sources.filter((s) => s !== 'consul-api-gateway'), 'consul-api-gateway'];
+    } else {
+      return sources;
+    }
+  }
 }


### PR DESCRIPTION
### Description
Make sure the `Consul API Gateway`-source filter is always displayed at the bottom of the services sources filter when present. This PR also moves the `Consul`-source to the top of the list.

<img width="524" alt="Screenshot 2022-10-13 at 17 20 56" src="https://user-images.githubusercontent.com/242299/195638505-19c7c5c5-de89-4a53-8a0e-66132fc2dafd.png">



### Testing & Reproduction steps
* `make start`
* go to the services overview and wait until a service has the `Consul API gateway` assigned.
* See that this source is always displayed at the bottom of the source dropdown now.

### Links
[NET-745](https://hashicorp.atlassian.net/browse/NET-745)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
