### PR TITLE
ui: enable synthetic nodes in mock data

### DIFF
--- a/ui/packages/consul-ui/app/utils/get-environment.js
+++ b/ui/packages/consul-ui/app/utils/get-environment.js
@@ -18,6 +18,9 @@ export default function (config = {}, win = window, doc = document) {
         .filter((item) => item !== '')
         .filter((item) => item.split('=').shift().startsWith('CONSUL_'));
     };
+
+    // Define the function that reads in "Scenarios", parse and set cookies and set theme if specified.
+    // See https://github.com/hashicorp/consul/blob/main/ui/packages/consul-ui/docs/bookmarklets.mdx
     win['Scenario'] = function (str = '') {
       if (str.length > 0) {
         cookies(str).forEach((item) => {
@@ -55,6 +58,7 @@ export default function (config = {}, win = window, doc = document) {
         );
       }
     };
+
     if (
       typeof win.location !== 'undefined' &&
       typeof win.location.hash === 'string' &&
@@ -63,6 +67,8 @@ export default function (config = {}, win = window, doc = document) {
       win['Scenario'](win.location.hash.substr(1));
     }
   });
+
+  // Defines a function that reads in the cookies and parses the cookie keys.
   const dev = function (str = doc.cookie) {
     return str
       .split(';')
@@ -72,6 +78,7 @@ export default function (config = {}, win = window, doc = document) {
         return [key, rest.join('=')];
       });
   };
+
   const user = function (str) {
     const item = win.localStorage.getItem(str);
     return item === null ? undefined : item;
@@ -205,6 +212,9 @@ export default function (config = {}, win = window, doc = document) {
             case 'CONSUL_ACLS_ENABLE':
               prev['CONSUL_ACLS_ENABLED'] = !!JSON.parse(String(value).toLowerCase());
               break;
+            case 'CONSUL_AGENTLESS_ENABLE':
+              prev['CONSUL_AGENTLESS_ENABLED'] = !!JSON.parse(String(value).toLowerCase());
+              break;
             case 'CONSUL_NSPACES_ENABLE':
               prev['CONSUL_NSPACES_ENABLED'] = !!JSON.parse(String(value).toLowerCase());
               break;
@@ -272,6 +282,7 @@ export default function (config = {}, win = window, doc = document) {
       case 'CONSUL_ACLS_ENABLED':
       case 'CONSUL_NSPACES_ENABLED':
       case 'CONSUL_PEERINGS_ENABLED':
+      case 'CONSUL_AGENTLESS_ENABLED':
       case 'CONSUL_HCP_ENABLED':
       case 'CONSUL_SSO_ENABLED':
       case 'CONSUL_PARTITIONS_ENABLED':

--- a/ui/packages/consul-ui/docs/bookmarklets.mdx
+++ b/ui/packages/consul-ui/docs/bookmarklets.mdx
@@ -10,6 +10,7 @@ Below is a list of the most commonly used functions as bookmarklets followed by 
 | [Save Current Scenario](javascript:Scenario()) | Opens a tab with links to allow you to create a bookmarklet or share a URL of your current scenario (your Consul UI related development/debug cookies) |
 | [Toggle Color Scheme](javascript:Scenario('CONSUL_COLOR_SCHEME=!')) | Toggle Color Scheme from light to dark or vice versa |
 | [Enable ACLs](javascript:Scenario('CONSUL_ACLS_ENABLE=1')) | Enable ACLs |
+| [Enable Agentless](javascript:Scenario('CONSUL_AGENTLESS_ENABLE=1')) | Enable synthetic nodes (agentless) in the mock data |
 | [Enable TProxy](javascript:Scenario('CONSUL_TPROXY_ENABLE=1')) | Enable TProxy |
 | [Enable Nspaces](javascript:Scenario('CONSUL_NSPACES_ENABLE=1')) | Enable Namespace Support |
 | [Enable Peers](javascript:Scenario('CONSUL_PEERINGS_ENABLE=1')) | Enable Peering Support |
@@ -40,6 +41,7 @@ token/secret.
 | -------- | ------------- | ----------- |
 | `CONSUL_ACLS_ENABLE` | false | Enable/disable ACLs support. |
 | `CONSUL_ACLS_LEGACY` | false | Enable/disable legacy ACLs support. |
+| `CONSUL_AGENTLESS_ENABLE` | false | Enable/disable synthetic nodes (agentless) in the mock data. |
 | `CONSUL_TPROXY_ENABLE` | false | Enable/disable TProxy support globally (if not a service may have this applied randomly). |
 | `CONSUL_NSPACES_ENABLE` | false | Enable/disable Namespace support. |
 | `CONSUL_SSO_ENABLE` | false | Enable/disable SSO support. |

--- a/ui/packages/consul-ui/mock-api/v1/health/service/_
+++ b/ui/packages/consul-ui/mock-api/v1/health/service/_
@@ -54,7 +54,7 @@
             "TaggedAddresses":{"lan":"${ip}","wan":"${ip}"},
             "Meta":{
               "${service}-network-segment":"",
-              "synthetic-node":${externalSource === 'kubernetes' ? true : false}
+              "synthetic-node":${env('CONSUL_AGENTLESS_ENABLED') && externalSource === 'kubernetes' ? true : false}
             },
 ${typeof location.search.peer !== 'undefined' ? `
             "PeerName": "${location.search.peer}",

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/nodes
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/nodes
@@ -24,7 +24,8 @@
               "wan":"${fake.internet.ip()}"
             },
             "Meta": {
-              "consul-network-segment":""
+              "consul-network-segment":"",
+              "synthetic-node": ${env('CONSUL_AGENTLESS_ENABLED') ? fake.helpers.randomize([true, false, false, false]) : false}
             },
             "Services":[
                 ${


### PR DESCRIPTION
### Description
Enable synthetic nodes in mock data by setting a cookie. I had to step through the `get-environment` utility to figure out what was going on, so I added a few comments. Michael and I already discussed some ways we could improve this, but that won't be included in this PR.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
