### PR TITLE
[OSS] increase protobuf size limit for cluster peering

### DIFF
--- a/agent/grpc-external/server.go
+++ b/agent/grpc-external/server.go
@@ -29,6 +29,7 @@ func NewServer(logger agentmiddleware.Logger, metricsObj *metrics.Metrics) *grpc
 
 	opts := []grpc.ServerOption{
 		grpc.MaxConcurrentStreams(2048),
+		grpc.MaxRecvMsgSize(50 * 1024 * 1024),
 		grpc.StatsHandler(agentmiddleware.NewStatsHandler(metricsObj, metricsLabels)),
 		middleware.WithUnaryServerChain(
 			// Add middlware interceptors to recover in case of panics.

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -367,6 +367,11 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 		// resources, not request/ack messages.
 		if msg.GetResponse() != nil {
 			if err != nil {
+				if id := msg.GetResponse().GetResourceID(); id != "" {
+					logger.Error("failed to send resource", "resourceID", id, "error", err)
+					status.TrackSendError(err.Error())
+					return nil
+				}
 				status.TrackSendError(err.Error())
 			} else {
 				status.TrackSendSuccess()

--- a/website/content/docs/connect/cluster-peering/index.mdx
+++ b/website/content/docs/connect/cluster-peering/index.mdx
@@ -55,7 +55,7 @@ The cluster peering beta release includes the following features and functionali
 Not all features and functionality are available in the beta release. In particular, consider the following technical constraints:
 
 - Mesh gateways for _server to server traffic_ are not available.
-- Services with node, instance, and check definitions totaling more than 4MB cannot be exported to a peer.
+- Services with node, instance, and check definitions totaling more than 50MB cannot be exported to a peer.
 - The `service-splitter` and `service-router` configuration entry kinds cannot directly target a peer. To split or route traffic to a service instance on a peer, you must supplement your desired dynamic routing definition with a `service-resolver` config entry on the dialing cluster. Refer to [L7 traffic management between peers](/docs/connect/cluster-peering/create-manage-peering#L7-traffic) for more information.
 - The `consul intention` CLI command is not supported. To manage intentions that specify services in peered clusters, use [configuration entries](/docs/connect/config-entries/service-intentions).
 - Accessing key/value stores across peers is not supported.


### PR DESCRIPTION
### Description
Backport of ENT-3239

increase grpc message size limit to 50MB, handle grpc ResouceExhausted error messages when it's related to a resource.

context:
Protobufs received by grpc-go are [limited to 4MB](https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize). Assuming large 5KB CheckServiceNode definitions, this allows to send ~800 instances in a single message.

That should be OK for most use-cases, particularly if we are merging health checks down into a single check. However, there could still be cases where a larger service is being replicated.

### Testing & Reproduction steps
* validated the size limit by lowering `MaxCallSendMsgSize` and `MaxRecvMsgSize` to 50KB.
* updated tests to catch the new error code 


### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
