### PR TITLE
ui: Bento-Box show scrollbars only when necessary

### DIFF
--- a/ui/packages/consul-peerings/app/components/consul/peer/bento-box/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/bento-box/index.hbs
@@ -1,5 +1,5 @@
 <Hds::Card::Container @level="base" @hasBorder={{true}} class="mt-6 mb-3">
-  <div class="flex h-24 p-6 overflow-x-scroll space-x-12">
+  <div class="flex h-24 p-6 overflow-x-auto space-x-12">
     <div class="shrink-0">
       <div
         class="mb-2 hds-typography-body-200 hds-font-weight-semibold text-hds-foreground-primary"


### PR DESCRIPTION
### Description
Only show scrollbars on the peering bento-box when necessary.

Before (on Windows and with scrollbars set to `always` on macOS):
<img width="780" alt="Screenshot 2022-10-13 at 20 29 44" src="https://user-images.githubusercontent.com/242299/195677806-fb755d74-ac3c-47af-864e-ea806899c04c.png">

After:
<img width="779" alt="Screenshot 2022-10-13 at 20 30 09" src="https://user-images.githubusercontent.com/242299/195677830-1aeac7cc-a0f1-4963-9017-2dc31f4184ae.png">


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
