### PR TITLE
docs: update /v1/agent/self

### DIFF
--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -283,7 +283,7 @@ format will not change in a backwards incompatible way between releases.
 `DebugConfig` contains the full runtime configuration but its format is subject
 to change without notice or deprecation. 
 
-~> This endpoint will not reflect [reloaded](/docs/agent/config#reloadable-configuration) configuration values.
+~> This endpoint does not reflect [reloaded](/docs/agent/config#reloadable-configuration) configuration values.
 
 | Method | Path          | Produces           |
 | ------ | ------------- | ------------------ |

--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -281,7 +281,9 @@ This endpoint returns the configuration and member information of the local
 agent. The `Config` element contains a subset of the configuration and its
 format will not change in a backwards incompatible way between releases.
 `DebugConfig` contains the full runtime configuration but its format is subject
-to change without notice or deprecation.
+to change without notice or deprecation. 
+
+~> This endpoint will not reflect [reloaded](/docs/agent/config#reloadable-configuration) configuration values.
 
 | Method | Path          | Produces           |
 | ------ | ------------- | ------------------ |


### PR DESCRIPTION
### Description
`/v1/agent/self` endpoint returns the configuration and member information of the local agent. This endpoint, however, does not reflect the runtime configurations after Consul reloads

### Testing & Reproduction steps
* Clone the repo and run `make` in `/website` directory
* Browsed and verified the change in http://localhost:3000/consul/api-docs/agent#read-configuration

### Links
* https://developer.hashicorp.com/consul/docs/agent/config#reloadable-configuration

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
