### PR TITLE
proxycfg: fix goroutine leak when service is re-registered

### DIFF
--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -317,7 +317,10 @@ func (s *state) run(ctx context.Context, snap *ConfigSnapshot) {
 			// This runs in another goroutine so we can't just do the send
 			// directly here as access to snap is racy. Instead, signal the main
 			// loop above.
-			sendCh <- struct{}{}
+			select {
+			case sendCh <- struct{}{}:
+			case <-ctx.Done():
+			}
 		})
 	}
 


### PR DESCRIPTION
### Description
Fixes a bug where we'd leak a goroutine in `state.run` when the given context was canceled while there was a pending update.
