### PR TITLE
peering: skip registering duplicate node and check from the peer

### DIFF
--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -272,6 +272,7 @@ func TestLeader_PeeringSync_Lifecycle_UnexportWhileDown(t *testing.T) {
 	insertNode := func(i int) {
 		req := structs.RegisterRequest{
 			Datacenter: "dc1",
+			ID:         types.NodeID(generateUUID()),
 			Node:       fmt.Sprintf("node%d", i+1),
 			Address:    fmt.Sprintf("127.0.0.%d", i+1),
 			NodeMeta: map[string]string{


### PR DESCRIPTION
### Description
When some resource such as a check is imported we currently always apply the newly received resource. This happens even if the resource was not modified.

For each imported resource we should compute a diff relative to the data stored locally. This will cost some CPU time but can save trips through Raft when data has not changed.

- Node: skip CatalogRegister duplicate node
- Service: skip CatalogRegister duplicate service instance
- Check: skip CatalogRegister duplicate check

### Testing & Reproduction steps

1. Register a service in the acceptor cluster with some check
2. Export the service
3. Change the meta or tag of the service, which changes the service. Then register the service again.
4. Issue a request to `/v1/health/service/` of the peering cluster.  As a result, the Index of the service will be changed, but that of check keeps the same.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
