### PR TITLE
test: ensure that all dependencies in a test agent use the test logger

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -51,6 +51,14 @@ func NewTestACLAgent(t *testing.T, name string, hcl string, resolveAuthz authzRe
 	dataDir := testutil.TempDir(t, "acl-agent")
 
 	logBuffer := testutil.NewLogBuffer(t)
+
+	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
+		Name:       name,
+		Level:      testutil.TestLogLevel,
+		Output:     logBuffer,
+		TimeFormat: "04:05.000",
+	})
+
 	loader := func(source config.Source) (config.LoadResult, error) {
 		dataDir := fmt.Sprintf(`data_dir = "%s"`, dataDir)
 		opts := config.LoadOpts{
@@ -63,15 +71,9 @@ func NewTestACLAgent(t *testing.T, name string, hcl string, resolveAuthz authzRe
 		}
 		return result, err
 	}
-	bd, err := NewBaseDeps(loader, logBuffer)
+	bd, err := NewBaseDeps(loader, logBuffer, logger)
 	require.NoError(t, err)
 
-	bd.Logger = hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Name:       name,
-		Level:      testutil.TestLogLevel,
-		Output:     logBuffer,
-		TimeFormat: "04:05.000",
-	})
 	bd.MetricsConfig = &lib.MetricsConfig{
 		Handler: metrics.NewInmemSink(1*time.Second, time.Minute),
 	}

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -219,7 +219,7 @@ func (a *TestAgent) Start(t *testing.T) error {
 		}
 		return result, err
 	}
-	bd, err := NewBaseDeps(loader, logOutput)
+	bd, err := NewBaseDeps(loader, logOutput, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create base deps: %w", err)
 	}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -199,7 +199,7 @@ func (c *cmd) run(args []string) int {
 		return 1
 	}
 
-	bd, err := agent.NewBaseDeps(loader, logGate)
+	bd, err := agent.NewBaseDeps(loader, logGate, nil)
 	if err != nil {
 		ui.Error(err.Error())
 		return 1


### PR DESCRIPTION
Some of the inner dependencies of a test agent were creating a different default logger than the one created specifically for the test (which ensures that the logs are tied to the testcase itself).

This rearranges it so that the test logger is used for the whole dependency construction pass.