### PR TITLE
agent: don't log warn when service is already deleted

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2659,6 +2659,9 @@ func (a *Agent) removeServiceLocked(serviceID structs.ServiceID, persist bool) e
 
 	// Remove service immediately
 	if err := a.State.RemoveServiceWithChecks(serviceID, checkIDs); err != nil {
+		if isServiceDoesNotExistErr(err) {
+			return nil
+		}
 		a.logger.Warn("Failed to deregister service",
 			"service", serviceID.String(),
 			"error", err,
@@ -4474,4 +4477,13 @@ func defaultIfEmpty(val, defaultVal string) string {
 		return val
 	}
 	return defaultVal
+}
+
+func isServiceDoesNotExistErr(err error) bool {
+	switch err.(type) {
+	case *local.ServiceDoesNotExistErr:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
Previously we would log a warning when we couldn't delete a service because it was already deleted. This isn't a situation in which we should be warning since the desired behaviour (deleting the service) has happened.

Fixes https://github.com/hashicorp/consul/issues/11711

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
