### PR TITLE
builds: fix "Killed" error with make dev

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -149,7 +149,9 @@ dev: dev-build
 dev-build:
 	mkdir -p bin
 	CGO_ENABLED=0 go install -ldflags "$(GOLDFLAGS)" -tags "$(GOTAGS)"
-	cp -f ${MAIN_GOPATH}/bin/consul ./bin/consul
+	# rm needed due to signature caching (https://apple.stackexchange.com/a/428388)
+	rm -f ./bin/consul
+	cp ${MAIN_GOPATH}/bin/consul ./bin/consul
 
 dev-docker: linux
 	@echo "Pulling consul container image - $(CONSUL_IMAGE_VERSION)"


### PR DESCRIPTION
Previously, I would sometimes get Killed errors when executing the binary created by `make dev`. This is because we were using `cp` and OSX has a bug where it caches the old signature and so doesn't allow the new binary to run (see https://apple.stackexchange.com/a/428388)
