### PR TITLE
ca: fix a masked bug in leaf cert generation that would not be notified of root cert rotation after the first one

### DIFF
--- a/.changelog/15005.txt
+++ b/.changelog/15005.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ca: fix a masked bug in leaf cert generation that would not be notified of root cert rotation after the first one
+```

--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -165,6 +165,7 @@ func (c *ConnectCALeaf) fetchDone(rootUpdateCh chan struct{}) {
 	if len(c.rootWatchSubscribers) == 0 && c.rootWatchCancel != nil {
 		// This was the last request. Stop the root watcher.
 		c.rootWatchCancel()
+		c.rootWatchCancel = nil
 	}
 }
 


### PR DESCRIPTION
### Description

In practice this was masked by #14956 and was only uncovered fixing the other bug.

    go test ./agent -run TestAgentConnectCALeafCert_goodNotLocal

would fail when only #14956 was fixed.
