### PR TITLE
docs: formatting on backend application and delete peering CRDs

### DIFF
--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -420,23 +420,23 @@ To end a peering connection, delete both the `PeeringAcceptor` and `PeeringDiale
 
 1. Confirm that you deleted your peering connection in `cluster-01` by querying the the `/health` HTTP endpoint. The peered services should no longer appear.
 
-  1. Exec into the server pod for the first cluster. 
+    1. Exec into the server pod for the first cluster. 
   
-    ```shell-session
-    $ kubectl exec -it consul-server-0 -- /bin/sh
-    ```
+      ```shell-session
+      $ kubectl exec -it consul-server-0 -- /bin/sh
+      ```
   
-  1. Export an ACL token to access the `/health` HTP endpoint for services. The bootstrap token may be used if an ACL token is not already provisioned. 
+    1. Export an ACL token to access the `/health` HTP endpoint for services. The bootstrap token may be used if an ACL token is not already provisioned. 
   
-    ```shell-session
-    $ export CONSUL_HTTP_TOKEN=<INSERT BOOTSTRAP ACL TOKEN> 
-    ```
+      ```shell-session
+      $ export CONSUL_HTTP_TOKEN=<INSERT BOOTSTRAP ACL TOKEN> 
+      ```
   
-  1. Query the the `/health` HTTP endpoint. The peered services should no longer appear.
+    1. Query the the `/health` HTTP endpoint. The peered services should no longer appear.
  
-   ```shell-session
-    $ curl "localhost:8500/v1/health/connect/backend?peer=cluster-02"
-    ```
+     ```shell-session
+      $ curl "localhost:8500/v1/health/connect/backend?peer=cluster-02"
+      ```
 
 ## Recreate or reset a peering connection
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -292,7 +292,7 @@ The examples described in this section demonstrate how to export a service named
 
 1. Add the `"consul.hashicorp.com/connect-inject": "true"` annotation to your service's pods before deploying the workload so that the services in `cluster-01` can dial `backend` in `cluster-02`. To dial the upstream service from an application, configure the application so that that requests are sent to the correct DNS name as specified in [Service Virtual IP Lookups](/docs/discovery/dns#service-virtual-ip-lookups). In the following example, the annotation that allows the workload to join the mesh and the configuration provided to the workload that enables the workload to dial the upstream service using the correct DNS name is highlighted. 
 
-    <CodeBlockConfig filename="frontend.yaml" highlight="34">
+    <CodeBlockConfig filename="frontend.yaml" highlight="36,51">
 
     ```yaml
     # Service to expose frontend
@@ -359,7 +359,7 @@ The examples described in this section demonstrate how to export a service named
 1. Apply the service file to the first cluster.
 
     ```shell-session
-    $ kubectl --context $CLUSTER1_CONTEXT apply --filename frontend.yaml
+    $ kubectl --context $CLUSTER1_CONTEXT delete --filename acceptor.yaml
     ```
 
 1. Run the following command in `frontend` and then check the output to confirm that you peered your clusters successfully.
@@ -405,10 +405,24 @@ The examples described in this section demonstrate how to export a service named
 ## End a peering connection
 
 To end a peering connection, delete both the `PeeringAcceptor` and `PeeringDialer` resources.
+ 
+1. Delete the `PeeringDialer` resource from the second cluster.
 
-To confirm that you deleted your peering connection, in `cluster-01`, query the `/health` HTTP endpoint. The peered services should no longer appear.
+  ```shell-session
+  $ kubectl --context $CLUSTER2_CONTEXT delete --filename dialer.yaml 
+  ```
+
+1. Delete the `PeeringAcceptor` resource from the first cluster.
+
+    ```shell-session
+    $ kubectl --context $CLUSTER1_CONTEXT delete --filename acceptor.yaml
+    ````
+
+1. Confirm that you deleted your peering connection, in `cluster-01`, by querying the the `/health` HTTP endpoint. The peered services should no longer appear.
 
 ```shell-session
+$ kubectl exec -it consul-server-0 -- /bin/sh
+$ export CONSUL_HTTP_TOKEN=<INSERT BOOTSTRAP ACL TOKEN> # export ACL token if ACLs are enabled
 $ curl "localhost:8500/v1/health/connect/backend?peer=cluster-02"
 ```
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -420,21 +420,23 @@ To end a peering connection, delete both the `PeeringAcceptor` and `PeeringDiale
 
 1. Confirm that you deleted your peering connection in `cluster-01` by querying the the `/health` HTTP endpoint. The peered services should no longer appear.
 
-
-  Exec into the server pod for the first cluster. 
-  ```shell-session
-  $ kubectl exec -it consul-server-0 -- /bin/sh
-  ```
+  1. Exec into the server pod for the first cluster. 
   
-  Export an ACL token to access the `/health` HTP endpoint for services. The bootstrap token may be used if an ACL token is not already provisioned. 
-  ```shell-session
-  $ export CONSUL_HTTP_TOKEN=<INSERT BOOTSTRAP ACL TOKEN> 
-  ```
+    ```shell-session
+    $ kubectl exec -it consul-server-0 -- /bin/sh
+    ```
   
-  Query the the `/health` HTTP endpoint. The peered services should no longer appear.
-  ```shell-session
-  $ curl "localhost:8500/v1/health/connect/backend?peer=cluster-02"
-  ```
+  1. Export an ACL token to access the `/health` HTP endpoint for services. The bootstrap token may be used if an ACL token is not already provisioned. 
+  
+    ```shell-session
+    $ export CONSUL_HTTP_TOKEN=<INSERT BOOTSTRAP ACL TOKEN> 
+    ```
+  
+  1. Query the the `/health` HTTP endpoint. The peered services should no longer appear.
+ 
+   ```shell-session
+    $ curl "localhost:8500/v1/health/connect/backend?peer=cluster-02"
+    ```
 
 ## Recreate or reset a peering connection
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -414,17 +414,17 @@ To end a peering connection, delete both the `PeeringAcceptor` and `PeeringDiale
 
 1. Delete the `PeeringAcceptor` resource from the first cluster.
 
-    ```shell-session
-    $ kubectl --context $CLUSTER1_CONTEXT delete --filename acceptor.yaml
-    ````
+  ```shell-session
+  $ kubectl --context $CLUSTER1_CONTEXT delete --filename acceptor.yaml
+  ````
 
 1. Confirm that you deleted your peering connection, in `cluster-01`, by querying the the `/health` HTTP endpoint. The peered services should no longer appear.
 
-```shell-session
-$ kubectl exec -it consul-server-0 -- /bin/sh
-$ export CONSUL_HTTP_TOKEN=<INSERT BOOTSTRAP ACL TOKEN> # export ACL token if ACLs are enabled
-$ curl "localhost:8500/v1/health/connect/backend?peer=cluster-02"
-```
+  ```shell-session
+  $ kubectl exec -it consul-server-0 -- /bin/sh
+  $ export CONSUL_HTTP_TOKEN=<INSERT BOOTSTRAP ACL TOKEN> # export ACL token if ACLs are enabled
+  $ curl "localhost:8500/v1/health/connect/backend?peer=cluster-02"
+  ```
 
 ## Recreate or reset a peering connection
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -359,7 +359,7 @@ The examples described in this section demonstrate how to export a service named
 1. Apply the service file to the first cluster.
 
     ```shell-session
-    $ kubectl --context $CLUSTER1_CONTEXT delete --filename acceptor.yaml
+    $ kubectl --context $CLUSTER1_CONTEXT apply --filename frontend.yaml
     ```
 
 1. Run the following command in `frontend` and then check the output to confirm that you peered your clusters successfully.

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -418,7 +418,7 @@ To end a peering connection, delete both the `PeeringAcceptor` and `PeeringDiale
   $ kubectl --context $CLUSTER1_CONTEXT delete --filename acceptor.yaml
   ````
 
-1. Confirm that you deleted your peering connection, in `cluster-01`, by querying the the `/health` HTTP endpoint. The peered services should no longer appear.
+1. Confirm that you deleted your peering connection in `cluster-01` by querying the the `/health` HTTP endpoint. The peered services should no longer appear.
 
 
   Exec into the server pod for the first cluster. 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -420,9 +420,19 @@ To end a peering connection, delete both the `PeeringAcceptor` and `PeeringDiale
 
 1. Confirm that you deleted your peering connection, in `cluster-01`, by querying the the `/health` HTTP endpoint. The peered services should no longer appear.
 
+
+  Exec into the server pod for the first cluster. 
   ```shell-session
   $ kubectl exec -it consul-server-0 -- /bin/sh
-  $ export CONSUL_HTTP_TOKEN=<INSERT BOOTSTRAP ACL TOKEN> # export ACL token if ACLs are enabled
+  ```
+  
+  Export an ACL token to access the `/health` HTP endpoint for services. The bootstrap token may be used if an ACL token is not already provisioned. 
+  ```shell-session
+  $ export CONSUL_HTTP_TOKEN=<INSERT BOOTSTRAP ACL TOKEN> 
+  ```
+  
+  Query the the `/health` HTTP endpoint. The peered services should no longer appear.
+  ```shell-session
   $ curl "localhost:8500/v1/health/connect/backend?peer=cluster-02"
   ```
 


### PR DESCRIPTION
### Description

- Highlighting on `backend` application was off and not highlighting annotation and config for Consul DNS name
- Add more details for removing Peering CRDs

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
