### PR TITLE
test: fix flaky TestHealthServiceNodes_NodeMetaFilter by waiting until the streaming subsystem has a valid grpc connection

### DIFF
--- a/agent/rpcclient/health/health.go
+++ b/agent/rpcclient/health/health.go
@@ -3,6 +3,8 @@ package health
 import (
 	"context"
 
+	"google.golang.org/grpc/connectivity"
+
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/submatview"
@@ -32,6 +34,16 @@ type CacheGetter interface {
 type MaterializedViewStore interface {
 	Get(ctx context.Context, req submatview.Request) (submatview.Result, error)
 	NotifyCallback(ctx context.Context, req submatview.Request, cID string, cb cache.Callback) error
+}
+
+// IsReadyForStreaming will indicate if the underlying gRPC connection is ready.
+func (c *Client) IsReadyForStreaming() bool {
+	conn := c.MaterializerDeps.Conn
+	if conn == nil {
+		return false
+	}
+
+	return conn.GetState() == connectivity.Ready
 }
 
 func (c *Client) ServiceNodes(


### PR DESCRIPTION
### Description

`TestHealthServiceNodes_NodeMetaFilter` is flaky when executing the streaming variant and in at least one investigation it flaked because the gRPC subsystem hadn't actually gotten a valid stream open to a server by the time the streaming parts tried to use it.

This updates the test (and also `TestHealthIngressServiceNodes`) to wait until that initial priming is complete before running the body of the test.