### PR TITLE
Add docs about upgrading primary mesh gateways

### DIFF
--- a/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
@@ -187,10 +187,12 @@ expected result:
 
 ### Upgrading the primary gateways
 
-Once federation has been established, updates for the addresses of new primary
-gateways are propagated through the gateways in the primary themselves. If the primary
-gateways are upgraded, and their previous instances are decommissioned before
-the updates are propagated, then the primary datacenter will become unreachable.
+Once federation is established, secondary datacenters will continuously request
+updated mesh gateway addresses from the primary datacenter. These requests
+themselves flow through the mesh gateways of the primary datacenter, since
+secondary datacenters cannot dial the primary datacenter's Consul servers directly.
+If the primary gateways are upgraded, and their previous instances are decommissioned
+before the updates are propagated, then the primary datacenter will become unreachable.
 
 To safely upgrade primary gateways, we recommend that you apply one of the following policies:
 - Avoid decommissioning primary gateway IP addresses. This is because the [primary_gateways](/docs/agent/config/config-files#primary_gateways) addresses configured on the secondary servers act as a fallback mechanism for re-establishing connectivity to the primary.

--- a/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
@@ -184,3 +184,17 @@ expected result:
 - Ensure any API request that activates datacenter request forwarding. such as
   [`/v1/catalog/services?dc=<OTHER_DATACENTER_NAME>`](/api-docs/catalog#dc-1)
   succeeds.
+
+### Upgrading the primary gateways
+
+Once federation has been established, updates for the addresses of new primary
+gateways are propagated through the gateways in the primary themselves. If the primary
+gateways are upgraded, and their previous instances are decommissioned before
+the updates are propagated, then the primary datacenter will become unreachable.
+
+To safely upgrade primary gateways it is preferable to do one of the following:
+- Avoid decommissioning primary gateway IP addresses, since the [primary_gateways](/docs/agent/config/config-files#primary_gateways) addresses configured on the secondary
+servers acts as a fallback mechanism to re-establish connectivity to the primary.
+
+- Verify that addresses of the new mesh gateways in the primary were propagated
+to the secondary datacenters before decommissioning the old mesh gateways in the primary.

--- a/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
@@ -192,9 +192,8 @@ gateways are propagated through the gateways in the primary themselves. If the p
 gateways are upgraded, and their previous instances are decommissioned before
 the updates are propagated, then the primary datacenter will become unreachable.
 
-To safely upgrade primary gateways it is preferable to do one of the following:
-- Avoid decommissioning primary gateway IP addresses, since the [primary_gateways](/docs/agent/config/config-files#primary_gateways) addresses configured on the secondary
-servers acts as a fallback mechanism to re-establish connectivity to the primary.
+To safely upgrade primary gateways, we recommend that you apply one of the following policies:
+- Avoid decommissioning primary gateway IP addresses. This is because the [primary_gateways](/docs/agent/config/config-files#primary_gateways) addresses configured on the secondary servers act as a fallback mechanism for re-establishing connectivity to the primary.
 
 - Verify that addresses of the new mesh gateways in the primary were propagated
 to the secondary datacenters before decommissioning the old mesh gateways in the primary.

--- a/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
@@ -188,9 +188,9 @@ expected result:
 ### Upgrading the primary gateways
 
 Once federation is established, secondary datacenters will continuously request
-updated mesh gateway addresses from the primary datacenter. These requests
-themselves flow through the mesh gateways of the primary datacenter, since
-secondary datacenters cannot dial the primary datacenter's Consul servers directly.
+updated mesh gateway addresses from the primary datacenter. Consul routes the requests
+ through the primary datacenter's mesh gateways. This is because
+secondary datacenters cannot directly dial the primary datacenter's Consul servers.
 If the primary gateways are upgraded, and their previous instances are decommissioned
 before the updates are propagated, then the primary datacenter will become unreachable.
 


### PR DESCRIPTION
### Description
Care must be taken when replacing mesh gateways in the primary datacenter. If the old gateway addresses become unreachable before the secondary datacenters receive the new addresses, then the primary datacenter overall will become unreachable.

This commit adds docs related to this class of upgrades.