### PR TITLE
test: possibly fix flaky TestEnvoy/case-ingress-gateway-multiple-services test

### DIFF
--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
@@ -30,7 +30,6 @@ load helpers
   assert_service_has_healthy_instances s2 1
 }
 
-############ FAIL
 @test "ingress-gateway should have healthy endpoints for s1" {
   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s1 HEALTHY 1
 }

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
@@ -22,6 +22,15 @@ load helpers
   assert_proxy_presents_cert_uri localhost:21001 s2
 }
 
+@test "s1 proxies should be healthy" {
+  assert_service_has_healthy_instances s1 1
+}
+
+@test "s2 proxies should be healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
+############ FAIL
 @test "ingress-gateway should have healthy endpoints for s1" {
   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s1 HEALTHY 1
 }


### PR DESCRIPTION
### Description

The integration test `TestEnvoy/case-ingress-gateway-multiple-services` is flaky and this possibly reduces the flakiness by explicitly waiting for services to show up in the catalog as healthy before waiting for them to show up in envoy as healthy which gives it just a bit more time to sync.