### PR TITLE
chore: fix the module path to align with the code structure

### DIFF
--- a/test/integration/consul-container/go.mod
+++ b/test/integration/consul-container/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/consul/integration/consul-container
+module github.com/hashicorp/consul/test/integration/consul-container
 
 go 1.18
 

--- a/test/integration/consul-container/libs/cluster/cluster.go
+++ b/test/integration/consul-container/libs/cluster/cluster.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/integration/consul-container/libs/node"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/node"
 	"github.com/stretchr/testify/require"
 )
 

--- a/test/integration/consul-container/libs/node/consul-container.go
+++ b/test/integration/consul-container/libs/node/consul-container.go
@@ -14,7 +14,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	"github.com/hashicorp/consul/integration/consul-container/libs/utils"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 
 const bootLogLine = "Consul agent running"

--- a/test/integration/consul-container/metrics/leader_test.go
+++ b/test/integration/consul-container/metrics/leader_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	libcluster "github.com/hashicorp/consul/integration/consul-container/libs/cluster"
-	"github.com/hashicorp/consul/integration/consul-container/libs/node"
-	"github.com/hashicorp/consul/integration/consul-container/libs/utils"
+	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/node"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 
 // Given a 3-server cluster, when the leader is elected, then leader's isLeader is 1 and non-leader's 0

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/hashicorp/consul/api"
 
-	libcluster "github.com/hashicorp/consul/integration/consul-container/libs/cluster"
-	"github.com/hashicorp/consul/integration/consul-container/libs/node"
-	"github.com/hashicorp/consul/integration/consul-container/libs/utils"
+	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/node"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 
 // Test health check GRPC call using Target Servers and Latest GA Clients


### PR DESCRIPTION
### Description

The module path in the changed go.mod is `github.com/hashicorp/consul/integration/consul-container`, which appears to miss `test` in the path. This PR uses the full path.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
