### PR TITLE
fix: wan address isn't used by peering token

### DIFF
--- a/.changelog/15065.txt
+++ b/.changelog/15065.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: fix the error of wan address isn't taken by the peering token.
+```

--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -207,14 +207,9 @@ func meshGatewayAdresses(state *state.Store, ws memdb.WatchSet, wan bool) ([]str
 
 func parseNodeAddr(node *structs.ServiceNode) string {
 	// Prefer the wan address
-	if v, ok := node.TaggedAddresses[structs.TaggedAddressWANIPv4]; ok {
-		return v
-	}
-
 	if v, ok := node.TaggedAddresses[structs.TaggedAddressWAN]; ok {
 		return v
 	}
-
 	return node.Address
 }
 

--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -205,6 +205,19 @@ func meshGatewayAdresses(state *state.Store, ws memdb.WatchSet, wan bool) ([]str
 	return addrs, nil
 }
 
+func parseNodeAddr(node *structs.ServiceNode) string {
+	// Prefer the wan address
+	if v, ok := node.TaggedAddresses[structs.TaggedAddressWANIPv4]; ok {
+		return v
+	}
+
+	if v, ok := node.TaggedAddresses[structs.TaggedAddressWAN]; ok {
+		return v
+	}
+
+	return node.Address
+}
+
 func serverAddresses(state *state.Store) ([]string, error) {
 	_, nodes, err := state.ServiceNodes(nil, "consul", structs.DefaultEnterpriseMetaInDefaultPartition(), structs.DefaultPeerKeyword)
 	if err != nil {
@@ -212,16 +225,18 @@ func serverAddresses(state *state.Store) ([]string, error) {
 	}
 	var addrs []string
 	for _, node := range nodes {
+		addr := parseNodeAddr(node)
+
 		// Prefer the TLS port if it is defined.
 		grpcPortStr := node.ServiceMeta["grpc_tls_port"]
 		if v, err := strconv.Atoi(grpcPortStr); err == nil && v > 0 {
-			addrs = append(addrs, node.Address+":"+grpcPortStr)
+			addrs = append(addrs, addr+":"+grpcPortStr)
 			continue
 		}
 		// Fallback to the standard port if TLS is not defined.
 		grpcPortStr = node.ServiceMeta["grpc_port"]
 		if v, err := strconv.Atoi(grpcPortStr); err == nil && v > 0 {
-			addrs = append(addrs, node.Address+":"+grpcPortStr)
+			addrs = append(addrs, addr+":"+grpcPortStr)
 			continue
 		}
 		// Skip node if neither defined.

--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -219,7 +219,7 @@ func parseNodeAddr(node *structs.ServiceNode) string {
 }
 
 func serverAddresses(state *state.Store) ([]string, error) {
-	_, nodes, err := state.ServiceNodes(nil, "consul", structs.DefaultEnterpriseMetaInDefaultPartition(), structs.DefaultPeerKeyword)
+	_, nodes, err := state.ServiceNodes(nil, structs.ConsulServiceName, structs.DefaultEnterpriseMetaInDefaultPartition(), structs.DefaultPeerKeyword)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description
Use wan address in the peering token.

### Testing & Reproduction steps
With the following agent config,
```
{
   bind_addr =  “172.16.1.10”
   advertise_addr_wan = “192.168.1.10"
}
ports {
  grpc_tls = 8502
  serf_wan = 8302
},
```
the generated token always has the private bind address in "ServerAddresses":["172.16.1.10:8502"]," , which prevents the peering cluster from reaching the acceptor cluster.

### Links
fix #15051

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
