### PR TITLE
Committing for - 15055

### DIFF
--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -197,7 +197,11 @@ func (c *FSM) Restore(old io.ReadCloser) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("Unrecognized msg type %d", msg)
+			if msg > 63 {
+				return fmt.Errorf("msg type <%d> is a Consul Enterprise log entry. Consul OSS does not recognize or load it", msg)
+			} else {
+				return fmt.Errorf("Unrecognized msg type %d", msg)
+			}
 		}
 		return nil
 	}

--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -197,7 +197,7 @@ func (c *FSM) Restore(old io.ReadCloser) error {
 				return err
 			}
 		default:
-			if msg > 63 {
+			if msg >= 64 {
 				return fmt.Errorf("msg type <%d> is a Consul Enterprise log entry. Consul OSS cannot restore it", msg)
 			} else {
 				return fmt.Errorf("Unrecognized msg type %d", msg)

--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -198,7 +198,7 @@ func (c *FSM) Restore(old io.ReadCloser) error {
 			}
 		default:
 			if msg > 63 {
-				return fmt.Errorf("msg type <%d> is a Consul Enterprise log entry. Consul OSS does not recognize or load it", msg)
+				return fmt.Errorf("msg type <%d> is a Consul Enterprise log entry. Consul OSS cannot restore it", msg)
 			} else {
 				return fmt.Errorf("Unrecognized msg type %d", msg)
 			}

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -908,7 +908,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	sink.Write([]byte{byte(structs.MessageType(entMockEntry.ID))})
 	encoder.Encode(entMockEntry)
 
-	require.EqualError(t, fsm.Restore(sink), "msg type <65> is a Consul Enterprise log entry. Consul OSS does not recognize or load it")
+	require.EqualError(t, fsm.Restore(sink), "msg type <65> is a Consul Enterprise log entry. Consul OSS cannot restore it")
 	sink.Cancel()
 }
 

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -882,6 +882,34 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	default:
 		require.Fail(t, "Old state not abandoned")
 	}
+
+	// To verify if a proper message is displayed when Consul OSS tries to
+	//  unsuccessfully restore entries from a Consul Ent snapshot.
+	buf = bytes.NewBuffer(nil)
+	sink = &MockSink{buf, false}
+	fsm, _ = New(nil, logger)
+
+	type EntMock struct {
+		ID   int
+		Type string
+	}
+
+	entMockEntry := EntMock{
+		ID:   65,
+		Type: "A Consul Ent Log Type",
+	}
+
+	// Write the header
+	header := SnapshotHeader{
+		LastIndex: 0,
+	}
+	encoder = codec.NewEncoder(sink, structs.MsgpackHandle)
+	encoder.Encode(&header)
+	sink.Write([]byte{byte(structs.MessageType(entMockEntry.ID))})
+	encoder.Encode(entMockEntry)
+
+	require.EqualError(t, fsm.Restore(sink), "msg type <65> is a Consul Enterprise log entry. Consul OSS does not recognize or load it")
+	sink.Cancel()
 }
 
 // convertACLTokenToLegacy attempts to convert an ACLToken into an legacy ACL.


### PR DESCRIPTION
Closes #15055

### Description
The new error message will indicate that the log entry is a Consul Enterprise one and will not be recognized or loaded by Consul OSS.

### Testing & Reproduction steps

Repro:
* Create a snapshot using a Consul Enterprise build.
* Change the binary to Consul OSS and try to restore the snapshot taken from the above step.
* You will notice the message - `'Unrecognized msg type %d'` and the startup would end.

Testing the changes:
* Repeating the above steps with the new binary will lead to the message - `'msg type <%d> is a Consul Enterprise log entry. Consul OSS does not recognize or load it'`
* Unit test case has been added to - `agent/consul/fsm/snapshot_oss_test.go`
* You could also test the entire `fsm` piece using - `go test github.com/hashicorp/consul/agent/consul/fsm`


### Links
This is for -> https://github.com/hashicorp/consul/issues/15055

### PR Checklist

* [Y] updated test coverage
* [N] external facing docs updated
* [Y] not a security concern
