### PR TITLE
integration test: specify image name for testing dev container

### DIFF
--- a/test/integration/consul-container/libs/node/consul-container.go
+++ b/test/integration/consul-container/libs/node/consul-container.go
@@ -144,7 +144,7 @@ func newContainerRequest(config Config, name, configFile, dataDir, license strin
 
 	app := testcontainers.ContainerRequest{
 		NetworkMode: dockercontainer.NetworkMode("container:" + name + "-pod"),
-		Image:       consulImage + ":" + config.Version,
+		Image:       config.Image + ":" + config.Version,
 		WaitingFor:  wait.ForLog(bootLogLine).WithStartupTimeout(10 * time.Second),
 		AutoRemove:  false,
 		Name:        name,

--- a/test/integration/consul-container/libs/node/consul-container_oss.go
+++ b/test/integration/consul-container/libs/node/consul-container_oss.go
@@ -2,5 +2,3 @@
 // +build !consulent
 
 package node
-
-const consulImage = "consul"

--- a/test/integration/consul-container/libs/node/node.go
+++ b/test/integration/consul-container/libs/node/node.go
@@ -18,6 +18,7 @@ type Node interface {
 // Config is a set of configurations required to create a Node
 type Config struct {
 	HCL     string
+	Image   string
 	Version string
 	Cmd     []string
 }

--- a/test/integration/consul-container/libs/utils/version_oss.go
+++ b/test/integration/consul-container/libs/utils/version_oss.go
@@ -5,5 +5,7 @@ package utils
 
 import "flag"
 
-var TargetImage = flag.String("target-version", "local", "docker image to be used as UUT (unit under test)")
-var LatestImage = flag.String("latest-version", "1.11", "docker image to be used as latest")
+var TargetImage = flag.String("target-image", "consul", "docker image name to be used under test (Default: consul)")
+var TargetVersion = flag.String("target-version", "local", "docker image version to be used as UUT (unit under test)")
+var LatestImage = flag.String("latest-image", "consul", "docker image name to be used under test (Default: consul)")
+var LatestVersion = flag.String("latest-version", "1.11", "docker image to be used as latest")

--- a/test/integration/consul-container/libs/utils/version_oss.go
+++ b/test/integration/consul-container/libs/utils/version_oss.go
@@ -5,6 +5,9 @@ package utils
 
 import "flag"
 
+// TODO: need a better way to abstract the container creation and configuration;
+//       please refer to the discussion in github PR
+
 var TargetImage = flag.String("target-image", "consul", "docker image name to be used under test (Default: consul)")
 var TargetVersion = flag.String("target-version", "local", "docker image version to be used as UUT (unit under test)")
 var LatestImage = flag.String("latest-image", "consul", "docker image name to be used under test (Default: consul)")

--- a/test/integration/consul-container/metrics/leader_test.go
+++ b/test/integration/consul-container/metrics/leader_test.go
@@ -29,7 +29,8 @@ func TestLeadershipMetrics(t *testing.T) {
 						statsite_address = "127.0.0.1:2180"
 					}`,
 			Cmd:     []string{"agent", "-client=0.0.0.0"},
-			Version: *utils.TargetImage,
+			Version: *utils.TargetVersion,
+			Image:   *utils.TargetImage,
 		})
 
 	numServer := 3
@@ -41,7 +42,8 @@ func TestLeadershipMetrics(t *testing.T) {
 					bootstrap_expect=3
 					server=true`,
 				Cmd:     []string{"agent", "-client=0.0.0.0"},
-				Version: *utils.TargetImage,
+				Version: *utils.TargetVersion,
+				Image:   *utils.TargetImage,
 			})
 
 	}

--- a/test/integration/consul-container/upgrade/README.md
+++ b/test/integration/consul-container/upgrade/README.md
@@ -4,3 +4,5 @@
 - run the tests.
 
 To specify targets and latest image pass `target-version` and `latest-version` to the tests. By default, it uses the `consul` docker image with respectively `local` and `latest` tags.
+
+To use dev consul image, pass `target-image` and `target-version`, `-target-image hashicorppreview/consul -target-version 1.14-dev`.

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -22,10 +22,10 @@ func TestTargetServersWithLatestGAClients(t *testing.T) {
 		numClients = 1
 	)
 
-	cluster := serversCluster(t, numServers, *utils.TargetImage)
+	cluster := serversCluster(t, numServers, *utils.TargetVersion, *utils.TargetImage)
 	defer terminate(t, cluster)
 
-	clients := clientsCreate(t, numClients, *utils.LatestImage, cluster.EncryptKey)
+	clients := clientsCreate(t, numClients, *utils.LatestImage, *utils.LatestVersion, cluster.EncryptKey)
 
 	require.NoError(t, cluster.AddNodes(clients))
 
@@ -78,7 +78,8 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 					log_level="DEBUG"
 					server=true`,
 			Cmd:     []string{"agent", "-client=0.0.0.0"},
-			Version: *utils.TargetImage,
+			Version: *utils.TargetVersion,
+			Image:   *utils.TargetImage,
 		})
 
 	for i := 1; i < 3; i++ {
@@ -89,7 +90,8 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 					bootstrap_expect=3
 					server=true`,
 				Cmd:     []string{"agent", "-client=0.0.0.0"},
-				Version: *utils.LatestImage,
+				Version: *utils.LatestVersion,
+				Image:   *utils.LatestImage,
 			})
 
 	}
@@ -102,7 +104,7 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 		numClients = 1
 	)
 
-	clients := clientsCreate(t, numClients, *utils.LatestImage, cluster.EncryptKey)
+	clients := clientsCreate(t, numClients, *utils.LatestImage, *utils.LatestVersion, cluster.EncryptKey)
 
 	require.NoError(t, cluster.AddNodes(clients))
 
@@ -156,7 +158,8 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 					bootstrap_expect=3
 					server=true`,
 				Cmd:     []string{"agent", "-client=0.0.0.0"},
-				Version: *utils.TargetImage,
+				Version: *utils.TargetVersion,
+				Image:   *utils.TargetImage,
 			})
 
 	}
@@ -166,7 +169,8 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 					log_level="DEBUG"
 					server=true`,
 			Cmd:     []string{"agent", "-client=0.0.0.0"},
-			Version: *utils.LatestImage,
+			Version: *utils.LatestVersion,
+			Image:   *utils.LatestImage,
 		})
 
 	cluster, err := libcluster.New(configs)
@@ -177,7 +181,7 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 		numClients = 1
 	)
 
-	clients := clientsCreate(t, numClients, *utils.LatestImage, cluster.EncryptKey)
+	clients := clientsCreate(t, numClients, *utils.LatestImage, *utils.LatestVersion, cluster.EncryptKey)
 
 	require.NoError(t, cluster.AddNodes(clients))
 
@@ -220,7 +224,7 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 	}
 }
 
-func clientsCreate(t *testing.T, numClients int, version string, serfKey string) []node.Node {
+func clientsCreate(t *testing.T, numClients int, image string, version string, serfKey string) []node.Node {
 	clients := make([]node.Node, numClients)
 	for i := 0; i < numClients; i++ {
 		var err error
@@ -232,6 +236,7 @@ func clientsCreate(t *testing.T, numClients int, version string, serfKey string)
 				encrypt = %q`, utils.RandName("consul-client"), serfKey),
 				Cmd:     []string{"agent", "-client=0.0.0.0"},
 				Version: version,
+				Image:   image,
 			})
 		require.NoError(t, err)
 	}
@@ -251,7 +256,7 @@ func serviceCreate(t *testing.T, client *api.Client, serviceName string) uint64 
 	return meta.LastIndex
 }
 
-func serversCluster(t *testing.T, numServers int, version string) *libcluster.Cluster {
+func serversCluster(t *testing.T, numServers int, version string, image string) *libcluster.Cluster {
 	var configs []node.Config
 	for i := 0; i < numServers; i++ {
 		configs = append(configs, node.Config{
@@ -261,6 +266,7 @@ func serversCluster(t *testing.T, numServers int, version string) *libcluster.Cl
 					server=true`,
 			Cmd:     []string{"agent", "-client=0.0.0.0"},
 			Version: version,
+			Image:   image,
 		})
 	}
 	cluster, err := libcluster.New(configs)


### PR DESCRIPTION
### Description
Sometimes we need to run integration for a dev image such as `hashicorppreview/consul:1.14-dev`. The current implementation hardcoded the image name to be `consul`.

This PR adds options to specify the image name to be tested.
- Some note is added to `README`

### Testing & Reproduction steps
NA

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
