### PR TITLE
fixed broken link/typo in service mesh reg page

### DIFF
--- a/website/content/docs/connect/registration/service-registration.mdx
+++ b/website/content/docs/connect/registration/service-registration.mdx
@@ -89,7 +89,7 @@ Specify the following parameters in the `proxy` code block to configure a sideca
 * `local_service_port`: Integer value that specifies the port that the proxy should use to connect to the _local_ service instance. Refer to the [proxy parameters reference](#local-service-port) for details.
 * `local_service_address`: String value that specifies the IP address or hostname that the proxy should use to connect to the _local_ service. Refer to the [proxy parameters reference](#local-service-address) for details.
 
-See (Sidecar Service Registration)[/docs/connect/registration/sidecar-service] for additional information about configuring service mesh proxies as sidecars.
+See [Sidecar Service Registration](/docs/connect/registration/sidecar-service) for additional information about configuring service mesh proxies as sidecars.
 
 ### Complete Configuration Example
 


### PR DESCRIPTION
### Description
This PR fixes a typo in the Service mesh > Register a Service page.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
