### PR TITLE
Return forbidden on permission denied

### DIFF
--- a/agent/http.go
+++ b/agent/http.go
@@ -21,6 +21,8 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/cache"
@@ -372,6 +374,9 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 
 		isForbidden := func(err error) bool {
 			if acl.IsErrPermissionDenied(err) || acl.IsErrNotFound(err) {
+				return true
+			}
+			if e, ok := status.FromError(err); ok && e.Code() == codes.PermissionDenied {
 				return true
 			}
 			return false

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -556,7 +556,7 @@ func (s *Server) exchangeSecret(ctx context.Context, peering *pbpeering.Peering,
 		// If we got a permission denied error that means out establishment secret is invalid, so we do not retry.
 		grpcErr, ok := grpcstatus.FromError(err)
 		if ok && grpcErr.Code() == codes.PermissionDenied {
-			return nil, fmt.Errorf("a new peering token must be generated: %w", grpcErr.Err())
+			return nil, grpcstatus.Errorf(codes.PermissionDenied, "a new peering token must be generated: %s", grpcErr.Message())
 		}
 		if err != nil {
 			dialErrors = multierror.Append(dialErrors, fmt.Errorf("failed to exchange peering secret through address %q: %w", addr, err))

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -510,6 +510,9 @@ func TestPeeringService_Establish_ThroughMeshGateway(t *testing.T) {
 			PeerName:     "my-peer-acceptor",
 			PeeringToken: peeringToken,
 		})
+		grpcErr, ok := grpcstatus.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.PermissionDenied, grpcErr.Code())
 		testutil.RequireErrorContains(t, err, "a new peering token must be generated")
 	})
 


### PR DESCRIPTION
### Description
This commit updates the establish endpoint to bubble up a 403 status code to callers when the establishment secret from the token is invalid. This is an additional signal that a new peering token must be generated.

### Testing & Reproduction steps
* Updated the gRPC handler's test
* Manually tested re-using a token via the CLI and got the following output:
> Error establishing peering for cluster-02: Unexpected response code: 403 (rpc error: code = PermissionDenied desc = a new peering token must be generated: invalid peering establishment secret)

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
