### PR TITLE
connect: Add Envoy 1.24 to integration tests, remove Envoy 1.20

### DIFF
--- a/.changelog/15093.txt
+++ b/.changelog/15093.txt
@@ -1,0 +1,6 @@
+```release-note: improvement
+connect: Add Envoy 1.24.0 to support matrix
+```
+```release-note: breaking-change
+connect: Removes support for Envoy 1.20
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,10 @@ references:
     VAULT_BINARY_VERSION: 1.9.4
     GO_VERSION: 1.18.1
   envoy-versions: &supported_envoy_versions
-    - &default_envoy_version "1.20.7"
-    - "1.21.5"
+    - &default_envoy_version "1.21.5"
     - "1.22.5"
-    - "1.23.1"
+    - "1.23.2"
+    - "1.24.0"
   nomad-versions: &supported_nomad_versions
     - &default_nomad_version "1.3.3"
     - "1.2.10"

--- a/agent/xds/envoy_versioning.go
+++ b/agent/xds/envoy_versioning.go
@@ -11,7 +11,7 @@ import (
 var (
 	// minSupportedVersion is the oldest mainline version we support. This should always be
 	// the zero'th point release of the last element of proxysupport.EnvoyVersions.
-	minSupportedVersion = version.Must(version.NewVersion("1.20.0"))
+	minSupportedVersion = version.Must(version.NewVersion("1.21.0"))
 
 	specificUnsupportedVersions = []unsupportedVersion{}
 )

--- a/agent/xds/envoy_versioning_test.go
+++ b/agent/xds/envoy_versioning_test.go
@@ -121,6 +121,7 @@ func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 		"1.17.4": {expectErr: "Envoy 1.17.4 " + errTooOld},
 		"1.18.6": {expectErr: "Envoy 1.18.6 " + errTooOld},
 		"1.19.5": {expectErr: "Envoy 1.19.5 " + errTooOld},
+		"1.20.7": {expectErr: "Envoy 1.20.7 " + errTooOld},
 	}
 
 	// Insert a bunch of valid versions.
@@ -135,10 +136,10 @@ func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 	}
 	*/
 	for _, v := range []string{
-		"1.20.0", "1.20.1", "1.20.2", "1.20.3", "1.20.4", "1.20.5", "1.20.6", "1.20.7",
 		"1.21.0", "1.21.1", "1.21.2", "1.21.3", "1.21.4", "1.21.5",
 		"1.22.0", "1.22.1", "1.22.2", "1.22.3", "1.22.4", "1.22.5",
-		"1.23.0", "1.23.1",
+		"1.23.0", "1.23.1", "1.23.2",
+		"1.24.0",
 	} {
 		cases[v] = testcase{expect: supportedProxyFeatures{}}
 	}

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -7,8 +7,8 @@ package proxysupport
 //
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
-	"1.23.1",
+	"1.24.0",
+	"1.23.2",
 	"1.22.5",
 	"1.21.5",
-	"1.20.7",
 }

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -39,9 +39,9 @@ Consul supports **four major Envoy releases** at the beginning of each major Con
 
 | Consul Version      | Compatible Envoy Versions                                                          |
 | ------------------- | -----------------------------------------------------------------------------------|
+| 1.14.x              | 1.24.0, 1.23.1, 1.22.5, 1.21.5                                                     |
 | 1.13.x              | 1.23.1, 1.22.5, 1.21.5, 1.20.7                                                     |
 | 1.12.x              | 1.22.5, 1.21.5, 1.20.7, 1.19.5                                                     |
-| 1.11.x              | 1.20.7, 1.19.5, 1.18.6, 1.17.4<sup>1</sup>                                         |
 
 1. Envoy 1.20.1 and earlier are vulnerable to [CVE-2022-21654](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21654) and [CVE-2022-21655](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21655). Both CVEs were patched in Envoy versions 1.18.6, 1.19.3, and 1.20.2.
 Envoy 1.16.x and older releases are no longer supported (see [HCSEC-2022-07](https://discuss.hashicorp.com/t/hcsec-2022-07-consul-s-connect-service-mesh-affected-by-recent-envoy-security-releases/36332)). Consul 1.9.x clusters should be upgraded to 1.10.x and Envoy upgraded to the latest supported Envoy version for that release, 1.18.6.


### PR DESCRIPTION
### Description
Envoy 1.24.0 was recently released. This adds it to our integration test matrix. Because we are introducing a new minor series of Envoy, this means we drop the oldest minor which is 1.20. 

### Testing & Reproduction steps
If the integration test suite fails, we will need to make changes, otherwise we are good.

### Links
- [Envoy 1.24.0](https://github.com/envoyproxy/envoy/releases/tag/v1.24.0)