### PR TITLE
[OSS] chore: update main for release/1.14.x branch

### DIFF
--- a/.github/workflows/nightly-test-1.14.x.yaml
+++ b/.github/workflows/nightly-test-1.14.x.yaml
@@ -1,0 +1,230 @@
+name: Nightly Test 1.14.x
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch: {}
+
+env:
+  EMBER_PARTITION_TOTAL: 4      # Has to be changed in tandem with the matrix.partition
+  BRANCH: "release/1.14.x"
+  BRANCH_NAME: "release-1.14.x" # Used for naming artifacts
+
+jobs:
+  frontend-test-workspace-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Workspace Tests
+        id: workspace-test
+        working-directory: ./ui
+        run: make test-workspace
+
+      - name: Node Tests
+        id: node-test
+        working-directory: ./ui/packages/consul-ui
+        run: make test-node
+
+  frontend-build-oss:
+    runs-on: ubuntu-latest
+    env:
+      JOBS: 2
+      CONSUL_NSPACES_ENABLED: 0
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Ember Build OSS
+        id: build-oss
+        working-directory: ./ui/packages/consul-ui
+        run: make build-ci
+
+      - name: Upload OSS Frontend
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend-oss-${{ env.BRANCH_NAME }}
+          path: ./ui/packages/consul-ui/dist
+          if-no-files-found: error
+
+  frontend-test-oss:
+    runs-on: ubuntu-latest
+    needs: [frontend-build-oss]
+    strategy:
+      matrix:
+        partition: [ 1, 2, 3, 4 ]
+    env:
+      CONSUL_NSPACES_ENABLED: 0
+      EMBER_TEST_REPORT: test-results/report-oss.xml #outputs test report for CircleCI test summary
+      EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Download OSS Frontend
+        uses: actions/download-artifact@v3
+        with:
+          name: frontend-oss-${{ env.BRANCH_NAME }}
+          path: ./ui/packages/consul-ui/dist
+
+      - name: Ember Test OSS
+        id: cache
+        working-directory: ./ui/packages/consul-ui
+        run: node_modules/.bin/ember exam --split=$EMBER_PARTITION_TOTAL --partition=${{ matrix.partition }} --path dist --silent -r xunit
+
+  frontend-build-ent:
+    runs-on: ubuntu-latest
+    env:
+      JOBS: 2
+      CONSUL_NSPACES_ENABLED: 1
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Ember Build ENT
+        id: build-oss
+        working-directory: ./ui/packages/consul-ui
+        run: make build-ci
+
+      - name: Upload ENT Frontend
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend-ent-${{ env.BRANCH_NAME }}
+          path: ./ui/packages/consul-ui/dist
+          if-no-files-found: error
+
+  frontend-test-ent:
+    runs-on: ubuntu-latest
+    needs: [frontend-build-ent]
+    strategy:
+      matrix:
+        partition: [ 1, 2, 3, 4 ]
+    env:
+      CONSUL_NSPACES_ENABLED: 1
+      EMBER_TEST_REPORT: test-results/report-oss.xml #outputs test report for CircleCI test summary
+      EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Download ENT Frontend
+        uses: actions/download-artifact@v3
+        with:
+          name: frontend-ent-${{ env.BRANCH_NAME }}
+          path: ./ui/packages/consul-ui/dist
+
+      - name: Ember Test ENT
+        id: cache
+        working-directory: ./ui/packages/consul-ui
+        run: node_modules/.bin/ember exam --split=$EMBER_PARTITION_TOTAL --partition=${{ matrix.partition }} --path dist --silent -r xunit
+
+  frontend-test-coverage-ent:
+    runs-on: ubuntu-latest
+    needs: [frontend-build-ent]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Download ENT Frontend
+        uses: actions/download-artifact@v3
+        with:
+          name: frontend-ent-${{ env.BRANCH_NAME }}
+          path: ./ui/packages/consul-ui/dist
+
+      - name: Run ENT Code Coverage
+        working-directory: ./ui/packages/consul-ui
+        run: make test-coverage-ci
+
+  slack-failure-notification:
+    runs-on: ubuntu-latest
+    needs: [frontend-test-oss, frontend-test-ent]
+    if: ${{ failure() }}
+    steps:
+      - name: Slack Notification
+        id: slack
+        uses: slackapi/slack-github-action@v1.19
+        with:
+          payload: |
+            {
+              "message": "One or more nightly UI tests have failed on branch ${{ env.BRANCH }} for Consul. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_UI_SLACK_WEBHOOK }}

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.14.0"
+	Version = "1.15.0"
 
 	// https://semver.org/#spec-item-10
 	VersionMetadata = ""


### PR DESCRIPTION
### Description
Branch `release/1.14.x` was just created, which moves `main` to build the dev version of Consul 1.15. This also adds a Nightly UI test job for the 1.14 branch. Despite git thinking this was renamed from `1.11`, I actually copied it from `main` to get the most current CI flow. 
