### PR TITLE
docs: update versions to include .x in release notes

### DIFF
--- a/website/content/docs/release-notes/consul-k8s/v0_49_x.mdx
+++ b/website/content/docs/release-notes/consul-k8s/v0_49_x.mdx
@@ -22,7 +22,7 @@ description: >-
 ## Supported Software
 
 - Consul 1.11.x, Consul 1.12.x and Consul 1.13.1+
-- Kubernetes 1.19-1.24
+- Kubernetes 1.19.x - 1.24.x 
 - Kubectl 1.19+
 - Helm 3.2+
 - Envoy proxy support is determined by the Consul version deployed. Refer to
@@ -35,7 +35,7 @@ For detailed information on upgrading, please refer to the [Upgrades page](/docs
 ## Known Issues
 The following issues are know to exist in the v0.49.0 release: 
 
-- Kubernetes 1.25 is not supported as the [Pod Security Admission controller](https://kubernetes.io/blog/2022/08/25/pod-security-admission-stable/) is currently not supported by Consul K8s. 
+- Kubernetes 1.25.x is not supported as the [Pod Security Admission controller](https://kubernetes.io/blog/2022/08/25/pod-security-admission-stable/) is currently not supported by Consul K8s. 
 
 ## Changelogs
 


### PR DESCRIPTION
### Description

Add .x next to supported k8s versions to make it explicit that all patch versions of k8s minor versions are supported 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
