### PR TITLE
fix: return error when config file with unknown extension is passed

### DIFF
--- a/.changelog/15107.txt
+++ b/.changelog/15107.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: fatal error if config file does not have HCL or JSON extension, instead of warn and skip
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -56,6 +56,10 @@ type LoadOpts struct {
 
 	// ConfigFiles is a slice of paths to config files and directories that will
 	// be loaded.
+	//
+	// It is an error for any config files to have an extension other than `hcl`
+	// or `json`, unless ConfigFormat is also set. However, non-HCL/JSON files in
+	// a config directory are merely skipped, with a warning.
 	ConfigFiles []string
 
 	// ConfigFormat forces all config files to be interpreted as this format
@@ -228,8 +232,7 @@ func (b *builder) sourcesFromPath(path string, format string) ([]Source, error) 
 
 	if !fi.IsDir() {
 		if !shouldParseFile(path, format) {
-			b.warn("skipping file %v, extension must be .hcl or .json, or config format must be set", path)
-			return nil, nil
+			return nil, fmt.Errorf("file %v has unknown extension; must be .hcl or .json, or config format must be set", path)
 		}
 
 		src, err := newSourceFromFile(path, format)

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -92,18 +92,21 @@ func TestNewBuilder_PopulatesSourcesFromConfigFiles(t *testing.T) {
 		filepath.Join(path, "c.yaml"),
 	}
 
-	t.Run("skip unknown files", func(t *testing.T) {
-		b, err := newBuilder(LoadOpts{ConfigFiles: append(paths, subpath)})
+	t.Run("fail on unknown files", func(t *testing.T) {
+		_, err := newBuilder(LoadOpts{ConfigFiles: append(paths, subpath)})
+		require.Error(t, err)
+	})
+
+	t.Run("skip on unknown files in dir", func(t *testing.T) {
+		b, err := newBuilder(LoadOpts{ConfigFiles: []string{subpath}})
 		require.NoError(t, err)
 
 		expected := []Source{
-			FileSource{Name: paths[0], Format: "hcl", Data: "content a"},
-			FileSource{Name: paths[1], Format: "json", Data: "content b"},
 			FileSource{Name: filepath.Join(subpath, "a.hcl"), Format: "hcl", Data: "content a"},
 			FileSource{Name: filepath.Join(subpath, "b.json"), Format: "json", Data: "content b"},
 		}
 		require.Equal(t, expected, b.Sources)
-		require.Len(t, b.Warnings, 2)
+		require.Len(t, b.Warnings, 1)
 	})
 
 	t.Run("force config format", func(t *testing.T) {

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -68,49 +68,11 @@ func TestShouldParseFile(t *testing.T) {
 }
 
 func TestNewBuilder_PopulatesSourcesFromConfigFiles(t *testing.T) {
-	subpath, paths := setupConfigFiles(t)
-
-	b, err := newBuilder(LoadOpts{ConfigFiles: append(paths, subpath)})
-	require.NoError(t, err)
-
-	expected := []Source{
-		FileSource{Name: paths[0], Format: "hcl", Data: "content a"},
-		FileSource{Name: paths[1], Format: "json", Data: "content b"},
-		FileSource{Name: filepath.Join(subpath, "a.hcl"), Format: "hcl", Data: "content a"},
-		FileSource{Name: filepath.Join(subpath, "b.json"), Format: "json", Data: "content b"},
-	}
-	require.Equal(t, expected, b.Sources)
-	require.Len(t, b.Warnings, 2)
-}
-
-func TestNewBuilder_PopulatesSourcesFromConfigFiles_WithConfigFormat(t *testing.T) {
-	subpath, paths := setupConfigFiles(t)
-
-	b, err := newBuilder(LoadOpts{ConfigFiles: append(paths, subpath), ConfigFormat: "hcl"})
-	require.NoError(t, err)
-
-	expected := []Source{
-		FileSource{Name: paths[0], Format: "hcl", Data: "content a"},
-		FileSource{Name: paths[1], Format: "hcl", Data: "content b"},
-		FileSource{Name: paths[2], Format: "hcl", Data: "content c"},
-		FileSource{Name: filepath.Join(subpath, "a.hcl"), Format: "hcl", Data: "content a"},
-		FileSource{Name: filepath.Join(subpath, "b.json"), Format: "hcl", Data: "content b"},
-		FileSource{Name: filepath.Join(subpath, "c.yaml"), Format: "hcl", Data: "content c"},
-	}
-	require.Equal(t, expected, b.Sources)
-}
-
-// writes a set of test files into a temp directory, and also to a subdirectory of
-// that temp directory, subpath
-//
-// TODO: this would be much nicer with gotest.tools/fs
-func setupConfigFiles(t *testing.T) (subpath string, paths []string) {
-	t.Helper()
 	path, err := os.MkdirTemp("", t.Name())
 	require.NoError(t, err)
 	t.Cleanup(func() { os.RemoveAll(path) })
 
-	subpath = filepath.Join(path, "sub")
+	subpath := filepath.Join(path, "sub")
 	err = os.Mkdir(subpath, 0755)
 	require.NoError(t, err)
 
@@ -124,11 +86,40 @@ func setupConfigFiles(t *testing.T) (subpath string, paths []string) {
 		err = os.WriteFile(filepath.Join(dir, "c.yaml"), []byte("content c"), 0644)
 		require.NoError(t, err)
 	}
-	return subpath, []string{
+	paths := []string{
 		filepath.Join(path, "a.hcl"),
 		filepath.Join(path, "b.json"),
 		filepath.Join(path, "c.yaml"),
 	}
+
+	t.Run("skip unknown files", func(t *testing.T) {
+		b, err := newBuilder(LoadOpts{ConfigFiles: append(paths, subpath)})
+		require.NoError(t, err)
+
+		expected := []Source{
+			FileSource{Name: paths[0], Format: "hcl", Data: "content a"},
+			FileSource{Name: paths[1], Format: "json", Data: "content b"},
+			FileSource{Name: filepath.Join(subpath, "a.hcl"), Format: "hcl", Data: "content a"},
+			FileSource{Name: filepath.Join(subpath, "b.json"), Format: "json", Data: "content b"},
+		}
+		require.Equal(t, expected, b.Sources)
+		require.Len(t, b.Warnings, 2)
+	})
+
+	t.Run("force config format", func(t *testing.T) {
+		b, err := newBuilder(LoadOpts{ConfigFiles: append(paths, subpath), ConfigFormat: "hcl"})
+		require.NoError(t, err)
+
+		expected := []Source{
+			FileSource{Name: paths[0], Format: "hcl", Data: "content a"},
+			FileSource{Name: paths[1], Format: "hcl", Data: "content b"},
+			FileSource{Name: paths[2], Format: "hcl", Data: "content c"},
+			FileSource{Name: filepath.Join(subpath, "a.hcl"), Format: "hcl", Data: "content a"},
+			FileSource{Name: filepath.Join(subpath, "b.json"), Format: "hcl", Data: "content b"},
+			FileSource{Name: filepath.Join(subpath, "c.yaml"), Format: "hcl", Data: "content c"},
+		}
+		require.Equal(t, expected, b.Sources)
+	})
 }
 
 func TestLoad_NodeName(t *testing.T) {


### PR DESCRIPTION
### Description

This should clear up a little confusion over error messages:

```bash
$ consul -version
Consul v1.13.3
Build Date 1970-01-01T00:00:01Z
Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)

$ cat > config.js # generate basic config
{"data_dir": "/tmp"}
```

#### Before

```bash
$ consul validate config.js # confusing error message: "I thought I set that?"
Config validation failed: data_dir cannot be empty
```

#### After

```bash
$ go run . validate config.js # after this PR: "ah, I need to set config format"
Config validation failed: file config.js has unknown extension; must be .hcl or .json, or config format must be set
exit status 1
$ go run . validate -config-format=json config.js
Configuration is valid!
```

Unlike in the config directory situation, where there might be unrelated files in the directory (e.g., README) that we should just skip, the user is directly specifying the file to load. If it is unloadable, that should be a fatal error.

Discovered in https://github.com/hashicorp/consul/issues/3897#issuecomment-1287368405

### Testing & Reproduction steps

See above

### PR Checklist

* [x] ~~updated test coverage~~: not sure we can test this in any nice way besides checking strings
* [x] ~~external facing docs updated~~: N/A
* [x] not a security concern
