### PR TITLE
fix(peering): replicating wan address

### DIFF
--- a/.changelog/15108.txt
+++ b/.changelog/15108.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: when wan address is set, peering stream should use the wan address.
+```

--- a/agent/grpc-external/services/peerstream/subscription_manager.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager.go
@@ -909,7 +909,13 @@ func (m *subscriptionManager) subscribeServerAddrs(
 			if srv.ExtGRPCPort == 0 {
 				continue
 			}
-			grpcAddr := srv.Address + ":" + strconv.Itoa(srv.ExtGRPCPort)
+			addr := srv.Address
+
+			// wan address is preferred
+			if v, ok := srv.TaggedAddresses[structs.TaggedAddressWAN]; ok && v != "" {
+				addr = v
+			}
+			grpcAddr := addr + ":" + strconv.Itoa(srv.ExtGRPCPort)
 			serverAddrs = append(serverAddrs, grpcAddr)
 		}
 		if len(serverAddrs) == 0 {

--- a/agent/grpc-external/services/peerstream/subscription_manager_test.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager_test.go
@@ -710,6 +710,35 @@ func TestSubscriptionManager_ServerAddrs(t *testing.T) {
 		)
 	})
 
+	testutil.RunStep(t, "added server with WAN address", func(t *testing.T) {
+		payload = append(payload, autopilotevents.ReadyServerInfo{
+			ID:          "eec8721f-c42b-48da-a5a5-07565158015e",
+			Address:     "198.18.0.3",
+			Version:     "1.13.1",
+			ExtGRPCPort: 9502,
+			TaggedAddresses: map[string]string{
+				structs.TaggedAddressWAN: "198.18.0.103",
+			},
+		})
+		backend.Publish([]stream.Event{
+			{
+				Topic:   autopilotevents.EventTopicReadyServers,
+				Index:   3,
+				Payload: payload,
+			},
+		})
+
+		expectEvents(t, subCh,
+			func(t *testing.T, got cache.UpdateEvent) {
+				require.Equal(t, subServerAddrs, got.CorrelationID)
+				addrs, ok := got.Result.(*pbpeering.PeeringServerAddresses)
+				require.True(t, ok)
+
+				require.Equal(t, []string{"198.18.0.1:8502", "198.18.0.2:9502", "198.18.0.103:9502"}, addrs.GetAddresses())
+			},
+		)
+	})
+
 	testutil.RunStep(t, "flipped to peering through mesh gateways", func(t *testing.T) {
 		require.NoError(t, backend.store.EnsureConfigEntry(1, &structs.MeshConfigEntry{
 			Peering: &structs.PeeringMeshConfig{


### PR DESCRIPTION
### Description
When sending server address to the dialing peer cluster, wan address should be used if there is any.

This PR is consistent to the fix for generating peering token (#15065).

### Testing & Reproduction steps

### Links
fix #15087

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
