### PR TITLE
ui: fix - customize ember-auto-import publicAssetURL in production

### DIFF
--- a/ui/packages/consul-ui/ember-cli-build.js
+++ b/ui/packages/consul-ui/ember-cli-build.js
@@ -17,6 +17,7 @@ module.exports = function (defaults, $ = process.env) {
 
   $ = utils.env($);
   const env = EmberApp.env();
+  const isProd = ['production'].includes(env);
   const prodlike = ['production', 'staging'];
   const devlike = ['development', 'staging'];
   const sourcemaps = !['production'].includes(env) && !$('BABEL_DISABLE_SOURCEMAPS', false);
@@ -197,6 +198,7 @@ module.exports = function (defaults, $ = process.env) {
       autoImport: {
         // allows use of a CSP without 'unsafe-eval' directive
         forbidEval: true,
+        publicAssetURL: isProd ? '{{.ContentPath}}assets' : undefined,
       },
       codemirror: {
         keyMaps: ['sublime'],


### PR DESCRIPTION
### Description
When building the application for production, the auto-generated URLs for webpack asset chunks that ember-auto-import v2 adds to `index.html` pointed to the wrong URL. Instead of containing the `{{.ContentPath}}`-placeholder they were pointing to `/ui/assets`. This is correct in the default use-case for bundling the UI in the consul-binary, but would break when trying to serve the UI from a different place than `/ui`.

#### The fix
The `lib/startup`-add-on is used to create a custom index.html page to boot up the app. Because of this being a custom approach, ember-auto-import isn't doing the right thing by default, as we aren't relying on setting `rootURL` to a different value when running the app in `production`. We need to set `publicAssetURL` explicitly in the configuration we pass to `ember-auto-import` to resolve this issue.

Reference:
https://github.com/ef4/ember-auto-import/blob/9a2887f1d09c1df2a41d7e6800820ba23183365e/docs/upgrade-guide-2.0.md#quick-summary


### Testing & Reproduction steps
For regular builds this wasn't an issue as `ember-auto-import` will fall back to the `rootURL` to determine what to prepend to the URL for webpack chunks. This breaks for whenever somebody tried to set `{{.ContentPath}}` to a different value than `/ui`, our default `rootURL`. To verify the changed behavior, you can run `yarn build` and look at the content of `dist/index.html`. Before this change, the webpack chunks that ember-auto-import adds into this file were prepended with `/ui/assets`. After this change, the URL the chunks point to will contain the expected placeholder `{{.ContentPath}}assets/chunk-...`

### Notable
This change only will customize `publicAssetURL` when building for `production`. This matches the behavior of `lib/startup`'s handling of `{{.ContentPath}}`.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
