### PR TITLE
[1.13 backport] auto cert 1.13.2 upgrade docs

### DIFF
--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -46,7 +46,7 @@ Upgrade to **Consul version 1.13.2 or later** if using
 In Consul 1.13.0 - 1.13.1, auto-encrypt and auto-config both cause Consul
 to require TLS for gRPC communication with Envoy proxies.
 In environments where Envoy proxies are not already configured
-to use TLS for gRPC, upgrading Consul Consul 1.13.0 - 1.13.1 will cause
+to use TLS for gRPC, upgrading to Consul 1.13.0 - 1.13.1 will cause
 Envoy proxies to disconnect from the control plane (Consul agents).
 
 If upgrading to version 1.13.2 you must also enable

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -48,11 +48,11 @@ to use TLS for gRPC, upgrading Consul 1.13.1 will cause
 Envoy proxies to disconnect from the control plane (Consul agents).
 
 If upgrading to version 1.13.2 from 1.13.1 you must enable
-[tls.grpc.use_auto_cert](https://developer.hashicorp.com/consul/docs/agent/config/config-files#use_auto_cert)
+[tls.grpc.use_auto_cert](/docs/agent/config/config-files#use_auto_cert)
 if you currently use the Connect CA and auto-encrypt certs for TLS
 on the gRPC port, and do not have certificates configured via
-[tls.grpc](https://developer.hashicorp.com/consul/docs/agent/config/config-files#tls_grpc)
-or [tls.defaults](https://developer.hashicorp.com/consul/docs/agent/config/config-files#tls_defaults).
+[tls.grpc](/docs/agent/config/config-files#tls_grpc)
+or [tls.defaults](/docs/agent/config/config-files#tls_defaults).
 The new `use_auto_cert` flag enables TLS for gRPC based on the presence
 of auto-encrypt certs.
 

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -49,7 +49,7 @@ In environments where Envoy proxies are not already configured
 to use TLS for gRPC, upgrading Consul Consul 1.13.0 - 1.13.1 will cause
 Envoy proxies to disconnect from the control plane (Consul agents).
 
-If upgrading to version 1.13.2 from 1.13.1 you must enable
+If upgrading to version 1.13.2 you must also enable
 [tls.grpc.use_auto_cert](/docs/agent/config/config-files#use_auto_cert)
 if you currently use the Connect CA and auto-encrypt certs for TLS
 on the gRPC port, and do not have certificates configured via

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -29,7 +29,7 @@ review the following guidances relevant to your deployment:
 
 Upgrade to **Consul version 1.13.1 or later**.
 
-Consul 1.13.0 contains a bug that prevents Consul server agents from restoring 
+Consul 1.13.0 contains a bug that prevents Consul server agents from restoring
 saved state on startup if the state
 
 1. was generated before Consul 1.13 (such as during an upgrade), and
@@ -39,25 +39,22 @@ This bug is fixed in Consul versions 1.13.1 and newer.
 
 #### Service mesh deployments using auto-encrypt or auto-config
 
-**Do not upgrade to Consul 1.13 yet** if using
-[auto-encrypt](/docs/agent/config/config-files#auto_encrypt) or
-[auto-config](/docs/agent/config/config-files#auto_config).
+Upgrade to **Consul version 1.13.2 or later**.
 
-In Consul 1.13, auto-encrypt and auto-config both cause Consul
+In Consul 1.13.1, auto-encrypt and auto-config both cause Consul
 to require TLS for gRPC communication with Envoy proxies.
 In environments where Envoy proxies are not already configured
-to use TLS for gRPC, upgrading Consul 1.13 will cause
+to use TLS for gRPC, upgrading Consul 1.13.1 will cause
 Envoy proxies to disconnect from the control plane (Consul agents).
 
-The underlying cause is the same as discussed in
-[deployments without the HTTPS port enabled on Consul agents](#service-mesh-deployments-without-the-https-port-enabled-on-consul-agents).
-However, when using auto-encrypt or auto-config,
-the problem **cannot** currently be avoided by 
-[modifying the agent's TLS configuration](#modify-the-consul-agent-s-tls-configuration)
-because auto-encrypt and auto-config automatically set
-interface-generic TLS configuration in a manner similar to
-[`tls.defaults`](/docs/agent/config/config-files#tls_defaults).
-We are working to address this problem in an upcoming 1.13 patch release.
+If upgrading to version 1.13.2 from 1.13.1 you must enable
+[tls.grpc.use_auto_cert](https://developer.hashicorp.com/consul/docs/agent/config/config-files#use_auto_cert)
+if you currently use the Connect CA and auto-encrypt certs for TLS
+on the gRPC port, and do not have certificates configured via
+[tls.grpc](https://developer.hashicorp.com/consul/docs/agent/config/config-files#tls_grpc)
+or [tls.defaults](https://developer.hashicorp.com/consul/docs/agent/config/config-files#tls_defaults).
+The new `use_auto_cert` flag enables TLS for gRPC based on the presence
+of auto-encrypt certs.
 
 #### Service mesh deployments without the HTTPS port enabled on Consul agents ((#grpc-tls))
 

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -39,7 +39,9 @@ This bug is fixed in Consul versions 1.13.1 and newer.
 
 #### Service mesh deployments using auto-encrypt or auto-config
 
-Upgrade to **Consul version 1.13.2 or later**.
+Upgrade to **Consul version 1.13.2 or later** if using
+[auto-encrypt](/docs/agent/config/config-files#auto_encrypt) or
+[auto-config](/docs/agent/config/config-files#auto_config).
 
 In Consul 1.13.1, auto-encrypt and auto-config both cause Consul
 to require TLS for gRPC communication with Envoy proxies.

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -49,7 +49,7 @@ In environments where Envoy proxies are not already configured
 to use TLS for gRPC, upgrading to Consul 1.13.0 - 1.13.1 will cause
 Envoy proxies to disconnect from the control plane (Consul agents).
 
-If upgrading to version 1.13.2 you must also enable
+If upgrading to version 1.13.2 or later, you must enable
 [tls.grpc.use_auto_cert](/docs/agent/config/config-files#use_auto_cert)
 if you currently use the Connect CA and auto-encrypt certs for TLS
 on the gRPC port, and do not have certificates configured via

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -46,7 +46,7 @@ Upgrade to **Consul version 1.13.2 or later** if using
 In Consul 1.13.0 - 1.13.1, auto-encrypt and auto-config both cause Consul
 to require TLS for gRPC communication with Envoy proxies.
 In environments where Envoy proxies are not already configured
-to use TLS for gRPC, upgrading Consul 1.13.1 will cause
+to use TLS for gRPC, upgrading Consul Consul 1.13.0 - 1.13.1 will cause
 Envoy proxies to disconnect from the control plane (Consul agents).
 
 If upgrading to version 1.13.2 from 1.13.1 you must enable

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -43,7 +43,7 @@ Upgrade to **Consul version 1.13.2 or later** if using
 [auto-encrypt](/docs/agent/config/config-files#auto_encrypt) or
 [auto-config](/docs/agent/config/config-files#auto_config).
 
-In Consul 1.13.1, auto-encrypt and auto-config both cause Consul
+In Consul 1.13.0 - 1.13.1, auto-encrypt and auto-config both cause Consul
 to require TLS for gRPC communication with Envoy proxies.
 In environments where Envoy proxies are not already configured
 to use TLS for gRPC, upgrading Consul 1.13.1 will cause

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -51,10 +51,8 @@ Envoy proxies to disconnect from the control plane (Consul agents).
 
 If upgrading to version 1.13.2 or later, you must enable
 [tls.grpc.use_auto_cert](/docs/agent/config/config-files#use_auto_cert)
-if you currently use the Connect CA and auto-encrypt certs for TLS
-on the gRPC port, and do not have certificates configured via
-[tls.grpc](/docs/agent/config/config-files#tls_grpc)
-or [tls.defaults](/docs/agent/config/config-files#tls_defaults).
+if you currently rely on Consul agents presenting the auto-encrypt or
+auto-config certs as the TLS server certs on the gRPC port.
 The new `use_auto_cert` flag enables TLS for gRPC based on the presence
 of auto-encrypt certs.
 


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/consul/pull/15028

Only difference is that it excludes the 1.14 specific content