### PR TITLE
Fix bug that resulted in generating Envoy configs that use CDS with an EDS Configuration

### DIFF
--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -629,9 +629,15 @@ func (s *ResourceGenerator) makeGatewayOutgoingClusterPeeringServiceClusters(cfg
 			// usual mesh gateway route for a service.
 			clusterName := node.Service.Connect.PeerMeta.PrimarySNI()
 
+			var hostnameEndpoints structs.CheckServiceNodes
+			if serviceGroup.UseCDS {
+				hostnameEndpoints = serviceGroup.Nodes
+			}
+
 			opts := clusterOpts{
-				name:     clusterName,
-				isRemote: true,
+				name:              clusterName,
+				isRemote:          true,
+				hostnameEndpoints: hostnameEndpoints,
 			}
 			cluster := s.makeGatewayCluster(cfgSnap, opts)
 

--- a/agent/xds/testdata/clusters/mesh-gateway-with-imported-peered-services.latest.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-with-imported-peered-services.latest.golden
@@ -5,14 +5,6 @@
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
       "name": "alt.default.default.peer-b.external.1c053652-8512-4373-90cf-5a7f6263a994.consul",
       "type": "LOGICAL_DNS",
-      "edsClusterConfig": {
-        "edsConfig": {
-          "ads": {
-
-          },
-          "resourceApiVersion": "V3"
-        }
-      },
       "connectTimeout": "5s",
       "loadAssignment": {
         "clusterName": "alt.default.default.peer-b.external.1c053652-8512-4373-90cf-5a7f6263a994.consul",


### PR DESCRIPTION
### Description

On `main` I ran into this error:
```
2022-10-24T20:41:20.205Z+00:00 [warning] envoy.config(13) delta config for type.googleapis.com/envoy.config.cluster.v3.Cluster rejected: Error adding/updating cluster(s) product-api.default.default.us-west-1.external.7c74b5a2-3341-399e-1355-8c767c764b30.consul: eds_cluster_config set in a non-EDS cluster
```

It's caused by `makeGatewayCluster` configuring EDS when it doesn't receive `hostnameEndpoints`.

### PR Checklist

* [X] updated test coverage
* [ ] external facing docs updated
* [X] not a security concern
