### PR TITLE
peering: rate limit the streamSend

### DIFF
--- a/.changelog/15150.txt
+++ b/.changelog/15150.txt
@@ -1,0 +1,5 @@
+```release-note:improvement
+peering: rate limiting the replication of exported services on both server and receiver
+         side: exported updates are batched and applied to raft
+```
+

--- a/.changelog/15150.txt
+++ b/.changelog/15150.txt
@@ -1,5 +1,4 @@
 ```release-note:improvement
-peering: rate limiting the replication of exported services on both server and receiver
-         side: exported updates are batched and applied to raft
+peering: rate limiting the replication of exported services on both server and receiver side
 ```
 

--- a/agent/grpc-external/services/peerstream/server.go
+++ b/agent/grpc-external/services/peerstream/server.go
@@ -20,8 +20,10 @@ import (
 // extracted from private peering
 
 const (
-	defaultOutgoingHeartbeatInterval = 15 * time.Second
-	defaultIncomingHeartbeatTimeout  = 2 * time.Minute
+	defaultOutgoingHeartbeatInterval    = 15 * time.Second
+	defaultIncomingHeartbeatTimeout     = 2 * time.Minute
+	defaultReplicationRaftApplyInterval = 500 * time.Millisecond
+	defaultOutgoingStreamSendLimit      = 10 // ops / second
 )
 
 type Server struct {
@@ -45,6 +47,13 @@ type Config struct {
 
 	// incomingHeartbeatTimeout is how long we'll wait between receiving heartbeats before we close the connection.
 	incomingHeartbeatTimeout time.Duration
+
+	// replicationRaftApplyRate is how often we apply the batched update to raft
+	replicationRaftApplyInterval time.Duration
+
+	// outgoingStreamSendLimit is the max number of streamSend
+	// that we allow during a one second period.
+	outgoingStreamSendLimit int
 }
 
 //go:generate mockery --name ACLResolver --inpackage
@@ -65,6 +74,12 @@ func NewServer(cfg Config) *Server {
 	}
 	if cfg.incomingHeartbeatTimeout == 0 {
 		cfg.incomingHeartbeatTimeout = defaultIncomingHeartbeatTimeout
+	}
+	if cfg.replicationRaftApplyInterval == 0 {
+		cfg.replicationRaftApplyInterval = defaultReplicationRaftApplyInterval
+	}
+	if cfg.outgoingStreamSendLimit == 0 {
+		cfg.outgoingStreamSendLimit = defaultOutgoingStreamSendLimit
 	}
 	return &Server{
 		Config:  cfg,

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -478,7 +478,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 	// The nonce is used to correlate response/(ack|nack) pairs.
 	var nonce uint64
 
-	streamSendTicker := time.NewTicker(time.Second / time.Duration(s.outgoingStreamSendLimit)) // limit to 100 ops per second
+	streamSendTicker := time.NewTicker(time.Second / time.Duration(s.outgoingStreamSendLimit)) // limit to 10 ops per second
 	defer streamSendTicker.Stop()
 	// The main loop that processes sends and receives.
 	for {

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -631,7 +631,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 			if resp := msg.GetResponse(); resp != nil {
 				reply, err := s.processResponse(streamReq.PeerName, streamReq.Partition, status, resp, serviceUpdateBatchCh)
 				if err != nil {
-					logger.Error("failed to persist resource", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
+					logger.Error("failed to persist resource", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID, "err", err.Error())
 					status.TrackRecvError(err.Error())
 				} else {
 					status.TrackRecvResourceSuccess()

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -1159,7 +1159,8 @@ func TestStreamResources_Server_CARootUpdates(t *testing.T) {
 
 func TestStreamResources_Server_AckNackNonce(t *testing.T) {
 	srv, store := newTestServer(t, func(c *Config) {
-		c.incomingHeartbeatTimeout = 500 * time.Millisecond
+		// Give handler enough time to send an ougoing message before heartbeat timeout
+		c.incomingHeartbeatTimeout = 5 * (time.Second / time.Duration(defaultOutgoingStreamSendLimit))
 	})
 
 	p := writePeeringToBeDialed(t, store, 1, "my-peer")
@@ -1216,7 +1217,8 @@ func TestStreamResources_Server_DisconnectsOnHeartbeatTimeout(t *testing.T) {
 	}
 
 	srv, store := newTestServer(t, func(c *Config) {
-		c.incomingHeartbeatTimeout = 500 * time.Millisecond
+		// Give handler enough time to send an ougoing message before heartbeat timeout
+		c.incomingHeartbeatTimeout = 5 * (time.Second / time.Duration(defaultOutgoingStreamSendLimit))
 	})
 	srv.Tracker.setClock(it.Now)
 
@@ -1255,7 +1257,8 @@ func TestStreamResources_Server_SendsHeartbeats(t *testing.T) {
 	it := incrementalTime{
 		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}
-	outgoingHeartbeatInterval := 100 * time.Millisecond
+	// Give handler enough time to send an ougoing message before heartbeat timeout
+	outgoingHeartbeatInterval := 5 * (time.Second / time.Duration(defaultOutgoingStreamSendLimit))
 
 	srv, store := newTestServer(t, func(c *Config) {
 		c.outgoingHeartbeatInterval = outgoingHeartbeatInterval
@@ -1308,7 +1311,9 @@ func TestStreamResources_Server_KeepsConnectionOpenWithHeartbeat(t *testing.T) {
 	it := incrementalTime{
 		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}
-	incomingHeartbeatTimeout := 500 * time.Millisecond
+
+	// Give handler enough time to send an ougoing message before heartbeat timeout
+	incomingHeartbeatTimeout := 5 * (time.Second / time.Duration(defaultOutgoingStreamSendLimit))
 
 	srv, store := newTestServer(t, func(c *Config) {
 		c.incomingHeartbeatTimeout = incomingHeartbeatTimeout
@@ -2031,7 +2036,8 @@ func Test_processResponse_ExportedServiceUpdates(t *testing.T) {
 				if !ok {
 					break wait_batch
 				}
-				time.Sleep(500 * time.Millisecond)
+				// wait for batched update applied to Raft
+				time.Sleep(defaultReplicationRaftApplyInterval)
 			}
 		}
 

--- a/agent/grpc-external/services/peerstream/testing.go
+++ b/agent/grpc-external/services/peerstream/testing.go
@@ -27,7 +27,7 @@ func (c *MockClient) Send(r *pbpeerstream.ReplicationMessage) error {
 }
 
 func (c *MockClient) Recv() (*pbpeerstream.ReplicationMessage, error) {
-	return c.RecvWithTimeout(10 * time.Millisecond)
+	return c.RecvWithTimeout(500 * time.Millisecond)
 }
 
 func (c *MockClient) RecvWithTimeout(dur time.Duration) (*pbpeerstream.ReplicationMessage, error) {

--- a/agent/grpc-external/services/peerstream/testing.go
+++ b/agent/grpc-external/services/peerstream/testing.go
@@ -27,7 +27,8 @@ func (c *MockClient) Send(r *pbpeerstream.ReplicationMessage) error {
 }
 
 func (c *MockClient) Recv() (*pbpeerstream.ReplicationMessage, error) {
-	return c.RecvWithTimeout(500 * time.Millisecond)
+	// Give handler enough time to send an ougoing message before heartbeat timeout
+	return c.RecvWithTimeout(5 * (time.Second / time.Duration(defaultOutgoingStreamSendLimit)))
 }
 
 func (c *MockClient) RecvWithTimeout(dur time.Duration) (*pbpeerstream.ReplicationMessage, error) {

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1986,6 +1986,21 @@ func (c *HealthCheck) CheckType() *CheckType {
 // HealthChecks is a collection of HealthCheck structs.
 type HealthChecks []*HealthCheck
 
+func (hs HealthChecks) Len() int {
+	return len(hs)
+}
+
+func (hs HealthChecks) Less(i, j int) bool {
+	if hs[i].CheckID <= hs[j].CheckID {
+		return true
+	}
+	return false
+}
+
+func (hs HealthChecks) Swap(i, j int) {
+	hs[i], hs[j] = hs[j], hs[i]
+}
+
 // CheckServiceNode is used to provide the node, its service
 // definition, as well as a HealthCheck that is associated.
 type CheckServiceNode struct {

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/api/watch"
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -415,8 +416,10 @@ func TestNodesWatch(t *testing.T) {
 	{
 		catalog := c.Catalog()
 
+		nodeID, _ := uuid.GenerateUUID()
 		reg := &api.CatalogRegistration{
 			Node:       "foobar",
+			ID:         nodeID,
 			Address:    "1.1.1.1",
 			Datacenter: "dc1",
 		}


### PR DESCRIPTION
### Description
When service instances are being streamed, there's no rate limit on `streamSend()` on the sender or raftWrite the receiver. This results in high resource utilization and wasted raft write. 

Proposed change: 
- on the sender side, we rate limit the `streamSend()` to `10 sends per second`.
- on the receiver, we deduplicate the received update to exported services.

For example, if there are 10 update to  an service instance in 1 second, we can use a `map[service-id]` struct to batch the update and apply the last update to the raft.

### Testing & Reproduction steps

### Links

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
