### PR TITLE
ui: Improve layout address list peer detail

### DIFF
--- a/ui/packages/consul-peerings/app/components/consul/peer/address/list/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/address/list/index.hbs
@@ -1,15 +1,25 @@
-<ListCollection
-  class="consul-peer-address-list"
-  ...attributes
-  @items={{@items}}
-as |item|>
-    <BlockSlot @name="header">
-      <p>
-        {{item}}
-        <CopyButton
-          @value={{item}}
-          @name="Address"
-        />
-      </p>
-    </BlockSlot>
-</ListCollection>
+<Providers::Dimension as |p|>
+  {{#if p.data.height}}
+    <div style={{p.data.fillRemainingHeightStyle}} class="overflow-y-scroll">
+      <VerticalCollection
+        @tagName="ul"
+        @estimateHeight={{p.data.height}}
+        @items={{@items}}
+        as |address index|
+      >
+        <li
+          class="px-3 h-12 hds-border-primary border-t-0 border-l-0 border-r-0 flex items-center justify-between group"
+        >
+          <div
+            class="hds-typography-display-300 text-hds-foreground-strong hds-font-weight-semibold"
+          >{{address}}</div>
+          <CopyButton
+            @value={{address}}
+            @name="Address"
+            class="opacity-0 group-hover:opacity-100"
+          />
+        </li>
+      </VerticalCollection>
+    </div>
+  {{/if}}
+</Providers::Dimension>


### PR DESCRIPTION
### Description
Improves the layout of the address list on the peer-detail page. This PR centers the IP address text and moves the copy button to the end of the row. The copy button will still only show up when hovering the row.
__Screenshot after change:__

<img width="901" alt="Screenshot 2022-10-26 at 15 44 26" src="https://user-images.githubusercontent.com/242299/198043668-fd531c4f-fa1a-439b-8ea8-075895bb88c7.png">

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
