### PR TITLE
ui: Fix PeerName is part of service uniqueness

### DIFF
--- a/ui/packages/consul-ui/app/models/service.js
+++ b/ui/packages/consul-ui/app/models/service.js
@@ -5,7 +5,7 @@ import { fragment } from 'ember-data-model-fragments/attributes';
 import replace, { nullValue } from 'consul-ui/decorators/replace';
 
 export const PRIMARY_KEY = 'uid';
-export const SLUG_KEY = 'Name';
+export const SLUG_KEY = 'Name,PeerName';
 
 export const Collection = class Collection {
   @tracked items;

--- a/ui/packages/consul-ui/app/utils/create-fingerprinter.js
+++ b/ui/packages/consul-ui/app/utils/create-fingerprinter.js
@@ -1,4 +1,5 @@
 import { get } from '@ember/object';
+import { isEmpty } from '@ember/utils';
 
 export default function (foreignKey, nspaceKey, partitionKey, hash = JSON.stringify) {
   return function (primaryKey, slugKey, foreignKeyValue, nspaceValue, partitionValue) {
@@ -10,15 +11,24 @@ export default function (foreignKey, nspaceKey, partitionKey, hash = JSON.string
         );
       }
       const slugKeys = slugKey.split(',');
-      const slugValues = slugKeys.map(function (slugKey) {
-        const slug = get(item, slugKey);
-        if (slug == null || slug.length < 1) {
-          throw new Error(
-            `Unable to create fingerprint, missing slug. Looking for value in \`${slugKey}\` got \`${slug}\``
-          );
-        }
-        return slug;
-      });
+      const slugValues = slugKeys
+        .map(function (slugKey) {
+          const slug = get(item, slugKey);
+
+          const isSlugEmpty = isEmpty(slug);
+
+          if (isSlugEmpty) {
+            // PeerName should be optional as part of id
+            if (slugKey === 'PeerName') {
+              return;
+            }
+            throw new Error(
+              `Unable to create fingerprint, missing slug. Looking for value in \`${slugKey}\` got \`${slug}\``
+            );
+          }
+          return slug;
+        })
+        .compact();
       // This ensures that all data objects have a Namespace and a Partition
       // value set, even in OSS.
       if (typeof item[nspaceKey] === 'undefined') {


### PR DESCRIPTION
We need to make a `PeerName` part of the service ID when present.

This makes sure that peers can export services named the same as other peers, but have the UI still treat them as separate services.

This also resolves an issue where services in the host cluster would display weirdly when named the same as a service imported via a peer.

<img width="814" alt="Screenshot 2022-10-26 at 16 56 52" src="https://user-images.githubusercontent.com/242299/198061281-5fd9318e-2ef7-4425-849f-7639926739d2.png">

### Testing & Reproduction steps
* set up a cluster setup that allows to create peerings
* create a service on cluster-a named the same as a service that will be exported from cluster-b
* see that both services are displayed as separate services in the service list and only the imported one displays peer information

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
