### PR TITLE
fix(peering): nil pointer in calling handleUpdateService

### DIFF
--- a/.changelog/15160.txt
+++ b/.changelog/15160.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: fix nil pointer in calling handleUpdateService
+```

--- a/agent/grpc-external/services/peerstream/replication.go
+++ b/agent/grpc-external/services/peerstream/replication.go
@@ -287,7 +287,6 @@ func (s *Server) handleUpsertExportedServiceList(
 	if err != nil {
 		return err
 	}
-
 	for _, sn := range serviceList {
 		if _, ok := exportedServices[sn]; !ok {
 			err := s.handleUpdateService(peerName, partition, sn, nil)
@@ -324,9 +323,12 @@ func (s *Server) handleUpdateService(
 		return fmt.Errorf("failed to read imported services: %w", err)
 	}
 
-	structsNodes, err := export.CheckServiceNodesToStruct()
-	if err != nil {
-		return fmt.Errorf("failed to convert protobuf instances to structs: %w", err)
+	structsNodes := []structs.CheckServiceNode{}
+	if export != nil {
+		structsNodes, err = export.CheckServiceNodesToStruct()
+		if err != nil {
+			return fmt.Errorf("failed to convert protobuf instances to structs: %w", err)
+		}
 	}
 
 	// Normalize the data into a convenient form for operation.


### PR DESCRIPTION
### Description
handleUpdateService is called either from handleService or `handleUpsertExportedServiceList`. `handleUpsertExportedServiceList` passes nil to the export parameter, which will potentially cause panic due to the nil pointer.

https://github.com/hashicorp/consul/blob/41e50a0f8d5f38c0ffd394c0cd99c8dd4ddb35d9/agent/grpc-external/services/peerstream/replication.go#L291-L295


### Testing & Reproduction steps

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
