### PR TITLE
Update required Helm chart version to match APIGW release notes

### DIFF
--- a/website/content/docs/api-gateway/tech-specs.mdx
+++ b/website/content/docs/api-gateway/tech-specs.mdx
@@ -21,7 +21,7 @@ Your datacenter must meet the following requirements prior to configuring the Co
   - Kubernetes 1.24 is not supported at this time.
 - `kubectl` 1.21+
 - Consul 1.11.2+
-- HashiCorp Consul Helm chart 0.45.0+
+- HashiCorp Consul Helm chart 0.47.1+
 - Consul Service Mesh must be deployed on the Kubernetes cluster that API Gateway is deployed on.
 - Envoy:  Envoy proxy support is determined by the Consul version deployed. Refer to [Envoy Integration](/docs/connect/proxies/envoy) for details.
 


### PR DESCRIPTION
### Description
The [README](https://github.com/hashicorp/consul-api-gateway/blob/main/README.md) and [Release Notes](https://developer.hashicorp.com/consul/docs/release-notes/consul-api-gateway/v0_4_x#supported-software) for Consul API Gateway v0.4 indicate that v0.47.1+ of the Consul Helm chart is required; however, it seems we missed updating the Tech Specs page.

### Testing & Reproduction steps


### Links
See README and Release Notes links above

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
