### PR TITLE
Fix peered service protocols using proxy-defaults.

### DIFF
--- a/agent/configentry/merge_service_config.go
+++ b/agent/configentry/merge_service_config.go
@@ -173,9 +173,19 @@ func MergeServiceConfig(defaults *structs.ServiceConfigResponse, service *struct
 			us.MeshGateway.Mode = remoteCfg.MeshGateway.Mode
 		}
 
+		preMergeProtocol, found := us.Config["protocol"]
 		// Merge in everything else that is read from the map
 		if err := mergo.Merge(&us.Config, remoteCfg.Config); err != nil {
 			return nil, err
+		}
+
+		// Reset the protocol to its pre-merged version for peering upstreams.
+		if us.DestinationPeer != "" {
+			if found {
+				us.Config["protocol"] = preMergeProtocol
+			} else {
+				delete(us.Config, "protocol")
+			}
 		}
 
 		// Delete the mesh gateway key from opaque config since this is the value that was resolved from

--- a/agent/configentry/merge_service_config_test.go
+++ b/agent/configentry/merge_service_config_test.go
@@ -447,6 +447,98 @@ func Test_MergeServiceConfig_UpstreamOverrides(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "peering upstreams ignore protocol overrides",
+			args: args{
+				defaults: &structs.ServiceConfigResponse{
+					UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
+						{
+							Upstream: structs.ServiceID{
+								ID:             "zap",
+								EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+							},
+							Config: map[string]interface{}{
+								"protocol": "http",
+							},
+						},
+					},
+				},
+				service: &structs.NodeService{
+					ID:      "foo-proxy",
+					Service: "foo-proxy",
+					Proxy: structs.ConnectProxyConfig{
+						Upstreams: structs.Upstreams{
+							structs.Upstream{
+								DestinationPeer: "some-peer",
+								DestinationName: "zap",
+								Config: map[string]interface{}{
+									"protocol": "tcp",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &structs.NodeService{
+				ID:      "foo-proxy",
+				Service: "foo-proxy",
+				Proxy: structs.ConnectProxyConfig{
+					Upstreams: structs.Upstreams{
+						structs.Upstream{
+							DestinationPeer: "some-peer",
+							DestinationName: "zap",
+							Config: map[string]interface{}{
+								"protocol": "tcp",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "peering upstreams ignore protocol overrides with unset value",
+			args: args{
+				defaults: &structs.ServiceConfigResponse{
+					UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
+						{
+							Upstream: structs.ServiceID{
+								ID:             "zap",
+								EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+							},
+							Config: map[string]interface{}{
+								"protocol": "http",
+							},
+						},
+					},
+				},
+				service: &structs.NodeService{
+					ID:      "foo-proxy",
+					Service: "foo-proxy",
+					Proxy: structs.ConnectProxyConfig{
+						Upstreams: structs.Upstreams{
+							structs.Upstream{
+								DestinationPeer: "some-peer",
+								DestinationName: "zap",
+								Config:          map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+			want: &structs.NodeService{
+				ID:      "foo-proxy",
+				Service: "foo-proxy",
+				Proxy: structs.ConnectProxyConfig{
+					Upstreams: structs.Upstreams{
+						structs.Upstream{
+							DestinationPeer: "some-peer",
+							DestinationName: "zap",
+							Config:          map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/integration/connect/envoy/case-cross-peers-http/primary/config_entries.hcl
+++ b/test/integration/connect/envoy/case-cross-peers-http/primary/config_entries.hcl
@@ -5,7 +5,8 @@ config_entries {
       name = "global"
 
       config {
-        protocol = "http"
+        # This shouldn't affect the imported listener's protocol, which should be http.
+        protocol = "tcp"
       }
     }
   ]


### PR DESCRIPTION
This change prevents `service-defaults` and `proxy-defaults` from overwriting the protocol on services imported through peering. Without this change, the protocol could mismatch what was expected on the remote mesh gateway.