### PR TITLE
Fix Peering Metrics Bug

### DIFF
--- a/.changelog/15178.txt
+++ b/.changelog/15178.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: Fix a bug that resulted in /v1/agent/metrics returning an error.
+```

--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -122,19 +122,14 @@ func (s *Server) emitPeeringMetricsOnce(metricsImpl *metrics.Metrics) error {
 		}
 
 		// peering health metric
-		if status.NeverConnected {
-			metricsImpl.SetGaugeWithLabels(leaderHealthyPeeringKeyDeprecated, float32(math.NaN()), labels)
-			metricsImpl.SetGaugeWithLabels(leaderHealthyPeeringKey, float32(math.NaN()), labels)
-		} else {
-			healthy := s.peerStreamServer.Tracker.IsHealthy(status)
-			healthyInt := 0
-			if healthy {
-				healthyInt = 1
-			}
-
-			metricsImpl.SetGaugeWithLabels(leaderHealthyPeeringKeyDeprecated, float32(healthyInt), labels)
-			metricsImpl.SetGaugeWithLabels(leaderHealthyPeeringKey, float32(healthyInt), labels)
+		healthy := 0
+		switch {
+		case status.NeverConnected:
+		case s.peerStreamServer.Tracker.IsHealthy(status):
+			healthy = 1
 		}
+		metricsImpl.SetGaugeWithLabels(leaderHealthyPeeringKeyDeprecated, float32(healthy), labels)
+		metricsImpl.SetGaugeWithLabels(leaderHealthyPeeringKey, float32(healthy), labels)
 	}
 
 	return nil

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"net"
 	"testing"
 	"time"
@@ -1445,7 +1444,7 @@ func TestLeader_PeeringMetrics_emitPeeringMetrics(t *testing.T) {
 		healthyMetric3, ok := intv.Gauges[keyHealthyMetric3]
 		require.True(r, ok, fmt.Sprintf("did not find the key %q", keyHealthyMetric3))
 
-		require.True(r, math.IsNaN(float64(healthyMetric3.Value)))
+		require.Equal(r, float32(0), healthyMetric3.Value)
 	})
 }
 


### PR DESCRIPTION
### Description
This bug was caused by the peering health metric being set to `NaN` when a peering has never been connected. This fixes the bug by setting the metric's value to `0` rather than `NaN`.

### PR Checklist

* [X] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
