### PR TITLE
Fix broken link in Consul API Gateway docs

### DIFF
--- a/website/content/docs/api-gateway/configuration/gatewayclassconfig.mdx
+++ b/website/content/docs/api-gateway/configuration/gatewayclassconfig.mdx
@@ -20,7 +20,7 @@ The following outline shows how to format the configurations in the `GatewayClas
 * [`consul`](#consul): object | optional
   * [`address`](#consul-address): string | optional
   * [`authentication`](#consul-authentication): object | optional
-    * [`account`]([#consul-authentication-account): string | optional
+    * [`account`](#consul-authentication-account): string | optional
     * [`managed`](#consul-authentication-managed): bool  | optional
     * [`method`](#consul-authentication-method): string | optional
     * [`namespace`](#consul-authentication-namespace): string  | optional


### PR DESCRIPTION
### Description
Remove extraneous `[` causing broken link in Consul API Gateway docs

### Testing & Reproduction steps
Verify that the `account` link [here](https://consul-ggzxbf4bz-hashicorp.vercel.app/consul/docs/api-gateway/configuration/gatewayclassconfig#configuration-model) works with this change in place

### Links
https://consul-ggzxbf4bz-hashicorp.vercel.app/consul/docs/api-gateway/configuration/gatewayclassconfig#configuration-model

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
