### PR TITLE
build: ensure 'make dev-docker' also produces a matching CLI binary at the same time

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -153,7 +153,7 @@ dev-build:
 	rm -f ./bin/consul
 	cp ${MAIN_GOPATH}/bin/consul ./bin/consul
 
-dev-docker: linux
+dev-docker: linux dev-build
 	@echo "Pulling consul container image - $(CONSUL_IMAGE_VERSION)"
 	@docker pull consul:$(CONSUL_IMAGE_VERSION) >/dev/null
 	@echo "Building Consul Development container - $(CONSUL_DEV_IMAGE)"


### PR DESCRIPTION
### Description

In many local setups you may run `make dev-docker` with the intent to run that consul image on a local docker install. But frequently you will also want to interact with that running install using the CLI running on your host machine.

This ensures that `make dev-docker` will also produce a dev binary (`make dev`) at the same time so that they can match.
