### PR TITLE
test: fix flaky TestSubscribeBackend_IntegrationWithServer_DeliversAllMessages test

### DIFF
--- a/agent/consul/subscribe_backend_test.go
+++ b/agent/consul/subscribe_backend_test.go
@@ -444,13 +444,18 @@ func verifyMonotonicStreamUpdates(ctx context.Context, logger testLogger, client
 			if err != nil {
 				return err
 			}
-			if expectPort != svc.Port {
+			switch svc.Port {
+			case expectPort:
+				atomic.AddUint64(updateCount, 1)
+				logger.Logf("subscriber %05d: got event with correct port=%d at index %d", i, expectPort, event.Index)
+				expectPort++
+			case expectPort - 1:
+				// atomic.AddUint64(updateCount, 1)
+				logger.Logf("subscriber %05d: got event with repeated prior port=%d at index %d", i, expectPort-1, event.Index)
+			default:
 				return fmt.Errorf("subscriber %05d: at index %d: expected port %d, got %d",
 					i, event.Index, expectPort, svc.Port)
 			}
-			atomic.AddUint64(updateCount, 1)
-			logger.Logf("subscriber %05d: got event with correct port=%d at index %d", i, expectPort, event.Index)
-			expectPort++
 		default:
 			// snapshot events
 			svc, err := svcOrErr(event)


### PR DESCRIPTION
### Description

Allow for some message duplication in subscription events during assertions.

I'm pretty sure the subscriptions machinery allows for messages to occasionally be duplicated instead of dropping them, as a once-and-only-once queue is a pipe dream and you have to pick one of the other two options.