### PR TITLE
Decrease retry time for failed peering connections.

### DIFF
--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -65,6 +65,8 @@ var (
 	maxFastConnRetries = uint(5)
 	// maxFastRetryBackoff is the maximum amount of time we'll wait between retries following the fast path.
 	maxFastRetryBackoff = 8192 * time.Millisecond
+	// maxRetryBackoffPeering is the maximum number of seconds we'll wait between retries when attempting to re-establish a peering connection.
+	maxRetryBackoffPeering = 64
 )
 
 func (s *Server) startPeeringStreamSync(ctx context.Context) {
@@ -713,10 +715,10 @@ func peeringRetryTimeout(failedAttempts uint, loopErr error) time.Duration {
 	}
 
 	// Else we go with the default backoff from retryLoopBackoff.
-	if (1 << failedAttempts) < maxRetryBackoff {
+	if (1 << failedAttempts) < maxRetryBackoffPeering {
 		return (1 << failedAttempts) * time.Second
 	}
-	return time.Duration(maxRetryBackoff) * time.Second
+	return time.Duration(maxRetryBackoffPeering) * time.Second
 }
 
 // isErrCode returns true if err is a gRPC error with given error code.

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -1586,10 +1586,12 @@ func TestLeader_Peering_peeringRetryTimeout_regularErrors(t *testing.T) {
 		{1, 2 * time.Second},
 		{2, 4 * time.Second},
 		{3, 8 * time.Second},
+		{4, 16 * time.Second},
+		{5, 32 * time.Second},
 		// Until max.
-		{8, 256 * time.Second},
-		{9, 256 * time.Second},
-		{10, 256 * time.Second},
+		{6, 64 * time.Second},
+		{10, 64 * time.Second},
+		{20, 64 * time.Second},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Decrease the max wait time to 64 seconds for failed peering connections.