### PR TITLE
docs: fix links in ent-license faq

### DIFF
--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -75,11 +75,11 @@ after license expiration and is defined in
 ## Q: Does this affect client agents?
 
 There are upgrade requirements that affect Consul Enterprise clients.
-Please review the [upgrade requirements](faq#q-what-are-the-upgrade-requirements) documentation.
+Please review the [upgrade requirements](#q-what-are-the-upgrade-requirements) documentation.
 
 ## Q: Does this affect snapshot agents?
 
-Same behavior as Consul clients. See answer for [Does this affect client agents? ](faq#q-does-this-affect-client-agents)
+Same behavior as Consul clients. See answer for [Does this affect client agents? ](#q-does-this-affect-client-agents)
 
 ## Q: What is the behavior if the license is missing?
 


### PR DESCRIPTION
### Description
Two of the links pointing to sections of the same page need to be fixed

The following two sections contain links that point to `https://consul.io/faq#LINK-HERE`.

- [Q: Does this affect client agents?](https://developer.hashicorp.com/consul/docs/enterprise/license/faq#q-does-this-affect-client-agents)
- [Q: Does this affect snapshot agents?
](https://developer.hashicorp.com/consul/docs/enterprise/license/faq#q-does-this-affect-snapshot-agents)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
