### PR TITLE
Remove stray line from merge conflict

### DIFF
--- a/website/content/commands/peering/generate-token.mdx
+++ b/website/content/commands/peering/generate-token.mdx
@@ -34,7 +34,6 @@ If the previously-generated token is not actively being used for a peer connecti
 
 - `-meta=<string>=<string>` - Specifies key/value pairs to associate with the peering connection token in `-meta="key"="value"` format. You can use the flag multiple times to set multiple metadata fields.
 
-<<<<<<< HEAD
 - `-server-external-addresses=<string>[,string,...]` - Specifies a comma-separated list of addresses
 to put into the generated token. Addresses are of the form of `{host or IP}:port`.
 You can specify one or more load balancers or external IPs that route external traffic to this cluster's Consul servers.


### PR DESCRIPTION
### Description
The [live docs](https://developer.hashicorp.com/consul/commands/peering/generate-token#meta) on the website have a stray line from a merge conflict that made it in

<img width="794" alt="image" src="https://user-images.githubusercontent.com/3476400/199834674-8956fdbc-9c8e-4750-805a-e6ee51eb70e7.png">

> **Note** This line is no longer present in the Consul 1.14.x [docs](https://raw.githubusercontent.com/hashicorp/consul/release/1.14.x/website/content/commands/peering/generate-token.mdx); however, those are not live on the docs site yet.

### Testing & Reproduction steps
Verify line is no longer present

### Links
[Live docs containing this stray line](https://developer.hashicorp.com/consul/commands/peering/generate-token#meta)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
