### PR TITLE
Fixing CLI ACL token processing unexpected precedence

### DIFF
--- a/.changelog/15274.txt
+++ b/.changelog/15274.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+Fix CLI ACL token processing unexpected precedence
+```

--- a/.changelog/15274.txt
+++ b/.changelog/15274.txt
@@ -1,3 +1,3 @@
 ```release-note: bug
-Fix CLI ACL token processing unexpected precedence
+cli: fix ACL token processing unexpected precedence
 ```

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -276,6 +276,8 @@ func TestAPI_NewClient_TokenFileCLIFirstPriority(t *testing.T) {
 	_, err := NewClient(&config)
 	errorMessage := fmt.Sprintf("Error loading token file %s : open %s: no such file or directory", nonExistentTokenFile, nonExistentTokenFile)
 	assert.EqualError(t, err, errorMessage)
+	os.Unsetenv("CONSUL_HTTP_TOKEN_FILE")
+	os.Unsetenv("CONSUL_HTTP_TOKEN")
 }
 
 func TestAPI_NewClient_TokenCLISecondPriority(t *testing.T) {
@@ -291,6 +293,8 @@ func TestAPI_NewClient_TokenCLISecondPriority(t *testing.T) {
 		t.Fatalf("Error Initializing new client: %v", err)
 	}
 	assert.Equal(t, c.config.Token, tokenString)
+	os.Unsetenv("CONSUL_HTTP_TOKEN_FILE")
+	os.Unsetenv("CONSUL_HTTP_TOKEN")
 }
 
 func TestAPI_NewClient_HttpTokenFileEnvVarThirdPriority(t *testing.T) {
@@ -301,6 +305,8 @@ func TestAPI_NewClient_HttpTokenFileEnvVarThirdPriority(t *testing.T) {
 	_, err := NewClient(DefaultConfig())
 	errorMessage := fmt.Sprintf("Error loading token file %s : open %s: no such file or directory", nonExistentTokenFileEnvVar, nonExistentTokenFileEnvVar)
 	assert.EqualError(t, err, errorMessage)
+	os.Unsetenv("CONSUL_HTTP_TOKEN_FILE")
+	os.Unsetenv("CONSUL_HTTP_TOKEN")
 }
 
 func TestAPI_NewClient_TokenEnvVarFinalPriority(t *testing.T) {
@@ -312,6 +318,7 @@ func TestAPI_NewClient_TokenEnvVarFinalPriority(t *testing.T) {
 		t.Fatalf("Error Initializing new client: %v", err)
 	}
 	assert.Equal(t, c.config.Token, httpTokenEnvVar)
+	os.Unsetenv("CONSUL_HTTP_TOKEN")
 }
 
 func TestAPI_AgentServices(t *testing.T) {

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -261,6 +262,56 @@ func TestAgent_ServiceRegisterOpts_WithContextTimeout(t *testing.T) {
 	opts := ServiceRegisterOpts{}.WithContext(ctx)
 	err = c.Agent().ServiceRegisterOpts(&AgentServiceRegistration{}, opts)
 	require.True(t, errors.Is(err, context.DeadlineExceeded), "expected timeout")
+}
+
+func TestAPI_NewClient_TokenFileCLIFirstPriority(t *testing.T) {
+	os.Setenv("CONSUL_HTTP_TOKEN_FILE", "httpTokenFile.txt")
+	os.Setenv("CONSUL_HTTP_TOKEN", "httpToken")
+	nonExistentTokenFile := "randomTokenFile.txt"
+	config := Config{
+		Token:     "randomToken",
+		TokenFile: nonExistentTokenFile,
+	}
+
+	_, err := NewClient(&config)
+	errorMessage := fmt.Sprintf("Error loading token file %s : open %s: no such file or directory", nonExistentTokenFile, nonExistentTokenFile)
+	assert.EqualError(t, err, errorMessage)
+}
+
+func TestAPI_NewClient_TokenCLISecondPriority(t *testing.T) {
+	os.Setenv("CONSUL_HTTP_TOKEN_FILE", "httpTokenFile.txt")
+	os.Setenv("CONSUL_HTTP_TOKEN", "httpToken")
+	tokenString := "randomToken"
+	config := Config{
+		Token: tokenString,
+	}
+
+	c, err := NewClient(&config)
+	if err != nil {
+		t.Fatalf("Error Initializing new client: %v", err)
+	}
+	assert.Equal(t, c.config.Token, tokenString)
+}
+
+func TestAPI_NewClient_HttpTokenFileEnvVarThirdPriority(t *testing.T) {
+	nonExistentTokenFileEnvVar := "httpTokenFile.txt"
+	os.Setenv("CONSUL_HTTP_TOKEN_FILE", nonExistentTokenFileEnvVar)
+	os.Setenv("CONSUL_HTTP_TOKEN", "httpToken")
+
+	_, err := NewClient(DefaultConfig())
+	errorMessage := fmt.Sprintf("Error loading token file %s : open %s: no such file or directory", nonExistentTokenFileEnvVar, nonExistentTokenFileEnvVar)
+	assert.EqualError(t, err, errorMessage)
+}
+
+func TestAPI_NewClient_TokenEnvVarFinalPriority(t *testing.T) {
+	httpTokenEnvVar := "httpToken"
+	os.Setenv("CONSUL_HTTP_TOKEN", httpTokenEnvVar)
+
+	c, err := NewClient(DefaultConfig())
+	if err != nil {
+		t.Fatalf("Error Initializing new client: %v", err)
+	}
+	assert.Equal(t, c.config.Token, httpTokenEnvVar)
 }
 
 func TestAPI_AgentServices(t *testing.T) {

--- a/api/api.go
+++ b/api/api.go
@@ -750,6 +750,11 @@ func NewClient(config *Config) (*Client, error) {
 	// If the TokenFile is set, always use that, even if a Token is configured.
 	// This is because when TokenFile is set it is read into the Token field.
 	// We want any derived clients to have to re-read the token file.
+	// The precedence of ACL token should be
+	// 1. -token-file cli option
+	// 2. -token cli option
+	// 3. CONSUL_HTTP_TOKEN_FILE environment variable
+	// 4. CONSUL_HTTP_TOKEN environment variable
 	if config.TokenFile != "" && config.TokenFile != defConfig.TokenFile {
 		data, err := os.ReadFile(config.TokenFile)
 		if err != nil {
@@ -769,6 +774,7 @@ func NewClient(config *Config) (*Client, error) {
 
 		if token := strings.TrimSpace(string(data)); token != "" {
 			config.Token = token
+			config.TokenFile = defConfig.TokenFile
 		}
 	} else {
 		config.Token = defConfig.Token

--- a/api/api.go
+++ b/api/api.go
@@ -750,7 +750,7 @@ func NewClient(config *Config) (*Client, error) {
 	// If the TokenFile is set, always use that, even if a Token is configured.
 	// This is because when TokenFile is set it is read into the Token field.
 	// We want any derived clients to have to re-read the token file.
-	// The precedence of ACL token should be
+	// The precedence of ACL token should be:
 	// 1. -token-file cli option
 	// 2. -token cli option
 	// 3. CONSUL_HTTP_TOKEN_FILE environment variable
@@ -765,7 +765,7 @@ func NewClient(config *Config) (*Client, error) {
 			config.Token = token
 		}
 	} else if config.Token != "" && defConfig.Token != config.Token {
-		goto FINISH
+		// Fall through
 	} else if defConfig.TokenFile != "" {
 		data, err := os.ReadFile(defConfig.TokenFile)
 		if err != nil {
@@ -779,7 +779,6 @@ func NewClient(config *Config) (*Client, error) {
 	} else {
 		config.Token = defConfig.Token
 	}
-FINISH:
 	return &Client{config: *config, headers: make(http.Header)}, nil
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -753,7 +753,7 @@ func NewClient(config *Config) (*Client, error) {
 	if config.TokenFile != "" && config.TokenFile != defConfig.TokenFile {
 		data, err := os.ReadFile(config.TokenFile)
 		if err != nil {
-			return nil, fmt.Errorf("Error loading token file: %s", err)
+			return nil, fmt.Errorf("Error loading token file %s : %s", config.TokenFile, err)
 		}
 
 		if token := strings.TrimSpace(string(data)); token != "" {
@@ -762,9 +762,9 @@ func NewClient(config *Config) (*Client, error) {
 	} else if config.Token != "" && defConfig.Token != config.Token {
 		goto FINISH
 	} else if defConfig.TokenFile != "" {
-		data, err := os.ReadFile(config.TokenFile)
+		data, err := os.ReadFile(defConfig.TokenFile)
 		if err != nil {
-			return nil, fmt.Errorf("Error loading token file: %s", err)
+			return nil, fmt.Errorf("Error loading token file %s : %s", defConfig.TokenFile, err)
 		}
 
 		if token := strings.TrimSpace(string(data)); token != "" {

--- a/api/api.go
+++ b/api/api.go
@@ -760,8 +760,7 @@ func NewClient(config *Config) (*Client, error) {
 			config.Token = token
 		}
 	} else if config.Token != "" && defConfig.Token != config.Token {
-		if config.Token != defConfig.TokenFile {
-		}
+		goto FINISH
 	} else if defConfig.TokenFile != "" {
 		data, err := os.ReadFile(config.TokenFile)
 		if err != nil {
@@ -774,7 +773,7 @@ func NewClient(config *Config) (*Client, error) {
 	} else {
 		config.Token = defConfig.Token
 	}
-
+FINISH:
 	return &Client{config: *config, headers: make(http.Header)}, nil
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -750,7 +750,7 @@ func NewClient(config *Config) (*Client, error) {
 	// If the TokenFile is set, always use that, even if a Token is configured.
 	// This is because when TokenFile is set it is read into the Token field.
 	// We want any derived clients to have to re-read the token file.
-	if config.TokenFile != "" {
+	if config.TokenFile != "" && config.TokenFile != defConfig.TokenFile {
 		data, err := os.ReadFile(config.TokenFile)
 		if err != nil {
 			return nil, fmt.Errorf("Error loading token file: %s", err)
@@ -759,8 +759,19 @@ func NewClient(config *Config) (*Client, error) {
 		if token := strings.TrimSpace(string(data)); token != "" {
 			config.Token = token
 		}
-	}
-	if config.Token == "" {
+	} else if config.Token != "" && defConfig.Token != config.Token {
+		if config.Token != defConfig.TokenFile {
+		}
+	} else if defConfig.TokenFile != "" {
+		data, err := os.ReadFile(config.TokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("Error loading token file: %s", err)
+		}
+
+		if token := strings.TrimSpace(string(data)); token != "" {
+			config.Token = token
+		}
+	} else {
 		config.Token = defConfig.Token
 	}
 


### PR DESCRIPTION
### Description
Closing  #14466 

### Testing & Reproduction steps
* I used the script below ( similar to the script in the Github Issue with minor  bash syntax changes )
* I did some local testings and found out the main reason was this block of code and the way `config` class is merged and loaded twice
https://github.com/hashicorp/consul/blob/25d272a67ab560d495575defaa311fbde9d7ab81/api/api.go#L740-L755
* The value of `config.Token` in this [function](https://github.com/hashicorp/consul/blob/25d272a67ab560d495575defaa311fbde9d7ab81/api/api.go#L653) can contain either the CLI provided or the Environment Variable due to the [merge](https://github.com/hashicorp/consul/blob/25d272a67ab560d495575defaa311fbde9d7ab81/command/flags/http.go#L150) function. Similarly, the same issue happens with `config.TokenFile` value. Hence, we need to check the value of `config.Token` against `defconfig.Token` to see whether its the CLI provided or from Environment Variable



```
#!/bin/bash
set -x
get_token () {
   local env_token_file="$1" # this
   local env_token="$2" # this
   local cli_token_file="$3"
   local cli_token="$4"
   
   export CONSUL_HTTP_TOKEN_FILE="$env_token_file"
   export CONSUL_HTTP_TOKEN="$env_token"
   
   args=""
   if test -n "$cli_token_file"
   then
      args="$args -token-file=$cli_token_file"
   fi
   if test -n "$cli_token"
   then
      args="$args -token=$cli_token"
   fi

   secretID=$(consul acl token read -self $args -format json | jq -r '.SecretID')
   echo $secretID
}


check_token() {
   local expected="$1"
   local actual="$2"

   if [ "$expected" != "$actual" ]
   then
      echo "BAD - Expected: $expected, Actual: $actual"
   else
      echo "OK  - Matched!"
   fi
}

if test -z "$BOOTSTRAP_TOKEN"
then
   BOOTSTRAP_TOKEN=$(consul acl bootstrap -format json | jq -r '.SecretID')
   echo $BOOTSTRAP_TOKEN
fi
T1=$(/home/tung/go/bin/consul acl token create -token="$BOOTSTRAP_TOKEN" -service-identity=one -format=json | jq -r '.SecretID')
T1_FILE=t1.token
T2=$(consul acl token create -token="$BOOTSTRAP_TOKEN" -service-identity=two -format=json | jq -r '.SecretID')
T2_FILE=t2.token
T3=$(consul acl token create -token="$BOOTSTRAP_TOKEN" -service-identity=three -format=json | jq -r '.SecretID')
T4=$(consul acl token create -token="$BOOTSTRAP_TOKEN" -service-identity=four -format=json | jq -r '.SecretID')
echo "$T1" > $T1_FILE
echo "$T2" > $T2_FILE

cat <<-EOF
T1: $T1
T2: $T2
T3: $T3
T4: $T4

EOF
printf "token-file cli parameter has highest precedence:                "
check_token "$T2" "$(get_token $T1_FILE "$T3" $T2_FILE "$T4")"
printf "token cli parameter takes precedence over env vars:             "
check_token "$T4" "$(get_token $T1_FILE "$T3" "" "$T4")"
printf "CONSUL_HTTP_TOKEN_FILE takes precedence over CONSUL_HTTP_TOKEN: "
check_token "$T1" "$(get_token $T1_FILE "$T3" "" "")"
printf "CONSUL_HTTP_TOKEN only:                                         "
check_token "$T3" "$(get_token "" "$T3" "" "")"

```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
