### PR TITLE
Update deprecation note to account for renamed field

### DIFF
--- a/api/config_entry_exports.go
+++ b/api/config_entry_exports.go
@@ -47,7 +47,7 @@ type ExportedService struct {
 // At most one of Partition or PeerName must be specified.
 type ServiceConsumer struct {
 	// Partition is the admin partition to export the service to.
-	// Deprecated: PeerName should be used for both remote peers and local partitions.
+	// Deprecated: Peer should be used for both remote peers and local partitions.
 	Partition string `json:",omitempty"`
 
 	// Peer is the name of the peer to export the service to.


### PR DESCRIPTION
### Description
#14854 renamed the `PeerName` field to `Peer` but didn't update the deprecation note for `Partition` which references the renamed field.

### Testing & Reproduction steps
👀 

### Links
N/A

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
