### PR TITLE
update ACLs for cluster peering

### DIFF
--- a/.changelog/15317.txt
+++ b/.changelog/15317.txt
@@ -1,3 +1,3 @@
 ```release-note:improvements
-acl: update ACLs, allow read on imported services and nodes with readAll permissions
+acl: Allow reading imported services and nodes from cluster peers with read all permissions
 ```

--- a/.changelog/15317.txt
+++ b/.changelog/15317.txt
@@ -1,0 +1,3 @@
+```release-note:improvements
+acl: update ACLs, allow read on imported services and nodes with readAll permissions
+```

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -20,6 +20,10 @@ type ExportFetcher interface {
 }
 
 type ExportedServices struct {
+	// Data is a map of [namespace] -> [service] -> [list of partitions the service is exported to]
+	// This includes both the names of typical service instances and their corresponding sidecar proxy
+	// instance names. Meaning that if "web" is exported, "web-sidecar-proxy" instances will also be
+	// shown as exported.
 	Data map[string]map[string][]string
 }
 

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -1578,7 +1578,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 	execNoNodesToken := createTokenWithPolicyName(t, codec1, "no-nodes", `service_prefix "foo" { policy = "read" }`, "root")
 	rules := `
-		service_prefix "foo" { policy = "read" }
+		service_prefix "" { policy = "read" }
 		node_prefix "" { policy = "read" }
 	`
 	execToken := createTokenWithPolicyName(t, codec1, "with-read", rules, "root")

--- a/agent/structs/aclfilter/filter_test.go
+++ b/agent/structs/aclfilter/filter_test.go
@@ -1107,12 +1107,51 @@ func TestACL_filterIndexedNodesWithGateways(t *testing.T) {
 				{Service: structs.ServiceNameFromString("foo")},
 				{Service: structs.ServiceNameFromString("bar")},
 			},
+			ImportedNodes: structs.CheckServiceNodes{
+				{
+					Node: &structs.Node{
+						Node:     "imported-node",
+						PeerName: "cluster-02",
+					},
+					Service: &structs.NodeService{
+						ID:       "zip",
+						Service:  "zip",
+						PeerName: "cluster-02",
+					},
+					Checks: structs.HealthChecks{
+						{
+							Node:        "node1",
+							CheckID:     "check1",
+							ServiceName: "zip",
+							PeerName:    "cluster-02",
+						},
+					},
+				},
+			},
 		}
 	}
 
-	t.Run("allowed", func(t *testing.T) {
+	type testCase struct {
+		authzFn func() acl.Authorizer
+		expect  *structs.IndexedNodesWithGateways
+	}
 
-		policy, err := acl.NewPolicyFromSource(`
+	run := func(t *testing.T, tc testCase) {
+		authz := tc.authzFn()
+
+		list := makeList()
+		New(authz, logger).Filter(list)
+
+		require.Equal(t, tc.expect, list)
+	}
+
+	tt := map[string]testCase{
+		"not filtered": {
+			authzFn: func() acl.Authorizer {
+				policy, err := acl.NewPolicyFromSource(`
+			service "baz" {
+				policy = "write"
+			}
 			service "foo" {
 			  policy = "read"
 			}
@@ -1123,22 +1162,63 @@ func TestACL_filterIndexedNodesWithGateways(t *testing.T) {
 			  policy = "read"
 			}
 		`, acl.SyntaxLegacy, nil, nil)
-		require.NoError(t, err)
+				require.NoError(t, err)
 
-		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-		require.NoError(t, err)
-
-		list := makeList()
-		New(authz, logger).Filter(list)
-
-		require.Len(t, list.Nodes, 1)
-		require.Len(t, list.Gateways, 2)
-		require.False(t, list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be false")
-	})
-
-	t.Run("not allowed to read the node", func(t *testing.T) {
-
-		policy, err := acl.NewPolicyFromSource(`
+				authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+				require.NoError(t, err)
+				return authz
+			},
+			expect: &structs.IndexedNodesWithGateways{
+				Nodes: structs.CheckServiceNodes{
+					{
+						Node: &structs.Node{
+							Node: "node1",
+						},
+						Service: &structs.NodeService{
+							ID:      "foo",
+							Service: "foo",
+						},
+						Checks: structs.HealthChecks{
+							{
+								Node:        "node1",
+								CheckID:     "check1",
+								ServiceName: "foo",
+							},
+						},
+					},
+				},
+				Gateways: structs.GatewayServices{
+					{Service: structs.ServiceNameFromString("foo")},
+					{Service: structs.ServiceNameFromString("bar")},
+				},
+				// Service write to "bar" allows reading all imported services
+				ImportedNodes: structs.CheckServiceNodes{
+					{
+						Node: &structs.Node{
+							Node:     "imported-node",
+							PeerName: "cluster-02",
+						},
+						Service: &structs.NodeService{
+							ID:       "zip",
+							Service:  "zip",
+							PeerName: "cluster-02",
+						},
+						Checks: structs.HealthChecks{
+							{
+								Node:        "node1",
+								CheckID:     "check1",
+								ServiceName: "zip",
+								PeerName:    "cluster-02",
+							},
+						},
+					},
+				},
+				QueryMeta: structs.QueryMeta{ResultsFilteredByACLs: false},
+			},
+		},
+		"not allowed to read the node": {
+			authzFn: func() acl.Authorizer {
+				policy, err := acl.NewPolicyFromSource(`
 			service "foo" {
 			  policy = "read"
 			}
@@ -1146,22 +1226,25 @@ func TestACL_filterIndexedNodesWithGateways(t *testing.T) {
 			  policy = "read"
 			}
 		`, acl.SyntaxLegacy, nil, nil)
-		require.NoError(t, err)
+				require.NoError(t, err)
 
-		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-		require.NoError(t, err)
-
-		list := makeList()
-		New(authz, logger).Filter(list)
-
-		require.Empty(t, list.Nodes)
-		require.Len(t, list.Gateways, 2)
-		require.True(t, list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
-	})
-
-	t.Run("allowed to read the node, but not the service", func(t *testing.T) {
-
-		policy, err := acl.NewPolicyFromSource(`
+				authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+				require.NoError(t, err)
+				return authz
+			},
+			expect: &structs.IndexedNodesWithGateways{
+				Nodes: structs.CheckServiceNodes{},
+				Gateways: structs.GatewayServices{
+					{Service: structs.ServiceNameFromString("foo")},
+					{Service: structs.ServiceNameFromString("bar")},
+				},
+				ImportedNodes: structs.CheckServiceNodes{},
+				QueryMeta:     structs.QueryMeta{ResultsFilteredByACLs: true},
+			},
+		},
+		"not allowed to read the service": {
+			authzFn: func() acl.Authorizer {
+				policy, err := acl.NewPolicyFromSource(`
 			node "node1" {
 			  policy = "read"
 			}
@@ -1169,22 +1252,24 @@ func TestACL_filterIndexedNodesWithGateways(t *testing.T) {
 			  policy = "read"
 			}
 		`, acl.SyntaxLegacy, nil, nil)
-		require.NoError(t, err)
+				require.NoError(t, err)
 
-		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-		require.NoError(t, err)
-
-		list := makeList()
-		New(authz, logger).Filter(list)
-
-		require.Empty(t, list.Nodes)
-		require.Len(t, list.Gateways, 1)
-		require.True(t, list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
-	})
-
-	t.Run("not allowed to read the other gatway service", func(t *testing.T) {
-
-		policy, err := acl.NewPolicyFromSource(`
+				authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+				require.NoError(t, err)
+				return authz
+			},
+			expect: &structs.IndexedNodesWithGateways{
+				Nodes: structs.CheckServiceNodes{},
+				Gateways: structs.GatewayServices{
+					{Service: structs.ServiceNameFromString("bar")},
+				},
+				ImportedNodes: structs.CheckServiceNodes{},
+				QueryMeta:     structs.QueryMeta{ResultsFilteredByACLs: true},
+			},
+		},
+		"not allowed to read the other gateway service": {
+			authzFn: func() acl.Authorizer {
+				policy, err := acl.NewPolicyFromSource(`
 			service "foo" {
 			  policy = "read"
 			}
@@ -1192,28 +1277,54 @@ func TestACL_filterIndexedNodesWithGateways(t *testing.T) {
 			  policy = "read"
 			}
 		`, acl.SyntaxLegacy, nil, nil)
-		require.NoError(t, err)
+				require.NoError(t, err)
 
-		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-		require.NoError(t, err)
+				authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+				require.NoError(t, err)
+				return authz
+			},
+			expect: &structs.IndexedNodesWithGateways{
+				Nodes: structs.CheckServiceNodes{
+					{
+						Node: &structs.Node{
+							Node: "node1",
+						},
+						Service: &structs.NodeService{
+							ID:      "foo",
+							Service: "foo",
+						},
+						Checks: structs.HealthChecks{
+							{
+								Node:        "node1",
+								CheckID:     "check1",
+								ServiceName: "foo",
+							},
+						},
+					},
+				},
+				Gateways: structs.GatewayServices{
+					{Service: structs.ServiceNameFromString("foo")},
+				},
+				ImportedNodes: structs.CheckServiceNodes{},
+				QueryMeta:     structs.QueryMeta{ResultsFilteredByACLs: true},
+			},
+		},
+		"denied": {
+			authzFn: acl.DenyAll,
+			expect: &structs.IndexedNodesWithGateways{
+				Nodes:         structs.CheckServiceNodes{},
+				Gateways:      structs.GatewayServices{},
+				ImportedNodes: structs.CheckServiceNodes{},
+				QueryMeta:     structs.QueryMeta{ResultsFilteredByACLs: true},
+			},
+		},
+	}
 
-		list := makeList()
-		New(authz, logger).Filter(list)
-
-		require.Len(t, list.Nodes, 1)
-		require.Len(t, list.Gateways, 1)
-		require.True(t, list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
-	})
-
-	t.Run("denied", func(t *testing.T) {
-
-		list := makeList()
-		New(acl.DenyAll(), logger).Filter(list)
-
-		require.Empty(t, list.Nodes)
-		require.Empty(t, list.Gateways)
-		require.True(t, list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
-	})
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
 }
 
 func TestACL_filterIndexedServiceDump(t *testing.T) {

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1998,6 +1998,15 @@ func (csn *CheckServiceNode) CanRead(authz acl.Authorizer) acl.EnforcementDecisi
 	authzContext := new(acl.AuthorizerContext)
 	csn.Service.EnterpriseMeta.FillAuthzContext(authzContext)
 
+	if csn.Node.PeerName != "" || csn.Service.PeerName != "" {
+		if authz.ServiceReadAll(authzContext) == acl.Allow ||
+			authz.ServiceWriteAny(authzContext) == acl.Allow {
+
+			return acl.Allow
+		}
+		return acl.Deny
+	}
+
 	if authz.NodeRead(csn.Node.Node, authzContext) != acl.Allow {
 		return acl.Deny
 	}


### PR DESCRIPTION
### Description
Update ACLs for cluster peering, allow imported services to be read with readAll or writeAny tokens. 

Context: [Enterprise PR](https://github.com/hashicorp/consul-enterprise/pull/3431)

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
