### PR TITLE
connect: strip port from DNS SANs for ingress gateway leaf cert

### DIFF
--- a/.changelog/15320.txt
+++ b/.changelog/15320.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: strip port from DNS SANs for ingress gateway leaf certificate to avoid an invalid hostname error when using the Vault provider.
+```

--- a/agent/connect/csr.go
+++ b/agent/connect/csr.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 )
 
 // SigAlgoForKey returns the preferred x509.SignatureAlgorithm for a given key
@@ -47,11 +48,28 @@ func SigAlgoForKeyType(keyType string) x509.SignatureAlgorithm {
 // along with the PEM-encoded private key for this certificate.
 func CreateCSR(uri CertURI, privateKey crypto.Signer,
 	dnsNames []string, ipAddresses []net.IP, extensions ...pkix.Extension) (string, error) {
+
+	// Drop everything after the ':' from the name when constructing the DNS SANs.
+	uniqueNames := make(map[string]struct{})
+	formattedDNSNames := make([]string, 0)
+	for _, host := range dnsNames {
+		hostSegments := strings.Split(host, ":")
+		formattedHost := hostSegments[0]
+		if _, ok := uniqueNames[formattedHost]; ok {
+			continue
+		}
+
+		if len(hostSegments) >= 1 {
+			formattedDNSNames = append(formattedDNSNames, formattedHost)
+			uniqueNames[formattedHost] = struct{}{}
+		}
+	}
+
 	template := &x509.CertificateRequest{
 		URIs:               []*url.URL{uri.URI()},
 		SignatureAlgorithm: SigAlgoForKey(privateKey),
 		ExtraExtensions:    extensions,
-		DNSNames:           dnsNames,
+		DNSNames:           formattedDNSNames,
 		IPAddresses:        ipAddresses,
 	}
 	HackSANExtensionForCSR(template)

--- a/agent/connect/csr.go
+++ b/agent/connect/csr.go
@@ -54,12 +54,12 @@ func CreateCSR(uri CertURI, privateKey crypto.Signer,
 	formattedDNSNames := make([]string, 0)
 	for _, host := range dnsNames {
 		hostSegments := strings.Split(host, ":")
-		formattedHost := hostSegments[0]
-		if _, ok := uniqueNames[formattedHost]; ok {
+		if len(hostSegments) == 0 || hostSegments[0] == "" {
 			continue
 		}
 
-		if len(hostSegments) >= 1 {
+		formattedHost := hostSegments[0]
+		if _, ok := uniqueNames[formattedHost]; !ok {
 			formattedDNSNames = append(formattedDNSNames, formattedHost)
 			uniqueNames[formattedHost] = struct{}{}
 		}

--- a/agent/connect/csr_test.go
+++ b/agent/connect/csr_test.go
@@ -18,6 +18,9 @@ func TestCreateCSR_FormatDNSSANs(t *testing.T) {
 		"foo.example.com",
 		"foo.example.com:8080",
 		"bar.example.com",
+		"*.example.com",
+		":8080",
+		"",
 	}, nil)
 	require.NoError(t, err)
 
@@ -28,5 +31,6 @@ func TestCreateCSR_FormatDNSSANs(t *testing.T) {
 	require.Equal(t, []string{
 		"foo.example.com",
 		"bar.example.com",
+		"*.example.com",
 	}, req.DNSNames)
 }

--- a/agent/connect/csr_test.go
+++ b/agent/connect/csr_test.go
@@ -1,0 +1,32 @@
+package connect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateCSR_FormatDNSSANs(t *testing.T) {
+	pk, _, err := GeneratePrivateKey()
+	require.NoError(t, err)
+	spiffeID := &SpiffeIDService{
+		Host:       "7528f42f-92e5-4db4-b84c-3405c3ca91e6",
+		Service:    "srv1",
+		Datacenter: "dc1",
+	}
+	csr, err := CreateCSR(spiffeID, pk, []string{
+		"foo.example.com",
+		"foo.example.com:8080",
+		"bar.example.com",
+	}, nil)
+	require.NoError(t, err)
+
+	req, err := ParseCSR(csr)
+	require.NoError(t, err)
+	require.Len(t, req.URIs, 1)
+	require.Equal(t, spiffeID.URI(), req.URIs[0])
+	require.Equal(t, []string{
+		"foo.example.com",
+		"bar.example.com",
+	}, req.DNSNames)
+}

--- a/agent/proxycfg/ingress_gateway.go
+++ b/agent/proxycfg/ingress_gateway.go
@@ -3,7 +3,6 @@ package proxycfg
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/proxycfg/internal/watch"
@@ -289,19 +288,7 @@ func (s *handlerIngressGateway) generateIngressDNSSANs(snap *ConfigSnapshot) []s
 		}
 	}
 
-	addedHosts := make(map[string]struct{})
-	for _, host := range snap.IngressGateway.Hosts {
-		if _, ok := addedHosts[host]; ok {
-			continue
-		}
-
-		// Drop everything after the ':' from the host when constructing the DNS SANs.
-		hostSegments := strings.Split(host, ":")
-		if len(hostSegments) >= 1 {
-			dnsNames = append(dnsNames, hostSegments[0])
-			addedHosts[hostSegments[0]] = struct{}{}
-		}
-	}
+	dnsNames = append(dnsNames, snap.IngressGateway.Hosts...)
 
 	return dnsNames
 }


### PR DESCRIPTION
Closes https://github.com/hashicorp/consul/issues/11092 - currently we're passing along whatever's in the `Hosts` field verbatim to construct the list of SANs. This PR changes that to strip the `:` and everything after it from each `Host` string so that it's in the format Vault expects when signing the leaf cert.