### PR TITLE
[OSS] fix: wait and try longer to peer through mesh gw

### DIFF
--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -1956,7 +1956,8 @@ func Test_Leader_PeeringSync_PeerThroughMeshGateways_ServerFallBack(t *testing.T
 	}))
 
 	// Create a peering at dialer by establishing a peering with acceptor's token
-	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+	// 7 second = 1 second wait + 3 second gw retry + 3 second token addr retry
+	ctx, cancel = context.WithTimeout(context.Background(), 7*time.Second)
 	t.Cleanup(cancel)
 
 	conn, err = grpc.DialContext(ctx, dialer.config.RPCAddr.String(),

--- a/agent/consul/peering_backend_test.go
+++ b/agent/consul/peering_backend_test.go
@@ -198,7 +198,7 @@ func TestPeeringBackend_GetDialAddresses(t *testing.T) {
 
 	type expectation struct {
 		addrs        []string
-		haveGateways bool
+		gatewayAddrs []string
 		err          string
 	}
 
@@ -214,13 +214,24 @@ func TestPeeringBackend_GetDialAddresses(t *testing.T) {
 			tc.setup(srv.fsm.State())
 		}
 
-		ring, haveGateways, err := backend.GetDialAddresses(testutil.Logger(t), nil, tc.peerID)
+		ring, gatewayRing, err := backend.GetDialAddresses(testutil.Logger(t), nil, tc.peerID)
 		if tc.expect.err != "" {
 			testutil.RequireErrorContains(t, err, tc.expect.err)
 			return
 		}
-		require.Equal(t, tc.expect.haveGateways, haveGateways)
+		require.Equal(t, len(tc.expect.gatewayAddrs) > 0, gatewayRing != nil)
 		require.NotNil(t, ring)
+
+		if len(tc.expect.gatewayAddrs) > 0 {
+			var addrs []string
+			gatewayRing.Do(func(value any) {
+				addr, ok := value.(string)
+
+				require.True(t, ok)
+				addrs = append(addrs, addr)
+			})
+			require.Equal(t, tc.expect.gatewayAddrs, addrs)
+		}
 
 		var addrs []string
 		ring.Do(func(value any) {
@@ -275,8 +286,7 @@ func TestPeeringBackend_GetDialAddresses(t *testing.T) {
 			},
 			peerID: dialerPeerID,
 			expect: expectation{
-				haveGateways: false,
-				addrs:        []string{"5.6.7.8:8502"},
+				addrs: []string{"5.6.7.8:8502"},
 			},
 		},
 		{
@@ -294,8 +304,7 @@ func TestPeeringBackend_GetDialAddresses(t *testing.T) {
 			},
 			peerID: dialerPeerID,
 			expect: expectation{
-				haveGateways: false,
-				addrs:        []string{"1.2.3.4:8502", "2.3.4.5:8503"},
+				addrs: []string{"1.2.3.4:8502", "2.3.4.5:8503"},
 			},
 		},
 		{
@@ -309,8 +318,7 @@ func TestPeeringBackend_GetDialAddresses(t *testing.T) {
 			},
 			peerID: dialerPeerID,
 			expect: expectation{
-				haveGateways: false,
-				addrs:        []string{"1.2.3.4:8502", "2.3.4.5:8503"},
+				addrs: []string{"1.2.3.4:8502", "2.3.4.5:8503"},
 			},
 		},
 		{
@@ -326,8 +334,6 @@ func TestPeeringBackend_GetDialAddresses(t *testing.T) {
 			},
 			peerID: dialerPeerID,
 			expect: expectation{
-				haveGateways: false,
-
 				// Fall back to remote server addresses
 				addrs: []string{"1.2.3.4:8502", "2.3.4.5:8503"},
 			},
@@ -372,10 +378,9 @@ func TestPeeringBackend_GetDialAddresses(t *testing.T) {
 			},
 			peerID: dialerPeerID,
 			expect: expectation{
-				haveGateways: true,
-
 				// Gateways come first, and we use their LAN addresses since this is for outbound communication.
-				addrs: []string{"6.7.8.9:8443", "5.6.7.8:8443", "1.2.3.4:8502", "2.3.4.5:8503"},
+				addrs:        []string{"5.6.7.8:8443", "6.7.8.9:8443", "1.2.3.4:8502", "2.3.4.5:8503"},
+				gatewayAddrs: []string{"5.6.7.8:8443", "6.7.8.9:8443"},
 			},
 		},
 		{

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -514,7 +514,7 @@ func TestPeeringService_Establish_ThroughMeshGateway(t *testing.T) {
 		require.Error(t, err)
 		testutil.RequireErrorContains(t, err, "connection refused")
 
-		require.Greater(t, time.Since(start), 5*time.Second)
+		require.Greater(t, time.Since(start), 3*time.Second)
 	})
 
 	testutil.RunStep(t, "peering can be established from token", func(t *testing.T) {
@@ -528,7 +528,7 @@ func TestPeeringService_Establish_ThroughMeshGateway(t *testing.T) {
 		// Capture peering token for re-use later
 		peeringToken = tokenResp.PeeringToken
 
-		// The context timeout is short, it checks that we do not wait the 350ms that we do when peering through mesh gateways
+		// The context timeout is short, it checks that we do not wait the 1s that we do when peering through mesh gateways
 		ctx, cancel = context.WithTimeout(context.Background(), 300*time.Millisecond)
 		t.Cleanup(cancel)
 
@@ -585,7 +585,7 @@ func TestPeeringService_Establish_ThroughMeshGateway(t *testing.T) {
 			},
 		}))
 
-		ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 6*time.Second)
 		t.Cleanup(cancel)
 
 		// Call to establish should succeed when we fall back to remote server address.
@@ -630,7 +630,8 @@ func TestPeeringService_Establish_ThroughMeshGateway(t *testing.T) {
 			},
 		}))
 
-		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		// Context is 1s sleep + 3s retry loop. Any longer and we're trying the remote gateway
+		ctx, cancel = context.WithTimeout(context.Background(), 4*time.Second)
 		t.Cleanup(cancel)
 
 		start := time.Now()
@@ -642,8 +643,8 @@ func TestPeeringService_Establish_ThroughMeshGateway(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Dialing through a gateway is preceded by a mandatory 350ms sleep.
-		require.Greater(t, time.Since(start), 350*time.Millisecond)
+		// Dialing through a gateway is preceded by a mandatory 1s sleep.
+		require.Greater(t, time.Since(start), 1*time.Second)
 
 		// target.called is true when the tcproxy's conn handler was invoked.
 		// This lets us know that the "Establish" success flowed through the proxy masquerading as a gateway.


### PR DESCRIPTION
### Description
When trying to establish a peering using mesh gateways, there is a high probability that because of the fallback behavior, you will end up bypassing the local mesh gateway and going directly to the remote cluster.

This PR attempts to solve the problem in two ways:

Increase the sleep time that allows the mesh gateway to update xDS from 350ms (~p50) to 1s (~p96)
Enter a retry loop of only gateway addresses for a few seconds, then fallback to all addresses.
