### PR TITLE
Ensure imported services are filtered in IndexedNodesWithGateways

### DIFF
--- a/.changelog/15317.txt
+++ b/.changelog/15317.txt
@@ -1,0 +1,3 @@
+```release-note:improvements
+acl: Allow reading imported services and nodes from cluster peers with read all permissions
+```

--- a/agent/structs/aclfilter/filter.go
+++ b/agent/structs/aclfilter/filter.go
@@ -147,6 +147,9 @@ func (f *Filter) Filter(subject any) {
 		if f.filterGatewayServices(&v.Gateways) {
 			v.QueryMeta.ResultsFilteredByACLs = true
 		}
+		if f.filterCheckServiceNodes(&v.ImportedNodes) {
+			v.QueryMeta.ResultsFilteredByACLs = true
+		}
 
 	default:
 		panic(fmt.Errorf("Unhandled type passed to ACL filter: %T %#v", subject, subject))
@@ -324,13 +327,11 @@ func (f *Filter) filterNodeServiceList(services *structs.NodeServiceList) bool {
 // true if any elements were removed.
 func (f *Filter) filterCheckServiceNodes(nodes *structs.CheckServiceNodes) bool {
 	csn := *nodes
-	var authzContext acl.AuthorizerContext
 	var removed bool
 
 	for i := 0; i < len(csn); i++ {
 		node := csn[i]
-		node.Service.FillAuthzContext(&authzContext)
-		if f.allowNode(node.Node.Node, &authzContext) && f.allowService(node.Service.Service, &authzContext) {
+		if node.CanRead(f.authorizer) == acl.Allow {
 			continue
 		}
 		f.logger.Debug("dropping node from result due to ACLs", "node", structs.NodeNameString(node.Node.Node, node.Node.GetEnterpriseMeta()))

--- a/agent/structs/aclfilter/filter_test.go
+++ b/agent/structs/aclfilter/filter_test.go
@@ -1293,12 +1293,51 @@ func TestACL_filterIndexedNodesWithGateways(t *testing.T) {
 				{Service: structs.ServiceNameFromString("foo")},
 				{Service: structs.ServiceNameFromString("bar")},
 			},
+			ImportedNodes: structs.CheckServiceNodes{
+				{
+					Node: &structs.Node{
+						Node:     "imported-node",
+						PeerName: "cluster-02",
+					},
+					Service: &structs.NodeService{
+						ID:       "zip",
+						Service:  "zip",
+						PeerName: "cluster-02",
+					},
+					Checks: structs.HealthChecks{
+						{
+							Node:        "node1",
+							CheckID:     "check1",
+							ServiceName: "zip",
+							PeerName:    "cluster-02",
+						},
+					},
+				},
+			},
 		}
 	}
 
-	t.Run("allowed", func(t *testing.T) {
+	type testCase struct {
+		authzFn func() acl.Authorizer
+		expect  *structs.IndexedNodesWithGateways
+	}
 
-		policy, err := acl.NewPolicyFromSource(`
+	run := func(t *testing.T, tc testCase) {
+		authz := tc.authzFn()
+
+		list := makeList()
+		New(authz, logger).Filter(list)
+
+		require.Equal(t, tc.expect, list)
+	}
+
+	tt := map[string]testCase{
+		"not filtered": {
+			authzFn: func() acl.Authorizer {
+				policy, err := acl.NewPolicyFromSource(`
+			service "baz" {
+				policy = "write"
+			}
 			service "foo" {
 			  policy = "read"
 			}
@@ -1309,22 +1348,63 @@ func TestACL_filterIndexedNodesWithGateways(t *testing.T) {
 			  policy = "read"
 			}
 		`, acl.SyntaxLegacy, nil, nil)
-		require.NoError(t, err)
+				require.NoError(t, err)
 
-		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-		require.NoError(t, err)
-
-		list := makeList()
-		New(authz, logger).Filter(list)
-
-		require.Len(t, list.Nodes, 1)
-		require.Len(t, list.Gateways, 2)
-		require.False(t, list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be false")
-	})
-
-	t.Run("not allowed to read the node", func(t *testing.T) {
-
-		policy, err := acl.NewPolicyFromSource(`
+				authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+				require.NoError(t, err)
+				return authz
+			},
+			expect: &structs.IndexedNodesWithGateways{
+				Nodes: structs.CheckServiceNodes{
+					{
+						Node: &structs.Node{
+							Node: "node1",
+						},
+						Service: &structs.NodeService{
+							ID:      "foo",
+							Service: "foo",
+						},
+						Checks: structs.HealthChecks{
+							{
+								Node:        "node1",
+								CheckID:     "check1",
+								ServiceName: "foo",
+							},
+						},
+					},
+				},
+				Gateways: structs.GatewayServices{
+					{Service: structs.ServiceNameFromString("foo")},
+					{Service: structs.ServiceNameFromString("bar")},
+				},
+				// Service write to "bar" allows reading all imported services
+				ImportedNodes: structs.CheckServiceNodes{
+					{
+						Node: &structs.Node{
+							Node:     "imported-node",
+							PeerName: "cluster-02",
+						},
+						Service: &structs.NodeService{
+							ID:       "zip",
+							Service:  "zip",
+							PeerName: "cluster-02",
+						},
+						Checks: structs.HealthChecks{
+							{
+								Node:        "node1",
+								CheckID:     "check1",
+								ServiceName: "zip",
+								PeerName:    "cluster-02",
+							},
+						},
+					},
+				},
+				QueryMeta: structs.QueryMeta{ResultsFilteredByACLs: false},
+			},
+		},
+		"not allowed to read the node": {
+			authzFn: func() acl.Authorizer {
+				policy, err := acl.NewPolicyFromSource(`
 			service "foo" {
 			  policy = "read"
 			}
@@ -1332,22 +1412,25 @@ func TestACL_filterIndexedNodesWithGateways(t *testing.T) {
 			  policy = "read"
 			}
 		`, acl.SyntaxLegacy, nil, nil)
-		require.NoError(t, err)
+				require.NoError(t, err)
 
-		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-		require.NoError(t, err)
-
-		list := makeList()
-		New(authz, logger).Filter(list)
-
-		require.Empty(t, list.Nodes)
-		require.Len(t, list.Gateways, 2)
-		require.True(t, list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
-	})
-
-	t.Run("allowed to read the node, but not the service", func(t *testing.T) {
-
-		policy, err := acl.NewPolicyFromSource(`
+				authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+				require.NoError(t, err)
+				return authz
+			},
+			expect: &structs.IndexedNodesWithGateways{
+				Nodes: structs.CheckServiceNodes{},
+				Gateways: structs.GatewayServices{
+					{Service: structs.ServiceNameFromString("foo")},
+					{Service: structs.ServiceNameFromString("bar")},
+				},
+				ImportedNodes: structs.CheckServiceNodes{},
+				QueryMeta:     structs.QueryMeta{ResultsFilteredByACLs: true},
+			},
+		},
+		"not allowed to read the service": {
+			authzFn: func() acl.Authorizer {
+				policy, err := acl.NewPolicyFromSource(`
 			node "node1" {
 			  policy = "read"
 			}
@@ -1355,22 +1438,24 @@ func TestACL_filterIndexedNodesWithGateways(t *testing.T) {
 			  policy = "read"
 			}
 		`, acl.SyntaxLegacy, nil, nil)
-		require.NoError(t, err)
+				require.NoError(t, err)
 
-		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-		require.NoError(t, err)
-
-		list := makeList()
-		New(authz, logger).Filter(list)
-
-		require.Empty(t, list.Nodes)
-		require.Len(t, list.Gateways, 1)
-		require.True(t, list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
-	})
-
-	t.Run("not allowed to read the other gatway service", func(t *testing.T) {
-
-		policy, err := acl.NewPolicyFromSource(`
+				authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+				require.NoError(t, err)
+				return authz
+			},
+			expect: &structs.IndexedNodesWithGateways{
+				Nodes: structs.CheckServiceNodes{},
+				Gateways: structs.GatewayServices{
+					{Service: structs.ServiceNameFromString("bar")},
+				},
+				ImportedNodes: structs.CheckServiceNodes{},
+				QueryMeta:     structs.QueryMeta{ResultsFilteredByACLs: true},
+			},
+		},
+		"not allowed to read the other gateway service": {
+			authzFn: func() acl.Authorizer {
+				policy, err := acl.NewPolicyFromSource(`
 			service "foo" {
 			  policy = "read"
 			}
@@ -1378,28 +1463,54 @@ func TestACL_filterIndexedNodesWithGateways(t *testing.T) {
 			  policy = "read"
 			}
 		`, acl.SyntaxLegacy, nil, nil)
-		require.NoError(t, err)
+				require.NoError(t, err)
 
-		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-		require.NoError(t, err)
+				authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+				require.NoError(t, err)
+				return authz
+			},
+			expect: &structs.IndexedNodesWithGateways{
+				Nodes: structs.CheckServiceNodes{
+					{
+						Node: &structs.Node{
+							Node: "node1",
+						},
+						Service: &structs.NodeService{
+							ID:      "foo",
+							Service: "foo",
+						},
+						Checks: structs.HealthChecks{
+							{
+								Node:        "node1",
+								CheckID:     "check1",
+								ServiceName: "foo",
+							},
+						},
+					},
+				},
+				Gateways: structs.GatewayServices{
+					{Service: structs.ServiceNameFromString("foo")},
+				},
+				ImportedNodes: structs.CheckServiceNodes{},
+				QueryMeta:     structs.QueryMeta{ResultsFilteredByACLs: true},
+			},
+		},
+		"denied": {
+			authzFn: acl.DenyAll,
+			expect: &structs.IndexedNodesWithGateways{
+				Nodes:         structs.CheckServiceNodes{},
+				Gateways:      structs.GatewayServices{},
+				ImportedNodes: structs.CheckServiceNodes{},
+				QueryMeta:     structs.QueryMeta{ResultsFilteredByACLs: true},
+			},
+		},
+	}
 
-		list := makeList()
-		New(authz, logger).Filter(list)
-
-		require.Len(t, list.Nodes, 1)
-		require.Len(t, list.Gateways, 1)
-		require.True(t, list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
-	})
-
-	t.Run("denied", func(t *testing.T) {
-
-		list := makeList()
-		New(acl.DenyAll(), logger).Filter(list)
-
-		require.Empty(t, list.Nodes)
-		require.Empty(t, list.Gateways)
-		require.True(t, list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
-	})
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
 }
 
 func TestACL_filterIndexedServiceDump(t *testing.T) {


### PR DESCRIPTION
1.13 backport of #3431

Previously the ACL filter was not operating on ImportedNodes of
IndexedNodesWithGateways, which means that the UI Nodes views
will always return data imported from a peer without filtering.
    
Because of this, imported nodes/services/checks could be viewed by
users lacking the appropriate ACL permissions.