### PR TITLE
docs: Include env vars in consul-dataplane reference

### DIFF
--- a/website/content/docs/connect/dataplane/consul-dataplane.mdx
+++ b/website/content/docs/connect/dataplane/consul-dataplane.mdx
@@ -44,50 +44,50 @@ The following options are required when starting `consul-dataplane` with the CLI
 
 ### Command Options
 
-- `-addresses` - Consul server gRPC addresses. Can be a DNS name or an executable command. Refer to [go-netaddrs](https://github.com/hashicorp/go-netaddrs#summary) for details and examples.
-- `-ca-certs` - The path to a file or directory containing CA certificates used to verify the server's certificate.
-- `-consul-dns-bind-addr` - The address bound to the Consul DNS proxy. Default is `"127.0.0.1"`.
-- `-consul-dns-bind-port` - The port that the Consul DNS proxy listens on. Default is `-1`, which disables the DNS proxy.
-- `-credential-type` - The type of credentials used to authenticate with Consul servers, either `"static"` or `"login"`.
-- `-envoy-admin-bind-address` - The address the Envoy admin server is available on. Default is `"127.0.0.1"`.
-- `-envoy-admin-bind-port` - The port the Envoy admin server is available on. Default is `19000`.
-- `-envoy-concurrency` - The number of worker threads that Envoy uses. Default is `2`.
-- `-envoy-ready-bind-address` - The address Envoy's readiness probe is available on.
-- `-envoy-ready-bind-port` - The port Envoy's readiness probe is available on.
-- `-grpc-port` - The Consul server gRPC port to which `consul-dataplane` connects. Default is `8502`.
-- `-log-json` - Enables log messages in JSON format. Default is `false`.
-- `-log-level` - Log level of the messages to print. Available log levels are `"trace"`, `"debug"`, `"info"`, `"warn"`, and `"error"`. Default is `"info"`.
-- `-login-auth-method` - The auth method used to log in.
-- `-login-bearer-token` - The bearer token presented to the auth method.
-- `-login-bearer-token-path` - The path to a file containing the bearer token presented to the auth method.
-- `-login-datacenter` - The datacenter containing the auth method.
-- `-login-meta` - A set of key/value pairs to attach to the ACL token. Each pair is formatted as `<key>=<value>`. This flag may be passed multiple times.
-- `-login-namespace` <EnterpriseAlert inline /> - The Consul Enterprise namespace containing the auth method.
-- `-login-partition` <EnterpriseAlert inline /> - The Consul Enterprise partition containing the auth method.
-- `-proxy-service-id` - The proxy service instance's ID.
-- `-server-watch-disabled` - Prevent `consul-dataplane` from consuming the server update stream. Use this flag when Consul servers are behind a load balancer. Default is `false`.
-- `-service-namespace` <EnterpriseAlert inline /> - The Consul Enterprise namespace in which the proxy service instance is registered.
-- `-service-node-id` - The ID of the Consul node to which the proxy service instance is registered.
-- `-service-node-name` - The name of the Consul node to which the proxy service instance is registered.
-- `-service-partition` <EnterpriseAlert inline /> - The Consul Enterprise partition in which the proxy service instance is registered.
-- `-static-token` - The ACL token used to authenticate requests to Consul servers when `-credential-type` is set to `"static"`.
-- `-telemetry-prom-ca-certs-path` - The path to a file or directory containing CA certificates used to verify the Prometheus server's certificate.
-- `-telemetry-prom-cert-file` - The path to the client certificate used to serve Prometheus metrics.
-- `-telemetry-prom-key-file` - The path to the client private key used to serve Prometheus metrics.
-- `-telemetry-prom-merge-port` - The local port used to serve merged Prometheus metrics. Default is `20100`. If your service instance uses the same default port, this flag must be set to a different port in order to avoid a port conflict.
-- `-telemetry-prom-retention-time` - The duration for Prometheus metrics aggregation. Default is `1m0s`. Refer to [`prometheus_retention_time`](/docs/agent/config/config-files#telemetry-prometheus_retention_time) for details on setting this value.
-- `-telemetry-prom-scrape-path` - The URL path where Envoy serves Prometheus metrics. Default is `"/metrics"`.
-- `-telemetry-prom-service-metrics-url` - The URL where your service instance serves Prometheus metrics. If this is set, the metrics at this URL are included in Consul Dataplane's merged Prometheus metrics.
-- `-telemetry-use-central-config` - Controls whether the proxy applies the central telemetry configuration. Default is `true`.
-- `-tls-cert` - The path to a client certificate file. This flag is required if `tls.grpc.verify_incoming` is enabled on the server.
-- `-tls-disabled` - Communicate with Consul servers over a plaintext connection. Useful for testing, but not recommended for production. Default is `false`.
-- `-tls-insecure-skip-verify` - Do not verify the server's certificate. Useful for testing, but not recommended for production. Default is `false`.
-- `-tls-key` - The path to a client private key file. This flag is required if `tls.grpc.verify_incoming` is enabled on the server.
-- `-tls-server-name` - The hostname to expect in the server certificate's subject. This flag is required if `-addresses` is not a DNS name.
+- `-addresses` - Consul server gRPC addresses. Can be a DNS name or an executable command. Accepted environment variable is `DP_CONSUL_ADDRESSES`. Refer to [go-netaddrs](https://github.com/hashicorp/go-netaddrs#summary) for details and examples.
+- `-ca-certs` - The path to a file or directory containing CA certificates used to verify the server's certificate. Accepted environment variable is `DP_CA_CERTS`.
+- `-consul-dns-bind-addr` - The address bound to the Consul DNS proxy. Default is `"127.0.0.1"`. Accepted environment variable is `DP_CONSUL_DNS_BIND_ADDR`.
+- `-consul-dns-bind-port` - The port that the Consul DNS proxy listens on. Default is `-1`, which disables the DNS proxy. Accepted environment variable is `DP_CONSUL_DNS_BIND_PORT`.
+- `-credential-type` - The type of credentials used to authenticate with Consul servers, either `"static"` or `"login"`. Accepted environment variable is `DP_CREDENTIAL_TYPE`.
+- `-envoy-admin-bind-address` - The address the Envoy admin server is available on. Default is `"127.0.0.1"`. Accepted environment variable is `DP_ENVOY_ADMIN_BIND_ADDRESS`.
+- `-envoy-admin-bind-port` - The port the Envoy admin server is available on. Default is `19000`. Accepted environment variable is `DP_ENVOY_ADMIN_BIND_PORT`.
+- `-envoy-concurrency` - The number of worker threads that Envoy uses. Default is `2`. Accepted environment variable is `DP_ENVOY_CONCURRENCY`.
+- `-envoy-ready-bind-address` - The address Envoy's readiness probe is available on. Accepted environment variable is `DP_ENVOY_READY_BIND_ADDRESS`.
+- `-envoy-ready-bind-port` - The port Envoy's readiness probe is available on. Accepted environment variable is `DP_ENVOY_READY_BIND_PORT`.
+- `-grpc-port` - The Consul server gRPC port to which `consul-dataplane` connects. Default is `8502`. Accepted environment variable is `DP_CONSUL_GRPC_PORT`.
+- `-log-json` - Enables log messages in JSON format. Default is `false`. Accepted environment variable is `DP_LOG_JSON`.
+- `-log-level` - Log level of the messages to print. Available log levels are `"trace"`, `"debug"`, `"info"`, `"warn"`, and `"error"`. Default is `"info"`. Accepted environment variable is `DP_LOG_LEVEL`.
+- `-login-auth-method` - The auth method used to log in. Accepted environment variable is `DP_CREDENTIAL_LOGIN_AUTH_METHOD`.
+- `-login-bearer-token` - The bearer token presented to the auth method. Accepted environment variable is `DP_CREDENTIAL_LOGIN_BEARER_TOKEN`.
+- `-login-bearer-token-path` - The path to a file containing the bearer token presented to the auth method. Accepted environment variable is `DP_CREDENTIAL_LOGIN_BEARER_TOKEN_PATH`.
+- `-login-datacenter` - The datacenter containing the auth method. Accepted environment variable is `DP_CREDENTIAL_LOGIN_DATACENTER`.
+- `-login-meta` - A set of key/value pairs to attach to the ACL token. Each pair is formatted as `<key>=<value>`. This flag may be passed multiple times. Accepted environment variables are `DP_CREDENTIAL_LOGIN_META{1..9}`.
+- `-login-namespace` <EnterpriseAlert inline /> - The Consul Enterprise namespace containing the auth method. Accepted environment variable is `DP_CREDENTIAL_LOGIN_NAMESPACE`.
+- `-login-partition` <EnterpriseAlert inline /> - The Consul Enterprise partition containing the auth method. Accepted environment variable is `DP_CREDENTIAL_LOGIN_PARTITION`.
+- `-proxy-service-id` - The proxy service instance's ID. Accepted environment variable is `DP_PROXY_SERVICE_ID`.
+- `-proxy-service-id-path` - The path to a file containing the proxy service instance's ID. Accepted environment variable is `DP_PROXY_SERVICE_ID_PATH`.
+- `-server-watch-disabled` - Prevent `consul-dataplane` from consuming the server update stream. Use this flag when Consul servers are behind a load balancer. Default is `false`. Accepted environment variable is `DP_SERVER_WATCH_DISABLED`.
+- `-service-namespace` <EnterpriseAlert inline /> - The Consul Enterprise namespace in which the proxy service instance is registered. Accepted environment variable is `DP_SERVICE_NAMESPACE`.
+- `-service-node-id` - The ID of the Consul node to which the proxy service instance is registered. Accepted environment variable is `DP_SERVICE_NODE_ID`.
+- `-service-node-name` - The name of the Consul node to which the proxy service instance is registered. Accepted environment variable is `DP_SERVICE_NODE_NAME`.
+- `-service-partition` <EnterpriseAlert inline /> - The Consul Enterprise partition in which the proxy service instance is registered. Accepted environment variable is `DP_SERVICE_PARTITION`.
+- `-static-token` - The ACL token used to authenticate requests to Consul servers when `-credential-type` is set to `"static"`. Accepted environment variable is `DP_CREDENTIAL_STATIC_TOKEN`.
+- `-telemetry-prom-ca-certs-path` - The path to a file or directory containing CA certificates used to verify the Prometheus server's certificate. Accepted environment variable is `DP_TELEMETRY_PROM_CA_CERTS_PATH`.
+- `-telemetry-prom-cert-file` - The path to the client certificate used to serve Prometheus metrics. Accepted environment variable is `DP_TELEMETRY_PROM_CERT_FILE`.
+- `-telemetry-prom-key-file` - The path to the client private key used to serve Prometheus metrics. Accepted environment variable is `DP_TELEMETRY_PROM_KEY_FILE`.
+- `-telemetry-prom-merge-port` - The local port used to serve merged Prometheus metrics. Default is `20100`. If your service instance uses the same default port, this flag must be set to a different port in order to avoid a port conflict. Accepted environment variable is `DP_TELEMETRY_PROM_MERGE_PORT`.
+- `-telemetry-prom-retention-time` - The duration for Prometheus metrics aggregation. Default is `1m0s`. Accepted environment variable is `DP_TELEMETRY_PROM_RETENTION_TIME`. Refer to [`prometheus_retention_time`](/docs/agent/config/config-files#telemetry-prometheus_retention_time) for details on setting this value.
+- `-telemetry-prom-scrape-path` - The URL path where Envoy serves Prometheus metrics. Default is `"/metrics"`. Accepted environment variable is `DP_TELEMETRY_PROM_SCRAPE_PATH`.
+- `-telemetry-prom-service-metrics-url` - The URL where your service instance serves Prometheus metrics. If this is set, the metrics at this URL are included in Consul Dataplane's merged Prometheus metrics. Accepted environment variable is `DP_TELEMETRY_PROM_SERVICE_METRICS_URL`.
+- `-telemetry-use-central-config` - Controls whether the proxy applies the central telemetry configuration. Default is `true`. Accepted environment variable is `DP_TELEMETRY_USE_CENTRAL_CONFIG`.
+- `-tls-cert` - The path to a client certificate file. This flag is required if `tls.grpc.verify_incoming` is enabled on the server. Accepted environment variable is `DP_TLS_CERT`.
+- `-tls-disabled` - Communicate with Consul servers over a plaintext connection. Useful for testing, but not recommended for production. Default is `false`. Accepted environment variable is `DP_TLS_DISABLED`.
+- `-tls-insecure-skip-verify` - Do not verify the server's certificate. Useful for testing, but not recommended for production. Default is `false`. `DP_TLS_INSECURE_SKIP_VERIFY`.
+- `-tls-key` - The path to a client private key file. This flag is required if `tls.grpc.verify_incoming` is enabled on the server. Accepted environment variable is `DP_TLS_KEY`.
+- `-tls-server-name` - The hostname to expect in the server certificate's subject. This flag is required if `-addresses` is not a DNS name. Accepted environment variable is `DP_TLS_SERVER_NAME`.
 - `-version` - Print the current version of `consul-dataplane`.
-- `-xds-bind-addr` - The address the Envoy xDS server is available on. Default is `"127.0.0.1"`.
-- `-xds-bind-port` - The port on which the Envoy xDS server is available. Default is `0`. When set
-  to `0`, an available port is selected at random.
+- `-xds-bind-addr` - The address the Envoy xDS server is available on. Default is `"127.0.0.1"`. Accepted environment variable is `DP_XDS_BIND_ADDR`.
+- `-xds-bind-port` - The port on which the Envoy xDS server is available. Default is `0`. When set to `0`, an available port is selected at random. Accepted environment variable is `DP_XDS_BIND_PORT`.
 
 ## Examples
 

--- a/website/content/docs/connect/dataplane/consul-dataplane.mdx
+++ b/website/content/docs/connect/dataplane/consul-dataplane.mdx
@@ -15,7 +15,7 @@ Usage: `consul-dataplane [options]`
 
 ### Requirements
 
-Consul Dataplane requires servers running Consul version `v1.14-beta1+`. To find a specific version of Consul, refer to [Hashicorp's Official Release Channels](https://www.hashicorp.com/official-release-channels).
+Consul Dataplane requires servers running Consul version `v1.14+`. To find a specific version of Consul, refer to [Hashicorp's Official Release Channels](https://www.hashicorp.com/official-release-channels).
 
 ### Startup
 

--- a/website/content/docs/connect/dataplane/index.mdx
+++ b/website/content/docs/connect/dataplane/index.mdx
@@ -7,11 +7,9 @@ description: >-
 
 # Simplified Service Mesh with Consul Dataplane
 
-~> **Consul Dataplane is currently in beta:** Functionality associated with Consul Dataplane is subject to change. You should never use the beta release in secure environments or production scenarios. Features in beta may have performance issues, scaling issues, and limited support.
-
 This topic provides an overview of Consul Dataplane, a lightweight process for managing Envoy proxies introduced in Consul v1.14.0. Consul Dataplane removes the need to run client agents on every node in a cluster for service discovery and service mesh. Instead, Consul deploys sidecar proxies that provide lower latency, support additional runtimes, and integrate with cloud infrastructure providers.
 
-Consul Dataplane requires servers running Consul v1.14.0-beta1+ and Consul K8s v1.0.0-beta1+.
+Consul Dataplane requires servers running Consul v1.14.0+ and Consul K8s v1.0.0+.
 
 ## What is Consul Dataplane?
 
@@ -39,38 +37,36 @@ To get started with Consul Dataplane, use the following reference resources:
 
 ### Installation
 
-To install the beta release of Consul Dataplane, set `VERSION` to `1.0.0-beta` and then follow the instructions to install a specific version of Consul [with the Helm Chart](/docs/k8s/installation/install#install-consul) or [with the Consul-k8s CLI](/docs/k8s/installation/install-cli#install-a-previous-version).
+To install Consul Dataplane, set `VERSION` to `1.0.0` and then follow the instructions to install a specific version of Consul [with the Helm Chart](/docs/k8s/installation/install#install-consul) or [with the Consul-k8s CLI](/docs/k8s/installation/install-cli#install-a-previous-version).
 
 #### Helm
 
 ```shell-session
-$ export VERSION=1.0.0-beta3
+$ export VERSION=1.0.0
 $ helm install consul hashicorp/consul --set global.name=consul --version ${VERSION} --create-namespace --namespace consul
 ```
 
 #### Consul-k8s CLI
 
 ```shell-session
-$ export VERSION=1.0.0-beta3 && \
+$ export VERSION=1.0.0 && \
     curl --location "https://releases.hashicorp.com/consul-k8s/${VERSION}/consul-k8s_${VERSION}_darwin_amd64.zip" --output consul-k8s-cli.zip
 ```
 
-## Beta release features
+## Feature support
 
-The beta release of Consul Dataplane supports the following features:
+Consul Dataplane supports the following features:
 
 - Single and multi-cluster installations, including those with WAN federation, cluster peering, and admin partitions are supported.
 - Ingress, terminating, and mesh gateways are supported.
 - Running Consul service mesh in AWS Fargate and GKE Autopilot is supported.
 - xDS load balancing is supported.
 - Servers running in Kubernetes and servers external to Kubernetes are both supported.
-
-Integration with HCP Consul is being tested in an invitation-only closed beta. HCP Consul support for Dataplane will be available for all users in a future release.
+- HCP Consul is supported.
 
 ### Technical Constraints
 
 Be aware of the following limitations and recommendations for Consul Dataplane:
 
 - Consul API Gateway is not currently supported.
-- Transparent proxies are not supported.
 - Consul Dataplane is not supported on Windows.

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -48,13 +48,11 @@ Envoy 1.16.x and older releases are no longer supported (see [HCSEC-2022-07](htt
 
 ### Envoy and Consul Dataplane
 
-~> **Note:** Consul Dataplane is currently in beta.
-
 Consul Dataplane is a feature introduced in Consul v1.14. Because each version of Consul Dataplane supports one specific version of Envoy, you must use the following versions of Consul, Consul Dataplane, and Envoy together.
 
 | Consul Version      | Consul Dataplane Version | Bundled Envoy Version  |
 | ------------------- | ------------------------ | ---------------------- |
-| 1.14.x              | 1.0.x                    | 1.23.x                 |
+| 1.14.x              | 1.0.x                    | 1.24.x                 |
 
 ## Getting Started
 


### PR DESCRIPTION
### Description

* Update the documentation for consul-dataplane config options to include newly-supported environment variables.
* Correct the bundled Envoy version to 1.24 for consul-dataplane GA release
* Remove "beta" text around Consul Dataplane

### Links

* https://github.com/hashicorp/consul-dataplane/#configuration-reference

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
