### PR TITLE
docs: update compatibility matrix

### DIFF
--- a/website/content/docs/k8s/compatibility.mdx
+++ b/website/content/docs/k8s/compatibility.mdx
@@ -11,13 +11,13 @@ For every release of Consul on Kubernetes, a Helm chart, `consul-k8s-control-pla
 
 ## Supported Consul versions
 
-Consul Kubernetes versions all of its components (`consul-k8s` CLI, `consul-k8s-control-plane`, and Helm chart) with a single semantic version. When installing or upgrading to a specific versions, ensure that you are using the correct Consul version with the compatible `consul-k8s` helm chart and/or CLI.   
+Consul Kubernetes versions all of its components (`consul-k8s` CLI, `consul-k8s-control-plane`, and Helm chart) with a single semantic version. When installing or upgrading to a specific versions, ensure that you are using the correct Consul version with the compatible `consul-k8s` helm chart and/or CLI.
 
 | Consul Version | Compatible consul-k8s Versions   |
 | -------------- | -------------------------------- |
-| 1.13.x         | 0.47.0 - latest                  |
-| 1.12.x         | 0.43.0 - latest                  |
-| 1.11.x         | 0.39.0 - 0.42.0, 0.44.0 - latest |
+| 1.13.x         | 0.49.x                           |
+| 1.12.x         | 0.43.0 - 0.49.x                  |
+| 1.11.x         | 0.39.0 - 0.42.0, 0.44.0 - 0.49.x |
 
 ## Supported Envoy versions
 
@@ -33,7 +33,7 @@ Starting with Consul K8s 0.39.0 and Consul 1.11.x, Consul Kubernetes supports th
 
 ## Platform specific compatibility notes
 
-### Red Hat OpenShift 
+### Red Hat OpenShift
 
 Consul Kubernetes delivered Red Hat OpenShift support starting with Consul Helm chart version 0.25.0 for Consul 1.8.4. Please note the following details regarding OpenShift support.
 


### PR DESCRIPTION
Update consul-k8s compatibility matrix to match stable release branches. Since after 1.0.0, consul <1.14 will only be compatible with up through consul-k8s 0.49.x

This change should go to the 1.13 branch of docs as well, so backporting them to 1.13. Not 100% sure if this is the right label.