### PR TITLE
fix: clarifying error message when acquiring a lock in remote dc

### DIFF
--- a/agent/session_endpoint.go
+++ b/agent/session_endpoint.go
@@ -47,6 +47,10 @@ func (s *HTTPHandlers) SessionCreate(resp http.ResponseWriter, req *http.Request
 
 	fixupEmptySessionChecks(&args.Session)
 
+	if (s.agent.config.Datacenter != args.Datacenter) && (!s.agent.config.ServerMode) {
+		return nil, fmt.Errorf("cross datacenter lock must be created at server agent")
+	}
+
 	// Create the session, get the ID
 	var out string
 	if err := s.agent.RPC("Session.Apply", &args, &out); err != nil {

--- a/website/content/commands/lock.mdx
+++ b/website/content/commands/lock.mdx
@@ -24,6 +24,10 @@ If the lock holder count is more than one, then a semaphore is used instead.
 A semaphore allows more than a single holder, but this is less efficient than
 a simple lock. This follows the [semaphore algorithm](https://learn.hashicorp.com/consul/developer-configuration/semaphore).
 
+If the lock is created with `-datacenter=<name>` to a remote WAN federated
+datacenter, the agent must be an server agent because client agents are
+unavailable to the remote datacenter.
+
 All locks using the same prefix must agree on the value of `-n`. If conflicting
 values of `-n` are provided, an error will be returned.
 

--- a/website/content/commands/lock.mdx
+++ b/website/content/commands/lock.mdx
@@ -24,7 +24,7 @@ If the lock holder count is more than one, then a semaphore is used instead.
 A semaphore allows more than a single holder, but this is less efficient than
 a simple lock. This follows the [semaphore algorithm](https://learn.hashicorp.com/consul/developer-configuration/semaphore).
 
-To apply a lock to a remote WAN federated datacenter, run the command with the `-datacenter=<name>` flag on a server agent. You cannot run use the command with `-datacenter` on client agents because they are unavailable to the remote datacenter.
+To apply a lock to a remote WAN federated datacenter, run the command with the `-datacenter=<name>` flag on a server agent. You cannot use the command with `-datacenter` on client agents because they are unavailable to the remote datacenter.
 
 All locks using the same prefix must agree on the value of `-n`. If conflicting
 values of `-n` are provided, an error will be returned.

--- a/website/content/commands/lock.mdx
+++ b/website/content/commands/lock.mdx
@@ -24,9 +24,7 @@ If the lock holder count is more than one, then a semaphore is used instead.
 A semaphore allows more than a single holder, but this is less efficient than
 a simple lock. This follows the [semaphore algorithm](https://learn.hashicorp.com/consul/developer-configuration/semaphore).
 
-If the lock is created with `-datacenter=<name>` to a remote WAN federated
-datacenter, the agent must be an server agent because client agents are
-unavailable to the remote datacenter.
+To apply a lock to a remote WAN federated datacenter, run the command with the `-datacenter=<name>` flag on a server agent. You cannot run use the command with `-datacenter` on client agents because they are unavailable to the remote datacenter.
 
 All locks using the same prefix must agree on the value of `-n`. If conflicting
 values of `-n` are provided, an error will be returned.


### PR DESCRIPTION
### Description
When user uses `consul lock` to acquire a lock in a remote dc, if the command is run at a client agent, the returned error message is 
`Lock acquisition failed: failed to create session: Unexpected response code: 500 (rpc error making call: rpc error making call: apply failed: Missing node registration)`
which is unclear about the actual root cause. This PR updates the error message to 

`Lock acquisition failed: failed to create session: Unexpected response code: 500 (cross datacenter lock must be created at server agent)`

### Testing & Reproduction steps

Please refer to the issue https://github.com/hashicorp/consul/issues/14212#issuecomment-1316215464

### Links
fix https://github.com/hashicorp/consul/issues/14212

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] not a security concern
