### PR TITLE
docs: add nomad incompatibility to 1.14 docs

### DIFF
--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -24,10 +24,10 @@ A breaking change was made in Consul 1.14 that:
 - [Consul Connect is enabled by default.](/docs/connect) To disable, set
 [`connect.enabled`](/docs/agent/config/config-files#connect_enabled) to `false`.
 
-Consul 1.14's Service Mesh changes are incompatible with Nomad 1.4.2 and
-earlier. Users of Consul Service Mesh through Nomad, should wait until
+The changes to Consul service mesh in version 1.14 are incompatible with Nomad 1.4.2 and
+earlier. If you operate Consul service mesh using Nomad 1.4.2 or earlier, do not upgrade to Consul 1.14 until 
 [hashicorp/nomad#15266](https://github.com/hashicorp/nomad/issues/15266) is
-fixed before upgrading to Consul 1.14.
+fixed.
 
 #### Changes to gRPC TLS configuration
 

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -24,6 +24,11 @@ A breaking change was made in Consul 1.14 that:
 - [Consul Connect is enabled by default.](/docs/connect) To disable, set
 [`connect.enabled`](/docs/agent/config/config-files#connect_enabled) to `false`.
 
+Consul 1.14's Service Mesh changes are incompatible with Nomad 1.4.2 and
+earlier. Users of Consul Service Mesh through Nomad, should wait until
+[hashicorp/nomad#15266](https://github.com/hashicorp/nomad/issues/15266) is
+fixed before upgrading to Consul 1.14.
+
 #### Changes to gRPC TLS configuration
 
 **Make configuration changes** if using [`ports.grpc`](/docs/agent/config/config-files#grpc_port) in conjunction with any of the following settings that enables encryption:


### PR DESCRIPTION
See https://github.com/hashicorp/nomad/issues/15266 for details.

I plan to submit a followup PR to update these docs once Nomad releases a fix. At that point Nomad users will still need to be informed that they must upgrade Nomad to a compatible version *before* upgrading Consul to 1.14.

Feel free to edit the wording or formatting or whatever. I just want to get any warning up for Nomad users ASAP so they don't discover this *after* having upgraded their Consul cluster and end up in a really bad state.