### PR TITLE
Include addresses.grpc_tls in upgrade docs.

### DIFF
--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -102,6 +102,7 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
   - `http` - The HTTP API. Defaults to `client_addr`
   - `https` - The HTTPS API. Defaults to `client_addr`
   - `grpc` - The gRPC API. Defaults to `client_addr`
+  - `grpc_tls` - The gRPC API with TLS. Defaults to `client_addr`
 
 - `alt_domain` Equivalent to the [`-alt-domain` command-line flag](/docs/agent/config/cli-flags#_alt_domain)
 

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -39,7 +39,10 @@ for encrypting communication over gRPC. The existing [`ports.grpc`](/docs/agent/
 [`ports.grpc_tls`](/docs/agent/config/config-files#grpc_tls_port) is the only port that serves encrypted gRPC traffic.
 The default value for the gRPC TLS port is 8503 for Consul servers. To disable the gRPC TLS port, use value -1.
 
-If you already use gRPC encryption, change the existing `ports.grpc` to `ports.grpc_tls` in your configuration to ensure compatibility.
+If you already use gRPC encryption, change the following fields to ensure compatibility:
+
++ Change `ports.grpc` to `ports.grpc_tls`. [visit ports documentation for details](/docs/agent/config/config-files#grpc_tls_port)
++ Change `addresses.grpc` to `addresses.grpc_tls`. [visit addresses documentation for details](/docs/agent/config/config-files#grpc_tls)
 
 #### Changes to peering
 


### PR DESCRIPTION
Fix missing documentation on upgrade process and new grpc_tls addresses config.