### PR TITLE
add multilimiter and tests

### DIFF
--- a/agent/consul/multilimiter/multilimiter.go
+++ b/agent/consul/multilimiter/multilimiter.go
@@ -8,14 +8,14 @@ import (
 	"time"
 )
 
-type limitedEntity interface {
+type LimitedEntity interface {
 	Key() []byte
 }
 
 type RateLimiter interface {
 	Start()
 	Stop()
-	Allow(entity limitedEntity) bool
+	Allow(entity LimitedEntity) bool
 	UpdateConfig(c Config)
 }
 
@@ -72,7 +72,7 @@ func (m *MultiLimiter) Stop() {
 	}
 }
 
-func (m *MultiLimiter) Allow(e limitedEntity) bool {
+func (m *MultiLimiter) Allow(e LimitedEntity) bool {
 	limiters := m.limiters.Load()
 	l, ok := limiters.Get(e.Key())
 	now := time.Now().Unix()

--- a/agent/consul/multilimiter/multilimiter.go
+++ b/agent/consul/multilimiter/multilimiter.go
@@ -1,0 +1,128 @@
+package multilimiter
+
+import (
+	"context"
+	radix "github.com/hashicorp/go-immutable-radix"
+	"golang.org/x/time/rate"
+	"sync/atomic"
+	"time"
+)
+
+type limitedEntity interface {
+	Key() []byte
+}
+
+type RateLimiter interface {
+	Start()
+	Stop()
+	Allow(entity limitedEntity) bool
+	UpdateConfig(c Config)
+}
+
+type Limiter struct {
+	limiter    *rate.Limiter
+	lastAccess atomic.Int64
+}
+
+type Config struct {
+	Rate         rate.Limit
+	Burst        int
+	CleanupLimit time.Duration
+	CleanupTick  time.Duration
+}
+
+type MultiLimiter struct {
+	limiters *atomic.Pointer[radix.Tree]
+	config   *atomic.Pointer[Config]
+	cancel   context.CancelFunc
+}
+
+func (m *MultiLimiter) UpdateConfig(c Config) {
+	m.config.CompareAndSwap(m.config.Load(), &c)
+}
+
+func NewMultiLimiter(c Config) *MultiLimiter {
+	limiters := atomic.Pointer[radix.Tree]{}
+	config := atomic.Pointer[Config]{}
+	config.Store(&c)
+	limiters.Store(radix.New())
+	if c.CleanupLimit == 0 {
+		c.CleanupLimit = 30 * time.Millisecond
+	}
+	if c.CleanupTick == 0 {
+		c.CleanupLimit = 1 * time.Second
+	}
+	m := &MultiLimiter{limiters: &limiters, config: &config}
+	return m
+}
+
+func (m *MultiLimiter) Start() {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	m.cancel = cancelFunc
+	go func() {
+		for {
+			m.cleanupLimited(ctx)
+		}
+	}()
+}
+
+func (m *MultiLimiter) Stop() {
+	if m.cancel != nil {
+		m.cancel()
+	}
+}
+
+func (m *MultiLimiter) Allow(e limitedEntity) bool {
+	limiters := m.limiters.Load()
+	l, ok := limiters.Get(e.Key())
+	now := time.Now().Unix()
+	if ok {
+		limiter := l.(*Limiter)
+		limiter.lastAccess.Store(now)
+		return limiter.limiter.Allow()
+	}
+	c := m.config.Load()
+	limiter := &Limiter{limiter: rate.NewLimiter(c.Rate, c.Burst)}
+	limiter.lastAccess.Store(now)
+	tree, _, _ := limiters.Insert(e.Key(), limiter)
+	m.limiters.Store(tree)
+
+	return limiter.limiter.Allow()
+}
+
+// Every minute check the map for visitors that haven't been seen for
+// more than 3 minutes and delete the entries.
+func (m *MultiLimiter) cleanupLimited(ctx context.Context) {
+	c := m.config.Load()
+	waiter := time.After(c.CleanupTick)
+
+	select {
+	case <-ctx.Done():
+		return
+	case now := <-waiter:
+		limiters := m.limiters.Load()
+		storedLimiters := limiters
+		iter := limiters.Root().Iterator()
+		k, v, ok := iter.Next()
+		var txn *radix.Txn
+		for ok {
+			limiter := v.(*Limiter)
+			lastAccess := limiter.lastAccess.Load()
+			lastAccessT := time.Unix(lastAccess, 0)
+			diff := now.Sub(lastAccessT)
+
+			if diff > c.CleanupLimit {
+				if txn == nil {
+					txn = limiters.Txn()
+				}
+				txn.Delete(k)
+			}
+			k, v, ok = iter.Next()
+		}
+		if txn != nil {
+			limiters = txn.Commit()
+
+			m.limiters.CompareAndSwap(storedLimiters, limiters)
+		}
+	}
+}

--- a/agent/consul/multilimiter/multilimiter_test.go
+++ b/agent/consul/multilimiter/multilimiter_test.go
@@ -1,0 +1,135 @@
+package multilimiter
+
+import (
+	"encoding/binary"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+type Limited struct {
+	key string
+}
+
+func (l Limited) Key() []byte {
+	return []byte(l.key)
+}
+
+func TestNewMultiLimiter(t *testing.T) {
+	c := Config{Rate: 0.1}
+	m := NewMultiLimiter(c)
+	require.NotNil(t, m)
+	require.NotNil(t, m.limiters)
+}
+
+func TestNewMultiLimiterStop(t *testing.T) {
+	c := Config{Rate: 0.1}
+	m := NewMultiLimiter(c)
+	require.NotNil(t, m)
+	require.NotNil(t, m.limiters)
+	require.Nil(t, m.cancel)
+	m.Stop()
+	require.Nil(t, m.cancel)
+	m.Start()
+	require.NotNil(t, m.cancel)
+	m.Stop()
+	m.Stop()
+
+}
+
+func TestRateLimiterUpdate(t *testing.T) {
+	c := Config{Rate: 0.1, CleanupLimit: 1 * time.Millisecond, CleanupTick: 10 * time.Millisecond}
+	m := NewMultiLimiter(c)
+	m.Allow(Limited{key: "test"})
+	limiters := m.limiters.Load()
+	l1, ok1 := limiters.Get([]byte("test"))
+	require.True(t, ok1)
+	require.NotNil(t, l1)
+	la1 := l1.(*Limiter).lastAccess.Load()
+	m.Allow(Limited{key: "test"})
+	limiters = m.limiters.Load()
+	l2, ok2 := limiters.Get([]byte("test"))
+	require.True(t, ok2)
+	require.NotNil(t, l2)
+	require.Equal(t, l1, l2)
+	la2 := l1.(*Limiter).lastAccess.Load()
+	require.Equal(t, la1, la2)
+
+}
+
+func TestRateLimiterCleanup(t *testing.T) {
+	c := Config{Rate: 0.1, CleanupLimit: 1 * time.Millisecond, CleanupTick: 10 * time.Millisecond}
+	m := NewMultiLimiter(c)
+	m.Start()
+	m.Allow(Limited{key: "test"})
+	limiters := m.limiters.Load()
+	l, ok := limiters.Get([]byte("test"))
+	require.True(t, ok)
+	require.NotNil(t, l)
+	time.Sleep(20 * time.Millisecond)
+	limiters = m.limiters.Load()
+	l, ok = limiters.Get([]byte("test"))
+	require.False(t, ok)
+	require.Nil(t, l)
+	m.Stop()
+	m.Allow(Limited{key: "test"})
+	time.Sleep(20 * time.Millisecond)
+	limiters = m.limiters.Load()
+	l, ok = limiters.Get([]byte("test"))
+	require.True(t, ok)
+	require.NotNil(t, l)
+}
+
+func TestRateLimiterUpdateConfig(t *testing.T) {
+	c := Config{Rate: 0.1, CleanupLimit: 1 * time.Millisecond, CleanupTick: 10 * time.Millisecond}
+	m := NewMultiLimiter(c)
+	require.Equal(t, *m.config.Load(), c)
+	c2 := Config{Rate: 1, CleanupLimit: 10 * time.Millisecond, CleanupTick: 100 * time.Millisecond}
+	m.UpdateConfig(c2)
+	require.Equal(t, *m.config.Load(), c2)
+}
+
+type ipLimited struct {
+	key []byte
+}
+
+func (i ipLimited) Key() []byte {
+	return i.key
+}
+
+func BenchmarkTestRateLimiterFixedIP(b *testing.B) {
+	var Config = Config{Rate: 1.0, Burst: 500}
+	m := NewMultiLimiter(Config)
+	ip := []byte{244, 233, 0, 1}
+	for j := 0; j < b.N; j++ {
+		m.Allow(ipLimited{key: ip})
+	}
+}
+
+func BenchmarkTestRateLimiterIncIP(b *testing.B) {
+	var Config = Config{Rate: 1.0, Burst: 500}
+	m := NewMultiLimiter(Config)
+	buf := make([]byte, 4)
+	for j := 0; j < b.N; j++ {
+		binary.LittleEndian.PutUint32(buf, uint32(j))
+		m.Allow(ipLimited{key: buf})
+	}
+}
+
+func BenchmarkTestRateLimiterRandomIP(b *testing.B) {
+	var Config = Config{Rate: 1.0, Burst: 500}
+	m := NewMultiLimiter(Config)
+	for j := 0; j < b.N; j++ {
+		m.Allow(ipLimited{key: randIP()})
+	}
+}
+
+func randIP() []byte {
+	buf := make([]byte, 4)
+
+	ip := rand.Uint32()
+
+	binary.LittleEndian.PutUint32(buf, ip)
+	return buf
+}


### PR DESCRIPTION
### Description
This PR adds an implementation of a `multilimiter` package that will be used to perform RPC server side rate limiting.

The `MultiLimiter` struct implements the `RateLimiter` interface which look as follow:

```go
type RateLimiter interface {
	Start()
	Stop()
	Allow(entity LimitedEntity) bool
	UpdateConfig(c Config)
}
```
The `LimitedEntity` interface look as follow:

```go
type LimitedEntity interface {
	Key() []byte
}
``` 
The `MultiLimiter` is using an immutable radix tree as an underlying structure, this is suitable specifically for IP as the data is optimal for a radix tree, specially when a consecutive range of IP is used. Also using immutable radix tree help optimizing read use cases (when it's a known IP) vs write case (when a new IP is introduced).


### Testing & Reproduction steps
* unit tests with 100% coverage
* benchmark tests with different type of data


* [x] updated test coverage
* [x] not a security concern
