### PR TITLE
Add Consul 1.14.0 known issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.14.0 (November 15, 2022)
 
+KNOWN ISSUES:
+
+* cli: `consul connect envoy` incorrectly enables TLS for gRPC connections when the HTTP API is TLS-enabled.
+
 BREAKING CHANGES:
 
 * config: Add new `ports.grpc_tls` configuration option.

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -30,7 +30,7 @@ earlier. If you operate Consul service mesh using Nomad 1.4.2 or earlier, do not
 fixed.
 
 For 1.14.0, there is a known issue with `consul connect envoy`. If the command is configured
-to utilize TLS for contacting the HTTP API, it will also incorrectly enable TLS for gRPC.
+to use TLS for contacting the HTTP API, it will also incorrectly enable TLS for gRPC.
 Users should not upgrade to 1.14.0 if they are using plaintext gRPC connections in
 conjunction with TLS-encrypted HTTP APIs.
 

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -29,6 +29,12 @@ earlier. If you operate Consul service mesh using Nomad 1.4.2 or earlier, do not
 [hashicorp/nomad#15266](https://github.com/hashicorp/nomad/issues/15266) is
 fixed.
 
+For 1.14.0, there is a known issue with `consul connect envoy`. If the command is configured
+to utilize TLS for contacting the HTTP API, it will also incorrectly enable TLS for gRPC.
+Users should not upgrade to 1.14.0 if they are using plaintext gRPC connections in
+conjunction with TLS-encrypted HTTP APIs.
+
+
 #### Changes to gRPC TLS configuration
 
 **Make configuration changes** if using [`ports.grpc`](/docs/agent/config/config-files#grpc_port) in conjunction with any of the following settings that enables encryption:


### PR DESCRIPTION
Add known-issue message to changelog.

When `consul connect envoy` is configured to utilize TLS for the HTTP API, it will also attempt to incorrectly utilize TLS for the outgoing gRPC connection.