### PR TITLE
[Hack]MemDB Multi Rate Limiter example

### DIFF
--- a/agent/consul/multilimiter/multilimiter_test.go
+++ b/agent/consul/multilimiter/multilimiter_test.go
@@ -20,14 +20,14 @@ func TestNewMultiLimiter(t *testing.T) {
 	c := Config{Rate: 0.1}
 	m := NewMultiLimiter(c)
 	require.NotNil(t, m)
-	require.NotNil(t, m.limiters)
+	require.NotNil(t, m.db)
 }
 
 func TestNewMultiLimiterStop(t *testing.T) {
 	c := Config{Rate: 0.1}
 	m := NewMultiLimiter(c)
 	require.NotNil(t, m)
-	require.NotNil(t, m.limiters)
+	require.NotNil(t, m.db)
 	require.Nil(t, m.cancel)
 	m.Stop()
 	require.Nil(t, m.cancel)
@@ -42,44 +42,43 @@ func TestRateLimiterUpdate(t *testing.T) {
 	c := Config{Rate: 0.1, CleanupLimit: 1 * time.Millisecond, CleanupTick: 10 * time.Millisecond}
 	m := NewMultiLimiter(c)
 	m.Allow(Limited{key: "test"})
-	limiters := m.limiters.Load()
-	l1, ok1 := limiters.Get([]byte("test"))
-	require.True(t, ok1)
+	txn := m.db.Txn(false)
+	l1, err := txn.First("limiter", "id", "test")
+	require.Nil(t, err)
 	require.NotNil(t, l1)
-	la1 := l1.(*Limiter).lastAccess.Load()
+	la1 := l1.(*Limiter).lastAccess
 	m.Allow(Limited{key: "test"})
-	limiters = m.limiters.Load()
-	l2, ok2 := limiters.Get([]byte("test"))
-	require.True(t, ok2)
+	l2, err := txn.First("limiter", "id", "test")
+	require.Nil(t, err)
 	require.NotNil(t, l2)
 	require.Equal(t, l1, l2)
-	la2 := l1.(*Limiter).lastAccess.Load()
+	la2 := l1.(*Limiter).lastAccess
 	require.Equal(t, la1, la2)
 
 }
 
-func TestRateLimiterCleanup(t *testing.T) {
-	c := Config{Rate: 0.1, CleanupLimit: 1 * time.Millisecond, CleanupTick: 10 * time.Millisecond}
-	m := NewMultiLimiter(c)
-	m.Start()
-	m.Allow(Limited{key: "test"})
-	limiters := m.limiters.Load()
-	l, ok := limiters.Get([]byte("test"))
-	require.True(t, ok)
-	require.NotNil(t, l)
-	time.Sleep(20 * time.Millisecond)
-	limiters = m.limiters.Load()
-	l, ok = limiters.Get([]byte("test"))
-	require.False(t, ok)
-	require.Nil(t, l)
-	m.Stop()
-	m.Allow(Limited{key: "test"})
-	time.Sleep(20 * time.Millisecond)
-	limiters = m.limiters.Load()
-	l, ok = limiters.Get([]byte("test"))
-	require.True(t, ok)
-	require.NotNil(t, l)
-}
+// func TestRateLimiterCleanup(t *testing.T) {
+// 	c := Config{Rate: 0.1, CleanupLimit: 1 * time.Millisecond, CleanupTick: 10 * time.Millisecond}
+// 	m := NewMultiLimiter(c)
+// 	m.Start()
+// 	m.Allow(Limited{key: "test"})
+// 	limiters := m.limiters.Load()
+// 	l, ok := limiters.Get([]byte("test"))
+// 	require.True(t, ok)
+// 	require.NotNil(t, l)
+// 	time.Sleep(20 * time.Millisecond)
+// 	limiters = m.limiters.Load()
+// 	l, ok = limiters.Get([]byte("test"))
+// 	require.False(t, ok)
+// 	require.Nil(t, l)
+// 	m.Stop()
+// 	m.Allow(Limited{key: "test"})
+// 	time.Sleep(20 * time.Millisecond)
+// 	limiters = m.limiters.Load()
+// 	l, ok = limiters.Get([]byte("test"))
+// 	require.True(t, ok)
+// 	require.NotNil(t, l)
+// }
 
 func TestRateLimiterUpdateConfig(t *testing.T) {
 	c := Config{Rate: 0.1, CleanupLimit: 1 * time.Millisecond, CleanupTick: 10 * time.Millisecond}


### PR DESCRIPTION
### Description
This is just an alternative to https://github.com/hashicorp/consul/pull/15467 that is using MemDB rather than immutable radix trees + atomic references.

I just quickly cobbled this together and only made revisions to make `Allow()` work.

## Observations
It looks like the test results below show that using memdb is slower...but would love confirmation from those more familiar with nuances of benchmark tests.  

If the above is true, then decision tree might look like:
- Are worried about any hidden gotchas related with managing coordination of writes?
  - if yes, consider MemDB approach as it is battle tested for that funciton
  - if no, stick with what is faster /lighter weight (which it looks like the work in  https://github.com/hashicorp/consul/pull/15467)
  - if we wind up having to add more code to the radix tree approach, we should keep an eye on the benchmarking to see if if it slows down to the point where MemDB becomes attractive again.

## Benchmark test results
### Allow() with Memdb

Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkTestRateLimiterRandomIP$ github.com/hashicorp/consul/agent/consul/multilimiter

goos: darwin
goarch: arm64
pkg: github.com/hashicorp/consul/agent/consul/multilimiter
BenchmarkTestRateLimiterRandomIP-10    	  203235	      6664 ns/op	   12010 B/op	      67 allocs/op
PASS
ok  	github.com/hashicorp/consul/agent/consul/multilimiter	1.524s


### Allow with immutable radix trees + atmoic references (what's in https://github.com/hashicorp/consul/pull/15467)

Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkTestRateLimiterRandomIP$ github.com/hashicorp/consul/agent/consul/multilimiter

goos: darwin
goarch: arm64
pkg: github.com/hashicorp/consul/agent/consul/multilimiter
BenchmarkTestRateLimiterRandomIP-10    	  400201	      4750 ns/op	   10007 B/op	      30 allocs/op
PASS
ok  	github.com/hashicorp/consul/agent/consul/multilimiter	2.049s
