### PR TITLE
docs: clarify Vault CA provider permissions needed

### DIFF
--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -169,6 +169,18 @@ The table below shows this endpoint's support for
 
 The corresponding CLI command is [`consul connect ca set-config`](/commands/connect/ca#set-config).
 
+~> **If currently using Vault CA provider:**
+   If you intend to change the CA provider from Vault to another,
+   or to change the Vault provider's [`RootPKIPath`](/docs/connect/ca/vault#rootpkipath),
+   you must temporarily provide the Vault
+   [auth method](/docs/connect/ca/vault#authmethod) or [token](/docs/connect/ca/vault#token)
+   with `sudo + update` permissions on the extremely privileged
+   [`<insert-RootPKIPath>/root/sign-self-issued` Vault endpoint](https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-self-issued)
+   to enable the root cross-signing operation.
+   Refer to the [Vault CA provider policy examples](/consul/docs/connect/ca/vault#vault-acl-policies)
+   for more information. We recommend removing these elevated permissions
+   immediately after this HTTP API call completes.
+
 ### JSON Request Body Schema
 
 - `Provider` `(string: <required>)` - Specifies the CA provider type to use.
@@ -177,11 +189,14 @@ The corresponding CLI command is [`consul connect ca set-config`](/commands/conn
   for the chosen provider. For more information on configuring the Connect CA
   providers, see [Provider Config](/docs/connect/ca).
 
-- `ForceWithoutCrossSigning` `(bool: <optional>)` - Indicates that the CA change
-  should be forced to complete even if the current CA doesn't support cross
-  signing. Changing root without cross-signing may cause temporary connection
-  failures until the rollout completes. See [Forced Rotation Without
-  Cross-Signing](/docs/connect/ca#forced-rotation-without-cross-signing)
+- `ForceWithoutCrossSigning` `(bool: false)` - Indicates that the CA change
+  should be forced to complete even if the current CA doesn't support root cross-signing.
+
+  ~> **Caution:** Setting this field to `true` will cause temporary connection failures
+  until service mesh proxies and/or Consul client agents receive a new certificate
+  that establishes trust with the new root.
+  Do not use this field unless you are sure you need it.
+  Refer to [Forced Rotation Without Cross-Signing](/docs/connect/ca#forced-rotation-without-cross-signing)
   for more detail.
 
 ### Sample Payload

--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -172,14 +172,9 @@ The corresponding CLI command is [`consul connect ca set-config`](/commands/conn
 ~> **If currently using Vault CA provider:**
    If you intend to change the CA provider from Vault to another,
    or to change the Vault provider's [`RootPKIPath`](/docs/connect/ca/vault#rootpkipath),
-   you must temporarily provide the Vault
-   [auth method](/docs/connect/ca/vault#authmethod) or [token](/docs/connect/ca/vault#token)
-   with `sudo + update` permissions on the extremely privileged
-   [`<root_pki_path>/root/sign-self-issued` Vault endpoint](/vault/api-docs/secret/pki#sign-self-issued)
-   to enable the root cross-signing operation.
-   Refer to the [Vault CA provider policy examples](/consul/docs/connect/ca/vault#vault-acl-policies)
-   for more information. We recommend removing these elevated permissions
-   immediately after this HTTP API call completes.
+   you must temporarily elevate the privileges of the Vault token
+   or auth method in use as described in the
+   [Vault CA provider documentation](/docs/connect/ca/vault#additional-vault-acl-policies-for-sensitive-operations).
 
 ### JSON Request Body Schema
 

--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -175,7 +175,7 @@ The corresponding CLI command is [`consul connect ca set-config`](/commands/conn
    you must temporarily provide the Vault
    [auth method](/docs/connect/ca/vault#authmethod) or [token](/docs/connect/ca/vault#token)
    with `sudo + update` permissions on the extremely privileged
-   [`<insert-RootPKIPath>/root/sign-self-issued` Vault endpoint](https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-self-issued)
+   [`<insert-RootPKIPath>/root/sign-self-issued` Vault endpoint](/vault/api-docs/secret/pki#sign-self-issued)
    to enable the root cross-signing operation.
    Refer to the [Vault CA provider policy examples](/consul/docs/connect/ca/vault#vault-acl-policies)
    for more information. We recommend removing these elevated permissions

--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -175,7 +175,7 @@ The corresponding CLI command is [`consul connect ca set-config`](/commands/conn
    you must temporarily provide the Vault
    [auth method](/docs/connect/ca/vault#authmethod) or [token](/docs/connect/ca/vault#token)
    with `sudo + update` permissions on the extremely privileged
-   [`<insert-RootPKIPath>/root/sign-self-issued` Vault endpoint](/vault/api-docs/secret/pki#sign-self-issued)
+   [`<root_pki_path>/root/sign-self-issued` Vault endpoint](/vault/api-docs/secret/pki#sign-self-issued)
    to enable the root cross-signing operation.
    Refer to the [Vault CA provider policy examples](/consul/docs/connect/ca/vault#vault-acl-policies)
    for more information. We recommend removing these elevated permissions

--- a/website/content/commands/connect/ca.mdx
+++ b/website/content/commands/connect/ca.mdx
@@ -97,6 +97,18 @@ Configuration updated!
 
 The return code will indicate success or failure.
 
+~> **If currently using Vault CA provider:**
+   If you intend to change the CA provider from Vault to another,
+   or to change the Vault provider's [`RootPKIPath`](/docs/connect/ca/vault#rootpkipath),
+   you must temporarily provide the Vault
+   [auth method](/docs/connect/ca/vault#authmethod) or [token](/docs/connect/ca/vault#token)
+   with `sudo + update` permissions on the extremely privileged
+   [`<insert-RootPKIPath>/root/sign-self-issued` Vault endpoint](https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-self-issued)
+   to enable the root cross-signing operation.
+   Refer to the [Vault CA provider policy examples](/consul/docs/connect/ca/vault#vault-acl-policies)
+   for more information. We recommend removing these elevated permissions
+   immediately after this command exits.
+
 #### Command Options
 
 - `-config-file` - (required) Specifies a JSON-formatted file to use for the new configuration.
@@ -104,10 +116,13 @@ The return code will indicate success or failure.
   [Update CA Configuration API](/api-docs/connect/ca#update-ca-configuration).
 
 - `-force-without-cross-signing` `(bool: <optional>)` - Indicates that the CA change
-  should be forced to complete even if the current CA doesn't support cross
-  signing. Changing root without cross-signing may cause temporary connection
-  failures until the rollout completes. See [Forced Rotation Without
-  Cross-Signing](/docs/connect/ca#forced-rotation-without-cross-signing)
+  should be forced to complete even if the current CA doesn't support root cross-signing.
+
+  ~> **Caution:** Use of this flag will cause temporary connection failures
+  until service mesh proxies and/or Consul client agents receive a new certificate
+  that establishes trust with the new root.
+  Do not use this flag unless you are sure you need it.
+  Refer to [Forced Rotation Without Cross-Signing](/docs/connect/ca#forced-rotation-without-cross-signing)
   for more detail.
 
 #### API Options

--- a/website/content/commands/connect/ca.mdx
+++ b/website/content/commands/connect/ca.mdx
@@ -103,7 +103,7 @@ The return code will indicate success or failure.
    you must temporarily provide the Vault
    [auth method](/docs/connect/ca/vault#authmethod) or [token](/docs/connect/ca/vault#token)
    with `sudo + update` permissions on the extremely privileged
-   [`<insert-RootPKIPath>/root/sign-self-issued` Vault endpoint](https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-self-issued)
+   [`<insert-RootPKIPath>/root/sign-self-issued` Vault endpoint](/vault/api-docs/secret/pki#sign-self-issued)
    to enable the root cross-signing operation.
    Refer to the [Vault CA provider policy examples](/consul/docs/connect/ca/vault#vault-acl-policies)
    for more information. We recommend removing these elevated permissions

--- a/website/content/commands/connect/ca.mdx
+++ b/website/content/commands/connect/ca.mdx
@@ -100,14 +100,9 @@ The return code will indicate success or failure.
 ~> **If currently using Vault CA provider:**
    If you intend to change the CA provider from Vault to another,
    or to change the Vault provider's [`RootPKIPath`](/docs/connect/ca/vault#rootpkipath),
-   you must temporarily provide the Vault
-   [auth method](/docs/connect/ca/vault#authmethod) or [token](/docs/connect/ca/vault#token)
-   with `sudo + update` permissions on the extremely privileged
-   [`<root_pki_path>/root/sign-self-issued` Vault endpoint](/vault/api-docs/secret/pki#sign-self-issued)
-   to enable the root cross-signing operation.
-   Refer to the [Vault CA provider policy examples](/consul/docs/connect/ca/vault#vault-acl-policies)
-   for more information. We recommend removing these elevated permissions
-   immediately after this command exits.
+   you must temporarily elevate the privileges of the Vault token
+   or auth method in use as described in the
+   [Vault CA provider documentation](/docs/connect/ca/vault#additional-vault-acl-policies-for-sensitive-operations).
 
 #### Command Options
 

--- a/website/content/commands/connect/ca.mdx
+++ b/website/content/commands/connect/ca.mdx
@@ -103,7 +103,7 @@ The return code will indicate success or failure.
    you must temporarily provide the Vault
    [auth method](/docs/connect/ca/vault#authmethod) or [token](/docs/connect/ca/vault#token)
    with `sudo + update` permissions on the extremely privileged
-   [`<insert-RootPKIPath>/root/sign-self-issued` Vault endpoint](/vault/api-docs/secret/pki#sign-self-issued)
+   [`<root_pki_path>/root/sign-self-issued` Vault endpoint](/vault/api-docs/secret/pki#sign-self-issued)
    to enable the root cross-signing operation.
    Refer to the [Vault CA provider policy examples](/consul/docs/connect/ca/vault#vault-acl-policies)
    for more information. We recommend removing these elevated permissions

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -210,48 +210,79 @@ The following Vault policy allows Consul to use pre-existing PKI paths in Vault.
 Consul is granted read-only access to the PKI mount points and the Root CA, but is
 granted full control of the Intermediate or Leaf CA for Connect clients.
 
-In this example the `RootPKIPath` is `connect_root` and the `IntermediatePKIPath`
-is `connect_inter`. These values should be updated for your environment.
+This example uses placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
+Please update those placeholders to match the path values in the CA provider configuration.
 
 <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
 ```hcl
-# Existing PKI Mounts
-path "/sys/mounts" {
+# -----------------------------------------------------------------------------
+# Vault Managed PKI Mounts
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Needed for Consul to read the PKI mounts already created in Vault
+
+path "/sys/mounts/<insert-RootPKIPath>" {
   capabilities = [ "read" ]
 }
 
-path "/sys/mounts/connect_root" {
+path "/sys/mounts/<insert-IntermediatePKIPath>" {
   capabilities = [ "read" ]
 }
 
-path "/sys/mounts/connect_inter" {
-  capabilities = [ "read" ]
-}
-
-# Needed for Consul 1.11+
-path "/sys/mounts/connect_inter/tune" {
+# Needed in Consul 1.11+ to update intermediate mount configuration
+path "/sys/mounts/<insert-IntermediatePKIPath>/tune" {
   capabilities = [ "update" ]
 }
 
-path "/connect_root/" {
+# -----------------------------------------------------------------------------
+# Needed for Consul to use the externally-managed, mounted PKI secrets engines
+
+path "/<insert-RootPKIPath>/" {
   capabilities = [ "read" ]
 }
 
-path "/connect_root/root/sign-intermediate" {
+path "/<insert-RootPKIPath>/root/sign-intermediate" {
   capabilities = [ "update" ]
 }
 
-path "/connect_inter/*" {
+path "/<insert-RootPKIPath>/*" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 
+# Needed only when changing the CA provider from Vault with this RootPKIPath
+# to either:
+# 1. A different CA provider (such as Consul's built-in provider)
+# 2. Changing the RootPKIPath used by the Vault CA provider
+#
+# SECURITY NOTE: Because this is an extremely privileged endpoint,
+# We recommend only temporarily granting this permission if there's a need
+# to modify Consul's CA provider configuration as in (1) or (2).
+# That's why this permission is currently commented out.
+#
+# path "<insert-RootPKIPath>/root/sign-self-issued" {
+#  capabilities = [ "sudo", "update" ]
+#}
+
+# -----------------------------------------------------------------------------
+# Needed for Consul to renew its Vault token (if renewable) whether provided
+# directly in the CA provider config or using an auth method.
+
 path "auth/token/renew-self" {
-	capabilities = [ "update" ]
+  capabilities = [ "update" ]
 }
 
 path "auth/token/lookup-self" {
-	capabilities = [ "read" ]
+  capabilities = [ "read" ]
+}
+
+# -----------------------------------------------------------------------------
+# Deprecated
+
+# Only needed before Consul 1.12
+path "/sys/mounts" {
+  capabilities = [ "read" ]
 }
 ```
 
@@ -263,36 +294,75 @@ The following Vault policy allows Consul to create and manage the PKI paths in V
 Consul is granted the ability to create the PKI mount points and given full
 control of the Root and Intermediate or Leaf CA for Connect clients.
 
-In this example the `RootPKIPath` is `connect_root` and the `IntermediatePKIPath`
-is `connect_inter`. These values should be updated for your environment.
+This example uses placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
+Please update those placeholders to match the path values in the CA provider configuration.
 
 <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
 
 ```hcl
+# -----------------------------------------------------------------------------
 # Consul Managed PKI Mounts
-path "/sys/mounts" {
-  capabilities = [ "read" ]
-}
+# -----------------------------------------------------------------------------
 
-path "/sys/mounts/connect_root" {
+# -----------------------------------------------------------------------------
+# Needed for Consul to create and manage the PKI mounts
+
+path "/sys/mounts/<insert-RootPKIPath>" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 
-path "/sys/mounts/connect_inter" {
+path "/sys/mounts/<insert-IntermediatePKIPath>" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 
-# Needed for Consul 1.11+
-path "/sys/mounts/connect_inter/tune" {
+# Enables Consul 1.11+ to update intermediate mount configuration
+path "/sys/mounts/<insert-IntermediatePKIPath>/tune" {
   capabilities = [ "update" ]
 }
 
-path "/connect_root/*" {
+# -----------------------------------------------------------------------------
+# Needed for Consul to use the mounted PKI secrets engines it owns
+
+path "/<insert-RootPKIPath>/*" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 
-path "/connect_inter/*" {
+path "/<insert-IntermediatePKIPath>/*" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
+}
+
+# Needed only when changing the CA provider from Vault with this RootPKIPath
+# to either:
+# 1. A different CA provider (such as Consul's built-in provider)
+# 2. Changing the RootPKIPath used by the Vault CA provider
+#
+# SECURITY NOTE: Because this is an extremely privileged endpoint,
+# We recommend only temporarily granting this permission if there's a need
+# to modify Consul's CA provider configuration as in (1) or (2).
+# That's why this permission is currently commented out.
+#
+# path "<insert-RootPKIPath>/root/sign-self-issued" {
+#  capabilities = [ "sudo", "update" ]
+#}
+
+# -----------------------------------------------------------------------------
+# Needed for Consul to renew its Vault token (if renewable) whether provided
+# directly in the CA provider config or using an auth method.
+
+path "auth/token/renew-self" {
+  capabilities = [ "update" ]
+}
+
+path "auth/token/lookup-self" {
+  capabilities = [ "read" ]
+}
+
+# -----------------------------------------------------------------------------
+# Deprecated
+
+# Only needed before Consul 1.12
+path "/sys/mounts" {
+  capabilities = [ "read" ]
 }
 ```
 

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -231,7 +231,6 @@ path "/sys/mounts/<intermediate_pki_path>" {
   capabilities = [ "read" ]
 }
 
-# Needed in Consul 1.11+ to update intermediate mount configuration
 path "/sys/mounts/<intermediate_pki_path>/tune" {
   capabilities = [ "update" ]
 }
@@ -276,14 +275,6 @@ path "auth/token/renew-self" {
 path "auth/token/lookup-self" {
   capabilities = [ "read" ]
 }
-
-# -----------------------------------------------------------------------------
-# Deprecated
-
-# Only needed before Consul 1.12
-path "/sys/mounts" {
-  capabilities = [ "read" ]
-}
 ```
 
 </CodeBlockConfig>
@@ -315,7 +306,6 @@ path "/sys/mounts/<intermediate_pki_path>" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 
-# Enables Consul 1.11+ to update intermediate mount configuration
 path "/sys/mounts/<intermediate_pki_path>/tune" {
   capabilities = [ "update" ]
 }
@@ -354,14 +344,6 @@ path "auth/token/renew-self" {
 }
 
 path "auth/token/lookup-self" {
-  capabilities = [ "read" ]
-}
-
-# -----------------------------------------------------------------------------
-# Deprecated
-
-# Only needed before Consul 1.12
-path "/sys/mounts" {
   capabilities = [ "read" ]
 }
 ```

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -357,4 +357,16 @@ capabilities = [ "sudo", "update" ]
 </CodeBlockConfig>
 
 We recommend adding this elevated privilege just before the CA provider
-modification, then removing immediately after.
+modification, then removing immediately after, using the following process:
+1. Create a new Vault token that includes both the `root/sign-self-issued`
+   permission and the standard permissions for Consul or Vault managed
+   PKI paths. If you intend to keep Vault as the provider but change `RootPKIPath`,
+   the Vault token needs standard `RootPKIPath` permissions on both the current
+   and new intended paths.
+1. Modify the CA provider configuration to use the new Vault token.
+1. Modify the CA provider configuration that triggers the extremely privileged
+   root cross-sign operation.
+1. If Vault is still the provider but `RootPKIPath` was changed,
+   modify the CA provider configuration to use a Vault token or auth method
+   with only the standard permissions, no longer including the `root/sign-self-issued`
+   permission.

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -364,6 +364,6 @@ configuration change to minimize the time that a privileged Vault token is in us
 1. Modify the CA provider configuration to use that new Vault token.
 1. Perform the CA provider configuration change that triggers the extremely privileged
    root cross-sign operation. If the configuration change maintains Vault
-   as the provider but changes `RootPKIPath`, the configuration change must
+   as the provider but modifies `RootPKIPath`, the configuration change must
    include a Vault token or auth method with standard permissions for the new
    Consul or Vault managed PKI paths.

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -199,7 +199,7 @@ that responsibility to Consul.
 Use [Vault-managed PKI paths](#vault-managed-pki-paths) to obtain the following benefits:
 - Enables use of a root CA external to Consul by instantiating the PKI secrets engine at
   [`RootPKIPath`](#rootpkipath) with an intermediate certificate
-- Retain full control over PKI mount creation, and `RootPKIPath` mount configuration
+- Retain full control over PKI mount creation, and over `RootPKIPath` mount configuration
 
 Otherwise, use [Consul-managed PKI paths](#consul-managed-pki-paths) to let Consul fully automate PKI management.
 
@@ -208,11 +208,11 @@ Otherwise, use [Consul-managed PKI paths](#consul-managed-pki-paths) to let Cons
 To use Vault-managed PKI paths, you must first instantiate and configure PKI secrets engines at
 `RootPKIPath` and `IntermediatePKIPath`.
 
-Next, define a Vault ACL policy that allows Consul to use those pre-existing PKI mounts in Vault.
+Next, define the following Vault ACL policy that allows Consul to use those pre-existing PKI mounts in Vault.
 The policy grants Consul limited use of the root PKI engine
 and full control of the intermediate PKI engine to issue service mesh certificates.
 
-In the following examples, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
+In the following Vault policy snippets, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
 Replace them to match the path values in the CA provider configuration.
 
 1. Add the following rules to your Vault policy definition file so that Consul
@@ -276,7 +276,7 @@ Replace them to match the path values in the CA provider configuration.
   
   </CodeBlockConfig>
 
-1. Conditional and temporary: Only include the following rules in your vault policy file
+1. Conditional and temporary: Only include the following rules in your Vault policy file
    while you are changing the CA provider from Vault to a different CA provider (such as Consul's built-in provider)
    or changing the `RootPKIPath` used by the Vault CA provider.
    Those CA provider modifications trigger a root CA change that requires an
@@ -297,10 +297,10 @@ Replace them to match the path values in the CA provider configuration.
 To use Consul-managed PKI paths, ensure no PKI secrets engines are mounted at
 `RootPKIPath` and `IntermediatePKIPath`.
 
-Next, define a Vault ACL policy that allows Consul to create and manage
+Next, define the following Vault ACL policy that allows Consul to create and manage
 both the root and intermediate PKI engines.
 
-In the following examples, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
+In the following Vault policy snippets, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
 Replace them to match the path values in the CA provider configuration.
 
 1. Add the following rules to your Vault policy definition file so that Consul
@@ -359,7 +359,7 @@ Replace them to match the path values in the CA provider configuration.
   
   </CodeBlockConfig>
 
-1. Conditional and temporary: Only include the following rules in your vault policy file
+1. Conditional and temporary: Only include the following rules in your Vault policy file
    while you are changing the CA provider from Vault to a different CA provider (such as Consul's built-in provider)
    or changing the `RootPKIPath` used by the Vault CA provider.
    Those CA provider modifications trigger a root CA change that requires an

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -15,13 +15,19 @@ This page describes how configure the Vault CA provider.
 
 ## Requirements
 
-- Read [Service Mesh Certificate Authority Overview](/docs/connect/ca) for important background information about how Consul manages certificates with configurable CA providers. 
+- Refer to [Service Mesh Certificate Authority Overview](/docs/connect/ca) for important background information about how Consul manages certificates with configurable CA providers. 
 
-- Vault 0.10.3 to 1.11.0. Note that in Vault 1.11.0 the intermediate CA becomes unable to issue the required leaf nodes if `auto-encrypt` or `auto-config` and TLS for agent communication are enabled. If you are already using Vault 1.11+ as a Connect CA, refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for details about the underlying cause and a recommended workaround.
+- Use Vault 0.10.3 to latest 1.10.x.
+
+~> **Note:** Do not use Vault v1.11.0+ as Consul's Connect CA provider — the intermediate CA becomes unable to issue the leaf nodes required by service mesh, and by Consul client agents if using auto-encrypt or auto-config and using TLS for agent communication. If you are already using Vault 1.11+ as a Connect CA, refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more information about the underlying cause and recommended workaround.
 
 ## Enable Vault as the CA
 
-You can enable Vault as the CA by either configuring the [`ca_provider`], [`ca_config`], and other required options in the agent configuration file or by passing the configuration to the [`/connect/ca/configuration`] API endpoint. Refer to [Configuration](#configuration) for details about configuration options and for example use cases. 
+You can enable Vault as the CA by configuring Consul to use `"vault"` as the CA provider
+and including the required provider configuration options.
+You can provide the CA configuration in the agent configuration file of server agents,
+or by calling the [update CA configuration API endpoint](/api-docs/connect/ca#update-ca-configuration).
+Refer to the [Configuration Reference](#configuration-reference) for details about configuration options and for example use cases. 
 
 The following example shows the required configurations for a default implementation:
 
@@ -36,9 +42,9 @@ connect {
   ca_provider = "vault"
   ca_config {
     address = "http://localhost:8200"
-    token = "..."
+    token = "<vault-token-with-necessary-policy>"
     root_pki_path = "connect-root"
-    intermediate_pki_path = "connect-intermediate"
+    intermediate_pki_path = "connect-dc1-intermediate"
   }
 }
 ```
@@ -52,9 +58,9 @@ connect {
   "Provider": "vault",
   "Config": {
     "Address": "http://localhost:8200",
-    "Token": "<token>",
+    "Token": "<vault-token-with-necessary-policy>",
     "RootPKIPath": "connect-root",
-    "IntermediatePKIPath": "connect-intermediate"
+    "IntermediatePKIPath": "connect-dc1-intermediate"
   }
 }
 ```
@@ -63,10 +69,12 @@ connect {
 
 </CodeTabs>
 
-
 ## Configuration Reference
 
-You can specify the following configuration options. Note that the first key refers to the value for the API and the value after the slash refers to the equivalent parameter in the agent configuration file. 
+You can specify the following configuration options.
+Note that a configuration option's name may differ between API calls and the agent configuration file.
+The first key refers to the option name for use in API calls.
+The key after the slash refers to the corresponding option name in the agent configuration file. 
 
 - `Address` / `address` (`string: <required>`) - The address of the Vault
   server.
@@ -97,7 +105,6 @@ You can specify the following configuration options. Note that the first key ref
     default mount path `/var/run/secrets/kubernetes.io/serviceaccount/token` if the `jwt` parameter
     is not provided.
 
-
 - `RootPKIPath` / `root_pki_path` (`string: <required>`) - The path to
   a PKI secrets engine for the root certificate.
 
@@ -112,7 +119,7 @@ You can specify the following configuration options. Note that the first key ref
   When WAN Federation is enabled, each secondary datacenter must use the same Vault cluster and share the same `root_pki_path`
   with the primary datacenter.
 
-  To use an intermediate certificate as the primary CA in Consul initialize the
+  To use an intermediate certificate as the primary CA in Consul, initialize the
   `RootPKIPath` in Vault with a PEM bundle. The first certificate in the bundle
   must be the intermediate certificate that Consul will use as the primary CA.
   The last certificate in the bundle must be a root certificate. The bundle
@@ -169,28 +176,47 @@ The Vault CA provider uses two separately configured
 [PKI secrets engines](https://www.vaultproject.io/docs/secrets/pki)
 for managing Consul service mesh certificates.
 
-The `RootPKIPath` is the PKI engine for the root certificate. Consul uses this root certificate to sign the intermediate certificate. Consul does not attempt to write or modify any data within the root PKI path.
+The `RootPKIPath` is the PKI engine for the root certificate.
+Consul uses this root certificate to sign the intermediate certificate.
+Consul does not attempt to write or modify any data within the root PKI path.
 
 The `IntermediatePKIPath` is the PKI engine used for storing the intermediate
 signed with the root certificate. The intermediate signs all leaf
 certificates, and Consul may periodically generate new intermediates for
 automatic rotation. Therefore, Consul requires write access to this path.
 
-If neither path exists, then Consul attempts to mount and
-initialize the PKI engine, which requires additional privileges of the Vault token in use.
-If the paths already exist, Consul uses them as configured.
+For each path, if the path does not exist, Consul attempts to mount and initialize
+a PKI secrets engine at that path. For this operation to succeed,
+the provided [Vault token](#token) must have the [required Vault privileges](#vault-acl-policies).
+If the path does already exist, Consul uses the PKI secrets engine at that path as configured.
 
-### Configure Vault ACL policies
+### Configure Vault ACL policies ((#vault-acl-policies))
 
-You can define an access control list (ACL) policy that assigns Vault PKI management to Consul or Vault. If you want to manually create and tune the PKI secret engines used to store the root and intermediate certificates, define a policy that uses Vault-managed PKI paths. If you want to automate PKI management, define a policy that uses Consul-managed PKI paths.
+The Vault CA provider requires a [Vault token](#token) with a specific set of Vault privileges
+depending on whether you would prefer to control mount configuration from Vault or to delegate
+that responsibility to Consul.
 
-#### Define a policy for Vault-managed PKI paths
+Use [Vault-managed PKI paths](#vault-managed-pki-paths) to obtain the following benefits:
+- Enables use of a root CA external to Consul by instantiating the PKI secrets engine at
+  [`RootPKIPath`](#rootpkipath) with an intermediate certificate
+- Retain full control over PKI mount creation, and `RootPKIPath` mount configuration
 
-You can define a Vault ACL policy that allows Consul to use pre-existing PKI paths in Vault. The policy grants Consul read-only access to the PKI mount points and the root CA and grants full control of the intermediate or leaf CA for Consul service mesh clients.
+Otherwise, use [Consul-managed PKI paths](#consul-managed-pki-paths) to let Consul fully automate PKI management.
 
-In the following examples, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`. Replace them to match the path values in the CA provider configuration.
+#### Define a policy for Vault-managed PKI paths ((#vault-managed-pki-paths))
 
-1. Add the following rules to you policy file so that Consul can read the PKI mounts already created in Vault:
+To use Vault-managed PKI paths, you must first instantiate and configure PKI secrets engines at
+`RootPKIPath` and `IntermediatePKIPath`.
+
+Next, define a Vault ACL policy that allows Consul to use those pre-existing PKI mounts in Vault.
+The policy grants Consul limited use of the root PKI engine
+and full control of the intermediate PKI engine to issue service mesh certificates.
+
+In the following examples, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
+Replace them to match the path values in the CA provider configuration.
+
+1. Add the following rules to your Vault policy definition file so that Consul
+   can read both PKI mounts and manage the intermediate PKI mount configuration:
 
   <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
@@ -210,7 +236,9 @@ In the following examples, the path configurations use placeholder values for `R
 
   </CodeBlockConfig>
 
-1. Add the following rules to you policy file so that Consul can use the  externally-managed PKI secrets engines that is already mounted: 
+1. Add the following rules to your Vault policy file so that Consul
+   has read-only access to the root PKI engine, can automatically rotate
+   intermediate CAs as needed, and has full use of the intermediate PKI engine:
 
   <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
@@ -223,26 +251,16 @@ In the following examples, the path configurations use placeholder values for `R
     capabilities = [ "update" ]
   }
 
-  path "/<root_pki_path>/*" {
+  path "/<intermediate_pki_path>/*" {
     capabilities = [ "create", "read", "update", "delete", "list" ]
   }
   ```
   </CodeBlockConfig>
 
-1. Only add the following rules to your policy file if you are changing the CA provider from Vault to a different CA provider (such as Consul's built-in provider) or changing the RootPKIPath used by the Vault CA provider:
-
-  <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
-
-  ```hcl
-  path "<root_pki_path>/root/sign-self-issued" {
-    capabilities = [ "sudo", "update" ]
-  }
-  ```
-  </CodeBlockConfig>
-  
-  Note that because this is an extremely privileged endpoint, we recommend only temporarily granting this permission if you need to modify Consul's CA provider configuration.
-
-1. Add the following rules to you policy file so that Consul renew its Vault token if the token is renewable. The rule enables the token to be renewed whether it is provided directly in the CA provider configuration or presented in an auth method.
+1. Add the following rules to your Vault policy file so that Consul
+   can renew its Vault token if the token is renewable.
+   The rule enables the token to be renewed whether it is provided
+   [directly](#token) in the CA provider configuration or presented in an [auth method](#authmethod).
 
   <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
@@ -258,13 +276,35 @@ In the following examples, the path configurations use placeholder values for `R
   
   </CodeBlockConfig>
 
-#### Define a policy for Consul-managed PKI paths
+1. Conditional and temporary: Only include the following rules in your vault policy file
+   while you are changing the CA provider from Vault to a different CA provider (such as Consul's built-in provider)
+   or changing the `RootPKIPath` used by the Vault CA provider.
+   Those CA provider modifications trigger a root CA change that requires an
+   extremely privileged root cross-sign operation.
+   We recommend removing this elevated privilege immediately after the CA provider modification is finished.
 
-You can define a Vault ACL policy that allows Consul to create and manage the PKI paths in Vault. The policy grants Consul the ability to create the PKI mount points and grants grants full control of the intermediate or leaf CA for Consul service mesh clients.
+  <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
-In the following examples, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`. Replace them to match the path values in the CA provider configuration.
+  ```hcl
+  path "<root_pki_path>/root/sign-self-issued" {
+    capabilities = [ "sudo", "update" ]
+  }
+  ```
+  </CodeBlockConfig>
 
-1. Add the following rules to your Consul policy definition file so that Consul can create and manage the PKI mounts:
+#### Define a policy for Consul-managed PKI paths ((#consul-managed-pki-paths))
+
+To use Consul-managed PKI paths, ensure no PKI secrets engines are mounted at
+`RootPKIPath` and `IntermediatePKIPath`.
+
+Next, define a Vault ACL policy that allows Consul to create and manage
+both the root and intermediate PKI engines.
+
+In the following examples, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
+Replace them to match the path values in the CA provider configuration.
+
+1. Add the following rules to your Vault policy definition file so that Consul
+   can create and manage both PKI engines:
 
   <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
 
@@ -283,7 +323,8 @@ In the following examples, the path configurations use placeholder values for `R
   ```
   </CodeBlockConfig>
 
-1. Add the following rules to your Consul policy definition file so that Consul can use the mounted PKI secrets engines it owns:
+1. Add the following rules to your Vault policy file so that Consul
+   has full use of both PKI engines:
 
   <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
 
@@ -299,21 +340,10 @@ In the following examples, the path configurations use placeholder values for `R
 
   </CodeBlockConfig>
 
-1. Only add the following rule to your Consul policy definition file when changing the CA provider from Vault to either a different CA provider (such as Consul's built-in provider) or changing the `RootPKIPath` used by the Vault CA provider:
-
-  <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
-  
-  ```hcl
-  path "<root_pki_path>/root/sign-self-issued" {
-    capabilities = [ "sudo", "update" ]
-  }
-  ```
-
-  </CodeBlockConfig>
-
-  Because this is an extremely privileged endpoint, we recommend temporarily granting this permission if you need to modify Consul's CA provider configuration.
-
-1. Add the following rules to your Consul policy definition file so that Consul can renew its Vault token if renewable. The token is renewed whether it is presetned directly in the CA provider configuration or in an auth method.
+1. Add the following rules to your Vault policy file so that Consul
+   can renew its Vault token if the token is renewable.
+   The rule enables the token to be renewed whether it is provided
+   [directly](#token) in the CA provider configuration or presented in an [auth method](#authmethod).
 
   <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
 
@@ -329,7 +359,18 @@ In the following examples, the path configurations use placeholder values for `R
   
   </CodeBlockConfig>
 
-<!-- Reference style links -->
-[`ca_config`]: /docs/agent/config/config-files#connect_ca_config
-[`ca_provider`]: /docs/agent/config/config-files#connect_ca_provider
-[`/connect/ca/configuration`]: /api-docs/connect/ca#update-ca-configuration
+1. Conditional and temporary: Only include the following rules in your vault policy file
+   while you are changing the CA provider from Vault to a different CA provider (such as Consul's built-in provider)
+   or changing the `RootPKIPath` used by the Vault CA provider.
+   Those CA provider modifications trigger a root CA change that requires an
+   extremely privileged root cross-sign operation.
+   We recommend removing this elevated privilege immediately after the CA provider modification is finished.
+
+  <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
+
+  ```hcl
+  path "<root_pki_path>/root/sign-self-issued" {
+    capabilities = [ "sudo", "update" ]
+  }
+  ```
+  </CodeBlockConfig>

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Vault as a Service Mesh Certificate Authority
 
-You can configure Consul to use [Vault](https://www.vaultproject.io/) as the certificate authority (CA), so that Vault can manage and sign certificates distributed to services in the mesh. 
+You can configure Consul to use [Vault](https://www.vaultproject.io/) as the certificate authority (CA) so that Vault can manage and sign certificates distributed to services in the mesh. 
 The Vault CA provider uses the [Vault PKI secrets engine](https://www.vaultproject.io/docs/secrets/pki) to generate and sign certificates. 
 This page describes how configure the Vault CA provider.
 
@@ -15,18 +15,19 @@ This page describes how configure the Vault CA provider.
 
 ## Requirements
 
-- Refer to [Service Mesh Certificate Authority Overview](/docs/connect/ca) for important background information about how Consul manages certificates with configurable CA providers. 
+- Refer to [Service Mesh Certificate Authority Overview](/docs/connect/ca) for important background information about how Consul manages certificates with configurable CA providers.
 
-- Use Vault 0.10.3 to latest 1.10.x.
+- Vault 0.10.3 to 1.10.x.
 
-~> **Note:** Do not use Vault v1.11.0+ as Consul's Connect CA provider — the intermediate CA becomes unable to issue the leaf nodes required by service mesh, and by Consul client agents if using auto-encrypt or auto-config and using TLS for agent communication. If you are already using Vault 1.11+ as a Connect CA, refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more information about the underlying cause and recommended workaround.
+~> **Compatibility warning:** Do not use Vault v1.11.0+ as Consul's Connect CA provider — the intermediate CA becomes unable to issue the leaf nodes required by service mesh, and by Consul client agents if using auto-encrypt or auto-config and using TLS for agent communication. If you are already using Vault 1.11+ as a Connect CA, refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more information about the underlying cause and recommended workaround.
 
 ## Enable Vault as the CA
 
 You can enable Vault as the CA by configuring Consul to use `"vault"` as the CA provider
 and including the required provider configuration options.
-You can provide the CA configuration in the agent configuration file of server agents,
-or by calling the [update CA configuration API endpoint](/api-docs/connect/ca#update-ca-configuration).
+You can provide the CA configuration in the server agents' configuration file
+or in the body of a `PUT` request to the
+[`/connect/ca/configuration`](/api-docs/connect/ca#update-ca-configuration) API endpoint.
 Refer to the [Configuration Reference](#configuration-reference) for details about configuration options and for example use cases. 
 
 The following example shows the required configurations for a default implementation:
@@ -203,20 +204,19 @@ Use [Vault-managed PKI paths](#vault-managed-pki-paths) to obtain the following 
 
 Otherwise, use [Consul-managed PKI paths](#consul-managed-pki-paths) to let Consul fully automate PKI management.
 
+The following sections describe the Vault policy needed for both options.
+The policy snippets use placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
+Replace them to match the path values in your CA provider configuration.
+
 #### Define a policy for Vault-managed PKI paths ((#vault-managed-pki-paths))
 
 To use Vault-managed PKI paths, you must first instantiate and configure PKI secrets engines at
 `RootPKIPath` and `IntermediatePKIPath`.
 
-Next, define the following Vault ACL policy that allows Consul to use those pre-existing PKI mounts in Vault.
-The policy grants Consul limited use of the root PKI engine
-and full control of the intermediate PKI engine to issue service mesh certificates.
+Then, attach the following Vault ACL policy to the CA provider's
+[Vault token](#token) or [auth method](#authmethod):
 
-In the following Vault policy snippets, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
-Replace them to match the path values in the CA provider configuration.
-
-1. Add the following rules to your Vault policy definition file so that Consul
-   can read both PKI mounts and manage the intermediate PKI mount configuration:
+1. Allow Consul to read both PKI mounts and to manage the intermediate PKI mount configuration:
 
   <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
@@ -236,9 +236,8 @@ Replace them to match the path values in the CA provider configuration.
 
   </CodeBlockConfig>
 
-1. Add the following rules to your Vault policy file so that Consul
-   has read-only access to the root PKI engine, can automatically rotate
-   intermediate CAs as needed, and has full use of the intermediate PKI engine:
+1. Allow Consul read-only access to the root PKI engine, to automatically rotate
+   intermediate CAs as needed, and full use of the intermediate PKI engine:
 
   <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
@@ -257,8 +256,7 @@ Replace them to match the path values in the CA provider configuration.
   ```
   </CodeBlockConfig>
 
-1. Add the following rules to your Vault policy file so that Consul
-   can renew its Vault token if the token is renewable.
+1. Allow Consul to renew its Vault token if the token is renewable.
    The rule enables the token to be renewed whether it is provided
    [directly](#token) in the CA provider configuration or presented in an [auth method](#authmethod).
 
@@ -276,35 +274,15 @@ Replace them to match the path values in the CA provider configuration.
   
   </CodeBlockConfig>
 
-1. Conditional and temporary: Only include the following rules in your Vault policy file
-   while you are changing the CA provider from Vault to a different CA provider (such as Consul's built-in provider)
-   or changing the `RootPKIPath` used by the Vault CA provider.
-   Those CA provider modifications trigger a root CA change that requires an
-   extremely privileged root cross-sign operation.
-   We recommend removing this elevated privilege immediately after the CA provider modification is finished.
-
-  <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
-
-  ```hcl
-  path "<root_pki_path>/root/sign-self-issued" {
-    capabilities = [ "sudo", "update" ]
-  }
-  ```
-  </CodeBlockConfig>
-
 #### Define a policy for Consul-managed PKI paths ((#consul-managed-pki-paths))
 
 To use Consul-managed PKI paths, ensure no PKI secrets engines are mounted at
 `RootPKIPath` and `IntermediatePKIPath`.
 
-Next, define the following Vault ACL policy that allows Consul to create and manage
-both the root and intermediate PKI engines.
+Then, attach the following Vault ACL policy to the CA provider's
+[Vault token](#token) or [auth method](#authmethod):
 
-In the following Vault policy snippets, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
-Replace them to match the path values in the CA provider configuration.
-
-1. Add the following rules to your Vault policy definition file so that Consul
-   can create and manage both PKI engines:
+1. Allow Consul to create and manage both PKI engines:
 
   <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
 
@@ -323,8 +301,7 @@ Replace them to match the path values in the CA provider configuration.
   ```
   </CodeBlockConfig>
 
-1. Add the following rules to your Vault policy file so that Consul
-   has full use of both PKI engines:
+1. Allow Consul full use of both PKI engines:
 
   <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
 
@@ -340,8 +317,7 @@ Replace them to match the path values in the CA provider configuration.
 
   </CodeBlockConfig>
 
-1. Add the following rules to your Vault policy file so that Consul
-   can renew its Vault token if the token is renewable.
+1. Allow Consul to renew its Vault token if the token is renewable.
    The rule enables the token to be renewed whether it is provided
    [directly](#token) in the CA provider configuration or presented in an [auth method](#authmethod).
 
@@ -359,18 +335,26 @@ Replace them to match the path values in the CA provider configuration.
   
   </CodeBlockConfig>
 
-1. Conditional and temporary: Only include the following rules in your Vault policy file
-   while you are changing the CA provider from Vault to a different CA provider (such as Consul's built-in provider)
-   or changing the `RootPKIPath` used by the Vault CA provider.
-   Those CA provider modifications trigger a root CA change that requires an
-   extremely privileged root cross-sign operation.
-   We recommend removing this elevated privilege immediately after the CA provider modification is finished.
+#### Additional Vault ACL policies for sensitive operations
 
-  <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
+Additional Vault permissions are required while you perform the
+following CA configuration changes:
+- Changing the provider from Vault to a different provider, such as Consul's built-in provider
+- Changing the `RootPKIPath`
 
-  ```hcl
-  path "<root_pki_path>/root/sign-self-issued" {
-    capabilities = [ "sudo", "update" ]
-  }
-  ```
-  </CodeBlockConfig>
+Those configuration modifications trigger a root CA change that requires an
+extremely privileged root cross-sign operation. 
+For that operation to succeed, the CA's [Vault token](#token) or
+[auth method](#authmethod) must contain the following rule:
+
+<CodeBlockConfig filename="temporary-sensitive-operation-pki-policy.hcl">
+
+```hcl
+path "<root_pki_path>/root/sign-self-issued" {
+capabilities = [ "sudo", "update" ]
+}
+```
+</CodeBlockConfig>
+
+We recommend adding this elevated privilege just before the CA provider
+modification, then removing immediately after.

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -351,7 +351,7 @@ For that operation to succeed, the CA provider's [Vault token](#token) or
 
 ```hcl
 path "<root_pki_path>/root/sign-self-issued" {
-capabilities = [ "sudo", "update" ]
+  capabilities = [ "sudo", "update" ]
 }
 ```
 </CodeBlockConfig>

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -356,17 +356,14 @@ capabilities = [ "sudo", "update" ]
 ```
 </CodeBlockConfig>
 
-We recommend adding this elevated privilege just before the CA provider
-modification, then removing immediately after, using the following process:
+We recommend using the following process when performing such a CA provider
+configuration change to minimize the time that a privileged Vault token is in use:
 1. Create a new Vault token that includes both the `root/sign-self-issued`
-   permission and the standard permissions for Consul or Vault managed
-   PKI paths. If you intend to keep Vault as the provider but change `RootPKIPath`,
-   the Vault token needs standard `RootPKIPath` permissions on both the current
-   and new intended paths.
-1. Modify the CA provider configuration to use the new Vault token.
-1. Modify the CA provider configuration that triggers the extremely privileged
-   root cross-sign operation.
-1. If Vault is still the provider but `RootPKIPath` was changed,
-   modify the CA provider configuration to use a Vault token or auth method
-   with only the standard permissions, no longer including the `root/sign-self-issued`
-   permission.
+   permission and the standard permissions for the current Consul or Vault
+   managed PKI paths.
+1. Modify the CA provider configuration to use that new Vault token.
+1. Perform the CA provider configuration change that triggers the extremely privileged
+   root cross-sign operation. If the configuration change maintains Vault
+   as the provider but changes `RootPKIPath`, the configuration change must
+   include a Vault token or auth method with standard permissions for the new
+   Consul or Vault managed PKI paths.

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -7,40 +7,23 @@ description: >-
 
 # Vault as a Service Mesh Certificate Authority
 
-Consul can be used with [Vault](https://www.vaultproject.io/) to
-manage and sign certificates.
-The Vault CA provider uses the
-[Vault PKI secrets engine](https://www.vaultproject.io/docs/secrets/pki)
-to generate and sign certificates.
+You can configure Consul to use [Vault](https://www.vaultproject.io/) as the certificate authority (CA), so that Vault can manage and sign certificates distributed to services in the mesh. 
+The Vault CA provider uses the [Vault PKI secrets engine](https://www.vaultproject.io/docs/secrets/pki) to generate and sign certificates. 
+This page describes how configure the Vault CA provider.
 
-This page documents the specifics of the Vault CA provider.
-Please read the [certificate management overview](/docs/connect/ca)
-page first to understand how Consul manages certificates with configurable
-CA providers.
-
--> **Tip:** Complete the [tutorial](https://learn.hashicorp.com/tutorials/consul/vault-pki-consul-connect-ca?in=consul/vault-secure) to learn how to configure Vault as the Consul Connect service mesh Certification Authority.
+> **Tutorial:** Complete the [Vault as Consul Service Mesh Certification Authority](/consul/tutorials/vault-secure/vault-pki-consul-connect-ca) tutorial for hands-on guidance on how to configure Vault as the Consul service mesh certification authority.
 
 ## Requirements
 
-Prior to using Vault as a CA provider for Consul, the following requirements
-must be met:
+- Read [Service Mesh Certificate Authority Overview](/docs/connect/ca) for important background information about how Consul manages certificates with configurable CA providers. 
 
-- **Vault 0.10.3 or later.** Consul uses URI SANs in the PKI engine which
-  were introduced in Vault 0.10.3. Prior versions of Vault are not
-  compatible with Connect.
+- Vault 0.10.3 to 1.11.0. Note that in Vault 1.11.0 the intermediate CA becomes unable to issue the required leaf nodes if `auto-encrypt` or `auto-config` and TLS for agent communication are enabled. If you are already using Vault 1.11+ as a Connect CA, refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for details about the underlying cause and a recommended workaround.
 
-~> **Note:** Do not use Vault v1.11.0+ as Consul's Connect CA provider — the intermediate CA will become unable to issue the leaf nodes required by service mesh, and by Consul client agents if using auto-encrypt or auto-config and using TLS for agent communication. If you are already using Vault 1.11+ as a Connect CA, refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more information about the underlying cause and recommended workaround.
+## Enable Vault as the CA
 
-## Configuration
+You can enable Vault as the CA by either configuring the [`ca_provider`], [`ca_config`], and other required options in the agent configuration file or by passing the configuration to the [`/connect/ca/configuration`] API endpoint. Refer to [Configuration](#configuration) for details about configuration options and for example use cases. 
 
-The Vault CA is enabled by setting the CA provider to `"vault"` and
-setting the required configuration values.
-
-The configuration may either be provided in the agent's configuration file using
-the [`ca_provider`] and [`ca_config`] options, or configured using the
-[`/connect/ca/configuration`] API endpoint.
-
-Example configurations are shown below:
+The following example shows the required configurations for a default implementation:
 
 <CodeTabs heading="Connect CA configuration" tabs={["Agent configuration", "API"]}>
 
@@ -80,11 +63,10 @@ connect {
 
 </CodeTabs>
 
-The configuration options are listed below.
 
--> **NOTE**: The first key is the value used in API calls, and the second key
-   (after the `/`) is used if you are adding the configuration to the agent's
-   configuration file.
+## Configuration Reference
+
+You can specify the following configuration options. Note that the first key refers to the value for the API and the value after the slash refers to the equivalent parameter in the agent configuration file. 
 
 - `Address` / `address` (`string: <required>`) - The address of the Vault
   server.
@@ -181,174 +163,171 @@ The configuration options are listed below.
 
 @include 'http_api_connect_ca_common_options.mdx'
 
-## Root and Intermediate PKI Paths
+### Root and Intermediate PKI Paths
 
 The Vault CA provider uses two separately configured
 [PKI secrets engines](https://www.vaultproject.io/docs/secrets/pki)
-for managing Connect certificates.
+for managing Consul service mesh certificates.
 
-The `RootPKIPath` is the PKI engine for the root certificate. Consul will
-use this root certificate to sign the intermediate certificate. Consul will
-never attempt to write or modify any data within the root PKI path.
+The `RootPKIPath` is the PKI engine for the root certificate. Consul uses this root certificate to sign the intermediate certificate. Consul does not attempt to write or modify any data within the root PKI path.
 
 The `IntermediatePKIPath` is the PKI engine used for storing the intermediate
-signed with the root certificate. The intermediate is used to sign all leaf
-certificates and Consul may periodically generate new intermediates for
+signed with the root certificate. The intermediate signs all leaf
+certificates, and Consul may periodically generate new intermediates for
 automatic rotation. Therefore, Consul requires write access to this path.
 
-If either path does not exist, then Consul will attempt to mount and
-initialize it. This requires additional privileges by the Vault token in use.
-If the paths already exist, Consul will use them as configured.
+If neither path exists, then Consul attempts to mount and
+initialize the PKI engine, which requires additional privileges of the Vault token in use.
+If the paths already exist, Consul uses them as configured.
 
-## Vault ACL Policies
+### Configure Vault ACL policies
 
-Vault PKI can be managed by either Consul or by Vault. If you want to manually create and tune the PKI secret engines used to store the root and intermediate certificates, use Vault Managed PKI Paths. If you want to have the PKI automatically managed for you, use Consul Managed PKI Paths.
+You can define an access control list (ACL) policy that assigns Vault PKI management to Consul or Vault. If you want to manually create and tune the PKI secret engines used to store the root and intermediate certificates, define a policy that uses Vault-managed PKI paths. If you want to automate PKI management, define a policy that uses Consul-managed PKI paths.
 
-### Vault Managed PKI Paths
+#### Define a policy for Vault-managed PKI paths
 
-The following Vault policy allows Consul to use pre-existing PKI paths in Vault.
-Consul is granted read-only access to the PKI mount points and the Root CA, but is
-granted full control of the Intermediate or Leaf CA for Connect clients.
+You can define a Vault ACL policy that allows Consul to use pre-existing PKI paths in Vault. The policy grants Consul read-only access to the PKI mount points and the root CA and grants full control of the intermediate or leaf CA for Consul service mesh clients.
 
-This example uses placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
-Please update those placeholders to match the path values in the CA provider configuration.
+In the following examples, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`. Replace them to match the path values in the CA provider configuration.
 
-<CodeBlockConfig filename="vault-managed-pki-policy.hcl">
+1. Add the following rules to you policy file so that Consul can read the PKI mounts already created in Vault:
 
-```hcl
-# -----------------------------------------------------------------------------
-# Vault Managed PKI Mounts
-# -----------------------------------------------------------------------------
+  <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
-# -----------------------------------------------------------------------------
-# Needed for Consul to read the PKI mounts already created in Vault
+  ```hcl
+  path "/sys/mounts/<root_pki_path>" {
+    capabilities = [ "read" ]
+  }
 
-path "/sys/mounts/<root_pki_path>" {
-  capabilities = [ "read" ]
-}
+  path "/sys/mounts/<intermediate_pki_path>" {
+    capabilities = [ "read" ]
+  }
 
-path "/sys/mounts/<intermediate_pki_path>" {
-  capabilities = [ "read" ]
-}
+  path "/sys/mounts/<intermediate_pki_path>/tune" {
+    capabilities = [ "update" ]
+  }
+  ```
 
-path "/sys/mounts/<intermediate_pki_path>/tune" {
-  capabilities = [ "update" ]
-}
+  </CodeBlockConfig>
 
-# -----------------------------------------------------------------------------
-# Needed for Consul to use the externally-managed, mounted PKI secrets engines
+1. Add the following rules to you policy file so that Consul can use the  externally-managed PKI secrets engines that is already mounted: 
 
-path "/<root_pki_path>/" {
-  capabilities = [ "read" ]
-}
+  <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
-path "/<root_pki_path>/root/sign-intermediate" {
-  capabilities = [ "update" ]
-}
+  ```hcl
+  path "/<root_pki_path>/" {
+    capabilities = [ "read" ]
+  }
+  
+  path "/<root_pki_path>/root/sign-intermediate" {
+    capabilities = [ "update" ]
+  }
 
-path "/<root_pki_path>/*" {
-  capabilities = [ "create", "read", "update", "delete", "list" ]
-}
+  path "/<root_pki_path>/*" {
+    capabilities = [ "create", "read", "update", "delete", "list" ]
+  }
+  ```
+  </CodeBlockConfig>
 
-# Needed only when changing the CA provider from Vault with this RootPKIPath
-# to either:
-# 1. A different CA provider (such as Consul's built-in provider)
-# 2. Changing the RootPKIPath used by the Vault CA provider
-#
-# SECURITY NOTE: Because this is an extremely privileged endpoint,
-# We recommend only temporarily granting this permission if there's a need
-# to modify Consul's CA provider configuration as in (1) or (2).
-# That's why this permission is currently commented out.
-#
-# path "<root_pki_path>/root/sign-self-issued" {
-#  capabilities = [ "sudo", "update" ]
-#}
+1. Only add the following rules to your policy file if you are changing the CA provider from Vault to a different CA provider (such as Consul's built-in provider) or changing the RootPKIPath used by the Vault CA provider:
 
-# -----------------------------------------------------------------------------
-# Needed for Consul to renew its Vault token (if renewable) whether provided
-# directly in the CA provider config or using an auth method.
+  <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
-path "auth/token/renew-self" {
-  capabilities = [ "update" ]
-}
+  ```hcl
+  path "<root_pki_path>/root/sign-self-issued" {
+    capabilities = [ "sudo", "update" ]
+  }
+  ```
+  </CodeBlockConfig>
+  
+  Note that because this is an extremely privileged endpoint, we recommend only temporarily granting this permission if you need to modify Consul's CA provider configuration.
 
-path "auth/token/lookup-self" {
-  capabilities = [ "read" ]
-}
-```
+1. Add the following rules to you policy file so that Consul renew its Vault token if the token is renewable. The rule enables the token to be renewed whether it is provided directly in the CA provider configuration or presented in an auth method.
 
-</CodeBlockConfig>
+  <CodeBlockConfig filename="vault-managed-pki-policy.hcl">
 
-### Consul Managed PKI Paths
+  ```hcl
+  path "auth/token/renew-self" {
+    capabilities = [ "update" ]
+  }
 
-The following Vault policy allows Consul to create and manage the PKI paths in Vault.
-Consul is granted the ability to create the PKI mount points and given full
-control of the Root and Intermediate or Leaf CA for Connect clients.
+  path "auth/token/lookup-self" {
+    capabilities = [ "read" ]
+  }
+  ```
+  
+  </CodeBlockConfig>
 
-This example uses placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
-Replace them to match the path values specified in your CA provider configuration.
+#### Define a policy for Consul-managed PKI paths
 
-<CodeBlockConfig filename="consul-managed-pki-policy.hcl">
+You can define a Vault ACL policy that allows Consul to create and manage the PKI paths in Vault. The policy grants Consul the ability to create the PKI mount points and grants grants full control of the intermediate or leaf CA for Consul service mesh clients.
 
-```hcl
-# -----------------------------------------------------------------------------
-# Consul Managed PKI Mounts
-# -----------------------------------------------------------------------------
+In the following examples, the path configurations use placeholder values for `RootPKIPath` and `IntermediatePKIPath`. Replace them to match the path values in the CA provider configuration.
 
-# -----------------------------------------------------------------------------
-# Needed for Consul to create and manage the PKI mounts
+1. Add the following rules to your Consul policy definition file so that Consul can create and manage the PKI mounts:
 
-path "/sys/mounts/<root_pki_path>" {
-  capabilities = [ "create", "read", "update", "delete", "list" ]
-}
+  <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
 
-path "/sys/mounts/<intermediate_pki_path>" {
-  capabilities = [ "create", "read", "update", "delete", "list" ]
-}
+  ```hcl
+  path "/sys/mounts/<root_pki_path>" {
+    capabilities = [ "create", "read", "update", "delete", "list" ]
+  }
 
-path "/sys/mounts/<intermediate_pki_path>/tune" {
-  capabilities = [ "update" ]
-}
+  path "/sys/mounts/<intermediate_pki_path>" {
+    capabilities = [ "create", "read", "update", "delete", "list" ]
+  }
 
-# -----------------------------------------------------------------------------
-# Needed for Consul to use the mounted PKI secrets engines it owns
+  path "/sys/mounts/<intermediate_pki_path>/tune" {
+    capabilities = [ "update" ]
+  }
+  ```
+  </CodeBlockConfig>
 
-path "/<root_pki_path>/*" {
-  capabilities = [ "create", "read", "update", "delete", "list" ]
-}
+1. Add the following rules to your Consul policy definition file so that Consul can use the mounted PKI secrets engines it owns:
 
-path "/<intermediate_pki_path>/*" {
-  capabilities = [ "create", "read", "update", "delete", "list" ]
-}
+  <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
 
-# Needed only when changing the CA provider from Vault with this RootPKIPath
-# to either:
-# 1. A different CA provider (such as Consul's built-in provider)
-# 2. Changing the RootPKIPath used by the Vault CA provider
-#
-# SECURITY NOTE: Because this is an extremely privileged endpoint,
-# We recommend only temporarily granting this permission if there's a need
-# to modify Consul's CA provider configuration as in (1) or (2).
-# That's why this permission is currently commented out.
-#
-# path "<root_pki_path>/root/sign-self-issued" {
-#  capabilities = [ "sudo", "update" ]
-#}
+  ```hcl
+  path "/<root_pki_path>/*" {
+    capabilities = [ "create", "read", "update", "delete", "list" ]
+  }
 
-# -----------------------------------------------------------------------------
-# Needed for Consul to renew its Vault token (if renewable) whether provided
-# directly in the CA provider config or using an auth method.
+  path "/<intermediate_pki_path>/*" {
+    capabilities = [ "create", "read", "update", "delete", "list" ]
+  }
+  ```
 
-path "auth/token/renew-self" {
-  capabilities = [ "update" ]
-}
+  </CodeBlockConfig>
 
-path "auth/token/lookup-self" {
-  capabilities = [ "read" ]
-}
-```
+1. Only add the following rule to your Consul policy definition file when changing the CA provider from Vault to either a different CA provider (such as Consul's built-in provider) or changing the `RootPKIPath` used by the Vault CA provider:
 
-</CodeBlockConfig>
+  <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
+  
+  ```hcl
+  path "<root_pki_path>/root/sign-self-issued" {
+    capabilities = [ "sudo", "update" ]
+  }
+  ```
+
+  </CodeBlockConfig>
+
+  Because this is an extremely privileged endpoint, we recommend temporarily granting this permission if you need to modify Consul's CA provider configuration.
+
+1. Add the following rules to your Consul policy definition file so that Consul can renew its Vault token if renewable. The token is renewed whether it is presetned directly in the CA provider configuration or in an auth method.
+
+  <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
+
+  ```hcl
+  path "auth/token/renew-self" {
+    capabilities = [ "update" ]
+  }
+
+  path "auth/token/lookup-self" {
+    capabilities = [ "read" ]
+  }
+  ```
+  
+  </CodeBlockConfig>
 
 <!-- Reference style links -->
 [`ca_config`]: /docs/agent/config/config-files#connect_ca_config

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -338,13 +338,13 @@ Then, attach the following Vault ACL policy to the CA provider's
 #### Additional Vault ACL policies for sensitive operations
 
 Additional Vault permissions are required while you perform the
-following CA configuration changes:
+following CA provider configuration changes:
 - Changing the provider from Vault to a different provider, such as Consul's built-in provider
 - Changing the `RootPKIPath`
 
 Those configuration modifications trigger a root CA change that requires an
 extremely privileged root cross-sign operation. 
-For that operation to succeed, the CA's [Vault token](#token) or
+For that operation to succeed, the CA provider's [Vault token](#token) or
 [auth method](#authmethod) must contain the following rule:
 
 <CodeBlockConfig filename="temporary-sensitive-operation-pki-policy.hcl">

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -223,31 +223,31 @@ Please update those placeholders to match the path values in the CA provider con
 # -----------------------------------------------------------------------------
 # Needed for Consul to read the PKI mounts already created in Vault
 
-path "/sys/mounts/<insert-RootPKIPath>" {
+path "/sys/mounts/<root_pki_path>" {
   capabilities = [ "read" ]
 }
 
-path "/sys/mounts/<insert-IntermediatePKIPath>" {
+path "/sys/mounts/<intermediate_pki_path>" {
   capabilities = [ "read" ]
 }
 
 # Needed in Consul 1.11+ to update intermediate mount configuration
-path "/sys/mounts/<insert-IntermediatePKIPath>/tune" {
+path "/sys/mounts/<intermediate_pki_path>/tune" {
   capabilities = [ "update" ]
 }
 
 # -----------------------------------------------------------------------------
 # Needed for Consul to use the externally-managed, mounted PKI secrets engines
 
-path "/<insert-RootPKIPath>/" {
+path "/<root_pki_path>/" {
   capabilities = [ "read" ]
 }
 
-path "/<insert-RootPKIPath>/root/sign-intermediate" {
+path "/<root_pki_path>/root/sign-intermediate" {
   capabilities = [ "update" ]
 }
 
-path "/<insert-RootPKIPath>/*" {
+path "/<root_pki_path>/*" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 
@@ -261,7 +261,7 @@ path "/<insert-RootPKIPath>/*" {
 # to modify Consul's CA provider configuration as in (1) or (2).
 # That's why this permission is currently commented out.
 #
-# path "<insert-RootPKIPath>/root/sign-self-issued" {
+# path "<root_pki_path>/root/sign-self-issued" {
 #  capabilities = [ "sudo", "update" ]
 #}
 
@@ -295,7 +295,7 @@ Consul is granted the ability to create the PKI mount points and given full
 control of the Root and Intermediate or Leaf CA for Connect clients.
 
 This example uses placeholder values for `RootPKIPath` and `IntermediatePKIPath`.
-Please update those placeholders to match the path values in the CA provider configuration.
+Replace them to match the path values specified in your CA provider configuration.
 
 <CodeBlockConfig filename="consul-managed-pki-policy.hcl">
 
@@ -307,27 +307,27 @@ Please update those placeholders to match the path values in the CA provider con
 # -----------------------------------------------------------------------------
 # Needed for Consul to create and manage the PKI mounts
 
-path "/sys/mounts/<insert-RootPKIPath>" {
+path "/sys/mounts/<root_pki_path>" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 
-path "/sys/mounts/<insert-IntermediatePKIPath>" {
+path "/sys/mounts/<intermediate_pki_path>" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 
 # Enables Consul 1.11+ to update intermediate mount configuration
-path "/sys/mounts/<insert-IntermediatePKIPath>/tune" {
+path "/sys/mounts/<intermediate_pki_path>/tune" {
   capabilities = [ "update" ]
 }
 
 # -----------------------------------------------------------------------------
 # Needed for Consul to use the mounted PKI secrets engines it owns
 
-path "/<insert-RootPKIPath>/*" {
+path "/<root_pki_path>/*" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 
-path "/<insert-IntermediatePKIPath>/*" {
+path "/<intermediate_pki_path>/*" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 
@@ -341,7 +341,7 @@ path "/<insert-IntermediatePKIPath>/*" {
 # to modify Consul's CA provider configuration as in (1) or (2).
 # That's why this permission is currently commented out.
 #
-# path "<insert-RootPKIPath>/root/sign-self-issued" {
+# path "<root_pki_path>/root/sign-self-issued" {
 #  capabilities = [ "sudo", "update" ]
 #}
 


### PR DESCRIPTION
After this PR is merged, the associated tutorials that include Vault policies for use with the Vault as a Connect CA provider must be updated as well.

[Preview link to the Vault policies changes](https://consul-n4pht8hnd-hashicorp.vercel.app/consul/docs/connect/ca/vault#vault-acl-policies)