### PR TITLE
fix(peering): increase the gRPC limit to 8MB

### DIFF
--- a/.changelog/15503.txt
+++ b/.changelog/15503.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-peering: fix the limit of replication gRPC message; increased to 50MB as stated in the document
+peering: fix the limit of replication gRPC message; set to 8MB
 ```

--- a/.changelog/15503.txt
+++ b/.changelog/15503.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: fix the limit of replication gRPC message; increased to 50MB as stated in the document
+```

--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -360,7 +360,7 @@ func (s *Server) establishStream(ctx context.Context,
 				// send keepalive pings even if there is no active streams
 				PermitWithoutStream: true,
 			}),
-			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(50 * 1024 * 1024)),
+			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(50*1024*1024), grpc.MaxCallRecvMsgSize(50*1024*1024)),
 		}
 
 		logger.Trace("dialing peer", "addr", addr)

--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -360,7 +360,7 @@ func (s *Server) establishStream(ctx context.Context,
 				// send keepalive pings even if there is no active streams
 				PermitWithoutStream: true,
 			}),
-			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(50*1024*1024), grpc.MaxCallRecvMsgSize(50*1024*1024)),
+			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(8*1024*1024), grpc.MaxCallRecvMsgSize(8*1024*1024)),
 		}
 
 		logger.Trace("dialing peer", "addr", addr)

--- a/agent/grpc-internal/client.go
+++ b/agent/grpc-internal/client.go
@@ -148,7 +148,9 @@ func (c *ClientConnPool) dial(datacenter string, serverType string) (*grpc.Clien
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:    30 * time.Second,
 			Timeout: 10 * time.Second,
-		}))
+		}),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(50*1024*1024), grpc.MaxCallRecvMsgSize(50*1024*1024)),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/grpc-internal/client.go
+++ b/agent/grpc-internal/client.go
@@ -149,7 +149,7 @@ func (c *ClientConnPool) dial(datacenter string, serverType string) (*grpc.Clien
 			Time:    30 * time.Second,
 			Timeout: 10 * time.Second,
 		}),
-		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(50*1024*1024), grpc.MaxCallRecvMsgSize(50*1024*1024)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(8*1024*1024), grpc.MaxCallRecvMsgSize(8*1024*1024)),
 	)
 	if err != nil {
 		return nil, err

--- a/website/content/docs/connect/cluster-peering/index.mdx
+++ b/website/content/docs/connect/cluster-peering/index.mdx
@@ -46,7 +46,7 @@ Regardless of whether you connect your clusters through WAN federation or cluste
 
 Consider the following technical constraints:
 
-- Services with node, instance, and check definitions totaling more than 50MB cannot be exported to a peer.
+- Services with node, instance, and check definitions totaling more than 8MB cannot be exported to a peer.
 - Two admin partitions in the same datacenter cannot be peered. Use [`exported-services`](/docs/connect/config-entries/exported-services#exporting-services-to-peered-clusters) directly.
 - The `consul intention` CLI command is not supported. To manage intentions that specify services in peered clusters, use [configuration entries](/docs/connect/config-entries/service-intentions).
 - Accessing key/value stores across peers is not supported.


### PR DESCRIPTION
### Description
Increase the gRPC limit to 50MB in both peering grpc client and health rpc client

The rpcclient limit is also updated since the health streaming client needs to pull the service from the catalog.

### Testing & Reproduction steps

```
2022-11-21T11:08:33.477-0500 [DEBUG] agent.http: Request finished: method=GET url="/v1/internal/ui/services?dc=dc3&index=26" from=127.0.0.1:51829 latency=5.240129042s
2022-11-21T11:08:33.502-0500 [DEBUG] agent.server.peering-syncer: stream disconnected due to 'resource exhausted' error; reconnecting: peer_id=f7e2b2a5-2453-de22-823f-69d898971567 peer_name=acceptor error="unexpected error receiving from the stream: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5245223 vs. 4194304)"


2022-11-21T11:32:45.270-0500 [ERROR] agent.rpcclient.health: subscribe call failed: err="rpc error: code = ResourceExhausted desc = grpc: received message larger than max (8389107 vs. 4194304)" failure_count=11 key=service-burst-0 topic=ServiceHealth
```

`/v1/health/service/large-service` return the error message

```
Error: Maximum response size reached
```

### Links

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
