### PR TITLE
docs: revert peering API changes

### DIFF
--- a/website/content/api-docs/peering.mdx
+++ b/website/content/api-docs/peering.mdx
@@ -34,8 +34,8 @@ The table below shows this endpoint's support for
 
 ### JSON Request Body Schema
 
-- `Peer` `(string: <required>)` - The name assigned to the peer cluster.
-  The `Peer` is used to reference the peer cluster in service discovery queries
+- `PeerName` `(string: <required>)` - The name assigned to the peer cluster.
+  The `PeerName` is used to reference the peer cluster in service discovery queries
   and configuration entries such as `service-intentions`. This field must be a
   valid DNS hostname label.
 
@@ -54,7 +54,7 @@ You can specify one or more load balancers or external IPs that route external t
 
 ```json
 {
-  "Peer": "cluster-02",
+  "PeerName": "cluster-02",
   "Meta": {
     "env": "production"
   }
@@ -101,8 +101,8 @@ The table below shows this endpoint's support for
 
 ### JSON Request Body Schema
 
-- `Peer` `(string: <required>)` - The name assigned to the peer cluster.
-  The `Peer` is used to reference the peer cluster in service discovery queries
+- `PeerName` `(string: <required>)` - The name assigned to the peer cluster.
+  The `PeerName` is used to reference the peer cluster in service discovery queries
   and configuration entries such as `service-intentions`. This field must be a
   valid DNS hostname label.
 
@@ -121,7 +121,7 @@ The table below shows this endpoint's support for
 
 ```json
 {
-  "Peer": "cluster-01",
+  "PeerName": "cluster-01",
   "PeeringToken": "eyJDQSI6bnVsbCwiU2V...",
   "Meta": {
     "env": "production"


### PR DESCRIPTION
### Description
These were changed as part of #15417, but `PeerName` was only removed from config entries in 1.14.

Will make another GitHub issue to make this uniform in a future release of Consul.
