### PR TITLE
Add changelog for snapshot agent updates

### DIFF
--- a/.changelog/_3556.txt
+++ b/.changelog/_3556.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+snapshot: **(Enterprise Only)** Add support for the snapshot agent to use an IAM role for authentication/authorization when managing snapshots in S3.
+```


### PR DESCRIPTION
### Description
This PR adds a changelog entry for the snapshot agent updates that add support for using IAM roles to get AWS credentials to manage snapshots in S3.

### PR Checklist

* [x] ~updated test coverage~ N/A
* [x] external facing docs updated: [Docs PR](https://github.com/hashicorp/consul/pull/15504)
* [x] not a security concern
