### PR TITLE
 docs: update Nomad 1.14 upgrade note to detail additional info.

### DIFF
--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -73,10 +73,10 @@ A breaking change was made in Consul 1.14 that:
 - [Consul Connect is enabled by default.](/docs/connect)
   To disable, set [`connect.enabled`](/docs/agent/config/config-files#connect_enabled) to `false`.
 
-The changes to Consul service mesh in version 1.14 are incompatible with Nomad 1.4.2 and
-earlier. If you operate Consul service mesh using Nomad 1.4.2 or earlier, do not upgrade to Consul 1.14 until
-[hashicorp/nomad#15266](https://github.com/hashicorp/nomad/issues/15266) is
-fixed.
+The changes to Consul service mesh in version 1.14 are incompatible with Nomad 1.4.3 and
+earlier. If you operate Consul service mesh using Nomad 1.4.3 or earlier, do not upgrade to
+Consul 1.14 until [hashicorp/nomad#15266](https://github.com/hashicorp/nomad/issues/15266) and
+[hashicorp/nomad#15360](https://github.com/hashicorp/nomad/issues/15360) have been fixed.
 
 For 1.14.0, there is a known issue with `consul connect envoy`. If the command is configured
 to use TLS for contacting the HTTP API, it will also incorrectly enable TLS for gRPC.


### PR DESCRIPTION
See https://github.com/hashicorp/nomad/issues/15266 and https://github.com/hashicorp/nomad/issues/15360 for details.

We plan to submit a followup PR to update these docs once Nomad releases all fixes. At that point Nomad users will still need to be informed that they must upgrade Nomad to a compatible version before upgrading Consul to 1.14.

Feel free to edit the wording or formatting or whatever.