### PR TITLE
Use rpcHoldTimeout to calculate blocking timeout

### DIFF
--- a/.changelog/15541.txt
+++ b/.changelog/15541.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fixed issue where blocking queries with short waits could timeout on the client
+```

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -186,6 +186,7 @@ func newConnPool(config *config.RuntimeConfig, logger hclog.Logger, tls *tlsutil
 		Logger:           logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
 		TLSConfigurator:  tls,
 		Datacenter:       config.Datacenter,
+		RPCHoldTimeout:   config.RPCHoldTimeout,
 		MaxQueryTime:     config.MaxQueryTime,
 		DefaultQueryTime: config.DefaultQueryTime,
 	}


### PR DESCRIPTION
### Description
Fixes https://github.com/hashicorp/consul/issues/15246

Reverts a bug I introduced while refactoring:
https://github.com/hashicorp/consul/pull/14965/files#diff-8f12aa7f72e8647fddfac936ab541982aae517babd3064a581bbcdcc2595c2dcL347-R360

Note that Timeout included `rpcHoldTimeout` but I extracted it out of `Timeout` into `HasTimedOut`. But we still need to consider it when calculating `BlockingTimeout`.

It's hard to write a test for this due to timeouts being very timing + random jitter dependent. It should not break any existing tests and at most it adds 7s to existing timeouts.

The problem I'm trying to solve is:
```
/v1/catalog/services?wait=2s&index=16165

client uses BlockingTimeout to calculate read timeout
2s + 2s/16 = 2.125s

server adds max possible jitter
2s + 2s/16 = 2.125s
```

if timeouts are nearly identical it is likelier for the client to timeout the connection before the server has had a chance to respond (or time out the blocking query).

With this PR:
```
GET /v1/catalog/services?wait=2s&index=16165

client uses (*QueryOptions).BlockingTimeout to calculate read timeout
2s + 2s/16 + 7s = 9.125s
             ^ RPCHoldTimeout buffer

server adds max possible jitter in (*Server).rpcQueryTimeout
2s + 2s/16 = 2.125s
```

Server will always be the one to apply timeout and return from a blocking query early 

