### PR TITLE
Add Config example for Config Entry Bootstrap

### DIFF
--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -434,6 +434,52 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     See the [configuration entry docs](/docs/agent/config-entries) for more
     details about the contents of each entry.
 
+  <CodeTabs>
+
+  ```hcl
+  config_entries {
+    bootstrap {
+      kind = "proxy-defaults"
+      name = "global"
+      config {
+         envoy_dogstatsd_url = "udp://127.0.0.1:9125"
+      }
+    }
+    bootstrap {
+      kind = "service-defaults"
+      name = "dashboard"
+      protocol = "http"
+    }
+  }
+  ```
+
+  ```json
+  {
+    "config_entries": [
+      {
+        "bootstrap": [
+          {
+            "kind": "proxy-defaults",
+            "name": "global",
+            "config": [
+              {
+                "envoy_dogstatsd_url": "udp://127.0.0.1:9125"
+              }
+            ]
+          },
+          {
+            "kind": "service-defaults",
+            "name": "dashboard",
+            "protocol": "http"
+          }
+        ]
+      }
+    ]
+  }
+  ```
+
+  </CodeTabs>
+
 - `datacenter` Equivalent to the [`-datacenter` command-line flag](/docs/agent/config/cli-flags#_datacenter).
 
 - `data_dir` Equivalent to the [`-data-dir` command-line flag](/docs/agent/config/cli-flags#_data_dir).


### PR DESCRIPTION
### Description
Add an example configuration on bootstrapping Config Entry using the agent configuration.

This was found from an old GH issue created by @mkeeler.

I have tested this using the following steps:

1. Create the config entry
```
cat <<EOF > agent.hcl
config_entries {
  bootstrap {
    kind = "proxy-defaults"
    name = "global"
    config {
       envoy_dogstatsd_url = "udp://127.0.0.1:9125"
    }
  }
  bootstrap {
    kind = "service-defaults"
    name = "dashboard"
    protocol = "http"
  }
}
EOF
```

2. Launch a dev agent

```
$ consul agent -dev -config-file agent.hcl
```

3. Verify both `service-defaults` and `proxy-defaults`.

```
consul config read -kind proxy-defaults -name global
{
    "Kind": "proxy-defaults",
    "Name": "global",
    "Partition": "default",
    "Namespace": "default",
    "TransparentProxy": {},
    "Config": {
        "envoy_dogstatsd_url": "udp://127.0.0.1:9125"
    },
    "MeshGateway": {},
    "Expose": {},
    "CreateIndex": 15,
    "ModifyIndex": 15
}
```

```
consul config read -kind service-defaults -name dashboard
{
    "Kind": "service-defaults",
    "Name": "dashboard",
    "Partition": "default",
    "Namespace": "default",
    "Protocol": "http",
    "TransparentProxy": {},
    "MeshGateway": {},
    "Expose": {},
    "CreateIndex": 17,
    "ModifyIndex": 17
}
```

### PR Checklist

* [x] external facing docs updated
* [x] not a security concern
