### PR TITLE
Fix acl dc validation

### DIFF
--- a/.changelog/15559.txt
+++ b/.changelog/15559.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: reject invalid datacenter input for roles/policies/tokens
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1156,24 +1156,6 @@ func advertiseAddrFunc(opts LoadOpts, advertiseAddr *net.IPAddr) (string, func()
 	}
 }
 
-// reBasicName validates that a field contains only lower case alphanumerics,
-// underscore and dash and is non-empty.
-var reBasicName = regexp.MustCompile("^[a-z0-9_-]+$")
-
-func validateBasicName(field, value string, allowEmpty bool) error {
-	if value == "" {
-		if allowEmpty {
-			return nil
-		}
-		return fmt.Errorf("%s cannot be empty", field)
-	}
-	if !reBasicName.MatchString(value) {
-		return fmt.Errorf("%s can only contain lowercase alphanumeric, - or _ characters."+
-			" received: %q", field, value)
-	}
-	return nil
-}
-
 // validate performs semantic validation of the runtime configuration.
 func (b *builder) validate(rt RuntimeConfig) error {
 	// validContentPath defines a regexp for a valid content path name.
@@ -1187,7 +1169,7 @@ func (b *builder) validate(rt RuntimeConfig) error {
 		return fmt.Errorf("raft_protocol version %d is not supported by this version of Consul", rt.RaftProtocol)
 	}
 
-	if err := validateBasicName("datacenter", rt.Datacenter, false); err != nil {
+	if err := lib.ValidateBasicName("datacenter", rt.Datacenter, false); err != nil {
 		return err
 	}
 	if rt.DataDir == "" && !rt.DevMode {
@@ -1202,7 +1184,7 @@ func (b *builder) validate(rt RuntimeConfig) error {
 		return fmt.Errorf("ui-content-path cannot have 'v[0-9]'. received: %q", rt.UIConfig.ContentPath)
 	}
 
-	if err := validateBasicName("ui_config.metrics_provider", rt.UIConfig.MetricsProvider, true); err != nil {
+	if err := lib.ValidateBasicName("ui_config.metrics_provider", rt.UIConfig.MetricsProvider, true); err != nil {
 		return err
 	}
 	if rt.UIConfig.MetricsProviderOptionsJSON != "" {
@@ -1230,7 +1212,7 @@ func (b *builder) validate(rt RuntimeConfig) error {
 		}
 	}
 	for k, v := range rt.UIConfig.DashboardURLTemplates {
-		if err := validateBasicName("ui_config.dashboard_url_templates key names", k, false); err != nil {
+		if err := lib.ValidateBasicName("ui_config.dashboard_url_templates key names", k, false); err != nil {
 			return err
 		}
 		u, err := url.Parse(v)
@@ -1314,7 +1296,7 @@ func (b *builder) validate(rt RuntimeConfig) error {
 	if rt.AutopilotMaxTrailingLogs < 0 {
 		return fmt.Errorf("autopilot.max_trailing_logs cannot be %d. Must be greater than or equal to zero", rt.AutopilotMaxTrailingLogs)
 	}
-	if err := validateBasicName("primary_datacenter", rt.PrimaryDatacenter, true); err != nil {
+	if err := lib.ValidateBasicName("primary_datacenter", rt.PrimaryDatacenter, true); err != nil {
 		return err
 	}
 	// In DevMode, UI is enabled by default, so to enable rt.UIDir, don't perform this check

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -848,6 +848,12 @@ func (a *ACL) PolicySet(args *structs.ACLPolicySetRequest, reply *structs.ACLPol
 		return fmt.Errorf("Invalid Policy: invalid Name. Only alphanumeric characters, '-' and '_' are allowed")
 	}
 
+	for _, dc := range policy.Datacenters {
+		if err := lib.ValidateBasicName("valid-datacenter", dc, true); err != nil {
+			return err
+		}
+	}
+
 	var idMatch *structs.ACLPolicy
 	var nameMatch *structs.ACLPolicy
 	var err error
@@ -1310,6 +1316,11 @@ func (a *ACL) RoleSet(args *structs.ACLRoleSetRequest, reply *structs.ACLRole) e
 		if !acl.IsValidServiceIdentityName(svcid.ServiceName) {
 			return fmt.Errorf("Service identity %q has an invalid name. Only lowercase alphanumeric characters, '-' and '_' are allowed", svcid.ServiceName)
 		}
+		for _, dc := range svcid.Datacenters {
+			if err := lib.ValidateBasicName("Service identity's datacenter", dc, true); err != nil {
+				return err
+			}
+		}
 	}
 	role.ServiceIdentities = role.ServiceIdentities.Deduplicate()
 
@@ -1317,8 +1328,8 @@ func (a *ACL) RoleSet(args *structs.ACLRoleSetRequest, reply *structs.ACLRole) e
 		if nodeid.NodeName == "" {
 			return fmt.Errorf("Node identity is missing the node name field on this role")
 		}
-		if nodeid.Datacenter == "" {
-			return fmt.Errorf("Node identity is missing the datacenter field on this role")
+		if err := lib.ValidateBasicName("Node identity's datacenter", nodeid.Datacenter, false); err != nil {
+			return err
 		}
 		if !acl.IsValidNodeIdentityName(nodeid.NodeName) {
 			return fmt.Errorf("Node identity has an invalid name. Only lowercase alphanumeric characters, '-' and '_' are allowed")

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -1247,7 +1247,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 		}
 		resp := structs.ACLToken{}
 		err := a.TokenSet(&req, &resp)
-		testutil.RequireErrorContains(t, err, "datacenter is not in a valid format")
+		testutil.RequireErrorContains(t, err, "datacenter can only contain lowercase alphanumeric")
 	})
 }
 

--- a/agent/consul/auth/token_writer.go
+++ b/agent/consul/auth/token_writer.go
@@ -429,6 +429,11 @@ func (w *TokenWriter) normalizeServiceIdentities(svcIDs structs.ACLServiceIdenti
 		if !acl.IsValidServiceIdentityName(id.ServiceName) {
 			return nil, fmt.Errorf("Service identity %q has an invalid name. Only lowercase alphanumeric characters, '-' and '_' are allowed", id.ServiceName)
 		}
+		for _, dc := range id.Datacenters {
+			if err := lib.ValidateBasicName("Service identity's datacenter", dc, true); err != nil {
+				return nil, err
+			}
+		}
 	}
 	return svcIDs.Deduplicate(), nil
 }
@@ -438,8 +443,9 @@ func (w *TokenWriter) normalizeNodeIdentities(nodeIDs structs.ACLNodeIdentities)
 		if id.NodeName == "" {
 			return nil, errors.New("Node identity is missing the node name field on this token")
 		}
-		if id.Datacenter == "" {
-			return nil, errors.New("Node identity is missing the datacenter field on this token")
+
+		if err := lib.ValidateBasicName("Node identity's datacenter", id.Datacenter, false); err != nil {
+			return nil, err
 		}
 		if !acl.IsValidNodeIdentityName(id.NodeName) {
 			return nil, fmt.Errorf("Node identity has an invalid name. Only lowercase alphanumeric characters, '-' and '_' are allowed")

--- a/agent/consul/auth/token_writer_test.go
+++ b/agent/consul/auth/token_writer_test.go
@@ -282,6 +282,11 @@ func TestTokenWriter_ServiceIdentities(t *testing.T) {
 			tokenLocal:    true,
 			errorContains: "cannot specify a list of datacenters on a local token",
 		},
+		"invalid dc in service identity": {
+			input:         []*structs.ACLServiceIdentity{{ServiceName: "web", Datacenters: []string{"dc1", "dc2#dc3"}}},
+			tokenLocal:    false,
+			errorContains: "datacenter can only contain lowercase alphanumeric",
+		},
 		"invalid service name": {
 			input:         []*structs.ACLServiceIdentity{{ServiceName: "INVALID!"}},
 			errorContains: "has an invalid name",
@@ -330,7 +335,11 @@ func TestTokenWriter_NodeIdentities(t *testing.T) {
 		},
 		"empty datacenter": {
 			input:         []*structs.ACLNodeIdentity{{NodeName: "web"}},
-			errorContains: "missing the datacenter field",
+			errorContains: "datacenter cannot be empty",
+		},
+		"invalid datacenter": {
+			input:         []*structs.ACLNodeIdentity{{NodeName: "web", Datacenter: "invalid-dc>"}},
+			errorContains: "datacenter can only contain lowercase alphanumeric",
 		},
 		"invalid node name": {
 			input:         []*structs.ACLNodeIdentity{{NodeName: "INVALID!", Datacenter: "dc1"}},

--- a/lib/validate.go
+++ b/lib/validate.go
@@ -1,0 +1,24 @@
+package lib
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	validBasicName = regexp.MustCompile("^[a-z0-9_-]+$")
+)
+
+func ValidateBasicName(field string, value string, allowEmpty bool) error {
+	if value == "" {
+		if allowEmpty {
+			return nil
+		} else {
+			return fmt.Errorf("%s cannot be empty", field)
+		}
+	} else if !validBasicName.MatchString(value) {
+		return fmt.Errorf("%s can only contain lowercase alphanumeric, - or _ characters."+
+			" received: %q", field, value)
+	}
+	return nil
+}

--- a/lib/validate_test.go
+++ b/lib/validate_test.go
@@ -1,0 +1,62 @@
+package lib
+
+import (
+	"testing"
+)
+
+func Test_ValidateBasicName(t *testing.T) {
+	type testArgs struct {
+		field      string
+		value      string
+		allowEmpty bool
+	}
+	tests := []struct {
+		name    string
+		args    testArgs
+		wantErr bool
+	}{
+		{
+			name: "ValidBasicName",
+			args: testArgs{
+				field:      "datacenter",
+				value:      "custom-datacenter",
+				allowEmpty: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid-dc-empty",
+			args: testArgs{
+				field:      "datacenter",
+				value:      "",
+				allowEmpty: false,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid-primary_datacenter-empty",
+			args: testArgs{
+				field:      "primary_datacenter",
+				value:      "",
+				allowEmpty: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid-primary_datacenter",
+			args: testArgs{
+				field:      "primary_datacenter",
+				value:      "dc#1",
+				allowEmpty: true,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateBasicName(tt.args.field, tt.args.value, tt.args.allowEmpty); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateBasicName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Description
During various ACL objects creation & updation (policy/role/token) the input value for datacenter is not validated.
The dc name should be in a valid format & in tune with the format allowed for the -datacenter value when starting up a consul agent

Testing & Reproduction steps
Reproduction steps are provided in the issue# 15229

Testing with the fix - Although new test cases have been added, I have included the manual test results with the fix under ref: [1] below.

Links
* This PR is to handle the issue reported under - https://github.com/hashicorp/consul/issues/15229
* This also takes into consideration the feedback provided by @jkirschner-hashicorp & @rboyer in my previous (self-invalidated) PR: https://github.com/hashicorp/consul/pull/15230

PR Checklist
[Y] updated test coverage
[N] external facing docs updated
[Y] not a security concern

[1]:

```
Policy validation:
	Create:
		(venv) vyanamandra bin $ ./consul acl policy create -name v1 -valid-datacenter="dc1[dc2]"
		Failed to create new policy: Unexpected response code: 500 (valid-datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1[dc2]")
		(venv) vyanamandra bin $ 

		(venv) vyanamandra bin $ ./consul acl policy create -name v3 -valid-datacenter=''
		ID:           933ee168-563c-4238-9a90-94291e7cfc53
		Name:         v3
		Description:  
		Datacenters:  
		Rules:


		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "n1-curl", "Rules": "node_prefix \"\" { policy = \"read\"}", "Datacenters": ["dc1#dc2"] } ' http://localhost:8500/v1/acl/policy
		valid-datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2"%                                                           
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "n1-curl", "Rules": "node_prefix \"\" { policy = \"read\"}", "Datacenters": [""] } ' http://localhost:8500/v1/acl/policy
		{
		    "ID": "0cbb30fd-ad38-2027-b840-457c20cfcb1b",
		    "Name": "n1-curl",
		    "Description": "",
		    "Rules": "node_prefix \"\" { policy = \"read\"}",
		    "Datacenters": [
		        ""
		    ],
		    "Hash": "MFo3jRvx2soM08AsiwgtLAKcHIYavzJVyp7eUB3a0Ew=",
		    "CreateIndex": 284,
		    "ModifyIndex": 284
		}
		(venv) vyanamandra bin $



	Update:
		(venv) vyanamandra bin $ ./consul acl policy update -name v3 -valid-datacenter="dc1dc2[dc3]"
		Error updating policy "6dfd4a2c-52f0-5f95-0e2a-1c20ba43561c": Unexpected response code: 500 (valid-datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1dc2[dc3]")
		(venv) vyanamandra bin $ 


		(venv) vyanamandra bin $ ./consul acl policy update -name v3 -valid-datacenter=' '
		Error updating policy "933ee168-563c-4238-9a90-94291e7cfc53": Unexpected response code: 500 (valid-datacenter can only contain lowercase alphanumeric, - or _ characters. received: " ")
		(venv) vyanamandra bin $ ./consul acl policy update -name v3 -valid-datacenter='' 
		ID:           933ee168-563c-4238-9a90-94291e7cfc53
		Name:         v3
		Description:  
		Datacenters:  
		Rules:

		(venv) vyanamandra bin $ 


		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "node-read", "Rules": "node_prefix \"\" { policy = \"read\"}", "Datacenters": ["dc1"] } ' http://localhost:8500/v1/acl/policy               
		{
		    "ID": "c8454f7d-510b-3ad1-0e39-aeebe5fca6f9",
		    "Name": "node-read",
		    "Description": "",
		    "Rules": "node_prefix \"\" { policy = \"read\"}",
		    "Datacenters": [
		        "dc1"
		    ],
		    "Hash": "UaWvnu3K8cvkTBL88yP1KGL3eksF+8U2Z36vIAxGbI8=",
		    "CreateIndex": 272,
		    "ModifyIndex": 272
		}
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "node-read", "Rules": "node_prefix \"\" { policy = \"read\"}", "Datacenters": ["dc1#dc2"] } ' http://localhost:8500/v1/acl/policy/c8454f7d-510b-3ad1-0e39-aeebe5fca6f9
		valid-datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2"%                                                           
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "node-read", "Rules": "node_prefix \"\" { policy = \"read\"}", "Datacenters": [""] } ' http://localhost:8500/v1/acl/policy/e4207739-7932-0814-cd00-a675f776012e   
		{
		    "ID": "c8454f7d-510b-3ad1-0e39-aeebe5fca6f9",
		    "Name": "node-read",
		    "Description": "",
		    "Rules": "node_prefix \"\" { policy = \"read\"}",
		    "Datacenters": [
		        ""
		    ],
		    "Hash": "9o26GEzG5CzNx0nyK4Xq+iLyJnPU6SN+6qyllWulPak=",
		    "CreateIndex": 272,
		    "ModifyIndex": 278
		}
		(venv) vyanamandra bin $ 



Role validation:
	Create:
		(venv) vyanamandra bin $ ./consul acl role create -name r5 -service-identity="s1:dc1#dc2"
		Failed to create new role: Unexpected response code: 500 (Service identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2")
		(venv) vyanamandra bin $ ./consul acl role create -name r5 -node-identity="s1:dc1#dc2"   
		Failed to create new role: Unexpected response code: 500 (Node identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2")
		(venv) vyanamandra bin $ ./consul acl role create -name r5 -node-identity="s1"        
		Malformed -node-identity argument: "s1"
		(venv) vyanamandra bin $ ./consul acl role create -name r5 -node-identity="s1:"
		Failed to create new role: Unexpected response code: 500 (Node identity's datacenter cannot be empty)
		(venv) vyanamandra bin $ ./consul acl role create -name r5 -service-identity="s1" 
		ID:           656d637e-65a1-335f-a52c-01613dfb0fd4
		Name:         r5
		Description:  
		Service Identities:
		   s1 (Datacenters: all)

		(venv) vyanamandra bin $ ./consul acl role create -name r6 -service-identity="s1:"
		ID:           24bcfa70-568b-a239-f6bd-367e38a1a16d
		Name:         r6
		Description:  
		Service Identities:
		   s1 (Datacenters: )

		(venv) vyanamandra bin $ 



		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "e0", "ServiceIdentities": [ { "ServiceName": "db", "Datacenters": [""] } ]}' http://localhost:8500/v1/acl/role
		{
		    "ID": "4fcf95a8-79b7-89bb-0b83-a542d2324718",
		    "Name": "e0",
		    "Description": "",
		    "ServiceIdentities": [
		        {
		            "ServiceName": "db",
		            "Datacenters": [
		                ""
		            ]
		        }
		    ],
		    "Hash": "wfb/M7Iv2wzvc7nep/t8klm/eGc/9N1aSynA+17W6iU=",
		    "CreateIndex": 303,
		    "ModifyIndex": 303
		}
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "e1", "ServiceIdentities": [ { "ServiceName": "db", "Datacenters": ["dc1#dc2"] } ]}' http://localhost:8500/v1/acl/role
		Service identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2"%                                                                                
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "e2", "NodeIdentities": [ { "NodeName": "node-1", "Datacenter": "dc2#dc3" } ] }' http://localhost:8500/v1/acl/role
		Node identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc2#dc3"%                                                                                   
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "e3", "NodeIdentities": [ { "NodeName": "node-1", "Datacenter": "" } ] }' http://localhost:8500/v1/acl/role
		Node identity's datacenter cannot be empty%                                                                                                                                                   
		(venv) vyanamandra bin $




	Update:
		(venv) vyanamandra bin $ ./consul acl role update -id=501e7558-e00f-11d2-68e9-23ad519df052 -service-identity="s1:dc1#dc2"
		Error updating role "656d637e-65a1-335f-a52c-01613dfb0fd4": Unexpected response code: 500 (Service identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2")
		(venv) vyanamandra bin $ ./consul acl role update -id=501e7558-e00f-11d2-68e9-23ad519df052 -node-identity="s1:dc1#dc2"   
		Error updating role "656d637e-65a1-335f-a52c-01613dfb0fd4": Unexpected response code: 500 (Node identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2")
		(venv) vyanamandra bin $ ./consul acl role update -id=501e7558-e00f-11d2-68e9-23ad519df052 -node-identity="s1:"       
		Error updating role "656d637e-65a1-335f-a52c-01613dfb0fd4": Unexpected response code: 500 (Node identity's datacenter cannot be empty)
		(venv) vyanamandra bin $ ./consul acl role update -id=501e7558-e00f-11d2-68e9-23ad519df052 -node-identity="s1:dc1dc2dc3"
		ID:           656d637e-65a1-335f-a52c-01613dfb0fd4
		Name:         r5
		Description:  
		Service Identities:
		   s1 (Datacenters: all)
		Node Identities:
		   s1 (Datacenter: dc1dc2dc3)

		(venv) vyanamandra bin $ 


		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "e6", "ServiceIdentities": [ { "ServiceName": "db", "Datacenters": [""] } ]}' http://localhost:8500/v1/acl/role/501e7558-e00f-11d2-68e9-23ad519df052
		{
		    "ID": "4fcf95a8-79b7-89bb-0b83-a542d2324718",
		    "Name": "e6",
		    "Description": "",
		    "ServiceIdentities": [
		        {
		            "ServiceName": "db",
		            "Datacenters": [
		                ""
		            ]
		        }
		    ],
		    "Hash": "WBj9UuhZTY0QSGuhTkLM/vr45hpoEiAKoLl8UZcrr0k=",
		    "CreateIndex": 303,
		    "ModifyIndex": 314
		}
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "e7", "ServiceIdentities": [ { "ServiceName": "db", "Datacenters": ["dc1#dc2"] } ]}' http://localhost:8500/v1/acl/role/501e7558-e00f-11d2-68e9-23ad519df052
		Service identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2"%                                                                                
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "e8", "NodeIdentities": [ { "NodeName": "node-1", "Datacenter": "dc2#dc3" } ] }' http://localhost:8500/v1/acl/role/501e7558-e00f-11d2-68e9-23ad519df052
		Node identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc2#dc3"%                                                                                   
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{ "Name": "e9", "NodeIdentities": [ { "NodeName": "node-1", "Datacenter": "" } ] }' http://localhost:8500/v1/acl/role/501e7558-e00f-11d2-68e9-23ad519df052
		Node identity's datacenter cannot be empty%                                                                                                                                                   
		(venv) vyanamandra bin $ 



Token validation:
	Create:
		(venv) vyanamandra bin $ ./consul acl token create -node-identity="n1"
		Malformed -node-identity argument: "n1"
		(venv) vyanamandra bin $ ./consul acl token create -node-identity="n1:"
		Failed to create new token: Unexpected response code: 500 (Node identity's datacenter cannot be empty)
		(venv) vyanamandra bin $ ./consul acl token create -node-identity="n1:dc1#dc2"
		Failed to create new token: Unexpected response code: 500 (Node identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2")
		(venv) vyanamandra bin $ ./consul acl token create -node-identity="n1:dc1dc2" 
		AccessorID:       364a551d-a2b5-cfad-9ea2-3faf25abd848
		SecretID:         4afe733c-7a71-07e7-0e44-d19e288c4275
		Description:      
		Local:            false
		Create Time:      2022-11-25 11:25:03.606844 -0800 PST
		Node Identities:
		   n1 (Datacenter: dc1dc2)





		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{"Local": false, "NodeIdentities": [{"NodeName": "n1", "Datacenter": ""}]}' http://localhost:8500/v1/acl/token
		Node identity's datacenter cannot be empty%                                                                                                                                                   
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{"Local": false, "NodeIdentities": [{"NodeName": "n1", "Datacenter": "dc1#dc2"}]}' http://localhost:8500/v1/acl/token
		Node identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2"%                                                                                           
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{"Local": false, "ServiceIdentities": [{"ServiceName": "n1", "Datacenters": ["dc3#dc4"]}]}' http://localhost:8500/v1/acl/token
		Service identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc3#dc4"%                                                                                
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{"Local": false, "ServiceIdentities": [{"ServiceName": "n1", "Datacenters": [""]}]}' http://localhost:8500/v1/acl/token
		{
		    "AccessorID": "7c8b32af-5382-41a6-e0c8-2d3dfa55e2da",
		    "SecretID": "42fc4f1d-5325-1467-ca60-dda60e2d38f4",
		    "Description": "",
		    "ServiceIdentities": [
		        {
		            "ServiceName": "n1",
		            "Datacenters": [
		                ""
		            ]
		        }
		    ],
		    "Local": false,
		    "CreateTime": "2022-11-25T11:50:55.340063-08:00",
		    "Hash": "EXXmIDF4AfTRIoQHVcUzfGGC/kPWh0URsPO+YyOghdU=",
		    "CreateIndex": 342,
		    "ModifyIndex": 342
		}
		(venv) vyanamandra bin $ 



	Update:
		(venv) vyanamandra bin $ ./consul acl token update -id 3fe08047-9121-86b1-2801-73898fb99083 -node-identity="n1:"         
		Failed to update token 364a551d-a2b5-cfad-9ea2-3faf25abd848: Unexpected response code: 500 (Node identity's datacenter cannot be empty)
		(venv) vyanamandra bin $ ./consul acl token update -id 3fe08047-9121-86b1-2801-73898fb99083 -node-identity="n1:dc1dc2#dc3"
		Failed to update token 364a551d-a2b5-cfad-9ea2-3faf25abd848: Unexpected response code: 500 (Node identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1dc2#dc3")
		(venv) vyanamandra bin $ ./consul acl token update -id 3fe08047-9121-86b1-2801-73898fb99083 -node-identity="n1:dc1dc2dc3" 
		AccessorID:       364a551d-a2b5-cfad-9ea2-3faf25abd848
		SecretID:         4afe733c-7a71-07e7-0e44-d19e288c4275
		Description:      
		Local:            false
		Create Time:      2022-11-25 11:25:03.606844 -0800 PST
		Node Identities:
		   n1 (Datacenter: dc1dc2dc3)

		(venv) vyanamandra bin $ 
		




		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{"Local": false, "NodeIdentities": [{"NodeName": "n2", "Datacenter": ""}]}' http://localhost:8500/v1/acl/token/3fe08047-9121-86b1-2801-73898fb99083
		Node identity's datacenter cannot be empty%                                                                                                                                                   
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{"Local": false, "NodeIdentities": [{"NodeName": "n3", "Datacenter": "dc1#dc2"}]}' http://localhost:8500/v1/acl/token/3fe08047-9121-86b1-2801-73898fb99083
		Node identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc1#dc2"%                                                                                   
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{"Local": false, "ServiceIdentities": [{"ServiceName": "s1", "Datacenters": ["dc3#dc4"]}]}' http://localhost:8500/v1/acl/token/3fe08047-9121-86b1-2801-73898fb99083
		Service identity's datacenter can only contain lowercase alphanumeric, - or _ characters. received: "dc3#dc4"%                                                                                
		(venv) vyanamandra bin $ curl -X PUT -H 'X-Consul-Token: root' -d '{"Local": false, "ServiceIdentities": [{"ServiceName": "s2", "Datacenters": ["dc33"]}]}' http://localhost:8500/v1/acl/token/3fe08047-9121-86b1-2801-73898fb99083
		{
		    "AccessorID": "7c8b32af-5382-41a6-e0c8-2d3dfa55e2da",
		    "SecretID": "42fc4f1d-5325-1467-ca60-dda60e2d38f4",
		    "Description": "",
		    "ServiceIdentities": [
		        {
		            "ServiceName": "s2",
		            "Datacenters": [
		                "dc33"
		            ]
		        }
		    ],
		    "Local": false,
		    "CreateTime": "2022-11-25T11:50:55.340063-08:00",
		    "Hash": "fSe6ICtZOoLiwxwd2DIZkTmLFXxQPG6vz5Cmni0hkks=",
		    "CreateIndex": 342,
		    "ModifyIndex": 351
		}
		(venv) vyanamandra bin $ 

```