### PR TITLE
Support acl token read -self and -expanded

### DIFF
--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -326,6 +326,9 @@ func (s *HTTPHandlers) ACLTokenSelf(resp http.ResponseWriter, req *http.Request)
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}
+	if _, ok := req.URL.Query()["expanded"]; ok {
+		args.Expanded = true
+	}
 
 	// copy the token parameter to the ID
 	args.TokenID = args.Token
@@ -342,6 +345,13 @@ func (s *HTTPHandlers) ACLTokenSelf(resp http.ResponseWriter, req *http.Request)
 
 	if out.Token == nil {
 		return nil, acl.ErrNotFound
+	}
+	if args.Expanded {
+		expanded := &structs.ACLTokenExpanded{
+			ACLToken:          out.Token,
+			ExpandedTokenInfo: out.ExpandedTokenInfo,
+		}
+		return expanded, nil
 	}
 
 	return out.Token, nil

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -747,6 +747,17 @@ func TestACL_HTTP(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, expected, token)
 		})
+		t.Run("Self-expanded", func(t *testing.T) {
+			expected := tokenMap[idMap["token-test"]]
+			req, _ := http.NewRequest("GET", "/v1/acl/token/self?expanded=true&token="+expected.SecretID, nil)
+			resp := httptest.NewRecorder()
+			obj, err := a.srv.ACLTokenSelf(resp, req)
+			require.NoError(t, err)
+			tokenResp, ok := obj.(*structs.ACLTokenExpanded)
+			require.True(t, ok)
+			require.Equal(t, expected, tokenResp.ACLToken)
+			require.Len(t, tokenResp.ExpandedPolicies, 3)
+		})
 		t.Run("Clone", func(t *testing.T) {
 			tokenInput := &structs.ACLToken{
 				Description: "cloned token",

--- a/api/acl.go
+++ b/api/acl.go
@@ -853,6 +853,34 @@ func (a *ACL) TokenReadSelf(q *QueryOptions) (*ACLToken, *QueryMeta, error) {
 	return &out, qm, nil
 }
 
+// TokenReadSelfExpanded retrieves the full token details and 
+// the contents of any policies of the token currently assigned 
+// to the API Client. In this manner its possible to read a token
+// by its Secret ID.
+func (a *ACL) TokenReadSelfExpanded(q *QueryOptions) (*ACLTokenExpanded, *QueryMeta, error) {
+	r := a.c.newRequest("GET", "/v1/acl/token/self")
+	r.setQueryOptions(q)
+	r.params.Set("expanded", "true")
+	rtt, resp, err := a.c.doRequest(r)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer closeResponseBody(resp)
+	if err := requireOK(resp); err != nil {
+		return nil, nil, err
+	}
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out ACLTokenExpanded
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+
+	return &out, qm, nil
+}
+
 // TokenList lists all tokens. The listing does not contain any SecretIDs as those
 // may only be retrieved by a call to TokenRead.
 func (a *ACL) TokenList(q *QueryOptions) ([]*ACLTokenListEntry, *QueryMeta, error) {

--- a/api/acl.go
+++ b/api/acl.go
@@ -853,8 +853,8 @@ func (a *ACL) TokenReadSelf(q *QueryOptions) (*ACLToken, *QueryMeta, error) {
 	return &out, qm, nil
 }
 
-// TokenReadSelfExpanded retrieves the full token details and 
-// the contents of any policies of the token currently assigned 
+// TokenReadSelfExpanded retrieves the full token details and
+// the contents of any policies of the token currently assigned
 // to the API Client. In this manner its possible to read a token
 // by its Secret ID.
 func (a *ACL) TokenReadSelfExpanded(q *QueryOptions) (*ACLTokenExpanded, *QueryMeta, error) {

--- a/command/acl/token/read/token_read.go
+++ b/command/acl/token/read/token_read.go
@@ -62,7 +62,7 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	if c.tokenID == "" && !c.self {
-		c.UI.Error(fmt.Sprintf("Must specify the -id parameter"))
+		c.UI.Error("Must specify the -id parameter")
 		return 1
 	}
 
@@ -92,14 +92,12 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 	} else {
-		// TODO: consider updating this CLI command and underlying HTTP API endpoint
-		// to support expanded read of a "self" token, which is a much better user workflow.
-		if c.expanded {
-			c.UI.Error("Cannot use both -expanded and -self. Instead, use -expanded and -id=<accessor id>.")
-			return 1
+		if !c.expanded {
+			t, _, err = client.ACL().TokenReadSelf(nil)
+		} else {
+			expanded, _, err = client.ACL().TokenReadSelfExpanded(nil)
 		}
 
-		t, _, err = client.ACL().TokenReadSelf(nil)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error reading token: %v", err))
 			return 1

--- a/website/content/api-docs/acl/tokens.mdx
+++ b/website/content/api-docs/acl/tokens.mdx
@@ -6,8 +6,6 @@ description: The /acl/token endpoints manage Consul's ACL Tokens.
 
 # ACL Token HTTP API
 
--> **1.4.0+:** The APIs are available in Consul versions 1.4.0 and later. The documentation for the legacy ACL API is [here](/api-docs/acl/legacy).
-
 The `/acl/token` endpoints [create](#create-a-token), [read](#read-a-token),
 [update](#update-a-token), [list](#list-tokens), [clone](#clone-a-token) and [delete](#delete-a-token) ACL tokens in Consul.
 
@@ -182,11 +180,11 @@ The corresponding CLI command is [`consul acl token read`](/commands/acl/token/r
 
 ### Path Parameters
 
-- `AccessorID` `(string: <required>)` - Specifies the accessor ID of the token you lookup.
+- `AccessorID` `(string: <required>)` - Specifies the accessor ID of the token to read.
 
 ### Query Parameters
 
-- `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace of the token you lookup.
+- `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace of the token to read.
   You can also [specify the namespace through other methods](#methods-to-specify-namespace).
 
 - `expanded` `(bool: false)` - If this field is set, the contents of all policies and
@@ -200,11 +198,8 @@ $ curl --request GET http://127.0.0.1:8500/v1/acl/token/6a1253d2-1785-24fd-91c2-
 
 ### Sample Response
 
--> **Note** If the token used for accessing the API has `acl:write` permissions,
-then the `SecretID` will contain the tokens real value. Only when accessed with
-a token with only `acl:read` permissions will the `SecretID` be redacted. This
-is to prevent privilege escalation whereby having `acl:read` privileges allows
-for reading other secrets which given even more permissions.
+-> **Note** The `SecretID` will be redacted unless the token used for accessing
+the API has `acl:write` permissions.
 
 ```json
 {
@@ -332,17 +327,22 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
-| `YES`            | `all`             | `none`        | `none`       |
+| `YES`            | `all`             | `none`        | `none` or `acl:read` for expanded self read       |
 
--> **Note** - This endpoint requires no specific privileges as it is just
-retrieving the data for a token that you must already possess its secret.
+-> **Note** - This endpoint requires no specific privileges since you
+are passing the SecretID.
 
 The corresponding CLI command is [`consul acl token read -self`](/commands/acl/token/read#self).
+
+### Query Parameters
+
+- `expanded` `(bool: false)` - If this field is set, the contents of all policies and
+  roles affecting the token will also be returned. Requires `acl:read` privileges on the token.
 
 ### Sample Request
 
 ```shell-session
-$ curl --header "X-Consul-Token: 6a1253d2-1785-24fd-91c2-f8e78c745511" \
+$ curl --header "X-Consul-Token: 89afcb2e-fa20-42fe-7490-fc867155eef4" \
    http://127.0.0.1:8500/v1/acl/token/self
 ```
 
@@ -351,7 +351,7 @@ $ curl --header "X-Consul-Token: 6a1253d2-1785-24fd-91c2-f8e78c745511" \
 ```json
 {
   "AccessorID": "6a1253d2-1785-24fd-91c2-f8e78c745511",
-  "SecretID": "45a3bd52-07c7-47a4-52fd-0745e0cfe967",
+  "SecretID": "89afcb2e-fa20-42fe-7490-fc867155eef4",
   "Description": "Agent token for 'node1'",
   "Policies": [
     {
@@ -370,6 +370,85 @@ $ curl --header "X-Consul-Token: 6a1253d2-1785-24fd-91c2-f8e78c745511" \
   "ModifyIndex": 59
 }
 ```
+
+Sample response when setting the `expanded` parameter:
+
+```json
+{
+    "AccessorID": "f6a1253d2-1785-24fd-91c2-f8e78c745511",
+    "SecretID": "89afcb2e-fa20-42fe-7490-fc867155eef4",
+    "Description": "test token",
+    "Policies": [
+        {
+            "ID": "beb04680-815b-4d7c-9e33-3d707c24672c",
+            "Name": "foo"
+        },
+        {
+            "ID": "18788457-584c-4812-80d3-23d403148a90",
+            "Name": "bar"
+        }
+    ],
+    "Local": false,
+    "CreateTime": "2020-05-22T18:52:31Z",
+    "Hash": "YWJjZGVmZ2g=",
+    "ExpandedPolicies": [
+        {
+            "ID": "beb04680-815b-4d7c-9e33-3d707c24672c",
+            "Name": "foo",
+            "Description": "user policy on token",
+            "Rules": "service_prefix \"\" {\n  policy = \"read\"\n}",
+            "Datacenters": null,
+            "Hash": null,
+            "CreateIndex": 0,
+            "ModifyIndex": 0
+        },
+        {
+            "ID": "18788457-584c-4812-80d3-23d403148a90",
+            "Name": "bar",
+            "Description": "other user policy on token",
+            "Rules": "operator = \"read\"",
+            "Datacenters": null,
+            "Hash": null,
+            "CreateIndex": 0,
+            "ModifyIndex": 0
+        },
+        {
+            "ID": "6204f4cd-4709-441c-ac1b-cb029e940263",
+            "Name": "acl policy",
+            "Description": "policy for acl reader role",
+            "Rules": "acl = \"read\"",
+            "Datacenters": null,
+            "Hash": null,
+            "CreateIndex": 0,
+            "ModifyIndex": 0
+        }
+    ],
+    "ExpandedRoles": [
+      {
+          "ID": "3b0a78fe-b9c3-40de-b8ea-7d4d6674b366",
+          "Name": "acl reader",
+          "Description": "allows reading acl objects",
+          "Policies": [
+              {
+                  "ID": "6204f4cd-4709-441c-ac1b-cb029e940263",
+                  "Name": "acl policy"
+              }
+          ],
+          "Hash": null,
+          "CreateIndex": 0,
+          "ModifyIndex": 0
+      }
+    ],
+    "NamespaceDefaultPolicies": null,
+    "NamespaceDefaultRoles": null,
+    "AgentACLDefaultPolicy": "allow",
+    "AgentACLDownPolicy": "deny",
+    "ResolvedByAgent": "server-1",
+    "CreateIndex": 42,
+    "ModifyIndex": 100
+}
+```
+
 
 ## Update a Token
 


### PR DESCRIPTION
### Description
Adds support for the `-self -expanded` combination for `consul acl token read`. During original implementation the codepath for `-self` was missed.

### Testing & Reproduction steps
* Added endpoint test case

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [ ] not a security concern
