### PR TITLE
Remove log line about server mgmt token init

### DIFF
--- a/.changelog/15610.txt
+++ b/.changelog/15610.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: avoid debug log spam in secondary datacenter servers due to management token not being initialized.
+```

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -116,7 +116,6 @@ func (s *serverACLResolverBackend) IsServerManagementToken(token string) bool {
 		return false
 	}
 	if mgmt == "" {
-		s.logger.Debug("server management token has not been initialized")
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(mgmt), []byte(token)) == 1


### PR DESCRIPTION
### Description
Currently the server management token is only being bootstrapped in the primary datacenter. That means that servers on the secondary datacenter will never have this token available, and would log this line any time a token is resolved.

Bootstrapping the token in secondary datacenters will be done in a follow-up.