### PR TITLE
peering: better represent non-passing states during peer check flattening

### DIFF
--- a/.changelog/15615.txt
+++ b/.changelog/15615.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: better represent non-passing states during peer check flattening
+```

--- a/agent/grpc-external/services/peerstream/subscription_manager.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager.go
@@ -664,6 +664,18 @@ func createDiscoChainHealth(
 	}
 }
 
+var statusScores = map[string]int{
+	// 0 is reserved for unknown
+	api.HealthMaint:    1,
+	api.HealthCritical: 2,
+	api.HealthWarning:  3,
+	api.HealthPassing:  4,
+}
+
+func isStatusBetter(curr, next string) bool {
+	return statusScores[next] < statusScores[curr]
+}
+
 func flattenChecks(
 	nodeName string,
 	serviceID string,
@@ -675,10 +687,18 @@ func flattenChecks(
 		return nil
 	}
 
+	// Similar logic to (api.HealthChecks).AggregatedStatus()
 	healthStatus := api.HealthPassing
-	for _, chk := range checks {
-		if chk.Status != api.HealthPassing {
-			healthStatus = chk.Status
+	if len(checks) > 0 {
+		for _, chk := range checks {
+			id := chk.CheckID
+			if id == api.NodeMaint || strings.HasPrefix(id, api.ServiceMaintPrefix) {
+				healthStatus = api.HealthMaint
+				break // always wins
+			}
+			if isStatusBetter(healthStatus, chk.Status) {
+				healthStatus = chk.Status
+			}
 		}
 	}
 

--- a/agent/grpc-external/services/peerstream/subscription_manager.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager.go
@@ -672,8 +672,11 @@ var statusScores = map[string]int{
 	api.HealthPassing:  4,
 }
 
-func isStatusBetter(curr, next string) bool {
-	return statusScores[next] < statusScores[curr]
+func getMostImportantStatus(a, b string) string {
+	if statusScores[a] < statusScores[b] {
+		return a
+	}
+	return b
 }
 
 func flattenChecks(
@@ -696,9 +699,7 @@ func flattenChecks(
 				healthStatus = api.HealthMaint
 				break // always wins
 			}
-			if isStatusBetter(healthStatus, chk.Status) {
-				healthStatus = chk.Status
-			}
+			healthStatus = getMostImportantStatus(healthStatus, chk.Status)
 		}
 	}
 


### PR DESCRIPTION
### Description

During peer stream replication we flatten checks from the source cluster and build one thin overall check to hide the irrelevant details from the consuming cluster. This flattening logic did correctly flip to non-passing if there were any non-passing checks, but WHICH status it got during that was random (warn/error).

Also it didn't represent "maintenance" operations. There is an `api` package call [`AggregatedStatus`](https://github.com/hashicorp/consul/blob/api/v1.17.0/api/health.go#L183) which more correctly flattened check statuses.

This PR replicated the more complete logic into the peer stream package.