### PR TITLE
Add warn log when all ACL policies are filtered out

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -633,7 +633,7 @@ func (r *ACLResolver) resolvePoliciesForIdentity(identity structs.ACLIdentity) (
 	policies = append(policies, syntheticPolicies...)
 	filtered := r.filterPoliciesByScope(policies)
 	if len(policies) > 0 && len(filtered) == 0 {
-		r.logger.Warn("all ACL policies have been filtered out based on datacenter", "accessor_id", identity.ID(), "datacenter", r.config.Datacenter)
+		r.logger.Warn("ACL token used lacks permissions in this datacenter: its associated ACL policies, service identities, and/or node identities are scoped to other datacenters", "accessor_id", identity.ID(), "datacenter", r.config.Datacenter)
 	}
 
 	return filtered, nil

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -632,6 +632,10 @@ func (r *ACLResolver) resolvePoliciesForIdentity(identity structs.ACLIdentity) (
 
 	policies = append(policies, syntheticPolicies...)
 	filtered := r.filterPoliciesByScope(policies)
+	if len(policies) > 0 && len(filtered) == 0 {
+		r.logger.Warn("all ACL policies have been filtered out based on datacenter", "accessor_id", identity.ID(), "datacenter", r.config.Datacenter)
+	}
+
 	return filtered, nil
 }
 


### PR DESCRIPTION
### Description
UX improvement for operators to help identify when they use a token meant for another datacenter.
