### PR TITLE
clean up go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ replace (
 	github.com/hashicorp/consul/sdk => ./sdk
 )
 
-// go-msgpack v1.1.5 has breaking changes and must be avoided
-exclude github.com/hashicorp/go-msgpack v1.1.5
+exclude (
+	github.com/hashicorp/go-msgpack v1.1.5 // has breaking changes and must be avoided
+	github.com/hashicorp/go-msgpack v1.1.6 // contains retractions but same as v1.1.5
+)
 
 require (
 	github.com/NYTimes/gziphandler v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,14 @@ module github.com/hashicorp/consul
 
 go 1.19
 
-replace github.com/hashicorp/consul/api => ./api
+replace (
+	github.com/hashicorp/consul/api => ./api
+	github.com/hashicorp/consul/proto-public => ./proto-public
+	github.com/hashicorp/consul/sdk => ./sdk
+)
 
-replace github.com/hashicorp/consul/sdk => ./sdk
-
-replace github.com/hashicorp/consul/proto-public => ./proto-public
-
-replace launchpad.net/gocheck => github.com/go-check/check v0.0.0-20140225173054-eb6ee6f84d0a
+// go-msgpack v1.1.5 has breaking changes and must be avoided
+exclude github.com/hashicorp/go-msgpack v1.1.5
 
 require (
 	github.com/NYTimes/gziphandler v1.0.1


### PR DESCRIPTION
Removes unused `replace` directive, groups the consul sub-modules into one block, and adds an `exclude` directive for msgpack
