### PR TITLE
use a separate go routine to write limiters

### DIFF
--- a/agent/consul/multilimiter/multilimiter.go
+++ b/agent/consul/multilimiter/multilimiter.go
@@ -101,7 +101,7 @@ func NewMultiLimiter(c Config) *MultiLimiter {
 		c.ReconcileCheckLimit = 1 * time.Second
 	}
 	chLimiter := make(chan *limiterWithKey, 100)
-	m := &MultiLimiter{limiters: &limiters, defaultConfig: &config, limitersConfigs: &configs, limiterCh: chLimiter, configsLock: sync.Mutex{}, once: sync.Once{}}
+	m := &MultiLimiter{limiters: &limiters, defaultConfig: &config, limitersConfigs: &configs, limiterCh: chLimiter}
 
 	return m
 }

--- a/agent/consul/multilimiter/multilimiter.go
+++ b/agent/consul/multilimiter/multilimiter.go
@@ -163,7 +163,8 @@ func (m *MultiLimiter) Allow(e LimitedEntity) bool {
 
 func (m *MultiLimiter) runStore(ctx context.Context) {
 	var txn *radix.Txn
-	waiter := time.NewTimer(10 * time.Millisecond)
+	commitInterval := 10 * time.Millisecond
+	waiter := time.NewTicker(commitInterval)
 	defer waiter.Stop()
 	for {
 		select {

--- a/agent/consul/multilimiter/multilimiter_test.go
+++ b/agent/consul/multilimiter/multilimiter_test.go
@@ -103,8 +103,8 @@ func TestRateLimiterCleanup(t *testing.T) {
 
 	m.Allow(Limited{key: key})
 	txn := m.limiters.Load().Txn()
-	m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
-	m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
+
+	storeLimiter(m, txn)
 	retry.Run(t, func(r *retry.R) {
 		time.Sleep(100 * time.Millisecond)
 		l := m.limiters.Load()
@@ -114,6 +114,20 @@ func TestRateLimiterCleanup(t *testing.T) {
 	l, ok = limiters.Get(key)
 	require.True(t, ok)
 	require.NotNil(t, l)
+}
+
+func storeLimiter(m *MultiLimiter, txn *radix.Txn) {
+	mockTicker := mockTicker{tickerCh: make(chan time.Time)}
+	ctx := context.Background()
+	m.runStoreOnce(ctx, &mockTicker, txn)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		mockTicker.tickerCh <- time.Now()
+		wg.Done()
+	}()
+	m.runStoreOnce(ctx, &mockTicker, txn)
+	wg.Wait()
 }
 
 func TestRateLimiterStore(t *testing.T) {
@@ -128,8 +142,7 @@ func TestRateLimiterStore(t *testing.T) {
 		ipNoPrefix2 := Key([]byte(""), []byte("127.0.0.2"))
 		{
 			m.Allow(ipLimited{key: ipNoPrefix1})
-			m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
-			m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
+			storeLimiter(m, txn)
 			l, ok := m.limiters.Load().Get(ipNoPrefix1)
 			require.True(t, ok)
 			require.NotNil(t, l)
@@ -138,8 +151,7 @@ func TestRateLimiterStore(t *testing.T) {
 		}
 		{
 			m.Allow(ipLimited{key: ipNoPrefix2})
-			m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
-			m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
+			storeLimiter(m, txn)
 			l, ok := m.limiters.Load().Get(ipNoPrefix2)
 			require.True(t, ok)
 			require.NotNil(t, l)
@@ -162,7 +174,7 @@ func TestRateLimiterStore(t *testing.T) {
 		limiters := m.limiters.Load()
 		m.Allow(ipLimited{key: ipNoPrefix1})
 		retry.Run(t, func(r *retry.R) {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1000 * time.Millisecond)
 			l := m.limiters.Load()
 			require.NotEqual(r, limiters, l)
 			limiters = l
@@ -196,16 +208,15 @@ func TestRateLimiterStore(t *testing.T) {
 func TestRateLimiterUpdateConfig(t *testing.T) {
 
 	// Create a MultiLimiter m with a defaultConfig c and check the defaultConfig is applied
-	c := Config{LimiterConfig: LimiterConfig{Rate: 0.1}, ReconcileCheckLimit: 100 * time.Millisecond, ReconcileCheckInterval: 10 * time.Millisecond}
-	m := NewMultiLimiter(c)
-	require.Equal(t, *m.defaultConfig.Load(), c)
 
 	t.Run("Allow a key and check defaultConfig is applied to that key", func(t *testing.T) {
+		c := Config{LimiterConfig: LimiterConfig{Rate: 0.1}, ReconcileCheckLimit: 100 * time.Millisecond, ReconcileCheckInterval: 10 * time.Millisecond}
+		m := NewMultiLimiter(c)
+		require.Equal(t, *m.defaultConfig.Load(), c)
 		ipNoPrefix := Key([]byte(""), []byte("127.0.0.1"))
 		m.Allow(ipLimited{key: ipNoPrefix})
 		txn := m.limiters.Load().Txn()
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
+		storeLimiter(m, txn)
 		l, ok := m.limiters.Load().Get(ipNoPrefix)
 		require.True(t, ok)
 		require.NotNil(t, l)
@@ -214,23 +225,28 @@ func TestRateLimiterUpdateConfig(t *testing.T) {
 	})
 
 	t.Run("Update nil prefix and make sure it's written in the root", func(t *testing.T) {
+		c := Config{LimiterConfig: LimiterConfig{Rate: 0.1}, ReconcileCheckLimit: 100 * time.Millisecond, ReconcileCheckInterval: 10 * time.Millisecond}
+		m := NewMultiLimiter(c)
+		require.Equal(t, *m.defaultConfig.Load(), c)
 		prefix := []byte(nil)
-		c := LimiterConfig{Rate: 2}
-		m.UpdateConfig(c, prefix)
+		c1 := LimiterConfig{Rate: 2}
+		m.UpdateConfig(c1, prefix)
 		v, ok := m.limitersConfigs.Load().Get([]byte(""))
 		require.True(t, ok)
 		require.NotNil(t, v)
 		c2 := v.(*LimiterConfig)
-		require.Equal(t, c, *c2)
+		require.Equal(t, c1, *c2)
 	})
 
 	t.Run("Allow 2 keys with prefix and check defaultConfig is applied to those keys", func(t *testing.T) {
+		c := Config{LimiterConfig: LimiterConfig{Rate: 0.1}, ReconcileCheckLimit: 100 * time.Millisecond, ReconcileCheckInterval: 10 * time.Millisecond}
+		m := NewMultiLimiter(c)
+		require.Equal(t, *m.defaultConfig.Load(), c)
 		prefix := []byte("namespace.write")
 		ip := Key(prefix, []byte("127.0.0.1"))
 		m.Allow(ipLimited{key: ip})
 		txn := m.limiters.Load().Txn()
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
+		storeLimiter(m, txn)
 		ip2 := Key(prefix, []byte("127.0.0.2"))
 		m.Allow(ipLimited{key: ip2})
 		l, ok := m.limiters.Load().Get(ip)
@@ -240,6 +256,9 @@ func TestRateLimiterUpdateConfig(t *testing.T) {
 		require.True(t, c.LimiterConfig.isApplied(limiter.limiter))
 	})
 	t.Run("Apply a defaultConfig to 'namespace.write' check the defaultConfig is applied to existing keys under that prefix", func(t *testing.T) {
+		c := Config{LimiterConfig: LimiterConfig{Rate: 0.1}, ReconcileCheckLimit: 100 * time.Millisecond, ReconcileCheckInterval: 10 * time.Millisecond}
+		m := NewMultiLimiter(c)
+		require.Equal(t, *m.defaultConfig.Load(), c)
 		prefix := []byte("namespace.write")
 		ip := Key(prefix, []byte("127.0.0.1"))
 		c3 := LimiterConfig{Rate: 2}
@@ -248,8 +267,7 @@ func TestRateLimiterUpdateConfig(t *testing.T) {
 		m.reconcileLimitedOnce(time.Now(), 100*time.Millisecond)
 		m.Allow(ipLimited{key: ip})
 		txn := m.limiters.Load().Txn()
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
+		storeLimiter(m, txn)
 		l3, ok3 := m.limiters.Load().Get(ip)
 		require.True(t, ok3)
 		require.NotNil(t, l3)
@@ -257,39 +275,42 @@ func TestRateLimiterUpdateConfig(t *testing.T) {
 		require.True(t, c3.isApplied(limiter3.limiter))
 	})
 	t.Run("Allow an IP with prefix and check prefix defaultConfig is applied to new keys under that prefix", func(t *testing.T) {
-		c := LimiterConfig{Rate: 3}
+		c := Config{LimiterConfig: LimiterConfig{Rate: 0.1}, ReconcileCheckLimit: 100 * time.Millisecond, ReconcileCheckInterval: 10 * time.Millisecond}
+		m := NewMultiLimiter(c)
+		require.Equal(t, *m.defaultConfig.Load(), c)
+		c1 := LimiterConfig{Rate: 3}
 		prefix := []byte("namespace.read")
-		m.UpdateConfig(c, prefix)
+		m.UpdateConfig(c1, prefix)
 		ip := Key(prefix, []byte("127.0.0.1"))
 		m.Allow(ipLimited{key: ip})
 		txn := m.limiters.Load().Txn()
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
+		storeLimiter(m, txn)
 		l, ok := m.limiters.Load().Get(ip)
 		require.True(t, ok)
 		require.NotNil(t, l)
 		limiter := l.(*Limiter)
-		require.True(t, c.isApplied(limiter.limiter))
+		require.True(t, c1.isApplied(limiter.limiter))
 	})
 
 	t.Run("Allow an IP with prefix and check after it's cleaned new Allow would give it the right defaultConfig", func(t *testing.T) {
+		c := Config{LimiterConfig: LimiterConfig{Rate: 0.1}, ReconcileCheckLimit: 100 * time.Millisecond, ReconcileCheckInterval: 10 * time.Millisecond}
+		m := NewMultiLimiter(c)
+		require.Equal(t, *m.defaultConfig.Load(), c)
 		prefix := []byte("namespace.read")
 		ip := Key(prefix, []byte("127.0.0.1"))
-		c := LimiterConfig{Rate: 1}
-		m.UpdateConfig(c, prefix)
+		c1 := LimiterConfig{Rate: 1}
+		m.UpdateConfig(c1, prefix)
 		// call reconcileLimitedOnce to make sure the update is applied
 		m.reconcileLimitedOnce(time.Now(), 100*time.Millisecond)
 		m.Allow(ipLimited{key: ip})
 		txn := m.limiters.Load().Txn()
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
+		storeLimiter(m, txn)
 		l, ok := m.limiters.Load().Get(ip)
 		require.True(t, ok)
 		require.NotNil(t, l)
 		limiter := l.(*Limiter)
-		require.True(t, c.isApplied(limiter.limiter))
-		time.Sleep(200 * time.Millisecond)
-		m.reconcileLimitedOnce(time.Now(), 100*time.Millisecond)
+		require.True(t, c1.isApplied(limiter.limiter))
+		m.reconcileLimitedOnce(time.Now().Add(100*time.Millisecond), 100*time.Millisecond)
 		l, ok = m.limiters.Load().Get(ip)
 		require.False(t, ok)
 		require.Nil(t, l)
@@ -307,8 +328,7 @@ func FuzzSingleConfig(f *testing.F) {
 	f.Fuzz(func(t *testing.T, ff []byte) {
 		m.Allow(Limited{key: ff})
 		txn := m.limiters.Load().Txn()
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
-		m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
+		storeLimiter(m, txn)
 		checkLimiter(t, ff, m.limiters.Load().Txn())
 		checkTree(t, m.limiters.Load().Txn())
 	})
@@ -490,4 +510,12 @@ func randIP() []byte {
 
 	binary.LittleEndian.PutUint32(buf, ip)
 	return buf
+}
+
+type mockTicker struct {
+	tickerCh chan time.Time
+}
+
+func (m *mockTicker) Ticker() <-chan time.Time {
+	return m.tickerCh
 }

--- a/agent/consul/multilimiter/multilimiter_test.go
+++ b/agent/consul/multilimiter/multilimiter_test.go
@@ -77,7 +77,7 @@ func TestRateLimiterCleanup(t *testing.T) {
 	key := makeKey([]byte("test"))
 	m.Allow(Limited{key: key})
 	retry.Run(t, func(r *retry.R) {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		l := m.limiters.Load()
 		require.NotEqual(r, limiters, l)
 		limiters = l
@@ -89,7 +89,7 @@ func TestRateLimiterCleanup(t *testing.T) {
 
 	// Wait > ReconcileCheckInterval and check that the key was cleaned up
 	retry.Run(t, func(r *retry.R) {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		l := m.limiters.Load()
 		require.NotEqual(r, limiters, l)
 		limiters = l
@@ -106,7 +106,7 @@ func TestRateLimiterCleanup(t *testing.T) {
 	m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
 	m.runStoreOnce(context.Background(), time.NewTicker(1*time.Microsecond), txn)
 	retry.Run(t, func(r *retry.R) {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		l := m.limiters.Load()
 		require.NotEqual(r, limiters, l)
 		limiters = l
@@ -162,7 +162,7 @@ func TestRateLimiterStore(t *testing.T) {
 		limiters := m.limiters.Load()
 		m.Allow(ipLimited{key: ipNoPrefix1})
 		retry.Run(t, func(r *retry.R) {
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 			l := m.limiters.Load()
 			require.NotEqual(r, limiters, l)
 			limiters = l
@@ -174,7 +174,7 @@ func TestRateLimiterStore(t *testing.T) {
 		require.True(t, c.isApplied(limiter.limiter))
 		m.Allow(ipLimited{key: ipNoPrefix2})
 		retry.Run(t, func(r *retry.R) {
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 			l := m.limiters.Load()
 			require.NotEqual(r, limiters, l)
 			limiters = l


### PR DESCRIPTION
### Description
This is an alternative to #15642 
Use a go buffered go routine to accumulate Limiters in a transaction and write them to the immutable-radix-tree every 10Ms.

 

### Testing & Reproduction steps


#### Without any synchronization code in #15467 
``` bash
❯ go test -bench=BenchmarkTestRateLimiterAllowC -count 5 -benchtime=1s  -timeout 6000s -run=XXX ./agent/consul/multilimiter
goos: darwin
goarch: amd64
pkg: github.com/hashicorp/consul/agent/consul/multilimiter
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
AC/no_prefill-16         	  556688	      2060 ns/op
AC/no_prefill-16         	  672924	      1964 ns/op
AC/no_prefill-16         	  627190	      1932 ns/op
AC/no_prefill-16         	  615247	      1952 ns/op
AC/no_prefill-16         	  661696	      1907 ns/op
AC/prefill_with_1K_keys-16         	  727677	      1894 ns/op
AC/prefill_with_1K_keys-16         	  611496	      2310 ns/op
AC/prefill_with_1K_keys-16         	  642594	      2043 ns/op
AC/prefill_with_1K_keys-16         	  590719	      1888 ns/op
AC/prefill_with_1K_keys-16         	  625422	      1937 ns/op
AC/prefill_with_10K_keys-16        	  494367	      2436 ns/op
AC/prefill_with_10K_keys-16        	  522981	      2491 ns/op
AC/prefill_with_10K_keys-16        	  529140	      2291 ns/op
AC/prefill_with_10K_keys-16        	  612369	      2356 ns/op
AC/prefill_with_10K_keys-16        	 1000000	      2607 ns/op
AC/prefill_with_100K_keys-16       	 1000000	      3285 ns/op
AC/prefill_with_100K_keys-16       	 1000000	      3626 ns/op
AC/prefill_with_100K_keys-16       	 1000000	      3891 ns/op
AC/prefill_with_100K_keys-16       	 1000000	      4479 ns/op
AC/prefill_with_100K_keys-16       	 1000000	      4352 ns/op
PASS
ok  	github.com/hashicorp/consul/agent/consul/multilimiter	66.699s
```

#### This branch (channel with transaction)

```bash
❯ go test -bench=BenchmarkTestRateLimiterAllowC -count 5 -benchtime=1s  -timeout 6000s -run=XXX ./agent/consul/multilimiter
goos: darwin
goarch: amd64
pkg: github.com/hashicorp/consul/agent/consul/multilimiter
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
AC/no_prefill-16         	  465397	      3929 ns/op
AC/no_prefill-16         	  736290	      3168 ns/op
AC/no_prefill-16         	  770343	      2957 ns/op
AC/no_prefill-16         	  669290	      3759 ns/op
AC/no_prefill-16         	  823153	      3547 ns/op
AC/prefill_with_1K_keys-16         	  807282	      4839 ns/op
AC/prefill_with_1K_keys-16         	  718530	      2788 ns/op
AC/prefill_with_1K_keys-16         	  786652	      4330 ns/op
AC/prefill_with_1K_keys-16         	  465585	      2994 ns/op
AC/prefill_with_1K_keys-16         	  715992	      2619 ns/op
AC/prefill_with_10K_keys-16        	  699630	      2876 ns/op
AC/prefill_with_10K_keys-16        	  703555	      3843 ns/op
AC/prefill_with_10K_keys-16        	  347377	      3426 ns/op
AC/prefill_with_10K_keys-16        	  659928	      3561 ns/op
AC/prefill_with_10K_keys-16        	  575187	      2929 ns/op
AC/prefill_with_100K_keys-16       	  552110	      2893 ns/op
AC/prefill_with_100K_keys-16       	  538591	      3101 ns/op
AC/prefill_with_100K_keys-16       	  542137	      2986 ns/op
AC/prefill_with_100K_keys-16       	  501328	      3057 ns/op
AC/prefill_with_100K_keys-16       	  493551	      3292 ns/op
PASS
ok  	github.com/hashicorp/consul/agent/consul/multilimiter	176.243s
```