### PR TITLE
docs: fix agent catalog services caching method

### DIFF
--- a/website/content/api-docs/catalog.mdx
+++ b/website/content/api-docs/catalog.mdx
@@ -268,9 +268,9 @@ The table below shows this endpoint's support for
 [agent caching](/api-docs/features/caching), and
 [required ACLs](/api-docs/api-structure#authentication).
 
-| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
-| ---------------- | ----------------- | ------------- | ------------ |
-| `NO`             | `none`            | `simple`      | `none`       |
+| Blocking Queries | Consistency Modes | Agent Caching      | ACL Required |
+| ---------------- | ----------------- | ------------------ | ------------ |
+| `NO`             | `none`            | `blocking refresh` | `none`       |
 
 The corresponding CLI command is [`consul catalog datacenters`](/commands/catalog/datacenters).
 
@@ -399,9 +399,9 @@ The table below shows this endpoint's support for
 [agent caching](/api-docs/features/caching), and
 [required ACLs](/api-docs/api-structure#authentication).
 
-| Blocking Queries | Consistency Modes | Agent Caching | ACL Required   |
-| ---------------- | ----------------- | ------------- | -------------- |
-| `YES`            | `all`             | `simple`      | `service:read` |
+| Blocking Queries | Consistency Modes | Agent Caching      | ACL Required   |
+| ---------------- | ----------------- | ------------------ | -------------- |
+| `YES`            | `all`             | `blocking refresh` | `service:read` |
 
 The corresponding CLI command is [`consul catalog services`](/commands/catalog/services).
 


### PR DESCRIPTION
### Description

The docs for [/catalog/services](https://developer.hashicorp.com/consul/api-docs/catalog#list-services) lists the agent caching type as `simple` and I think should actually be `blocking refresh`.

- [cachetype.CatalogListServices](https://github.com/hashicorp/consul/blob/main/agent/cache-types/catalog_list_services.go#L15)




### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] not a security concern
