### PR TITLE
ignore `mktg-.*` branches for CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1053,6 +1053,7 @@ workflows:
           filters:
             branches:
               ignore:
+                - /^mktg-.*/ # Digital Team Terraform-generated branches' prefix
                 - stable-website
                 - /^docs\/.*/
                 - /^ui\/.*/


### PR DESCRIPTION
### Description

There is a class of PRs/branches (ex. https://github.com/hashicorp/consul/pull/15650) that are opened by https://go.hashi.co/mktg-terraform to manage `/website` files. CI Tests, which often appear to be flaky, should not be run for these PRs

### Testing & Reproduction steps
- N/A

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
