### PR TITLE
Fix broken link to Consul Dataplane index

### DIFF
--- a/website/content/docs/k8s/architecture.mdx
+++ b/website/content/docs/k8s/architecture.mdx
@@ -43,6 +43,6 @@ By default, Consul on Kubernetes uses an alternate service mesh configuration th
 
 ![Diagram of Consul Dataplanes in Kubernetes deployment](/img/k8s-dataplanes-architecture.png)
 
-Refer to [Simplified Service Mesh with Consul Dataplanes](/docs/connect/dataplane/index) for more information.
+Refer to [Simplified Service Mesh with Consul Dataplanes](/docs/connect/dataplane) for more information.
 
 Consul Dataplane is the default proxy manager in Consul on Kubernetes 1.14 and later. If you are on Consul 1.13 or older, refer to [upgrading to Consul Dataplane](/docs/k8s/upgrade#upgrading-to-consul-dataplanes) for specific upgrade instructions.


### PR DESCRIPTION
### Description
The `/index` appears to result in a 404.

### Testing & Reproduction steps
Removing the `/index` in the URL results in the correct path loading.

### Links
- [Consul on Kubernetes: Architecture](https://developer.hashicorp.com/consul/docs/k8s/architecture)