### PR TITLE
Detect Vault 1.11+ import in secondary datacenters and update default issuer

### DIFF
--- a/.changelog/15661.txt
+++ b/.changelog/15661.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fixed issue where using Vault 1.11+ as CA provider in a secondary datacenter would eventually break Intermediate CAs
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ references:
     GIT_COMMITTER_NAME: circleci-consul
     S3_ARTIFACT_BUCKET: consul-dev-artifacts-v2
     BASH_ENV: .circleci/bash_env.sh
-    VAULT_BINARY_VERSION: 1.9.4
     GO_VERSION: 1.19.2
   envoy-versions: &supported_envoy_versions
     - &default_envoy_version "1.21.5"
@@ -32,6 +31,11 @@ references:
     - &default_nomad_version "1.3.3"
     - "1.2.10"
     - "1.1.16"
+  vault-versions: &supported_vault_versions
+    - &default_vault_version "1.12.2"
+    - "1.11.6"
+    - "1.10.9"
+    - "1.9.10"
   images:
     # When updating the Go version, remember to also update the versions in the
     # workflows section for go-test-lib jobs.
@@ -587,7 +591,6 @@ jobs:
       - setup_remote_docker
       - run: make ci.dev-docker
       - run: *notify-slack-failure
-
   nomad-integration-test: &NOMAD_TESTS
     docker:
       - image: docker.mirror.hashicorp.services/cimg/go:1.19
@@ -939,9 +942,15 @@ jobs:
   test-connect-ca-providers:
     docker:
       - image: *GOLANG_IMAGE
+    parameters:
+      vault-version:
+        type: enum
+        enum: *supported_vault_versions
+        default: *default_vault_version
     environment:
       <<: *ENVIRONMENT
-    steps:
+      VAULT_BINARY_VERSION: << parameters.vault-version >>
+    steps: &VAULT_INTEGRATION_TEST_STEPS
       - run:
           name: Install vault
           command: |
@@ -1067,8 +1076,12 @@ workflows:
           name: "lint-32bit"
           go-arch: "386"
           <<: *filter-ignore-non-go-branches
-      - test-connect-ca-providers: *filter-ignore-non-go-branches
       - go-test-arm64: *filter-ignore-non-go-branches
+      - test-connect-ca-providers:
+          matrix:
+            parameters:
+              vault-version: *supported_vault_versions
+          <<: *filter-ignore-non-go-branches
       - dev-build: *filter-ignore-non-go-branches
       - go-test:
           requires: [dev-build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -938,8 +938,8 @@ jobs:
           path: *TEST_RESULTS_DIR
       - run: *notify-slack-failure
 
-  # run integration tests for the connect ca providers
-  test-connect-ca-providers:
+  # run integration tests for the connect ca providers with vault
+  vault-integration-test:
     docker:
       - image: *GOLANG_IMAGE
     parameters:
@@ -1077,12 +1077,6 @@ workflows:
           go-arch: "386"
           <<: *filter-ignore-non-go-branches
       - go-test-arm64: *filter-ignore-non-go-branches
-      - test-connect-ca-providers:
-          name: "go-test-connect-ca with vault"
-          matrix:
-            parameters:
-              vault-version: *supported_vault_versions
-          <<: *filter-ignore-non-go-branches
       - dev-build: *filter-ignore-non-go-branches
       - go-test:
           requires: [dev-build]
@@ -1162,6 +1156,11 @@ workflows:
           matrix:
             parameters:
               nomad-version: *supported_nomad_versions
+      - vault-integration-test:
+          matrix:
+            parameters:
+              vault-version: *supported_vault_versions
+          <<: *filter-ignore-non-go-branches
       - envoy-integration-test:
           requires:
             - dev-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1078,6 +1078,7 @@ workflows:
           <<: *filter-ignore-non-go-branches
       - go-test-arm64: *filter-ignore-non-go-branches
       - test-connect-ca-providers:
+          name: "go-test-connect-ca with vault"
           matrix:
             parameters:
               vault-version: *supported_vault_versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -957,6 +957,7 @@ jobs:
             wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_BINARY_VERSION}/vault_${VAULT_BINARY_VERSION}_linux_amd64.zip
             sudo unzip -d /usr/local/bin /tmp/vault.zip
             rm -rf /tmp/vault*
+            vault version
       - checkout
       - run: go mod download
       - run:

--- a/agent/connect/ca/mock_Provider.go
+++ b/agent/connect/ca/mock_Provider.go
@@ -107,7 +107,7 @@ func (_m *MockProvider) GenerateIntermediate() (string, error) {
 }
 
 // GenerateIntermediateCSR provides a mock function with given fields:
-func (_m *MockProvider) GenerateIntermediateCSR() (string, error) {
+func (_m *MockProvider) GenerateIntermediateCSR() (string, string, error) {
 	ret := _m.Called()
 
 	var r0 string
@@ -117,14 +117,21 @@ func (_m *MockProvider) GenerateIntermediateCSR() (string, error) {
 		r0 = ret.Get(0).(string)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
+	var r1 string
+	if rf, ok := ret.Get(1).(func() string); ok {
 		r1 = rf()
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(string)
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func() error); ok {
+		r2 = rf()
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // GenerateRoot provides a mock function with given fields:
@@ -149,12 +156,12 @@ func (_m *MockProvider) GenerateRoot() (RootResult, error) {
 }
 
 // SetIntermediate provides a mock function with given fields: intermediatePEM, rootPEM
-func (_m *MockProvider) SetIntermediate(intermediatePEM string, rootPEM string) error {
-	ret := _m.Called(intermediatePEM, rootPEM)
+func (_m *MockProvider) SetIntermediate(intermediatePEM string, rootPEM string, keyId string) error {
+	ret := _m.Called(intermediatePEM, rootPEM, keyId)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = rf(intermediatePEM, rootPEM)
+	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = rf(intermediatePEM, rootPEM, keyId)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/agent/connect/ca/provider.go
+++ b/agent/connect/ca/provider.go
@@ -179,14 +179,17 @@ type SecondaryProvider interface {
 	//
 	// After the certificate is signed, SecondaryProvider.SetIntermediate will
 	// be called to store the intermediate CA.
-	GenerateIntermediateCSR() (string, error)
+	//
+	// The second return value is an opaque string meant to be passed back to
+	// the subsequent call to SetIntermediate.
+	GenerateIntermediateCSR() (string, string, error)
 
 	// SetIntermediate is called to store a newly signed leaf signing certificate and
 	// the chain of certificates back to the root CA certificate.
 	//
 	// The provider should save the certificates and use them to
 	// Provider.Sign leaf certificates.
-	SetIntermediate(intermediatePEM, rootPEM string) error
+	SetIntermediate(intermediatePEM, rootPEM, opaque string) error
 }
 
 // RootResult is the result returned by PrimaryProvider.GenerateRoot.

--- a/agent/connect/ca/provider_aws_test.go
+++ b/agent/connect/ca/provider_aws_test.go
@@ -216,7 +216,7 @@ func TestAWSBootstrapAndSignSecondary(t *testing.T) {
 			"ExistingARN": p2State[AWSStateCAARNKey],
 		})
 		p2 = testAWSProvider(t, cfg2)
-		require.NoError(t, p2.SetIntermediate(newIntPEM, newRootPEM))
+		require.NoError(t, p2.SetIntermediate(newIntPEM, newRootPEM, ""))
 
 		root, err = p1.GenerateRoot()
 		require.NoError(t, err)

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -417,7 +417,7 @@ func TestConsulProvider_SignIntermediate(t *testing.T) {
 func testSignIntermediateCrossDC(t *testing.T, provider1, provider2 Provider) {
 
 	// Get the intermediate CSR from provider2.
-	csrPEM, err := provider2.GenerateIntermediateCSR()
+	csrPEM, opaque, err := provider2.GenerateIntermediateCSR()
 	require.NoError(t, err)
 	csr, err := connect.ParseCSR(csrPEM)
 	require.NoError(t, err)
@@ -430,7 +430,7 @@ func testSignIntermediateCrossDC(t *testing.T, provider1, provider2 Provider) {
 	rootPEM := root.PEM
 
 	// Give the new intermediate to provider2 to use.
-	require.NoError(t, provider2.SetIntermediate(intermediatePEM, rootPEM))
+	require.NoError(t, provider2.SetIntermediate(intermediatePEM, rootPEM, opaque))
 
 	// Have provider2 sign a leaf cert and make sure the chain is correct.
 	spiffeService := &connect.SpiffeIDService{

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
 
@@ -903,7 +904,6 @@ func TestVaultProvider_ReconfigureIntermediateTTL(t *testing.T) {
 }
 
 func TestVaultCAProvider_GenerateIntermediate(t *testing.T) {
-
 	SkipIfVaultNotPresent(t)
 
 	provider, _ := testVaultProviderWithConfig(t, true, nil)
@@ -922,6 +922,76 @@ func TestVaultCAProvider_GenerateIntermediate(t *testing.T) {
 
 	require.Equal(t, new, newActive)
 	require.NotEqual(t, orig, new)
+}
+
+func TestVaultCAProvider_GenerateIntermediate_inSecondary(t *testing.T) {
+	SkipIfVaultNotPresent(t)
+
+	// Primary DC will be a consul provider.
+	conf := testConsulCAConfig()
+	delegate := newMockDelegate(t, conf)
+	primaryProvider := TestConsulProvider(t, delegate)
+	require.NoError(t, primaryProvider.Configure(testProviderConfig(conf)))
+	_, err := primaryProvider.GenerateRoot()
+	require.NoError(t, err)
+
+	// Ensure that we don't configure vault to try and mint leafs that
+	// outlive their CA during the test (which hard fails in vault).
+	intermediateCertTTL := getIntermediateCertTTL(t, conf)
+	leafCertTTL := intermediateCertTTL - 4*time.Hour
+
+	provider, _ := testVaultProviderWithConfig(t, false, map[string]any{
+		"LeafCertTTL": []uint8(leafCertTTL.String()),
+	})
+
+	var origIntermediate string
+	testutil.RunStep(t, "initialize secondary provider", func(t *testing.T) {
+		// Get the intermediate CSR from provider.
+		csrPEM, opaque, err := provider.GenerateIntermediateCSR()
+		require.NoError(t, err)
+		csr, err := connect.ParseCSR(csrPEM)
+		require.NoError(t, err)
+
+		// Sign the CSR with primaryProvider.
+		intermediatePEM, err := primaryProvider.SignIntermediate(csr)
+		require.NoError(t, err)
+		root, err := primaryProvider.GenerateRoot()
+		require.NoError(t, err)
+		rootPEM := root.PEM
+
+		// Give the new intermediate to provider to use.
+		require.NoError(t, provider.SetIntermediate(intermediatePEM, rootPEM, opaque))
+
+		origIntermediate, err = provider.ActiveIntermediate()
+		require.NoError(t, err)
+	})
+
+	testutil.RunStep(t, "renew secondary provider", func(t *testing.T) {
+		// Get the intermediate CSR from provider.
+		csrPEM, opaque, err := provider.GenerateIntermediateCSR()
+		require.NoError(t, err)
+		csr, err := connect.ParseCSR(csrPEM)
+		require.NoError(t, err)
+
+		// Sign the CSR with primaryProvider.
+		intermediatePEM, err := primaryProvider.SignIntermediate(csr)
+		require.NoError(t, err)
+		root, err := primaryProvider.GenerateRoot()
+		require.NoError(t, err)
+		rootPEM := root.PEM
+
+		// Give the new intermediate to provider to use.
+		require.NoError(t, provider.SetIntermediate(intermediatePEM, rootPEM, opaque))
+
+		// This test was created to ensure that our calls to Vault
+		// returns a new Intermediate certificate and further calls
+		// to ActiveIntermediate return the same new cert.
+		newActiveIntermediate, err := provider.ActiveIntermediate()
+		require.NoError(t, err)
+
+		require.NotEqual(t, origIntermediate, newActiveIntermediate)
+		require.Equal(t, intermediatePEM, newActiveIntermediate)
+	})
 }
 
 func TestVaultCAProvider_VaultManaged(t *testing.T) {

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -947,7 +947,7 @@ func TestVaultCAProvider_GenerateIntermediate_inSecondary(t *testing.T) {
 	var origIntermediate string
 	testutil.RunStep(t, "initialize secondary provider", func(t *testing.T) {
 		// Get the intermediate CSR from provider.
-		csrPEM, opaque, err := provider.GenerateIntermediateCSR()
+		csrPEM, issuerID, err := provider.GenerateIntermediateCSR()
 		require.NoError(t, err)
 		csr, err := connect.ParseCSR(csrPEM)
 		require.NoError(t, err)
@@ -960,7 +960,7 @@ func TestVaultCAProvider_GenerateIntermediate_inSecondary(t *testing.T) {
 		rootPEM := root.PEM
 
 		// Give the new intermediate to provider to use.
-		require.NoError(t, provider.SetIntermediate(intermediatePEM, rootPEM, opaque))
+		require.NoError(t, provider.SetIntermediate(intermediatePEM, rootPEM, issuerID))
 
 		origIntermediate, err = provider.ActiveIntermediate()
 		require.NoError(t, err)
@@ -968,7 +968,7 @@ func TestVaultCAProvider_GenerateIntermediate_inSecondary(t *testing.T) {
 
 	testutil.RunStep(t, "renew secondary provider", func(t *testing.T) {
 		// Get the intermediate CSR from provider.
-		csrPEM, opaque, err := provider.GenerateIntermediateCSR()
+		csrPEM, issuerID, err := provider.GenerateIntermediateCSR()
 		require.NoError(t, err)
 		csr, err := connect.ParseCSR(csrPEM)
 		require.NoError(t, err)
@@ -981,7 +981,7 @@ func TestVaultCAProvider_GenerateIntermediate_inSecondary(t *testing.T) {
 		rootPEM := root.PEM
 
 		// Give the new intermediate to provider to use.
-		require.NoError(t, provider.SetIntermediate(intermediatePEM, rootPEM, opaque))
+		require.NoError(t, provider.SetIntermediate(intermediatePEM, rootPEM, issuerID))
 
 		// This test was created to ensure that our calls to Vault
 		// returns a new Intermediate certificate and further calls

--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -103,15 +103,6 @@ func SkipIfVaultNotPresent(t testing.T) {
 	if err != nil || path == "" {
 		t.Skipf("%q not found on $PATH - download and install to run this test", vaultBinaryName)
 	}
-
-	{
-		cmd := exec.Command(vaultBinaryName, "version")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Start(); err != nil {
-			t.Fatalf("blah: %w", err)
-		}
-	}
 }
 
 func NewTestVaultServer(t testing.T) *TestVaultServer {

--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -103,6 +103,15 @@ func SkipIfVaultNotPresent(t testing.T) {
 	if err != nil || path == "" {
 		t.Skipf("%q not found on $PATH - download and install to run this test", vaultBinaryName)
 	}
+
+	{
+		cmd := exec.Command(vaultBinaryName, "version")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("blah: %w", err)
+		}
+	}
 }
 
 func NewTestVaultServer(t testing.T) *TestVaultServer {

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -1052,7 +1052,7 @@ func (c *CAManager) primaryRenewIntermediate(provider ca.Provider, newActiveRoot
 // provider.
 // Should only be called while the state lock is held by setting the state to non-ready.
 func (c *CAManager) secondaryRequestNewSigningCert(provider ca.Provider, newActiveRoot *structs.CARoot) error {
-	csr, err := provider.GenerateIntermediateCSR()
+	csr, opaque, err := provider.GenerateIntermediateCSR()
 	if err != nil {
 		return err
 	}
@@ -1064,7 +1064,7 @@ func (c *CAManager) secondaryRequestNewSigningCert(provider ca.Provider, newActi
 		return nil
 	}
 
-	if err := provider.SetIntermediate(intermediatePEM, newActiveRoot.RootCert); err != nil {
+	if err := provider.SetIntermediate(intermediatePEM, newActiveRoot.RootCert, opaque); err != nil {
 		return fmt.Errorf("Failed to set the intermediate certificate with the CA provider: %v", err)
 	}
 

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -1033,9 +1033,14 @@ func setupPrimaryCA(t *testing.T, client *vaultapi.Client, path string, rootPEM 
 	})
 	require.NoError(t, err, "failed to sign intermediate")
 
+	cert := intermediate.Data["certificate"].(string)
+
 	var buf strings.Builder
-	buf.WriteString(lib.EnsureTrailingNewline(intermediate.Data["certificate"].(string)))
-	buf.WriteString(lib.EnsureTrailingNewline(rootPEM))
+	buf.WriteString(lib.EnsureTrailingNewline(cert))
+	if !strings.Contains(strings.TrimSpace(cert), strings.TrimSpace(rootPEM)) {
+		// Vault < v1.11 included the root in the output of sign-intermediate.
+		buf.WriteString(lib.EnsureTrailingNewline(rootPEM))
+	}
 
 	_, err = client.Logical().Write(path+"/intermediate/set-signed", map[string]interface{}{
 		"certificate": buf.String(),

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -248,11 +248,11 @@ func (m *mockCAProvider) State() (map[string]string, error)     { return nil, ni
 func (m *mockCAProvider) GenerateRoot() (ca.RootResult, error) {
 	return ca.RootResult{PEM: m.rootPEM}, nil
 }
-func (m *mockCAProvider) GenerateIntermediateCSR() (string, error) {
+func (m *mockCAProvider) GenerateIntermediateCSR() (string, string, error) {
 	m.callbackCh <- "provider/GenerateIntermediateCSR"
-	return "", nil
+	return "", "", nil
 }
-func (m *mockCAProvider) SetIntermediate(intermediatePEM, rootPEM string) error {
+func (m *mockCAProvider) SetIntermediate(intermediatePEM, rootPEM, _ string) error {
 	m.callbackCh <- "provider/SetIntermediate"
 	return nil
 }


### PR DESCRIPTION
### Description
The fix outlined and merged in https://github.com/hashicorp/consul/pull/15253 fixed the issue as it occurs in the primary DC. There is a similar issue that arises when vault is used as the Connect CA in a secondary datacenter that is fixed by this PR.

Additionally: this PR adds support to run the existing suite of vault related integration tests against the last 4 versions of vualt (1.9, 1.10, 1.11, 1.12)
