### PR TITLE
docs: Agentless performance clarifications

### DIFF
--- a/website/content/docs/connect/dataplane/index.mdx
+++ b/website/content/docs/connect/dataplane/index.mdx
@@ -26,10 +26,10 @@ The most significant differences between traditional deployments and Consul Data
 As a result, small deployments require fewer resources overall. For deployments that are especially large or expected to experience high levels of churn, consider the following impacts to your network's performance:
 
 1. In our internal tests, which used 5000 proxies and services flapping every 2 seconds, additional CPU utilization remained under 10% on the control plane.
-2. As you deploy more services, the resource usage for dataplanes grows on a linear scale.
-3. Envoy reconfigurations are rate limited to prevent excessive configuration changes from generating significant load on the servers.
-4. To avoid generating significant load on an individual server, proxy configuration is load balanced proactively.
-5. The frequency of the orchestrator's liveness and readiness probes determine how quickly Consul's control plane can become aware of failures. There is no impact on service mesh applications, however, as Envoy proxies have a passive ability to detect endpoint failure and steer traffic to healthy instances.
+1. As you deploy more services, the resource usage for dataplanes grows on a linear scale.
+1. Envoy reconfigurations are rate limited to prevent excessive configuration changes from generating significant load on the servers.
+1. To avoid generating significant load on an individual server, proxy configuration is load balanced proactively.
+1. The frequency of the orchestrator's liveness and readiness probes determine how quickly Consul's control plane can become aware of failures. There is no impact on service mesh applications, however, as Envoy proxies have a passive ability to detect endpoint failure and steer traffic to healthy instances.
 
 ## Benefits
 

--- a/website/content/docs/connect/dataplane/index.mdx
+++ b/website/content/docs/connect/dataplane/index.mdx
@@ -21,15 +21,15 @@ Consul Dataplane manages Envoy proxies and leaves responsibility for other funct
 
 ### Impact on performance
 
-The most significant differences between traditional deployments and Consul Dataplane deployments result from the removal of node-level client agents with gossip communication. They are replaced by _dataplanes_, which are the sidecars injected alongside each service instance that handle communication between Consul servers and Envoy proxies.
+The most significant differences between traditional deployments and Consul Dataplane deployments result from the removal of node-level client agents with gossip communication. They are replaced by _dataplanes_, which are the sidecars injected alongside each service instance that handle communication between Consul servers and Envoy proxies. While dataplanes use fewer resources than client agents, Consul servers need to consume additional resources in order to generate xDS resources for Envoy proxies.
 
-Be aware of the following changes and their impact on your network's performance:
+As a result, small deployments require fewer resources overall. For deployments that are especially large or expected to experience high levels of churn, consider the following impacts to your network's performance:
 
-1. Consul servers consume additional resources in order to generate xDS resources for Envoy proxies. In our internal load tests, performing at high scale and churn resulted in additional CPU utilization rates under 10% on the control plane. 
-1. As you deploy more services, the resource usage for dataplanes grows on a linear scale.
-1. Envoy reconfigurations are rate limited to prevent excessive configuration changes from generating significant load on the servers.
-1. To avoid generating significant load on an individual server, proxy configuration is load balanced proactively.
-1. The frequency of the orchestrator's liveness and readiness probes determine how quickly Consul's control plane can become aware of failures. There is no impact on service mesh applications, however, as Envoy proxies have a passive ability to detect endpoint failure and steer traffic to healthy instances.
+1. In our internal tests, which used 5000 proxies and services flapping every 2 seconds, additional CPU utilization remained under 10% on the control plane.
+2. As you deploy more services, the resource usage for dataplanes grows on a linear scale.
+3. Envoy reconfigurations are rate limited to prevent excessive configuration changes from generating significant load on the servers.
+4. To avoid generating significant load on an individual server, proxy configuration is load balanced proactively.
+5. The frequency of the orchestrator's liveness and readiness probes determine how quickly Consul's control plane can become aware of failures. There is no impact on service mesh applications, however, as Envoy proxies have a passive ability to detect endpoint failure and steer traffic to healthy instances.
 
 ## Benefits
 


### PR DESCRIPTION
### Description
Per [discussion on Slack](https://hashicorp.slack.com/archives/C02GG0RFPQC/p1669851806650559), this PR updates the section on performance for Consul Dataplane.

In particular, these edits add specificity around the internal testing results and explicitly state that dataplanes use fewer resources in small deployments.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
