### PR TITLE
docs: Update Consul K8s CRDs

### DIFF
--- a/website/content/docs/k8s/crds/index.mdx
+++ b/website/content/docs/k8s/crds/index.mdx
@@ -21,7 +21,9 @@ with Kubernetes Custom Resources. Configuration entries provide cluster-wide def
 You can specify the following values in the `kind` field. Click on a configuration entry to view its documentation:
 
 - [`Mesh`](/docs/connect/config-entries/mesh) (requires Consul 1.10.0+)
-- [`ExportedServices`](/docs/connect/config-entries/exported-services) <EnterpriseAlert inline />
+- [`ExportedServices`](/docs/connect/config-entries/exported-services)
+- [`PeeringAcceptor`](/docs/connect/cluster-peering/k8s#peeringacceptor)
+- [`PeeringDialer`](/docs/connect/cluster-peering/k8s#peeringdialer)
 - [`ProxyDefaults`](/docs/connect/config-entries/proxy-defaults)
 - [`ServiceDefaults`](/docs/connect/config-entries/service-defaults)
 - [`ServiceSplitter`](/docs/connect/config-entries/service-splitter)


### PR DESCRIPTION
### Description
Remove Enterprise from ExportedServices CRD, and add PeeringDialer and PeeringAcceptor. The CRDs still do need to be defined but linking to the K8s Cluster Peering doc for now. 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
