### PR TITLE
connect: use -dev-no-store-token for test vaults to reduce source of flakes

### DIFF
--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -1,7 +1,6 @@
 package ca
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -144,13 +143,17 @@ func NewTestVaultServer(t testing.T) *TestVaultServer {
 		clientAddr,
 		"-address",
 		clusterAddr,
+		// We pass '-dev-no-store-token' to avoid having multiple vaults oddly
+		// interact and fail like this:
+		//
+		//   Error initializing Dev mode: rename /home/circleci/.vault-token.tmp /home/circleci/.vault-token: no such file or directory
+		//
+		"-dev-no-store-token",
 	}
 
-	buf := newLogBuffer(t)
-
 	cmd := exec.Command(vaultBinaryName, args...)
-	cmd.Stdout = buf
-	cmd.Stderr = buf
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
 	require.NoError(t, cmd.Start())
 
 	testVault := &TestVaultServer{
@@ -358,42 +361,4 @@ func createVaultTokenAndPolicy(t testing.T, client *vaultapi.Client, policyName,
 	})
 	require.NoError(t, err)
 	return tok.Auth.ClientToken
-}
-
-// copied from sdk/testutil/testlog.go:NewLogBuffer
-//
-// newLogBuffer returns an io.Writer which buffers all writes. When the test
-// ends, t.Failed is checked. If the test has failed all log output is printed
-// to stdout.
-//
-// Set the env var NOLOGBUFFER=1 to disable buffering, resulting in all log
-// output being written immediately to stdout.
-//
-// Typically log output is written for failed tests.
-func newLogBuffer(t testing.T) io.Writer {
-	if sendTestLogsToStdout {
-		return os.Stdout
-	}
-	buf := &logBuffer{buf: new(bytes.Buffer)}
-	t.Cleanup(func() {
-		if true || t.Failed() {
-			buf.Lock()
-			defer buf.Unlock()
-			buf.buf.WriteTo(os.Stdout)
-		}
-	})
-	return buf
-}
-
-var sendTestLogsToStdout = os.Getenv("NOLOGBUFFER") == "1"
-
-type logBuffer struct {
-	buf *bytes.Buffer
-	sync.Mutex
-}
-
-func (lb *logBuffer) Write(p []byte) (n int, err error) {
-	lb.Lock()
-	defer lb.Unlock()
-	return lb.buf.Write(p)
 }


### PR DESCRIPTION
### Description

It turns out that by default the dev mode vault server will attempt to interact with the filesystem to store the provided root token. If multiple vault instances are running they'll all awkwardly share the filesystem and if timing results in one server stopping while another one is starting then the starting one will error with:

    Error initializing Dev mode: rename /home/circleci/.vault-token.tmp /home/circleci/.vault-token: no such file or directory

This change uses `-dev-no-store-token` to bypass that source of flakes. Also the stdout/stderr from the vault process is included if the test fails.

The introduction of more `t.Parallel` use in https://github.com/hashicorp/consul/pull/15669 increased the likelihood of this failure, but any of the tests with multiple vaults in use (or running multiple package tests in parallel that all use vault) were eventually going to flake on this.