### PR TITLE
docs: Small docs updates, peering and K8s CNI

### DIFF
--- a/website/content/docs/connect/config-entries/index.mdx
+++ b/website/content/docs/connect/config-entries/index.mdx
@@ -17,8 +17,8 @@ The following configuration entries are supported:
 - [Mesh](/docs/connect/config-entries/mesh) - controls
   mesh-wide configuration that applies across namespaces and federated datacenters.
   
-- [Exported Services](/docs/connect/config-entries/exported-services) <EnterpriseAlert inline /> - enables 
-  Consul to export service instances to other admin partitions. 
+- [Exported Services](/docs/connect/config-entries/exported-services) - enables 
+  Consul to export service instances to other peers or to other admin partitions local or remote to the datacenter. 
 
 - [Proxy Defaults](/docs/connect/config-entries/proxy-defaults) - controls
   proxy configuration

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -181,7 +181,7 @@ The following table describes the available CNI plugin options:
 | ---------- | ----------- | ------------- |
 | `cni.enabled` | Boolean value that enables or disables the CNI plugin. If `true`, the plugin is responsible for redirecting traffic in the service mesh. If `false`, redirection is handled by the `connect-inject init` container. | `false` |
 | `cni.logLevel` | String value that specifies the log level for the installer and plugin. You can specify the following values: `info`, `debug`, `error`. | `info` |
-| `cni.namespace` | Set the namespace to install the CNI plugin into. Overrides global namespace settings for CNI resources. Ex: `kube-system` | namespace used for `consul-k8s` install, i.e. `consul` |
+| `cni.namespace` | Set the namespace to install the CNI plugin into. Overrides global namespace settings for CNI resources, i.e. `kube-system` | namespace used for `consul-k8s` install, i.e. `consul` |
 | `cni.multus` | Boolean value that enables multus CNI plugin support. If `true`, multus will be enabled. If `false`, Consul CNI will operate as a chained plugin. | `false` |
 | `cni.cniBinDir` | String value that specifies the location on the Kubernetes node where the CNI plugin is installed. | `/opt/cni/bin` |
 | `cni.cniNetDir` | String value that specifies the location on the Kubernetes node for storing the CNI configuration. | `/etc/cni/net.d` |

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -181,7 +181,7 @@ The following table describes the available CNI plugin options:
 | ---------- | ----------- | ------------- |
 | `cni.enabled` | Boolean value that enables or disables the CNI plugin. If `true`, the plugin is responsible for redirecting traffic in the service mesh. If `false`, redirection is handled by the `connect-inject init` container. | `false` |
 | `cni.logLevel` | String value that specifies the log level for the installer and plugin. You can specify the following values: `info`, `debug`, `error`. | `info` |
-| `cni.namespace` | Set the namespace to install the CNI plugin into. Overrides global namespace settings for CNI resources. Ex: `kube-system` | namespace used for `consul-k8s` install i.e. `consul` |
+| `cni.namespace` | Set the namespace to install the CNI plugin into. Overrides global namespace settings for CNI resources. Ex: `kube-system` | namespace used for `consul-k8s` install, i.e. `consul` |
 | `cni.multus` | Boolean value that enables multus CNI plugin support. If `true`, multus will be enabled. If `false`, Consul CNI will operate as a chained plugin. | `false` |
 | `cni.cniBinDir` | String value that specifies the location on the Kubernetes node where the CNI plugin is installed. | `/opt/cni/bin` |
 | `cni.cniNetDir` | String value that specifies the location on the Kubernetes node for storing the CNI configuration. | `/etc/cni/net.d` |

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -181,7 +181,7 @@ The following table describes the available CNI plugin options:
 | ---------- | ----------- | ------------- |
 | `cni.enabled` | Boolean value that enables or disables the CNI plugin. If `true`, the plugin is responsible for redirecting traffic in the service mesh. If `false`, redirection is handled by the `connect-inject init` container. | `false` |
 | `cni.logLevel` | String value that specifies the log level for the installer and plugin. You can specify the following values: `info`, `debug`, `error`. | `info` |
-| `cni.namespace` | Set the namespace to install the CNI plugin into. Overrides global namespace settings for CNI resources, i.e. `kube-system` | namespace used for `consul-k8s` install, i.e. `consul` |
+| `cni.namespace` | Set the namespace to install the CNI plugin into. Overrides global namespace settings for CNI resources, for example `kube-system` | namespace used for `consul-k8s` install, for example `consul` |
 | `cni.multus` | Boolean value that enables multus CNI plugin support. If `true`, multus will be enabled. If `false`, Consul CNI will operate as a chained plugin. | `false` |
 | `cni.cniBinDir` | String value that specifies the location on the Kubernetes node where the CNI plugin is installed. | `/opt/cni/bin` |
 | `cni.cniNetDir` | String value that specifies the location on the Kubernetes node for storing the CNI configuration. | `/etc/cni/net.d` |

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -181,7 +181,7 @@ The following table describes the available CNI plugin options:
 | ---    | ---         | ---     |
 | `cni.enabled` | Boolean value that enables or disables the CNI plugin. If `true`, the plugin is responsible for redirecting traffic in the service mesh. If `false`, redirection is handled by the `connect-inject init` container. | `false` |
 | `cni.logLevel` | String value that specifies the log level for the installer and plugin. You can specify the following values: `info`, `debug`, `error`. | `info` |
-| `cni.namespace` | Set the namespace to install the CNI plugin into. Overrides global namespace settings for CNI resources. Ex: `kube-system` | `consul` |
+| `cni.namespace` | Set the namespace to install the CNI plugin into. Overrides global namespace settings for CNI resources. Ex: `kube-system` | namespace used for `consul-k8s` install i.e. `consul` |
 | `cni.multus` | Boolean value that enables multus CNI plugin support. If `true`, multus will be enabled. If `false`, Consul CNI will operate as a chained plugin. | `false` |
 | `cni.cniBinDir` | String value that specifies the location on the Kubernetes node where the CNI plugin is installed. | `/opt/cni/bin` |
 | `cni.cniNetDir` | String value that specifies the location on the Kubernetes node for storing the CNI configuration. | `/etc/cni/net.d` |

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -25,7 +25,7 @@ The Helm chart has no required configuration, so it installs a Consul cluster wi
 
 ## Requirements
 
-Using the Helm Chart requires Helm version 3.2+. Visit the [Helm website](https://helm.sh/docs/intro/install/) to download the latest version.
+Using the Helm Chart requires Helm version 3.6+. Visit the [Helm website](https://helm.sh/docs/intro/install/) to download the latest version.
 
 ## Install Consul
 

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -177,8 +177,8 @@ To configure the plugin to be installed, add the following configuration to your
 
 The following table describes the available CNI plugin options:
 
-| Option | Description | Default |
-| ---    | ---         | ---     |
+| Option     | Description | Default       |
+| ---------- | ----------- | ------------- |
 | `cni.enabled` | Boolean value that enables or disables the CNI plugin. If `true`, the plugin is responsible for redirecting traffic in the service mesh. If `false`, redirection is handled by the `connect-inject init` container. | `false` |
 | `cni.logLevel` | String value that specifies the log level for the installer and plugin. You can specify the following values: `info`, `debug`, `error`. | `info` |
 | `cni.namespace` | Set the namespace to install the CNI plugin into. Overrides global namespace settings for CNI resources. Ex: `kube-system` | namespace used for `consul-k8s` install i.e. `consul` |


### PR DESCRIPTION
### Description
- Remove enterprise from exportedServices config entry list entry
- Alter CNI namespace config to say for installed namespace. 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
