### PR TITLE
Flakiness test: case-cfg-splitter-peering-ingress-gateways

### DIFF
--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -874,6 +874,10 @@ func (s *ResourceGenerator) makeRouteActionForSplitter(
 		clusters = append(clusters, cw)
 	}
 
+	if len(clusters) <= 0 {
+		return nil, fmt.Errorf("number of clusters in splitter must be > 0; got %d", len(clusters))
+	}
+
 	return &envoy_route_v3.Route_Route{
 		Route: &envoy_route_v3.RouteAction{
 			ClusterSpecifier: &envoy_route_v3.RouteAction_WeightedClusters{

--- a/test/integration/connect/envoy/case-cfg-resolver-cluster-peering-failover/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-cluster-peering-failover/primary/verify.bats
@@ -35,7 +35,7 @@ load helpers
 }
 
 @test "peer the two clusters together" {
-  create_peering primary alpha
+  retry_default create_peering primary alpha
 }
 
 @test "s2 alpha proxies should be healthy in primary" {

--- a/test/integration/connect/envoy/case-cfg-splitter-cluster-peering/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-splitter-cluster-peering/primary/verify.bats
@@ -31,7 +31,7 @@ load helpers
 }
 
 @test "peer the two clusters together" {
-  create_peering primary alpha
+  retry_default create_peering primary alpha
 }
 
 @test "s2 alpha proxies should be healthy in primary" {

--- a/test/integration/connect/envoy/case-cfg-splitter-peering-ingress-gateways/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-splitter-peering-ingress-gateways/primary/verify.bats
@@ -2,7 +2,6 @@
 
 load helpers
 
-
 @test "ingress-primary proxy admin is up" {
   retry_default curl -f -s localhost:20000/stats -o /dev/null
 }
@@ -12,7 +11,7 @@ load helpers
 }
 
 @test "services should be healthy in primary" {
-  assert_service_has_healthy_instances s1 1 alpha
+  assert_service_has_healthy_instances s1 1 primary
 }
 
 @test "services should be healthy in alpha" {
@@ -26,7 +25,12 @@ load helpers
 }
 
 @test "peer the two clusters together" {
-  create_peering primary alpha
+  retry_long create_peering primary alpha
+}
+
+@test "s1, s2 alpha proxies should be imported to primary" {
+  retry_long assert_service_has_imported primary s1 primary-to-alpha
+  retry_long assert_service_has_imported primary s2 primary-to-alpha
 }
 
 @test "s1 alpha proxies should be healthy in primary" {
@@ -68,3 +72,5 @@ load helpers
   retry_long assert_expected_fortio_name s1-alpha split.ingress.consul 10002
   retry_long assert_expected_fortio_name s2-alpha split.ingress.consul 10002
 }
+
+# sleep 9999

--- a/test/integration/connect/envoy/case-cfg-splitter-peering-ingress-gateways/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-splitter-peering-ingress-gateways/primary/verify.bats
@@ -73,4 +73,3 @@ load helpers
   retry_long assert_expected_fortio_name s2-alpha split.ingress.consul 10002
 }
 
-# sleep 9999

--- a/test/integration/connect/envoy/case-cross-peer-control-plane-mgw/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cross-peer-control-plane-mgw/primary/verify.bats
@@ -31,7 +31,12 @@ load helpers
 }
 
 @test "peer the two clusters together" {
-  create_peering primary alpha
+  retry_default create_peering primary alpha
+}
+
+@test "s2 alpha proxies should be imported in primary" {
+  retry_long assert_service_has_imported primary s2 primary-to-alpha
+  [ "$status" -eq 0 ]
 }
 
 @test "acceptor gateway-primary should have healthy endpoints for primary servers" {

--- a/test/integration/connect/envoy/case-cross-peers-http-router/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cross-peers-http-router/primary/verify.bats
@@ -35,7 +35,7 @@ load helpers
 }
 
 @test "peer the two clusters together" {
-  create_peering primary alpha
+  retry_default create_peering primary alpha
 }
 
 @test "s2 alpha proxies should be healthy in primary" {

--- a/test/integration/connect/envoy/case-cross-peers-http/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cross-peers-http/primary/verify.bats
@@ -31,7 +31,7 @@ load helpers
 }
 
 @test "peer the two clusters together" {
-  create_peering primary alpha
+  retry_default create_peering primary alpha
 }
 
 @test "s2 alpha proxies should be healthy in primary" {

--- a/test/integration/connect/envoy/case-cross-peers-resolver-redirect-tcp/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cross-peers-resolver-redirect-tcp/primary/verify.bats
@@ -31,7 +31,7 @@ load helpers
 }
 
 @test "peer the two clusters together" {
-  create_peering primary alpha
+  retry_default create_peering primary alpha
 }
 
 @test "s2 alpha proxies should be healthy in primary" {

--- a/test/integration/connect/envoy/case-cross-peers/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cross-peers/primary/verify.bats
@@ -31,7 +31,7 @@ load helpers
 }
 
 @test "peer the two clusters together" {
-  create_peering primary alpha
+  retry_default create_peering primary alpha
 }
 
 @test "s2 alpha proxies should be healthy in primary" {

--- a/test/integration/connect/envoy/case-ingress-gateway-peering-failover/primary/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-peering-failover/primary/verify.bats
@@ -23,7 +23,7 @@ load helpers
 }
 
 @test "peer the two clusters together" {
-  create_peering primary alpha
+  retry_default create_peering primary alpha
 }
 
 @test "s2 alpha proxies should be healthy in primary" {
@@ -36,7 +36,6 @@ load helpers
   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 failover-target~s2.default.primary.internal HEALTHY 1
   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 failover-target~s2.default.primary-to-alpha.external HEALTHY 1
 }
-
 
 @test "ingress-gateway should be able to connect to s2" {
   assert_expected_fortio_name s2 127.0.0.1 10000
@@ -53,7 +52,6 @@ load helpers
 @test "s2 proxies should be unhealthy in primary" {
   assert_service_has_healthy_instances s2 0 primary
 }
-
 
 @test "s1 upstream should have healthy endpoints for s2 in the failover cluster peer" {
   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 failover-target~s2.default.primary.internal UNHEALTHY 1

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -957,7 +957,7 @@ function assert_service_has_imported {
 
   echo "$output" | jq --raw-output '.StreamStatus.ImportedServices' | grep -e "${SERVICE_NAME}"
   if [ $? -ne 0 ]; then
-    echo "Error found serivce: ${SERVICE_NAME}"
+    echo "Error finding service: ${SERVICE_NAME}"
     return 1
   fi
 }

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -940,7 +940,11 @@ function create_peering {
   sleep 1
   run curl -s -f "http://consul-${GENERATE_PEER}-client:8500/v1/peering/${GENERATE_PEER}-to-${ESTABLISH_PEER}"
   state="$(echo "$output" | jq --raw-output .State)"
-  [ "$state" == "ACTIVE" ]
+
+  if [ "$state" != "ACTIVE" ]; then
+    echo "fail to peering: $output"
+    return 1
+  fi
 }
 
 function assert_service_has_imported {


### PR DESCRIPTION
### Description
This PR adds additional steps to the flaky test case (_case-cfg-splitter-peering-ingress-gateways_) to help troubleshoot an failed run.

The two added assertions:
1. Verify the peering state is _ACTIVE_ and retry peering
2. Read the peering to make sure service is imported

**Analysis**

This flaky test failed at 

```
not ok 7 s1 alpha proxies should be healthy in primary
# (from function `assert_service_has_healthy_instances' in file /workdir/primary/bats/helpers.bash, line 492,
#  in test file /workdir/primary/bats/verify.bats, line 33)
#   `assert_service_has_healthy_instances s1 1 primary "" "" primary-to-alpha' failed
not ok 8 s2 alpha proxies should be healthy in primary
```

This PR reveals that the peering state is _PENDING_, even after retry:
```
not ok 6 peer the two clusters together
not ok 7 s1, s2 alpha proxies should be imported to primary
```

Log from alpha the dialing cluster:

```
2022-12-07T06:02:18.353Z [TRACE] agent: [core][Channel #1009] Resolver state updated: {
  "Addresses": [
    {
      "Addr": "172.28.0.2:8503",
      "ServerName": "",
      "Attributes": null,
      "BalancerAttributes": null,
      "Type": 0,
      "Metadata": null
    }
  ],
  "ServiceConfig": null,
  "Attributes": null
} (resolver returned new addresses)
2022-12-07T06:02:18.353Z [TRACE] agent: [core][Channel #1009] Channel switches to new LB policy "pick_first"
2022-12-07T06:02:18.353Z [TRACE] agent: [core][Channel #1009 SubChannel #1010] Subchannel created
2022-12-07T06:02:18.354Z [TRACE] agent: [core]blockingPicker: the picked transport is not ready, loop back to repick
2022-12-07T06:02:18.354Z [TRACE] agent: [core][Channel #1009 SubChannel #1010] Subchannel Connectivity change to CONNECTING
2022-12-07T06:02:18.354Z [TRACE] agent: [core][Channel #1009 SubChannel #1010] Subchannel picks a new address "172.28.0.2:8503" to connect
2022-12-07T06:02:18.354Z [TRACE] agent: [core][Channel #1009] Channel Connectivity change to CONNECTING
2022-12-07T06:02:18.358Z [WARN]  agent: [core][Channel #1009 SubChannel #1010] grpc: addrConn.createTransport failed to connect to {
  "Addr": "172.28.0.2:8503",
  "ServerName": "server.primary.peering.e0aaa25e-716e-a206-955e-6490ebd07dab.consul",
  "Attributes": null,
  "BalancerAttributes": null,
  "Type": 0,
  "Metadata": null
}. Err: connection error: desc = "transport: authentication handshake failed: remote error: tls: unrecognized name"
2022-12-07T06:02:18.358Z [TRACE] agent: [core][Channel #1009 SubChannel #1010] Subchannel Connectivity change to TRANSIENT_FAILURE
2022-12-07T06:02:18.358Z [TRACE] agent: [core][Channel #1009] Channel Connectivity change to TRANSIENT_FAILURE
2022-12-07T06:02:18.364Z [TRACE] agent.server: rpc_server_call: method=Status.RaftStats errored=false request_type=read rpc_type=net/rpc leader=true
```

Log from primary the acceptor cluster:

```
==> Starting Consul agent...
              Version: '1.15.0-dev'
             Revision: '06880bd51+CHANGES'
           Build Date: '2022-12-01 17:30:29 +0000 UTC'
              Node ID: 'c06de924-df0d-7d30-5435-cf19679e5660'
            Node name: 'consul-primary-server'
           Datacenter: 'primary' (Segment: '<all>')
               Server: true (Bootstrap: false)
          Client Addr: [0.0.0.0] (HTTP: 8500, HTTPS: -1, gRPC: 8502, gRPC-TLS: 8503, DNS: 8600)
         Cluster Addr: 192.168.144.2 (LAN: 8301, WAN: 8302)
    Gossip Encryption: false
     Auto-Encrypt-TLS: false
            HTTPS TLS: Verify Incoming: false, Verify Outgoing: false, Min Version: TLSv1_2
             gRPC TLS: Verify Incoming: false, Min Version: TLSv1_2
     Internal RPC TLS: Verify Incoming: false, Verify Outgoing: false (Verify Hostname: false), Min Version: TLSv1_2

==> Log data will now stream in as it occurs:

2022-12-05T04:53:02.726Z [INFO]  agent.server.raft: initial configuration: index=1 servers="[{Suffrage:Voter ID:c06de924-df0d-7d30-5435-cf19679e5660 Address:192.168.144.2:8300}]"
2022-12-05T04:53:02.729Z [INFO]  agent.server.raft: entering follower state: follower="Node at 192.168.144.2:8300 [Follower]" leader-address= leader-id=
2022-12-05T04:53:02.744Z [INFO]  agent.server.serf.wan: serf: EventMemberJoin: consul-primary-server.primary 192.168.144.2
2022-12-05T04:53:02.749Z [INFO]  agent.server.serf.lan: serf: EventMemberJoin: consul-primary-server 192.168.144.2
2022-12-05T04:53:02.749Z [INFO]  agent.router: Initializing LAN area manager
2022-12-05T04:53:02.756Z [INFO]  agent.server: Adding LAN server: server="consul-primary-server (Addr: tcp/192.168.144.2:8300) (DC: primary)"
2022-12-05T04:53:02.766Z [INFO]  agent.server: Handled event for server in area: event=member-join server=consul-primary-server.primary area=wan
2022-12-05T04:53:02.773Z [INFO]  agent.server.autopilot: reconciliation now disabled
2022-12-05T04:53:02.776Z [WARN]  agent: [core][Channel #1 SubChannel #3] grpc: addrConn.createTransport failed to connect to {
  "Addr": "primary-192.168.144.2:8300",
  "ServerName": "consul-primary-server",
  "Attributes": null,
  "BalancerAttributes": null,
  "Type": 0,
  "Metadata": null
}. Err: connection error: desc = "transport: Error while dialing dial tcp <nil>->192.168.144.2:8300: operation was canceled"
2022-12-05T04:53:02.783Z [WARN]  agent.server.raft: heartbeat timeout reached, starting election: last-leader-addr= last-leader-id=
2022-12-05T04:53:02.785Z [INFO]  agent.server.raft: entering candidate state: node="Node at 192.168.144.2:8300 [Candidate]" term=2
2022-12-05T04:53:02.788Z [DEBUG] agent.server.raft: voting for self: term=2 id=c06de924-df0d-7d30-5435-cf19679e5660
```

More logs from primary the acceptor cluster:
```
2022-12-07T16:26:01.726Z [WARN]  agent.cache: handling error in Cache.Notify: cache-type=connect-ca-leaf error="CA is uninitialized and unable to sign certificates yet: no root certificate" index=0
2022-12-07T16:26:01.727Z [DEBUG] agent.server.cert-manager: got cache update event: correlationID=leaf error="CA is uninitialized and unable to sign certificates yet: no root certificate"
2022-12-07T16:26:01.729Z [ERROR] agent.server.cert-manager: failed to handle cache update event: error="leaf cert watch returned an error: CA is uninitialized and unable to sign certificates yet: no root certificate"
2022-12-07T16:26:01.751Z [DEBUG] agent.server.xds_capacity_controller: updating drain rate limit: rate_limit=1
2022-12-07T16:26:01.752Z [INFO]  agent: Synced node info


2022-12-07T16:26:38.819Z [WARN]  agent.grpc-api.peering: did not find peer in stream tracker; cannot populate imported and exported services count or reconcile peering state: peerID=513c6398-b809-accb-2868-0e96fe247fd6
2022-12-07T16:26:44.670Z [WARN]  agent.grpc-api.peering: did not find peer in stream tracker; cannot populate imported and exported services count or reconcile peering state: peerID=513c6398-b809-accb-2868-0e96fe247fd6
2022-12-07T16:26:46.624Z [DEBUG] agent.server.memberlist.lan: memberlist: Stream connection from=172.19.0.3:50888
2022-12-07T16:26:50.581Z [WARN]  agent.grpc-api.peering: did not find peer in stream tracker; cannot populate imported and exported services count or reconcile peering state: peerID=513c6398-b809-accb-2868-0e96fe247fd6
2022-12-07T16:26:56.382Z [WARN]  agent.grpc-api.peering: did not find peer in stream tracker; cannot populate imported and exported services count or reconcile peering state: peerID=513c6398-b809-accb-2868-0e96fe247fd6

```

### Testing & Reproduction steps
Run the test case case-cfg-splitter-peering-ingress-gateways for > 30 times and it will fail once or twice.

### Links
[From circle CI test insight](https://app.circleci.com/insights/github/hashicorp/consul/workflows/test-integrations/tests?branch=integ-test-upgrade-test):

<img width="988" alt="Screen Shot 2022-12-07 at 10 30 07 AM" src="https://user-images.githubusercontent.com/463631/206220995-f51d36e1-27a5-4a43-9c16-eeda26408f66.png">


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
