### PR TITLE
added link to admin partitions under K8s SM

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -960,6 +960,10 @@
             "path": "k8s/connect"
           },
           {
+            "title": "Admin Partitions",
+            "href": "/docs/enterprise/admin-partitions"
+          },
+          {
             "title": "Transparent Proxy",
             "href": "/docs/connect/transparent-proxy"
           },


### PR DESCRIPTION
### Description
This PR adds a link to the admin partitions documentation in the Kubernetes > Service Mesh chapter. The purpose is to make navigation to the AP docs easier for users who are already aware that AP is primarily a feature for K8s. 

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
