### PR TITLE
docs: Fix go-sockaddr links

### DIFF
--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -2220,3 +2220,7 @@ server.
     The default value is `250`. It is based on a load test of 5,000 streams connected to a single server with two CPU cores.
 
     If necessary, you can lower or increase the limit without a rolling restart by using the `consul reload` command or by sending the server a `SIGHUP`.
+
+<!-- list of reference-style links -->
+
+[go-sockaddr]: https://godoc.org/github.com/hashicorp/go-sockaddr/template


### PR DESCRIPTION
### Description

This fixes go-sockaddr links in the [agent configuration reference page](https://developer.hashicorp.com/consul/docs/agent/config/config-files#addresses), which was causing a literal `[go-sockaddr]` to render in the html:

<img width="854" alt="Screen Shot 2022-12-07 at 4 42 18 PM" src="https://user-images.githubusercontent.com/1077740/206316560-28df94ac-7442-4ff7-b830-4bad218b675b.png">

This issue was present in the `1.12.x`, `1.13.x`, and `1.14.x (latest)` versions of docs, so I've backported the change to those branches. (I did not see this issue in `1.11.x` or prior versions).

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
