### PR TITLE
test: fix flaky TestStreamResources_Server_DisconnectsOnHeartbeatTimeout test

### DIFF
--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -316,7 +316,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 	logger := s.Logger.Named("stream").
 		With("peer_name", streamReq.PeerName).
 		With("peer_id", streamReq.LocalID).
-		With("dailer", !streamReq.IsAcceptor())
+		With("dialer", !streamReq.IsAcceptor())
 	logger.Trace("handling stream for peer")
 
 	// handleStreamCtx is local to this function.

--- a/agent/grpc-external/services/peerstream/stream_tracker.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker.go
@@ -156,7 +156,7 @@ func (t *Tracker) IsHealthy(s Status) bool {
 	// If last Nack is after last Ack, it means the peer is unable to
 	// handle our replication message
 	if s.LastAck == nil {
-		s.LastAck = &time.Time{}
+		s.LastAck = nil
 	}
 
 	if s.LastNack != nil &&
@@ -168,7 +168,7 @@ func (t *Tracker) IsHealthy(s Status) bool {
 	// If last recv error is newer than last recv success, we were unable
 	// to handle the peer's replication message.
 	if s.LastRecvResourceSuccess == nil {
-		s.LastRecvResourceSuccess = &time.Time{}
+		s.LastRecvResourceSuccess = nil
 	}
 
 	if s.LastRecvError != nil &&
@@ -321,7 +321,7 @@ func (s *MutableStatus) TrackNack(msg string) {
 func (s *MutableStatus) TrackConnected() {
 	s.mu.Lock()
 	s.Connected = true
-	s.DisconnectTime = &time.Time{}
+	s.DisconnectTime = nil
 	s.DisconnectErrorMessage = ""
 	s.mu.Unlock()
 }

--- a/agent/grpc-external/services/peerstream/stream_tracker_test.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker_test.go
@@ -186,7 +186,7 @@ func TestTracker_EnsureConnectedDisconnected(t *testing.T) {
 		expect := Status{
 			Connected:      true,
 			LastAck:        lastSuccess,
-			DisconnectTime: &time.Time{},
+			DisconnectTime: nil,
 			// DisconnectTime gets cleared on re-connect.
 		}
 
@@ -279,7 +279,7 @@ func TestMutableStatus_TrackConnected(t *testing.T) {
 
 	require.True(t, s.IsConnected())
 	require.True(t, s.Connected)
-	require.Equal(t, &time.Time{}, s.DisconnectTime)
+	require.Nil(t, s.DisconnectTime)
 	require.Empty(t, s.DisconnectErrorMessage)
 }
 

--- a/agent/grpc-external/services/peerstream/testing.go
+++ b/agent/grpc-external/services/peerstream/testing.go
@@ -52,7 +52,7 @@ func NewMockClient(ctx context.Context) *MockClient {
 }
 
 // DrainStream reads messages from the stream until both the exported service list and
-// trust bundle messages have been read. We do this because their ording is indeterministic.
+// trust bundle messages have been read. We do this because their ordering is indeterministic.
 func (c *MockClient) DrainStream(t *testing.T) {
 	seen := make(map[string]struct{})
 	for len(seen) < 2 {


### PR DESCRIPTION
### Description

This test previously was destined for flakiness given how time was used in the comparison. Now it is a little looser in the expectation so it should be far less likely to flake.

Additional changes:
- fixed typo in logging key
- (controversial?) when clearing a `*time.Time` value `nil` is now used instead of `&time.Time{}`. The code and test logic seemed to already be handling `nil` times specially so I switched it back which simplifies some things.