### PR TITLE
Remove mention of enterprise license form

### DIFF
--- a/website/content/docs/enterprise/index.mdx
+++ b/website/content/docs/enterprise/index.mdx
@@ -59,8 +59,7 @@ To access Consul Enterprise in a self-managed installation,
 [apply a purchased license](/docs/enterprise/license/overview)
 to the Consul Enterprise binary that grants access to the desired features.
 
-You can also try out Consul Enterprise before purchasing by
-[requesting a 30-day trial license](https://www.hashicorp.com/products/consul/trial).
+Contact your [HashiCorp Support contact](https://support.hashicorp.com/) for a development license.
 
 ## Consul Enterprise Feature Availability
 

--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -99,7 +99,7 @@ Consul snapshot agents will attempt to retrieve the license from servers if cert
 
 ## Q: Where can users get a trial license for Consul Enterprise?
 
-Visit [consul.io/trial](https://www.hashicorp.com/products/consul/trial) for a free 30-day trial license.
+Contact your [HashiCorp Support contact](https://support.hashicorp.com/) for a development license.
 
 ~> **Trial install will cease operation 24 hours after 30-day license expiration**:
    Trial licenses are not meant to be used in production.


### PR DESCRIPTION
### Description
The license form is no longer available so this recommends contacting a support representative instead.

### PR Checklist

* [x] external facing docs updated
* [x] not a security concern
