### PR TITLE
Fix DialedDirectly configuration for Consul dataplane.

### DIFF
--- a/.changelog/15760.txt
+++ b/.changelog/15760.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fix issue where DialedDirectly configuration was not used by Consul Dataplane.
+```

--- a/agent/consul/discoverychain/compile.go
+++ b/agent/consul/discoverychain/compile.go
@@ -1007,15 +1007,15 @@ RESOLVE_AGAIN:
 		// Default mesh gateway settings
 		if serviceDefault := c.entries.GetService(targetID); serviceDefault != nil {
 			target.MeshGateway = serviceDefault.MeshGateway
-			target.TransparentProxy = serviceDefault.TransparentProxy
+			target.TransparentProxy.DialedDirectly = serviceDefault.TransparentProxy.DialedDirectly
 		}
 		proxyDefault := c.entries.GetProxyDefaults(targetID.PartitionOrDefault())
 		if proxyDefault != nil {
 			if target.MeshGateway.Mode == structs.MeshGatewayModeDefault {
 				target.MeshGateway.Mode = proxyDefault.MeshGateway.Mode
 			}
-			if target.TransparentProxy.IsZero() {
-				target.TransparentProxy = proxyDefault.TransparentProxy
+			if !target.TransparentProxy.DialedDirectly {
+				target.TransparentProxy.DialedDirectly = proxyDefault.TransparentProxy.DialedDirectly
 			}
 		}
 

--- a/agent/consul/discoverychain/compile.go
+++ b/agent/consul/discoverychain/compile.go
@@ -1007,10 +1007,16 @@ RESOLVE_AGAIN:
 		// Default mesh gateway settings
 		if serviceDefault := c.entries.GetService(targetID); serviceDefault != nil {
 			target.MeshGateway = serviceDefault.MeshGateway
+			target.TransparentProxy = serviceDefault.TransparentProxy
 		}
 		proxyDefault := c.entries.GetProxyDefaults(targetID.PartitionOrDefault())
-		if proxyDefault != nil && target.MeshGateway.Mode == structs.MeshGatewayModeDefault {
-			target.MeshGateway.Mode = proxyDefault.MeshGateway.Mode
+		if proxyDefault != nil {
+			if target.MeshGateway.Mode == structs.MeshGatewayModeDefault {
+				target.MeshGateway.Mode = proxyDefault.MeshGateway.Mode
+			}
+			if target.TransparentProxy.IsZero() {
+				target.TransparentProxy = proxyDefault.TransparentProxy
+			}
 		}
 
 		if c.overrideMeshGateway.Mode != structs.MeshGatewayModeDefault {

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -2359,7 +2359,16 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						{
 							CorrelationID: "discovery-chain:" + dbUID.String(),
 							Result: &structs.DiscoveryChainResponse{
-								Chain: discoverychain.TestCompileConfigEntries(t, "db", "default", "default", "dc1", "trustdomain.consul", nil),
+								Chain: discoverychain.TestCompileConfigEntries(
+									t, "db", "default", "default", "dc1", "trustdomain.consul", nil,
+									&structs.ServiceConfigEntry{
+										Kind: structs.ServiceDefaults,
+										Name: "db",
+										TransparentProxy: structs.TransparentProxyConfig{
+											DialedDirectly: true,
+										},
+									},
+								),
 							},
 							Err: nil,
 						},
@@ -2396,7 +2405,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 											Proxy: structs.ConnectProxyConfig{
 												DestinationServiceName: "db",
 												TransparentProxy: structs.TransparentProxyConfig{
-													DialedDirectly: true,
+													DialedDirectly: false, // This is set true by the service-defaults entry above.
 												},
 											},
 											RaftIndex: structs.RaftIndex{
@@ -2455,7 +2464,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 										Proxy: structs.ConnectProxyConfig{
 											DestinationServiceName: "db",
 											TransparentProxy: structs.TransparentProxyConfig{
-												DialedDirectly: true,
+												DialedDirectly: false,
 											},
 										},
 										RaftIndex: structs.RaftIndex{

--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -190,10 +190,12 @@ func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u UpdateEv
 			upstreamsSnapshot.PassthroughIndices[addr] = indexedTarget{idx: csnIdx, upstreamID: uid, targetID: targetID}
 			passthroughs[addr] = struct{}{}
 		}
+		// Always clear out the existing target passthroughs list so that clusters are cleaned up
+		// correctly if no entries are populated.
+		upstreamsSnapshot.PassthroughUpstreams[uid] = make(map[string]map[string]struct{})
 		if len(passthroughs) > 0 {
-			upstreamsSnapshot.PassthroughUpstreams[uid] = map[string]map[string]struct{}{
-				targetID: passthroughs,
-			}
+			// Add the passthroughs to the target if any were found.
+			upstreamsSnapshot.PassthroughUpstreams[uid][targetID] = passthroughs
 		}
 
 	case strings.HasPrefix(u.CorrelationID, "mesh-gateway:"):

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -192,8 +192,9 @@ type DiscoveryTarget struct {
 	Datacenter    string `json:",omitempty"`
 	Peer          string `json:",omitempty"`
 
-	MeshGateway MeshGatewayConfig     `json:",omitempty"`
-	Subset      ServiceResolverSubset `json:",omitempty"`
+	MeshGateway      MeshGatewayConfig      `json:",omitempty"`
+	Subset           ServiceResolverSubset  `json:",omitempty"`
+	TransparentProxy TransparentProxyConfig `json:",omitempty"`
 
 	ConnectTimeout time.Duration `json:",omitempty"`
 


### PR DESCRIPTION
The `DialedDirectly` configuration on upstreams is ignored by Consul Dataplane, because it selects data through the streaming backend which does not support the `MergeCentralConfig` flag. This means that any service-defaults or proxy-defaults configurations on upstreams were ignored.

This PR adds the `DialedDirectly` config into the compiled discovery chain targets, so that the "merged" version is available to the proxy config.

This PR also fixes an existing issue where passthrough clusters were not properly cleaned up whenever the `DialedDirectly` field is toggled on and off during runtime.