### PR TITLE
agent: Fix assignment of error when auto-reloading cert and key file changes.

### DIFF
--- a/.changelog/15769.txt
+++ b/.changelog/15769.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fix assignment of error when auto-reloading cert and key file changes.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/consul/proto/pboperator"
 	"io"
 	"net"
 	"net/http"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/hashicorp/consul/proto/pboperator"
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
@@ -4026,13 +4027,13 @@ func (a *Agent) reloadConfig(autoReload bool) error {
 			{a.config.TLS.HTTPS, newCfg.TLS.HTTPS},
 		} {
 			if f.oldCfg.KeyFile != f.newCfg.KeyFile {
-				a.configFileWatcher.Replace(f.oldCfg.KeyFile, f.newCfg.KeyFile)
+				err = a.configFileWatcher.Replace(f.oldCfg.KeyFile, f.newCfg.KeyFile)
 				if err != nil {
 					return err
 				}
 			}
 			if f.oldCfg.CertFile != f.newCfg.CertFile {
-				a.configFileWatcher.Replace(f.oldCfg.CertFile, f.newCfg.CertFile)
+				err = a.configFileWatcher.Replace(f.oldCfg.CertFile, f.newCfg.CertFile)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
### Description
For both the key and cert file watcher code, a call to `a.configFileWatcher.Replace()` is made but the error returned from this called is not used...but a check is right below it like this:
```
				a.configFileWatcher.Replace(f.oldCfg.KeyFile, f.newCfg.KeyFile)
				if err != nil {
					return err
				}
```
This seems to be an omission rather than strategic.  In its current case, this will either check on a previous error, or will never get triggered because a previous check would have exited.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
