### PR TITLE
Update changelog checker to handle ent-only entry

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -29,12 +29,12 @@ jobs:
           # for PRs against the main branch, the changelog file name should match the PR number
           if [ "${{ github.event.pull_request.base.ref }}" = "${{ github.event.repository.default_branch }}" ]; then
             enforce_matching_pull_request_number="matching this PR number "
-            changelog_file_path=".changelog/${{ github.event.pull_request.number }}.txt"
+            changelog_file_path=".changelog/(_)?${{ github.event.pull_request.number }}.txt"
           else
-            changelog_file_path=".changelog/*.txt"
+            changelog_file_path=".changelog/[_0-9]*.txt"
           fi
 
-          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/main")" -- ${changelog_file_path})
+          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/main")" | egrep ${changelog_file_path})
 
           # If we do not find a file in .changelog/, we fail the check
           if [ -z "$changelog_files" ]; then


### PR DESCRIPTION
### Description
Currently the changelog checker workflow doesn't account for enterprise-only changelog entries where we prefix the filename with an underscore, because there's no public PR to link to.

This PR updates how we check for the existence of a changelog entry by considering a `_` prefix as valid in enterprise. 

Note that this only helps the check pass in enterprise. The changelog checker workflow will still fail in OSS when it encounters a changelog entry for an enterprise-only PR because the number of the file won't match the OSS PR number. 

### Testing & Reproduction steps
* Tested manually with and without an underscore in enterprise