### PR TITLE
Fix curl vs curl-minimal install conflict in ubi9 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -233,7 +233,7 @@ COPY LICENSE /licenses/mozilla.txt
 # Its shasum is hardcoded. If you upgrade the dumb-init verion you'll need to
 # also update the shasum.
 RUN set -eux && \
-    microdnf install -y ca-certificates curl gnupg libcap openssl iputils jq iptables wget unzip tar && \
+    microdnf install -y ca-certificates gnupg libcap openssl iputils jq iptables wget unzip tar && \
     wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 && \
     echo 'e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df /usr/bin/dumb-init' > dumb-init-shasum && \
     sha256sum --check dumb-init-shasum && \


### PR DESCRIPTION
ubi9 already has curl-minimal installed. Attempting to install curl results in a microdnf conflict and errors out.

Fixes https://github.com/hashicorp/consul-enterprise/actions/runs/3705700950/jobs/6280228266

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern