### PR TITLE
Force installation of shadow-utils for access to groupadd exe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -233,7 +233,7 @@ COPY LICENSE /licenses/mozilla.txt
 # Its shasum is hardcoded. If you upgrade the dumb-init verion you'll need to
 # also update the shasum.
 RUN set -eux && \
-    microdnf install -y ca-certificates gnupg libcap openssl iputils jq iptables wget unzip tar && \
+    microdnf install -y ca-certificates shadow-utils gnupg libcap openssl iputils jq iptables wget unzip tar && \
     wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 && \
     echo 'e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df /usr/bin/dumb-init' > dumb-init-shasum && \
     sha256sum --check dumb-init-shasum && \


### PR DESCRIPTION
Removing curl inadvertently dropped the transitive dependency on shadow-utils which is required for teh groupadd executable. Since curl-minimal does not have this dependency, make it explicit as part of the `microdnf install`.

Fixes issue introduced in [PR #15808](https://github.com/hashicorp/consul/pull/15808)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
