### PR TITLE
JIRA: Small fix to search plugin for JIRA issues

### DIFF
--- a/.github/workflows/jira-pr.yaml
+++ b/.github/workflows/jira-pr.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set ticket type
         id: set-ticket-type
         run: |
-          echo "TYPE=Github Issue" >> $GITHUB_OUTPUT
+          echo "TYPE=GH Issue" >> $GITHUB_OUTPUT
           
       - name: Set ticket labels
         if: github.event.action == 'opened'


### PR DESCRIPTION
### Description
Fix for following error, should be `GH Issue`

```
2022/12/15 18:55:33 API call GET /rest/api/3/search failed (400): {"errorMessages":["The value 'Github Issue' does not exist for the field 'issuetype'."],"warningMessages":[]}
```

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
