### PR TITLE
Enhancement: Consul Compatibility Checking

### DIFF
--- a/.changelog/15818.txt
+++ b/.changelog/15818.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+connect: for early awareness of Envoy incompatibilities, when using the `consul connect envoy` command the Envoy version will now be checked for compatibility. If incompatible Consul will error and exit.
+```
+```release-note:breaking-change
+connect: Consul will now error and exit when using the `consul connect envoy` command if the Envoy version is incompatible. To ignore this check use flag `--ignore-envoy-compatibility`
+```

--- a/agent/xds/envoy_versioning.go
+++ b/agent/xds/envoy_versioning.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 
 	"github.com/hashicorp/go-version"
 )
@@ -11,7 +12,7 @@ import (
 var (
 	// minSupportedVersion is the oldest mainline version we support. This should always be
 	// the zero'th point release of the last element of proxysupport.EnvoyVersions.
-	minSupportedVersion = version.Must(version.NewVersion("1.21.0"))
+	minSupportedVersion = version.Must(version.NewVersion(proxysupport.GetMinEnvoyMinorVersion()))
 
 	specificUnsupportedVersions = []unsupportedVersion{}
 )

--- a/agent/xds/envoy_versioning_test.go
+++ b/agent/xds/envoy_versioning_test.go
@@ -68,7 +68,6 @@ func TestDetermineEnvoyVersionFromNode(t *testing.T) {
 
 func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 	const (
-		err1_13   = "is too old of a point release and is not supported by Consul because it does not support RBAC rules using url_path. Please upgrade to version 1.13.1+."
 		errTooOld = "is too old and is not supported by Consul"
 	)
 

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -1,5 +1,7 @@
 package proxysupport
 
+import "strings"
+
 // EnvoyVersions lists the latest officially supported versions of envoy.
 //
 // This list must be sorted by semver descending. Only one point release for
@@ -11,4 +13,29 @@ var EnvoyVersions = []string{
 	"1.23.2",
 	"1.22.5",
 	"1.21.5",
+}
+
+// UnsupportedEnvoyVersions lists any unsupported Envoy versions (mainly minor versions) that fall
+// within the range of EnvoyVersions above.
+// For example, if patch 1.21.3 (patch 3) had a breaking change, and was not supported
+// even though 1.21 is a supported major release, you would then add 1.21.3 to this list.
+// This list will be empty in most cases.
+//
+// see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
+var UnsupportedEnvoyVersions = []string{}
+
+// GetMaxEnvoyMinorVersion grabs the first value in EnvoyVersions and strips the patch number off in order
+// to return the maximum supported Envoy minor version
+// For example, if the input string is "1.14.1", the function would return "1.14".
+func GetMaxEnvoyMinorVersion() string {
+	s := strings.Split(EnvoyVersions[0], ".")
+	return s[0] + "." + s[1]
+}
+
+// GetMinEnvoyMinorVersion grabs the last value in EnvoyVersions and strips the patch number off in order
+// to return the minimum supported Envoy minor version
+// For example, if the input string is "1.12.1", the function would return "1.12".
+func GetMinEnvoyMinorVersion() string {
+	s := strings.Split(EnvoyVersions[len(EnvoyVersions)-1], ".")
+	return s[0] + "." + s[1]
 }

--- a/agent/xds/proxysupport/proxysupport_test.go
+++ b/agent/xds/proxysupport/proxysupport_test.go
@@ -1,0 +1,30 @@
+package proxysupport
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProxySupportOrder(t *testing.T) {
+	versions := make([]*version.Version, len(EnvoyVersions))
+	beforeSort := make([]*version.Version, len(EnvoyVersions))
+	for i, raw := range EnvoyVersions {
+		v, _ := version.NewVersion(raw)
+		versions[i] = v
+		beforeSort[i] = v
+	}
+
+	// After this, the versions are properly sorted
+	// go-version has a collection container, but it only allows for sorting in ascending order
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[j].LessThan(versions[i])
+	})
+
+	// Check that we already have a sorted list
+	for i := range EnvoyVersions {
+		assert.True(t, versions[i].Equal(beforeSort[i]))
+	}
+}

--- a/command/connect/envoy/exec.go
+++ b/command/connect/envoy/exec.go
@@ -1,0 +1,44 @@
+package envoy
+
+import (
+	"errors"
+	"os/exec"
+	"regexp"
+)
+
+const (
+	envoyVersionFlag = "--version"
+)
+
+// execCommand lets us mock out the exec.Command function
+var execCommand = exec.Command
+
+func execEnvoyVersion(binary string) (string, error) {
+	cmd := execCommand(binary, envoyVersionFlag)
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	version, err := parseEnvoyVersionNumber(string(output))
+	if err != nil {
+		return "", err
+	}
+	return version, nil
+}
+
+func parseEnvoyVersionNumber(fullVersion string) (string, error) {
+	// Use a regular expression to match the major.minor.patch version string in the fullVersion
+	// Example input:
+	// `envoy  version: 69958e4fe32da561376d8b1d367b5e6942dfba24/1.24.1/Distribution/RELEASE/BoringSSL`
+	re := regexp.MustCompile(`(\d+\.\d+\.\d+)`)
+	matches := re.FindStringSubmatch(fullVersion)
+
+	// If no matches were found, return an error
+	if len(matches) == 0 {
+		return "", errors.New("unable to parse Envoy version from output")
+	}
+
+	// Return the first match (the major.minor.patch version string)
+	return matches[0], nil
+}

--- a/command/connect/envoy/exec_test.go
+++ b/command/connect/envoy/exec_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -131,6 +132,79 @@ func TestExecEnvoy(t *testing.T) {
 			require.Regexp(t, `-bootstrap.json$`, got.ConfigPath)
 		})
 	}
+}
+
+func TestExecEnvoyVersion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	tests := []struct {
+		name           string
+		cmdOutput      string
+		expectedOutput string
+	}{
+		{
+			name:           "actual-version-output-1-24-1",
+			cmdOutput:      `envoy  version: 69958e4fe32da561376d8b1d367b5e6942dfba24/1.24.1/Distribution/RELEASE/BoringSSL`,
+			expectedOutput: "1.24.1",
+		},
+		{
+			name:           "format-change",
+			cmdOutput:      `envoy  version: (69958e4fe32da561376d8b1d367b5e6942dfba24)__(1.24.1)/Distribution/RELEASE/BoringSSL`,
+			expectedOutput: "1.24.1",
+		},
+		{
+			name:           "zeroes",
+			cmdOutput:      `envoy  version: 69958e4fe32da561376d8b1d367b5e6942dfba24/0.0.0/Distribution/RELEASE/BoringSSL`,
+			expectedOutput: "0.0.0",
+		},
+		{
+			name:           "test-multi-digit",
+			cmdOutput:      `envoy  version: 69958e4fe32da561376d8b1d367b5e6942dfba24/1246390.9401081.1238495/Distribution/RELEASE/BoringSSL`,
+			expectedOutput: "1246390.9401081.1238495",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fe := fakeEnvoy{
+				desiredOutput: tc.cmdOutput,
+			}
+			execCommand = fe.ExecCommand
+			// Reset back to base exec.Command
+			defer func() { execCommand = exec.Command }()
+			version, err := execEnvoyVersion("fake-envoy")
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedOutput, version)
+		})
+	}
+}
+
+type fakeEnvoy struct {
+	desiredOutput string
+}
+
+func (fe fakeEnvoy) ExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestEnvoyExecHelperProcess", "--", command}
+	cs = append(cs, args...)
+	// last argument will be the output
+	cs = append(cs, fe.desiredOutput)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+func TestEnvoyExecHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	output := os.Args[len(os.Args)-1]
+	fmt.Fprint(os.Stdout, output)
+	os.Exit(0)
 }
 
 type FakeEnvoyExecData struct {

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -104,6 +104,10 @@ Usage: `consul connect envoy [options] [-- pass-through options]`
   TLS on the Prometheus metrics endpoint. Only applicable when `envoy_prometheus_bind_addr`
   is set in proxy config.
 
+- `-ignore-envoy-compatibility` - If set to `true`, this flag ignores the Envoy version
+compatibility check. We recommend setting this flag to `false` to ensure
+compatibility with Envoy and prevent potential issues. Default is `false`.
+
 - `-- [pass-through options]` - Any options given after a double dash are passed
   directly through to the `envoy` invocation. See [Envoy's
   documentation](https://www.envoyproxy.io/docs) for more details. The command


### PR DESCRIPTION
### Description
Note: **docs team see last commit for docs change**

This PR introduces an enhancement to enable users to detect incompatible versions of Envoy early. This PR was motivated by issue [#13131](https://github.com/hashicorp/consul/issues/13131).

With the addition of these code changes, when using the `consul connect envoy` command the version of envoy being connected to is compared against the supported versions coded into the Consul binary. If the version of Envoy is deemed to be incompatible, then an error will be logged and the service will exit. 

Since this is a potentially breaking change, and there may be reasons that a user is using a version of Consul that we don't recognize as compatible (such as custom builds of Envoy), a flag has also been added to disable the check: `--ignore-envoy-compatibility`. By default this flag will be set to `false` and we will perform the check and error out as necessary.

Example: `consul connect envoy -admin-bind=0.0.0.0:19000 -sidecar-for=svc1 --ignore-envoy-compatibility`

#### How do we determine compatibility?
Compatibility is defined in [proxysupport.go](https://github.com/hashicorp/consul/blob/1406d428ddc83215a13a1fa0a3b3a7112b00e598/agent/xds/proxysupport/proxysupport.go#LL9C5-L9C5)
```Go
var EnvoyVersions = []string{
	"1.24.0",
	"1.23.2",
	"1.22.5",
	"1.21.5",
}
```
For the above list, Consul is compatible with any version `>= 1.21.0` and `<1.25`. For example, we are compatible with `1.21.1`, `1.21.2`, etc. and anything in between up to any future patches to `1.24`.

A list of explicitly unsupported Envoy versions has also been added to `proxysupport.go` in case there is a requirement to explicitly callout patches for breaking compatibility (e.g. if 1.21.2 had a known compatibility breaking change).

#### Log Message Example
```console
dc1svc1    | Envoy version 1.18.3 is not supported. If there is a reason you need to use this version of envoy use the ignore-envoy-compatibility flag. Using an unsupported version of Envoy is not recommended and your experience may vary. For more information on compatibility see https://developer.hashicorp.com/consul/docs/connect/proxies/envoy#envoy-and-consul-client-agent
```

This resolves #13131

As always, I try to add some extra context to my commits, so that's usually the best way to go through my PRs.

### Testing & Reproduction steps
#### Manual Testing Scenarios
- **Lower Bound Test**: Tested a patch version below `1.21.5`, confirmed `no error`
- **In Between Test**: Tested a patch version between `1.21` and `1.24`, confirmed `no error`
- **Upper Bound Test**: Modified the list in `proxysupport.go` so that `1.23.1` was the top of the list, confirmed that `1.23.2` resulted in `no error`
- **Upper Out Of Bounds Test**: Modified the list in `proxysupport.go` so that `1.23.1` was the top of the list, confirmed that `1.24.0` resulted in `error` and exited
- **Lower Out Of Bounds Test**: Tested with Envoy `1.18`, confirmed that this resulted in an `error` and exited
- **Flag Testing**: Tested with `1.18` using `--ignore-envoy-compatibility` confirmed that there was `no error` for compatibility
- **Incompatibility List Testing**: added `1.21.1` to the incompatibility list, confirmed connecting to this version resulted in an `error` and exit

### Links
N/A

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
