### PR TITLE
tests: Pin api submodule to compatibile version for upgrade tests

### DIFF
--- a/test/integration/consul-container/go.mod
+++ b/test/integration/consul-container/go.mod
@@ -2,11 +2,14 @@ module github.com/hashicorp/consul/test/integration/consul-container
 
 go 1.19
 
+replace github.com/hashicorp/consul/api/v118 => github.com/hashicorp/consul/api v1.18.0
+
 require (
 	github.com/docker/docker v20.10.11+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/hashicorp/consul v1.14.1
 	github.com/hashicorp/consul/api v1.18.0
+	github.com/hashicorp/consul/api/v118 v118.0.0-00010101000000-000000000000
 	github.com/hashicorp/consul/sdk v0.13.0
 	github.com/hashicorp/serf v0.10.1
 	github.com/itchyny/gojq v0.12.9

--- a/test/integration/consul-container/go.sum
+++ b/test/integration/consul-container/go.sum
@@ -447,6 +447,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -490,6 +491,8 @@ github.com/hashicorp/consul-awsauth v0.0.0-20220713182709-05ac1c5c2706 h1:1ZEjnv
 github.com/hashicorp/consul-awsauth v0.0.0-20220713182709-05ac1c5c2706/go.mod h1:1Cs8FlmD1BfSQXJGcFLSV5FuIx1AbJP+EJGdxosoS2g=
 github.com/hashicorp/consul-net-rpc v0.0.0-20221205195236-156cfab66a69 h1:wzWurXrxfSyG1PHskIZlfuXlTSCj1Tsyatp9DtaasuY=
 github.com/hashicorp/consul-net-rpc v0.0.0-20221205195236-156cfab66a69/go.mod h1:svUZZDvotY8zTODknUePc6mZ9pX8nN0ViGwWcUSOBEA=
+github.com/hashicorp/consul/api v1.18.0 h1:R7PPNzTCeN6VuQNDwwhZWJvzCtGSrNpJqfb22h3yH9g=
+github.com/hashicorp/consul/api v1.18.0/go.mod h1:owRRGJ9M5xReDC5nfT8FTJrNAPbT4NM6p/k+d03q2v4=
 github.com/hashicorp/consul/proto-public v0.2.1 h1:9dZGW68IEuajEkaAAdXCUovVuKyccBOS0jub4Gee5II=
 github.com/hashicorp/consul/proto-public v0.2.1/go.mod h1:iWNlBDJIZQJC3bBiCThoqg9i7uk/4RQZYkqH1wiQrss=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -1192,6 +1195,7 @@ golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/test/integration/consul-container/libs/agent/agent.go
+++ b/test/integration/consul-container/libs/agent/agent.go
@@ -3,7 +3,7 @@ package agent
 import (
 	"context"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 )
 
 // Agent represent a Consul agent abstraction

--- a/test/integration/consul-container/libs/agent/container.go
+++ b/test/integration/consul-container/libs/agent/container.go
@@ -14,7 +14,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 

--- a/test/integration/consul-container/libs/assert/peering.go
+++ b/test/integration/consul-container/libs/assert/peering.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
 

--- a/test/integration/consul-container/libs/assert/service.go
+++ b/test/integration/consul-container/libs/assert/service.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
 

--- a/test/integration/consul-container/libs/cluster/cluster.go
+++ b/test/integration/consul-container/libs/cluster/cluster.go
@@ -15,7 +15,7 @@ import (
 	"github.com/teris-io/shortid"
 	"github.com/testcontainers/testcontainers-go"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	libagent "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 )

--- a/test/integration/consul-container/libs/cluster/helpers.go
+++ b/test/integration/consul-container/libs/cluster/helpers.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 	// "github.com/hashicorp/consul/sdk/testutil/retry"
 	libagent "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"

--- a/test/integration/consul-container/libs/service/helpers.go
+++ b/test/integration/consul-container/libs/service/helpers.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 	libnode "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 )
 

--- a/test/integration/consul-container/libs/utils/helpers.go
+++ b/test/integration/consul-container/libs/utils/helpers.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 )
 
 func ApplyDefaultProxySettings(c *api.Client) (bool, error) {

--- a/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
+++ b/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	libagent "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"

--- a/test/integration/consul-container/test/upgrade/fullstopupgrade_test.go
+++ b/test/integration/consul-container/test/upgrade/fullstopupgrade_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	libagent "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"

--- a/test/integration/consul-container/test/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/test/upgrade/healthcheck_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 
 	libagent "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"

--- a/test/integration/consul-container/test/upgrade/peers_http_test.go
+++ b/test/integration/consul-container/test/upgrade/peers_http_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v118"
 	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"


### PR DESCRIPTION
### Description
This is an alternative to #15827. The details are in #15827 but the gist is that because the upgrade tests use the latest version of the `api` submodule, the test code will fail when running against a Consul 1.14 container instance because it is sending a config field that is not known. I was able to pull in a compatible api submodule using a `replace` directive. It seems to work, so I'm wondering if we should use this instead of removing the test code that triggers the compatibility issue. 

### Testing & Reproduction steps
```
cd test/integration/consul-container
go test -run TestPeering_UpgradeToTarget_fromLatest ./... --target-version local --latest-version latest
```