### PR TITLE
tests: change AccessLogsConfig field to pointer so it will be parsed as nil

### DIFF
--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -295,7 +295,7 @@ type ProxyConfigEntry struct {
 	Config           map[string]interface{}  `json:",omitempty"`
 	MeshGateway      MeshGatewayConfig       `json:",omitempty" alias:"mesh_gateway"`
 	Expose           ExposeConfig            `json:",omitempty"`
-	AccessLogs       AccessLogsConfig        `json:",omitempty"`
+	AccessLogs       *AccessLogsConfig       `json:",omitempty"`
 
 	Meta        map[string]string `json:",omitempty"`
 	CreateIndex uint64

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -433,7 +433,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					OutboundListenerPort: 808,
 					DialedDirectly:       true,
 				},
-				AccessLogs: AccessLogsConfig{
+				AccessLogs: &AccessLogsConfig{
 					Enabled:             true,
 					DisableListenerLogs: true,
 					Type:                FileLogSinkType,


### PR DESCRIPTION
### Description
This is another alternative to fix the upgrade test by changing the AccessLog to pointer in `ProxyConfigEntry` so that empty struct will be parsed as nil by json. Since this is a new field, any old version of Consul can't parse the field.

### Testing & Reproduction steps

Please refer to #15830, #15827 

### Links

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
