### PR TITLE
Fix incorrect protocol check on discovery chains with peer targets.

### DIFF
--- a/.changelog/15833.txt
+++ b/.changelog/15833.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fix issue where service-resolver protocol checks incorrectly errored for failover peer targets.
+```

--- a/agent/consul/discoverychain/compile.go
+++ b/agent/consul/discoverychain/compile.go
@@ -874,8 +874,14 @@ RESOLVE_AGAIN:
 
 	targetID := target.ServiceID()
 
-	if err := c.recordServiceProtocol(targetID); err != nil {
-		return nil, err
+	// Only validate protocol if it is not a peered service.
+	// TODO: Add in remote peer protocol validation when building a chain.
+	// This likely would require querying the imported services, which
+	// shouldn't belong in the discovery chain compilation here.
+	if target.Peer == "" {
+		if err := c.recordServiceProtocol(targetID); err != nil {
+			return nil, err
+		}
 	}
 
 	// Fetch the config entry.

--- a/agent/consul/discoverychain/compile_test.go
+++ b/agent/consul/discoverychain/compile_test.go
@@ -40,6 +40,8 @@ func TestCompile(t *testing.T) {
 		"service and subset redirect":                      testcase_ServiceAndSubsetRedirect(),
 		"datacenter redirect":                              testcase_DatacenterRedirect(),
 		"redirect to cluster peer":                         testcase_PeerRedirect(),
+		"redirect to cluster peer http proxy-defaults":     testcase_PeerRedirectProxyDefHTTP(),
+		"redirect to cluster peer http service-defaults":   testcase_PeerRedirectSvcDefHTTP(),
 		"datacenter redirect with mesh gateways":           testcase_DatacenterRedirect_WithMeshGateways(),
 		"service failover":                                 testcase_ServiceFailover(),
 		"service failover through redirect":                testcase_ServiceFailoverThroughRedirect(),
@@ -1105,6 +1107,102 @@ func testcase_PeerRedirect() compileTestCase {
 
 	expect := &structs.CompiledDiscoveryChain{
 		Protocol:  "tcp",
+		StartNode: "resolver:other.default.default.external.cluster-01",
+		Nodes: map[string]*structs.DiscoveryGraphNode{
+			"resolver:other.default.default.external.cluster-01": {
+				Type: structs.DiscoveryGraphNodeTypeResolver,
+				Name: "other.default.default.external.cluster-01",
+				Resolver: &structs.DiscoveryResolver{
+					Default:        true,
+					ConnectTimeout: 5 * time.Second,
+					Target:         "other.default.default.external.cluster-01",
+				},
+			},
+		},
+		Targets: map[string]*structs.DiscoveryTarget{
+			"other.default.default.external.cluster-01": newTarget(structs.DiscoveryTargetOpts{
+				Service: "other",
+				Peer:    "cluster-01",
+			}, func(t *structs.DiscoveryTarget) {
+				t.SNI = ""
+				t.Name = ""
+				t.Datacenter = ""
+			}),
+		},
+	}
+	return compileTestCase{entries: entries, expect: expect}
+}
+
+func testcase_PeerRedirectProxyDefHTTP() compileTestCase {
+	entries := newEntries()
+	entries.AddProxyDefaults(&structs.ProxyConfigEntry{
+		Kind: structs.ProxyDefaults,
+		Name: structs.ProxyConfigGlobal,
+		Config: map[string]interface{}{
+			"Protocol": "http",
+		},
+	})
+	entries.AddResolvers(
+		&structs.ServiceResolverConfigEntry{
+			Kind: "service-resolver",
+			Name: "main",
+			Redirect: &structs.ServiceResolverRedirect{
+				Service: "other",
+				Peer:    "cluster-01",
+			},
+		},
+	)
+
+	expect := &structs.CompiledDiscoveryChain{
+		Protocol:  "http",
+		StartNode: "resolver:other.default.default.external.cluster-01",
+		Nodes: map[string]*structs.DiscoveryGraphNode{
+			"resolver:other.default.default.external.cluster-01": {
+				Type: structs.DiscoveryGraphNodeTypeResolver,
+				Name: "other.default.default.external.cluster-01",
+				Resolver: &structs.DiscoveryResolver{
+					Default:        true,
+					ConnectTimeout: 5 * time.Second,
+					Target:         "other.default.default.external.cluster-01",
+				},
+			},
+		},
+		Targets: map[string]*structs.DiscoveryTarget{
+			"other.default.default.external.cluster-01": newTarget(structs.DiscoveryTargetOpts{
+				Service: "other",
+				Peer:    "cluster-01",
+			}, func(t *structs.DiscoveryTarget) {
+				t.SNI = ""
+				t.Name = ""
+				t.Datacenter = ""
+			}),
+		},
+	}
+	return compileTestCase{entries: entries, expect: expect}
+}
+
+func testcase_PeerRedirectSvcDefHTTP() compileTestCase {
+	entries := newEntries()
+	entries.AddServices(
+		&structs.ServiceConfigEntry{
+			Kind:     structs.ServiceDefaults,
+			Name:     "main",
+			Protocol: "http",
+		},
+	)
+	entries.AddResolvers(
+		&structs.ServiceResolverConfigEntry{
+			Kind: "service-resolver",
+			Name: "main",
+			Redirect: &structs.ServiceResolverRedirect{
+				Service: "other",
+				Peer:    "cluster-01",
+			},
+		},
+	)
+
+	expect := &structs.CompiledDiscoveryChain{
+		Protocol:  "http",
 		StartNode: "resolver:other.default.default.external.cluster-01",
 		Nodes: map[string]*structs.DiscoveryGraphNode{
 			"resolver:other.default.default.external.cluster-01": {


### PR DESCRIPTION
The following message is incorrectly printed out whenever saving a service-resolver with a peer failover target.

`discovery chain "my-chain" uses inconsistent protocols; service "my-service" has "tcp" which is not "http"`

This PR excludes peer targets from the protocol validation logic when building discovery chains, which should prevent the error from occurring.

Steps to reproduce:

1. Set up a service-defaults with “http” protocol on a service “mylocal”
2. Set up a peering connection and import a remote service “myremote” (this remote's protocol shouldn't matter to reproduce the issue)
3. Attempt to save a resolver for “mylocal” that has a failover to “myremote” configured.

Be careful to ensure that no "myremote" service-default exists in the local cluster, as it will actually be looked up, and the error will not surface.