### PR TITLE
grpc custom balancer - UpdateClientConnState Break - instead of returning early

### DIFF
--- a/agent/grpc-internal/balancer/custombalancer.go
+++ b/agent/grpc-internal/balancer/custombalancer.go
@@ -45,7 +45,7 @@ func (b *customPickfirstBalancer) UpdateClientConnState(state balancer.ClientCon
 		// of addresses matched the currently connected address, it would
 		// be an effective no-op.
 		if a.Equal(b.activeAddr) {
-			return nil
+			break
 		}
 
 		// Attempt to make a new SubConn with a single address so we can


### PR DESCRIPTION
Small followup to https://github.com/hashicorp/consul/pull/15701
