### PR TITLE
JIRA: Add Service Mesh work stream to JIRA API call

### DIFF
--- a/.github/workflows/jira-pr.yaml
+++ b/.github/workflows/jira-pr.yaml
@@ -59,6 +59,7 @@ jobs:
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
           extraFields: '{ "customfield_10089": "${{ github.event.pull_request.html_url }}",
                           "customfield_10371": { "value": "GitHub" },            
+                          "customfield_10535": [{ "value": "Service Mesh" }],
                           "components": [{ "name": "${{ github.event.repository.name }}" }],
                           "labels": ${{ steps.set-ticket-labels.outputs.LABELS }} }'
         env:


### PR DESCRIPTION
### Description
Currently an error when community PRs are filed pop up due to the default Workstream custom field not being populated. 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
