### PR TITLE
fixed bad markdown in network segments usage

### DIFF
--- a/website/content/docs/enterprise/network-segments/create-network-segment.mdx
+++ b/website/content/docs/enterprise/network-segments/create-network-segment.mdx
@@ -171,9 +171,10 @@ $ curl http://127.0.0.1:8500/v1/agent/members?segment=alpha
    }
 }
 ```
-Refer to the [`/agent/members` API endpoint documentation](/consul/api-docs/agent#list-members) for additional information.
 
 </CodeBlockConfig>
+
+Refer to the [`/agent/members` API endpoint documentation](/consul/api-docs/agent#list-members) for additional information.
 
 </Tab>
 <Tab heading="UI">


### PR DESCRIPTION
### Description
This PR fixes a markdown error in the network segments usage documentation.


### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
