### PR TITLE
Fix issue with incorrect proxycfg watch on upstream peer-targets.

### DIFF
--- a/.changelog/15865.txt
+++ b/.changelog/15865.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fix issue where watches on upstream failover peer targets did not always query the correct data.
+```

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -873,10 +873,10 @@ func (s *ConfigSnapshot) ToConfigSnapshotUpstreams() (*ConfigSnapshotUpstreams, 
 	}
 }
 
-func (u *ConfigSnapshotUpstreams) UpstreamPeerMeta(uid UpstreamID) structs.PeeringServiceMeta {
+func (u *ConfigSnapshotUpstreams) UpstreamPeerMeta(uid UpstreamID) (structs.PeeringServiceMeta, bool) {
 	nodes, _ := u.PeerUpstreamEndpoints.Get(uid)
 	if len(nodes) == 0 {
-		return structs.PeeringServiceMeta{}
+		return structs.PeeringServiceMeta{}, false
 	}
 
 	// In agent/rpc/peering/subscription_manager.go we denormalize the
@@ -892,9 +892,9 @@ func (u *ConfigSnapshotUpstreams) UpstreamPeerMeta(uid UpstreamID) structs.Peeri
 	// catalog to avoid this weird construction.
 	csn := nodes[0]
 	if csn.Service == nil {
-		return structs.PeeringServiceMeta{}
+		return structs.PeeringServiceMeta{}, false
 	}
-	return *csn.Service.Connect.PeerMeta
+	return *csn.Service.Connect.PeerMeta, true
 }
 
 // PeeredUpstreamIDs returns a slice of peered UpstreamIDs from explicit config entries

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -343,7 +343,10 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			continue
 		}
 
-		peerMeta := cfgSnap.ConnectProxy.UpstreamPeerMeta(uid)
+		peerMeta, found := cfgSnap.ConnectProxy.UpstreamPeerMeta(uid)
+		if !found {
+			s.Logger.Warn("failed to fetch upstream peering metadata for listener", "uid", uid)
+		}
 		cfg := s.getAndModifyUpstreamConfigForPeeredListener(uid, upstreamCfg, peerMeta)
 
 		// If escape hatch is present, create a listener from it and move on to the next


### PR DESCRIPTION
Sometimes when envoy was configured to do failovers to peered clusters, the SNI / SAN information was missing from the xDS configuration, which means that it was impossible to connect to the mesh gateway correctly.

This issue occurs because the incorrect partition / datacenter was used when creating watches from upstream targets. The datacenter / partition from discovery-chain peer-targets should NOT be used to perform lookups, since the fields are intentionally cleared during compilation (disco chain target fields indicate the destination's data, not the source's data).

Instead, the local datacenter / partition should be provided to the query so that it can properly lookup services.