### PR TITLE
docs: peering API - removed technical preview callout

### DIFF
--- a/website/content/api-docs/peering.mdx
+++ b/website/content/api-docs/peering.mdx
@@ -6,11 +6,6 @@ description: The /peering endpoints allow for managing cluster peerings.
 
 # Cluster Peering - HTTP API
 
-~> **Cluster peering is currently in technical preview:** Functionality associated
-with cluster peering is subject to change. You should never use the technical
-preview release in secure environments or production scenarios. Features in
-technical preview may have performance issues, scaling issues, and limited support.
-
 The functionality described here is available only in
 [Consul](https://www.hashicorp.com/products/consul/) version 1.13.0 and later.
 


### PR DESCRIPTION
### Description
Cluster Peering is no longer in technical preview. It has been released to GA and customers are encouraged to use it in production.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
