### PR TITLE
Fix missing comment in generated enterprise rate-limit file

### DIFF
--- a/internal/tools/protoc-gen-consul-rate-limit/postprocess/main.go
+++ b/internal/tools/protoc-gen-consul-rate-limit/postprocess/main.go
@@ -23,7 +23,8 @@ import "github.com/hashicorp/consul/agent/consul/rate"
 `
 
 	entTags = `//go:build consulent
-// +build consulent`
+// +build consulent
+`
 )
 
 func main() {


### PR DESCRIPTION
### Description
Fixes bug in #15564 where gofmt would strip out the generated code warning comment because it was on the same line as the build tag.
