### PR TITLE
Fix TLS_BadVerify test assertions on macOS

### DIFF
--- a/agent/checks/check_test.go
+++ b/agent/checks/check_test.go
@@ -844,6 +844,9 @@ func TestCheckHTTP_TLS_BadVerify(t *testing.T) {
 
 // isInvalidCertificateError checks the error string for an untrusted certificate error.
 // The specific error message is different on Linux and macOS.
+//
+// TODO: Revisit this when https://github.com/golang/go/issues/52010 is resolved.
+// We may be able to simplify this to check only one error string.
 func isInvalidCertificateError(err string) bool {
 	return strings.Contains(err, "certificate signed by unknown authority") ||
 		strings.Contains(err, "certificate is not trusted")

--- a/agent/checks/check_test.go
+++ b/agent/checks/check_test.go
@@ -836,10 +836,17 @@ func TestCheckHTTP_TLS_BadVerify(t *testing.T) {
 		if got, want := notif.State(cid), api.HealthCritical; got != want {
 			r.Fatalf("got state %q want %q", got, want)
 		}
-		if !strings.Contains(notif.Output(cid), "certificate signed by unknown authority") {
+		if !isInvalidCertificateError(notif.Output(cid)) {
 			r.Fatalf("should fail with certificate error %v", notif.OutputMap())
 		}
 	})
+}
+
+// isInvalidCertificateError checks the error string for an untrusted certificate error.
+// The specific error message is different on Linux and macOS.
+func isInvalidCertificateError(err string) bool {
+	return strings.Contains(err, "certificate signed by unknown authority") ||
+		strings.Contains(err, "certificate is not trusted")
 }
 
 func mockTCPServer(network string) net.Listener {
@@ -1400,9 +1407,8 @@ func TestCheckH2PING_TLS_BadVerify(t *testing.T) {
 		if got, want := notif.State(cid), api.HealthCritical; got != want {
 			r.Fatalf("got state %q want %q", got, want)
 		}
-		expectedOutput := "certificate signed by unknown authority"
-		if !strings.Contains(notif.Output(cid), expectedOutput) {
-			r.Fatalf("should have included output %s: %v", expectedOutput, notif.OutputMap())
+		if !isInvalidCertificateError(notif.Output(cid)) {
+			r.Fatalf("should fail with certificate error %v", notif.OutputMap())
 		}
 	})
 }


### PR DESCRIPTION
### Description

On macOS, we get a different error message for an untrusted TLS certificate which causes a couple of check tests cases to fail. This fixes the assertion so that these tests pass on macOS.

### Testing & Reproduction steps

```
go test ./agent/checks -run TLS_BadVerify
```

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
