### PR TITLE
Update example link for Consul K8s NGINX ingress controller

### DIFF
--- a/website/content/docs/k8s/connect/ingress-controllers.mdx
+++ b/website/content/docs/k8s/connect/ingress-controllers.mdx
@@ -90,5 +90,5 @@ above to your own uses cases.
 
 - [Traefik Consul example - kschoche](https://github.com/kschoche/traefik-consul)
 - [Kong and Traefik Ingress Controller examples - joatmon08](https://github.com/joatmon08/consul-k8s-ingress-controllers)
-- [NGINX Ingress Controller example - dhiaayahci](https://github.com/dhiaayachi/eks-consul-ingressnginx)
+- [NGINX Ingress Controller example](https://github.com/hashicorp-education/consul-k8s-nginx-ingress-controller)
 


### PR DESCRIPTION
### Description
Update example link for Consul K8s NGINX ingress controller. New link is: https://github.com/hashicorp-education/consul-k8s-nginx-ingress-controller

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
