### PR TITLE
Rate limit improvements and fixes

### DIFF
--- a/agent/consul/rate/handler.go
+++ b/agent/consul/rate/handler.go
@@ -211,7 +211,7 @@ func (h *Handler) Allow(op Operation) error {
 		enforced := l.mode == ModeEnforcing
 		h.logger.Trace("RPC exceeded allowed rate limit",
 			"rpc", op.Name,
-			"source_addr", op.SourceAddr.String(),
+			"source_addr", op.SourceAddr,
 			"limit_type", l.desc,
 			"limit_enforced", enforced,
 		)

--- a/agent/consul/rate/handler.go
+++ b/agent/consul/rate/handler.go
@@ -18,14 +18,14 @@ var (
 	// rate limit was exhausted, but may succeed on a different server.
 	//
 	// Results in a RESOURCE_EXHAUSTED or "429 Too Many Requests" response.
-	ErrRetryElsewhere = errors.New("rate limit exceeded, try a different server")
+	ErrRetryElsewhere = errors.New("rate limit exceeded, try again later or against a different server")
 
 	// ErrRetryLater indicates that the operation was not allowed because the rate
 	// limit was exhausted, and trying a different server won't help (e.g. because
 	// the operation can only be performed on the leader).
 	//
 	// Results in an UNAVAILABLE or "503 Service Unavailable" response.
-	ErrRetryLater = errors.New("rate limit exceeded, try again later")
+	ErrRetryLater = errors.New("rate limit exceeded for operation that can only be performed by the leader, try again later")
 )
 
 // Mode determines the action that will be taken when a rate limit has been


### PR DESCRIPTION
### Description
Addresses a couple of issues found while manually testing server-side rate limiting:

- Fixes a panic when `Operation.SourceAddr` is nil (internal net/rpc calls)
- Adds proper HTTP response codes (429 and 503) for rate limit errors
- Makes the error messages clearer
