### PR TITLE
Fix protobuf generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+github.com

--- a/build-support/scripts/protobuf.sh
+++ b/build-support/scripts/protobuf.sh
@@ -91,6 +91,7 @@ function postprocess_protobuf_code {
     fi
 
     local proto_go_path="${proto_path%%.proto}.pb.go"
+    local proto_go_grpc_path="${proto_path%%.proto}_grpc.pb.go"
     local proto_go_bin_path="${proto_path%%.proto}.pb.binary.go"
     local proto_go_rpcglue_path="${proto_path%%.proto}.rpcglue.pb.go"
 
@@ -104,15 +105,14 @@ function postprocess_protobuf_code {
     local build_tags
     build_tags="$(head -n 2 "${proto_path}" | grep '^//go:build\|// +build' || true)"
     if test -n "${build_tags}"; then
-       for file in "${proto_go_bin_path}" "${proto_go_grpc_path}"
-       do
-            if test -f "${file}"
-            then
-                echo -e "${build_tags}\n" >> "${file}.new"
-                cat "${file}" >> "${file}.new"
-                mv "${file}.new" "${file}"
-            fi
-        done
+       local file 
+       file="${proto_go_grpc_path}"
+       if test -f "${file}"
+       then
+           echo -e "${build_tags}\n" >> "${file}.new"
+           cat "${file}" >> "${file}.new"
+           mv "${file}.new" "${file}"
+       fi
     fi
 
     # NOTE: this has to run after we fix up the build tags above


### PR DESCRIPTION
After https://github.com/hashicorp/protoc-gen-go-binary/pull/1, the build tags were inserted twice. This resulted in errors like:

`proto/pbautoconf/auto_config_ent.go:9:2: partition.pb.binary.go: multiple //go:build comments`

and diffs like:

```
circleci@9356716f44df:~/project$ git diff
diff --git a/proto/pbnamespace/namespace.pb.binary.go b/proto/pbnamespace/namespace.pb.binary.go
index 81bfdba402..afc71613c7 100644
--- a/proto/pbnamespace/namespace.pb.binary.go
+++ b/proto/pbnamespace/namespace.pb.binary.go
@@ -1,6 +1,9 @@
 //go:build consulent
 // +build consulent

+//go:build consulent
+// +build consulent
+
 // Code generated by protoc-gen-go-binary. DO NOT EDIT.
 // source: proto/pbnamespace/namespace.proto

diff --git a/proto/pbpartition/partition.pb.binary.go b/proto/pbpartition/partition.pb.binary.go
index e7c74837de..71cf66c015 100644
--- a/proto/pbpartition/partition.pb.binary.go
+++ b/proto/pbpartition/partition.pb.binary.go
@@ -1,6 +1,9 @@
 //go:build consulent
 // +build consulent

+//go:build consulent
+// +build consulent
+
 // Code generated by protoc-gen-go-binary. DO NOT EDIT.
 // source: proto/pbpartition/partition.proto
```

This removes the code that manually copies the build tags.