### PR TITLE
Pin to specific version of protoc-gen-go-binary

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,6 +22,12 @@ MOG_VERSION='v0.3.0'
 ###
 PROTOC_GO_INJECT_TAG_VERSION='v1.3.0'
 
+###
+# PROTOC_GEN_GO_BINARY_VERSION can be either a valid string for "go install <module>@<version>"
+# or the string @DEV to imply use whatever is currently installed locally.
+###
+PROTOC_GEN_GO_BINARY_VERSION="v0.0.1"
+
 GOTAGS ?=
 GOPATH=$(shell go env GOPATH)
 GOARCH?=$(shell go env GOARCH)

--- a/build-support/scripts/protobuf.sh
+++ b/build-support/scripts/protobuf.sh
@@ -167,6 +167,7 @@ function proto_tools_install {
     protoc_gen_go_version="$(grep github.com/golang/protobuf go.mod | awk '{print $2}')"
     mog_version="$(make --no-print-directory print-MOG_VERSION)"
     protoc_go_inject_tag_version="$(make --no-print-directory print-PROTOC_GO_INJECT_TAG_VERSION)"
+    protoc_gen_go_binary_version="$(make --no-print-directory print-PROTOC_GEN_GO_BINARY_VERSION)"
 
     # echo "go: ${protoc_gen_go_version}"
     # echo "mog: ${mog_version}"
@@ -178,9 +179,11 @@ function proto_tools_install {
         "${protoc_gen_go_version}" \
         'github.com/golang/protobuf/protoc-gen-go'
 
-    install_unversioned_tool \
+    install_versioned_tool \
         protoc-gen-go-binary \
-        'github.com/hashicorp/protoc-gen-go-binary@master'
+        "github.com/hashicorp/protoc-gen-go-binary" \
+        "${protoc_gen_go_binary_version}" \
+        'github.com/hashicorp/protoc-gen-go-binary'
 
     install_versioned_tool \
         'protoc-go-inject-tag' \


### PR DESCRIPTION
### Description
Manual backport of #15920. Instead of using the newer version of protoc-gen-go-binary I just pinned this to the version we happened to be using.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
