### PR TITLE
Format Raft TimeSinceLastContact as Seconds

### DIFF
--- a/.changelog/15937.txt
+++ b/.changelog/15937.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent/hcp: HCP Management Plane is expecting the json representation of a durationpb, instead of a Go Duration string
+```

--- a/agent/hcp/client.go
+++ b/agent/hcp/client.go
@@ -180,7 +180,7 @@ func serverStatusToHCP(s *ServerStatus) *gnmmod.HashicorpCloudGlobalNetworkManag
 			AppliedIndex:         strconv.FormatUint(s.Raft.AppliedIndex, 10),
 			IsLeader:             s.Raft.IsLeader,
 			KnownLeader:          s.Raft.KnownLeader,
-			TimeSinceLastContact: s.Raft.TimeSinceLastContact.String(),
+			TimeSinceLastContact: formatDuration(s.Raft.TimeSinceLastContact),
 		},
 		RPCPort: int32(s.RPCPort),
 		TLS: &gnmmod.HashicorpCloudGlobalNetworkManager20220215TLSInfo{

--- a/agent/hcp/duration.go
+++ b/agent/hcp/duration.go
@@ -1,0 +1,20 @@
+package hcp
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func formatDuration(d time.Duration) string {
+	protoDuration := durationpb.New(d)
+	dur := fmt.Sprintf("%d.%.9d", protoDuration.Seconds, protoDuration.Nanos)
+	// remove trailing 0's
+	dur = strings.TrimSuffix(dur, "000")
+	dur = strings.TrimSuffix(dur, "000")
+	dur = strings.TrimSuffix(dur, ".000")
+	// add trailing s
+	return dur + "s"
+}

--- a/agent/hcp/duration.go
+++ b/agent/hcp/duration.go
@@ -1,20 +1,18 @@
 package hcp
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func formatDuration(d time.Duration) string {
 	protoDuration := durationpb.New(d)
-	dur := fmt.Sprintf("%d.%.9d", protoDuration.Seconds, protoDuration.Nanos)
-	// remove trailing 0's
-	dur = strings.TrimSuffix(dur, "000")
-	dur = strings.TrimSuffix(dur, "000")
-	dur = strings.TrimSuffix(dur, ".000")
-	// add trailing s
-	return dur + "s"
+	durByte, err := protojson.Marshal(protoDuration)
+	if err != nil {
+		return "0s"
+	}
+	return strings.Trim(string(durByte), `"`)
 }

--- a/agent/hcp/duration_test.go
+++ b/agent/hcp/duration_test.go
@@ -1,0 +1,59 @@
+package hcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_formatDuration(t *testing.T) {
+	cases := []struct {
+		name     string
+		d        time.Duration
+		expected string
+	}{
+		{
+			name:     "NegativeDuration",
+			d:        time.Second * 5 * -1,
+			expected: "-5s",
+		},
+		{
+			name:     "NormalDuration",
+			d:        time.Second * 5,
+			expected: "5s",
+		},
+		{
+			name:     "MoreThanAMinute",
+			d:        time.Minute * 2,
+			expected: "120s",
+		},
+		{
+			name:     "MixMinuteAndSecond",
+			d:        time.Minute*2 + time.Second*5,
+			expected: "125s",
+		},
+		{
+			name:     "MixedSecondAndNanosecond",
+			d:        time.Second*5 + time.Nanosecond*200,
+			expected: "5.000000200s",
+		},
+		{
+			name:     "MixedSecondAndNanosecondWithTrim",
+			d:        time.Second*5 + time.Nanosecond*2000,
+			expected: "5.000002s",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, formatDuration(tc.d))
+		})
+	}
+
+	t.Run("MoreThanMinute", func(t *testing.T) {
+		d := time.Second * 120
+		expectedVal := "120s"
+		require.Equal(t, expectedVal, formatDuration(d))
+	})
+}


### PR DESCRIPTION
### Description
When we format the TimeSinceLastContact as a string duration and send it to
HCP we regularly receive a 400 error when the duration is over 1 minute.
This is because the parser on HCP is parsing the value as a durationpb.
The JSON string representation of the durationpb is
"<seconds>.<nanoseconds>s". Use the durationpb json representation so
that we parse it correctly on the other end.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
