### PR TITLE
Add ratelimit Envoy builtin extension

### DIFF
--- a/.changelog/15942.txt
+++ b/.changelog/15942.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+xds: Add a built-in Envoy extension that inserts HTTP local ratellimit filter.
+```

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -59,6 +59,7 @@ var AllConfigEntryKinds = []string{
 const (
 	BuiltinAWSLambdaExtension string = "builtin/aws/lambda"
 	BuiltinLuaExtension       string = "builtin/lua"
+	BuiltinRatelimitExtension string = "builtin/ratelimit"
 )
 
 // ConfigEntry is the interface for centralized configuration stored in Raft.
@@ -316,6 +317,7 @@ func builtInExtension(name string) bool {
 	extensions := map[string]struct{}{
 		BuiltinAWSLambdaExtension: {},
 		BuiltinLuaExtension:       {},
+		BuiltinRatelimitExtension: {},
 	}
 
 	_, ok := extensions[name]

--- a/agent/xds/builtinextensions/ratelimit/copied.go
+++ b/agent/xds/builtinextensions/ratelimit/copied.go
@@ -1,0 +1,59 @@
+package ratelimit
+
+import (
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// This is copied from xds and not put into the shared package because I'm not
+// convinced it should be shared.
+
+func makeUpstreamTLSTransportSocket(tlsContext *envoy_tls_v3.UpstreamTlsContext) (*envoy_core_v3.TransportSocket, error) {
+	if tlsContext == nil {
+		return nil, nil
+	}
+	return makeTransportSocket("tls", tlsContext)
+}
+
+func makeTransportSocket(name string, config proto.Message) (*envoy_core_v3.TransportSocket, error) {
+	any, err := ptypes.MarshalAny(config)
+	if err != nil {
+		return nil, err
+	}
+	return &envoy_core_v3.TransportSocket{
+		Name: name,
+		ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
+			TypedConfig: any,
+		},
+	}, nil
+}
+
+func makeEnvoyHTTPFilter(name string, cfg proto.Message) (*envoy_http_v3.HttpFilter, error) {
+	any, err := ptypes.MarshalAny(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &envoy_http_v3.HttpFilter{
+		Name:       name,
+		ConfigType: &envoy_http_v3.HttpFilter_TypedConfig{TypedConfig: any},
+	}, nil
+}
+
+func makeFilter(name string, cfg proto.Message) (*envoy_listener_v3.Filter, error) {
+	any, err := ptypes.MarshalAny(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &envoy_listener_v3.Filter{
+		Name:       name,
+		ConfigType: &envoy_listener_v3.Filter_TypedConfig{TypedConfig: any},
+	}, nil
+}

--- a/agent/xds/builtinextensions/ratelimit/ratelimit.go
+++ b/agent/xds/builtinextensions/ratelimit/ratelimit.go
@@ -1,0 +1,167 @@
+package ratelimit
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_ratelimit "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/local_ratelimit/v3"
+	envoy_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	envoy_resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/hashicorp/go-multierror"
+	"github.com/mitchellh/mapstructure"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/hashicorp/consul/agent/xds/builtinextensiontemplate"
+	"github.com/hashicorp/consul/agent/xds/xdscommon"
+	"github.com/hashicorp/consul/api"
+)
+
+type ratelimit struct {
+	ProxyType     string
+	Listener      string
+	MaxTokens     int
+	TokensPerFill int
+	FillInterval  int
+}
+
+var _ builtinextensiontemplate.Plugin = (*ratelimit)(nil)
+
+// MakeRatelimitExtension is a builtinextensiontemplate.PluginConstructor for a builtinextensiontemplate.EnvoyExtension.
+func MakeRatelimitExtension(ext xdscommon.ExtensionConfiguration) (builtinextensiontemplate.Plugin, error) {
+	var resultErr error
+	var plugin ratelimit
+
+	if name := ext.EnvoyExtension.Name; name != api.BuiltinRatelimitExtension {
+		return nil, fmt.Errorf("expected extension name 'ratelimit' but got %q", name)
+	}
+
+	if err := mapstructure.Decode(ext.EnvoyExtension.Arguments, &plugin); err != nil {
+		return nil, fmt.Errorf("error decoding extension arguments: %v", err)
+	}
+
+	if plugin.FillInterval == 0 {
+		resultErr = multierror.Append(resultErr, fmt.Errorf("fillInterval is required"))
+	}
+
+	if plugin.MaxTokens == 0 {
+		resultErr = multierror.Append(resultErr, fmt.Errorf("MaxTokens must be greater than 0"))
+	}
+
+	if plugin.TokensPerFill == 0 {
+		resultErr = multierror.Append(resultErr, fmt.Errorf("TokensPerFill must be greater than 0"))
+	}
+
+	if err := validateProxyType(plugin.ProxyType); err != nil {
+		resultErr = multierror.Append(resultErr, err)
+	}
+
+	if err := validateListener(plugin.Listener); err != nil {
+		resultErr = multierror.Append(resultErr, err)
+	}
+
+	return plugin, resultErr
+}
+
+// CanApply determines if the extension can apply to the given extension configuration.
+func (p ratelimit) CanApply(config xdscommon.ExtensionConfiguration) bool {
+	return string(config.Kind) == p.ProxyType && p.matchesListenerDirection(config)
+}
+
+func (p ratelimit) matchesListenerDirection(config xdscommon.ExtensionConfiguration) bool {
+	return !config.IsUpstream() && p.Listener == "inbound"
+}
+
+// PatchRoute does nothing.
+func (p ratelimit) PatchRoute(route *envoy_route_v3.RouteConfiguration) (*envoy_route_v3.RouteConfiguration, bool, error) {
+	return route, false, nil
+}
+
+// PatchCluster does nothing.
+func (p ratelimit) PatchCluster(c *envoy_cluster_v3.Cluster) (*envoy_cluster_v3.Cluster, bool, error) {
+	return c, false, nil
+}
+
+// PatchFilter inserts a http local rate_limit filter at the head of
+// envoy.filters.network.http_connection_manager filters
+func (p ratelimit) PatchFilter(filter *envoy_listener_v3.Filter) (*envoy_listener_v3.Filter, bool, error) {
+	if filter.Name != "envoy.filters.network.http_connection_manager" {
+		return filter, false, nil
+	}
+	if typedConfig := filter.GetTypedConfig(); typedConfig == nil {
+		return filter, false, errors.New("error getting typed config for http filter")
+	}
+
+	config := envoy_resource_v3.GetHTTPConnectionManager(filter)
+	if config == nil {
+		return filter, false, errors.New("error unmarshalling filter")
+	}
+
+	tokenBucket := envoy_type_v3.TokenBucket{
+		MaxTokens: uint32(p.MaxTokens),
+		TokensPerFill: &wrappers.UInt32Value{
+			Value: uint32(p.TokensPerFill),
+		},
+		FillInterval: durationpb.New(time.Duration(p.FillInterval) * time.Second),
+	}
+
+	ratelimitHttpFilter, err := makeEnvoyHTTPFilter(
+		"envoy.filters.http.local_ratelimit",
+		&envoy_ratelimit.LocalRateLimit{
+			TokenBucket: &tokenBucket,
+			StatPrefix:  "local_ratelimit.",
+			FilterEnabled: &envoy_core_v3.RuntimeFractionalPercent{
+				DefaultValue: &envoy_type_v3.FractionalPercent{
+					Numerator:   100,
+					Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+				},
+			},
+			FilterEnforced: &envoy_core_v3.RuntimeFractionalPercent{
+				DefaultValue: &envoy_type_v3.FractionalPercent{
+					Numerator:   100,
+					Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+				},
+			},
+		},
+	)
+	if err != nil {
+		return filter, false, err
+	}
+
+	changedFilters := make([]*envoy_http_v3.HttpFilter, 0, len(config.HttpFilters)+1)
+
+	// The ratelimitHttpFilter is inserted as the first element of the http
+	// filter chain.
+	changedFilters = append(changedFilters, ratelimitHttpFilter)
+	changedFilters = append(changedFilters, config.HttpFilters...)
+	config.HttpFilters = changedFilters
+
+	newFilter, err := makeFilter("envoy.filters.network.http_connection_manager", config)
+	if err != nil {
+		return filter, false, errors.New("error making new filter")
+	}
+
+	return newFilter, true, nil
+}
+
+func validateProxyType(t string) error {
+	if t != "connect-proxy" {
+		return fmt.Errorf("unexpected ProxyType %q", t)
+	}
+
+	return nil
+}
+
+func validateListener(t string) error {
+	if t != "inbound" && t != "outbound" {
+		return fmt.Errorf("unexpected Listener %q", t)
+	}
+
+	return nil
+}

--- a/agent/xds/builtinextensiontemplate/template.go
+++ b/agent/xds/builtinextensiontemplate/template.go
@@ -166,6 +166,8 @@ func (envoyExtension EnvoyExtension) patchTerminatingGatewayListener(config xdsc
 			if ok {
 				filters = append(filters, newFilter)
 				patched = true
+			} else {
+				filters = append(filters, filter)
 			}
 		}
 		filterChain.Filters = filters
@@ -209,6 +211,8 @@ func (envoyExtension EnvoyExtension) patchConnectProxyListener(config xdscommon.
 			if ok {
 				filters = append(filters, newFilter)
 				patched = true
+			} else {
+				filters = append(filters, filter)
 			}
 		}
 		filterChain.Filters = filters

--- a/agent/xds/extensions.go
+++ b/agent/xds/extensions.go
@@ -3,6 +3,7 @@ package xds
 import (
 	"github.com/hashicorp/consul/agent/xds/builtinextensions/lambda"
 	"github.com/hashicorp/consul/agent/xds/builtinextensions/lua"
+	"github.com/hashicorp/consul/agent/xds/builtinextensions/ratelimit"
 	"github.com/hashicorp/consul/agent/xds/builtinextensiontemplate"
 	"github.com/hashicorp/consul/agent/xds/xdscommon"
 	"github.com/hashicorp/consul/api"
@@ -15,6 +16,8 @@ func GetBuiltInExtension(ext xdscommon.ExtensionConfiguration) (builtinextension
 		c = lambda.MakeLambdaExtension
 	case api.BuiltinLuaExtension:
 		c = lua.MakeLuaExtension
+	case api.BuiltinRatelimitExtension:
+		c = ratelimit.MakeRatelimitExtension
 	default:
 		var e builtinextensiontemplate.EnvoyExtension
 		return e, false

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -31,6 +31,7 @@ const (
 const (
 	BuiltinAWSLambdaExtension string = "builtin/aws/lambda"
 	BuiltinLuaExtension       string = "builtin/lua"
+	BuiltinRatelimitExtension string = "builtin/ratelimit"
 )
 
 type ConfigEntry interface {

--- a/test/integration/connect/envoy/case-envoyext-ratelimit/capture.sh
+++ b/test/integration/connect/envoy/case-envoyext-ratelimit/capture.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+snapshot_envoy_admin localhost:19000 s1 primary || true
+snapshot_envoy_admin localhost:19001 s2 primary || true

--- a/test/integration/connect/envoy/case-envoyext-ratelimit/service_s1.hcl
+++ b/test/integration/connect/envoy/case-envoyext-ratelimit/service_s1.hcl
@@ -1,0 +1,16 @@
+services {
+  name = "s1"
+  port = 8080
+  connect {
+    sidecar_service {
+      proxy {
+        upstreams = [
+          {
+            destination_name = "s2"
+            local_bind_port = 5000
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/integration/connect/envoy/case-envoyext-ratelimit/service_s2.hcl
+++ b/test/integration/connect/envoy/case-envoyext-ratelimit/service_s2.hcl
@@ -1,0 +1,5 @@
+services {
+  name = "s2"
+  port = 8181
+  connect { sidecar_service {} }
+}

--- a/test/integration/connect/envoy/case-envoyext-ratelimit/setup.sh
+++ b/test/integration/connect/envoy/case-envoyext-ratelimit/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eEuo pipefail
+
+upsert_config_entry primary '
+Kind = "service-defaults"
+Name = "s2"
+Protocol = "http"
+EnvoyExtensions = [
+  {
+    Name = "builtin/ratelimit",
+    Arguments = {
+      ProxyType = "connect-proxy"
+      Listener = "inbound"
+      maxTokens = 1,
+      tokensPerFill = 1,
+      fillInterval = 120,
+    }
+  }
+]
+'
+
+register_services primary
+
+gen_envoy_bootstrap s1 19000 primary
+gen_envoy_bootstrap s2 19001 primary

--- a/test/integration/connect/envoy/case-envoyext-ratelimit/vars.sh
+++ b/test/integration/connect/envoy/case-envoyext-ratelimit/vars.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export REQUIRED_SERVICES="s1 s1-sidecar-proxy s2 s2-sidecar-proxy"

--- a/test/integration/connect/envoy/case-envoyext-ratelimit/verify.bats
+++ b/test/integration/connect/envoy/case-envoyext-ratelimit/verify.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "s1 proxy admin is up on :19000" {
+  retry_default curl -f -s localhost:19000/stats -o /dev/null
+}
+
+@test "s2 proxy admin is up on :19001" {
+  retry_default curl -f -s localhost:19001/stats -o /dev/null
+}
+
+@test "s1 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21000 s1
+}
+
+@test "s2 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
+@test "s1 upstream should have healthy endpoints for s2" {
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1
+}
+
+@test "first connection to s2 - success" {
+  run retry_default curl -s -f -d hello localhost:5000
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "ratelimit to s2 is in effect - return code 429" {
+  retry_default must_fail_http_connection localhost:5000 429
+}


### PR DESCRIPTION
### Description
- Create the built-in http ratelimit Envoy extension ([link](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/local_ratelimit/v3/local_rate_limit.proto#envoy-v3-api-msg-extensions-filters-http-local-ratelimit-v3-localratelimit) to envoy api)
- The ratelimit extension will insert an `envoy.filters.http.local_ratelimit` to the head of the inbound listener's filter chain.

Example

```
Kind = "service-defaults"
Name = "s2"
Protocol = "http"
EnvoyExtensions = [
  {
    Name = "builtin/ratelimit",
    Arguments = {
      ProxyType = "connect-proxy"
      Listener = "inbound"
      maxTokens = 20,
      tokensPerFill = 5,
      fillInterval = 30,
    }
  }
]
```

### Testing & Reproduction steps

Integration test

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
