### PR TITLE
upgrade test: test service-intention in single cluster scenario

### DIFF
--- a/test/integration/consul-container/libs/assert/service.go
+++ b/test/integration/consul-container/libs/assert/service.go
@@ -4,18 +4,42 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
 )
 
 const (
-	defaultHTTPTimeout = 100 * time.Second
+	defaultHTTPTimeout = 120 * time.Second
 	defaultHTTPWait    = defaultWait
 )
+
+// HTTPServiceFailTcpConnection verifies that a TCP connection must not be allowed to ip:port
+func HTTPServiceFailTcpConnection(t *testing.T, ip string, port int) {
+	phrase := "hello"
+	failer := func() *retry.Timer {
+		return &retry.Timer{Timeout: defaultHTTPTimeout, Wait: defaultHTTPWait}
+	}
+
+	client := http.DefaultClient
+	urlreq := fmt.Sprintf("http://%s:%d", ip, port)
+
+	retry.RunWith(failer(), t, func(r *retry.R) {
+		t.Logf("making call to %s", urlreq)
+		reader := strings.NewReader(phrase)
+		_, err := client.Post(urlreq, "text/plain", reader)
+		require.Error(r, err)
+
+		urlErr, ok := err.(*url.Error)
+		require.True(r, ok)
+		require.Contains(r, urlErr.Unwrap().Error(), "EOF")
+	})
+}
 
 // HTTPServiceEchoes verifies that a post to the given ip/port combination returns the data
 // in the response body

--- a/test/integration/consul-container/libs/cluster/agent.go
+++ b/test/integration/consul-container/libs/cluster/agent.go
@@ -1,9 +1,10 @@
-package agent
+package cluster
 
 import (
 	"context"
 
 	"github.com/hashicorp/consul/api"
+	libservice "github.com/hashicorp/consul/test/integration/consul-container/libs/service"
 )
 
 // Agent represent a Consul agent abstraction
@@ -16,6 +17,7 @@ type Agent interface {
 	IsServer() bool
 	RegisterTermination(func() error)
 	Terminate() error
+	RegisterConnectSidecar(*libservice.ConnectContainer)
 	Upgrade(ctx context.Context, config Config) error
 	Exec(ctx context.Context, cmd []string) (int, error)
 	DataDir() string

--- a/test/integration/consul-container/libs/cluster/builder.go
+++ b/test/integration/consul-container/libs/cluster/builder.go
@@ -1,4 +1,4 @@
-package agent
+package cluster
 
 import (
 	"encoding/json"

--- a/test/integration/consul-container/libs/cluster/encryption.go
+++ b/test/integration/consul-container/libs/cluster/encryption.go
@@ -1,4 +1,4 @@
-package agent
+package cluster
 
 import (
 	"crypto/rand"

--- a/test/integration/consul-container/libs/cluster/log.go
+++ b/test/integration/consul-container/libs/cluster/log.go
@@ -1,4 +1,4 @@
-package agent
+package cluster
 
 import (
 	"fmt"

--- a/test/integration/consul-container/libs/service/examples.go
+++ b/test/integration/consul-container/libs/service/examples.go
@@ -10,7 +10,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	libnode "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 
@@ -87,7 +86,7 @@ func (g exampleContainer) GetServiceName() string {
 	return g.serviceName
 }
 
-func NewExampleService(ctx context.Context, name string, httpPort int, grpcPort int, node libnode.Agent) (Service, error) {
+func NewExampleService(ctx context.Context, name string, httpPort int, grpcPort int, node Agent) (Service, error) {
 	namePrefix := fmt.Sprintf("%s-service-example-%s", node.GetDatacenter(), name)
 	containerName := utils.RandName(namePrefix)
 

--- a/test/integration/consul-container/libs/service/gateway.go
+++ b/test/integration/consul-container/libs/service/gateway.go
@@ -9,7 +9,6 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/hashicorp/consul/api"
-	libnode "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 
@@ -19,7 +18,6 @@ type gatewayContainer struct {
 	container   testcontainers.Container
 	ip          string
 	port        int
-	req         testcontainers.ContainerRequest
 	serviceName string
 }
 
@@ -72,7 +70,7 @@ func (g gatewayContainer) GetServiceName() string {
 	return g.serviceName
 }
 
-func NewGatewayService(ctx context.Context, name string, kind string, node libnode.Agent) (Service, error) {
+func NewGatewayService(ctx context.Context, name string, kind string, node Agent) (Service, error) {
 	namePrefix := fmt.Sprintf("%s-service-gateway-%s", node.GetDatacenter(), name)
 	containerName := utils.RandName(namePrefix)
 

--- a/test/integration/consul-container/libs/service/helpers.go
+++ b/test/integration/consul-container/libs/service/helpers.go
@@ -7,10 +7,9 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/consul/api"
-	libnode "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 )
 
-func CreateAndRegisterStaticServerAndSidecar(node libnode.Agent) (Service, Service, error) {
+func CreateAndRegisterStaticServerAndSidecar(node Agent) (Service, Service, error) {
 	// Create a service and proxy instance
 	serverService, err := NewExampleService(context.Background(), "static-server", 8080, 8079, node)
 	if err != nil {
@@ -72,7 +71,7 @@ func CreateAndRegisterStaticServerAndSidecar(node libnode.Agent) (Service, Servi
 	return serverService, serverConnectProxy, nil
 }
 
-func CreateAndRegisterStaticClientSidecar(node libnode.Agent, peerName string, localMeshGateway bool) (*ConnectContainer, error) {
+func CreateAndRegisterStaticClientSidecar(node Agent, peerName string, localMeshGateway bool) (*ConnectContainer, error) {
 	// Create a service and proxy instance
 	clientConnectProxy, err := NewConnectService(context.Background(), "static-client-sidecar", "static-client", 5000, node)
 	if err != nil {

--- a/test/integration/consul-container/test/basic/connect_service_test.go
+++ b/test/integration/consul-container/test/basic/connect_service_test.go
@@ -5,11 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	libagent "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	libservice "github.com/hashicorp/consul/test/integration/consul-container/libs/service"
-	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+	"github.com/hashicorp/consul/test/integration/consul-container/test/topology"
 )
 
 // TestBasicConnectService Summary
@@ -22,49 +21,20 @@ import (
 //   - Create an example static-client sidecar, then register both the service and sidecar with Consul
 //   - Make sure a call to the client sidecar local bind port returns a response from the upstream, static-server
 func TestBasicConnectService(t *testing.T) {
-	cluster := createCluster(t)
-	defer terminate(t, cluster)
+	cluster := topology.BasicSingleClusterTopology(t, &libcluster.Options{
+		Datacenter: "dc1",
+		NumServer:  1,
+		NumClient:  1,
+	})
+	defer func() {
+		err := cluster.Terminate()
+		require.NoErrorf(t, err, "termining cluster")
+	}()
 
 	clientService := createServices(t, cluster)
 	_, port := clientService.GetAddr()
 
 	libassert.HTTPServiceEchoes(t, "localhost", port)
-}
-
-func terminate(t *testing.T, cluster *libcluster.Cluster) {
-	err := cluster.Terminate()
-	require.NoError(t, err)
-}
-
-// createCluster
-func createCluster(t *testing.T) *libcluster.Cluster {
-	opts := libagent.BuildOptions{
-		InjectAutoEncryption:   true,
-		InjectGossipEncryption: true,
-	}
-	ctx, err := libagent.NewBuildContext(opts)
-	require.NoError(t, err)
-
-	conf, err := libagent.NewConfigBuilder(ctx).ToAgentConfig()
-	require.NoError(t, err)
-	t.Logf("Cluster config:\n%s", conf.JSON)
-
-	configs := []libagent.Config{*conf}
-
-	cluster, err := libcluster.New(configs)
-	require.NoError(t, err)
-
-	client, err := cluster.GetClient(nil, true)
-	require.NoError(t, err)
-	libcluster.WaitForLeader(t, cluster, client)
-	libcluster.WaitForMembers(t, client, 1)
-
-	// Default Proxy Settings
-	ok, err := utils.ApplyDefaultProxySettings(client)
-	require.NoError(t, err)
-	require.True(t, ok)
-
-	return cluster
 }
 
 func createServices(t *testing.T, cluster *libcluster.Cluster) libservice.Service {

--- a/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
+++ b/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	libagent "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	libservice "github.com/hashicorp/consul/test/integration/consul-container/libs/service"
@@ -164,15 +163,15 @@ func terminate(t *testing.T, cluster *libcluster.Cluster) {
 }
 
 // rotateServer add a new server agent to the cluster, then forces the prior agent to leave.
-func rotateServer(t *testing.T, cluster *libcluster.Cluster, client *api.Client, ctx *libagent.BuildContext, node libagent.Agent) {
-	conf, err := libagent.NewConfigBuilder(cluster.BuildContext).
+func rotateServer(t *testing.T, cluster *libcluster.Cluster, client *api.Client, ctx *libcluster.BuildContext, node libcluster.Agent) {
+	conf, err := libcluster.NewConfigBuilder(cluster.BuildContext).
 		Bootstrap(0).
 		Peering(true).
 		RetryJoin("agent-3"). // Always use the client agent since it never leaves the cluster
 		ToAgentConfig()
 	require.NoError(t, err)
 
-	err = cluster.Add([]libagent.Config{*conf})
+	err = cluster.Add([]libcluster.Config{*conf})
 	require.NoError(t, err, "could not start new node")
 
 	libcluster.WaitForMembers(t, client, 5)

--- a/test/integration/consul-container/test/topology/basic_topology.go
+++ b/test/integration/consul-container/test/topology/basic_topology.go
@@ -1,4 +1,4 @@
-package cluster
+package topology
 
 import (
 	"fmt"
@@ -6,38 +6,29 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul/api"
+	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 
-type Options struct {
-	Datacenter string
-	NumServer  int
-	NumClient  int
-	Version    string
-}
-
-// CreatingPeeringClusterAndSetup creates a cluster with peering enabled
-// It also creates and registers a mesh-gateway at the client agent.
-// The API client returned is pointed at the client agent.
-func CreatingPeeringClusterAndSetup(t *testing.T, clusterOpts *Options) (*Cluster, *api.Client) {
-	var configs []Config
-
-	opts := BuildOptions{
+// BasicSingleClusterTopology sets up a scenario for single cluster test.
+func BasicSingleClusterTopology(t *testing.T, clusterOpts *libcluster.Options) *libcluster.Cluster {
+	opts := libcluster.BuildOptions{
 		Datacenter:             clusterOpts.Datacenter,
 		InjectAutoEncryption:   true,
 		InjectGossipEncryption: true,
 		ConsulVersion:          clusterOpts.Version,
 	}
-	ctx, err := NewBuildContext(opts)
+	ctx, err := libcluster.NewBuildContext(opts)
 	require.NoError(t, err)
 
+	var configs []libcluster.Config
 	numServer := clusterOpts.NumServer
 	for i := 0; i < numServer; i++ {
-		serverConf, err := NewConfigBuilder(ctx).
+		serverConf, err := libcluster.NewConfigBuilder(ctx).
 			Bootstrap(numServer).
 			Peering(true).
-			RetryJoin(fmt.Sprintf("agent-%d", (i+1)%3)). // Round-robin join the servers
+			Telemetry("127.0.0.0:2180").
+			RetryJoin(fmt.Sprintf("agent-%d", (i+1)%numServer)). // Round-robin join the servers
 			ToAgentConfig()
 		require.NoError(t, err)
 		t.Logf("%s server config %d: \n%s", clusterOpts.Datacenter, i, serverConf.JSON)
@@ -46,30 +37,32 @@ func CreatingPeeringClusterAndSetup(t *testing.T, clusterOpts *Options) (*Cluste
 	}
 
 	// Add a stable client to register the service
-	clientConf, err := NewConfigBuilder(ctx).
+	clientConf, err := libcluster.NewConfigBuilder(ctx).
 		Client().
 		Peering(true).
 		RetryJoin("agent-0", "agent-1", "agent-2").
 		ToAgentConfig()
 	require.NoError(t, err)
-
 	t.Logf("%s client config: \n%s", clusterOpts.Datacenter, clientConf.JSON)
-
 	configs = append(configs, *clientConf)
 
-	cluster, err := New(configs)
+	cluster, err := libcluster.New(configs)
 	require.NoError(t, err)
 	cluster.BuildContext = ctx
 
-	client, err := cluster.GetClient(nil, false)
+	// node := cluster.Agents[0]
+	// Use the client agent as the HTTP endpoint since we will not rotate it
+	clientNodes, err := cluster.Clients()
 	require.NoError(t, err)
-	WaitForLeader(t, cluster, client)
-	WaitForMembers(t, client, numServer+1)
+	require.True(t, len(clientNodes) > 0)
+	client := clientNodes[0].GetClient()
+	libcluster.WaitForLeader(t, cluster, client)
+	libcluster.WaitForMembers(t, client, numServer+1)
 
 	// Default Proxy Settings
 	ok, err := utils.ApplyDefaultProxySettings(client)
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	return cluster, client
+	return cluster
 }

--- a/test/integration/consul-container/test/upgrade/badauthz_test.go
+++ b/test/integration/consul-container/test/upgrade/badauthz_test.go
@@ -1,0 +1,84 @@
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
+	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
+	libservice "github.com/hashicorp/consul/test/integration/consul-container/libs/service"
+	libutils "github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+	"github.com/hashicorp/consul/test/integration/consul-container/test/topology"
+)
+
+// Test service intention continues functioning after upgrade
+// Steps:
+// 1. Create a cluster with one server and one client
+// 2. Register a static-server at server agent and a static-client at the client agent
+// 3. Upgrade the cluster
+// 4. Write the service-intention to allow the connection
+func TestBadauthz_UpgradeToTarget_fromLatest(t *testing.T) {
+	cluster := topology.BasicSingleClusterTopology(t, &libcluster.Options{
+		Datacenter: "dc1",
+		NumServer:  1,
+		NumClient:  1,
+		Version:    *libutils.LatestVersion,
+	})
+	defer func() {
+		err := cluster.Terminate()
+		require.NoErrorf(t, err, "termining cluster")
+	}()
+
+	// Register an static-server service
+	clientNodes, err := cluster.Clients()
+	require.NoError(t, err)
+	require.True(t, len(clientNodes) > 0)
+	_, _, err = libservice.CreateAndRegisterStaticServerAndSidecar(clientNodes[0])
+	require.NoError(t, err)
+	client := clientNodes[0].GetClient()
+	libassert.CatalogServiceExists(t, client, "static-server")
+	libassert.CatalogServiceExists(t, client, "static-server-sidecar-proxy")
+
+	// Register an static-client service
+	serverNodes, err := cluster.Servers()
+	require.NoError(t, err)
+	require.True(t, len(serverNodes) > 0)
+	staticClientSvcSidecar, err := libservice.CreateAndRegisterStaticClientSidecar(serverNodes[0], "", true)
+	require.NoError(t, err)
+
+	cluster.ConfigEntryWrite(`
+	Kind = "service-intentions"
+	Name = "static-server"
+	Sources = [
+  		{
+    		Name   = "static-client"
+    		Action = "deny"
+  		}
+	]
+	`)
+	_, port := staticClientSvcSidecar.GetAddr()
+	libassert.HTTPServiceFailTcpConnection(t, "localhost", port)
+
+	// Upgrade the cluster to targetVersion
+	t.Logf("Upgrade to version %s", *libutils.TargetVersion)
+	err = cluster.StandardUpgrade(t, context.Background(), *libutils.TargetVersion)
+	require.NoError(t, err)
+
+	// Verify intentions work after upgrade
+	err = cluster.ConfigEntryWrite(`
+	Kind = "service-intentions"
+	Name = "static-server"
+	Sources = [
+			{
+			Name   = "static-client"
+			Action = "allow"
+			}
+	]
+	`)
+	require.NoError(t, err)
+
+	_, port = staticClientSvcSidecar.GetAddr()
+	libassert.HTTPServiceEchoes(t, "localhost", port)
+}

--- a/test/integration/consul-container/test/upgrade/badauthz_test.go
+++ b/test/integration/consul-container/test/upgrade/badauthz_test.go
@@ -81,7 +81,7 @@ func TestBadauthz_UpgradeToTarget_fromLatest(t *testing.T) {
 		libassert.HTTPServiceFailTcpConnection(t, "localhost", port)
 
 		// Upgrade the cluster to targetVersion
-		t.Logf("Upgrade to version %s", *libutils.TargetVersion)
+		t.Logf("Upgrade to version %s", tc.targetVersion)
 		err = cluster.StandardUpgrade(t, context.Background(), tc.targetVersion)
 		require.NoError(t, err)
 

--- a/test/integration/consul-container/test/upgrade/badauthz_test.go
+++ b/test/integration/consul-container/test/upgrade/badauthz_test.go
@@ -2,7 +2,9 @@ package upgrade
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -20,35 +22,52 @@ import (
 // 3. Upgrade the cluster
 // 4. Write the service-intention to allow the connection
 func TestBadauthz_UpgradeToTarget_fromLatest(t *testing.T) {
-	cluster := topology.BasicSingleClusterTopology(t, &libcluster.Options{
-		Datacenter: "dc1",
-		NumServer:  1,
-		NumClient:  1,
-		Version:    *libutils.LatestVersion,
-	})
-	defer func() {
-		err := cluster.Terminate()
-		require.NoErrorf(t, err, "termining cluster")
-	}()
+	type testcase struct {
+		oldversion    string
+		targetVersion string
+	}
+	tcs := []testcase{
+		//{
+		//  TODO: Recreat config during upgrade due to the breaking change to ports.grpc_tls
+		// 	oldversion:    "1.13",
+		// 	targetVersion: *libutils.TargetVersion,
+		// },
+		{
+			oldversion:    "1.14",
+			targetVersion: *libutils.TargetVersion,
+		},
+	}
 
-	// Register an static-server service
-	clientNodes, err := cluster.Clients()
-	require.NoError(t, err)
-	require.True(t, len(clientNodes) > 0)
-	_, _, err = libservice.CreateAndRegisterStaticServerAndSidecar(clientNodes[0])
-	require.NoError(t, err)
-	client := clientNodes[0].GetClient()
-	libassert.CatalogServiceExists(t, client, "static-server")
-	libassert.CatalogServiceExists(t, client, "static-server-sidecar-proxy")
+	run := func(t *testing.T, tc testcase) {
+		cluster := topology.BasicSingleClusterTopology(t, &libcluster.Options{
+			Datacenter: "dc1",
+			NumServer:  1,
+			NumClient:  1,
+			Version:    tc.oldversion,
+		})
+		defer func() {
+			err := cluster.Terminate()
+			require.NoErrorf(t, err, "termining cluster")
+		}()
 
-	// Register an static-client service
-	serverNodes, err := cluster.Servers()
-	require.NoError(t, err)
-	require.True(t, len(serverNodes) > 0)
-	staticClientSvcSidecar, err := libservice.CreateAndRegisterStaticClientSidecar(serverNodes[0], "", true)
-	require.NoError(t, err)
+		// Register an static-server service
+		clientNodes, err := cluster.Clients()
+		require.NoError(t, err)
+		require.True(t, len(clientNodes) > 0)
+		_, _, err = libservice.CreateAndRegisterStaticServerAndSidecar(clientNodes[0])
+		require.NoError(t, err)
+		client := clientNodes[0].GetClient()
+		libassert.CatalogServiceExists(t, client, "static-server")
+		libassert.CatalogServiceExists(t, client, "static-server-sidecar-proxy")
 
-	cluster.ConfigEntryWrite(`
+		// Register an static-client service
+		serverNodes, err := cluster.Servers()
+		require.NoError(t, err)
+		require.True(t, len(serverNodes) > 0)
+		staticClientSvcSidecar, err := libservice.CreateAndRegisterStaticClientSidecar(serverNodes[0], "", true)
+		require.NoError(t, err)
+
+		cluster.ConfigEntryWrite(`
 	Kind = "service-intentions"
 	Name = "static-server"
 	Sources = [
@@ -58,16 +77,16 @@ func TestBadauthz_UpgradeToTarget_fromLatest(t *testing.T) {
   		}
 	]
 	`)
-	_, port := staticClientSvcSidecar.GetAddr()
-	libassert.HTTPServiceFailTcpConnection(t, "localhost", port)
+		_, port := staticClientSvcSidecar.GetAddr()
+		libassert.HTTPServiceFailTcpConnection(t, "localhost", port)
 
-	// Upgrade the cluster to targetVersion
-	t.Logf("Upgrade to version %s", *libutils.TargetVersion)
-	err = cluster.StandardUpgrade(t, context.Background(), *libutils.TargetVersion)
-	require.NoError(t, err)
+		// Upgrade the cluster to targetVersion
+		t.Logf("Upgrade to version %s", *libutils.TargetVersion)
+		err = cluster.StandardUpgrade(t, context.Background(), tc.targetVersion)
+		require.NoError(t, err)
 
-	// Verify intentions work after upgrade
-	err = cluster.ConfigEntryWrite(`
+		// Verify intentions work after upgrade
+		err = cluster.ConfigEntryWrite(`
 	Kind = "service-intentions"
 	Name = "static-server"
 	Sources = [
@@ -77,8 +96,17 @@ func TestBadauthz_UpgradeToTarget_fromLatest(t *testing.T) {
 			}
 	]
 	`)
-	require.NoError(t, err)
+		require.NoError(t, err)
 
-	_, port = staticClientSvcSidecar.GetAddr()
-	libassert.HTTPServiceEchoes(t, "localhost", port)
+		_, port = staticClientSvcSidecar.GetAddr()
+		libassert.HTTPServiceEchoes(t, "localhost", port)
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("upgrade from %s to %s", tc.oldversion, tc.targetVersion),
+			func(t *testing.T) {
+				run(t, tc)
+			})
+		time.Sleep(3 * time.Second)
+	}
 }

--- a/test/integration/consul-container/test/upgrade/fullstopupgrade_test.go
+++ b/test/integration/consul-container/test/upgrade/fullstopupgrade_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/consul/api"
 
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	libagent "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
@@ -43,14 +42,14 @@ func TestStandardUpgradeToTarget_fromLatest(t *testing.T) {
 
 	run := func(t *testing.T, tc testcase) {
 
-		var configs []libagent.Config
+		var configs []libcluster.Config
 
-		configCtx, err := libagent.NewBuildContext(libagent.BuildOptions{
+		configCtx, err := libcluster.NewBuildContext(libcluster.BuildOptions{
 			ConsulVersion: tc.oldversion,
 		})
 		require.NoError(t, err)
 		numServers := 1
-		leaderConf, err := libagent.NewConfigBuilder(configCtx).
+		leaderConf, err := libcluster.NewConfigBuilder(configCtx).
 			Bootstrap(numServers).
 			ToAgentConfig()
 		require.NoError(t, err)

--- a/test/integration/consul-container/test/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/test/upgrade/healthcheck_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/consul/api"
 
-	libagent "github.com/hashicorp/consul/test/integration/consul-container/libs/agent"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
@@ -71,9 +70,9 @@ func TestTargetServersWithLatestGAClients(t *testing.T) {
 
 // Test health check GRPC call using Mixed (majority latest) Servers and Latest GA Clients
 func TestMixedServersMajorityLatestGAClient(t *testing.T) {
-	var configs []libagent.Config
+	var configs []libcluster.Config
 
-	leaderConf, err := libagent.NewConfigBuilder(nil).ToAgentConfig()
+	leaderConf, err := libcluster.NewConfigBuilder(nil).ToAgentConfig()
 	require.NoError(t, err)
 
 	configs = append(configs, *leaderConf)
@@ -91,7 +90,7 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 
 	for i := 1; i < 3; i++ {
 		configs = append(configs,
-			libagent.Config{
+			libcluster.Config{
 				JSON:    serverConf,
 				Cmd:     []string{"agent"},
 				Version: *utils.LatestVersion,
@@ -152,10 +151,10 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 
 // Test health check GRPC call using Mixed (majority target) Servers and Latest GA Clients
 func TestMixedServersMajorityTargetGAClient(t *testing.T) {
-	var configs []libagent.Config
+	var configs []libcluster.Config
 
 	for i := 0; i < 2; i++ {
-		serverConf, err := libagent.NewConfigBuilder(nil).Bootstrap(3).ToAgentConfig()
+		serverConf, err := libcluster.NewConfigBuilder(nil).Bootstrap(3).ToAgentConfig()
 		require.NoError(t, err)
 		configs = append(configs, *serverConf)
 	}
@@ -169,7 +168,7 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 	}`
 
 	configs = append(configs,
-		libagent.Config{
+		libcluster.Config{
 			JSON:    leaderConf,
 			Cmd:     []string{"agent"},
 			Version: *utils.LatestVersion,
@@ -227,8 +226,8 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 	}
 }
 
-func clientsCreate(t *testing.T, numClients int, image string, version string, cluster *libcluster.Cluster) []libagent.Agent {
-	clients := make([]libagent.Agent, numClients)
+func clientsCreate(t *testing.T, numClients int, image string, version string, cluster *libcluster.Cluster) []libcluster.Agent {
+	clients := make([]libcluster.Agent, numClients)
 
 	// This needs a specialized config since it is using an older version of the agent.
 	// That is missing fields like GRPC_TLS and PEERING, which are passed as defaults
@@ -241,8 +240,8 @@ func clientsCreate(t *testing.T, numClients int, image string, version string, c
 
 	for i := 0; i < numClients; i++ {
 		var err error
-		clients[i], err = libagent.NewConsulContainer(context.Background(),
-			libagent.Config{
+		clients[i], err = libcluster.NewConsulContainer(context.Background(),
+			libcluster.Config{
 				JSON:    conf,
 				Cmd:     []string{"agent"},
 				Version: version,
@@ -277,9 +276,9 @@ func serviceCreate(t *testing.T, client *api.Client, serviceName string) uint64 
 }
 
 func serversCluster(t *testing.T, numServers int, version string, image string) *libcluster.Cluster {
-	var configs []libagent.Config
+	var configs []libcluster.Config
 
-	conf, err := libagent.NewConfigBuilder(nil).
+	conf, err := libcluster.NewConfigBuilder(nil).
 		Bootstrap(numServers).
 		ToAgentConfig()
 	require.NoError(t, err)


### PR DESCRIPTION
### Description
This PR adds service-intention upgrade test in single cluster scenario: `TestBadauthz_UpgradeToTarget_fromLatest` verifies service-intention continue functioning after upgrade.

Additional changes include:
- A single cluster topology creation function: `BasicSingleClusterTopology` that can be used by single cluster test
- Restart connect sidecar during upgrade (`consul connect` will exit when the consul agent is restarted. So we need to restart the sidecar and upgrade the mapped app port)
- combine agent and cluster package to reduce import cycle (This aligns with RB's test PR in ent)
- Move `meshgateway` out of creating cluster helper function to avoid import cycle

### Testing & Reproduction steps

### Links

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
