### PR TITLE
[OSS] docs(access logs): new docs for access logging

### DIFF
--- a/.changelog/15864.txt
+++ b/.changelog/15864.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-connect: adds support for Envoy access logging. Access logging can be enabled using the [`proxy-defaults`](https://developer.hashicorp.com/consul/docs/connect/config-entries/proxy-defaults#accesslogs) config entry.
+connect: adds support for Envoy [access logging](https://developer.hashicorp.com/consul/docs/connect/observability/access-logs). Access logging can be enabled using the [`proxy-defaults`](https://developer.hashicorp.com/consul/docs/connect/config-entries/proxy-defaults#accesslogs) config entry.
 ```

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -161,7 +161,9 @@ compatibility with Envoy and prevent potential issues. Default is `false`.
      different port than the port specified in `-address` so that they do not
      conflict with the health check endpoint.
 
-- `-admin-access-log-path` The path to write the access log for the administration
+- `-admin-access-log-path` - 
+  **Deprecated in Consul 1.15.0 in favor of [`proxy-defaults` access logs](/docs/connect/config-entries/proxy-defaults#accesslogs).**
+  The path to write the access log for the administration
   server. If no access log is desired specify `/dev/null`. By default it will
   use `/dev/null`.
 

--- a/website/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/website/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -7,8 +7,8 @@ description: >-
 
 # Proxy Defaults Configuration Entry
 
-The `proxy-defaults` configuration entry (`ProxyDefaults` on Kubernetes) allows you to configure global defaults for underlying mesh proxies, e.g. Envoy. 
-This contrasts the [`mesh` config entry](/docs/connect/config-entries/mesh), which effects cross-proxy, mesh-wide changes.
+The `proxy-defaults` configuration entry (`ProxyDefaults` on Kubernetes) allows you to configure global defaults for Envoy proxies in the service mesh.
+This contrasts the [`mesh` config entry](/docs/connect/config-entries/mesh), which affects cross-proxy, mesh-wide changes.
 Only one global entry is supported. 
 For Consul Enterprise, only the global entry in the `default` partition is recognized.
 
@@ -485,14 +485,14 @@ spec:
         {
           name: 'Enabled',
           type: 'bool: false',
-          description: 'If enabled, access logs are emitted for all proxies in the mesh, including gateways.',
+          description: 'When enabled, access logs are emitted for all proxies in the mesh, including gateways.',
         },
         {
           name: 'DisableListenerLogs',
           type: 'bool: false',
-          description: `If enabled, access logs for traffic rejected at the listener-level will not be emitted.
+          description: `When enabled, access logs for traffic rejected at the listener-level are not emitted.
           This traffic includes connections that do not match any of Envoy's configured filters, such as Consul upstream services.
-          Setting this option to true if you don't care to log unknown requests that aren't being forwarded by Envoy.`,
+          Set this option to `true` if you do not want to log unknown requests that Envoy is not forwarding`,
         },
         {
           name: 'Type',
@@ -506,20 +506,20 @@ spec:
         },
         {
           name: 'JSONFormat',
-          type: 'string: (see default as follows)',
-          description: `A JSON-formated string that represent the format for each emitted access log.
-          This is set by default to [this format string](/docs/connect/observability/access-logs#default-log-format).
-          Envoy [Command Operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) can be used to customize the data emitted. 
+          type: 'string: "[default access log format](/consul/docs/connect/observability/access-logs#default-log-format)"',
+          description: `A JSON-formatted string that represents the format of each emitted access log.
+          By default, it is set  to the [default access log format](/consul/docs/connect/observability/access-logs#default-log-format).
+          You can use Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) to customize the emitted data. 
           Nesting is supported. 
           Invalid if a custom format is specified with TextFormat.`,
         },
         {
           name: 'TextFormat',
           type: 'string: ""',
-          description: `A formated string that represent the format for each emitted access log.
-          Envoy [Command Operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) can be used to customize the data emitted. 
-          A new line will automatically be added to the string.
-          Invalid if specified with a custom JSONFormat.`,
+          description: `A formatted string that represents the format of each emitted access log.
+          Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) can be used to customize the data emitted. 
+          A new line is added to the string automatically.
+          Invalid when a custom JSONFormat is already specified.`,
         }
       ],
     },
@@ -649,8 +649,8 @@ spec:
 
 ### Access Logs
 
-The following example minimally configures access logs for all proxies.
-[Access Logs](/docs/connect/observability/access-logs) details advanced configuration.
+The following example is a minimal configuration for enabling access logs for all proxies.
+Refer to [access logs](/docs/connect/observability/access-logs) for advanced configurations.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 

--- a/website/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/website/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -7,9 +7,8 @@ description: >-
 
 # Proxy Defaults Configuration Entry
 
-The `proxy-defaults` configuration entry (`ProxyDefaults` on Kubernetes) allows you to globally configure passthrough Envoy settings for proxies in the mesh.
-Proxies are included in sidecars and gateways.
-This contrasts the [`mesh` config entry](/docs/connect/config-entries/mesh), which configures higher-level Consul features, that also configure Consul servers.
+The `proxy-defaults` configuration entry (`ProxyDefaults` on Kubernetes) allows you to globally configure passthrough Envoy settings for proxies in the service mesh, including both sidecars and gateways.
+It is different from the [`mesh` configuration entry](/docs/connect/config-entries/mesh), which sets Consul features for cluster peering, transparent proxy, and TLS behavior that also affect Consul servers.
 
 Only one global entry is supported. 
 For Consul Enterprise, only the global entry in the `default` partition is recognized.

--- a/website/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/website/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -7,8 +7,10 @@ description: >-
 
 # Proxy Defaults Configuration Entry
 
-The `proxy-defaults` configuration entry (`ProxyDefaults` on Kubernetes) allows you to configure global defaults for Envoy proxies in the service mesh.
-This contrasts the [`mesh` config entry](/docs/connect/config-entries/mesh), which affects cross-proxy, mesh-wide changes.
+The `proxy-defaults` configuration entry (`ProxyDefaults` on Kubernetes) allows you to globally configure passthrough Envoy settings for proxies in the mesh.
+Proxies are included in sidecars and gateways.
+This contrasts the [`mesh` config entry](/docs/connect/config-entries/mesh), which configures higher-level Consul features, that also configure Consul servers.
+
 Only one global entry is supported. 
 For Consul Enterprise, only the global entry in the `default` partition is recognized.
 
@@ -492,7 +494,7 @@ spec:
           type: 'bool: false',
           description: `When enabled, access logs for traffic rejected at the listener-level are not emitted.
           This traffic includes connections that do not match any of Envoy's configured filters, such as Consul upstream services.
-          Set this option to `true` if you do not want to log unknown requests that Envoy is not forwarding`,
+          Set this option to \`true\` if you do not want to log unknown requests that Envoy is not forwarding`,
         },
         {
           name: 'Type',
@@ -506,7 +508,7 @@ spec:
         },
         {
           name: 'JSONFormat',
-          type: 'string: "[default access log format](/consul/docs/connect/observability/access-logs#default-log-format)"',
+          type: 'string: (default as follows)',
           description: `A JSON-formatted string that represents the format of each emitted access log.
           By default, it is set  to the [default access log format](/consul/docs/connect/observability/access-logs#default-log-format).
           You can use Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) to customize the emitted data. 

--- a/website/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/website/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -2,20 +2,19 @@
 layout: docs
 page_title: Proxy Defaults - Configuration Entry Reference
 description: >-
-  The proxy defaults configuration entry kind defines default behaviors for sidecar proxies in the service mesh. Use the reference guide to learn about `""proxy-defaults""` config entry parameters and how to expose HTTP paths through Envoy.
+  The proxy defaults configuration entry kind defines default behaviors for proxies in the service mesh. Use the reference guide to learn about `""proxy-defaults""` config entry parameters.
 ---
 
 # Proxy Defaults Configuration Entry
 
-The `proxy-defaults` configuration entry (`ProxyDefaults` on Kubernetes) allows you
-to configure global defaults across all services for Connect proxy
-configurations. Only one global entry is supported.
+The `proxy-defaults` configuration entry (`ProxyDefaults` on Kubernetes) allows you to configure global defaults for underlying mesh proxies, e.g. Envoy. 
+This contrasts the [`mesh` config entry](/docs/connect/config-entries/mesh), which effects cross-proxy, mesh-wide changes.
+Only one global entry is supported. 
+For Consul Enterprise, only the global entry in the `default` partition is recognized.
 
 ## Introduction
 
-You can customize some service registration settings for service mesh sidecar
-proxies centrally using the `proxy-defaults` configuration entry in the `kind`
-field.
+You can customize some service registration settings for service mesh proxies centrally using the `proxy-defaults` configuration entry in the `kind` field.
 
 You can still override this centralized configuration for specific services
 with the [`service-defaults`](/docs/connect/config-entries/service-defaults)
@@ -74,6 +73,14 @@ Expose {
     }
   ]
 }
+AccessLogs {
+  Enabled              = < true | false >
+  DisableListenerLogs  = < true | false , disables listener access logs for unrecognized traffic>
+  Type                 = "< file | stdout | stdout, the destination for access logs >"
+  Path                 = "< set the output path for 'file' based access logs >"
+  JSONFormat           = "< json representation of access log format >"
+  TextFormat           = "< text representation of access log format >"
+}
 ```
 
 ```yaml
@@ -99,6 +106,13 @@ spec:
         localPathPort: <port where the local service is listening for connections to the path>
         listenerPort: <port where the proxy will listen for connections>
         protocol:= <protocol of the listener>
+  accessLogs:
+    enabled: < true | false >
+    disableListenerLogs:  < true | false , disables listener access logs for unrecognized traffic>
+    type: < file | stdout | stdout, the destination for access logs >
+    path: < set the output path for 'file' based access logs >
+    jsonFormat: < json representation of access log format >
+    textFormat: < text representation of access log format >
 ```
 
 ```json
@@ -129,6 +143,14 @@ spec:
         "Protocol": "<protocol of the listener>"
       }
     ]
+  },
+  "AccessLogs": {
+    "Enabled": < true | false >,
+    "DisableListenerLogs": < true | false , disables listener access logs for unrecognized traffic>,
+    "Type": "< file | stdout | stdout, the destination for access logs >",
+    "Path": "< set the output path for 'file' based access logs >",
+    "JSONFormat": "< json representation of access log format >",
+    "TextFormat": "< text representation of access log format >"
   }
 }
 ```
@@ -173,6 +195,14 @@ Expose {
     }
   ]
 }
+AccessLogs {
+  Enabled              = < true | false >
+  DisableListenerLogs  = < true | false , disables listener access logs for unrecognized traffic>
+  Type                 = "< file | stdout | stdout, the destination for access logs >"
+  Path                 = "< set the output path for 'file' based access logs >"
+  JSONFormat           = "< json representation of access log format >"
+  TextFormat           = "< text representation of access log format >"
+}
 ```
 
 ```yaml
@@ -199,6 +229,13 @@ spec:
         localPathPort: <port where the local service is listening for connections to the path>
         listenerPort: <port where the proxy will listen for connections>
         protocol:= <protocol of the listener>
+  accessLogs:
+    enabled: < true | false >
+    disableListenerLogs:  < true | false , disables listener access logs for unrecognized traffic>
+    type: < file | stdout | stdout, the destination for access logs >
+    path: < set the output path for 'file' based access logs >
+    jsonFormat: < json representation of access log format >
+    textFormat: < text representation of access log format >
 ```
 
 ```json
@@ -230,6 +267,14 @@ spec:
         "Protocol": "<protocol of the listener>"
       }
     ]
+  },
+  "AccessLogs": {
+    "Enabled": < true | false >,
+    "DisableListenerLogs": < true | false , disables listener access logs for unrecognized traffic>,
+    "Type": "< file | stdout | stdout, the destination for access logs >",
+    "Path": "< set the output path for 'file' based access logs >",
+    "JSONFormat": "< json representation of access log format >",
+    "TextFormat": "< text representation of access log format >"
   }
 }
 ```
@@ -431,6 +476,53 @@ spec:
         },
       ],
     },
+    {
+      name: 'AccessLogs',
+      type: 'AccessLogsConfig: <optional>',
+      description: `Controls the configuration of [Envoy's access logging](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/observability/access_logging.html?highlight=access%20logs) 
+                      for all proxies in the mesh, including gateways. It also configures access logs on [Envoy's administration interface](https://www.envoyproxy.io/docs/envoy/latest/operations/admin.html?highlight=administration%20logs).`,
+      children: [
+        {
+          name: 'Enabled',
+          type: 'bool: false',
+          description: 'If enabled, access logs are emitted for all proxies in the mesh, including gateways.',
+        },
+        {
+          name: 'DisableListenerLogs',
+          type: 'bool: false',
+          description: `If enabled, access logs for traffic rejected at the listener-level will not be emitted.
+          This traffic includes connections that do not match any of Envoy's configured filters, such as Consul upstream services.
+          Setting this option to true if you don't care to log unknown requests that aren't being forwarded by Envoy.`,
+        },
+        {
+          name: 'Type',
+          type: 'string: "stdout"',
+          description: 'The destination for access logs.  One of \`stdout\`, \`stderr\`, or \`file\`.',
+        },
+        {
+          name: 'Path',
+          type: 'string: ""',
+          description: 'The destination file for access logs. Only valid with \`Type\` set to \`file\`.',
+        },
+        {
+          name: 'JSONFormat',
+          type: 'string: (see default as follows)',
+          description: `A JSON-formated string that represent the format for each emitted access log.
+          This is set by default to [this format string](/docs/connect/observability/access-logs#default-log-format).
+          Envoy [Command Operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) can be used to customize the data emitted. 
+          Nesting is supported. 
+          Invalid if a custom format is specified with TextFormat.`,
+        },
+        {
+          name: 'TextFormat',
+          type: 'string: ""',
+          description: `A formated string that represent the format for each emitted access log.
+          Envoy [Command Operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) can be used to customize the data emitted. 
+          A new line will automatically be added to the string.
+          Invalid if specified with a custom JSONFormat.`,
+        }
+      ],
+    },
   ]}
 />
 
@@ -438,7 +530,7 @@ spec:
 
 ### Default protocol
 
-The following example configures the default protocol for all sidecar proxies.
+The following example configures the default protocol for all proxies.
 
 <Tabs>
 <Tab heading="Consul OSS">
@@ -521,7 +613,7 @@ spec:
 
 ### Prometheus
 
-The following example configures all sidecar proxies to expose Prometheus metrics.
+The following example configures all proxies to expose Prometheus metrics.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
@@ -555,9 +647,46 @@ spec:
 
 </CodeTabs>
 
+### Access Logs
+
+The following example minimally configures access logs for all proxies.
+[Access Logs](/docs/connect/observability/access-logs) details advanced configuration.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind      = "proxy-defaults"
+Name      = "global"
+AccessLogs {
+  Enabled = true
+}
+```
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ProxyDefaults
+metadata:
+  name: global
+spec:
+  accessLogs:
+    enabled: true
+```
+
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "AccessLogs": {
+    "Enabled": true
+  }
+}
+```
+
+</CodeTabs>
+
 ### Proxy-specific defaults
 
-The following example configures some custom default values for all sidecar proxies.
+The following example configures some custom default values for all proxies.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 

--- a/website/content/docs/connect/observability/access-logs.mdx
+++ b/website/content/docs/connect/observability/access-logs.mdx
@@ -1,0 +1,202 @@
+---
+layout: docs
+page_title: Service Mesh Observability - Access Logs
+description: >-
+  Consul Service Mesh can emit logs for application connections and requests passing through mesh proxies. Learn how to configure access logs for your mesh.
+---
+
+# Access Logs
+
+Consul Service Mesh can emit logs for application connections and requests passing through mesh proxies, including gateways.
+Viewing this application traffic is useful in these ways:
+  * **Diagnosing and Troubleshooting Issues**: Operators and application owners need to identify misconfigurations of the mesh or application by analyzing failed connections/requests.
+  * **Threat Detection**: Operators may be interested in unauthorized attempts to access the mesh and their origins.
+  * **Audit Compliance**: For traffic entering and exiting the mesh through gateways, operators may have security compliance requirements for recording logs of individual connections or requests.
+
+Access logs are only available when using Envoy proxy. 
+They are supported for both proxies started through the [`consul connect envoy`](/commands/connect/envoy) CLI command and [`consul-dataplane`](https://developer.hashicorp.com/consul/docs/connect/dataplane).
+
+## Enabling
+
+Access logs are controlled globally via the [`proxy-defaults`](/docs/connect/config-entries/proxy-defaults#accesslogs) config entry. 
+The minimal necessary configuration to enable them is as follows:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind      = "proxy-defaults"
+Name      = "global"
+AccessLogs {
+  Enabled = true
+}
+```
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ProxyDefaults
+metadata:
+  name: global
+spec:
+  accessLogs:
+    enabled: true
+```
+
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "AccessLogs": {
+    "Enabled": true
+  }
+}
+```
+
+</CodeTabs>
+
+Access logs will be emitted for all proxies when enabled, including sidecars and gateways. 
+Both inbound and outbound traffic through the proxy will be logged, in addition to requests to [Envoy's administration interface](https://www.envoyproxy.io/docs/envoy/latest/operations/admin.html?highlight=administration%20logs#administration-interface).
+Note that access logs can only be enabled for the administration interface before Envoy starts up, otherwise a restart of the proxy is required.
+
+## Default Format
+
+Access logs use the following format when no additional customization is provided:
+
+~> **Warning for Consul operators:** The following log format contains IP addresses which may be a data compliance issue, depending on your regulatory environment.
+Operators should carefully inspect their chosen access log format as not to leak sensitive or personally identifiable information. 
+
+```json
+{
+	"start_time":                        "%START_TIME%",
+	"route_name":                        "%ROUTE_NAME%",
+	"method":                            "%REQ(:METHOD)%",
+	"path":                              "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+	"protocol":                          "%PROTOCOL%",
+	"response_code":                     "%RESPONSE_CODE%",
+	"response_flags":                    "%RESPONSE_FLAGS%",
+	"response_code_details":             "%RESPONSE_CODE_DETAILS%",
+	"connection_termination_details":    "%CONNECTION_TERMINATION_DETAILS%",
+	"bytes_received":                    "%BYTES_RECEIVED%",
+	"bytes_sent":                        "%BYTES_SENT%",
+	"duration":                          "%DURATION%",
+	"upstream_service_time":             "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%",
+	"x_forwarded_for":                   "%REQ(X-FORWARDED-FOR)%",
+	"user_agent":                        "%REQ(USER-AGENT)%",
+	"request_id":                        "%REQ(X-REQUEST-ID)%",
+	"authority":                         "%REQ(:AUTHORITY)%",
+	"upstream_host":                     "%UPSTREAM_HOST%",
+	"upstream_cluster":                  "%UPSTREAM_CLUSTER%",
+	"upstream_local_address":            "%UPSTREAM_LOCAL_ADDRESS%",
+	"downstream_local_address":          "%DOWNSTREAM_LOCAL_ADDRESS%",
+	"downstream_remote_address":         "%DOWNSTREAM_REMOTE_ADDRESS%",
+	"requested_server_name":             "%REQUESTED_SERVER_NAME%",
+	"upstream_transport_failure_reason": "%UPSTREAM_TRANSPORT_FAILURE_REASON%"
+}
+```
+
+Depending on the connection type, such TCP or HTTP, some of these fields may be empty.
+
+## Format Customization
+
+Envoy uses [Command Operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) to expose information about application traffic. 
+Operators use these fields to customize the access logs emitted per connection. 
+
+### JSON Format
+
+JSON-formatted access logs are useful for parsing by Application Monitoring Platforms (APMs).
+Set [`JSONFormat`](/docs/connect/config-entries/proxy-defaults#jsonformat) to the string representation of the desired JSON object to customize this format.
+Nesting is supported.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind      = "proxy-defaults"
+Name      = "global"
+AccessLogs {
+  Enabled = true
+  JSONFormat = <<EOF
+{
+    "myCustomKey" : {
+        "myStartTime" : "%START_TIME%",
+        "myProtocol" : "%PROTOCOL%"
+    }
+}
+EOF
+}
+```
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ProxyDefaults
+metadata:
+  name: global
+spec:
+  accessLogs:
+    enabled: true
+    jsonFormat: |
+      {
+        "myCustomKey" : {
+          "myStartTime" : "%START_TIME%",
+          "myProtocol" : "%PROTOCOL%"
+        }
+      }
+```
+
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "AccessLogs": {
+    "Enabled": true,
+    "JSONFormat": "{ \"myCustomKey\" : { \"myStartTime\" : \"%START_TIME%\", \"myProtocol\" : \"%PROTOCOL%\"} }"
+  }
+}
+```
+
+</CodeTabs>
+
+### Text Format
+
+Set [`TextFormat`](/docs/connect/config-entries/proxy-defaults#textformat) to the desired customized string to use text-formatted access logs.
+A newline is automatically added to the end of the log format to keep each access log on its own line in the output.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind      = "proxy-defaults"
+Name      = "global"
+AccessLogs {
+  Enabled = true
+  TextFormat = "MY START TIME: %START_TIME%, THIS CONNECTIONS PROTOCOL IS %PROTOCOL%" 
+}
+```
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ProxyDefaults
+metadata:
+  name: global
+spec:
+  accessLogs:
+    enabled: true
+    textFormat: "MY START TIME: %START_TIME%, THIS CONNECTIONS PROTOCOL IS %PROTOCOL%" 
+```
+
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "AccessLogs": {
+    "Enabled": true,
+    "JSONFormat": "MY START TIME: %START_TIME%, THIS CONNECTIONS PROTOCOL IS %PROTOCOL%" 
+  }
+}
+```
+
+</CodeTabs>
+
+
+## Kubernetes
+
+The Envoy debugging logs are written to `stderr` as part of it's normal operation in any of the `consul-dataplane`, `envoy`, or `envoy-sidecar` containers.
+The log sink [`Type`](http://localhost:3000/consul/docs/connect/config-entries/proxy-defaults#type) is set to `stdout` by default for access logs when enabled.
+A log aggregating solution should be able to separate the machine-readable access logs from the Envoy process debug logs.

--- a/website/content/docs/connect/observability/access-logs.mdx
+++ b/website/content/docs/connect/observability/access-logs.mdx
@@ -2,24 +2,25 @@
 layout: docs
 page_title: Service Mesh Observability - Access Logs
 description: >-
-  Consul Service Mesh can emit logs for application connections and requests passing through mesh proxies. Learn how to configure access logs for your mesh.
+  Consul can emit access logs for application connections and requests that pass through Envoy proxies in the service mesh. Learn how to configure access logs, including minimum configuration requirements and the default log format.
 ---
 
 # Access Logs
 
-Consul Service Mesh can emit logs for application connections and requests passing through mesh proxies, including sidecars and gateways.
-Viewing this application traffic is useful in these ways:
-  * **Diagnosing and Troubleshooting Issues**: Operators and application owners need to identify misconfigurations of the mesh or application by analyzing failed connections/requests.
-  * **Threat Detection**: Operators may be interested in unauthorized attempts to access the mesh and their origins.
-  * **Audit Compliance**: For traffic entering and exiting the mesh through gateways, operators may have security compliance requirements for recording logs of individual connections or requests.
+This topic describes configuration and usage for access logs. Consul can emit access logs to record application connections and requests that pass through proxies in a service mesh, including sidecar proxies and gateways.
+You can use the application traffic records in access to logs to help you performance the following operations:
 
-Access logs are only available when using Envoy proxy. 
-They are supported for both proxies started through the [`consul connect envoy`](/commands/connect/envoy) CLI command and [`consul-dataplane`](https://developer.hashicorp.com/consul/docs/connect/dataplane).
+  - **Diagnosing and Troubleshooting Issues**: Operators and application owners can identify configuration issues in the service mesh or the application by analyzing failed connections and requests.
+  - **Threat Detection**: Operators can review details about unauthorized attempts to access the service mesh and their origins.
+  - **Audit Compliance**: Operators can use access less for security compliance requirements for traffic entering and exiting the service mesh through gateways.
 
-## Enabling
+Consul supports access logs capture through Envoy proxies started through the [`consul connect envoy`](/consul/commands/connect/envoy) CLI command and [`consul-dataplane`](/consul/docs/connect/dataplane). Other proxies are not supported.
 
-Access logs are controlled globally via the [`proxy-defaults`](/docs/connect/config-entries/proxy-defaults#accesslogs) config entry. 
-The minimal necessary configuration to enable them is as follows:
+## Enable access logs
+
+Access logs configurations are defined globally in the [`proxy-defaults`](/docs/connect/config-entries/proxy-defaults#accesslogs) configuration entry. 
+
+The following example is a minimal configuration for enabling access logs:
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
@@ -53,16 +54,17 @@ spec:
 
 </CodeTabs>
 
-Access logs will be emitted for all proxies when enabled, including sidecars and gateways. 
-Both inbound and outbound traffic through the proxy will be logged, in addition to requests to [Envoy's administration interface](https://www.envoyproxy.io/docs/envoy/latest/operations/admin.html?highlight=administration%20logs#administration-interface).
-Note that access logs can only be enabled for the administration interface before Envoy starts up, otherwise a restart of the proxy is required.
+All proxies, including sidecars and gateways, emit access logs when the behavior is enabled.
+Both inbound and outbound traffic through the proxy are logged, including requests made directly to [Envoy's administration interface](https://www.envoyproxy.io/docs/envoy/latest/operations/admin.html?highlight=administration%20logs#administration-interface). 
 
-## Default Format
+If you enable access logs after the Envoy proxy was started, access logs for the administration interface are not captured until you restart the proxy.
+
+## Default log format
 
 Access logs use the following format when no additional customization is provided:
 
-~> **Warning for Consul operators:** The following log format contains IP addresses which may be a data compliance issue, depending on your regulatory environment.
-Operators should carefully inspect their chosen access log format as not to leak sensitive or personally identifiable information. 
+~> **Security warning:** The following log format contains IP addresses which may be a data compliance issue, depending on your regulatory environment.
+Operators should carefully inspect their chosen access log format to prevent leaking sensitive or personally identifiable information. 
 
 ```json
 {
@@ -95,15 +97,19 @@ Operators should carefully inspect their chosen access log format as not to leak
 
 Depending on the connection type, such TCP or HTTP, some of these fields may be empty.
 
-## Format Customization
+## Custom log format
 
-Envoy uses [Command Operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) to expose information about application traffic. 
-Operators use these fields to customize the access logs emitted per connection. 
+Envoy uses [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) to expose information about application traffic. 
+You can use these fields to customize the access logs that proxies emit. 
 
-### JSON Format
+Custom logs can be either JSON format or text format.
 
-JSON-formatted access logs are useful for parsing by Application Monitoring Platforms (APMs).
-Set [`JSONFormat`](/docs/connect/config-entries/proxy-defaults#jsonformat) to the string representation of the desired JSON object to customize this format.
+### JSON format
+
+You can format access logs in JSON so that you can parse them with Application Monitoring Platforms (APMs).
+
+To use a custom access log, in the `proxy-defaults` configuration entry, set [`JSONFormat`](/docs/connect/config-entries/proxy-defaults#jsonformat) to the string representation of the desired JSON.
+
 Nesting is supported.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
@@ -154,10 +160,11 @@ spec:
 
 </CodeTabs>
 
-### Text Format
+### Text format
 
-Set [`TextFormat`](/docs/connect/config-entries/proxy-defaults#textformat) to the desired customized string to use text-formatted access logs.
-A newline is automatically added to the end of the log format to keep each access log on its own line in the output.
+To use a custom access log formatted in plaintext, in the `proxy-defaults` configuration entry, set [`TextFormat`](/docs/connect/config-entries/proxy-defaults#textformat) to the desired customized string.
+
+New lines are automatically added to the end of the log to keep each access log on its own line in the output.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
@@ -197,6 +204,6 @@ spec:
 
 ## Kubernetes
 
-The Envoy debugging logs are written to `stderr` as part of it's normal operation in any of the `consul-dataplane`, `envoy`, or `envoy-sidecar` containers.
+As part of its normal operation, the Envoy debugging logs for the `consul-dataplane`, `envoy`, or `envoy-sidecar` containers are written to `stderr`.
 The log sink [`Type`](http://localhost:3000/consul/docs/connect/config-entries/proxy-defaults#type) is set to `stdout` by default for access logs when enabled.
-A log aggregating solution should be able to separate the machine-readable access logs from the Envoy process debug logs.
+Use a log aggregating solution to separate the machine-readable access logs from the Envoy process debug logs.

--- a/website/content/docs/connect/observability/access-logs.mdx
+++ b/website/content/docs/connect/observability/access-logs.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Access Logs
 
-Consul Service Mesh can emit logs for application connections and requests passing through mesh proxies, including gateways.
+Consul Service Mesh can emit logs for application connections and requests passing through mesh proxies, including sidecars and gateways.
 Viewing this application traffic is useful in these ways:
   * **Diagnosing and Troubleshooting Issues**: Operators and application owners need to identify misconfigurations of the mesh or application by analyzing failed connections/requests.
   * **Threat Detection**: Operators may be interested in unauthorized attempts to access the mesh and their origins.

--- a/website/content/docs/connect/observability/access-logs.mdx
+++ b/website/content/docs/connect/observability/access-logs.mdx
@@ -205,5 +205,51 @@ spec:
 ## Kubernetes
 
 As part of its normal operation, the Envoy debugging logs for the `consul-dataplane`, `envoy`, or `envoy-sidecar` containers are written to `stderr`.
-The log sink [`Type`](http://localhost:3000/consul/docs/connect/config-entries/proxy-defaults#type) is set to `stdout` by default for access logs when enabled.
+The access log [`Type`](/docs/connect/config-entries/proxy-defaults#type) is set to `stdout` by default for access logs when enabled.
 Use a log aggregating solution to separate the machine-readable access logs from the Envoy process debug logs.
+
+## Write to a file
+
+You can write access logs to a file on the host where Envoy runs.
+The is most relevant when running Envoy on a VM.
+
+~> **operations warning:** Envoy does not rotate log files. 
+Have a log rotation solution, such as [logrotate](https://www.redhat.com/sysadmin/setting-logrotate), in place to prevent the host's disk space from being consumed by access logs when writing to a file. 
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind      = "proxy-defaults"
+Name      = "global"
+AccessLogs {
+  Enabled = true
+  Type = "file"
+  Path = "/var/log/envoy/access-logs.txt" 
+}
+```
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ProxyDefaults
+metadata:
+  name: global
+spec:
+  accessLogs:
+    enabled: true
+    type: file
+    path: "/var/log/envoy/access-logs.txt" 
+```
+
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "AccessLogs": {
+    "Enabled": true,
+    "Type": "file",
+    "Path": "/var/log/envoy/access-logs.txt"
+  }
+}
+```
+
+</CodeTabs>

--- a/website/content/docs/connect/observability/access-logs.mdx
+++ b/website/content/docs/connect/observability/access-logs.mdx
@@ -210,11 +210,9 @@ Use a log aggregating solution to separate the machine-readable access logs from
 
 ## Write to a file
 
-You can write access logs to a file on the host where Envoy runs.
-The is most relevant when running Envoy on a VM.
+You can configure Consul to write access logs to a file on the host where Envoy runs.
 
-~> **operations warning:** Envoy does not rotate log files. 
-Have a log rotation solution, such as [logrotate](https://www.redhat.com/sysadmin/setting-logrotate), in place to prevent the host's disk space from being consumed by access logs when writing to a file. 
+Envoy does not rotate log files. A log rotation solution, such as [logrotate](https://www.redhat.com/sysadmin/setting-logrotate), can prevent access logs from consuming too much of the host's disk space when writing to a file. 
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -442,6 +442,10 @@
             "path": "connect/observability"
           },
           {
+            "title": "Access Logs",
+            "path": "connect/observability/access-logs"
+          },
+          {
             "title": "UI Visualization",
             "path": "connect/observability/ui-visualization"
           }


### PR DESCRIPTION
### Description
Docs supporting the new Access Logging feature for consul service mesh.

### Testing & Reproduction steps
N/A

### Links
N/A

### PR Checklist

* [ ] ~updated test coverage~
* [X] external facing docs updated
* [X] not a security concern
