### PR TITLE
upgrade test: Add envoy GRPC test scenario [NET-2035]

### DIFF
--- a/test/integration/consul-container/go.mod
+++ b/test/integration/consul-container/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/consul/test/integration/consul-container
 go 1.19
 
 require (
+	fortio.org/fortio v1.38.4
 	github.com/docker/docker v20.10.11+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/hashicorp/consul v1.14.1
@@ -14,7 +15,8 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569
 	github.com/testcontainers/testcontainers-go v0.13.0
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+	golang.org/x/mod v0.6.0
+	google.golang.org/grpc v1.50.0
 )
 
 require (
@@ -42,7 +44,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v0.2.0 // indirect
 	github.com/go-openapi/analysis v0.21.2 // indirect
 	github.com/go-openapi/errors v0.20.2 // indirect
@@ -148,7 +150,8 @@ require (
 	go.etcd.io/bbolt v1.3.5 // indirect
 	go.mongodb.org/mongo-driver v1.10.0 // indirect
 	go.opencensus.io v0.22.4 // indirect
-	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
+	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/exp v0.0.0-20221111204811-129d8d6c17ab // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
@@ -158,7 +161,6 @@ require (
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220921223823-23cae91e6737 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect

--- a/test/integration/consul-container/go.sum
+++ b/test/integration/consul-container/go.sum
@@ -22,6 +22,9 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+fortio.org/assert v1.1.2 h1:t6WGDqPD5VFrUvx30U0+3mgXXcoPonrdKqt0vfJHn8E=
+fortio.org/fortio v1.38.4 h1:HkVsu9E4emMU+i2D2HjPll1Dbu5IqCRTeKeoiYWxFWA=
+fortio.org/fortio v1.38.4/go.mod h1:xZTReCI6wlPJQN+JssVO6jsqXJV2vC32dcZJrUaqmcU=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
@@ -301,8 +304,8 @@ github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebP
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
-github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -1003,8 +1006,9 @@ golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1015,6 +1019,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221111204811-129d8d6c17ab h1:1S7USr8/C0Sgk4egxq4zZ07zYt2Xh1IiFp8hUMXH/us=
+golang.org/x/exp v0.0.0-20221111204811-129d8d6c17ab/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1036,8 +1042,8 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
+golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1193,6 +1199,7 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1327,8 +1334,8 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.49.0 h1:WTLtQzmQori5FUH25Pq4WT22oCsv8USpQ+F6rqtsmxw=
-google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
+google.golang.org/grpc v1.50.0 h1:fPVVDxY9w++VjTZsYvXWqEf9Rqar/e+9zYfxKK+W+YU=
+google.golang.org/grpc v1.50.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/test/integration/consul-container/libs/assert/grpc.go
+++ b/test/integration/consul-container/libs/assert/grpc.go
@@ -1,0 +1,31 @@
+package assert
+
+import (
+	"context"
+	"testing"
+
+	"fortio.org/fortio/fgrpc"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func GRPCPing(t *testing.T, addr string) {
+	pingConn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	pingCl := fgrpc.NewPingServerClient(pingConn)
+	payload := addr
+	// TODO: not sure why, but this doesn't work the first time, needs some time to become ready
+	var msg *fgrpc.PingMessage
+	retry.Run(t, func(r *retry.R) {
+		msg, err = pingCl.Ping(context.Background(), &fgrpc.PingMessage{
+			Payload: payload,
+		})
+		if err != nil {
+			r.Error(err)
+		}
+	})
+	assert.Equal(t, payload, msg.Payload)
+}

--- a/test/integration/consul-container/libs/assert/service.go
+++ b/test/integration/consul-container/libs/assert/service.go
@@ -90,7 +90,7 @@ func CatalogServiceHealthy(t *testing.T, c *api.Client, svc string) {
 	retry.Run(t, func(r *retry.R) {
 		services, _, err := c.Health().Service(svc, "", true, nil)
 		if err != nil {
-			r.Fatalf("client call: %w", err)
+			r.Fatalf("client call: %s", err)
 		}
 		if len(services) == 0 {
 			r.Fatalf("did not find catalog entry for %s", svc)

--- a/test/integration/consul-container/libs/assert/service.go
+++ b/test/integration/consul-container/libs/assert/service.go
@@ -84,3 +84,16 @@ func CatalogServiceExists(t *testing.T, c *api.Client, svc string) {
 		}
 	})
 }
+
+// CatalogServiceHealthy verifies the service is healthy
+func CatalogServiceHealthy(t *testing.T, c *api.Client, svc string) {
+	retry.Run(t, func(r *retry.R) {
+		services, _, err := c.Health().Service(svc, "", true, nil)
+		if err != nil {
+			r.Fatalf("client call: %w", err)
+		}
+		if len(services) == 0 {
+			r.Fatalf("did not find catalog entry for %s", svc)
+		}
+	})
+}

--- a/test/integration/consul-container/libs/service/helpers.go
+++ b/test/integration/consul-container/libs/service/helpers.go
@@ -16,7 +16,7 @@ func CreateAndRegisterStaticServerAndSidecar(node Agent) (Service, Service, erro
 		return nil, nil, err
 	}
 
-	serverConnectProxy, err := NewConnectService(context.Background(), "static-server-sidecar", "static-server", 8080, node) // bindPort not used
+	serverConnectProxy, err := NewConnectService(context.Background(), "static-server-sidecar", "static-server", 8079, node) // bindPort not used
 	if err != nil {
 		return nil, nil, err
 	}
@@ -27,7 +27,7 @@ func CreateAndRegisterStaticServerAndSidecar(node Agent) (Service, Service, erro
 	// Register the static-server service and sidecar
 	req := &api.AgentServiceRegistration{
 		Name:    "static-server",
-		Port:    8080,
+		Port:    8079,
 		Address: serverServiceIP,
 		Connect: &api.AgentServiceConnect{
 			SidecarService: &api.AgentServiceRegistration{
@@ -51,13 +51,13 @@ func CreateAndRegisterStaticServerAndSidecar(node Agent) (Service, Service, erro
 				Proxy: &api.AgentServiceConnectProxyConfig{
 					DestinationServiceName: "static-server",
 					LocalServiceAddress:    serverServiceIP,
-					LocalServicePort:       8080,
+					LocalServicePort:       8079,
 				},
 			},
 		},
 		Check: &api.AgentServiceCheck{
 			Name:     "Static Server Listening",
-			TCP:      fmt.Sprintf("%s:%d", serverServiceIP, 8080),
+			GRPC:     fmt.Sprintf("%s:%d", serverServiceIP, 8079),
 			Interval: "10s",
 			Status:   api.HealthPassing,
 		},

--- a/test/integration/consul-container/test/basic/connect_service_test.go
+++ b/test/integration/consul-container/test/basic/connect_service_test.go
@@ -42,7 +42,7 @@ func createServices(t *testing.T, cluster *libcluster.Cluster) libservice.Servic
 	client := node.GetClient()
 
 	// Create a service and proxy instance
-	_, _, err := libservice.CreateAndRegisterStaticServerAndSidecar(node)
+	_, _, err := libservice.CreateAndRegisterStaticServerAndSidecar(node, false)
 	require.NoError(t, err)
 
 	libassert.CatalogServiceExists(t, client, "static-server-sidecar-proxy")

--- a/test/integration/consul-container/test/topology/peering_topology.go
+++ b/test/integration/consul-container/test/topology/peering_topology.go
@@ -74,7 +74,7 @@ func BasicPeeringTwoClustersSetup(t *testing.T, consulVersion string) (*libclust
 	clientNodes, err = acceptingCluster.Clients()
 	require.NoError(t, err)
 	require.True(t, len(clientNodes) > 0)
-	staticServerSvc, _, err := libservice.CreateAndRegisterStaticServerAndSidecar(clientNodes[0])
+	staticServerSvc, _, err := libservice.CreateAndRegisterStaticServerAndSidecar(clientNodes[0], false)
 	require.NoError(t, err)
 	libassert.CatalogServiceExists(t, acceptingClient, "static-server")
 	libassert.CatalogServiceExists(t, acceptingClient, "static-server-sidecar-proxy")

--- a/test/integration/consul-container/test/upgrade/badauthz_test.go
+++ b/test/integration/consul-container/test/upgrade/badauthz_test.go
@@ -54,7 +54,7 @@ func TestBadauthz_UpgradeToTarget_fromLatest(t *testing.T) {
 		clientNodes, err := cluster.Clients()
 		require.NoError(t, err)
 		require.True(t, len(clientNodes) > 0)
-		_, _, err = libservice.CreateAndRegisterStaticServerAndSidecar(clientNodes[0])
+		_, _, err = libservice.CreateAndRegisterStaticServerAndSidecar(clientNodes[0], false)
 		require.NoError(t, err)
 		client := clientNodes[0].GetClient()
 		libassert.CatalogServiceExists(t, client, "static-server")

--- a/test/integration/consul-container/test/upgrade/badauthz_test.go
+++ b/test/integration/consul-container/test/upgrade/badauthz_test.go
@@ -85,6 +85,10 @@ func TestBadauthz_UpgradeToTarget_fromLatest(t *testing.T) {
 		err = cluster.StandardUpgrade(t, context.Background(), tc.targetVersion)
 		require.NoError(t, err)
 
+		// Ensure deny still in effect after
+		_, port = staticClientSvcSidecar.GetAddr()
+		libassert.HTTPServiceFailTcpConnection(t, "localhost", port)
+
 		// Verify intentions work after upgrade
 		err = cluster.ConfigEntryWrite(`
 	Kind = "service-intentions"

--- a/test/integration/consul-container/test/upgrade/grpc_test.go
+++ b/test/integration/consul-container/test/upgrade/grpc_test.go
@@ -58,7 +58,7 @@ func TestGRPC_UpgradeToTarget_fromLatest(t *testing.T) {
 		clientNodes, err := cluster.Clients()
 		require.NoError(t, err)
 		require.True(t, len(clientNodes) > 0)
-		_, _, err = libservice.CreateAndRegisterStaticServerAndSidecar(clientNodes[0])
+		_, _, err = libservice.CreateAndRegisterStaticServerAndSidecar(clientNodes[0], true)
 		require.NoError(t, err)
 		client := clientNodes[0].GetClient()
 		libassert.CatalogServiceExists(t, client, "static-server")

--- a/test/integration/consul-container/test/upgrade/grpc_test.go
+++ b/test/integration/consul-container/test/upgrade/grpc_test.go
@@ -1,0 +1,121 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"fortio.org/fortio/fgrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
+	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
+	libservice "github.com/hashicorp/consul/test/integration/consul-container/libs/service"
+	libutils "github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+	"github.com/hashicorp/consul/test/integration/consul-container/test/topology"
+)
+
+// Test service intention continues functioning after upgrade
+// Steps:
+// 1. Create a cluster with one server and one client
+// 2. Register a static-server at server agent and a static-client at the client agent
+// 3. Upgrade the cluster
+// 4. Write the service-intention to allow the connection
+func TestGRPC_UpgradeToTarget_fromLatest(t *testing.T) {
+	type testcase struct {
+		oldversion    string
+		targetVersion string
+	}
+	tcs := []testcase{
+		//{
+		//  TODO: Recreat config during upgrade due to the breaking change to ports.grpc_tls
+		// 	oldversion:    "1.13",
+		// 	targetVersion: *libutils.TargetVersion,
+		// },
+		{
+			oldversion:    "1.14",
+			targetVersion: *libutils.TargetVersion,
+		},
+	}
+
+	run := func(t *testing.T, tc testcase) {
+		cluster := topology.BasicSingleClusterTopology(t, &libcluster.Options{
+			Datacenter: "dc1",
+			NumServer:  1,
+			NumClient:  1,
+			Version:    tc.oldversion,
+		})
+		defer func() {
+			err := cluster.Terminate()
+			require.NoErrorf(t, err, "termining cluster")
+		}()
+
+		// Register an static-server service
+		clientNodes, err := cluster.Clients()
+		require.NoError(t, err)
+		require.True(t, len(clientNodes) > 0)
+		_, _, err = libservice.CreateAndRegisterStaticServerAndSidecar(clientNodes[0])
+		require.NoError(t, err)
+		client := clientNodes[0].GetClient()
+		libassert.CatalogServiceExists(t, client, "static-server")
+		libassert.CatalogServiceExists(t, client, "static-server-sidecar-proxy")
+
+		// Register an static-client service
+		serverNodes, err := cluster.Servers()
+		require.NoError(t, err)
+		require.True(t, len(serverNodes) > 0)
+		staticClientSvcSidecar, err := libservice.CreateAndRegisterStaticClientSidecar(serverNodes[0], "", true)
+		require.NoError(t, err)
+
+		/*
+				cluster.ConfigEntryWrite(`
+			Kind      = "service-defaults"
+			Name      = "static-server"
+			Protocol  = "http2"
+			`)
+				cluster.ConfigEntryWrite(`
+			Kind      = "proxy-defaults"
+			Name      = "global"
+			Config {
+			protocol = "http2"
+			}
+			`)
+		*/
+
+		libassert.CatalogServiceHealthy(t, client, "static-server-sidecar-proxy")
+		_, clientPort := staticClientSvcSidecar.GetAddr()
+
+		grpcPing := func() {
+			pingConn, err := grpc.Dial(fmt.Sprintf("localhost:%d", clientPort), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			require.NoError(t, err)
+			pingCl := fgrpc.NewPingServerClient(pingConn)
+			// TODO: not sure why, but this doesn't work the first time, needs some time to become ready
+			retry.Run(t, func(r *retry.R) {
+				_, err = pingCl.Ping(context.Background(), &fgrpc.PingMessage{})
+				if err != nil {
+					r.Fatalf("ping: %s", err)
+				}
+			})
+		}
+		grpcPing()
+
+		// Upgrade the cluster to targetVersion
+		t.Logf("Upgrade to version %s", tc.targetVersion)
+		err = cluster.StandardUpgrade(t, context.Background(), tc.targetVersion)
+		require.NoError(t, err)
+
+		grpcPing()
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("upgrade from %s to %s", tc.oldversion, tc.targetVersion),
+			func(t *testing.T) {
+				run(t, tc)
+			})
+		time.Sleep(3 * time.Second)
+	}
+}

--- a/test/integration/consul-container/test/upgrade/grpc_test.go
+++ b/test/integration/consul-container/test/upgrade/grpc_test.go
@@ -6,12 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"fortio.org/fortio/fgrpc"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	libservice "github.com/hashicorp/consul/test/integration/consul-container/libs/service"
@@ -19,23 +15,21 @@ import (
 	"github.com/hashicorp/consul/test/integration/consul-container/test/topology"
 )
 
-// Test service intention continues functioning after upgrade
+// Test GRPC continues functioning after upgrade
 // Steps:
 // 1. Create a cluster with one server and one client
 // 2. Register a static-server at server agent and a static-client at the client agent
-// 3. Upgrade the cluster
-// 4. Write the service-intention to allow the connection
+// 3. Do some tests (namely, a GRPC ping)
+// 4. Upgrade the cluster
+// 5. Repeat tests
+//
+// This is based on envoy/case-grpc bats test
 func TestGRPC_UpgradeToTarget_fromLatest(t *testing.T) {
 	type testcase struct {
 		oldversion    string
 		targetVersion string
 	}
 	tcs := []testcase{
-		//{
-		//  TODO: Recreat config during upgrade due to the breaking change to ports.grpc_tls
-		// 	oldversion:    "1.13",
-		// 	targetVersion: *libutils.TargetVersion,
-		// },
 		{
 			oldversion:    "1.14",
 			targetVersion: *libutils.TargetVersion,
@@ -71,44 +65,26 @@ func TestGRPC_UpgradeToTarget_fromLatest(t *testing.T) {
 		staticClientSvcSidecar, err := libservice.CreateAndRegisterStaticClientSidecar(serverNodes[0], "", true)
 		require.NoError(t, err)
 
-		/*
-				cluster.ConfigEntryWrite(`
-			Kind      = "service-defaults"
-			Name      = "static-server"
-			Protocol  = "http2"
-			`)
-				cluster.ConfigEntryWrite(`
-			Kind      = "proxy-defaults"
-			Name      = "global"
-			Config {
-			protocol = "http2"
-			}
-			`)
-		*/
-
 		libassert.CatalogServiceHealthy(t, client, "static-server-sidecar-proxy")
 		_, clientPort := staticClientSvcSidecar.GetAddr()
+		// TODO: other checks from case-grpc/verify.bats:
+		// - check proxy admin is up
+		// - check cert URIs
+		// - check client has healthy upstream endpoints to server
+		// - check client is sending gRPC metrics to statsd
 
-		grpcPing := func() {
-			pingConn, err := grpc.Dial(fmt.Sprintf("localhost:%d", clientPort), grpc.WithTransportCredentials(insecure.NewCredentials()))
-			require.NoError(t, err)
-			pingCl := fgrpc.NewPingServerClient(pingConn)
-			// TODO: not sure why, but this doesn't work the first time, needs some time to become ready
-			retry.Run(t, func(r *retry.R) {
-				_, err = pingCl.Ping(context.Background(), &fgrpc.PingMessage{})
-				if err != nil {
-					r.Fatalf("ping: %s", err)
-				}
-			})
+		tests := func() {
+			libassert.GRPCPing(t, fmt.Sprintf("localhost:%d", clientPort))
 		}
-		grpcPing()
+		tests()
 
 		// Upgrade the cluster to targetVersion
 		t.Logf("Upgrade to version %s", tc.targetVersion)
 		err = cluster.StandardUpgrade(t, context.Background(), tc.targetVersion)
 		require.NoError(t, err)
 
-		grpcPing()
+		tests()
+		// TODO: envoy grpc filter verification
 	}
 
 	for _, tc := range tcs {

--- a/test/integration/consul-container/test/upgrade/grpc_test.go
+++ b/test/integration/consul-container/test/upgrade/grpc_test.go
@@ -58,7 +58,7 @@ func TestGRPC_UpgradeToTarget_fromLatest(t *testing.T) {
 		libassert.CatalogServiceExists(t, client, "static-server")
 		libassert.CatalogServiceExists(t, client, "static-server-sidecar-proxy")
 
-		// Register an static-client service
+		// Register static-client service
 		serverNodes, err := cluster.Servers()
 		require.NoError(t, err)
 		require.True(t, len(serverNodes) > 0)


### PR DESCRIPTION
Adapts the meat of the envoy GRPC integration test at https://github.com/hashicorp/consul/blob/main/test/integration/connect/envoy/case-grpc/verify.bats. In addition, adds an upgrade step to ensure behavior is consistent between versions.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
