### PR TITLE
docs: clarify reloadable config option usage

### DIFF
--- a/website/content/docs/agent/config/index.mdx
+++ b/website/content/docs/agent/config/index.mdx
@@ -51,9 +51,12 @@ required ports and their default settings.
 
 ## Reloadable Configuration
 
-Reloading configuration does not reload all configuration items. The
-items which are reloaded include:
+The following agent configuration options are reloadable at runtime.
+To make a Consul agent automatically reload these options when changed in its configuration files on disk,
+start the agent with its [`auto_reload_config` configuration option](/consul/docs/agent/config/config-files#auto_reload_config) set to `true`.
+You can also manually trigger reload with the [reload command](/commands/reload).
 
+Reloadable agent configuration options:
 - ACL Tokens
 - [Configuration Entry Bootstrap](/docs/agent/config/config-files#config_entries_bootstrap)
 - Checks

--- a/website/content/docs/agent/config/index.mdx
+++ b/website/content/docs/agent/config/index.mdx
@@ -51,10 +51,12 @@ required ports and their default settings.
 
 ## Reloadable Configuration
 
-The following agent configuration options are reloadable at runtime.
-To make a Consul agent automatically reload these options when changed in its configuration files on disk,
-start the agent with its [`auto_reload_config` configuration option](/consul/docs/agent/config/config-files#auto_reload_config) set to `true`.
-You can also manually trigger reload with the [reload command](/commands/reload).
+Some agent configuration options are reloadable at runtime.
+You can run the [`consul reload` command](/commands/reload) to manually reload supported options from configuration files in the configuration directory.
+To configure the agent to automatically reload configuration files updated on disk,
+set the [`auto_reload_config` configuration option](/consul/docs/agent/config/config-files#auto_reload_config) parameter to `true`.
+
+The following agent configuration options are reloadable at runtime: 
 
 Reloadable agent configuration options:
 - ACL Tokens

--- a/website/content/docs/agent/config/index.mdx
+++ b/website/content/docs/agent/config/index.mdx
@@ -57,8 +57,6 @@ To configure the agent to automatically reload configuration files updated on di
 set the [`auto_reload_config` configuration option](/consul/docs/agent/config/config-files#auto_reload_config) parameter to `true`.
 
 The following agent configuration options are reloadable at runtime: 
-
-Reloadable agent configuration options:
 - ACL Tokens
 - [Configuration Entry Bootstrap](/docs/agent/config/config-files#config_entries_bootstrap)
 - Checks


### PR DESCRIPTION
Improvements:
- Alter wording to make it more obvious when reading quickly that this is a list of reloadable options, not a list of non-reloadable option
- Mention that auto-reload is possible and how to configure it