### PR TITLE
Integration test for server rate limiting

### DIFF
--- a/agent/consul/rate/handler.go
+++ b/agent/consul/rate/handler.go
@@ -230,7 +230,13 @@ func (h *Handler) Allow(op Operation) error {
 		})
 
 		if enforced {
-			// TODO(NET-1382) - use the logger to print rate limiter logs.
+			h.logger.Warn("RPC blocked due to exceeded allowed rate limit",
+				"rpc", op.Name,
+				"source_addr", op.SourceAddr,
+				"limit_type", l.desc,
+				"limit_enforced", enforced,
+			)
+
 			if h.leaderStatusProvider.IsLeader() && op.Type == OperationTypeWrite {
 				return ErrRetryLater
 			}

--- a/agent/consul/rate/handler.go
+++ b/agent/consul/rate/handler.go
@@ -207,7 +207,7 @@ func (h *Handler) Allow(op Operation) error {
 		// TODO(NET-1382): is this the correct log-level?
 
 		enforced := l.mode == ModeEnforcing
-		h.logger.Trace("RPC exceeded allowed rate limit",
+		h.logger.Warn("RPC exceeded allowed rate limit",
 			"rpc", op.Name,
 			"source_addr", op.SourceAddr,
 			"limit_type", l.desc,
@@ -230,13 +230,6 @@ func (h *Handler) Allow(op Operation) error {
 		})
 
 		if enforced {
-			h.logger.Warn("RPC blocked due to exceeded allowed rate limit",
-				"rpc", op.Name,
-				"source_addr", op.SourceAddr,
-				"limit_type", l.desc,
-				"limit_enforced", enforced,
-			)
-
 			if h.leaderStatusProvider.IsLeader() && op.Type == OperationTypeWrite {
 				return ErrRetryLater
 			}

--- a/test/integration/consul-container/libs/cluster/agent.go
+++ b/test/integration/consul-container/libs/cluster/agent.go
@@ -40,6 +40,7 @@ type Config struct {
 	Image         string
 	Version       string
 	Cmd           []string
+	LogConsumer   testcontainers.LogConsumer
 
 	// service defaults
 	UseAPIWithTLS  bool // TODO

--- a/test/integration/consul-container/libs/cluster/container.go
+++ b/test/integration/consul-container/libs/cluster/container.go
@@ -198,9 +198,13 @@ func NewConsulContainer(ctx context.Context, config Config, network string, inde
 			_ = consulContainer.StopLogProducer()
 		})
 
-		consulContainer.FollowOutput(&LogConsumer{
-			Prefix: opts.name,
-		})
+		if config.LogConsumer != nil {
+			consulContainer.FollowOutput(config.LogConsumer)
+		} else {
+			consulContainer.FollowOutput(&LogConsumer{
+				Prefix: opts.name,
+			})
+		}
 	}
 
 	node := &consulContainerNode{

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -1,0 +1,118 @@
+package ratelimit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/api"
+	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+)
+
+const (
+	retryableErrorMsg    = "Unexpected response code: 429 (rate limit exceeded, try again later or against a different server)"
+	nonRetryableErrorMsg = "Unexpected response code: 503 (rate limit exceeded for operation that can only be performed by the leader, try again later)"
+)
+
+// TestRateLimit
+// This test validates
+// - enforcing mode
+//   - read_rate - returns 429 - was blocked and returns retryable error
+//   - write_rate - returns 503 - was blocked and is not retryable
+//   - on each
+//     - fires metrics forexceeding
+//     - logs for exceeding
+
+func TestRateLimit(t *testing.T) {
+	type testOperation struct {
+		action           func(client *api.Client) error
+		expectedErrorMsg string
+	}
+	type testCase struct {
+		dsc        string
+		cmd        string
+		operations []testOperation
+	}
+
+	testCases := []testCase{
+		{
+			dsc: "Mode: enforcing",
+			cmd: "-hcl=limits { request_limits { mode = \"enforcing\" read_rate = 0 write_rate = 0 }}",
+			operations: []testOperation{
+				{
+					action: func(client *api.Client) error {
+						_, _, err := client.Catalog().Nodes(&api.QueryOptions{})
+						return err
+					},
+					expectedErrorMsg: retryableErrorMsg,
+				},
+				{
+					action: func(client *api.Client) error {
+						_, err := utils.ApplyDefaultProxySettings(client)
+						return err
+					},
+					expectedErrorMsg: nonRetryableErrorMsg,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.dsc, func(t *testing.T) {
+			cluster := createCluster(t, tc.cmd)
+			defer terminate(t, cluster)
+
+			client, err := cluster.GetClient(nil, true)
+			require.NoError(t, err)
+			for _, op := range tc.operations {
+				err = op.action(client)
+				if len(op.expectedErrorMsg) > 0 {
+					require.Error(t, err)
+					require.Equal(t, op.expectedErrorMsg, err.Error())
+				}
+			}
+			metrics, err := client.Agent().Metrics()
+			require.NoError(t, err)
+			for counter := range metrics.Counters {
+				t.Logf("Counter: %+v", counter)
+			}
+		})
+	}
+}
+
+func terminate(t *testing.T, cluster *libcluster.Cluster) {
+	err := cluster.Terminate()
+	require.NoError(t, err)
+}
+
+// createCluster
+func createCluster(t *testing.T, cmd string) *libcluster.Cluster {
+	opts := libcluster.BuildOptions{
+		InjectAutoEncryption:   true,
+		InjectGossipEncryption: true,
+	}
+	ctx := libcluster.NewBuildContext(t, opts)
+
+	conf := libcluster.NewConfigBuilder(ctx).ToAgentConfig(t)
+
+	t.Logf("Cluster config:\n%s", conf.JSON)
+
+	parsedConfigs := []libcluster.Config{*conf}
+
+	cfgs := []libcluster.Config{}
+	for _, cfg := range parsedConfigs {
+		cfg.Cmd = append(cfg.Cmd, cmd)
+		cfgs = append(cfgs, cfg)
+	}
+	cluster, err := libcluster.New(t, cfgs)
+	require.NoError(t, err)
+
+	client, err := cluster.GetClient(nil, true)
+
+	require.NoError(t, err)
+	libcluster.WaitForLeader(t, cluster, client)
+	libcluster.WaitForMembers(t, client, 1)
+
+	return cluster
+}

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -130,6 +130,8 @@ func TestRateLimit(t *testing.T) {
 
 			client, err := cluster.GetClient(nil, true)
 			require.NoError(t, err)
+
+			// validate returned errors to client
 			for _, op := range tc.operations {
 				if op.expectLog {
 					urlsExpectingLogging = append(urlsExpectingLogging, op.action.httpAction)
@@ -155,6 +157,7 @@ func TestRateLimit(t *testing.T) {
 				require.True(t, found, fmt.Sprintf("Log not found for: %s", httpRequest))
 			}
 
+			// validate metrics
 			metricInfo, err := client.Agent().Metrics()
 			// TODO(NET-1978): currently returns NaN error
 			//			require.NoError(t, err)

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -65,7 +65,7 @@ func TestRateLimit(t *testing.T) {
 	testCases := []testCase{
 		// HTTP & net/RPC
 		{
-			description: "HTTP & net/RPC / Mode: disabled - errors: no / logs: no / metrics: no",
+			description: "HTTP & net/RPC / Mode: disabled - errors: no / exceeded logs: no / blocked logs: no / metrics: no",
 			cmd:         "-hcl=limits { request_limits { mode = \"disabled\" read_rate = 0 write_rate = 0 }}",
 			operations: []operation{
 				{
@@ -85,7 +85,7 @@ func TestRateLimit(t *testing.T) {
 			},
 		},
 		{
-			description: "HTTP & net/RPC / Mode: permissive - errors: no / logs: no / metrics: yes",
+			description: "HTTP & net/RPC / Mode: permissive - errors: no / exceeded logs: yes / blocked logs: no / metrics: yes",
 			cmd:         "-hcl=limits { request_limits { mode = \"permissive\" read_rate = 0 write_rate = 0 }}",
 			operations: []operation{
 				{
@@ -105,7 +105,7 @@ func TestRateLimit(t *testing.T) {
 			},
 		},
 		{
-			description: "HTTP & net/RPC / Mode: enforcing - errors: yes / logs: yes / metrics: yes",
+			description: "HTTP & net/RPC / Mode: enforcing - errors: yes / exceeded logs: yes / blocked logs: yes / metrics: yes",
 			cmd:         "-hcl=limits { request_limits { mode = \"enforcing\" read_rate = 0 write_rate = 0 }}",
 			operations: []operation{
 				{

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -165,11 +165,13 @@ func TestRateLimit(t *testing.T) {
 				// putting this last as there are cases where logs
 				// were not present in consumer when assertion was made.
 				if op.expectExceededLog {
-					checkLogsForMessage(t, logConsumer.Msgs, fmt.Sprintf("[TRACE] agent.server.rpc-rate-limit: RPC exceeded allowed rate limit: rpc=%s", op.action.rateLimitOperation),
+					checkLogsForMessage(t, logConsumer.Msgs,
+						fmt.Sprintf("[TRACE] agent.server.rpc-rate-limit: RPC exceeded allowed rate limit: rpc=%s", op.action.rateLimitOperation),
 						op.action.rateLimitOperation, "exceeded")
 				}
 				if op.expectBlockedLog {
-					checkLogsForMessage(t, logConsumer.Msgs, fmt.Sprintf("[WARN]  agent.server.rpc-rate-limit: RPC blocked due to exceeded allowed rate limit: rpc=%s", op.action.rateLimitOperation),
+					checkLogsForMessage(t, logConsumer.Msgs,
+						fmt.Sprintf("[WARN]  agent.server.rpc-rate-limit: RPC blocked due to exceeded allowed rate limit: rpc=%s", op.action.rateLimitOperation),
 						op.action.rateLimitOperation, "blocked")
 				}
 			}

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -66,7 +66,7 @@ func TestRateLimit(t *testing.T) {
 		// HTTP & net/RPC
 		{
 			description: "HTTP & net/RPC / Mode: disabled - errors: no / exceeded logs: no / blocked logs: no / metrics: no",
-			cmd:         "-hcl=limits { request_limits { mode = \"disabled\" read_rate = 0 write_rate = 0 }}",
+			cmd:         `-hcl=limits { request_limits { mode = "disabled" read_rate = 0 write_rate = 0 }}`,
 			operations: []operation{
 				{
 					action:            putKV,
@@ -86,7 +86,7 @@ func TestRateLimit(t *testing.T) {
 		},
 		{
 			description: "HTTP & net/RPC / Mode: permissive - errors: no / exceeded logs: yes / blocked logs: no / metrics: yes",
-			cmd:         "-hcl=limits { request_limits { mode = \"permissive\" read_rate = 0 write_rate = 0 }}",
+			cmd:         `-hcl=limits { request_limits { mode = "permissive" read_rate = 0 write_rate = 0 }}`,
 			operations: []operation{
 				{
 					action:            putKV,
@@ -106,7 +106,7 @@ func TestRateLimit(t *testing.T) {
 		},
 		{
 			description: "HTTP & net/RPC / Mode: enforcing - errors: yes / exceeded logs: yes / blocked logs: yes / metrics: yes",
-			cmd:         "-hcl=limits { request_limits { mode = \"enforcing\" read_rate = 0 write_rate = 0 }}",
+			cmd:         `-hcl=limits { request_limits { mode = "enforcing" read_rate = 0 write_rate = 0 }}`,
 			operations: []operation{
 				{
 					action:            putKV,

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -26,7 +26,7 @@ const (
 //     - fires metrics forexceeding
 //     - logs for exceeding
 
-func TestRateLimit(t *testing.T) {
+func TestServerRequestRateLimit(t *testing.T) {
 	type action struct {
 		function           func(client *api.Client) error
 		rateLimitOperation string

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -71,13 +71,13 @@ func TestRateLimit(t *testing.T) {
 			cmd:         "-hcl=limits { request_limits { mode = \"disabled\" read_rate = 0 write_rate = 0 }}",
 			operations: []operation{
 				{
-					action:           getNodes,
+					action:           putConfig,
 					expectedErrorMsg: "",
 					expectLog:        false,
 					expectMetric:     false,
 				},
 				{
-					action:           putConfig,
+					action:           getNodes,
 					expectedErrorMsg: "",
 					expectLog:        false,
 					expectMetric:     false,
@@ -89,13 +89,13 @@ func TestRateLimit(t *testing.T) {
 			cmd:         "-hcl=limits { request_limits { mode = \"permissive\" read_rate = 0 write_rate = 0 }}",
 			operations: []operation{
 				{
-					action:           getNodes,
+					action:           putConfig,
 					expectedErrorMsg: "",
 					expectLog:        false,
 					expectMetric:     false,
 				},
 				{
-					action:           putConfig,
+					action:           getNodes,
 					expectedErrorMsg: "",
 					expectLog:        false,
 					expectMetric:     false,
@@ -107,14 +107,14 @@ func TestRateLimit(t *testing.T) {
 			cmd:         "-hcl=limits { request_limits { mode = \"enforcing\" read_rate = 0 write_rate = 0 }}",
 			operations: []operation{
 				{
-					action:           getNodes,
-					expectedErrorMsg: retryableErrorMsg,
+					action:           putConfig,
+					expectedErrorMsg: nonRetryableErrorMsg,
 					expectLog:        true,
 					expectMetric:     true,
 				},
 				{
-					action:           putConfig,
-					expectedErrorMsg: nonRetryableErrorMsg,
+					action:           getNodes,
+					expectedErrorMsg: retryableErrorMsg,
 					expectLog:        true,
 					expectMetric:     true,
 				},
@@ -150,7 +150,7 @@ func TestRateLimit(t *testing.T) {
 			for _, httpRequest := range urlsExpectingLogging {
 				found := false
 				for _, msg := range logConsumer.Msgs {
-					if strings.Contains(msg, httpRequest) {
+					if strings.Contains(msg, httpRequest) && strings.Contains(msg, "error=\"rate limit exceeded") {
 						found = true
 					}
 				}

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -161,7 +161,7 @@ func TestRateLimit(t *testing.T) {
 			metricInfo, err := client.Agent().Metrics()
 			// TODO(NET-1978): currently returns NaN error
 			//			require.NoError(t, err)
-			if metricInfo != nil {
+			if metricInfo != nil && err == nil {
 				for _, op := range tc.operations {
 					if op.expectMetric {
 						for _, counter := range metricInfo.Counters {

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -196,6 +196,7 @@ func checkLogsForMessage(t *retry.R, logs []string, msg string, operationName st
 	for _, log := range logs {
 		if strings.Contains(log, msg) {
 			found = true
+			break
 		}
 	}
 	require.Equal(t, logShouldExist, found, fmt.Sprintf("%s log check failed for: %s. Log expected: %t", logType, operationName, logShouldExist))


### PR DESCRIPTION
### Description
Adding in an integration test to assert that the following effects occur:
- error messages returned to clients
- trace logs when limits exceed
- warning logs when limits blocked
- metrics when limits exceeded

This is currently only for HTTP/ net-RPC.