### PR TITLE
Update TG Docs with SAN match option when using SNI

### DIFF
--- a/website/content/docs/connect/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/connect/config-entries/terminating-gateway.mdx
@@ -679,7 +679,8 @@ spec:
           name: 'SNI',
           type: 'string: ""',
           description:
-            'An optional hostname or domain name to specify during the TLS handshake.',
+          `An optional hostname or domain name to specify during the TLS handshake. This option will also configure [strict SAN matching](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-certificatevalidationcontext-match-typed-subject-alt-names), which requires
+            the external services to have certificates with SANs, not having which will result in \`CERTIFICATE_VERIFY_FAILED\` error.`,
         },
       ],
     },


### PR DESCRIPTION
### Description
When using SNI in Terminating Gateway, Consul configures envoy to have strict SAN matching. This requires all external services to have SANs in their certificates, and not having it will throw `CERTIFICATE_VERIFY_FAILED` error.

eg:

```
$ cat tg.hcl
Kind = "terminating-gateway"
Name = "terminating-gateway"

Services = [
  {
      Name = "counting"
      CAfile = "/consul/consul-ca.pem"
      SNI = "abc.example.com"
  }
]



$ curl -s localhost:19000/config_dump | grep match_subject -A4
"match_subject_alt_names": [
 {
    "exact": "abc.example.com"
 }
]
```
### Links
* https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-certificatevalidationcontext-match-typed-subject-alt-names

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
