### PR TITLE
api: enable query options on agent force-leave endpoint

### DIFF
--- a/.changelog/15987.txt
+++ b/.changelog/15987.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Enable setting query options on agent force-leave endpoint.
+```

--- a/api/agent.go
+++ b/api/agent.go
@@ -1052,6 +1052,8 @@ func (a *Agent) ForceLeavePrune(node string) error {
 
 // ForceLeaveOpts is used to have the agent eject a failed node or remove it
 // completely from the list of members.
+//
+// DEPRECATED - Use ForceLeaveOptions instead.
 func (a *Agent) ForceLeaveOpts(node string, opts ForceLeaveOpts) error {
 	return a.ForceLeaveOptions(node, opts, nil)
 }

--- a/api/agent.go
+++ b/api/agent.go
@@ -1053,7 +1053,14 @@ func (a *Agent) ForceLeavePrune(node string) error {
 // ForceLeaveOpts is used to have the agent eject a failed node or remove it
 // completely from the list of members.
 func (a *Agent) ForceLeaveOpts(node string, opts ForceLeaveOpts) error {
+	return a.ForceLeaveOptions(node, opts, nil)
+}
+
+// ForceLeaveOptions is used to have the agent eject a failed node or remove it
+// completely from the list of members. Allows usage of QueryOptions on-top of ForceLeaveOpts
+func (a *Agent) ForceLeaveOptions(node string, opts ForceLeaveOpts, q *QueryOptions) error {
 	r := a.c.newRequest("PUT", "/v1/agent/force-leave/"+node)
+	r.setQueryOptions(q)
 	if opts.Prune {
 		r.params.Set("prune", "1")
 	}

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -1362,6 +1362,20 @@ func TestAPI_AgentForceLeavePrune(t *testing.T) {
 	}
 }
 
+func TestAPI_AgentForceLeaveOptions(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	agent := c.Agent()
+
+	// Eject somebody with token
+	err := agent.ForceLeaveOptions(s.Config.NodeName, ForceLeaveOpts{Prune: true}, &QueryOptions{Token: "testToken"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
 func TestAPI_AgentMonitor(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)


### PR DESCRIPTION
### Description
This PR adds support for setting QueryOptions on the force-leave endpoints.
We are using Consul <> Vault ACL tokens and in-need of providing token for this purpose.

### Testing & Reproduction steps

If it not provided a response similar to the below is given: 

```< date: Mon, 16 Jan 2023 22:23:57 GMT
< content-type: text/plain; charset=utf-8
< content-length: 113
< vary: Accept-Encoding
< x-consul-default-acl-policy: deny
<
* Connection #0 to host consul.server.net left intact
Permission denied: token with AccessorID 'dacd6887-313d-cb3f-1820-0994797e4375' lacks permission 'operator:write'
```


https://github.com/hashicorp/consul/issues/16805