### PR TITLE
Add a flag for enabling debug logs to the `connect envoy` command

### DIFF
--- a/.changelog/15988.txt
+++ b/.changelog/15988.txt
@@ -1,0 +1,3 @@
+```release-note:improvements
+cli: Added a flag, `-enable-config-gen-logging`, to the `connect envoy` command to display log messages when generating the bootstrap config.
+```

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -235,6 +235,12 @@ func (c *cmd) init() {
 	c.dialFunc = func(network string, address string) (net.Conn, error) {
 		return net.DialTimeout(network, address, 3*time.Second)
 	}
+
+	opts := hclog.LoggerOptions{Level: hclog.Off}
+	if c.enableLogging {
+		opts.Level = hclog.Debug
+	}
+	c.logger = hclog.New(&opts)
 }
 
 // canBindInternal is here mainly so we can unit test this with a constant net.Addr list
@@ -279,12 +285,6 @@ func (c *cmd) Run(args []string) int {
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}
-
-	opts := hclog.LoggerOptions{Level: hclog.Off}
-	if c.enableLogging {
-		opts.Level = hclog.Debug
-	}
-	c.logger = hclog.New(&opts)
 
 	// Setup Consul client
 	var err error

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-version"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/mapstructure"
@@ -42,6 +43,7 @@ type cmd struct {
 	http   *flags.HTTPFlags
 	help   string
 	client *api.Client
+	logger hclog.Logger
 
 	// flags
 	meshGateway              bool
@@ -65,6 +67,7 @@ type cmd struct {
 	prometheusCertFile       string
 	prometheusKeyFile        string
 	ignoreEnvoyCompatibility bool
+	enableLogging            bool
 
 	// mesh gateway registration information
 	register           bool
@@ -221,6 +224,9 @@ func (c *cmd) init() {
 			"flag to `false` to ensure compatibility with Envoy and prevent potential issues. "+
 			"Default is `false`.")
 
+	c.flags.BoolVar(&c.enableLogging, "enable-config-gen-logging", false,
+		"Output debug log messages during config generation")
+
 	c.http = &flags.HTTPFlags{}
 	flags.Merge(c.flags, c.http.ClientFlags())
 	flags.Merge(c.flags, c.http.MultiTenancyFlags())
@@ -274,6 +280,12 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
+	opts := hclog.LoggerOptions{Level: hclog.Off}
+	if c.enableLogging {
+		opts.Level = hclog.Debug
+	}
+	c.logger = hclog.New(&opts)
+
 	// Setup Consul client
 	var err error
 	c.client, err = c.http.APIClient()
@@ -281,6 +293,8 @@ func (c *cmd) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
 		return 1
 	}
+	c.logger.Debug("Initialized API client")
+
 	// TODO: refactor
 	return c.run(c.flags.Args())
 }
@@ -350,6 +364,7 @@ func (c *cmd) run(args []string) int {
 			c.proxyID = c.gatewaySvcName
 
 		}
+		c.logger.Debug("Set Proxy ID", "proxy-id", c.proxyID)
 	}
 	if c.proxyID == "" {
 		c.UI.Error("No proxy ID specified. One of -proxy-id, -sidecar-for, or -gateway is " +
@@ -443,6 +458,7 @@ func (c *cmd) run(args []string) int {
 			c.UI.Error(fmt.Sprintf("Error registering service %q: %s", svc.Name, err))
 			return 1
 		}
+		c.logger.Debug("Proxy registration complete")
 
 		if !c.bootstrap {
 			// We need stdout to be reserved exclusively for the JSON blob, so
@@ -457,6 +473,7 @@ func (c *cmd) run(args []string) int {
 	}
 
 	// Generate config
+	c.logger.Debug("Generating bootstrap config")
 	bootstrapJson, err := c.generateConfig()
 	if err != nil {
 		c.UI.Error(err.Error())
@@ -465,11 +482,13 @@ func (c *cmd) run(args []string) int {
 
 	if c.bootstrap {
 		// Just output it and we are done
+		c.logger.Debug("Outputting bootstrap config")
 		c.UI.Output(string(bootstrapJson))
 		return 0
 	}
 
 	// Find Envoy binary
+	c.logger.Debug("Finding envoy binary")
 	binary, err := c.findBinary()
 	if err != nil {
 		c.UI.Error("Couldn't find envoy binary: " + err.Error())
@@ -497,6 +516,7 @@ func (c *cmd) run(args []string) int {
 		}
 	}
 
+	c.logger.Debug("Executing envoy binary")
 	err = execEnvoy(binary, nil, args, bootstrapJson)
 	if err == errUnsupportedOS {
 		c.UI.Error("Directly running Envoy is only supported on linux and macOS " +
@@ -618,6 +638,7 @@ func (c *cmd) generateConfig() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	c.logger.Debug("Generated template args")
 
 	var bsCfg BootstrapConfig
 
@@ -665,6 +686,7 @@ func (c *cmd) generateConfig() ([]byte, error) {
 		datacenter = svcList.Node.Datacenter
 		c.gatewayKind = svcList.Services[0].Kind
 	}
+	c.logger.Debug("Fetched registration info")
 	if svcProxyConfig == nil {
 		return nil, errors.New("service is not a Connect proxy or gateway")
 	}
@@ -700,6 +722,7 @@ func (c *cmd) generateConfig() ([]byte, error) {
 	if err := generateAccessLogs(c, args); err != nil {
 		return nil, err
 	}
+	c.logger.Debug("Generated access logs")
 
 	// Setup ready listener for ingress gateway to pass healthcheck
 	if c.gatewayKind == api.ServiceKindIngressGateway {

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -126,8 +126,7 @@ compatibility with Envoy and prevent potential issues. Default is `false`.
   always specifies `--config-file` and `--v2-config-only` and by default passes
   `--disable-hot-restart` see [hot restart](#envoy-hot-restart).
 
-- `-enable-config-gen-logging` - If present, debug log messages will be enabled for
-  generation of the Envoy bootstrap config.
+- `-enable-config-gen-logging` - This flag enables debug message logging when generating the Envoy bootstrap configuration to help troubleshoot issues. Logs output to `stderr`. For more information about generating the Envoy bootstrap configuration, refer to [Envoy proxy configuration](/consul/docs/connect/proxies/envoy#bootstrap-configuration).
 
 #### Envoy Sidecar Proxy Options
 

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -126,6 +126,9 @@ compatibility with Envoy and prevent potential issues. Default is `false`.
   always specifies `--config-file` and `--v2-config-only` and by default passes
   `--disable-hot-restart` see [hot restart](#envoy-hot-restart).
 
+- `-enable-config-gen-logging` - If present, debug log messages will be enabled for
+  generation of the Envoy bootstrap config.
+
 #### Envoy Sidecar Proxy Options
 
 - `-sidecar-for` - The _ID_ (not name if they differ) of the service instance

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -124,6 +124,12 @@ Envoy requires an initial bootstrap configuration file. You can either create th
 
 Connect to a local Consul client agent and run the [`consul connect envoy` command](/consul/commands/connect/envoy) to create the Envoy bootstrap configuration. The command either outputs the bootstrap configuration directly to stdout or generates the configuration and issues an `exec` command to the Envoy binary as a convenience wrapper. For more information about using `exec` to bootstrap Envoy, refer to [Exec Security Details](/consul/commands/connect/envoy#exec-security-details).
 
+If you experience issues when bootstrapping Envoy proxies from the CLI, use the
+`-enable-config-gen-logging` flag to enable debug message logging. These logs can
+help you troubleshoot issues during Envoy bootstrapping. For more information about
+available flags and parameters, refer to the
+[`consul connect envoy CLI` reference](/commands/connect/envoy).
+
 ### Generate the bootstrap file from Consul Dataplane
 
 Consul Dataplane automatically configures and manages an Envoy process. Consul Dataplane generates the Envoy bootstrap configuration file prior to starting Envoy. To configure how Consul Dataplane starts Envoy, refer to the [Consul Dataplane CLI reference](/consul/docs/connect/dataplane/consul-dataplane).

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -126,8 +126,8 @@ Connect to a local Consul client agent and run the [`consul connect envoy` comma
 
 If you experience issues when bootstrapping Envoy proxies from the CLI, use the
 `-enable-config-gen-logging` flag to enable debug message logging. These logs can
-help you troubleshoot issues during Envoy bootstrapping. For more information about
-available flags and parameters, refer to the
+help you troubleshoot issues that occur during the bootstrapping process. 
+For more information about available flags and parameters, refer to the
 [`consul connect envoy CLI` reference](/consul/commands/connect/envoy).
 
 ### Generate the bootstrap file from Consul Dataplane

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -128,7 +128,7 @@ If you experience issues when bootstrapping Envoy proxies from the CLI, use the
 `-enable-config-gen-logging` flag to enable debug message logging. These logs can
 help you troubleshoot issues during Envoy bootstrapping. For more information about
 available flags and parameters, refer to the
-[`consul connect envoy CLI` reference](/commands/connect/envoy).
+[`consul connect envoy CLI` reference](/consul/commands/connect/envoy).
 
 ### Generate the bootstrap file from Consul Dataplane
 


### PR DESCRIPTION
This PR adds a flag, `-enable-config-gen-logging`, to the `connect envoy` command to display some log messages when generating the bootstrap config. It can be hard to troubleshoot slowness that happens during the multiple api requests during this command due to the current lack of logs, so this flag enables outputting some messages (on stderr) to help with that.