### PR TITLE
[OSS] chore(ci): fix compat ent compat tests for sidecars and gateways

### DIFF
--- a/test/integration/consul-container/libs/service/assets/Dockerfile-consul-envoy
+++ b/test/integration/consul-container/libs/service/assets/Dockerfile-consul-envoy
@@ -1,7 +1,8 @@
-# Note this arg has to be before the first FROM
+# Note these args have to be before the first FROM
+ARG CONSUL_IMAGE
 ARG ENVOY_VERSION
 
-FROM consul:local as consul
+FROM ${CONSUL_IMAGE} as consul
 
 FROM docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}
 COPY --from=consul /bin/consul /bin/consul

--- a/test/integration/consul-container/libs/service/connect.go
+++ b/test/integration/consul-container/libs/service/connect.go
@@ -79,8 +79,10 @@ func NewConnectService(ctx context.Context, name string, serviceName string, ser
 	containerName := utils.RandName(namePrefix)
 
 	envoyVersion := getEnvoyVersion()
+	agentConfig := node.GetConfig()
 	buildargs := map[string]*string{
 		"ENVOY_VERSION": utils.StringToPointer(envoyVersion),
+		"CONSUL_IMAGE":  utils.StringToPointer(agentConfig.DockerImage()),
 	}
 
 	dockerfileCtx, err := getDevContainerDockerfile()

--- a/test/integration/consul-container/libs/service/gateway.go
+++ b/test/integration/consul-container/libs/service/gateway.go
@@ -74,8 +74,10 @@ func NewGatewayService(ctx context.Context, name string, kind string, node libcl
 	containerName := utils.RandName(namePrefix)
 
 	envoyVersion := getEnvoyVersion()
+	agentConfig := node.GetConfig()
 	buildargs := map[string]*string{
 		"ENVOY_VERSION": utils.StringToPointer(envoyVersion),
+		"CONSUL_IMAGE":  utils.StringToPointer(agentConfig.DockerImage()),
 	}
 
 	dockerfileCtx, err := getDevContainerDockerfile()


### PR DESCRIPTION
### Description
Should fix issues with missing `consul:local` image used as the base for sidecars/gateways. This image is not available in ENT pipelines. Use the same image that was used to create the cluster.
