### PR TITLE
[docs] Adjusting links for rewrite project

### DIFF
--- a/website/content/api-docs/operator/segment.mdx
+++ b/website/content/api-docs/operator/segment.mdx
@@ -18,7 +18,7 @@ The network area functionality described here is available only in
 later. Network segments are operator-defined sections of agents on the LAN, typically
 isolated from other segments by network configuration.
 
-Please check the [Network Segments tutorial](https://learn.hashicorp.com/tutorials/consul/network-partition-datacenters) for more details.
+Please check the [Network Segments documentation](/consul/docs/enterprise/network-segments/network-segments-overview) for more details.
 
 ## List Network Segments
 

--- a/website/content/docs/connect/connectivity-tasks.mdx
+++ b/website/content/docs/connect/connectivity-tasks.mdx
@@ -67,6 +67,6 @@ connections through the gateway are authorized. Then traditional tools like fire
 connections from the known gateway nodes to the destination services.
 
 For more information about terminating gateways, review the [complete documentation](/docs/connect/gateways/terminating-gateway)
-and the [terminating gateway tutorial](https://learn.hashicorp.com/tutorials/consul/teminating-gateways-connect-external-services).
+and the [terminating gateway tutorial](https://learn.hashicorp.com/tutorials/consul/terminating-gateways-connect-external-services).
 
 ![Terminating Gateway Architecture](/img/terminating-gateways.png)

--- a/website/content/docs/connect/gateways/index.mdx
+++ b/website/content/docs/connect/gateways/index.mdx
@@ -72,6 +72,6 @@ connections through the gateway are authorized. Then traditional tools like fire
 connections from the known gateway nodes to the destination services.
 
 For more information about terminating gateways, review the [complete documentation](/docs/connect/gateways/terminating-gateway)
-and the [terminating gateway tutorial](https://learn.hashicorp.com/tutorials/consul/teminating-gateways-connect-external-services).
+and the [terminating gateway tutorial](https://learn.hashicorp.com/tutorials/consul/terminating-gateways-connect-external-services).
 
 ![Terminating Gateway Architecture](/img/terminating-gateways.png)

--- a/website/content/docs/connect/gateways/terminating-gateway.mdx
+++ b/website/content/docs/connect/gateways/terminating-gateway.mdx
@@ -77,7 +77,7 @@ a terminating gateway as long as they discover upstreams with the
 ## Running and Using a Terminating Gateway
 
 For a complete example of how to enable connections from services in the Consul service mesh to
-services outside the mesh, review the [terminating gateway tutorial](https://learn.hashicorp.com/tutorials/consul/teminating-gateways-connect-external-services).
+services outside the mesh, review the [terminating gateway tutorial](https://learn.hashicorp.com/tutorials/consul/terminating-gateways-connect-external-services).
 
 ## Terminating Gateway Configuration
 

--- a/website/content/docs/discovery/services.mdx
+++ b/website/content/docs/discovery/services.mdx
@@ -14,7 +14,7 @@ a health check. A health check associated with a service is considered to be an
 application-level check. Define services in a configuration file or add it at
 runtime using the HTTP interface.
 
-Complete the [Getting Started tutorials](https://learn.hashicorp.com/tutorials/consul/get-started-service-discovery?utm_source=docs) to get hands-on experience registering a simple service with a health check on your local machine.
+Complete the [Getting Started tutorials](/consul/tutorials/get-started-vms/virtual-machine-gs-service-discovery) to get hands-on experience registering a simple service with a health check on your local machine.
 
 ## Service Definition
 

--- a/website/content/docs/enterprise/network-segments/network-segments-overview.mdx
+++ b/website/content/docs/enterprise/network-segments/network-segments-overview.mdx
@@ -37,9 +37,7 @@ Server agents are members of all segments. The datacenter includes the `<default
 Each client agent can only be a member of one segment at a time. Client agents are members of the `<default>` segment unless they are configured to join a different segment. 
 For a client agent to join the Consul datacenter, it must connect to another agent (client or server) within its configured segment.
 
-
-
-Complete the [Network Segments](https://learn.hashicorp.com/tutorials/consul/network-partition-datacenters) tutorial to learn more about network segments.
+Read the [Network Segments documentation](/consul/docs/enterprise/network-segments/network-segments-overview) to learn more about network segments.
 
 -> **Info:** Network segments enable you to operate a Consul datacenter without full
 mesh (LAN) connectivity between agents. To federate multiple Consul datacenters

--- a/website/content/docs/integrate/partnerships.mdx
+++ b/website/content/docs/integrate/partnerships.mdx
@@ -167,13 +167,13 @@ Here are links to resources, documentation, examples and best practices to guide
 
 The only knowledge necessary to write a plugin is basic command-line skills and knowledge of the [Go programming language](http://www.golang.org). Use the plugin interface to develop your integration. All integrations should contain unit and acceptance testing.
 
-**HCP Consul**:  As a managed service, minimal configuration is required to deploy HCP Consul server clusters. You only need to install Consul client agents. Furthermore, HashiCorp provides all new users an initial credit, which provides approximately two months worth of [development cluster](https://cloud.hashicorp.com/products/consul/pricing) access. When deployed with AWS or Azure free tier services, there should be no cost beyond the time spent by the designated tester. Refer to the [Deploy HCP Consul tutorial](https://learn.hashicorp.com/tutorials/cloud/consul-introduction?utm_source=docs) for details on getting started.
+**HCP Consul**:  As a managed service, minimal configuration is required to deploy HCP Consul server clusters. You only need to install Consul client agents. Furthermore, HashiCorp provides all new users an initial credit, which provides approximately two months worth of [development cluster](https://cloud.hashicorp.com/products/consul/pricing) access. When deployed with AWS or Azure free tier services, there should be no cost beyond the time spent by the designated tester. Refer to the [Deploy HCP Consul tutorial](/consul/tutorials/get-started-hcp/hcp-gs-deploy) for details on getting started.
 
 HCP Consul is currently only deployed on AWS and Microsoft Azure, so your application can be deployed to or run in AWS or Azure. 
 
 #### HCP Consul Resource Links:
 
-- [Getting Started with HCP Consul](https://learn.hashicorp.com/tutorials/cloud/consul-introduction?utm_source=docs)
+- [Getting Started with HCP Consul](/consul/tutorials/get-started-hcp/hcp-gs-deploy)
 - [HCP Consul End-to-End Deployment](https://learn.hashicorp.com/tutorials/cloud/consul-end-to-end-overview?in=consul/cloud-deploy-automation)
 - [Deploy HCP Consul with EKS using Terraform](https://learn.hashicorp.com/tutorials/cloud/consul-end-to-end-eks?in=consul/cloud-deploy-automation)
 - [HCP Consul Deployment Automation](https://learn.hashicorp.com/collections/consul/cloud-deploy-automation)

--- a/website/content/docs/integrate/partnerships.mdx
+++ b/website/content/docs/integrate/partnerships.mdx
@@ -177,7 +177,7 @@ HCP Consul is currently only deployed on AWS and Microsoft Azure, so your applic
 - [HCP Consul End-to-End Deployment](https://learn.hashicorp.com/tutorials/cloud/consul-end-to-end-overview?in=consul/cloud-deploy-automation)
 - [Deploy HCP Consul with EKS using Terraform](https://learn.hashicorp.com/tutorials/cloud/consul-end-to-end-eks?in=consul/cloud-deploy-automation)
 - [HCP Consul Deployment Automation](https://learn.hashicorp.com/collections/consul/cloud-deploy-automation)
-- [HCP Consul documentation]( https://cloud.hashicorp.com/docs/consul/usage)
+- [HCP Consul documentation](https://cloud.hashicorp.com/docs/consul/usage)
 
 **Consul Enterprise**: An integration qualifies for Consul Enterprise when it is tested and compatible with Consul Enterprise Namespaces.
 

--- a/website/content/docs/lambda/registration/index.mdx
+++ b/website/content/docs/lambda/registration/index.mdx
@@ -72,7 +72,7 @@ Refer to the following documentation and tutorials for instructions on how to se
 
 - [Terminating gateways documentation](/docs/connect/gateways#terminating-gateways)
 - [Terminating gateways on Kubernetes documentation](/docs/k8s/connect/terminating-gateways)
-- [Connect External Services to Consul With Terminating Gateways tutorial](https://learn.hashicorp.com/tutorials/consul/teminating-gateways-connect-external-services)
+- [Connect External Services to Consul With Terminating Gateways tutorial](https://learn.hashicorp.com/tutorials/consul/terminating-gateways-connect-external-services)
 
 To register a Lambda service with a terminating gateway, add the service to the
 `Services` field of the terminating gateway's `terminating-gateway`


### PR DESCRIPTION
## What

- Fixes a 4 `learn.hashicorp.com` links that had typos in them
- Updates some `learn.hashicorp.com` links that redirect to go to devdot paths
- Fixes a docs link that had an extra space in the `href` portion of the MDX syntax
