### PR TITLE
Fix configuration merging for implicit tproxy upstreams.

### DIFF
--- a/.changelog/16000.txt
+++ b/.changelog/16000.txt
@@ -1,3 +1,3 @@
 ```release-note:breaking-change
-connect: Fix configuration merging for transparent proxy upstreams. Proxy-defaults and service-defaults config entries were not correctly merged for implicit upstreams in transparent proxy mode and would result in some configuration not being applied. To avoid issues when upgrading, ensure that any proxy-defaults or service-defaults have the correct information for upstreams, as this configuration will become active.
+connect: Fix configuration merging for transparent proxy upstreams. Proxy-defaults and service-defaults config entries were not correctly merged for implicit upstreams in transparent proxy mode and would result in some configuration not being applied. To avoid issues when upgrading, ensure that any proxy-defaults or service-defaults have correct configuration for upstreams, since all fields will now be properly used to configure proxies.
 ```

--- a/.changelog/16000.txt
+++ b/.changelog/16000.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+connect: Fix configuration merging for transparent proxy upstreams. Proxy-defaults and service-defaults config entries were not correctly merged for implicit upstreams in transparent proxy mode and would result in some configuration not being applied. To avoid issues when upgrading, ensure that any proxy-defaults or service-defaults have the correct information for upstreams, as this configuration will become active.
+```

--- a/agent/configentry/resolve_test.go
+++ b/agent/configentry/resolve_test.go
@@ -121,6 +121,14 @@ func Test_ComputeResolvedServiceConfig(t *testing.T) {
 				MeshGateway: remoteMeshGW,
 				UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
 					{
+						Upstream: wildcard,
+						Config: map[string]interface{}{
+							"mesh_gateway": structs.MeshGatewayConfig{
+								Mode: structs.MeshGatewayModeRemote,
+							},
+						},
+					},
+					{
 						Upstream: uid,
 						Config: map[string]interface{}{
 							"mesh_gateway": remoteMeshGW,
@@ -183,6 +191,15 @@ func Test_ComputeResolvedServiceConfig(t *testing.T) {
 					Path:                "/tmp/accesslog.txt",
 					JSONFormat:          "{ \"custom_start_time\": \"%START_TIME%\" }",
 				},
+				UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
+					{
+						Upstream: wildcard,
+						Config: map[string]interface{}{
+							"foo":          "bar",
+							"mesh_gateway": remoteMeshGW,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -209,6 +226,12 @@ func Test_ComputeResolvedServiceConfig(t *testing.T) {
 			want: &structs.ServiceConfigResponse{
 				MeshGateway: noneMeshGW, // service-defaults has a higher precedence.
 				UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
+					{
+						Upstream: wildcard,
+						Config: map[string]interface{}{
+							"mesh_gateway": noneMeshGW,
+						},
+					},
 					{
 						Upstream: uid,
 						Config: map[string]interface{}{

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1057,6 +1057,9 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 			"protocol": "http",
 		},
 		UpstreamConfigs: map[string]map[string]interface{}{
+			"*": {
+				"foo": int64(1),
+			},
 			"bar": {
 				"protocol": "grpc",
 			},
@@ -1270,6 +1273,9 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams(t *testing.T) {
 					"protocol": "grpc",
 				},
 				UpstreamConfigs: map[string]map[string]interface{}{
+					"*": {
+						"protocol": "grpc",
+					},
 					"mysql": {
 						"protocol": "http",
 					},
@@ -1314,6 +1320,12 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams(t *testing.T) {
 					"protocol": "grpc",
 				},
 				UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
+					{
+						Upstream: wildcard,
+						Config: map[string]interface{}{
+							"protocol": "grpc",
+						},
+					},
 					{
 						Upstream: cache,
 						Config: map[string]interface{}{
@@ -2052,6 +2064,9 @@ func TestConfigEntry_ResolveServiceConfig_UpstreamProxyDefaultsProtocol(t *testi
 			"protocol": "http",
 		},
 		UpstreamConfigs: map[string]map[string]interface{}{
+			"*": {
+				"protocol": "http",
+			},
 			"bar": {
 				"protocol": "http",
 			},
@@ -2107,6 +2122,9 @@ func TestConfigEntry_ResolveServiceConfig_ProxyDefaultsProtocol_UsedForAllUpstre
 			"protocol": "http",
 		},
 		UpstreamConfigs: map[string]map[string]interface{}{
+			"*": {
+				"protocol": "http",
+			},
 			"bar": {
 				"protocol": "http",
 			},

--- a/agent/proxycfg/naming.go
+++ b/agent/proxycfg/naming.go
@@ -180,3 +180,11 @@ func UpstreamsToMap(us structs.Upstreams) map[UpstreamID]*structs.Upstream {
 	}
 	return upstreamMap
 }
+
+func NewWildcardUID(entMeta *acl.EnterpriseMeta) UpstreamID {
+	wildcardSID := structs.NewServiceID(
+		structs.WildcardSpecifier,
+		entMeta.WithWildcardNamespace(),
+	)
+	return NewUpstreamIDFromServiceID(wildcardSID)
+}

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
@@ -419,7 +420,13 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 				"protocol": "http",
 			},
 			UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
-				structs.OpaqueUpstreamConfig{
+				{
+					Upstream: structs.NewServiceID(structs.WildcardSpecifier, acl.DefaultEnterpriseMeta().WithWildcardNamespace()),
+					Config: map[string]interface{}{
+						"foo": int64(1),
+					},
+				},
+				{
 					Upstream: structs.NewServiceID("redis", nil),
 					Config: map[string]interface{}{
 						"protocol": "tcp",
@@ -467,7 +474,13 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 				"protocol": "http",
 			},
 			UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
-				structs.OpaqueUpstreamConfig{
+				{
+					Upstream: structs.NewServiceID(structs.WildcardSpecifier, acl.DefaultEnterpriseMeta().WithWildcardNamespace()),
+					Config: map[string]interface{}{
+						"foo": int64(1),
+					},
+				},
+				{
 					Upstream: structs.NewServiceID("redis", nil),
 					Config: map[string]interface{}{
 						"protocol": "tcp",
@@ -646,7 +659,13 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 				"protocol": "http",
 			},
 			UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
-				structs.OpaqueUpstreamConfig{
+				{
+					Upstream: structs.NewServiceID(structs.WildcardSpecifier, acl.DefaultEnterpriseMeta().WithWildcardNamespace()),
+					Config: map[string]interface{}{
+						"foo": int64(1),
+					},
+				},
+				{
 					Upstream: structs.NewServiceID("redis", nil),
 					Config: map[string]interface{}{
 						"protocol": "tcp",

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -87,18 +87,10 @@ func (s *ResourceGenerator) clustersFromSnapshotConnectProxy(cfgSnap *proxycfg.C
 		clusters = append(clusters, passthroughs...)
 	}
 
-	getUpstream := func(uid proxycfg.UpstreamID) (*structs.Upstream, bool) {
-		upstream := cfgSnap.ConnectProxy.UpstreamConfig[uid]
-
-		explicit := upstream.HasLocalPortOrSocket()
-		implicit := cfgSnap.ConnectProxy.IsImplicitUpstream(uid)
-		return upstream, !implicit && !explicit
-	}
-
 	// NOTE: Any time we skip a chain below we MUST also skip that discovery chain in endpoints.go
 	// so that the sets of endpoints generated matches the sets of clusters.
 	for uid, chain := range cfgSnap.ConnectProxy.DiscoveryChain {
-		upstream, skip := getUpstream(uid)
+		upstream, skip := cfgSnap.ConnectProxy.GetUpstream(uid, &cfgSnap.ProxyID.EnterpriseMeta)
 		if skip {
 			continue
 		}
@@ -123,7 +115,7 @@ func (s *ResourceGenerator) clustersFromSnapshotConnectProxy(cfgSnap *proxycfg.C
 	// upstream in endpoints.go so that the sets of endpoints generated matches
 	// the sets of clusters.
 	for _, uid := range cfgSnap.ConnectProxy.PeeredUpstreamIDs() {
-		upstream, skip := getUpstream(uid)
+		upstream, skip := cfgSnap.ConnectProxy.GetUpstream(uid, &cfgSnap.ProxyID.EnterpriseMeta)
 		if skip {
 			continue
 		}


### PR DESCRIPTION
This PR fixes an issue where tproxy would not correctly use service-defaults and proxy-defaults for implicit upstreams. Normally, we handle this by taking configuration from an auto-generated wildcard `*` upstream, but that was not done in all cases -- notably peer upstreams.

The changes here are essentially:

1. Change the merging logic so that the wildcard upstream has correct proxy-defaults and service-defaults values combined into it. It did not previously merge all fields, and the wildcard upstream did not exist unless service-defaults existed (it ignored proxy-defaults, essentially).
2. Change the way we fetch upstream configuration in the xDS layer so that it falls back to the wildcard when no matching upstream is found. This is what allows implicit peer upstreams to have the correct "merged" config.
3. Change proxycfg to always watch local mesh gateway endpoints whenever a peer upstream is found. This simplifies the logic so that we do not have to inspect the "merged" configuration on peer upstreams to extract the mesh gateway mode.

It's worth noting that another large issue still needs to be resolved in a different PR (https://github.com/hashicorp/consul/pull/15956), where the `ServiceDefaults.UpstreamConfig.Overrides[].Peer` field does NOT exist. This manifests in two ways after these changes:
1. Explicit (non-tproxy) peer upstreams incorrectly have overrides applied to them, since the functions in `agent/configentry/merge_service_config.go` and `agent/configentry/resolve.go` are oblivious to the concept of a peer.
2. Implicit (tproxy) peer upstreams do not have overrides applied to them, because the UID that proxycfg expects is `default/default/mysvc?peer=cluster-02`, but the overrides UID is `default/default/mysvc`. This is technically correct behavior, but it's noted here, because overrides will NOT work for peer upstreams in tproxy mode until the `agent/configentry` package is updated.