### PR TITLE
[NET-1728] Updating docs to remove use of token query parameter

### DIFF
--- a/website/content/api-docs/api-structure.mdx
+++ b/website/content/api-docs/api-structure.mdx
@@ -40,9 +40,9 @@ $ curl \
     http://127.0.0.1:8500/v1/agent/members
 ```
 
-Previously this was provided via a `?token=` query parameter. This functionality
-exists on many endpoints for backwards compatibility, but its use is **highly
+Previously this was provided via a `?token=` query parameter but its use is **highly
 discouraged**, since it can show up in access logs as part of the URL.
+This functionality is deprecated and will be removed in future versions.
 
 To learn more about the ACL system read the [documentation](/docs/security/acl).
 

--- a/website/content/api-docs/api-structure.mdx
+++ b/website/content/api-docs/api-structure.mdx
@@ -42,7 +42,7 @@ $ curl \
 
 Previously this was provided via a `?token=` query parameter but its use is **highly
 discouraged**, since it can show up in access logs as part of the URL.
-This functionality is deprecated and will be removed in future versions.
+This functionality is deprecated and will be removed from Consul in a future version.
 
 To learn more about the ACL system read the [documentation](/docs/security/acl).
 

--- a/website/content/docs/security/acl/acl-legacy.mdx
+++ b/website/content/docs/security/acl/acl-legacy.mdx
@@ -663,12 +663,13 @@ Here's a sample request using the HCL form:
 ```shell-session
 $ curl \
     --request PUT \
+    --header "X-Consul-Token: <management token>" \
     --data \
 '{
   "Name": "my-app-token",
   "Type": "client",
   "Rules": "key \"\" { policy = \"read\" } key \"foo/\" { policy = \"write\" } key \"foo/private/\" { policy = \"deny\" } operator = \"read\""
-}' http://127.0.0.1:8500/v1/acl/create?token=<management token>
+}' http://127.0.0.1:8500/v1/acl/create
 ```
 
 Here's an equivalent request using the JSON form:
@@ -676,12 +677,13 @@ Here's an equivalent request using the JSON form:
 ```shell-session
 $ curl \
     --request PUT \
+    --header "X-Consul-Token: <management token>" \
     --data \
 '{
   "Name": "my-app-token",
   "Type": "client",
   "Rules": "{\"key\":{\"\":{\"policy\":\"read\"},\"foo/\":{\"policy\":\"write\"},\"foo/private\":{\"policy\":\"deny\"}},\"operator\":\"read\"}"
-}' http://127.0.0.1:8500/v1/acl/create?token=<management token>
+}' http://127.0.0.1:8500/v1/acl/create
 ```
 
 On success, the token ID is returned:

--- a/website/content/docs/security/acl/acl-policies.mdx
+++ b/website/content/docs/security/acl/acl-policies.mdx
@@ -286,11 +286,12 @@ The following example adds a set of rules to a policy called `my-app-policy`. Th
 ```shell-session
 $ curl \
     --request PUT \
+    --header "X-Consul-Token: <token with ACL 'write' access>" \
     --data \
 '{
   "Name": "my-app-policy",
   "Rules": "key \"\" { policy = \"read\" } key \"foo/\" { policy = \"write\" } key \"foo/private/\" { policy = \"deny\" } operator = \"read\""
-}' http://127.0.0.1:8500/v1/acl/policy?token=<token with ACL "write" access>
+}' http://127.0.0.1:8500/v1/acl/policy
 ```
 
 The following call performs the same operation as the previous example using JSON:
@@ -298,11 +299,12 @@ The following call performs the same operation as the previous example using JSO
 ```shell-session
 $ curl \
     --request PUT \
+    --header "X-Consul-Token: <management token>" \
     --data \
 '{
   "Name": "my-app-policy",
   "Rules": "{\"key\":{\"\":{\"policy\":\"read\"},\"foo/\":{\"policy\":\"write\"},\"foo/private\":{\"policy\":\"deny\"}},\"operator\":\"read\"}"
-}' http://127.0.0.1:8500/v1/acl/policy?token=<management token>
+}' http://127.0.0.1:8500/v1/acl/policy
 ```
 
 The policy configuration is returned when the call is successfully performed:


### PR DESCRIPTION
### Description
- Updating docs to remove the use of token query parameters

<!--
### Testing
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.
-->

### PR Checklist

* [x] external facing docs updated
* [x] not a security concern
