### PR TITLE
Add plumbing for Native API GW Subscriptions

### DIFF
--- a/agent/proxycfg-glue/config_entry.go
+++ b/agent/proxycfg-glue/config_entry.go
@@ -62,6 +62,16 @@ func newConfigEntryRequest(req *structs.ConfigEntryQuery, deps ServerDataSourceD
 		topic = pbsubscribe.Topic_IngressGateway
 	case structs.ServiceDefaults:
 		topic = pbsubscribe.Topic_ServiceDefaults
+	case structs.APIGateway:
+		topic = pbsubscribe.Topic_APIGateway
+	case structs.HTTPRoute:
+		topic = pbsubscribe.Topic_HTTPRoute
+	case structs.TCPRoute:
+		topic = pbsubscribe.Topic_TCPRoute
+	case structs.InlineCertificate:
+		topic = pbsubscribe.Topic_InlineCertificate
+	case structs.BoundAPIGateway:
+		topic = pbsubscribe.Topic_BoundAPIGateway
 	default:
 		return nil, fmt.Errorf("cannot map config entry kind: %s to a topic", req.Kind)
 	}


### PR DESCRIPTION
### Description

Adds switch statements for mapping config entry types to the pbsubscribe topics for each of the config entries added as part of Consul Native API Gateways.

### PR Checklist

* ~[ ] updated test coverage~
* ~[ ] external facing docs updated~
* ~[ ] not a security concern~
