### PR TITLE
test(integration): add access logging test

### DIFF
--- a/test/integration/consul-container/libs/cluster/agent.go
+++ b/test/integration/consul-container/libs/cluster/agent.go
@@ -17,7 +17,6 @@ type Agent interface {
 	GetName() string
 	GetPod() testcontainers.Container
 	ClaimAdminPort() int
-	ClaimConnectPort() int
 	GetConfig() Config
 	GetInfo() AgentInfo
 	GetDatacenter() string

--- a/test/integration/consul-container/libs/cluster/agent.go
+++ b/test/integration/consul-container/libs/cluster/agent.go
@@ -3,8 +3,9 @@ package cluster
 import (
 	"context"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/hashicorp/consul/api"
 
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
@@ -16,6 +17,7 @@ type Agent interface {
 	GetName() string
 	GetPod() testcontainers.Container
 	ClaimAdminPort() int
+	ClaimConnectPort() int
 	GetConfig() Config
 	GetInfo() AgentInfo
 	GetDatacenter() string

--- a/test/integration/consul-container/libs/cluster/container.go
+++ b/test/integration/consul-container/libs/cluster/container.go
@@ -10,11 +10,12 @@ import (
 	"time"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
-	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/hashicorp/consul/api"
 
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
@@ -44,7 +45,8 @@ type consulContainerNode struct {
 	clientCACertFile string
 	ip               string
 
-	nextAdminPortOffset int
+	nextAdminPortOffset   int
+	nextConnectPortOffset int
 
 	info AgentInfo
 }
@@ -56,6 +58,12 @@ func (c *consulContainerNode) GetPod() testcontainers.Container {
 func (c *consulContainerNode) ClaimAdminPort() int {
 	p := 19000 + c.nextAdminPortOffset
 	c.nextAdminPortOffset++
+	return p
+}
+
+func (c *consulContainerNode) ClaimConnectPort() int {
+	p := 21000 + c.nextConnectPortOffset
+	c.nextConnectPortOffset++
 	return p
 }
 
@@ -428,11 +436,11 @@ func newContainerRequest(config Config, opts containerOpts) (podRequest, consulR
 
 			"8443/tcp", // Envoy Gateway Listener
 
-			"5000/tcp", // Envoy Connect Listener
-			"8079/tcp", // Envoy Connect Listener
-			"8080/tcp", // Envoy Connect Listener
-			"9998/tcp", // Envoy Connect Listener
-			"9999/tcp", // Envoy Connect Listener
+			"5000/tcp", // Envoy App Listener
+			"8079/tcp", // Envoy App Listener
+			"8080/tcp", // Envoy App Listener
+			"9998/tcp", // Envoy App Listener
+			"9999/tcp", // Envoy App Listener
 
 			"19000/tcp", // Envoy Admin Port
 			"19001/tcp", // Envoy Admin Port
@@ -444,6 +452,13 @@ func newContainerRequest(config Config, opts containerOpts) (podRequest, consulR
 			"19007/tcp", // Envoy Admin Port
 			"19008/tcp", // Envoy Admin Port
 			"19009/tcp", // Envoy Admin Port
+
+			"21000/tcp", // Envoy Connect Listener
+			"21001/tcp", // Envoy Connect Listener
+			"21002/tcp", // Envoy Connect Listener
+			"21003/tcp", // Envoy Connect Listener
+			"21004/tcp", // Envoy Connect Listener
+			"21005/tcp", // Envoy Connect Listener
 		},
 		Hostname: opts.hostname,
 		Networks: opts.addtionalNetworks,

--- a/test/integration/consul-container/libs/cluster/container.go
+++ b/test/integration/consul-container/libs/cluster/container.go
@@ -61,12 +61,6 @@ func (c *consulContainerNode) ClaimAdminPort() int {
 	return p
 }
 
-func (c *consulContainerNode) ClaimConnectPort() int {
-	p := 21000 + c.nextConnectPortOffset
-	c.nextConnectPortOffset++
-	return p
-}
-
 // NewConsulContainer starts a Consul agent in a container with the given config.
 func NewConsulContainer(ctx context.Context, config Config, network string, index int) (Agent, error) {
 	if config.ScratchDir == "" {
@@ -452,13 +446,6 @@ func newContainerRequest(config Config, opts containerOpts) (podRequest, consulR
 			"19007/tcp", // Envoy Admin Port
 			"19008/tcp", // Envoy Admin Port
 			"19009/tcp", // Envoy Admin Port
-
-			"21000/tcp", // Envoy Connect Listener
-			"21001/tcp", // Envoy Connect Listener
-			"21002/tcp", // Envoy Connect Listener
-			"21003/tcp", // Envoy Connect Listener
-			"21004/tcp", // Envoy Connect Listener
-			"21005/tcp", // Envoy Connect Listener
 		},
 		Hostname: opts.hostname,
 		Networks: opts.addtionalNetworks,

--- a/test/integration/consul-container/libs/service/connect.go
+++ b/test/integration/consul-container/libs/service/connect.go
@@ -25,7 +25,6 @@ type ConnectContainer struct {
 	ip               string
 	appPort          int
 	adminPort        int
-	publicPort       int
 	mappedPublicPort int
 	serviceName      string
 }
@@ -109,7 +108,6 @@ func NewConnectService(ctx context.Context, name string, serviceName string, ser
 	dockerfileCtx.BuildArgs = buildargs
 
 	adminPort := node.ClaimAdminPort()
-	publicPort := node.ClaimConnectPort()
 
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: dockerfileCtx,
@@ -154,29 +152,26 @@ func NewConnectService(ctx context.Context, name string, serviceName string, ser
 	}
 
 	var (
-		appPortStr    = strconv.Itoa(serviceBindPort)
-		adminPortStr  = strconv.Itoa(adminPort)
-		publicPortStr = strconv.Itoa(publicPort)
+		appPortStr   = strconv.Itoa(serviceBindPort)
+		adminPortStr = strconv.Itoa(adminPort)
 	)
 
-	info, err := cluster.LaunchContainerOnNode(ctx, node, req, []string{appPortStr, adminPortStr, publicPortStr})
+	info, err := cluster.LaunchContainerOnNode(ctx, node, req, []string{appPortStr, adminPortStr})
 	if err != nil {
 		return nil, err
 	}
 
 	out := &ConnectContainer{
-		ctx:              ctx,
-		container:        info.Container,
-		ip:               info.IP,
-		appPort:          info.MappedPorts[appPortStr].Int(),
-		adminPort:        info.MappedPorts[adminPortStr].Int(),
-		publicPort:       publicPort,
-		mappedPublicPort: info.MappedPorts[publicPortStr].Int(),
-		serviceName:      name,
+		ctx:         ctx,
+		container:   info.Container,
+		ip:          info.IP,
+		appPort:     info.MappedPorts[appPortStr].Int(),
+		adminPort:   info.MappedPorts[adminPortStr].Int(),
+		serviceName: name,
 	}
 
-	fmt.Printf("NewConnectService: name %s, mappedAppPort %d, bind port %d, public listener port %d\\n\"",
-		serviceName, out.appPort, serviceBindPort, publicPort)
+	fmt.Printf("NewConnectService: name %s, bind port %d, public listener port %d\\n\"",
+		serviceName, out.appPort, serviceBindPort)
 
 	return out, nil
 }

--- a/test/integration/consul-container/libs/service/service.go
+++ b/test/integration/consul-container/libs/service/service.go
@@ -5,12 +5,13 @@ import "github.com/hashicorp/consul/api"
 // Service represents a process that will be registered with the
 // Consul catalog, including Consul components such as sidecars and gateways
 type Service interface {
-	Terminate() error
-	GetName() string
-	GetAddr() (string, int)
-	Start() (err error)
 	// Export a service to the peering cluster
 	Export(partition, peer string, client *api.Client) error
-	GetServiceName() string
+	GetAddr() (string, int)
 	GetAdminAddr() (string, int)
+	GetLogs() (string, error)
+	GetName() string
+	GetServiceName() string
+	Start() (err error)
+	Terminate() error
 }

--- a/test/integration/consul-container/libs/topology/peering_topology.go
+++ b/test/integration/consul-container/libs/topology/peering_topology.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/api"
 
 	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
@@ -78,7 +79,7 @@ func BasicPeeringTwoClustersSetup(
 	}
 
 	_, port := clientSidecarService.GetAddr()
-	libassert.HTTPServiceEchoes(t, "localhost", port)
+	libassert.HTTPServiceEchoes(t, "localhost", port, "")
 
 	return &BuiltCluster{
 			Cluster:   acceptingCluster,

--- a/test/integration/consul-container/test/basic/connect_service_test.go
+++ b/test/integration/consul-container/test/basic/connect_service_test.go
@@ -27,7 +27,7 @@ func TestBasicConnectService(t *testing.T) {
 	_, port := clientService.GetAddr()
 	_, adminPort := clientService.GetAdminAddr()
 
-	libassert.HTTPServiceEchoes(t, "localhost", port)
+	libassert.HTTPServiceEchoes(t, "localhost", port, "")
 	libassert.GetEnvoyListenerTCPFilters(t, adminPort)
 }
 

--- a/test/integration/consul-container/test/observability/access_logs_test.go
+++ b/test/integration/consul-container/test/observability/access_logs_test.go
@@ -114,26 +114,6 @@ func TestAccessLogs(t *testing.T) {
 
 	// TODO: add a test to check that connections without a matching filter chain are NOT logged
 
-	// Validate access logs can be turned off
-	proxyDefault = &api.ProxyConfigEntry{
-		Kind: api.ProxyDefaults,
-		Name: api.ProxyConfigGlobal,
-		AccessLogs: &api.AccessLogsConfig{
-			Enabled: false,
-		},
-	}
-
-	set, _, err = cluster.Agents[0].GetClient().ConfigEntries().Set(proxyDefault, nil)
-	require.NoError(t, err)
-	require.True(t, set)
-	time.Sleep(5 * time.Second) // time for xDS to propagate
-
-	_, port = clientService.GetAddr()
-	libassert.HTTPServiceEchoes(t, "localhost", port, "mango")
-	time.Sleep(5 * time.Second) // time to flush buffers
-
-	require.False(t, libassert.ServiceLogContains(t, clientService, "mango"))
-	require.False(t, libassert.ServiceLogContains(t, serverService, "mango"))
 }
 
 func createCluster(t *testing.T) *libcluster.Cluster {

--- a/test/integration/consul-container/test/observability/access_logs_test.go
+++ b/test/integration/consul-container/test/observability/access_logs_test.go
@@ -1,0 +1,198 @@
+package observability
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
+
+	"github.com/hashicorp/consul/api"
+	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
+	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
+	libservice "github.com/hashicorp/consul/test/integration/consul-container/libs/service"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+)
+
+// TestAccessLogs Summary
+// This test ensures that when enabled through `proxy-defaults`, Envoy will emit access logs.
+// Philosophically, we are trying to ensure the config options make their way to Envoy more than
+// trying to test Envoy's behavior. For this reason and simplicity file operations are not tested.
+//
+// Steps:
+//   - Create a single agent cluster.
+//   - Enable default access logs. We do this so Envoy's admin interface inherits the configuration on startup
+//   - Create the example static-server and sidecar containers, then register them both with Consul
+//   - Create an example static-client sidecar, then register both the service and sidecar with Consul
+//   - Make sure a call to the client sidecar emits an access log at the client-sidecar (outbound) and
+//     server-sidecar (inbound).
+//   - Make sure hitting the Envoy admin interface generates an access log
+//   - Change access log configuration to use custom text format and disable Listener logs
+//   - Make sure a call to the client sidecar emits an access log at the client-sidecar (outbound) and
+//     server-sidecar (inbound).
+//   - Clear the access log configuration from `proxy-defaults`
+//   - Make sure a call to the client sidecar local bind port succeeds but does not emit a log
+//
+// Notes:
+//   - Does not test disabling listener logs. In practice, it's hard to get them to emit. The best chance would
+//     be running a service that throws a 404 on a random path or maybe use some path-based disco chains
+//   - JSON keys have no guaranteed ordering, so simple key-value pairs are tested
+func TestAccessLogs(t *testing.T) {
+	if semver.IsValid(utils.TargetVersion) && semver.Compare(utils.TargetVersion, "v1.15") < 0 {
+		t.Skip()
+	}
+
+	cluster := createCluster(t)
+
+	// Turn on access logs. Do this before starting the sidecars so that they inherit the configuration
+	// for their admin interface
+	proxyDefault := &api.ProxyConfigEntry{
+		Kind: api.ProxyDefaults,
+		Name: api.ProxyConfigGlobal,
+		AccessLogs: &api.AccessLogsConfig{
+			Enabled:    true,
+			JSONFormat: "{\"banana_path\":\"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%\"}",
+		},
+	}
+	set, _, err := cluster.Agents[0].GetClient().ConfigEntries().Set(proxyDefault, nil)
+	require.NoError(t, err)
+	require.True(t, set)
+
+	serverService, clientService := createServices(t, cluster)
+	_, port := clientService.GetAddr()
+
+	// Validate Custom JSON
+	require.Eventually(t, func() bool {
+		libassert.HTTPServiceEchoes(t, "localhost", port, "banana")
+		client := libassert.ServiceLogContains(t, clientService, "\"banana_path\":\"/banana\"")
+		server := libassert.ServiceLogContains(t, serverService, "\"banana_path\":\"/banana\"")
+		return client && server
+	}, 20*time.Second, 1*time.Second)
+
+	// Validate Logs on the Admin Interface
+	serverSidecar, ok := serverService.(*libservice.ConnectContainer)
+	require.True(t, ok)
+	ip, port := serverSidecar.GetAdminAddr()
+
+	httpClient := cleanhttp.DefaultClient()
+	url := fmt.Sprintf("http://%s:%d/clusters?fruit=bananas", ip, port)
+	_, err = httpClient.Get(url)
+	require.NoError(t, err, "error making call to Envoy admin interface")
+
+	require.Eventually(t, func() bool {
+		return libassert.ServiceLogContains(t, serverService, "\"banana_path\":\"/clusters?fruit=bananas\"")
+	}, 15*time.Second, 1*time.Second)
+
+	// TODO: add a test to check that connections without a matching filter chain are logged
+
+	// Validate Listener Logs
+	proxyDefault = &api.ProxyConfigEntry{
+		Kind: api.ProxyDefaults,
+		Name: api.ProxyConfigGlobal,
+		AccessLogs: &api.AccessLogsConfig{
+			Enabled:             true,
+			DisableListenerLogs: true,
+			TextFormat:          "Orange you glad I didn't say banana: %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%, %RESPONSE_FLAGS%",
+		},
+	}
+
+	set, _, err = cluster.Agents[0].GetClient().ConfigEntries().Set(proxyDefault, nil)
+	require.NoError(t, err)
+	require.True(t, set)
+
+	// Validate Custom Text
+	_, port = clientService.GetAddr()
+	require.Eventually(t, func() bool {
+		libassert.HTTPServiceEchoes(t, "localhost", port, "orange")
+		client := libassert.ServiceLogContains(t, clientService, "Orange you glad I didn't say banana: /orange, -")
+		server := libassert.ServiceLogContains(t, serverService, "Orange you glad I didn't say banana: /orange, -")
+		return client && server
+	}, 30*time.Second, 1*time.Second)
+
+	// TODO: add a test to check that connections without a matching filter chain are NOT logged
+
+	// Validate access logs can be turned off
+	proxyDefault = &api.ProxyConfigEntry{
+		Kind: api.ProxyDefaults,
+		Name: api.ProxyConfigGlobal,
+		AccessLogs: &api.AccessLogsConfig{
+			Enabled: false,
+		},
+	}
+
+	set, _, err = cluster.Agents[0].GetClient().ConfigEntries().Set(proxyDefault, nil)
+	require.NoError(t, err)
+	require.True(t, set)
+
+	_, port = clientService.GetAddr()
+	libassert.HTTPServiceEchoes(t, "localhost", port, "mango")
+	time.Sleep(5 * time.Second) // time to flush buffers
+
+	require.False(t, libassert.ServiceLogContains(t, clientService, "mango"))
+	require.False(t, libassert.ServiceLogContains(t, serverService, "mango"))
+}
+
+func createCluster(t *testing.T) *libcluster.Cluster {
+	opts := libcluster.BuildOptions{
+		InjectAutoEncryption:   true,
+		InjectGossipEncryption: true,
+		// TODO: fix the test to not need the service/envoy stack to use :8500
+		AllowHTTPAnyway: true,
+	}
+	ctx := libcluster.NewBuildContext(t, opts)
+
+	conf := libcluster.NewConfigBuilder(ctx).
+		ToAgentConfig(t)
+	t.Logf("Cluster config:\n%s", conf.JSON)
+
+	configs := []libcluster.Config{*conf}
+
+	cluster, err := libcluster.New(t, configs)
+	require.NoError(t, err)
+
+	node := cluster.Agents[0]
+	client := node.GetClient()
+
+	libcluster.WaitForLeader(t, cluster, client)
+	libcluster.WaitForMembers(t, client, 1)
+
+	// Default Proxy Settings
+	ok, err := utils.ApplyDefaultProxySettings(client)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	return cluster
+}
+
+func createServices(t *testing.T, cluster *libcluster.Cluster) (libservice.Service, libservice.Service) {
+	node := cluster.Agents[0]
+	client := node.GetClient()
+
+	// Register service as HTTP
+	serviceDefault := &api.ServiceConfigEntry{
+		Kind:     api.ServiceDefaults,
+		Name:     libservice.StaticServerServiceName,
+		Protocol: "http",
+	}
+
+	ok, _, err := client.ConfigEntries().Set(serviceDefault, nil)
+	require.NoError(t, err, "error writing HTTP service-default")
+	require.True(t, ok, "did not write HTTP service-default")
+
+	// Create a service and proxy instance
+	_, serverConnectProxy, err := libservice.CreateAndRegisterStaticServerAndSidecar(node)
+	require.NoError(t, err)
+
+	libassert.CatalogServiceExists(t, client, fmt.Sprintf("%s-sidecar-proxy", libservice.StaticServerServiceName))
+	libassert.CatalogServiceExists(t, client, libservice.StaticServerServiceName)
+
+	// Create a client proxy instance with the server as an upstream
+	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false)
+	require.NoError(t, err)
+
+	libassert.CatalogServiceExists(t, client, fmt.Sprintf("%s-sidecar-proxy", libservice.StaticClientServiceName))
+
+	return serverConnectProxy, clientConnectProxy
+}

--- a/test/integration/consul-container/test/observability/access_logs_test.go
+++ b/test/integration/consul-container/test/observability/access_logs_test.go
@@ -101,6 +101,7 @@ func TestAccessLogs(t *testing.T) {
 	set, _, err = cluster.Agents[0].GetClient().ConfigEntries().Set(proxyDefault, nil)
 	require.NoError(t, err)
 	require.True(t, set)
+	time.Sleep(5 * time.Second) // time for xDS to propagate
 
 	// Validate Custom Text
 	_, port = clientService.GetAddr()
@@ -109,7 +110,7 @@ func TestAccessLogs(t *testing.T) {
 		client := libassert.ServiceLogContains(t, clientService, "Orange you glad I didn't say banana: /orange, -")
 		server := libassert.ServiceLogContains(t, serverService, "Orange you glad I didn't say banana: /orange, -")
 		return client && server
-	}, 30*time.Second, 1*time.Second)
+	}, 60*time.Second, 500*time.Millisecond) // For some reason it takes a long time for the server sidecar to update
 
 	// TODO: add a test to check that connections without a matching filter chain are NOT logged
 
@@ -125,6 +126,7 @@ func TestAccessLogs(t *testing.T) {
 	set, _, err = cluster.Agents[0].GetClient().ConfigEntries().Set(proxyDefault, nil)
 	require.NoError(t, err)
 	require.True(t, set)
+	time.Sleep(5 * time.Second) // time for xDS to propagate
 
 	_, port = clientService.GetAddr()
 	libassert.HTTPServiceEchoes(t, "localhost", port, "mango")

--- a/test/integration/consul-container/test/observability/metrics_leader_test.go
+++ b/test/integration/consul-container/test/observability/metrics_leader_test.go
@@ -1,13 +1,13 @@
-package metrics
+package observability
 
 import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 )
 

--- a/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
+++ b/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/stretchr/testify/require"
 
 	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
@@ -89,7 +90,7 @@ func TestPeering_RotateServerAndCAThenFail_(t *testing.T) {
 		libassert.PeeringExports(t, client, peerName, 1)
 
 		_, port := clientSidecarService.GetAddr()
-		libassert.HTTPServiceEchoes(t, "localhost", port)
+		libassert.HTTPServiceEchoes(t, "localhost", port, "")
 	}
 
 	testutil.RunStep(t, "rotate exporting cluster's root CA", func(t *testing.T) {
@@ -138,7 +139,7 @@ func TestPeering_RotateServerAndCAThenFail_(t *testing.T) {
 
 		// Connectivity should still be contained
 		_, port := clientSidecarService.GetAddr()
-		libassert.HTTPServiceEchoes(t, "localhost", port)
+		libassert.HTTPServiceEchoes(t, "localhost", port, "")
 
 		verifySidecarHasTwoRootCAs(t, clientSidecarService)
 	})
@@ -159,7 +160,7 @@ func TestPeering_RotateServerAndCAThenFail_(t *testing.T) {
 		time.Sleep(30 * time.Second)
 
 		_, port := clientSidecarService.GetAddr()
-		libassert.HTTPServiceEchoes(t, "localhost", port)
+		libassert.HTTPServiceEchoes(t, "localhost", port, "")
 	})
 }
 


### PR DESCRIPTION
### Description
Adding an integration test for access logs. It does not comprehensively execute the API, but it does demonstrate a possible workflow.

### Testing & Reproduction steps
* Use go test to run the integration test.

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] not a security concern
