### PR TITLE
Warn when the token query param is used for auth

### DIFF
--- a/.changelog/16009.txt
+++ b/.changelog/16009.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
-acl: Warn when query token parameter is used for authentication.
+```release-note:deprecation
+acl: Deprecate the `token` query parameter and warn when it is used for authentication.
 ```

--- a/.changelog/16009.txt
+++ b/.changelog/16009.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Authentication: Warn when query token parameter is used for authentication.
+```

--- a/.changelog/16009.txt
+++ b/.changelog/16009.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-Authentication: Warn when query token parameter is used for authentication.
+acl: Warn when query token parameter is used for authentication.
 ```

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -245,7 +245,8 @@ func TestACL_HTTP(t *testing.T) {
 				Datacenters: []string{"dc1"},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonBody(policyInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/policy", jsonBody(policyInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLPolicyCreate(resp, req)
 			require.NoError(t, err)
@@ -274,7 +275,8 @@ func TestACL_HTTP(t *testing.T) {
 				Rules: `key_prefix "" { policy = "read" }`,
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonBody(policyInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/policy", jsonBody(policyInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLPolicyCreate(resp, req)
 			require.NoError(t, err)
@@ -303,7 +305,8 @@ func TestACL_HTTP(t *testing.T) {
 				Rules: `node_prefix "" { policy = "read" }`,
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonBody(policyInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/policy", jsonBody(policyInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLPolicyCreate(resp, req)
 			require.NoError(t, err)
@@ -335,7 +338,8 @@ func TestACL_HTTP(t *testing.T) {
 				Datacenters: []string{"dc1"},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/policy/"+idMap["policy-read-all-nodes"]+"?token=root", jsonBody(policyInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/policy/"+idMap["policy-read-all-nodes"], jsonBody(policyInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLPolicyCRUD(resp, req)
 			require.Error(t, err)
@@ -343,7 +347,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 
 		t.Run("Policy CRUD Missing ID in URL", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/policy/?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/policy/", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLPolicyCRUD(resp, req)
 			require.Error(t, err)
@@ -358,7 +363,8 @@ func TestACL_HTTP(t *testing.T) {
 				Datacenters: []string{"dc1"},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/policy/"+idMap["policy-read-all-nodes"]+"?token=root", jsonBody(policyInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/policy/"+idMap["policy-read-all-nodes"], jsonBody(policyInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLPolicyCRUD(resp, req)
 			require.NoError(t, err)
@@ -390,7 +396,8 @@ func TestACL_HTTP(t *testing.T) {
 				Datacenters: []string{"dc1"},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonBody(policyInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/policy", jsonBody(policyInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLPolicyCreate(resp, req)
 			require.Error(t, err)
@@ -401,7 +408,8 @@ func TestACL_HTTP(t *testing.T) {
 			body := bytes.NewBuffer(nil)
 			body.Write([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/policy?token=root", body)
+			req, _ := http.NewRequest("PUT", "/v1/acl/policy", body)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLPolicyCreate(resp, req)
 			require.Error(t, err)
@@ -409,7 +417,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 
 		t.Run("Delete", func(t *testing.T) {
-			req, _ := http.NewRequest("DELETE", "/v1/acl/policy/"+idMap["policy-minimal"]+"?token=root", nil)
+			req, _ := http.NewRequest("DELETE", "/v1/acl/policy/"+idMap["policy-minimal"], nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLPolicyCRUD(resp, req)
 			require.NoError(t, err)
@@ -418,7 +427,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 
 		t.Run("List", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/policies?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/policies", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLPolicyList(resp, req)
 			require.NoError(t, err)
@@ -447,7 +457,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 
 		t.Run("Read", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/policy/"+idMap["policy-read-all-nodes"]+"?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/policy/"+idMap["policy-read-all-nodes"], nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLPolicyCRUD(resp, req)
 			require.NoError(t, err)
@@ -458,7 +469,8 @@ func TestACL_HTTP(t *testing.T) {
 
 		t.Run("Read Name", func(t *testing.T) {
 			policyName := "read-all-nodes"
-			req, _ := http.NewRequest("GET", "/v1/acl/policy/name/"+policyName+"?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/policy/name/"+policyName, nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLPolicyReadByName(resp, req)
 			require.NoError(t, err)
@@ -491,7 +503,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/role?token=root", jsonBody(roleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/role", jsonBody(roleInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLRoleCreate(resp, req)
 			require.NoError(t, err)
@@ -524,7 +537,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/role?token=root", jsonBody(roleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/role", jsonBody(roleInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLRoleCreate(resp, req)
 			require.NoError(t, err)
@@ -558,7 +572,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/role/"+idMap["role-test"]+"?token=root", jsonBody(roleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/role/"+idMap["role-test"], jsonBody(roleInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLRoleCRUD(resp, req)
 			require.Error(t, err)
@@ -566,7 +581,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 
 		t.Run("Role CRUD Missing ID in URL", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/role/?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/role/", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLRoleCRUD(resp, req)
 			require.Error(t, err)
@@ -590,7 +606,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/role/"+idMap["role-test"]+"?token=root", jsonBody(roleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/role/"+idMap["role-test"], jsonBody(roleInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLRoleCRUD(resp, req)
 			require.NoError(t, err)
@@ -626,7 +643,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/role?token=root", jsonBody(roleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/role", jsonBody(roleInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLRoleCreate(resp, req)
 			require.Error(t, err)
@@ -637,7 +655,8 @@ func TestACL_HTTP(t *testing.T) {
 			body := bytes.NewBuffer(nil)
 			body.Write([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/role?token=root", body)
+			req, _ := http.NewRequest("PUT", "/v1/acl/role", body)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLRoleCreate(resp, req)
 			require.Error(t, err)
@@ -645,7 +664,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 
 		t.Run("Delete", func(t *testing.T) {
-			req, _ := http.NewRequest("DELETE", "/v1/acl/role/"+idMap["role-service-id-web"]+"?token=root", nil)
+			req, _ := http.NewRequest("DELETE", "/v1/acl/role/"+idMap["role-service-id-web"], nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLRoleCRUD(resp, req)
 			require.NoError(t, err)
@@ -654,7 +674,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 
 		t.Run("List", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/roles?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/roles", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLRoleList(resp, req)
 			require.NoError(t, err)
@@ -684,7 +705,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 
 		t.Run("Read", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/role/"+idMap["role-test"]+"?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/role/"+idMap["role-test"], nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLRoleCRUD(resp, req)
 			require.NoError(t, err)
@@ -716,7 +738,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCreate(resp, req)
 			require.NoError(t, err)
@@ -754,7 +777,8 @@ func TestACL_HTTP(t *testing.T) {
 				Local: true,
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCreate(resp, req)
 			require.NoError(t, err)
@@ -777,7 +801,9 @@ func TestACL_HTTP(t *testing.T) {
 		})
 		t.Run("Read", func(t *testing.T) {
 			expected := tokenMap[idMap["token-test"]]
-			req, _ := http.NewRequest("GET", "/v1/acl/token/"+expected.AccessorID+"?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/token/"+expected.AccessorID, nil)
+			req.Header.Add("X-Consul-Token", "root")
+
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCRUD(resp, req)
 			require.NoError(t, err)
@@ -787,7 +813,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 		t.Run("Read-expanded", func(t *testing.T) {
 			expected := tokenMap[idMap["token-test"]]
-			req, _ := http.NewRequest("GET", "/v1/acl/token/"+expected.AccessorID+"?token=root&expanded=true", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/token/"+expected.AccessorID+"?expanded=true", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCRUD(resp, req)
 			require.NoError(t, err)
@@ -798,7 +825,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 		t.Run("Self", func(t *testing.T) {
 			expected := tokenMap[idMap["token-test"]]
-			req, _ := http.NewRequest("GET", "/v1/acl/token/self?token="+expected.SecretID, nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/token/self", nil)
+			req.Header.Add("X-Consul-Token", expected.SecretID)
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenSelf(resp, req)
 			require.NoError(t, err)
@@ -813,7 +841,8 @@ func TestACL_HTTP(t *testing.T) {
 
 			baseToken := tokenMap[idMap["token-test"]]
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token/"+baseToken.AccessorID+"/clone?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token/"+baseToken.AccessorID+"/clone", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCRUD(resp, req)
 			require.NoError(t, err)
@@ -852,7 +881,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token/"+originalToken.AccessorID+"?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token/"+originalToken.AccessorID, jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCRUD(resp, req)
 			require.NoError(t, err)
@@ -874,7 +904,8 @@ func TestACL_HTTP(t *testing.T) {
 		})
 
 		t.Run("CRUD Missing Token Accessor ID", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/token/?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/token/", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCRUD(resp, req)
 			require.Error(t, err)
@@ -896,7 +927,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token/"+originalToken.AccessorID+"?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token/"+originalToken.AccessorID, jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCRUD(resp, req)
 			require.Error(t, err)
@@ -904,7 +936,8 @@ func TestACL_HTTP(t *testing.T) {
 			require.True(t, isHTTPBadRequest(err))
 		})
 		t.Run("Delete", func(t *testing.T) {
-			req, _ := http.NewRequest("DELETE", "/v1/acl/token/"+idMap["token-cloned"]+"?token=root", nil)
+			req, _ := http.NewRequest("DELETE", "/v1/acl/token/"+idMap["token-cloned"], nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCRUD(resp, req)
 			require.NoError(t, err)
@@ -912,7 +945,8 @@ func TestACL_HTTP(t *testing.T) {
 			delete(idMap, "token-cloned")
 		})
 		t.Run("List", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/tokens?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/tokens", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLTokenList(resp, req)
 			require.NoError(t, err)
@@ -943,7 +977,8 @@ func TestACL_HTTP(t *testing.T) {
 			}
 		})
 		t.Run("List by Policy", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/tokens?token=root&policy="+structs.ACLPolicyGlobalManagementID, nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/tokens?policy="+structs.ACLPolicyGlobalManagementID, nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLTokenList(resp, req)
 			require.NoError(t, err)
@@ -971,7 +1006,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCreate(resp, req)
 			require.NoError(t, err)
@@ -1009,7 +1045,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCreate(resp, req)
 			require.NoError(t, err)
@@ -1048,7 +1085,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLTokenCreate(resp, req)
 			require.NoError(t, err)
@@ -1086,7 +1124,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCreate(resp, req)
 			require.Error(t, err)
@@ -1108,7 +1147,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCreate(resp, req)
 			require.Error(t, err)
@@ -1130,7 +1170,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCreate(resp, req)
 			require.Error(t, err)
@@ -1152,7 +1193,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCreate(resp, req)
 			require.Error(t, err)
@@ -1174,7 +1216,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCreate(resp, req)
 			require.Error(t, err)
@@ -1196,7 +1239,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCreate(resp, req)
 			require.Error(t, err)
@@ -1213,7 +1257,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCreate(resp, req)
 			require.Error(t, err)
@@ -1230,7 +1275,8 @@ func TestACL_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCreate(resp, req)
 			require.Error(t, err)
@@ -1279,7 +1325,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method", jsonBody(methodInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLAuthMethodCreate(resp, req)
 			require.NoError(t, err)
@@ -1309,7 +1356,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				MaxTokenTTL:   500_000_000_000,
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method", jsonBody(methodInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLAuthMethodCreate(resp, req)
 			require.NoError(t, err)
@@ -1339,7 +1387,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				MaxTokenTTL:   500_000_000_000,
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root&dc=remote", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?dc=remote", jsonBody(methodInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLAuthMethodCRUD(resp, req)
 			require.Error(t, err)
@@ -1356,7 +1405,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/not-test?token=root", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/not-test", jsonBody(methodInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLAuthMethodCRUD(resp, req)
 			require.Error(t, err)
@@ -1373,7 +1423,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/test?token=root", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/test", jsonBody(methodInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLAuthMethodCRUD(resp, req)
 			require.NoError(t, err)
@@ -1395,7 +1446,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			body := bytes.NewBuffer(nil)
 			body.Write([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root", body)
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method", body)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLAuthMethodCreate(resp, req)
 			require.Error(t, err)
@@ -1403,7 +1455,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("List", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/auth-methods?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/auth-methods", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLAuthMethodList(resp, req)
 			require.NoError(t, err)
@@ -1435,7 +1488,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("Delete", func(t *testing.T) {
-			req, _ := http.NewRequest("DELETE", "/v1/acl/auth-method/other?token=root", nil)
+			req, _ := http.NewRequest("DELETE", "/v1/acl/auth-method/other", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLAuthMethodCRUD(resp, req)
 			require.NoError(t, err)
@@ -1443,7 +1497,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("Read", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/auth-method/test?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/auth-method/test", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLAuthMethodCRUD(resp, req)
 			require.NoError(t, err)
@@ -1463,7 +1518,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "web",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule", jsonBody(ruleInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLBindingRuleCreate(resp, req)
 			require.NoError(t, err)
@@ -1494,7 +1550,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "fancy-role",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule", jsonBody(ruleInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLBindingRuleCreate(resp, req)
 			require.NoError(t, err)
@@ -1525,14 +1582,16 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "fancy-role",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root&dc=remote", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?dc=remote", jsonBody(ruleInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.EqualError(t, err, "No path to datacenter")
 		})
 
 		t.Run("BindingRule CRUD Missing ID in URL", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.Error(t, err)
@@ -1548,7 +1607,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "${serviceaccount.name}",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule/"+idMap["rule-test"]+"?token=root", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule/"+idMap["rule-test"], jsonBody(ruleInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.NoError(t, err)
@@ -1580,7 +1640,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "vault",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule", jsonBody(ruleInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCreate(resp, req)
 			require.Error(t, err)
@@ -1591,7 +1652,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			body := bytes.NewBuffer(nil)
 			body.Write([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root", body)
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule", body)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCreate(resp, req)
 			require.Error(t, err)
@@ -1599,7 +1661,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("List", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/binding-rules?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/binding-rules", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLBindingRuleList(resp, req)
 			require.NoError(t, err)
@@ -1630,7 +1693,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("Delete", func(t *testing.T) {
-			req, _ := http.NewRequest("DELETE", "/v1/acl/binding-rule/"+idMap["rule-other"]+"?token=root", nil)
+			req, _ := http.NewRequest("DELETE", "/v1/acl/binding-rule/"+idMap["rule-other"], nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.NoError(t, err)
@@ -1639,7 +1703,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("Read", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/"+idMap["rule-test"]+"?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/"+idMap["rule-test"], nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.NoError(t, err)
@@ -1660,7 +1725,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				Meta:        map[string]string{"foo": "bar"},
 			}
 
-			req, _ := http.NewRequest("POST", "/v1/acl/login?token=root", jsonBody(loginInput))
+			req, _ := http.NewRequest("POST", "/v1/acl/login", jsonBody(loginInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLLogin(resp, req)
 			require.NoError(t, err)
@@ -1693,7 +1759,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				Meta:        map[string]string{"blah": "woot"},
 			}
 
-			req, _ := http.NewRequest("POST", "/v1/acl/login?token=root", jsonBody(loginInput))
+			req, _ := http.NewRequest("POST", "/v1/acl/login", jsonBody(loginInput))
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLLogin(resp, req)
 			require.NoError(t, err)
@@ -1721,7 +1788,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("List Tokens by (incorrect) Method", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/tokens?token=root&authmethod=other", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/tokens?authmethod=other", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLTokenList(resp, req)
 			require.NoError(t, err)
@@ -1731,7 +1799,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("List Tokens by (correct) Method", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/tokens?token=root&authmethod=test", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/tokens?authmethod=test", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLTokenList(resp, req)
 			require.NoError(t, err)
@@ -1762,14 +1831,16 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 
 		t.Run("Logout", func(t *testing.T) {
 			tok := tokenMap[idMap["token-test-1"]]
-			req, _ := http.NewRequest("POST", "/v1/acl/logout?token="+tok.SecretID, nil)
+			req, _ := http.NewRequest("POST", "/v1/acl/logout", nil)
+			req.Header.Add("X-Consul-Token", tok.SecretID)
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLLogout(resp, req)
 			require.NoError(t, err)
 		})
 
 		t.Run("Token is gone after Logout", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/token/"+idMap["token-test-1"]+"?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/token/"+idMap["token-test-1"], nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCRUD(resp, req)
 			require.Error(t, err)

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -52,7 +52,8 @@ func createACLTokenWithAgentReadPolicy(t *testing.T, srv *HTTPHandlers) string {
 		Rules: `agent_prefix "" { policy = "read" }`,
 	}
 
-	req, _ := http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonReader(policyReq))
+	req, _ := http.NewRequest("PUT", "/v1/acl/policy", jsonReader(policyReq))
+	req.Header.Add("X-Consul-Token", "root")
 	resp := httptest.NewRecorder()
 	srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -62,7 +63,8 @@ func createACLTokenWithAgentReadPolicy(t *testing.T, srv *HTTPHandlers) string {
 		Policies:    []structs.ACLTokenPolicyLink{{Name: "agent-read"}},
 	}
 
-	req, _ = http.NewRequest("PUT", "/v1/acl/token?token=root", jsonReader(tokenReq))
+	req, _ = http.NewRequest("PUT", "/v1/acl/token", jsonReader(tokenReq))
+	req.Header.Add("X-Consul-Token", "root")
 	resp = httptest.NewRecorder()
 	srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -398,7 +400,8 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 			}
 		`)
 
-		req := httptest.NewRequest("GET", fmt.Sprintf("/v1/agent/services?token=%s", token), nil)
+		req := httptest.NewRequest("GET", "/v1/agent/services", nil)
+		req.Header.Add("X-Consul-Token", token)
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 
@@ -412,7 +415,8 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 	})
 
 	t.Run("root token", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/v1/agent/services?token=root", nil)
+		req, _ := http.NewRequest("GET", "/v1/agent/services", nil)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		dec := json.NewDecoder(resp.Body)
@@ -571,7 +575,8 @@ func TestAgent_Service(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)
 				// Re-register with new proxy config, make sure we copy the struct so we
 				// don't alter it and affect later test cases.
-				req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(updatedProxy))
+				req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(updatedProxy))
+				req.Header.Add("X-Consul-Token", "root")
 				resp := httptest.NewRecorder()
 				a.srv.h.ServeHTTP(resp, req)
 				require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
@@ -604,7 +609,8 @@ func TestAgent_Service(t *testing.T) {
 			updateFunc: func() {
 				time.Sleep(100 * time.Millisecond)
 				// Re-register with _same_ proxy config
-				req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(sidecarProxy))
+				req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(sidecarProxy))
+				req.Header.Add("X-Consul-Token", "root")
 				resp := httptest.NewRecorder()
 				a.srv.h.ServeHTTP(resp, req)
 				require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
@@ -694,7 +700,8 @@ func TestAgent_Service(t *testing.T) {
 
 			// Register the basic service to ensure it's in a known state to start.
 			{
-				req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(sidecarProxy))
+				req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(sidecarProxy))
+				req.Header.Add("X-Consul-Token", "root")
 				resp := httptest.NewRecorder()
 				a.srv.h.ServeHTTP(resp, req)
 				require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
@@ -1395,7 +1402,8 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 			}
 		`, a.Config.NodeName))
 
-		req := httptest.NewRequest("GET", fmt.Sprintf("/v1/agent/checks?token=%s", token), nil)
+		req := httptest.NewRequest("GET", "/v1/agent/checks", nil)
+		req.Header.Add("X-Consul-Token", token)
 		resp := httptest.NewRecorder()
 
 		a.srv.h.ServeHTTP(resp, req)
@@ -1409,7 +1417,8 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 	})
 
 	t.Run("root token", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/v1/agent/checks?token=root", nil)
+		req, _ := http.NewRequest("GET", "/v1/agent/checks", nil)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 
@@ -1535,7 +1544,8 @@ func TestAgent_Self_ACLDeny(t *testing.T) {
 	})
 
 	t.Run("agent recovery token", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/v1/agent/self?token=towel", nil)
+		req, _ := http.NewRequest("GET", "/v1/agent/self", nil)
+		req.Header.Add("X-Consul-Token", "towel")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -1543,7 +1553,8 @@ func TestAgent_Self_ACLDeny(t *testing.T) {
 
 	t.Run("read-only token", func(t *testing.T) {
 		ro := createACLTokenWithAgentReadPolicy(t, a.srv)
-		req, _ := http.NewRequest("GET", fmt.Sprintf("/v1/agent/self?token=%s", ro), nil)
+		req, _ := http.NewRequest("GET", "/v1/agent/self", nil)
+		req.Header.Add("X-Consul-Token", ro)
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -1568,7 +1579,8 @@ func TestAgent_Metrics_ACLDeny(t *testing.T) {
 	})
 
 	t.Run("agent recovery token", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/v1/agent/metrics?token=towel", nil)
+		req, _ := http.NewRequest("GET", "/v1/agent/metrics", nil)
+		req.Header.Add("X-Consul-Token", "towel")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -1576,7 +1588,8 @@ func TestAgent_Metrics_ACLDeny(t *testing.T) {
 
 	t.Run("read-only token", func(t *testing.T) {
 		ro := createACLTokenWithAgentReadPolicy(t, a.srv)
-		req, _ := http.NewRequest("GET", fmt.Sprintf("/v1/agent/metrics?token=%s", ro), nil)
+		req, _ := http.NewRequest("GET", "/v1/agent/metrics", nil)
+		req.Header.Add("X-Consul-Token", ro)
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -1922,7 +1935,8 @@ func TestAgent_Reload_ACLDeny(t *testing.T) {
 
 	t.Run("read-only token", func(t *testing.T) {
 		ro := createACLTokenWithAgentReadPolicy(t, a.srv)
-		req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/agent/reload?token=%s", ro), nil)
+		req, _ := http.NewRequest("PUT", "/v1/agent/reload", nil)
+		req.Header.Add("X-Consul-Token", ro)
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusForbidden, resp.Code)
@@ -2009,9 +2023,11 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 	testrpc.WaitForLeader(t, b.RPC, "dc1")
 
-	joinPath := fmt.Sprintf("/v1/agent/join/127.0.0.1:%d?token=root", b.Config.SerfPortLAN)
+	joinPath := fmt.Sprintf("/v1/agent/join/127.0.0.1:%d", b.Config.SerfPortLAN)
+	req, _ := http.NewRequest("PUT", joinPath, nil)
+	req.Header.Add("X-Consul-Token", "root")
 	resp := httptest.NewRecorder()
-	a.srv.h.ServeHTTP(resp, httptest.NewRequest(http.MethodPut, joinPath, nil))
+	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
 
 	t.Run("no token", func(t *testing.T) {
@@ -2036,7 +2052,8 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 			}
 		`, b.Config.NodeName))
 
-		req := httptest.NewRequest("GET", fmt.Sprintf("/v1/agent/members?token=%s", token), nil)
+		req := httptest.NewRequest("GET", "/v1/agent/members", nil)
+		req.Header.Add("X-Consul-Token", token)
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 
@@ -2050,7 +2067,8 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 	})
 
 	t.Run("root token", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/v1/agent/members?token=root", nil)
+		req, _ := http.NewRequest("GET", "/v1/agent/members", nil)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 
@@ -2146,7 +2164,8 @@ func TestAgent_Join_ACLDeny(t *testing.T) {
 	})
 
 	t.Run("agent recovery token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/agent/join/%s?token=towel", addr), nil)
+		req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/agent/join/%s", addr), nil)
+		req.Header.Add("X-Consul-Token", "towel")
 		resp := httptest.NewRecorder()
 		a1.srv.h.ServeHTTP(resp, req)
 
@@ -2155,7 +2174,8 @@ func TestAgent_Join_ACLDeny(t *testing.T) {
 
 	t.Run("read-only token", func(t *testing.T) {
 		ro := createACLTokenWithAgentReadPolicy(t, a1.srv)
-		req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/agent/join/%s?token=%s", addr, ro), nil)
+		req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/agent/join/%s", addr), nil)
+		req.Header.Add("X-Consul-Token", ro)
 		resp := httptest.NewRecorder()
 		a1.srv.h.ServeHTTP(resp, req)
 
@@ -2257,7 +2277,8 @@ func TestAgent_Leave_ACLDeny(t *testing.T) {
 
 	t.Run("read-only token", func(t *testing.T) {
 		ro := createACLTokenWithAgentReadPolicy(t, a.srv)
-		req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/agent/leave?token=%s", ro), nil)
+		req, _ := http.NewRequest("PUT", "/v1/agent/leave", nil)
+		req.Header.Add("X-Consul-Token", ro)
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 
@@ -2267,7 +2288,8 @@ func TestAgent_Leave_ACLDeny(t *testing.T) {
 	// this sub-test will change the state so that there is no leader.
 	// it must therefore be the last one in this list.
 	t.Run("agent recovery token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", "/v1/agent/leave?token=towel", nil)
+		req, _ := http.NewRequest("PUT", "/v1/agent/leave", nil)
+		req.Header.Add("X-Consul-Token", "towel")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 
@@ -2353,7 +2375,8 @@ func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 	})
 
 	t.Run("agent recovery token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", uri+"?token=towel", nil)
+		req, _ := http.NewRequest("PUT", uri, nil)
+		req.Header.Add("X-Consul-Token", "towel")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusForbidden, resp.Code)
@@ -2361,7 +2384,8 @@ func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 
 	t.Run("read-only token", func(t *testing.T) {
 		ro := createACLTokenWithAgentReadPolicy(t, a.srv)
-		req, _ := http.NewRequest("PUT", fmt.Sprintf(uri+"?token=%s", ro), nil)
+		req, _ := http.NewRequest("PUT", uri, nil)
+		req.Header.Add("X-Consul-Token", ro)
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusForbidden, resp.Code)
@@ -2374,7 +2398,8 @@ func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
                 `
 		opToken := testCreateToken(t, a, rules)
 
-		req, _ := http.NewRequest("PUT", fmt.Sprintf(uri+"?token=%s", opToken), nil)
+		req, _ := http.NewRequest("PUT", uri, nil)
+		req.Header.Add("X-Consul-Token", opToken)
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -2509,7 +2534,8 @@ func TestAgent_RegisterCheck(t *testing.T) {
 		Name: "test",
 		TTL:  15 * time.Second,
 	}
-	req, _ := http.NewRequest("PUT", "/v1/agent/check/register?token=abc123", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/agent/check/register", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "abc123")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -2551,7 +2577,8 @@ func TestAgent_RegisterCheck_UDP(t *testing.T) {
 		Name:     "test",
 		Interval: 10 * time.Second,
 	}
-	req, _ := http.NewRequest("PUT", "/v1/agent/check/register?token=abc123", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/agent/check/register", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "abc123")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -2678,7 +2705,8 @@ func TestAgent_RegisterCheckScriptsExecDisable(t *testing.T) {
 		ScriptArgs: []string{"true"},
 		Interval:   time.Second,
 	}
-	req, _ := http.NewRequest("PUT", "/v1/agent/check/register?token=abc123", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/agent/check/register", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "abc123")
 	res := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(res, req)
 	if http.StatusInternalServerError != res.Code {
@@ -2708,7 +2736,8 @@ func TestAgent_RegisterCheckScriptsExecRemoteDisable(t *testing.T) {
 		ScriptArgs: []string{"true"},
 		Interval:   time.Second,
 	}
-	req, _ := http.NewRequest("PUT", "/v1/agent/check/register?token=abc123", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/agent/check/register", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "abc123")
 	res := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(res, req)
 	if http.StatusInternalServerError != res.Code {
@@ -2810,7 +2839,8 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 	}
 
 	// ensure the service is ready for registering a check for it.
-	req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(svc))
+	req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(svc))
+	req.Header.Add("X-Consul-Token", "root")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -2821,7 +2851,8 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 		Rules: `service "foo" { policy = "write"}`,
 	}
 
-	req, _ = http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonReader(policyReq))
+	req, _ = http.NewRequest("PUT", "/v1/acl/policy", jsonReader(policyReq))
+	req.Header.Add("X-Consul-Token", "root")
 	resp = httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -2832,7 +2863,8 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 		Rules: fmt.Sprintf(`node "%s" { policy = "write" }`, a.config.NodeName),
 	}
 
-	req, _ = http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonReader(policyReq))
+	req, _ = http.NewRequest("PUT", "/v1/acl/policy", jsonReader(policyReq))
+	req.Header.Add("X-Consul-Token", "root")
 	resp = httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -2847,7 +2879,8 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 		},
 	}
 
-	req, _ = http.NewRequest("PUT", "/v1/acl/token?token=root", jsonReader(tokenReq))
+	req, _ = http.NewRequest("PUT", "/v1/acl/token", jsonReader(tokenReq))
+	req.Header.Add("X-Consul-Token", "root")
 	resp = httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -2869,7 +2902,8 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 		},
 	}
 
-	req, _ = http.NewRequest("PUT", "/v1/acl/token?token=root", jsonReader(tokenReq))
+	req, _ = http.NewRequest("PUT", "/v1/acl/token", jsonReader(tokenReq))
+	req.Header.Add("X-Consul-Token", "root")
 	resp = httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -2892,7 +2926,8 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 
 	t.Run("svc token - node check", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
-			req, _ := http.NewRequest("PUT", "/v1/agent/check/register?token="+svcToken.SecretID, jsonReader(nodeCheck))
+			req, _ := http.NewRequest("PUT", "/v1/agent/check/register", jsonReader(nodeCheck))
+			req.Header.Add("X-Consul-Token", svcToken.SecretID)
 			resp := httptest.NewRecorder()
 			a.srv.h.ServeHTTP(resp, req)
 			require.Equal(t, http.StatusForbidden, resp.Code)
@@ -2901,7 +2936,8 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 
 	t.Run("node token - node check", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
-			req, _ := http.NewRequest("PUT", "/v1/agent/check/register?token="+nodeToken.SecretID, jsonReader(nodeCheck))
+			req, _ := http.NewRequest("PUT", "/v1/agent/check/register", jsonReader(nodeCheck))
+			req.Header.Add("X-Consul-Token", nodeToken.SecretID)
 			resp := httptest.NewRecorder()
 			a.srv.h.ServeHTTP(resp, req)
 			require.Equal(t, http.StatusOK, resp.Code)
@@ -2919,7 +2955,8 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 
 	t.Run("node token - svc check", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
-			req, _ := http.NewRequest("PUT", "/v1/agent/check/register?token="+nodeToken.SecretID, jsonReader(svcCheck))
+			req, _ := http.NewRequest("PUT", "/v1/agent/check/register", jsonReader(svcCheck))
+			req.Header.Add("X-Consul-Token", nodeToken.SecretID)
 			resp := httptest.NewRecorder()
 			a.srv.h.ServeHTTP(resp, req)
 			require.Equal(t, http.StatusForbidden, resp.Code)
@@ -2928,7 +2965,8 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 
 	t.Run("svc token - svc check", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
-			req, _ := http.NewRequest("PUT", "/v1/agent/check/register?token="+svcToken.SecretID, jsonReader(svcCheck))
+			req, _ := http.NewRequest("PUT", "/v1/agent/check/register", jsonReader(svcCheck))
+			req.Header.Add("X-Consul-Token", svcToken.SecretID)
 			resp := httptest.NewRecorder()
 			a.srv.h.ServeHTTP(resp, req)
 			require.Equal(t, http.StatusOK, resp.Code)
@@ -2992,7 +3030,8 @@ func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
 	})
 
 	t.Run("root token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", "/v1/agent/check/deregister/test?token=root", nil)
+		req, _ := http.NewRequest("PUT", "/v1/agent/check/deregister/test", nil)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -3006,7 +3045,8 @@ func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
 	})
 
 	t.Run("non-existent check with token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", "/v1/agent/check/deregister/_nope_?token=root", nil)
+		req, _ := http.NewRequest("PUT", "/v1/agent/check/deregister/_nope_", nil)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusNotFound, resp.Code)
@@ -3068,7 +3108,8 @@ func TestAgent_PassCheck_ACLDeny(t *testing.T) {
 	})
 
 	t.Run("root token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", "/v1/agent/check/pass/test?token=root", nil)
+		req, _ := http.NewRequest("PUT", "/v1/agent/check/pass/test", nil)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -3130,7 +3171,8 @@ func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
 	})
 
 	t.Run("root token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", "/v1/agent/check/warn/test?token=root", nil)
+		req, _ := http.NewRequest("PUT", "/v1/agent/check/warn/test", nil)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -3192,7 +3234,8 @@ func TestAgent_FailCheck_ACLDeny(t *testing.T) {
 	})
 
 	t.Run("root token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", "/v1/agent/check/fail/test?token=root", nil)
+		req, _ := http.NewRequest("PUT", "/v1/agent/check/fail/test", nil)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -3296,7 +3339,8 @@ func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
 
 	t.Run("root token", func(t *testing.T) {
 		args := checkUpdate{api.HealthPassing, "hello-passing"}
-		req, _ := http.NewRequest("PUT", "/v1/agent/check/update/test?token=root", jsonReader(args))
+		req, _ := http.NewRequest("PUT", "/v1/agent/check/update/test", jsonReader(args))
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -3350,7 +3394,8 @@ func testAgent_RegisterService(t *testing.T, extraHCL string) {
 			Warning: 3,
 		},
 	}
-	req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=abc123", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "abc123")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	if http.StatusOK != resp.Code {
@@ -4064,7 +4109,8 @@ func testAgent_RegisterService_ACLDeny(t *testing.T, extraHCL string) {
 	})
 
 	t.Run("root token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(args))
+		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -4100,7 +4146,8 @@ func testAgent_RegisterService_InvalidAddress(t *testing.T, extraHCL string) {
 				Address: addr,
 				Port:    8000,
 			}
-			req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=abc123", jsonReader(args))
+			req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+			req.Header.Add("X-Consul-Token", "abc123")
 			resp := httptest.NewRecorder()
 			a.srv.h.ServeHTTP(resp, req)
 			if got, want := resp.Code, 400; got != want {
@@ -4162,7 +4209,8 @@ func testAgent_RegisterService_UnmanagedConnectProxy(t *testing.T, extraHCL stri
 		},
 	}
 
-	req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=abc123", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "abc123")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -4240,7 +4288,8 @@ func testCreateToken(t *testing.T, a *TestAgent, rules string) string {
 		},
 		"Local": false,
 	}
-	req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "root")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -4258,7 +4307,8 @@ func testCreatePolicy(t *testing.T, a *TestAgent, name, rules string) string {
 		"Name":  name,
 		"Rules": rules,
 	}
-	req, _ := http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/acl/policy", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "root")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
@@ -4695,7 +4745,8 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 
 			br := bytes.NewBufferString(tt.json)
 
-			req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token="+token, br)
+			req, _ := http.NewRequest("PUT", "/v1/agent/service/register", br)
+			req.Header.Add("X-Consul-Token", token)
 			resp := httptest.NewRecorder()
 			a.srv.h.ServeHTTP(resp, req)
 			if tt.wantErr != "" {
@@ -4749,7 +4800,8 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 			// was added via sidecar not just coincidental ID clash)
 			{
 				req := httptest.NewRequest("PUT",
-					"/v1/agent/service/deregister/"+svcID+"?token="+token, nil)
+					"/v1/agent/service/deregister/"+svcID, nil)
+				req.Header.Add("X-Consul-Token", token)
 				resp := httptest.NewRecorder()
 				a.srv.h.ServeHTTP(resp, req)
 				require.Equal(t, http.StatusOK, resp.Code)
@@ -5190,7 +5242,8 @@ func testAgent_RegisterServiceDeregisterService_Sidecar_UDP(t *testing.T, extraH
 
 			br := bytes.NewBufferString(tt.json)
 
-			req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token="+token, br)
+			req, _ := http.NewRequest("PUT", "/v1/agent/service/register", br)
+			req.Header.Add("X-Consul-Token", token)
 			resp := httptest.NewRecorder()
 			a.srv.h.ServeHTTP(resp, req)
 			if tt.wantErr != "" {
@@ -5244,7 +5297,8 @@ func testAgent_RegisterServiceDeregisterService_Sidecar_UDP(t *testing.T, extraH
 			// was added via sidecar not just coincidental ID clash)
 			{
 				req := httptest.NewRequest("PUT",
-					"/v1/agent/service/deregister/"+svcID+"?token="+token, nil)
+					"/v1/agent/service/deregister/"+svcID, nil)
+				req.Header.Add("X-Consul-Token", token)
 				resp := httptest.NewRecorder()
 				a.srv.h.ServeHTTP(resp, req)
 				require.Equal(t, http.StatusOK, resp.Code)
@@ -5299,7 +5353,8 @@ func testAgent_RegisterService_UnmanagedConnectProxyInvalid(t *testing.T, extraH
 		},
 	}
 
-	req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=abc123", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "abc123")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
@@ -5394,7 +5449,8 @@ func testAgent_RegisterService_ScriptCheck_ExecDisable(t *testing.T, extraHCL st
 			Warning: 3,
 		},
 	}
-	req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=abc123", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "abc123")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	if http.StatusInternalServerError != resp.Code {
@@ -5446,7 +5502,8 @@ func testAgent_RegisterService_ScriptCheck_ExecRemoteDisable(t *testing.T, extra
 			Warning: 3,
 		},
 	}
-	req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=abc123", jsonReader(args))
+	req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "abc123")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	if http.StatusInternalServerError != resp.Code {
@@ -5522,7 +5579,8 @@ func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 	})
 
 	t.Run("root token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", "/v1/agent/service/deregister/test?token=root", nil)
+		req, _ := http.NewRequest("PUT", "/v1/agent/service/deregister/test", nil)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
@@ -6097,7 +6155,8 @@ func TestAgent_TokenTriggersFullSync(t *testing.T) {
 			Rules: `node_prefix "" { policy = "write" }`,
 		}
 
-		req, err := http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonBody(policy))
+		req, err := http.NewRequest("PUT", "/v1/acl/policy", jsonBody(policy))
+		req.Header.Add("X-Consul-Token", "root")
 		require.NoError(t, err)
 
 		resp := httptest.NewRecorder()
@@ -6120,7 +6179,8 @@ func TestAgent_TokenTriggersFullSync(t *testing.T) {
 			},
 		}
 
-		req, err := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(token))
+		req, err := http.NewRequest("PUT", "/v1/acl/token", jsonBody(token))
+		req.Header.Add("X-Consul-Token", "root")
 		require.NoError(t, err)
 
 		resp := httptest.NewRecorder()
@@ -6158,7 +6218,7 @@ func TestAgent_TokenTriggersFullSync(t *testing.T) {
 	for _, tt := range cases {
 		tt := tt
 		t.Run(tt.path, func(t *testing.T) {
-			url := fmt.Sprintf("/v1/agent/token/%s?token=root", tt.path)
+			url := fmt.Sprintf("/v1/agent/token/%s", tt.path)
 
 			a := NewTestAgent(t, `
 				primary_datacenter = "dc1"
@@ -6183,6 +6243,7 @@ func TestAgent_TokenTriggersFullSync(t *testing.T) {
 			token := createNodeToken(t, a, "test")
 
 			req, err := http.NewRequest("PUT", url, body(token.SecretID))
+			req.Header.Add("X-Consul-Token", "root")
 			require.NoError(t, err)
 
 			resp := httptest.NewRecorder()
@@ -6270,7 +6331,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:        "bad token name",
 			method:      "PUT",
-			url:         "nope?token=root",
+			url:         "nope",
 			body:        body("X"),
 			code:        http.StatusNotFound,
 			expectedErr: `Token "nope" is unknown`,
@@ -6278,7 +6339,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:        "bad JSON",
 			method:      "PUT",
-			url:         "acl_token?token=root",
+			url:         "acl_token",
 			body:        badJSON(),
 			code:        http.StatusBadRequest,
 			expectedErr: `Request decode failed: json: cannot unmarshal bool into Go value of type api.AgentToken`,
@@ -6286,7 +6347,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:      "set user legacy",
 			method:    "PUT",
-			url:       "acl_token?token=root",
+			url:       "acl_token",
 			body:      body("U"),
 			code:      http.StatusOK,
 			raw:       tokens{user: "U", userSource: tokenStore.TokenSourceAPI},
@@ -6295,7 +6356,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:      "set default",
 			method:    "PUT",
-			url:       "default?token=root",
+			url:       "default",
 			body:      body("U"),
 			code:      http.StatusOK,
 			raw:       tokens{user: "U", userSource: tokenStore.TokenSourceAPI},
@@ -6304,7 +6365,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:      "set agent legacy",
 			method:    "PUT",
-			url:       "acl_agent_token?token=root",
+			url:       "acl_agent_token",
 			body:      body("A"),
 			code:      http.StatusOK,
 			init:      tokens{user: "U", agent: "U"},
@@ -6314,7 +6375,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:      "set agent",
 			method:    "PUT",
-			url:       "agent?token=root",
+			url:       "agent",
 			body:      body("A"),
 			code:      http.StatusOK,
 			init:      tokens{user: "U", agent: "U"},
@@ -6324,7 +6385,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:      "set master legacy",
 			method:    "PUT",
-			url:       "acl_agent_master_token?token=root",
+			url:       "acl_agent_master_token",
 			body:      body("M"),
 			code:      http.StatusOK,
 			raw:       tokens{agentRecovery: "M", agentRecoverySource: tokenStore.TokenSourceAPI},
@@ -6333,7 +6394,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:      "set master",
 			method:    "PUT",
-			url:       "agent_master?token=root",
+			url:       "agent_master",
 			body:      body("M"),
 			code:      http.StatusOK,
 			raw:       tokens{agentRecovery: "M", agentRecoverySource: tokenStore.TokenSourceAPI},
@@ -6342,7 +6403,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:      "set recovery",
 			method:    "PUT",
-			url:       "agent_recovery?token=root",
+			url:       "agent_recovery",
 			body:      body("R"),
 			code:      http.StatusOK,
 			raw:       tokens{agentRecovery: "R", agentRecoverySource: tokenStore.TokenSourceAPI},
@@ -6351,7 +6412,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:      "set repl legacy",
 			method:    "PUT",
-			url:       "acl_replication_token?token=root",
+			url:       "acl_replication_token",
 			body:      body("R"),
 			code:      http.StatusOK,
 			raw:       tokens{repl: "R", replSource: tokenStore.TokenSourceAPI},
@@ -6360,7 +6421,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:      "set repl",
 			method:    "PUT",
-			url:       "replication?token=root",
+			url:       "replication",
 			body:      body("R"),
 			code:      http.StatusOK,
 			raw:       tokens{repl: "R", replSource: tokenStore.TokenSourceAPI},
@@ -6369,7 +6430,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:      "set registration",
 			method:    "PUT",
-			url:       "config_file_service_registration?token=root",
+			url:       "config_file_service_registration",
 			body:      body("G"),
 			code:      http.StatusOK,
 			raw:       tokens{registration: "G", registrationSource: tokenStore.TokenSourceAPI},
@@ -6378,7 +6439,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:   "clear user legacy",
 			method: "PUT",
-			url:    "acl_token?token=root",
+			url:    "acl_token",
 			body:   body(""),
 			code:   http.StatusOK,
 			init:   tokens{user: "U"},
@@ -6387,7 +6448,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:   "clear default",
 			method: "PUT",
-			url:    "default?token=root",
+			url:    "default",
 			body:   body(""),
 			code:   http.StatusOK,
 			init:   tokens{user: "U"},
@@ -6396,7 +6457,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:   "clear agent legacy",
 			method: "PUT",
-			url:    "acl_agent_token?token=root",
+			url:    "acl_agent_token",
 			body:   body(""),
 			code:   http.StatusOK,
 			init:   tokens{agent: "A"},
@@ -6405,7 +6466,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:   "clear agent",
 			method: "PUT",
-			url:    "agent?token=root",
+			url:    "agent",
 			body:   body(""),
 			code:   http.StatusOK,
 			init:   tokens{agent: "A"},
@@ -6414,7 +6475,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:   "clear master legacy",
 			method: "PUT",
-			url:    "acl_agent_master_token?token=root",
+			url:    "acl_agent_master_token",
 			body:   body(""),
 			code:   http.StatusOK,
 			init:   tokens{agentRecovery: "M"},
@@ -6423,7 +6484,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:   "clear master",
 			method: "PUT",
-			url:    "agent_master?token=root",
+			url:    "agent_master",
 			body:   body(""),
 			code:   http.StatusOK,
 			init:   tokens{agentRecovery: "M"},
@@ -6432,7 +6493,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:   "clear recovery",
 			method: "PUT",
-			url:    "agent_recovery?token=root",
+			url:    "agent_recovery",
 			body:   body(""),
 			code:   http.StatusOK,
 			init:   tokens{agentRecovery: "R"},
@@ -6441,7 +6502,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:   "clear repl legacy",
 			method: "PUT",
-			url:    "acl_replication_token?token=root",
+			url:    "acl_replication_token",
 			body:   body(""),
 			code:   http.StatusOK,
 			init:   tokens{repl: "R"},
@@ -6450,7 +6511,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:   "clear repl",
 			method: "PUT",
-			url:    "replication?token=root",
+			url:    "replication",
 			body:   body(""),
 			code:   http.StatusOK,
 			init:   tokens{repl: "R"},
@@ -6459,7 +6520,7 @@ func TestAgent_Token(t *testing.T) {
 		{
 			name:   "clear registration",
 			method: "PUT",
-			url:    "config_file_service_registration?token=root",
+			url:    "config_file_service_registration",
 			body:   body(""),
 			code:   http.StatusOK,
 			init:   tokens{registration: "G"},
@@ -6472,6 +6533,7 @@ func TestAgent_Token(t *testing.T) {
 			url := fmt.Sprintf("/v1/agent/token/%s", tt.url)
 			resp := httptest.NewRecorder()
 			req, _ := http.NewRequest(tt.method, url, tt.body)
+			req.Header.Add("X-Consul-Token", "root")
 
 			a.srv.h.ServeHTTP(resp, req)
 			require.Equal(t, tt.code, resp.Code)
@@ -6649,7 +6711,8 @@ func TestAgentConnectCALeafCert_aclDefaultDeny(t *testing.T) {
 			Connect: &structs.ServiceConnect{},
 		}
 
-		req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(reg))
+		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(reg))
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
@@ -6686,7 +6749,8 @@ func TestAgentConnectCALeafCert_aclServiceWrite(t *testing.T) {
 			Connect: &structs.ServiceConnect{},
 		}
 
-		req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(reg))
+		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(reg))
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
@@ -6694,7 +6758,8 @@ func TestAgentConnectCALeafCert_aclServiceWrite(t *testing.T) {
 
 	token := createACLTokenWithServicePolicy(t, a.srv, "write")
 
-	req, _ := http.NewRequest("GET", "/v1/agent/connect/ca/leaf/test?token="+token, nil)
+	req, _ := http.NewRequest("GET", "/v1/agent/connect/ca/leaf/test", nil)
+	req.Header.Add("X-Consul-Token", token)
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 
@@ -6711,7 +6776,8 @@ func createACLTokenWithServicePolicy(t *testing.T, srv *HTTPHandlers, policy str
 		Rules: fmt.Sprintf(`service "test" { policy = "%v" }`, policy),
 	}
 
-	req, _ := http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonReader(policyReq))
+	req, _ := http.NewRequest("PUT", "/v1/acl/policy", jsonReader(policyReq))
+	req.Header.Add("X-Consul-Token", "root")
 	resp := httptest.NewRecorder()
 	_, err := srv.ACLPolicyCreate(resp, req)
 	require.NoError(t, err)
@@ -6721,7 +6787,8 @@ func createACLTokenWithServicePolicy(t *testing.T, srv *HTTPHandlers, policy str
 		Policies:    []structs.ACLTokenPolicyLink{{Name: "service-test-write"}},
 	}
 
-	req, _ = http.NewRequest("PUT", "/v1/acl/token?token=root", jsonReader(tokenReq))
+	req, _ = http.NewRequest("PUT", "/v1/acl/token", jsonReader(tokenReq))
+	req.Header.Add("X-Consul-Token", "root")
 	resp = httptest.NewRecorder()
 	srv.h.ServeHTTP(resp, req)
 
@@ -6756,7 +6823,8 @@ func TestAgentConnectCALeafCert_aclServiceReadDeny(t *testing.T) {
 			Connect: &structs.ServiceConnect{},
 		}
 
-		req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(reg))
+		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(reg))
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		a.srv.h.ServeHTTP(resp, req)
 		require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
@@ -6764,7 +6832,8 @@ func TestAgentConnectCALeafCert_aclServiceReadDeny(t *testing.T) {
 
 	token := createACLTokenWithServicePolicy(t, a.srv, "read")
 
-	req, _ := http.NewRequest("GET", "/v1/agent/connect/ca/leaf/test?token="+token, nil)
+	req, _ := http.NewRequest("GET", "/v1/agent/connect/ca/leaf/test", nil)
+	req.Header.Add("X-Consul-Token", token)
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusForbidden, resp.Code)
@@ -7856,8 +7925,8 @@ func TestAgentConnectAuthorize_serviceWrite(t *testing.T) {
 		Target:        "test",
 		ClientCertURI: connect.TestSpiffeIDService(t, "web").URI().String(),
 	}
-	req, _ := http.NewRequest("POST",
-		"/v1/agent/connect/authorize?token="+token, jsonReader(args))
+	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize", jsonReader(args))
+	req.Header.Add("X-Consul-Token", token)
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 
@@ -7880,7 +7949,8 @@ func TestAgentConnectAuthorize_defaultDeny(t *testing.T) {
 		Target:        "foo",
 		ClientCertURI: connect.TestSpiffeIDService(t, "web").URI().String(),
 	}
-	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize?token=root", jsonReader(args))
+	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "root")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	assert.Equal(t, 200, resp.Code)
@@ -7922,7 +7992,8 @@ func TestAgentConnectAuthorize_defaultAllow(t *testing.T) {
 		Target:        "foo",
 		ClientCertURI: connect.TestSpiffeIDService(t, "web").URI().String(),
 	}
-	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize?token=root", jsonReader(args))
+	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize", jsonReader(args))
+	req.Header.Add("X-Consul-Token", "root")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)
 	assert.Equal(t, 200, resp.Code)
@@ -7959,7 +8030,8 @@ func TestAgent_Host(t *testing.T) {
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
-	req, _ := http.NewRequest("GET", "/v1/agent/host?token=initial-management", nil)
+	req, _ := http.NewRequest("GET", "/v1/agent/host", nil)
+	req.Header.Add("X-Consul-Token", "initial-management")
 	resp := httptest.NewRecorder()
 	// TODO: AgentHost should write to response so that we can test using ServeHTTP()
 	respRaw, err := a.srv.AgentHost(resp, req)
@@ -7997,7 +8069,8 @@ func TestAgent_HostBadACL(t *testing.T) {
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
-	req, _ := http.NewRequest("GET", "/v1/agent/host?token=agent", nil)
+	req, _ := http.NewRequest("GET", "/v1/agent/host", nil)
+	req.Header.Add("X-Consul-Token", "agent")
 	resp := httptest.NewRecorder()
 	// TODO: AgentHost should write to response so that we can test using ServeHTTP()
 	_, err := a.srv.AgentHost(resp, req)

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -2024,7 +2024,7 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 	testrpc.WaitForLeader(t, b.RPC, "dc1")
 
 	joinPath := fmt.Sprintf("/v1/agent/join/127.0.0.1:%d", b.Config.SerfPortLAN)
-	req, _ := http.NewRequest("PUT", joinPath, nil)
+	req := httptest.NewRequest("PUT", joinPath, nil)
 	req.Header.Add("X-Consul-Token", "root")
 	resp := httptest.NewRecorder()
 	a.srv.h.ServeHTTP(resp, req)

--- a/agent/coordinate_endpoint_test.go
+++ b/agent/coordinate_endpoint_test.go
@@ -342,7 +342,8 @@ func TestCoordinate_Update_ACLDeny(t *testing.T) {
 	})
 
 	t.Run("valid token", func(t *testing.T) {
-		req, _ := http.NewRequest("PUT", "/v1/coordinate/update?token=root", jsonReader(body))
+		req, _ := http.NewRequest("PUT", "/v1/coordinate/update", jsonReader(body))
+		req.Header.Add("X-Consul-Token", "root")
 		if _, err := a.srv.CoordinateUpdate(nil, req); err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/agent/event_endpoint_test.go
+++ b/agent/event_endpoint_test.go
@@ -85,8 +85,9 @@ func TestEventFire_token(t *testing.T) {
 	}
 	for _, c := range tcases {
 		// Try to fire the event over the HTTP interface
-		url := fmt.Sprintf("/v1/event/fire/%s?token=%s", c.event, token)
+		url := fmt.Sprintf("/v1/event/fire/%s", c.event)
 		req, _ := http.NewRequest("PUT", url, nil)
+		req.Header.Add("X-Consul-Token", token)
 		resp := httptest.NewRecorder()
 		_, err := a.srv.EventFire(resp, req)
 
@@ -236,7 +237,8 @@ func TestEventList_ACLFilter(t *testing.T) {
 				}
 			`)
 
-			req := httptest.NewRequest("GET", fmt.Sprintf("/v1/event/list?token=%s", token), nil)
+			req := httptest.NewRequest("GET", "/v1/event/list", nil)
+			req.Header.Add("X-Consul-Token", token)
 			resp := httptest.NewRecorder()
 
 			obj, err := a.srv.EventList(resp, req)
@@ -252,7 +254,8 @@ func TestEventList_ACLFilter(t *testing.T) {
 
 	t.Run("root token", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
-			req := httptest.NewRequest("GET", "/v1/event/list?token=root", nil)
+			req := httptest.NewRequest("GET", "/v1/event/list", nil)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 
 			obj, err := a.srv.EventList(resp, req)

--- a/agent/http.go
+++ b/agent/http.go
@@ -368,7 +368,7 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 				}
 				logURL = strings.Replace(logURL, token, "<hidden>", -1)
 				httpLogger.Warn("This request is using a token query parameter "+
-					"which is deprecated and will be removed in future Consul versions.",
+					"which is deprecated and will be removed in Consul 1.17",
 					"logUrl", logURL)
 			}
 		}

--- a/agent/http.go
+++ b/agent/http.go
@@ -368,7 +368,7 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 				}
 				logURL = strings.Replace(logURL, token, "<hidden>", -1)
 			}
-			httpLogger.Warn("This request is using a token query parameter "+
+			httpLogger.Warn("This request used the token query parameter "+
 				"which is deprecated and will be removed in Consul 1.17",
 				"logUrl", logURL)
 		}

--- a/agent/http.go
+++ b/agent/http.go
@@ -367,10 +367,10 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 					continue
 				}
 				logURL = strings.Replace(logURL, token, "<hidden>", -1)
-				httpLogger.Warn("This request is using a token query parameter "+
-					"which is deprecated and will be removed in Consul 1.17",
-					"logUrl", logURL)
 			}
+			httpLogger.Warn("This request is using a token query parameter "+
+				"which is deprecated and will be removed in Consul 1.17",
+				"logUrl", logURL)
 		}
 		logURL = aclEndpointRE.ReplaceAllString(logURL, "$1<hidden>$4")
 

--- a/agent/http.go
+++ b/agent/http.go
@@ -367,6 +367,9 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 					continue
 				}
 				logURL = strings.Replace(logURL, token, "<hidden>", -1)
+				httpLogger.Warn("This request is using a token query parameter "+
+					"which is deprecated and will be removed in future Consul versions.",
+					"logUrl", logURL)
 			}
 		}
 		logURL = aclEndpointRE.ReplaceAllString(logURL, "$1<hidden>$4")

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -148,7 +148,8 @@ func TestPreparedQuery_Create(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	req, _ := http.NewRequest("POST", "/v1/query?token=my-token", body)
+	req, _ := http.NewRequest("POST", "/v1/query", body)
+	req.Header.Add("X-Consul-Token", "my-token")
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.PreparedQueryGeneral(resp, req)
 	if err != nil {
@@ -234,7 +235,8 @@ func TestPreparedQuery_List(t *testing.T) {
 		}
 
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/query?token=my-token&consistent=true", body)
+		req, _ := http.NewRequest("GET", "/v1/query?consistent=true", body)
+		req.Header.Add("X-Consul-Token", "my-token")
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.PreparedQueryGeneral(resp, req)
 		if err != nil {
@@ -329,7 +331,8 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		}
 
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/query/my-id/execute?token=my-token&consistent=true&near=my-node&limit=5", body)
+		req, _ := http.NewRequest("GET", "/v1/query/my-id/execute?consistent=true&near=my-node&limit=5", body)
+		req.Header.Add("X-Consul-Token", "my-token")
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.PreparedQuerySpecific(resp, req)
 		if err != nil {
@@ -385,7 +388,8 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		}
 
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/query/my-id/execute?token=my-token&consistent=true&near=_ip&limit=5", body)
+		req, _ := http.NewRequest("GET", "/v1/query/my-id/execute?consistent=true&near=_ip&limit=5", body)
+		req.Header.Add("X-Consul-Token", "my-token")
 		req.Header.Add("X-Forwarded-For", "127.0.0.1")
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.PreparedQuerySpecific(resp, req)
@@ -442,7 +446,8 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		}
 
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/query/my-id/execute?token=my-token&consistent=true&near=_ip&limit=5", body)
+		req, _ := http.NewRequest("GET", "/v1/query/my-id/execute?consistent=true&near=_ip&limit=5", body)
+		req.Header.Add("X-Consul-Token", "my-token")
 		req.Header.Add("X-Forwarded-For", "198.18.0.1")
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.PreparedQuerySpecific(resp, req)
@@ -460,7 +465,8 @@ func TestPreparedQuery_Execute(t *testing.T) {
 			t.Fatalf("bad: %v", r)
 		}
 
-		req, _ = http.NewRequest("GET", "/v1/query/my-id/execute?token=my-token&consistent=true&near=_ip&limit=5", body)
+		req, _ = http.NewRequest("GET", "/v1/query/my-id/execute?consistent=true&near=_ip&limit=5", body)
+		req.Header.Add("X-Consul-Token", "my-token")
 		req.Header.Add("X-Forwarded-For", "198.18.0.1, 198.19.0.1")
 		resp = httptest.NewRecorder()
 		obj, err = a.srv.PreparedQuerySpecific(resp, req)
@@ -735,7 +741,8 @@ func TestPreparedQuery_Explain(t *testing.T) {
 		}
 
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/query/my-id/explain?token=my-token&consistent=true&near=my-node&limit=5", body)
+		req, _ := http.NewRequest("GET", "/v1/query/my-id/explain?consistent=true&near=my-node&limit=5", body)
+		req.Header.Add("X-Consul-Token", "my-token")
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.PreparedQuerySpecific(resp, req)
 		if err != nil {
@@ -828,7 +835,8 @@ func TestPreparedQuery_Get(t *testing.T) {
 		}
 
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/query/my-id?token=my-token&consistent=true", body)
+		req, _ := http.NewRequest("GET", "/v1/query/my-id?consistent=true", body)
+		req.Header.Add("X-Consul-Token", "my-token")
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.PreparedQuerySpecific(resp, req)
 		if err != nil {
@@ -936,7 +944,8 @@ func TestPreparedQuery_Update(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	req, _ := http.NewRequest("PUT", "/v1/query/my-id?token=my-token", body)
+	req, _ := http.NewRequest("PUT", "/v1/query/my-id", body)
+	req.Header.Add("X-Consul-Token", "my-token")
 	resp := httptest.NewRecorder()
 	if _, err := a.srv.PreparedQuerySpecific(resp, req); err != nil {
 		t.Fatalf("err: %v", err)
@@ -988,7 +997,8 @@ func TestPreparedQuery_Delete(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	req, _ := http.NewRequest("DELETE", "/v1/query/my-id?token=my-token", body)
+	req, _ := http.NewRequest("DELETE", "/v1/query/my-id", body)
+	req.Header.Add("X-Consul-Token", "my-token")
 	resp := httptest.NewRecorder()
 	if _, err := a.srv.PreparedQuerySpecific(resp, req); err != nil {
 		t.Fatalf("err: %v", err)
@@ -1087,7 +1097,8 @@ func TestPreparedQuery_Integration(t *testing.T) {
 	// List them all.
 	{
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/query?token=root", body)
+		req, _ := http.NewRequest("GET", "/v1/query", body)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.PreparedQueryGeneral(resp, req)
 		if err != nil {

--- a/agent/snapshot_endpoint_test.go
+++ b/agent/snapshot_endpoint_test.go
@@ -25,7 +25,8 @@ func TestSnapshot(t *testing.T) {
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/snapshot?token=root", body)
+		req, _ := http.NewRequest("GET", "/v1/snapshot", body)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		if _, err := a.srv.Snapshot(resp, req); err != nil {
 			t.Fatalf("err: %v", err)
@@ -51,7 +52,8 @@ func TestSnapshot(t *testing.T) {
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
-		req, _ := http.NewRequest("PUT", "/v1/snapshot?token=root", snap)
+		req, _ := http.NewRequest("PUT", "/v1/snapshot", snap)
+		req.Header.Add("X-Consul-Token", "root")
 		resp := httptest.NewRecorder()
 		if _, err := a.srv.Snapshot(resp, req); err != nil {
 			t.Fatalf("err: %v", err)
@@ -71,7 +73,8 @@ func TestSnapshot_Options(t *testing.T) {
 			defer a.Shutdown()
 
 			body := bytes.NewBuffer(nil)
-			req, _ := http.NewRequest(method, "/v1/snapshot?token=anonymous", body)
+			req, _ := http.NewRequest(method, "/v1/snapshot", body)
+			req.Header.Add("X-Consul-Token", "anonymous")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.Snapshot(resp, req)
 			if !acl.IsErrPermissionDenied(err) {
@@ -97,7 +100,8 @@ func TestSnapshot_Options(t *testing.T) {
 			defer a.Shutdown()
 
 			body := bytes.NewBuffer(nil)
-			req, _ := http.NewRequest(method, "/v1/snapshot?token=root&stale", body)
+			req, _ := http.NewRequest(method, "/v1/snapshot?stale", body)
+			req.Header.Add("X-Consul-Token", "root")
 			resp := httptest.NewRecorder()
 			_, err := a.srv.Snapshot(resp, req)
 			if method == "GET" {

--- a/website/content/api-docs/api-structure.mdx
+++ b/website/content/api-docs/api-structure.mdx
@@ -40,9 +40,9 @@ $ curl \
     http://127.0.0.1:8500/v1/agent/members
 ```
 
-Previously this was provided via a `?token=` query parameter but its use is **highly
-discouraged**, since it can show up in access logs as part of the URL.
-This functionality is deprecated and will be removed in future versions.
+Though the token could also be provided via a `?token=` query parameter,
+that method is **highly discouraged** because the token can show up in access logs as part of the URL.
+The `?token=` query parameter is deprecated and will be removed in Consul 1.17.
 
 To learn more about the ACL system read the [documentation](/docs/security/acl).
 

--- a/website/content/api-docs/api-structure.mdx
+++ b/website/content/api-docs/api-structure.mdx
@@ -40,9 +40,9 @@ $ curl \
     http://127.0.0.1:8500/v1/agent/members
 ```
 
-Previously this was provided via a `?token=` query parameter. This functionality
-exists on many endpoints for backwards compatibility, but its use is **highly
+Previously this was provided via a `?token=` query parameter but its use is **highly
 discouraged**, since it can show up in access logs as part of the URL.
+This functionality is deprecated and will be removed in future versions.
 
 To learn more about the ACL system read the [documentation](/docs/security/acl).
 

--- a/website/content/api-docs/api-structure.mdx
+++ b/website/content/api-docs/api-structure.mdx
@@ -40,8 +40,8 @@ $ curl \
     http://127.0.0.1:8500/v1/agent/members
 ```
 
-Though the token could also be provided via a `?token=` query parameter,
-that method is **highly discouraged** because the token can show up in access logs as part of the URL.
+**Security Note:** Though you could pass the token through the `?token=` query parameter,
+this method is highly discouraged because the token can show up in access logs as part of the URL. 
 The `?token=` query parameter is deprecated and will be removed in Consul 1.17.
 
 To learn more about the ACL system read the [documentation](/docs/security/acl).

--- a/website/content/docs/security/acl/acl-legacy.mdx
+++ b/website/content/docs/security/acl/acl-legacy.mdx
@@ -663,12 +663,13 @@ Here's a sample request using the HCL form:
 ```shell-session
 $ curl \
     --request PUT \
+    --header "X-Consul-Token: <management token>" \
     --data \
 '{
   "Name": "my-app-token",
   "Type": "client",
   "Rules": "key \"\" { policy = \"read\" } key \"foo/\" { policy = \"write\" } key \"foo/private/\" { policy = \"deny\" } operator = \"read\""
-}' http://127.0.0.1:8500/v1/acl/create?token=<management token>
+}' http://127.0.0.1:8500/v1/acl/create
 ```
 
 Here's an equivalent request using the JSON form:
@@ -676,12 +677,13 @@ Here's an equivalent request using the JSON form:
 ```shell-session
 $ curl \
     --request PUT \
+    --header "X-Consul-Token: <management token>" \
     --data \
 '{
   "Name": "my-app-token",
   "Type": "client",
   "Rules": "{\"key\":{\"\":{\"policy\":\"read\"},\"foo/\":{\"policy\":\"write\"},\"foo/private\":{\"policy\":\"deny\"}},\"operator\":\"read\"}"
-}' http://127.0.0.1:8500/v1/acl/create?token=<management token>
+}' http://127.0.0.1:8500/v1/acl/create
 ```
 
 On success, the token ID is returned:

--- a/website/content/docs/security/acl/acl-policies.mdx
+++ b/website/content/docs/security/acl/acl-policies.mdx
@@ -286,11 +286,12 @@ The following example adds a set of rules to a policy called `my-app-policy`. Th
 ```shell-session
 $ curl \
     --request PUT \
+    --header "X-Consul-Token: <token with ACL 'write' access>" \
     --data \
 '{
   "Name": "my-app-policy",
   "Rules": "key \"\" { policy = \"read\" } key \"foo/\" { policy = \"write\" } key \"foo/private/\" { policy = \"deny\" } operator = \"read\""
-}' http://127.0.0.1:8500/v1/acl/policy?token=<token with ACL "write" access>
+}' http://127.0.0.1:8500/v1/acl/policy
 ```
 
 The following call performs the same operation as the previous example using JSON:
@@ -298,11 +299,12 @@ The following call performs the same operation as the previous example using JSO
 ```shell-session
 $ curl \
     --request PUT \
+    --header "X-Consul-Token: <management token>" \
     --data \
 '{
   "Name": "my-app-policy",
   "Rules": "{\"key\":{\"\":{\"policy\":\"read\"},\"foo/\":{\"policy\":\"write\"},\"foo/private\":{\"policy\":\"deny\"}},\"operator\":\"read\"}"
-}' http://127.0.0.1:8500/v1/acl/policy?token=<management token>
+}' http://127.0.0.1:8500/v1/acl/policy
 ```
 
 The policy configuration is returned when the call is successfully performed:

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -23,12 +23,12 @@ The `connect.enable_serverless_plugin` configuration option was removed. Lambda 
 #### Deprecating authentication via token query parameter
 
 Providing a Consul ACL token in API requests using the `token` query parameter is deprecated and will be removed in Consul 1.17.
-Instead, the token should be provided using the `X-Consul-Token` header or with the Bearer scheme in the authorization header as described in the [API authentication documentation](/consul/api-docs/api-structure#authentication).
-	
-To check whether the `token` query parameter is in use, search your Consul agent logs for the message:
+Instead, you should provide the token through the `X-Consul-Token` header or with the Bearer scheme in the authorization header as described in the [API authentication documentation](/consul/api-docs/api-structure#authentication).
 
-```shell-session
-$ This request is using a token query parameter which is deprecated and will be removed in Consul 1.17
+Check whether you are using a `token` query parameter by searching your Consul agent logs for the message:
+
+```shell-session hideClipboard
+$ This request used the token query parameter which is deprecated and will be removed in Consul 1.17
 ```
 
 Deprecated authentication using the `token` query parameter: 

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -20,6 +20,26 @@ upgrade flow.
 
 The `connect.enable_serverless_plugin` configuration option was removed. Lambda integration is now enabled by default.
 
+#### Deprecating authentication via token query parameter
+
+When authenticating API requests, the use of the `token` query parameter is deprecated. The Consul token should be provided to API requests using the `X-Consul-Token` header or with the
+Bearer scheme in the authorization header.
+
+Before Consul v1.15: 
+
+```shell-session
+$ curl \
+    http://127.0.0.1:8500/v1/agent/members?token=<consul token>
+```
+
+In Consul v1.15 and higher:
+
+```shell-session
+$ curl \
+    --header "X-Consul-Token: <consul token>" \
+    http://127.0.0.1:8500/v1/agent/members
+```
+
 #### Lambda Configuration
 
 Instead of configuring Lambda functions in the `Meta` field of `service-defaults` configuration entries, configure them with the `EnvoyExtensions` field.

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -22,17 +22,23 @@ The `connect.enable_serverless_plugin` configuration option was removed. Lambda 
 
 #### Deprecating authentication via token query parameter
 
-When authenticating API requests, the use of the `token` query parameter is deprecated. The Consul token should be provided to API requests using the `X-Consul-Token` header or with the
-Bearer scheme in the authorization header.
+Providing a Consul ACL token in API requests using the `token` query parameter is deprecated and will be removed in Consul 1.17.
+Instead, the token should be provided using the `X-Consul-Token` header or with the Bearer scheme in the authorization header as described in the [API authentication documentation](/consul/api-docs/api-structure#authentication).
+	
+To check whether the `token` query parameter is in use, search your Consul agent logs for the message:
 
-Before Consul v1.15: 
+```shell-session
+$ This request is using a token query parameter which is deprecated and will be removed in Consul 1.17
+```
+
+Deprecated authentication using the `token` query parameter: 
 
 ```shell-session
 $ curl \
     http://127.0.0.1:8500/v1/agent/members?token=<consul token>
 ```
 
-In Consul v1.15 and higher:
+Recommended authentication method:
 
 ```shell-session
 $ curl \


### PR DESCRIPTION
### Description
- Emit a warning log message every time the token query param is used 
- Update docs to reflect the deprecation of the token query param 

Makes progress on #11917. Remaining work: fully remove in a future release.

### Testing & Reproduction steps

#### Manual testing steps 
* Ran consul locally (make dev...)
* Tried a request with header
```
curl \
    --header "X-Consul-Token: <my token>" \
    "http://127.0.0.1:8500/v1/agent/members"

## No logs
```
* Tried a request with token without the header
```
curl \
    "http://127.0.0.1:8500/v1/agent/members?token=<my token>"

## log message
2023-01-18T15:37:36.989-0500 [WARN]  agent.http: This request is using a token query parameter; This is deprecated and will be removed in future Consul versions.: logUrl=/v1/agent/members?token=<hidden>
```
* Tried a request with token and the header present
```
curl \
    --header "X-Consul-Token: <my token>" \
    "http://127.0.0.1:8500/v1/agent/members?token=<my token>"

## log message
2023-01-18T15:48:18.764-0500 [WARN]  agent.http: This request is using a token query parameter; This is deprecated and will be removed in future Consul versions.: logUrl=/v1/agent/members?token=<hidden>
```

### Still todo
* [x] update tests that still use token query params to use header instead
* [x] Generate change-log

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern