### PR TITLE
Decrease polling frequency on peer proxy config data.

### DIFF
--- a/agent/cache-types/peerings.go
+++ b/agent/cache-types/peerings.go
@@ -35,7 +35,7 @@ func (r *PeeringListRequest) CacheInfo() cache.RequestInfo {
 
 		// OPTIMIZE(peering): Cache.notifyPollingQuery polls at this interval. We need to revisit how that polling works.
 		//        	          Using an exponential backoff when the result hasn't changed may be preferable.
-		MaxAge: 10 * time.Second,
+		MaxAge: 5 * time.Second,
 	}
 
 	v, err := hashstructure.Hash([]interface{}{

--- a/agent/cache-types/peerings.go
+++ b/agent/cache-types/peerings.go
@@ -35,7 +35,7 @@ func (r *PeeringListRequest) CacheInfo() cache.RequestInfo {
 
 		// OPTIMIZE(peering): Cache.notifyPollingQuery polls at this interval. We need to revisit how that polling works.
 		//        	          Using an exponential backoff when the result hasn't changed may be preferable.
-		MaxAge: 1 * time.Second,
+		MaxAge: 10 * time.Second,
 	}
 
 	v, err := hashstructure.Hash([]interface{}{

--- a/agent/cache-types/peerings_test.go
+++ b/agent/cache-types/peerings_test.go
@@ -81,6 +81,7 @@ func TestPeerings_badReqType(t *testing.T) {
 
 // This test asserts that we can continuously poll this cache type, given that it doesn't support blocking.
 func TestPeerings_MultipleUpdates(t *testing.T) {
+	t.Parallel()
 	c := cache.New(cache.Options{})
 
 	client := NewMockPeeringLister(t)
@@ -104,7 +105,7 @@ func TestPeerings_MultipleUpdates(t *testing.T) {
 	c.RegisterType(PeeringListName, &Peerings{Client: client})
 
 	ch := make(chan cache.UpdateEvent)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 	t.Cleanup(cancel)
 
 	require.NoError(t, c.Notify(ctx, PeeringListName, &PeeringListRequest{

--- a/agent/cache-types/peerings_test.go
+++ b/agent/cache-types/peerings_test.go
@@ -105,7 +105,7 @@ func TestPeerings_MultipleUpdates(t *testing.T) {
 	c.RegisterType(PeeringListName, &Peerings{Client: client})
 
 	ch := make(chan cache.UpdateEvent)
-	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	t.Cleanup(cancel)
 
 	require.NoError(t, c.Notify(ctx, PeeringListName, &PeeringListRequest{

--- a/agent/cache-types/trust_bundle.go
+++ b/agent/cache-types/trust_bundle.go
@@ -33,7 +33,7 @@ func (r *TrustBundleReadRequest) CacheInfo() cache.RequestInfo {
 
 		// OPTIMIZE(peering): Cache.notifyPollingQuery polls at this interval. We need to revisit how that polling works.
 		//        	          Using an exponential backoff when the result hasn't changed may be preferable.
-		MaxAge: 10 * time.Second,
+		MaxAge: 5 * time.Second,
 	}
 
 	v, err := hashstructure.Hash([]interface{}{

--- a/agent/cache-types/trust_bundle.go
+++ b/agent/cache-types/trust_bundle.go
@@ -33,7 +33,7 @@ func (r *TrustBundleReadRequest) CacheInfo() cache.RequestInfo {
 
 		// OPTIMIZE(peering): Cache.notifyPollingQuery polls at this interval. We need to revisit how that polling works.
 		//        	          Using an exponential backoff when the result hasn't changed may be preferable.
-		MaxAge: 1 * time.Second,
+		MaxAge: 10 * time.Second,
 	}
 
 	v, err := hashstructure.Hash([]interface{}{

--- a/agent/cache-types/trust_bundle_test.go
+++ b/agent/cache-types/trust_bundle_test.go
@@ -59,6 +59,7 @@ func TestTrustBundle_badReqType(t *testing.T) {
 
 // This test asserts that we can continuously poll this cache type, given that it doesn't support blocking.
 func TestTrustBundle_MultipleUpdates(t *testing.T) {
+	t.Parallel()
 	c := cache.New(cache.Options{})
 
 	client := NewMockTrustBundleReader(t)
@@ -82,7 +83,7 @@ func TestTrustBundle_MultipleUpdates(t *testing.T) {
 	c.RegisterType(TrustBundleReadName, &TrustBundle{Client: client})
 
 	ch := make(chan cache.UpdateEvent)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 	t.Cleanup(cancel)
 
 	err := c.Notify(ctx, TrustBundleReadName, &TrustBundleReadRequest{

--- a/agent/cache-types/trust_bundle_test.go
+++ b/agent/cache-types/trust_bundle_test.go
@@ -83,7 +83,7 @@ func TestTrustBundle_MultipleUpdates(t *testing.T) {
 	c.RegisterType(TrustBundleReadName, &TrustBundle{Client: client})
 
 	ch := make(chan cache.UpdateEvent)
-	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	t.Cleanup(cancel)
 
 	err := c.Notify(ctx, TrustBundleReadName, &TrustBundleReadRequest{

--- a/agent/cache-types/trust_bundles.go
+++ b/agent/cache-types/trust_bundles.go
@@ -35,7 +35,7 @@ func (r *TrustBundleListRequest) CacheInfo() cache.RequestInfo {
 
 		// OPTIMIZE(peering): Cache.notifyPollingQuery polls at this interval. We need to revisit how that polling works.
 		//        	          Using an exponential backoff when the result hasn't changed may be preferable.
-		MaxAge: 10 * time.Second,
+		MaxAge: 5 * time.Second,
 	}
 
 	v, err := hashstructure.Hash([]interface{}{

--- a/agent/cache-types/trust_bundles.go
+++ b/agent/cache-types/trust_bundles.go
@@ -35,7 +35,7 @@ func (r *TrustBundleListRequest) CacheInfo() cache.RequestInfo {
 
 		// OPTIMIZE(peering): Cache.notifyPollingQuery polls at this interval. We need to revisit how that polling works.
 		//        	          Using an exponential backoff when the result hasn't changed may be preferable.
-		MaxAge: 1 * time.Second,
+		MaxAge: 10 * time.Second,
 	}
 
 	v, err := hashstructure.Hash([]interface{}{

--- a/agent/cache-types/trust_bundles_test.go
+++ b/agent/cache-types/trust_bundles_test.go
@@ -86,6 +86,7 @@ func TestTrustBundles_badReqType(t *testing.T) {
 
 // This test asserts that we can continuously poll this cache type, given that it doesn't support blocking.
 func TestTrustBundles_MultipleUpdates(t *testing.T) {
+	t.Parallel()
 	c := cache.New(cache.Options{})
 
 	client := NewMockTrustBundleLister(t)
@@ -109,7 +110,7 @@ func TestTrustBundles_MultipleUpdates(t *testing.T) {
 	c.RegisterType(TrustBundleListName, &TrustBundles{Client: client})
 
 	ch := make(chan cache.UpdateEvent)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 	t.Cleanup(cancel)
 
 	err := c.Notify(ctx, TrustBundleListName, &TrustBundleListRequest{

--- a/agent/cache-types/trust_bundles_test.go
+++ b/agent/cache-types/trust_bundles_test.go
@@ -110,7 +110,7 @@ func TestTrustBundles_MultipleUpdates(t *testing.T) {
 	c.RegisterType(TrustBundleListName, &TrustBundles{Client: client})
 
 	ch := make(chan cache.UpdateEvent)
-	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	t.Cleanup(cancel)
 
 	err := c.Notify(ctx, TrustBundleListName, &TrustBundleListRequest{


### PR DESCRIPTION
This is a temporary fix to reduce the performance cost of fetching peering data in proxycfg. A better long-term fix should be added that uses streaming or blocking-queries to ensure updates are triggered only when changes are made, rather than polling.