### PR TITLE
test(integration): fix agent https connections from services

### DIFF
--- a/test/integration/consul-container/libs/cluster/agent.go
+++ b/test/integration/consul-container/libs/cluster/agent.go
@@ -3,9 +3,9 @@ package cluster
 import (
 	"context"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/testcontainers/testcontainers-go"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 
@@ -30,7 +30,7 @@ type Agent interface {
 
 // Config is a set of configurations required to create a Agent
 //
-// Constructed by (Builder).ToAgentConfig()
+// Constructed by (AgentConfigFactory).ToAgentConfig()
 type Config struct {
 	ScratchDir    string
 	CertVolume    string
@@ -42,8 +42,8 @@ type Config struct {
 	Cmd           []string
 	LogConsumer   testcontainers.LogConsumer
 
-	// service defaults
-	UseAPIWithTLS  bool // TODO
+	// Preferences inherited by services
+	UseAPIWithTLS  bool
 	UseGRPCWithTLS bool
 }
 

--- a/test/integration/consul-container/libs/cluster/cluster.go
+++ b/test/integration/consul-container/libs/cluster/cluster.go
@@ -12,12 +12,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/serf/serf"
 	"github.com/stretchr/testify/require"
 	"github.com/teris-io/shortid"
 	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
 
 // Cluster provides an interface for creating and controlling a Consul cluster
@@ -26,7 +27,7 @@ import (
 // craft a test case.
 type Cluster struct {
 	Agents []Agent
-	// BuildContext *BuildContext // TODO
+	// ClusterContext *ClusterContext // TODO
 	CACert      string
 	CAKey       string
 	ID          string

--- a/test/integration/consul-container/libs/cluster/container.go
+++ b/test/integration/consul-container/libs/cluster/container.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
-	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 

--- a/test/integration/consul-container/libs/cluster/encryption.go
+++ b/test/integration/consul-container/libs/cluster/encryption.go
@@ -36,7 +36,7 @@ func newSerfEncryptionKey() (string, error) {
 	return base64.StdEncoding.EncodeToString(key), nil
 }
 
-func (c *BuildContext) createTLSCAFiles(t *testing.T) {
+func (c *ClusterContext) createTLSCAFiles(t *testing.T) {
 	id, err := uuid.GenerateUUID()
 	require.NoError(t, err, "could not create cert volume UUID")
 
@@ -93,7 +93,7 @@ func (c *BuildContext) createTLSCAFiles(t *testing.T) {
 	c.caCert = w.String()
 }
 
-func (c *BuildContext) createTLSCertFiles(t *testing.T, dc string) (keyFileName, certFileName string) {
+func (c *ClusterContext) createTLSCertFiles(t *testing.T, dc string) (keyFileName, certFileName string) {
 	require.NotEmpty(t, "the CA has not been initialized yet")
 
 	err := utils.DockerExec([]string{"run",

--- a/test/integration/consul-container/test/basic/connect_service_test.go
+++ b/test/integration/consul-container/test/basic/connect_service_test.go
@@ -32,15 +32,13 @@ func TestBasicConnectService(t *testing.T) {
 }
 
 func createCluster(t *testing.T) *libcluster.Cluster {
-	opts := libcluster.BuildOptions{
+	opts := libcluster.ClusterOptions{
 		InjectAutoEncryption:   true,
 		InjectGossipEncryption: true,
-		// TODO: fix the test to not need the service/envoy stack to use :8500
-		AllowHTTPAnyway: true,
 	}
-	ctx := libcluster.NewBuildContext(t, opts)
+	ctx := libcluster.NewClusterContext(t, opts)
 
-	conf := libcluster.NewConfigBuilder(ctx).
+	conf := libcluster.NewAgentConfigFactory(ctx).
 		ToAgentConfig(t)
 	t.Logf("Cluster config:\n%s", conf.JSON)
 

--- a/test/integration/consul-container/test/metrics/leader_test.go
+++ b/test/integration/consul-container/test/metrics/leader_test.go
@@ -4,30 +4,31 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/stretchr/testify/require"
 
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 )
 
 // Given a 3-server cluster, when the leader is elected, then leader's isLeader is 1 and non-leader's 0
 func TestLeadershipMetrics(t *testing.T) {
-	opts := libcluster.BuildOptions{
+	opts := libcluster.ClusterOptions{
 		InjectAutoEncryption:   true,
 		InjectGossipEncryption: true,
 	}
-	ctx := libcluster.NewBuildContext(t, opts)
+	ctx := libcluster.NewClusterContext(t, opts)
 
 	var configs []libcluster.Config
 
-	statsConf := libcluster.NewConfigBuilder(ctx).
+	statsConf := libcluster.NewAgentConfigFactory(ctx).
 		Telemetry("127.0.0.0:2180").
 		ToAgentConfig(t)
 
 	configs = append(configs, *statsConf)
 
-	conf := libcluster.NewConfigBuilder(ctx).
+	conf := libcluster.NewAgentConfigFactory(ctx).
 		Bootstrap(3).
 		ToAgentConfig(t)
 

--- a/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
+++ b/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/stretchr/testify/require"
 
 	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
@@ -164,8 +165,8 @@ func TestPeering_RotateServerAndCAThenFail_(t *testing.T) {
 }
 
 // rotateServer add a new server agent to the cluster, then forces the prior agent to leave.
-func rotateServer(t *testing.T, cluster *libcluster.Cluster, client *api.Client, ctx *libcluster.BuildContext, node libcluster.Agent) {
-	conf := libcluster.NewConfigBuilder(ctx).
+func rotateServer(t *testing.T, cluster *libcluster.Cluster, client *api.Client, ctx *libcluster.ClusterContext, node libcluster.Agent) {
+	conf := libcluster.NewAgentConfigFactory(ctx).
 		Bootstrap(0).
 		Peering(true).
 		RetryJoin("agent-3"). // Always use the client agent since it never leaves the cluster

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -217,13 +217,13 @@ func (g *TestLogConsumer) Accept(l testcontainers.Log) {
 
 // createCluster
 func createCluster(t *testing.T, cmd string, logConsumer *TestLogConsumer) *libcluster.Cluster {
-	opts := libcluster.BuildOptions{
+	opts := libcluster.ClusterOptions{
 		InjectAutoEncryption:   true,
 		InjectGossipEncryption: true,
 	}
-	ctx := libcluster.NewBuildContext(t, opts)
+	ctx := libcluster.NewClusterContext(t, opts)
 
-	conf := libcluster.NewConfigBuilder(ctx).ToAgentConfig(t)
+	conf := libcluster.NewAgentConfigFactory(ctx).ToAgentConfig(t)
 	conf.LogConsumer = logConsumer
 
 	t.Logf("Cluster config:\n%s", conf.JSON)

--- a/test/integration/consul-container/test/upgrade/fullstopupgrade_test.go
+++ b/test/integration/consul-container/test/upgrade/fullstopupgrade_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/stretchr/testify/require"
 
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
@@ -40,7 +41,7 @@ func TestStandardUpgradeToTarget_fromLatest(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testcase) {
-		configCtx := libcluster.NewBuildContext(t, libcluster.BuildOptions{
+		configCtx := libcluster.NewClusterContext(t, libcluster.ClusterOptions{
 			ConsulImageName: utils.TargetImageName,
 			ConsulVersion:   tc.oldversion,
 		})
@@ -49,7 +50,7 @@ func TestStandardUpgradeToTarget_fromLatest(t *testing.T) {
 			numServers = 1
 		)
 
-		serverConf := libcluster.NewConfigBuilder(configCtx).
+		serverConf := libcluster.NewAgentConfigFactory(configCtx).
 			Bootstrap(numServers).
 			ToAgentConfig(t)
 		t.Logf("Cluster config:\n%s", serverConf.JSON)

--- a/test/integration/consul-container/test/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/test/upgrade/healthcheck_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/api"
 
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
@@ -61,17 +62,17 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 // Test health check GRPC call using Mixed (majority conditional) Servers and Latest GA Clients
 func testMixedServersGAClient(t *testing.T, majorityIsTarget bool) {
 	var (
-		latestOpts = libcluster.BuildOptions{
+		latestOpts = libcluster.ClusterOptions{
 			ConsulImageName: utils.LatestImageName,
 			ConsulVersion:   utils.LatestVersion,
 		}
-		targetOpts = libcluster.BuildOptions{
+		targetOpts = libcluster.ClusterOptions{
 			ConsulImageName: utils.TargetImageName,
 			ConsulVersion:   utils.TargetVersion,
 		}
 
-		majorityOpts libcluster.BuildOptions
-		minorityOpts libcluster.BuildOptions
+		majorityOpts libcluster.ClusterOptions
+		minorityOpts libcluster.ClusterOptions
 	)
 
 	if majorityIsTarget {
@@ -89,9 +90,9 @@ func testMixedServersGAClient(t *testing.T, majorityIsTarget bool) {
 
 	var configs []libcluster.Config
 	{
-		ctx := libcluster.NewBuildContext(t, minorityOpts)
+		ctx := libcluster.NewClusterContext(t, minorityOpts)
 
-		conf := libcluster.NewConfigBuilder(ctx).
+		conf := libcluster.NewAgentConfigFactory(ctx).
 			ToAgentConfig(t)
 		t.Logf("Cluster server (leader) config:\n%s", conf.JSON)
 
@@ -99,9 +100,9 @@ func testMixedServersGAClient(t *testing.T, majorityIsTarget bool) {
 	}
 
 	{
-		ctx := libcluster.NewBuildContext(t, majorityOpts)
+		ctx := libcluster.NewClusterContext(t, majorityOpts)
 
-		conf := libcluster.NewConfigBuilder(ctx).
+		conf := libcluster.NewAgentConfigFactory(ctx).
 			Bootstrap(numServers).
 			ToAgentConfig(t)
 		t.Logf("Cluster server config:\n%s", conf.JSON)

--- a/test/integration/consul-container/test/upgrade/helper_test.go
+++ b/test/integration/consul-container/test/upgrade/helper_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/api"
 
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 )
@@ -13,13 +14,13 @@ import (
 func serversCluster(t *testing.T, numServers int, image, version string) *libcluster.Cluster {
 	t.Helper()
 
-	opts := libcluster.BuildOptions{
+	opts := libcluster.ClusterOptions{
 		ConsulImageName: image,
 		ConsulVersion:   version,
 	}
-	ctx := libcluster.NewBuildContext(t, opts)
+	ctx := libcluster.NewClusterContext(t, opts)
 
-	conf := libcluster.NewConfigBuilder(ctx).
+	conf := libcluster.NewAgentConfigFactory(ctx).
 		Bootstrap(numServers).
 		ToAgentConfig(t)
 	t.Logf("Cluster server config:\n%s", conf.JSON)
@@ -36,13 +37,13 @@ func serversCluster(t *testing.T, numServers int, image, version string) *libclu
 func clientsCreate(t *testing.T, numClients int, image, version string, cluster *libcluster.Cluster) {
 	t.Helper()
 
-	opts := libcluster.BuildOptions{
+	opts := libcluster.ClusterOptions{
 		ConsulImageName: image,
 		ConsulVersion:   version,
 	}
-	ctx := libcluster.NewBuildContext(t, opts)
+	ctx := libcluster.NewClusterContext(t, opts)
 
-	conf := libcluster.NewConfigBuilder(ctx).
+	conf := libcluster.NewAgentConfigFactory(ctx).
 		Client().
 		ToAgentConfig(t)
 	t.Logf("Cluster client config:\n%s", conf.JSON)


### PR DESCRIPTION
### Description
Fix the existing connect integration test cases so that services/envoy don't need to contact the servers with plaintext protocols.

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] not a security concern
