### PR TITLE
docs: Consul K8s upgrade leave on terminate

### DIFF
--- a/website/content/docs/k8s/upgrade/index.mdx
+++ b/website/content/docs/k8s/upgrade/index.mdx
@@ -185,6 +185,10 @@ Initiate the server upgrade:
     image: 'consul:123.456'
   server:
     updatePartition: 3
+    extraConfig: |
+      {
+        "leave_on_terminate": "true"
+      }
   ```
 
   </CodeBlockConfig>

--- a/website/content/docs/k8s/upgrade/index.mdx
+++ b/website/content/docs/k8s/upgrade/index.mdx
@@ -175,7 +175,7 @@ that can be used.
 Initiate the server upgrade:
 
 1. Change the `global.image` value to the desired Consul version.
-1. Set the `server.updatePartition` value to the number of server replicas. By default there are 3 servers, so you would set this value to `3`.
+1. Set the `server.updatePartition` value to the number of server replicas. By default there are 3 servers, so you would set this value to `3`. In addition, apply extraConfig to the servers so that Consul server pods leave properly when they are terminating during a rolling restart. 
 1. Set the `updateStrategy` for clients to `OnDelete`.
 
   <CodeBlockConfig filename="values.yaml">
@@ -193,6 +193,8 @@ Initiate the server upgrade:
   cluster are updated. Only instances with an index _greater than_ the
   `updatePartition` value are updated (zero-indexed). Therefore, by setting
   it equal to replicas, updates should not occur immediately.
+  
+  Note that any config changes applied through Helm on the servers are applied through a rolling update, unless the config value can be updated using a [`consul reload`'](/consul/commands/reload) command or via the Consul API. See [reloadable config](/docs/agent/config) for more information. 
 
 1. Next, perform the upgrade:
 

--- a/website/content/docs/k8s/upgrade/index.mdx
+++ b/website/content/docs/k8s/upgrade/index.mdx
@@ -175,7 +175,7 @@ that can be used.
 Initiate the server upgrade:
 
 1. Change the `global.image` value to the desired Consul version.
-1. Set the `server.updatePartition` value to the number of server replicas. By default there are 3 servers, so you would set this value to `3`. In addition, apply extraConfig to the servers so that Consul server pods leave properly when they are terminating during a rolling restart. 
+1. Set the `server.updatePartition` value to the number of server replicas. By default there are 3 servers, so you would set this value to `3`. In addition, apply the `leave_on_terminate: true` agent configuration using the `extraConfig` stanza, so that Consul server pods leave the LAN pool properly when they are terminating during a rolling restart. 
 1. Set the `updateStrategy` for clients to `OnDelete`.
 
   <CodeBlockConfig filename="values.yaml">


### PR DESCRIPTION
### Description

Add more instructions to guide users to use "leave_on_terminate" when upgrading via Helm. See https://github.com/hashicorp/consul-k8s/issues/1516#issuecomment-1253923057 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
