### PR TITLE
Fix proxy-defaults incorrectly merging config on upstreams.

### DIFF
--- a/agent/configentry/resolve_test.go
+++ b/agent/configentry/resolve_test.go
@@ -141,8 +141,10 @@ func Test_ComputeResolvedServiceConfig(t *testing.T) {
 			name: "proxy inherits kitchen sink from proxy-defaults",
 			args: args{
 				scReq: &structs.ServiceConfigRequest{
-					Name: "sid",
+					Name:        "sid",
+					UpstreamIDs: uids,
 				},
+				upstreamIDs: uids,
 				entries: &ResolvedServiceConfigSet{
 					ProxyDefaults: map[string]*structs.ProxyConfigEntry{
 						acl.DefaultEnterpriseMeta().PartitionOrDefault(): {
@@ -195,7 +197,12 @@ func Test_ComputeResolvedServiceConfig(t *testing.T) {
 					{
 						Upstream: wildcard,
 						Config: map[string]interface{}{
-							"foo":          "bar",
+							"mesh_gateway": remoteMeshGW,
+						},
+					},
+					{
+						Upstream: uid,
+						Config: map[string]interface{}{
 							"mesh_gateway": remoteMeshGW,
 						},
 					},

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1025,8 +1025,9 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 	// Create a dummy proxy/service config in the state store to look up.
 	state := s1.fsm.State()
 	require.NoError(t, state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
-		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
+		Kind:        structs.ProxyDefaults,
+		Name:        structs.ProxyConfigGlobal,
+		MeshGateway: structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeLocal},
 		Config: map[string]interface{}{
 			"foo": 1,
 		},
@@ -1056,12 +1057,25 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 			"foo":      int64(1),
 			"protocol": "http",
 		},
+		MeshGateway: structs.MeshGatewayConfig{
+			Mode: structs.MeshGatewayModeLocal,
+		},
 		UpstreamConfigs: map[string]map[string]interface{}{
 			"*": {
-				"foo": int64(1),
+				"mesh_gateway": map[string]interface{}{
+					"Mode": "local",
+				},
 			},
 			"bar": {
 				"protocol": "grpc",
+				"mesh_gateway": map[string]interface{}{
+					"Mode": "local",
+				},
+			},
+			"baz": {
+				"mesh_gateway": map[string]interface{}{
+					"Mode": "local",
+				},
 			},
 		},
 		Meta: map[string]string{"foo": "bar"},

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
@@ -422,12 +421,6 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 			},
 			UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
 				{
-					Upstream: structs.NewServiceID(structs.WildcardSpecifier, acl.DefaultEnterpriseMeta().WithWildcardNamespace()),
-					Config: map[string]interface{}{
-						"foo": int64(1),
-					},
-				},
-				{
 					Upstream: structs.NewServiceID("redis", nil),
 					Config: map[string]interface{}{
 						"protocol": "tcp",
@@ -475,12 +468,6 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 				"protocol": "http",
 			},
 			UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
-				{
-					Upstream: structs.NewServiceID(structs.WildcardSpecifier, acl.DefaultEnterpriseMeta().WithWildcardNamespace()),
-					Config: map[string]interface{}{
-						"foo": int64(1),
-					},
-				},
 				{
 					Upstream: structs.NewServiceID("redis", nil),
 					Config: map[string]interface{}{
@@ -660,12 +647,6 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 				"protocol": "http",
 			},
 			UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
-				{
-					Upstream: structs.NewServiceID(structs.WildcardSpecifier, acl.DefaultEnterpriseMeta().WithWildcardNamespace()),
-					Config: map[string]interface{}{
-						"foo": int64(1),
-					},
-				},
 				{
 					Upstream: structs.NewServiceID("redis", nil),
 					Config: map[string]interface{}{


### PR DESCRIPTION
This PR modifies behavior that was introduced in: https://github.com/hashicorp/consul/pull/16000

Only the mesh-gateway-mode and protocol should be inherited from proxy-defaults into upstreams. This PR modifies the merging logic to reflect that specific behavior.