### PR TITLE
feat: panic handler in rpc rate limit interceptor

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -489,7 +489,7 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server, incom
 	}
 
 	rpcServerOpts := []func(*rpc.Server){
-		rpc.WithPreBodyInterceptor(middleware.GetNetRPCRateLimitingInterceptor(s.incomingRPCLimiter)),
+		rpc.WithPreBodyInterceptor(middleware.GetNetRPCRateLimitingInterceptor(s.incomingRPCLimiter, middleware.NewPanicHandler(s.logger))),
 	}
 
 	if flat.GetNetRPCInterceptorFunc != nil {

--- a/agent/rpc/middleware/recovery.go
+++ b/agent/rpc/middleware/recovery.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+// NewPanicHandler returns a RecoveryHandlerFunc type function
+// to handle panic in RPC server's handlers.
+func NewPanicHandler(logger hclog.Logger) RecoveryHandlerFunc {
+	return func(p interface{}) (err error) {
+		// Log the panic and the stack trace of the Goroutine that caused the panic.
+		stacktrace := hclog.Stacktrace()
+		logger.Error("panic serving rpc request",
+			"panic", p,
+			"stack", stacktrace,
+		)
+
+		return fmt.Errorf("rpc: panic serving request")
+	}
+}
+
+type RecoveryHandlerFunc func(p interface{}) (err error)


### PR DESCRIPTION
### Description
Add a panic handler that logs the error which is passed into the RPC rate limit interceptor (similar gRPC codepath)

### PR Checklist

* [x] updated test coverage
* [ ] ~~external facing docs updated~~
* [x] not a security 