### PR TITLE
Apply agent partition to load services and agent api

### DIFF
--- a/.changelog/16024.txt
+++ b/.changelog/16024.txt
@@ -1,0 +1,5 @@
+
+```release-note:improvement
+partitiion: **(Consul Enterprise only)** when loading service from on-disk config file or sending API request to agent endpoint,
+if the partition is unspecified, consul will default the partition in the request to agent's partition
+```

--- a/.changelog/16024.txt
+++ b/.changelog/16024.txt
@@ -1,4 +1,3 @@
-
 ```release-note:improvement
 partitiion: **(Consul Enterprise only)** when loading service from on-disk config file or sending API request to agent endpoint,
 if the partition is unspecified, consul will default the partition in the request to agent's partition

--- a/agent/agent_endpoint_oss.go
+++ b/agent/agent_endpoint_oss.go
@@ -12,3 +12,6 @@ import (
 func (s *HTTPHandlers) validateRequestPartition(_ http.ResponseWriter, _ *acl.EnterpriseMeta) bool {
 	return true
 }
+
+func (s *HTTPHandlers) defaultMetaPartitionToAgent(entMeta *acl.EnterpriseMeta) {
+}


### PR DESCRIPTION
### Description
OSS split of ent [PR](https://github.com/hashicorp/consul-enterprise/pull/4100)


### Testing & Reproduction steps

- load service in OSS -> ent (manually tested)

1. Register a service in oss client agent, e.g., C-1
1. Stop C-1
1. Replace C-1's binary with an ent binary 
1. Add non-partition to C-1's config file and join the cluster
1. The service should be loaded from C-1's on-disk service config 

- Agent endpoint

1. Start a client agent in non-default partition
1. register a service at the client agent without partition field in service definition


### Links
https://github.com/hashicorp/consul/issues/15881
https://github.com/hashicorp/consul/issues/15963

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
