### PR TITLE
test: prevent the container tests from depending on consul

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,14 @@ jobs:
       - run: go install github.com/reillywatson/enumcover/cmd/enumcover@master && enumcover ./...
       - run: *notify-slack-failure
 
+  lint-container-test-deps:
+    docker:
+      - image: *GOLANG_IMAGE
+    steps:
+      - checkout
+      - run: make lint-container-test-deps
+      - run: *notify-slack-failure
+
   lint:
     description: "Run golangci-lint"
     parameters:
@@ -1076,6 +1084,7 @@ workflows:
       - check-generated-protobuf: *filter-ignore-non-go-branches
       - check-generated-deep-copy: *filter-ignore-non-go-branches
       - lint-enums: *filter-ignore-non-go-branches
+      - lint-container-test-deps: *filter-ignore-non-go-branches
       - lint-consul-retry: *filter-ignore-non-go-branches
       - lint: *filter-ignore-non-go-branches
       - lint:


### PR DESCRIPTION
### Description

The consul container tests orchestrate running containers from various versions of consul to test things like upgrades. Having the test framework itself depend on the consul codebase inherently links it to a specific version of consul which may make some test approaches in the future difficult.

This change prohibits any such relationship via a custom linting rule. Unfortunately because the `api`, `sdk`, and `test/integration/consul-container` packages are submodules of `github.com/hashicorp/consul` the `gomodguard` linter is incapable of handling those separately hence the need for some custom bash instead.