### PR TITLE
test: run integration tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ steps:
   install-gotestsum: &install-gotestsum
     name: install gotestsum
     environment:
-      GOTESTSUM_RELEASE: 1.6.4
+      GOTESTSUM_RELEASE: 1.9.0
     command: |
       ARCH=`uname -m`
       if [[ "$ARCH" == "aarch64" ]]; then
@@ -869,12 +869,16 @@ jobs:
             cd ./test/integration/consul-container
             docker run --rm consul:local consul version
             gotestsum \
+              --raw-command \
               --format=short-verbose \
               --debug \
               --rerun-fails=3 \
               --packages="./..." \
               -- \
+              go test \
+              -p=4 \
               -timeout=30m \
+              -json \
               ./... \
               --target-image consul \
               --target-version local \

--- a/test/integration/consul-container/test/basic/connect_service_test.go
+++ b/test/integration/consul-container/test/basic/connect_service_test.go
@@ -21,6 +21,7 @@ import (
 //   - Create an example static-client sidecar, then register both the service and sidecar with Consul
 //   - Make sure a call to the client sidecar local bind port returns a response from the upstream, static-server
 func TestBasicConnectService(t *testing.T) {
+	t.Parallel()
 	cluster := createCluster(t)
 
 	clientService := createServices(t, cluster)

--- a/test/integration/consul-container/test/observability/metrics_leader_test.go
+++ b/test/integration/consul-container/test/observability/metrics_leader_test.go
@@ -13,6 +13,8 @@ import (
 
 // Given a 3-server cluster, when the leader is elected, then leader's isLeader is 1 and non-leader's 0
 func TestLeadershipMetrics(t *testing.T) {
+	t.Parallel()
+
 	opts := libcluster.BuildOptions{
 		InjectAutoEncryption:   true,
 		InjectGossipEncryption: true,

--- a/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
+++ b/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
@@ -47,6 +47,8 @@ import (
 //   - Terminate the server nodes in the exporting cluster
 //   - Make sure there is still service connectivity from the importing cluster
 func TestPeering_RotateServerAndCAThenFail_(t *testing.T) {
+	t.Parallel()
+
 	accepting, dialing := libtopology.BasicPeeringTwoClustersSetup(t, utils.TargetVersion)
 	var (
 		acceptingCluster     = accepting.Cluster

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -29,6 +29,8 @@ const (
 //     - logs for exceeding
 
 func TestServerRequestRateLimit(t *testing.T) {
+	t.Parallel()
+
 	type action struct {
 		function           func(client *api.Client) error
 		rateLimitOperation string

--- a/test/integration/consul-container/test/upgrade/fullstopupgrade_test.go
+++ b/test/integration/consul-container/test/upgrade/fullstopupgrade_test.go
@@ -6,16 +6,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 
 // Test upgrade a cluster of latest version to the target version
 func TestStandardUpgradeToTarget_fromLatest(t *testing.T) {
+	t.Parallel()
+
 	type testcase struct {
 		oldversion    string
 		targetVersion string

--- a/test/integration/consul-container/test/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/test/upgrade/healthcheck_test.go
@@ -4,15 +4,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul/api"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 
 // Test health check GRPC call using Target Servers and Latest GA Clients
 func TestTargetServersWithLatestGAClients(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numServers = 3
 		numClients = 1
@@ -50,11 +52,15 @@ func TestTargetServersWithLatestGAClients(t *testing.T) {
 
 // Test health check GRPC call using Mixed (majority latest) Servers and Latest GA Clients
 func TestMixedServersMajorityLatestGAClient(t *testing.T) {
+	t.Parallel()
+
 	testMixedServersGAClient(t, false)
 }
 
 // Test health check GRPC call using Mixed (majority target) Servers and Latest GA Clients
 func TestMixedServersMajorityTargetGAClient(t *testing.T) {
+	t.Parallel()
+
 	testMixedServersGAClient(t, true)
 }
 

--- a/test/integration/consul-container/test/upgrade/peers_http_test.go
+++ b/test/integration/consul-container/test/upgrade/peers_http_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul/api"
 	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
 	libtopology "github.com/hashicorp/consul/test/integration/consul-container/libs/topology"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
@@ -16,6 +16,8 @@ import (
 // TestPeering_UpgradeToTarget_fromLatest checks peering status after dialing cluster
 // and accepting cluster upgrade
 func TestPeering_UpgradeToTarget_fromLatest(t *testing.T) {
+	t.Parallel()
+
 	type testcase struct {
 		oldversion    string
 		targetVersion string


### PR DESCRIPTION
### Description
Integration tests are taking ~12mins to complete, which is about double the other steps in the pipeline. Setting an arbitrary level of parallelism to p=4 cuts the time down to ~5min.

Builds off of #16045 