### PR TITLE
[docs] Updating MD links in ConfigEntryReference components

### DIFF
--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -936,7 +936,7 @@ You can specify the following parameters to configure ingress gateway configurat
       enterprise: true,
       description:
         'Specifies the namespace in which the configuration entry will apply. The value must match the namespace in which the gateway is registered.' +
-        ' If omitted, the namespace will be inherited from the `ns` request parameter (refer to the [`config` API endpoint documentation](/api-docs/config#ns)).' +
+        ' If omitted, the namespace will be inherited from the `ns` request parameter (refer to the [`config` API endpoint documentation](/consul/api-docs/config#ns)).' +
         ' or will default to the `default` namespace.',
       yaml: false,
     },
@@ -953,8 +953,8 @@ You can specify the following parameters to configure ingress gateway configurat
       enterprise: true,
       description:
         'Specifies the admin partition in which the configuration will apply. The value must match the partition in which the gateway is registered.' +
-        ' If omitted, the partition will be inherited from the request (refer to the [`config` API endpoint documentation](/api-docs/config)).' +
-        ' See [Admin Partitions](/docs/enterprise/admin-partitions) for additional information.',
+        ' If omitted, the partition will be inherited from the request (refer to the [`config` API endpoint documentation](/consul/api-docs/config)).' +
+        ' See [Admin Partitions](/consul/docs/enterprise/admin-partitions) for additional information.',
       yaml: false,
     },
     {
@@ -968,7 +968,7 @@ You can specify the following parameters to configure ingress gateway configurat
           name: 'namespace',
           enterprise: true,
           description:
-            'Refer to the [Kubernetes Namespaces documentation for Consul Enterprise](/docs/k8s/crds#consul-enterprise). The `namespace` parameter is not supported in Consul OSS (see [Kubernetes Namespaces in Consul OSS](/docs/k8s/crds#consul-oss)).',
+            'Refer to the [Kubernetes Namespaces documentation for Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise). The `namespace` parameter is not supported in Consul OSS (see [Kubernetes Namespaces in Consul OSS](/consul/docs/k8s/crds#consul-oss)).',
         },
       ],
       hcl: false,
@@ -1023,13 +1023,13 @@ You can specify the following parameters to configure ingress gateway configurat
           name: 'SDS',
           type: 'SDSConfig: <optional>',
           description:
-            'Defines a set of parameters that configures the gateway to load TLS certificates from an external SDS service. See [SDS](/docs/connect/gateways/ingress-gateway#sds) for more details on usage.<br><br>SDS properties defined in this field are used as defaults for all listeners on the gateway.',
+            'Defines a set of parameters that configures the gateway to load TLS certificates from an external SDS service. See [SDS](/consul/docs/connect/gateways/ingress-gateway#sds) for more details on usage.<br><br>SDS properties defined in this field are used as defaults for all listeners on the gateway.',
           children: [
             {
               name: 'ClusterName',
               type: 'string',
               description:
-                "Specifies the name of the SDS cluster from which Consul should retrieve certificates. This cluster must be [specified in the Gateway's bootstrap configuration](/docs/connect/gateways/ingress-gateway#sds).",
+                "Specifies the name of the SDS cluster from which Consul should retrieve certificates. This cluster must be [specified in the Gateway's bootstrap configuration](/consul/docs/connect/gateways/ingress-gateway#sds).",
             },
             {
               name: 'CertResource',
@@ -1110,7 +1110,7 @@ You can specify the following parameters to configure ingress gateway configurat
           type: 'int: 0',
           description: `The port on which the ingress listener should receive
                         traffic. The port will be bound to the IP address that
-                        was specified in the [\`-address\`](/commands/connect/envoy#address)
+                        was specified in the [\`-address\`](/consul/commands/connect/envoy#address)
                         flag when starting the gateway.
                         <b>Note:</b> The ingress listener port must not conflict
                         with the health check port specified in the \`-address\`
@@ -1135,7 +1135,7 @@ You can specify the following parameters to configure ingress gateway configurat
               type: 'string: ""',
               description: `The name of the service that should be exposed
                                   through this listener. This can be either a service registered in the
-                                  catalog, or a service defined only by [other config entries](/docs/connect/l7-traffic). If the wildcard specifier,
+                                  catalog, or a service defined only by [other config entries](/consul/docs/connect/l7-traffic). If the wildcard specifier,
                                   \`*\`, is provided, then ALL services will be exposed through the listener.
                                   This is not supported for listeners with protocol \`tcp\`.`,
             },
@@ -1174,14 +1174,14 @@ You can specify the following parameters to configure ingress gateway configurat
             {
               name: 'RequestHeaders',
               type: 'HTTPHeaderModifiers: <optional>',
-              description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+              description: `A set of [HTTP-specific header modification rules](/consul/docs/connect/config-entries/service-router#httpheadermodifiers)
               that will be applied to requests routed to this service.
               This cannot be used with a \`tcp\` listener.`,
             },
             {
               name: 'ResponseHeaders',
               type: 'HTTPHeaderModifiers: <optional>',
-              description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+              description: `A set of [HTTP-specific header modification rules](/consul/docs/connect/config-entries/service-router#httpheadermodifiers)
               that will be applied to responses from this service.
               This cannot be used with a \`tcp\` listener.`,
             },
@@ -1202,7 +1202,7 @@ You can specify the following parameters to configure ingress gateway configurat
                       name: 'ClusterName',
                       type: 'string',
                       description:
-                        "The SDS cluster name to connect to to retrieve certificates. This cluster must be [specified in the Gateway's bootstrap configuration](/docs/connect/gateways/ingress-gateway#sds).",
+                        "The SDS cluster name to connect to to retrieve certificates. This cluster must be [specified in the Gateway's bootstrap configuration](/consul/docs/connect/gateways/ingress-gateway#sds).",
                     },
                     {
                       name: 'CertResource',
@@ -1295,13 +1295,13 @@ You can specify the following parameters to configure ingress gateway configurat
               name: 'SDS',
               type: 'SDSConfig: <optional>',
               description:
-                'Defines a set of parameters that configures the listener to load TLS certificates from an external SDS service. See [SDS](/docs/connect/gateways/ingress-gateway#sds) for more details on usage.<br><br>SDS properties set here will be used as defaults for all services on this listener.',
+                'Defines a set of parameters that configures the listener to load TLS certificates from an external SDS service. See [SDS](/consul/docs/connect/gateways/ingress-gateway#sds) for more details on usage.<br><br>SDS properties set here will be used as defaults for all services on this listener.',
               children: [
                 {
                   name: 'ClusterName',
                   type: 'string',
                   description:
-                    "The SDS cluster name to connect to to retrieve certificates. This cluster must be [specified in the Gateway's bootstrap configuration](/docs/connect/gateways/ingress-gateway#sds).",
+                    "The SDS cluster name to connect to to retrieve certificates. This cluster must be [specified in the Gateway's bootstrap configuration](/consul/docs/connect/gateways/ingress-gateway#sds).",
                 },
                 {
                   name: 'CertResource',

--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -296,7 +296,7 @@ Note that the Kubernetes example does not include a `partition` field. Configura
       type: `string: "default"`,
       enterprise: true,
       description:
-        'Specifies the name of the admin partition in which the configuration entry applies. Refer to the [Admin Partitions documentation](/docs/enterprise/admin-partitions) for additional information.',
+        'Specifies the name of the admin partition in which the configuration entry applies. Refer to the [Admin Partitions documentation](/consul/docs/enterprise/admin-partitions) for additional information.',
       yaml: false,
     },
     {
@@ -317,7 +317,7 @@ Note that the Kubernetes example does not include a `partition` field. Configura
           name: 'namespace',
           enterprise: true,
           description:
-            'Must be set to `default`. If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/docs/k8s/crds#consul-enterprise) for additional information.',
+            'Must be set to `default`. If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/consul/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for additional information.',
         },
       ],
       hcl: false,
@@ -326,7 +326,7 @@ Note that the Kubernetes example does not include a `partition` field. Configura
       name: 'TransparentProxy',
       type: 'TransparentProxyConfig: <optional>',
       description:
-        'Controls configuration specific to proxies in `transparent` [mode](/docs/connect/config-entries/service-defaults#mode). Added in v1.10.0.',
+        'Controls configuration specific to proxies in `transparent` [mode](/consul/docs/connect/config-entries/service-defaults#mode). Added in v1.10.0.',
       children: [
         {
           name: 'MeshDestinationsOnly',
@@ -443,7 +443,7 @@ Note that the Kubernetes example does not include a `partition` field. Configura
       name: 'Peering',
       type: 'PeeringMeshConfig: <optional>',
       description:
-        'Controls configuration specific to [peering connections](/docs/connect/cluster-peering).',
+        'Controls configuration specific to [peering connections](/consul/docs/connect/cluster-peering).',
       children: [
         {
           name: 'PeerThroughMeshGateways',

--- a/website/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/website/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -313,7 +313,7 @@ spec:
       type: `string: "default"`,
       enterprise: true,
       description:
-        'Specifies the name of the admin partition in which the configuration entry applies. Refer to the [Admin Partitions documentation](/docs/enterprise/admin-partitions) for additional information.',
+        'Specifies the name of the admin partition in which the configuration entry applies. Refer to the [Admin Partitions documentation](/consul/docs/enterprise/admin-partitions) for additional information.',
       yaml: false,
     },
     {
@@ -334,7 +334,7 @@ spec:
           name: 'namespace',
           enterprise: true,
           description:
-            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/docs/k8s/crds#consul-enterprise) for more details.',
+            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/consul/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for more details.',
         },
       ],
       hcl: false,
@@ -345,8 +345,8 @@ spec:
       description: `An arbitrary map of configuration values used by Connect proxies.
     The available configurations depend on the Connect proxy you use.
      Any values that your proxy allows can be configured globally here. To explore these options please see the documentation for your chosen proxy.
-     <ul><li>[Envoy](/docs/connect/proxies/envoy#proxy-config-options)</li>
-     <li>[Consul's built-in proxy](/docs/connect/proxies/built-in#proxy-config-key-reference)</li></ul>`,
+     <ul><li>[Envoy](/consul/docs/connect/proxies/envoy#proxy-config-options)</li>
+     <li>[Consul's built-in proxy](/consul/docs/connect/proxies/built-in#proxy-config-key-reference)</li></ul>`,
     },
     {
       name: 'EnvoyExtensions',
@@ -408,7 +408,7 @@ spec:
       name: 'MeshGateway',
       type: 'MeshGatewayConfig: <optional>',
       description: `Controls the default
-      [mesh gateway configuration](/docs/connect/gateways/mesh-gateway#connect-proxy-configuration)
+      [mesh gateway configuration](/consul/docs/connect/gateways/mesh-gateway#connect-proxy-configuration)
       for all proxies. Added in v1.6.0.`,
       children: [
         {
@@ -422,7 +422,7 @@ spec:
       name: 'Expose',
       type: 'ExposeConfig: <optional>',
       description: `Controls the default
-                      [expose path configuration](/docs/connect/registration/service-registration#expose-paths-configuration-reference)
+                      [expose path configuration](/consul/docs/connect/registration/service-registration#expose-paths-configuration-reference)
                       for Envoy. Added in v1.6.2.<br><br>
                       Exposing paths through Envoy enables a service to protect itself by only listening on localhost, while still allowing
                       non-Connect-enabled applications to contact an HTTP endpoint.
@@ -433,8 +433,8 @@ spec:
           type: 'bool: false',
           description: `If enabled, all HTTP and gRPC checks registered with the agent are exposed through Envoy.
         Envoy will expose listeners for these checks and will only accept connections originating from localhost or Consul's
-        [advertise address](/docs/agent/config/config-files#advertise). The port for these listeners are dynamically allocated from
-        [expose_min_port](/docs/agent/config/config-files#expose_min_port) to [expose_max_port](/docs/agent/config/config-files#expose_max_port).
+        [advertise address](/consul/docs/agent/config/config-files#advertise). The port for these listeners are dynamically allocated from
+        [expose_min_port](/consul/docs/agent/config/config-files#expose_min_port) to [expose_max_port](/consul/docs/agent/config/config-files#expose_max_port).
         This flag is useful when a Consul client cannot reach registered services over localhost.`,
         },
         {

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -807,7 +807,7 @@ represents a location outside the Consul cluster. They can be dialed directly wh
           description: `If enabled, all HTTP and gRPC checks registered with the agent are exposed through Envoy.
         Envoy will expose listeners for these checks and will only accept connections originating from localhost or Consul's
         [advertise address](/consul/docs/agent/config/config-files#advertise). The port for these listeners are dynamically allocated from
-        [expose_min_port](/docs/agent/config/config-files#expose_min_port) to [expose_max_port](/docs/agent/config/config-files#expose_max_port).
+        [expose_min_port](/consul/docs/agent/config/config-files#expose_min_port) to [expose_max_port](/consul/docs/agent/config/config-files#expose_max_port).
         This flag is useful when a Consul client cannot reach registered services over localhost. One example is when running
         Consul on Kubernetes, and Consul agents run in their own pods.`,
         },

--- a/website/content/docs/connect/config-entries/service-intentions.mdx
+++ b/website/content/docs/connect/config-entries/service-intentions.mdx
@@ -354,7 +354,7 @@ spec:
     {
       name: 'Name',
       description:
-        "The name of the destination service for all intentions defined in this config entry. This may be set to the wildcard character (`*`) to match all services that don't otherwise have intentions defined. Wildcard intentions cannot be used when defining L7 [`Permissions`](/docs/connect/config-entries/service-intentions#permissions).",
+        "The name of the destination service for all intentions defined in this config entry. This may be set to the wildcard character (`*`) to match all services that don't otherwise have intentions defined. Wildcard intentions cannot be used when defining L7 [`Permissions`](/consul/docs/connect/config-entries/service-intentions#permissions).",
       type: 'string: <required>',
       yaml: false,
     },
@@ -363,7 +363,7 @@ spec:
       type: `string: "default"`,
       enterprise: true,
       description:
-        "Specifies the namespaces the config entry will apply to. This may be set to the wildcard character (`*`) to match all services in all namespaces that don't otherwise have intentions defined. Wildcard intentions cannot be used when defining L7 [`Permissions`](/docs/connect/config-entries/service-intentions#permissions).",
+        "Specifies the namespaces the config entry will apply to. This may be set to the wildcard character (`*`) to match all services in all namespaces that don't otherwise have intentions defined. Wildcard intentions cannot be used when defining L7 [`Permissions`](/consul/docs/connect/config-entries/service-intentions#permissions).",
       yaml: false,
     },
     {
@@ -386,12 +386,12 @@ spec:
         {
           name: 'name',
           description:
-            'Unlike other config entries, the `metadata.name` field is not used to set the name of the service being configured. Instead, that is set in `spec.destination.name`. Thus this name can be set to anything. See [ServiceIntentions Special Case (OSS)](/docs/k8s/crds#serviceintentions-special-case) or [ServiceIntentions Special Case (Enterprise)](/docs/k8s/crds#serviceintentions-special-case-enterprise) for more details.',
+            'Unlike other config entries, the `metadata.name` field is not used to set the name of the service being configured. Instead, that is set in `spec.destination.name`. Thus this name can be set to anything. See [ServiceIntentions Special Case (OSS)](/consul/docs/k8s/crds#serviceintentions-special-case) or [ServiceIntentions Special Case (Enterprise)](/consul/docs/k8s/crds#serviceintentions-special-case-enterprise) for more details.',
         },
         {
           name: 'namespace',
           description:
-            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/docs/k8s/crds#consul-enterprise) for more details.',
+            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/consul/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for more details.',
         },
       ],
       hcl: false,
@@ -405,7 +405,7 @@ spec:
           hcl: false,
           type: 'string: <required>',
           description:
-            "The name of the destination service for all intentions defined in this config entry. This may be set to the wildcard character (`*`) to match all services that don't otherwise have intentions defined. Wildcard intentions cannot be used when defining L7 [`Permissions`](/docs/connect/config-entries/service-intentions#permissions).",
+            "The name of the destination service for all intentions defined in this config entry. This may be set to the wildcard character (`*`) to match all services that don't otherwise have intentions defined. Wildcard intentions cannot be used when defining L7 [`Permissions`](/consul/docs/connect/config-entries/service-intentions#permissions).",
         },
         {
           name: 'namespace',
@@ -413,7 +413,7 @@ spec:
           enterprise: true,
           type: 'string: <optional>',
           description:
-            "Specifies the namespaces the config entry will apply to. This may be set to the wildcard character (`*`) to match all services in all namespaces that don't otherwise have intentions defined. If not set, the namespace used will depend on the `connectInject.consulNamespaces` configuration. See [ServiceIntentions Special Case (Enterprise)](/docs/k8s/crds#serviceintentions-special-case-enterprise) for more details. Wildcard intentions cannot be used when defining L7 [`Permissions`](/docs/connect/config-entries/service-intentions#permissions).",
+            "Specifies the namespaces the config entry will apply to. This may be set to the wildcard character (`*`) to match all services in all namespaces that don't otherwise have intentions defined. If not set, the namespace used will depend on the `connectInject.consulNamespaces` configuration. See [ServiceIntentions Special Case (Enterprise)](/consul/docs/k8s/crds#serviceintentions-special-case-enterprise) for more details. Wildcard intentions cannot be used when defining L7 [`Permissions`](/consul/docs/connect/config-entries/service-intentions#permissions).",
         },
       ],
     },
@@ -448,9 +448,9 @@ spec:
       type: 'string: ""',
       description: {
         hcl:
-          "Specifies the [peer](/docs/connect/cluster-peering/index.mdx) of the source service. `Peer` is mutually exclusive with `Partition`.",
+          "Specifies the [peer](/consul/docs/connect/cluster-peering/index.mdx) of the source service. `Peer` is mutually exclusive with `Partition`.",
         yaml:
-          "Specifies the [peer](/docs/connect/cluster-peering/index.mdx) of the source service. `peer` is mutually exclusive with `partition`.",
+          "Specifies the [peer](/consul/docs/connect/cluster-peering/index.mdx) of the source service. `peer` is mutually exclusive with `partition`.",
       },
     },
     {
@@ -496,7 +496,7 @@ spec:
                       first permission to match in the list is terminal and stops further
                       evaluation. As with L4 intentions, traffic that fails to match any of the
                       provided permissions in this intention will be subject to the default
-                      intention behavior is defined by the default [ACL policy](/docs/agent/config/config-files#acl_default_policy).<br><br>
+                      intention behavior is defined by the default [ACL policy](/consul/docs/agent/config/config-files#acl_default_policy).<br><br>
                       This should be omitted for an L4 intention as it is mutually exclusive with
                       the \`Action\` field.<br><br>
                       Setting \`Permissions\` is not valid if a wildcard is used for the \`Name\` or \`Namespace\` because they can only be
@@ -506,7 +506,7 @@ spec:
                       first permission to match in the list is terminal and stops further
                       evaluation. As with L4 intentions, traffic that fails to match any of the
                       provided permissions in this intention will be subject to the default
-                      intention behavior is defined by the default [ACL policy](/docs/agent/config/config-files#acl_default_policy).<br><br>
+                      intention behavior is defined by the default [ACL policy](/consul/docs/agent/config/config-files#acl_default_policy).<br><br>
                       This should be omitted for an L4 intention as it is mutually exclusive with
                       the \`action\` field.<br><br>
                       Setting \`permissions\` is not valid if a wildcard is used for the \`spec.destination.name\` or \`spec.destination.namespace\`
@@ -517,7 +517,7 @@ spec:
       name: 'Precedence',
       type: 'int: <read-only>',
       description:
-        'An [integer precedence value](/docs/connect/intentions#precedence-and-match-order) computed from the source and destination naming components.',
+        'An [integer precedence value](/consul/docs/connect/intentions#precedence-and-match-order) computed from the source and destination naming components.',
       yaml: false,
     },
     {
@@ -542,9 +542,9 @@ spec:
       description: `This is the UUID to uniquely identify
                       this intention in the system. Cannot be set directly and is exposed here as
                       an artifact of the config entry migration and is primarily used to allow
-                      legacy intention [API](/api-docs/connect/intentions#update-intention-by-id)
-                      [endpoints](/api-docs/connect/intentions#read-specific-intention-by-id) to
-                      continue to function for a period of time after [upgrading to 1.9.0](/docs/upgrading/upgrade-specific#consul-1-9-0).`,
+                      legacy intention [API](/consul/api-docs/connect/intentions#update-intention-by-id)
+                      [endpoints](/consul/api-docs/connect/intentions#read-specific-intention-by-id) to
+                      continue to function for a period of time after [upgrading to 1.9.0](/consul/docs/upgrading/upgrade-specific#consul-1-9-0).`,
       yaml: false,
     },
     {
@@ -554,9 +554,9 @@ spec:
                       metadata pairs attached to the intention, rather than to the enclosing config
                       entry. Cannot be set directly and is exposed here as an artifact of the
                       config entry migration and is primarily used to allow legacy intention
-                      [API](/api-docs/connect/intentions#update-intention-by-id)
-                      [endpoints](/api-docs/connect/intentions#read-specific-intention-by-id) to
-                      continue to function for a period of time after [upgrading to 1.9.0](/docs/upgrading/upgrade-specific#consul-1-9-0).`,
+                      [API](/consul/api-docs/connect/intentions#update-intention-by-id)
+                      [endpoints](/consul/api-docs/connect/intentions#read-specific-intention-by-id) to
+                      continue to function for a period of time after [upgrading to 1.9.0](/consul/docs/upgrading/upgrade-specific#consul-1-9-0).`,
       yaml: false,
     },
     {
@@ -565,9 +565,9 @@ spec:
       description: `The timestamp that this intention was
                       created. Cannot be set directly and is exposed here as an artifact of the
                       config entry migration and is primarily used to allow legacy intention
-                      [API](/api-docs/connect/intentions#update-intention-by-id)
-                      [endpoints](/api-docs/connect/intentions#read-specific-intention-by-id) to
-                      continue to function for a period of time after [upgrading to 1.9.0](/docs/upgrading/upgrade-specific#consul-1-9-0).`,
+                      [API](/consul/api-docs/connect/intentions#update-intention-by-id)
+                      [endpoints](/consul/api-docs/connect/intentions#read-specific-intention-by-id) to
+                      continue to function for a period of time after [upgrading to 1.9.0](/consul/docs/upgrading/upgrade-specific#consul-1-9-0).`,
       yaml: false,
     },
     {
@@ -576,9 +576,9 @@ spec:
       description: `The timestamp that this intention was
                       last updated. Cannot be set directly and is exposed here as an artifact of the
                       config entry migration and is primarily used to allow legacy intention
-                      [API](/api-docs/connect/intentions#update-intention-by-id)
-                      [endpoints](/api-docs/connect/intentions#read-specific-intention-by-id) to
-                      continue to function for a period of time after [upgrading to 1.9.0](/docs/upgrading/upgrade-specific#consul-1-9-0).`,
+                      [API](/consul/api-docs/connect/intentions#update-intention-by-id)
+                      [endpoints](/consul/api-docs/connect/intentions#read-specific-intention-by-id) to
+                      continue to function for a period of time after [upgrading to 1.9.0](/consul/docs/upgrading/upgrade-specific#consul-1-9-0).`,
       yaml: false,
     },
   ]}

--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -429,7 +429,7 @@ spec:
         {
           name: 'namespace',
           description:
-            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/docs/k8s/crds#consul-enterprise) for more details.',
+            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/consul/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for more details.',
         },
       ],
       hcl: false,
@@ -531,7 +531,7 @@ spec:
           type: 'string: ""',
           description:
               `Specifies the destination cluster peer to resolve the target service name from.
-                  Ensure that [intentions are defined](/docs/connect/cluster-peering/create-manage-peering#authorize-services-for-peers)
+                  Ensure that [intentions are defined](/consul/docs/connect/cluster-peering/create-manage-peering#authorize-services-for-peers)
                   on the peered cluster to allow the source service to access this redirect target service as an upstream. When
                   the peer name is specified, Consul uses Envoy's outlier detection to determine
                   the health of the redirect target based on whether communication attempts to the
@@ -640,7 +640,7 @@ spec:
               type: 'string: ""',
               description:
               `Specifies the destination cluster peer to resolve the target service name from.
-                  Ensure that [intentions are defined](/docs/connect/cluster-peering/create-manage-peering#authorize-services-for-peers)
+                  Ensure that [intentions are defined](/consul/docs/connect/cluster-peering/create-manage-peering#authorize-services-for-peers)
                   on the peered cluster to allow the source service to access this failover target service as an upstream.
                   When the peer name is specified, Consul uses Envoy's outlier detection
                   to determine the health of the failover target based on

--- a/website/content/docs/connect/config-entries/service-router.mdx
+++ b/website/content/docs/connect/config-entries/service-router.mdx
@@ -449,7 +449,7 @@ spec:
         {
           name: 'namespace',
           description:
-            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/docs/k8s/crds#consul-enterprise) for more details.',
+            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/consul/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for more details.',
         },
       ],
       hcl: false,
@@ -724,14 +724,14 @@ spec:
     {
       name: 'RequestHeaders',
       type: 'HTTPHeaderModifiers: <optional>',
-      description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+      description: `A set of [HTTP-specific header modification rules](/consul/docs/connect/config-entries/service-router#httpheadermodifiers)
       that will be applied to requests routed to this service.
       This cannot be used with a \`tcp\` listener.`,
     },
     {
       name: 'ResponseHeaders',
       type: 'HTTPHeaderModifiers: <optional>',
-      description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+      description: `A set of [HTTP-specific header modification rules](/consul/docs/connect/config-entries/service-router#httpheadermodifiers)
       that will be applied to responses from this service.
       This cannot be used with a \`tcp\` listener.`,
     },

--- a/website/content/docs/connect/config-entries/service-splitter.mdx
+++ b/website/content/docs/connect/config-entries/service-splitter.mdx
@@ -284,7 +284,7 @@ spec:
         {
           name: 'namespace',
           description:
-            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/docs/k8s/crds#consul-enterprise) for more details.',
+            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/consul/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for more details.',
         },
       ],
       hcl: false,
@@ -333,14 +333,14 @@ spec:
         {
           name: 'RequestHeaders',
           type: 'HTTPHeaderModifiers: <optional>',
-          description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+          description: `A set of [HTTP-specific header modification rules](/consul/docs/connect/config-entries/service-router#httpheadermodifiers)
           that will be applied to requests routed to this split.
           This cannot be used with a \`tcp\` listener.`,
         },
         {
           name: 'ResponseHeaders',
           type: 'HTTPHeaderModifiers: <optional>',
-          description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+          description: `A set of [HTTP-specific header modification rules](/consul/docs/connect/config-entries/service-router#httpheadermodifiers)
           that will be applied to responses from this split.
           This cannot be used with a \`tcp\` listener.`,
         },

--- a/website/content/docs/connect/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/connect/config-entries/terminating-gateway.mdx
@@ -583,7 +583,7 @@ spec:
       enterprise: true,
       description:
         'Specifies the namespace to which the configuration entry will apply. This must match the namespace in which the gateway is registered.' +
-        ' If omitted, the namespace will be inherited from [the request](/api-docs/config#ns)' +
+        ' If omitted, the namespace will be inherited from [the request](/consul/api-docs/config#ns)' +
         ' or will default to the `default` namespace.',
       yaml: false,
     },
@@ -593,7 +593,7 @@ spec:
       enterprise: true,
       description:
         'Specifies the admin partition to which the configuration entry will apply. This must match the partition in which the gateway is registered.' +
-        ' If omitted, the partition will be inherited from [the request](/api-docs/config)' +
+        ' If omitted, the partition will be inherited from [the request](/consul/api-docs/config)' +
         ' or will default to the `default` partition.',
       yaml: false,
     },
@@ -614,7 +614,7 @@ spec:
         {
           name: 'namespace',
           description:
-            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/docs/k8s/crds#consul-enterprise) for more details.',
+            'If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/consul/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for more details.',
         },
       ],
       hcl: false,


### PR DESCRIPTION
## What

Where links in Markdown syntax are passed into `ConfigEntryReference` components, prefixes links to docs content with `/consul`.

## Why

In preparation for https://github.com/hashicorp/consul/pull/15976, because the link rewrite plugin cannot reach these links to update them automatically.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203750517664196