### PR TITLE
docs: clarify service defaults example

### DIFF
--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -56,14 +56,14 @@ spec:
 <Tab heading="Consul OSS">
 
 Set default connection limits and mesh gateway mode across all upstreams
-of "counting", and also override the mesh gateway mode used when dialing
-the "dashboard" service.
+of "dashboard", and also override the mesh gateway mode used when dialing
+its upstream "counting" service.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-defaults"
-Name = "counting"
+Name = "dashboard"
 
 UpstreamConfig = {
   Defaults = {
@@ -79,7 +79,7 @@ UpstreamConfig = {
 
   Overrides = [
     {
-      Name = "dashboard"
+      Name = "counting"
       MeshGateway = {
         Mode = "remote"
       }
@@ -92,7 +92,7 @@ UpstreamConfig = {
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
 metadata:
-  name: counting
+  name: dashboard
 spec:
   upstreamConfig:
     defaults:
@@ -103,7 +103,7 @@ spec:
         maxPendingRequests: 512
         maxConcurrentRequests: 512
     overrides:
-      - name: dashboard
+      - name: counting
         meshGateway:
           mode: remote
 ```
@@ -111,7 +111,7 @@ spec:
 ```json
 {
   "Kind": "service-defaults",
-  "Name": "counting",
+  "Name": "dashboard",
   "UpstreamConfig": {
     "Defaults": {
       "MeshGateway": {
@@ -125,7 +125,7 @@ spec:
     },
     "Overrides": [
       {
-        "Name": "dashboard",
+        "Name": "counting",
         "MeshGateway": {
           "Mode": "remote"
         }
@@ -141,14 +141,15 @@ spec:
 <Tab heading="Consul Enterprise">
 
 Set default connection limits and mesh gateway mode across all upstreams
-of "counting" and also override the mesh gateway mode used when dialing
-the "dashboard" service in the "frontend" namespace.
+of "dashboard" in the "product" namespace,
+and also override the mesh gateway mode used when dialing
+its upstream "counting" service in the "backend" namespace.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-defaults"
-Name = "counting"
+Name = "dashboard"
 Namespace = "product"
 
 UpstreamConfig = {
@@ -165,8 +166,8 @@ UpstreamConfig = {
 
   Overrides = [
     {
-      Name = "dashboard"
-      Namespace = "frontend"
+      Name = "counting"
+      Namespace = "backend"
       MeshGateway = {
         Mode = "remote"
       }
@@ -179,7 +180,7 @@ UpstreamConfig = {
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
 metadata:
-  name: counting
+  name: dashboard
   namespace: product
 spec:
   upstreamConfig:
@@ -191,8 +192,8 @@ spec:
         maxPendingRequests: 512
         maxConcurrentRequests: 512
     overrides:
-      - name: dashboard
-        namespace: frontend
+      - name: counting
+        namespace: backend
         meshGateway:
           mode: remote
 ```
@@ -200,7 +201,7 @@ spec:
 ```json
 {
   "Kind": "service-defaults",
-  "Name": "counting",
+  "Name": "dashboard",
   "Namespace": "product",
   "UpstreamConfig": {
     "Defaults": {
@@ -215,8 +216,8 @@ spec:
     },
     "Overrides": [
       {
-        "Name": "dashboard",
-        "Namespace": "frontend",
+        "Name": "counting",
+        "Namespace": "backend",
         "MeshGateway": {
           "Mode": "remote"
         }


### PR DESCRIPTION
The docs as-is imply that traffic goes from counting -> dashboard, when it actually goes from dashboard -> counting in all HashiCups examples.