### PR TITLE
test: container tests wait for available networks

### DIFF
--- a/test/integration/consul-container/libs/cluster/cluster.go
+++ b/test/integration/consul-container/libs/cluster/cluster.go
@@ -37,6 +37,7 @@ type Cluster struct {
 }
 
 type TestingT interface {
+	Logf(format string, args ...any)
 	Cleanup(f func())
 }
 

--- a/test/integration/consul-container/libs/cluster/network.go
+++ b/test/integration/consul-container/libs/cluster/network.go
@@ -2,10 +2,14 @@ package cluster
 
 import (
 	"context"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/testcontainers/testcontainers-go"
 )
+
+const tooManyNetworksError = "could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network: failed to create network"
 
 func createNetwork(t TestingT, name string) (testcontainers.Network, error) {
 	req := testcontainers.GenericNetworkRequest{
@@ -15,12 +19,23 @@ func createNetwork(t TestingT, name string) (testcontainers.Network, error) {
 			CheckDuplicate: true,
 		},
 	}
+	first := true
+RETRY:
 	network, err := testcontainers.GenericNetwork(context.Background(), req)
 	if err != nil {
+		if strings.Contains(err.Error(), tooManyNetworksError) {
+			if first {
+				t.Logf("waiting until possible to get a network")
+				first = false
+			}
+			time.Sleep(1 * time.Second)
+			goto RETRY
+		}
 		return nil, errors.Wrap(err, "could not create network")
 	}
 	t.Cleanup(func() {
 		_ = network.Remove(context.Background())
 	})
+
 	return network, nil
 }


### PR DESCRIPTION
### Description

If multiple container tests are run in parallel it is highly likely that one will randomly fail due to an inability to get a docker network for the test case. This change detects that scenario and sleep retries until it succeeds. Hopefully this means it will be safe to mark some tests as safe to run in parallel without flaking them out.