### PR TITLE
flaky test: use retry long to wait for config entry upgrade

### DIFF
--- a/test/integration/connect/envoy/case-badauthz/verify.bats
+++ b/test/integration/connect/envoy/case-badauthz/verify.bats
@@ -27,7 +27,7 @@ load helpers
 }
 
 @test "s2 should have network rbac rules loaded from xDS" {
-  retry_default assert_envoy_network_rbac_policy_count localhost:19001 1
+  retry_long assert_envoy_network_rbac_policy_count localhost:19001 1
 }
 
 @test "s1 upstream should NOT be able to connect to s2" {

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -784,7 +784,7 @@ function setup_upsert_l4_intention {
   local DESTINATION=$2
   local ACTION=$3
 
-  retry_long docker_curl primary -sL -XPUT "http://127.0.0.1:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
+  retry_default docker_curl primary -sL -XPUT "http://127.0.0.1:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
     -d"{\"Action\": \"${ACTION}\"}" >/dev/null
 }
 

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -784,7 +784,7 @@ function setup_upsert_l4_intention {
   local DESTINATION=$2
   local ACTION=$3
 
-  retry_default docker_curl primary -sL -XPUT "http://127.0.0.1:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
+  retry_long docker_curl primary -sL -XPUT "http://127.0.0.1:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
     -d"{\"Action\": \"${ACTION}\"}" >/dev/null
 }
 


### PR DESCRIPTION
### Description
The TestEnvoy/case-http-badauthz failed due to following error. Not sure what causes the error, so try increasing the retry times.

`agent.http: Request error: method=PUT url="/v1/connect/intentions/exact?source=s1&destination=s2" from=127.0.0.1:39148 error="Intentions are read only while being upgraded to config entries"
`

### Links
Failed test instance:

https://app.circleci.com/pipelines/github/hashicorp/consul/49943/workflows/a3c2a39d-f863-439d-849e-e8a74465685a/jobs/1145045/tests


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
