### PR TITLE
Mw/lambda envoy extension parse region (#4107)

### DIFF
--- a/agent/proxycfg/testing_terminating_gateway.go
+++ b/agent/proxycfg/testing_terminating_gateway.go
@@ -954,9 +954,8 @@ func TestConfigSnapshotTerminatingGatewayWithLambdaService(t testing.T, extraUpd
 				{
 					Name: structs.BuiltinAWSLambdaExtension,
 					Arguments: map[string]interface{}{
-						"ARN":                "lambda-arn",
+						"ARN":                "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
 						"PayloadPassthrough": true,
-						"Region":             "us-east-1",
 					},
 				},
 			},

--- a/agent/xds/builtin_extension_oss_test.go
+++ b/agent/xds/builtin_extension_oss_test.go
@@ -48,10 +48,9 @@ func TestBuiltinExtensionsFromSnapshot(t *testing.T) {
 				{
 					Name: api.BuiltinAWSLambdaExtension,
 					Arguments: map[string]interface{}{
-						"ARN":                "lambda-arn",
+						"ARN":                "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
 						"PayloadPassthrough": payloadPassthrough,
 						"InvocationMode":     invocationMode,
-						"Region":             "us-east-1",
 					},
 				},
 			},

--- a/agent/xds/builtinextensions/lambda/lambda_test.go
+++ b/agent/xds/builtinextensions/lambda/lambda_test.go
@@ -1,9 +1,16 @@
 package lambda
 
 import (
+	"fmt"
 	"testing"
 
+	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	pstruct "google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/hashicorp/consul/agent/xds/xdscommon"
 	"github.com/hashicorp/consul/api"
@@ -32,10 +39,6 @@ func TestMakeLambdaExtension(t *testing.T) {
 			region: "blah",
 			ok:     false,
 		},
-		"missing region": {
-			arn: "arn",
-			ok:  false,
-		},
 		"including payload passthrough": {
 			arn:                "arn",
 			region:             "blah",
@@ -43,7 +46,6 @@ func TestMakeLambdaExtension(t *testing.T) {
 			expected: lambda{
 				ARN:                "arn",
 				PayloadPassthrough: true,
-				Region:             "blah",
 				Kind:               kind,
 			},
 			ok: true,
@@ -66,7 +68,6 @@ func TestMakeLambdaExtension(t *testing.T) {
 					Name: extensionName,
 					Arguments: map[string]interface{}{
 						"ARN":                tc.arn,
-						"Region":             tc.region,
 						"PayloadPassthrough": tc.payloadPassthrough,
 					},
 				},
@@ -79,6 +80,106 @@ func TestMakeLambdaExtension(t *testing.T) {
 				require.Equal(t, tc.expected, plugin)
 			} else {
 				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestPatchCluster(t *testing.T) {
+	cases := []struct {
+		name           string
+		lambda         lambda
+		input          *envoy_cluster_v3.Cluster
+		expectedRegion string
+		isErrExpected  bool
+	}{
+		{
+			name: "nominal",
+			input: &envoy_cluster_v3.Cluster{
+				Name: "test-cluster",
+			},
+			lambda: lambda{
+				ARN:                "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
+				PayloadPassthrough: true,
+				Kind:               "some-name",
+				InvocationMode:     "Asynchronous",
+			},
+			expectedRegion: "us-east-1",
+		},
+		{
+			name: "error invalid arn",
+			input: &envoy_cluster_v3.Cluster{
+				Name: "test-cluster",
+			},
+			lambda: lambda{
+				ARN:                "?!@%^SA",
+				PayloadPassthrough: true,
+				Kind:               "some-name",
+				InvocationMode:     "Asynchronous",
+			},
+			isErrExpected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			transportSocket, err := makeUpstreamTLSTransportSocket(&envoy_tls_v3.UpstreamTlsContext{
+				Sni: "*.amazonaws.com",
+			})
+			require.NoError(t, err)
+
+			expectedCluster := &envoy_cluster_v3.Cluster{
+				Name:                 tc.input.Name,
+				ConnectTimeout:       tc.input.ConnectTimeout,
+				ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_LOGICAL_DNS},
+				DnsLookupFamily:      envoy_cluster_v3.Cluster_V4_ONLY,
+				LbPolicy:             envoy_cluster_v3.Cluster_ROUND_ROBIN,
+				Metadata: &envoy_core_v3.Metadata{
+					FilterMetadata: map[string]*pstruct.Struct{
+						"com.amazonaws.lambda": {
+							Fields: map[string]*pstruct.Value{
+								"egress_gateway": {Kind: &pstruct.Value_BoolValue{BoolValue: true}},
+							},
+						},
+					},
+				},
+				LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
+					ClusterName: tc.input.Name,
+					Endpoints: []*envoy_endpoint_v3.LocalityLbEndpoints{
+						{
+							LbEndpoints: []*envoy_endpoint_v3.LbEndpoint{
+								{
+									HostIdentifier: &envoy_endpoint_v3.LbEndpoint_Endpoint{
+										Endpoint: &envoy_endpoint_v3.Endpoint{
+											Address: &envoy_core_v3.Address{
+												Address: &envoy_core_v3.Address_SocketAddress{
+													SocketAddress: &envoy_core_v3.SocketAddress{
+														Address: fmt.Sprintf("lambda.%s.amazonaws.com", tc.expectedRegion),
+														PortSpecifier: &envoy_core_v3.SocketAddress_PortValue{
+															PortValue: 443,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				TransportSocket: transportSocket,
+			}
+
+			// Test patching the cluster
+			patchedCluster, patchSuccess, err := tc.lambda.PatchCluster(tc.input)
+			if tc.isErrExpected {
+				assert.Error(t, err)
+				assert.False(t, patchSuccess)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, patchSuccess)
+				assert.Equal(t, expectedCluster, patchedCluster)
 			}
 		})
 	}

--- a/agent/xds/testdata/builtin_extension/listeners/lambda-connect-proxy-opposite-meta.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lambda-connect-proxy-opposite-meta.latest.golden
@@ -44,7 +44,7 @@
                     "name": "envoy.filters.http.aws_lambda",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.aws_lambda.v3.Config",
-                      "arn": "lambda-arn",
+                      "arn": "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
                       "invocationMode": "ASYNCHRONOUS"
                     }
                   },

--- a/agent/xds/testdata/builtin_extension/listeners/lambda-connect-proxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lambda-connect-proxy.latest.golden
@@ -44,7 +44,7 @@
                     "name": "envoy.filters.http.aws_lambda",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.aws_lambda.v3.Config",
-                      "arn": "lambda-arn",
+                      "arn": "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
                       "payloadPassthrough": true
                     }
                   },

--- a/agent/xds/testdata/builtin_extension/listeners/lambda-terminating-gateway-with-service-resolvers.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lambda-terminating-gateway-with-service-resolvers.latest.golden
@@ -154,7 +154,7 @@
                     "name": "envoy.filters.http.aws_lambda",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.aws_lambda.v3.Config",
-                      "arn": "lambda-arn",
+                      "arn": "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
                       "payloadPassthrough": true
                     }
                   },
@@ -245,7 +245,7 @@
                     "name": "envoy.filters.http.aws_lambda",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.aws_lambda.v3.Config",
-                      "arn": "lambda-arn",
+                      "arn": "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
                       "payloadPassthrough": true
                     }
                   },
@@ -390,7 +390,7 @@
                     "name": "envoy.filters.http.aws_lambda",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.aws_lambda.v3.Config",
-                      "arn": "lambda-arn",
+                      "arn": "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
                       "payloadPassthrough": true
                     }
                   },

--- a/agent/xds/testdata/builtin_extension/listeners/lambda-terminating-gateway.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lambda-terminating-gateway.latest.golden
@@ -208,7 +208,7 @@
                     "name": "envoy.filters.http.aws_lambda",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.aws_lambda.v3.Config",
-                      "arn": "lambda-arn",
+                      "arn": "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
                       "payloadPassthrough": true
                     }
                   },

--- a/agent/xds/xdscommon/xdscommon_oss_test.go
+++ b/agent/xds/xdscommon/xdscommon_oss_test.go
@@ -46,9 +46,8 @@ func TestGetExtensionConfigurations_TerminatingGateway(t *testing.T) {
 				EnvoyExtension: api.EnvoyExtension{
 					Name: structs.BuiltinAWSLambdaExtension,
 					Arguments: map[string]interface{}{
-						"ARN":                "lambda-arn",
+						"ARN":                "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
 						"PayloadPassthrough": true,
-						"Region":             "us-east-1",
 					},
 				},
 				ServiceName: webService,
@@ -109,9 +108,8 @@ func TestGetExtensionConfigurations_ConnectProxy(t *testing.T) {
 		{
 			Name: structs.BuiltinAWSLambdaExtension,
 			Arguments: map[string]interface{}{
-				"ARN":                "lambda-arn",
+				"ARN":                "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
 				"PayloadPassthrough": true,
-				"Region":             "us-east-1",
 			},
 		},
 		{
@@ -152,9 +150,8 @@ func TestGetExtensionConfigurations_ConnectProxy(t *testing.T) {
 						EnvoyExtension: api.EnvoyExtension{
 							Name: structs.BuiltinAWSLambdaExtension,
 							Arguments: map[string]interface{}{
-								"ARN":                "lambda-arn",
+								"ARN":                "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
 								"PayloadPassthrough": true,
-								"Region":             "us-east-1",
 							},
 						},
 						ServiceName: dbService,
@@ -201,9 +198,8 @@ func TestGetExtensionConfigurations_ConnectProxy(t *testing.T) {
 						EnvoyExtension: api.EnvoyExtension{
 							Name: structs.BuiltinAWSLambdaExtension,
 							Arguments: map[string]interface{}{
-								"ARN":                "lambda-arn",
+								"ARN":                "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
 								"PayloadPassthrough": true,
-								"Region":             "us-east-1",
 							},
 						},
 						ServiceName: dbService,
@@ -251,9 +247,8 @@ func TestGetExtensionConfigurations_ConnectProxy(t *testing.T) {
 						EnvoyExtension: api.EnvoyExtension{
 							Name: structs.BuiltinAWSLambdaExtension,
 							Arguments: map[string]interface{}{
-								"ARN":                "lambda-arn",
+								"ARN":                "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234",
 								"PayloadPassthrough": true,
-								"Region":             "us-east-1",
 							},
 						},
 						ServiceName: webService,


### PR DESCRIPTION
### Description
This is a backport of Enterprise changes

* updated builtin extension to parse region directly from ARN
- added a unit test
- added some comments/light refactoring

* updated golden files with proper ARNs
- ARNs need to be right format now that they are being processed

* updated tests and integration tests
- removed 'region' from all EnvoyExtension arguments
- added properly formatted ARN which includes the same region found in the removed "Region" field: 'us-east-1'

### Testing & Reproduction steps

### Links

### PR Checklist

* [x] updated test coverage
* [n/a] external facing docs updated
* [x] not a security concern
