### PR TITLE
Update service-resolver.mdx

### DIFF
--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -455,9 +455,9 @@ spec:
         {
           name: 'Filter',
           type: 'string: ""',
-          description: `The [filter expression](/consul/api-docs/features/filtering) to be used for selecting
-                            instances of the requested service. If empty, all healthy instances are
-                            returned. This expression can filter on the same selectors as the
+          description: `The filter expression to be used for selecting instances of the 
+                            requested service. If empty, all healthy instances are returned. 
+                            This expression can filter on the same selectors as the
                             [Health API endpoint](/consul/api-docs/health#filtering-2).`,
         },
         {

--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -455,7 +455,7 @@ spec:
         {
           name: 'Filter',
           type: 'string: ""',
-          description: `The filter expression to be used for selecting instances of the 
+          description: `The filter expression for selecting instances of the 
                             requested service. If empty, all healthy instances are returned. 
                             This expression can filter on the same selectors as the
                             [Health API endpoint](/consul/api-docs/health#filtering-2).`,


### PR DESCRIPTION
### Description

Fixing links in the Documentation for service-resolver filter options.

### Links

Affected block: https://developer.hashicorp.com/consul/docs/connect/config-entries/service-resolver#filter

Working links:
* https://developer.hashicorp.com/consul/api-docs/health#filtering
* https://developer.hashicorp.com/consul/api-docs/health#filtering-2

Removing the first link since the information seems not accurate based on the examples provided in the page.