### PR TITLE
Use agent token for service/check deregistration during anti-entropy

### DIFF
--- a/.changelog/16097.txt
+++ b/.changelog/16097.txt
@@ -1,3 +1,3 @@
 ```release-note:bug-fix
-agent: Only use the `agent` token for internal deregistration of checks and services during anti-entropy syncing. The service token, specified in the `token` field of the check or service definition, is no longer used for deregistration. This fixes an issue where the agent failed to ever deregseter a service or check if the service token was deleted.
+agent: Only use the `agent` token for internal deregistration of checks and services during anti-entropy syncing. The service token specified in the `token` field of the check or service definition is no longer used for deregistration. This fixes an issue where the agent failed to ever deregister a service or check if the service token was deleted.
 ```

--- a/.changelog/16097.txt
+++ b/.changelog/16097.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: only use the `agent` token and do not attempt using a service token for internal deregistration of checks and services
+```

--- a/.changelog/16097.txt
+++ b/.changelog/16097.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
-agent: only use the `agent` token and do not attempt using a service token for internal deregistration of checks and services
+```release-note:bug-fix
+agent: Only use the `agent` token for internal deregistration of checks and services during anti-entropy syncing. The service token, specified in the `token` field of the check or service definition, is no longer used for deregistration. This fixes an issue where the agent failed to ever deregseter a service or check if the service token was deleted.
 ```

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1318,7 +1318,10 @@ func (l *State) deleteService(key structs.ServiceID) error {
 		l.logger.Info("Deregistered service", "service", key.ID)
 		return nil
 
-	case acl.IsErrPermissionDenied(err), acl.IsErrNotFound(err):
+	case acl.IsErrNotFound(err):
+		l.services[key].Token = ""
+		fallthrough
+	case acl.IsErrPermissionDenied(err):
 		// todo(fs): mark the service to be in sync to prevent excessive retrying before next full sync
 		// todo(fs): some backoff strategy might be a better solution
 		l.services[key].InSync = true
@@ -1359,8 +1362,10 @@ func (l *State) deleteCheck(key structs.CheckID) error {
 		l.pruneCheck(key)
 		l.logger.Info("Deregistered check", "check", key.String())
 		return nil
-
-	case acl.IsErrPermissionDenied(err), acl.IsErrNotFound(err):
+	case acl.IsErrNotFound(err):
+		l.checks[key].Token = ""
+		fallthrough
+	case acl.IsErrPermissionDenied(err):
 		// todo(fs): mark the check to be in sync to prevent excessive retrying before next full sync
 		// todo(fs): some backoff strategy might be a better solution
 		l.checks[key].InSync = true

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -829,10 +829,6 @@ func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 }
 
 var testRegisterRules = `
- node "" {
- 	policy = "write"
- }
-
  service "api" {
  	policy = "write"
  }
@@ -862,6 +858,9 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 	`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	// The agent token is the only token used for deleteService.
+	setAgentToken(t, a)
 
 	token := createToken(t, a, testRegisterRules)
 
@@ -1153,15 +1152,19 @@ type RPC interface {
 func createToken(t *testing.T, rpc RPC, policyRules string) string {
 	t.Helper()
 
+	uniqueId, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	policyName := "the-policy-" + uniqueId
+
 	reqPolicy := structs.ACLPolicySetRequest{
 		Datacenter: "dc1",
 		Policy: structs.ACLPolicy{
-			Name:  "the-policy",
+			Name:  policyName,
 			Rules: policyRules,
 		},
 		WriteRequest: structs.WriteRequest{Token: "root"},
 	}
-	err := rpc.RPC(context.Background(), "ACL.PolicySet", &reqPolicy, &structs.ACLPolicy{})
+	err = rpc.RPC(context.Background(), "ACL.PolicySet", &reqPolicy, &structs.ACLPolicy{})
 	require.NoError(t, err)
 
 	token, err := uuid.GenerateUUID()
@@ -1171,13 +1174,36 @@ func createToken(t *testing.T, rpc RPC, policyRules string) string {
 		Datacenter: "dc1",
 		ACLToken: structs.ACLToken{
 			SecretID: token,
-			Policies: []structs.ACLTokenPolicyLink{{Name: "the-policy"}},
+			Policies: []structs.ACLTokenPolicyLink{{Name: policyName}},
 		},
 		WriteRequest: structs.WriteRequest{Token: "root"},
 	}
 	err = rpc.RPC(context.Background(), "ACL.TokenSet", &reqToken, &structs.ACLToken{})
 	require.NoError(t, err)
 	return token
+}
+
+// setAgentToken sets the 'agent' token for this agent. It creates a new token
+// with node:write for the agent's node name, and service:write for any
+// service.
+func setAgentToken(t *testing.T, a *agent.TestAgent) {
+	var policy = fmt.Sprintf(`
+	  node "%s" {
+		policy = "write"
+	  }
+	  service_prefix "" {
+		policy = "read"
+	  }
+	`, a.Config.NodeName)
+
+	token := createToken(t, a, policy)
+
+	_, err := a.Client().Agent().UpdateAgentACLToken(token, &api.WriteOptions{Token: "root"})
+	if err != nil {
+		t.Fatalf("setting agent token: %v", err)
+	}
+
+	t.Logf("set agent token: %v", token)
 }
 
 func TestAgentAntiEntropy_Checks(t *testing.T) {
@@ -1480,6 +1506,9 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, dc)
+
+	// The agent token is the only token used for deleteCheck.
+	setAgentToken(t, a)
 
 	token := createToken(t, a, testRegisterRules)
 

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1202,8 +1202,6 @@ func setAgentToken(t *testing.T, a *agent.TestAgent) {
 	if err != nil {
 		t.Fatalf("setting agent token: %v", err)
 	}
-
-	t.Logf("set agent token: %v", token)
 }
 
 func TestAgentAntiEntropy_Checks(t *testing.T) {


### PR DESCRIPTION
### Description

The changes agent anti-entropy syncs to only use agent token for deregistration of services and checks.

The previous behavior had the agent attempt to use the "service" token (i.e. from the `token` field in a service definition file) and if that was not set, then it would use the agent token.

The previous behavior was problematic because, if the service token had been deleted, the deregistration request would fail. The agent would retry the deregistration during each anti-entropy sync, and the situation would never resolve.

The new behavior is to only/always use the agent token to service/check deregistration during anti-entropy. This is:

* Simpler: No fallback logic to try different tokens
* Faster (slightly): No time spent attempting the service token
* Correct: The agent token is able to deregister services on that agent's node, because:
  * node:write permissions allow deregistration of services/checks on that node.
  * The agent token must have node:write permission, or else the agent is not be able to (de)register itself into the catalog

### Testing & Reproduction steps

<details>
  <summary>Expand for test steps</summary>

* Define a service definition like the following (named `wumbo`). This contains a service and check with their `token` field set.

  ```
  $ cat config/service.hcl
  service {
    name = "wumbo"
    id = "wumbo-id"
    token = "33333333-22b6-43f1-88f0-4c49d2a63554"

    check {
      name = "inline check"
      ttl = "9999h"
      status = "passing"
    }
  }

  check {
    name = "standalone check"
    ttl = "9999h"
    status = "passing"
    service_id = "wumbo-id"
    token = "33333333-22b6-43f1-88f0-4c49d2a63554"
  } 
  ```

* Start a consul agent

  ```
  $ cat config/agent.hcl
  log_level = "debug"
  node_name = "client1"
  leave_on_terminate = true

  acl = {
    default_policy = "deny"
    down_policy = "extend-cache"
    enable_token_persistence = true
    enabled = true
    tokens = {
      initial_management = "63fb8a77-22b6-43f1-88f0-4c49d2a63554"
      agent = "00000000-22b6-43f1-88f0-4c49d2a63554"
    }
  }

  $ consul agent -dev -config-dir ./config
  ```

* Create the service  and agent tokens (taking advantage of client provided ids):

  ```
  export CONSUL_HTTP_TOKEN=63fb8a77-22b6-43f1-88f0-4c49d2a63554
  consul acl token create -service-identity wumbo -secret 33333333-22b6-43f1-88f0-4c49d2a63554 -accessor 087a8e18-21a7-41e1-b952-878b606e750a
  consul acl token create -node-identity client1:dc1 -secret 00000000-22b6-43f1-88f0-4c49d2a63554 -accessor 8afcfcf1-c5f5-4c92-9470-f3f4763b3fb2
  ```

* Verify the service is soon registered

   ```
   $ consul catalog services
  consul
  wumbo
  ```

  In the Consul agent logs, you should see:

  ```
  2023-01-27T13:26:44.963-0600 [INFO]  agent: Synced node info
  2023-01-27T13:26:44.964-0600 [INFO]  agent: Synced service: service=wumbo-id
  2023-01-27T13:26:44.964-0600 [DEBUG] agent: Check in sync: check=service:wumbo-id
  2023-01-27T13:26:44.964-0600 [DEBUG] agent: Check in sync: check="standalone check"
  2023-01-27T13:26:44.964-0600 [DEBUG] agent: Node info in sync
  2023-01-27T13:26:44.964-0600 [DEBUG] agent: Service in sync: service=wumbo-id
  2023-01-27T13:26:44.964-0600 [DEBUG] agent: Check in sync: check="standalone check"
  2023-01-27T13:26:44.964-0600 [DEBUG] agent: Check in sync: check=service:wumbo-id
  ```

* Delete the service token (the agent should not use this token for the service/check deletion. this ensures we'll see failures if it does use the service token)

  ```
  $ consul acl token delete -id 087a8e18-21a7-41e1-b952-878b606e750a
  Token "087a8e18-21a7-41e1-b952-878b606e750a" deleted successfully
  ```

* Deregister the service

  ```
  $ consul services deregister -id wumbo-id
  Deregistered service: wumbo-id
  ```

* Verify the service is deregistered

  ```
  $ consul catalog services
  consul
  ```

  In the agent logs, you should see

  ```
  2023-01-27T13:35:23.064-0600 [DEBUG] agent: Node info in sync
  2023-01-27T13:35:23.065-0600 [INFO]  agent: Deregistered service: service=wumbo-id
  2023-01-27T13:35:23.065-0600 [DEBUG] agent: Node info in sync
  2023-01-27T13:35:23.065-0600 [DEBUG] agent: removed check: check="standalone check"
  2023-01-27T13:35:23.065-0600 [DEBUG] agent: removed check: check=service:wumbo-id
  2023-01-27T13:35:23.065-0600 [DEBUG] agent: removed service: service=wumbo-id
  2023-01-27T13:35:23.065-0600 [DEBUG] agent: Node info in sync
  ```
  
</details>

### Links

This is a replacement/alternative to https://github.com/hashicorp/consul/pull/14436

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
