### PR TITLE
Upgrade test: retain sidecar containers during upgrade.

### DIFF
--- a/test/integration/consul-container/libs/assert/envoy.go
+++ b/test/integration/consul-container/libs/assert/envoy.go
@@ -106,7 +106,6 @@ func processMetrics(metrics []string, prefix, metric string, condition func(v in
 			strings.Contains(line, metric) {
 
 			metric := strings.Split(line, ":")
-			fmt.Println(metric[1])
 
 			v, err := strconv.Atoi(strings.TrimSpace(metric[1]))
 			if err != nil {

--- a/test/integration/consul-container/libs/cluster/agent.go
+++ b/test/integration/consul-container/libs/cluster/agent.go
@@ -23,7 +23,7 @@ type Agent interface {
 	IsServer() bool
 	RegisterTermination(func() error)
 	Terminate() error
-	TerminateAndRetainPod() error
+	TerminateAndRetainPod(bool) error
 	Upgrade(ctx context.Context, config Config) error
 	Exec(ctx context.Context, cmd []string) (int, error)
 	DataDir() string

--- a/test/integration/consul-container/libs/service/connect.go
+++ b/test/integration/consul-container/libs/service/connect.go
@@ -89,13 +89,13 @@ func (g ConnectContainer) GetAdminAddr() (string, int) {
 // node. The container exposes port serviceBindPort and envoy admin port
 // (19000) by mapping them onto host ports. The container's name has a prefix
 // combining datacenter and name.
-func NewConnectService(ctx context.Context, name string, serviceName string, serviceBindPort int, node libcluster.Agent) (*ConnectContainer, error) {
+func NewConnectService(ctx context.Context, sidecarServiceName string, serviceName string, serviceBindPort int, node libcluster.Agent) (*ConnectContainer, error) {
 	nodeConfig := node.GetConfig()
 	if nodeConfig.ScratchDir == "" {
 		return nil, fmt.Errorf("node ScratchDir is required")
 	}
 
-	namePrefix := fmt.Sprintf("%s-service-connect-%s", node.GetDatacenter(), name)
+	namePrefix := fmt.Sprintf("%s-service-connect-%s", node.GetDatacenter(), sidecarServiceName)
 	containerName := utils.RandName(namePrefix)
 
 	envoyVersion := getEnvoyVersion()
@@ -174,11 +174,13 @@ func NewConnectService(ctx context.Context, name string, serviceName string, ser
 		ip:          info.IP,
 		appPort:     info.MappedPorts[appPortStr].Int(),
 		adminPort:   info.MappedPorts[adminPortStr].Int(),
-		serviceName: name,
+		serviceName: sidecarServiceName,
 	}
 
-	fmt.Printf("NewConnectService: name %s, bind port %d, public listener port %d\\n\"",
+	fmt.Printf("NewConnectService: name %s, mapped App Port %d, service bind port %d\n",
 		serviceName, out.appPort, serviceBindPort)
+	fmt.Printf("NewConnectService sidecar: name %s, mapped admin port %d, admin port %d\n",
+		sidecarServiceName, out.adminPort, adminPort)
 
 	return out, nil
 }


### PR DESCRIPTION
### Description
oss split of ent [PR](https://github.com/hashicorp/consul-enterprise/pull/4195)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
