### PR TITLE
ACL error improvements: incomplete bootstrapping and non-existent token

### DIFF
--- a/.changelog/16105.txt
+++ b/.changelog/16105.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+acl errors: Delete and get requests now return descriptive errors when the specified resource cannot be found. Other ACL request errors provide more information about when a resource is missing.
+```

--- a/.changelog/16105.txt
+++ b/.changelog/16105.txt
@@ -5,7 +5,7 @@ acl errors: Delete and get requests now return descriptive errors when the speci
 3. Read Token/Policy/Role endpoints now return 404 when the resource cannot be found.
   - New error format: "Cannot find * to delete"
 4. Logout now returns a 401 error when the supplied token cannot be found
-  - New error format: "Token supplied with request not found"
+  - New error format: "Supplied token does not exist"
 5. Token Self endpoint now returns 404 when the token cannot be found.
   - New error format: "Supplied token does not exist"
 ```

--- a/.changelog/16105.txt
+++ b/.changelog/16105.txt
@@ -1,3 +1,11 @@
 ```release-note:breaking-change
-acl errors: Delete and get requests now return descriptive errors when the specified resource cannot be found. Other ACL request errors provide more information about when a resource is missing.
+acl errors: Delete and get requests now return descriptive errors when the specified resource cannot be found. Other ACL request errors provide more information about when a resource is missing. Add error for when the ACL system has not been bootstrapped.
+1. Delete Token/Policy/AuthMethod/Role/BindingRule endpoints now return 404 when the resource cannot be found.
+  - New error formats: "Requested * does not exist: ACL not found", "* not found in namespace $NAMESPACE: ACL not found"
+3. Read Token/Policy/Role endpoints now return 404 when the resource cannot be found.
+  - New error format: "Cannot find * to delete"
+4. Logout now returns a 401 error when the supplied token cannot be found
+  - New error format: "Token supplied with request not found"
+5. Token Self endpoint now returns 404 when the token cannot be found.
+  - New error format: "Supplied token does not exist"
 ```

--- a/acl/errors.go
+++ b/acl/errors.go
@@ -143,7 +143,7 @@ func extractAccessorID(authz interface{}) string {
 
 func ACLResourceNotExistError(resourceType string, entMeta EnterpriseMeta) error {
 	if ns := entMeta.NamespaceOrEmpty(); ns != "" {
-		return fmt.Errorf("%s not found in namespace %s: %w", resourceType, ns, ErrNotFound)
+		return fmt.Errorf("Requested %s not found in namespace %s: %w", resourceType, ns, ErrNotFound)
 	}
-	return fmt.Errorf("%s does not exist: %w", resourceType, ErrNotFound)
+	return fmt.Errorf("Requested %s does not exist: %w", resourceType, ErrNotFound)
 }

--- a/acl/errors.go
+++ b/acl/errors.go
@@ -140,3 +140,10 @@ func extractAccessorID(authz interface{}) string {
 	}
 	return accessor
 }
+
+func ACLResourceNotExistError(resourceType string, entMeta EnterpriseMeta) error {
+	if ns := entMeta.NamespaceOrEmpty(); ns != "" {
+		return fmt.Errorf("%s not found in namespace %s: %w", resourceType, ns, ErrNotFound)
+	}
+	return fmt.Errorf("%s does not exist: %w", resourceType, ErrNotFound)
+}

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -393,7 +393,7 @@ func (s *HTTPHandlers) ACLTokenGet(resp http.ResponseWriter, req *http.Request, 
 	}
 
 	if out.Token == nil {
-		return nil, acl.ErrNotFound
+		return nil, fmt.Errorf("token does not exist: %w", acl.ErrNotFound)
 	}
 
 	if args.Expanded {

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -1014,7 +1014,7 @@ func (s *HTTPHandlers) ACLLogout(resp http.ResponseWriter, req *http.Request) (i
 	s.parseToken(req, &args.Token)
 
 	if args.Token == "" {
-		return nil, HTTPError{StatusCode: http.StatusUnauthorized, Reason: "Token supplied with request not found"}
+		return nil, HTTPError{StatusCode: http.StatusUnauthorized, Reason: "Supplied token does not exist"}
 	}
 
 	var ignored bool

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -169,11 +169,8 @@ func (s *HTTPHandlers) ACLPolicyRead(resp http.ResponseWriter, req *http.Request
 	if out.Policy == nil {
 		// if no error was returned above, the policy does not exist
 		resp.WriteHeader(http.StatusNotFound)
-		if ns := args.EnterpriseMeta.NamespaceOrEmpty(); ns != "" {
-			msg := fmt.Sprintf("Requested policy not found in namespace %s", ns)
-			return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: msg}
-		}
-		return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: "Requested policy does not exist"}
+		msg := acl.ACLResourceNotExistError("policy", args.EnterpriseMeta)
+		return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: msg.Error()}
 	}
 
 	return out.Policy, nil
@@ -408,11 +405,8 @@ func (s *HTTPHandlers) ACLTokenGet(resp http.ResponseWriter, req *http.Request, 
 	if out.Token == nil {
 		// if no error was returned above, the token does not exist
 		resp.WriteHeader(http.StatusNotFound)
-		if ns := args.EnterpriseMeta.NamespaceOrEmpty(); ns != "" {
-			msg := fmt.Sprintf("Requested token not found in namespace %s", ns)
-			return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: msg}
-		}
-		return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: "Requested token does not exist"}
+		msg := acl.ACLResourceNotExistError("token", args.EnterpriseMeta)
+		return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: msg.Error()}
 	}
 
 	if args.Expanded {
@@ -612,11 +606,8 @@ func (s *HTTPHandlers) ACLRoleRead(resp http.ResponseWriter, req *http.Request, 
 	if out.Role == nil {
 		// if not permission denied error is returned above, role does not exist
 		resp.WriteHeader(http.StatusNotFound)
-		if ns := args.EnterpriseMeta.NamespaceOrEmpty(); ns != "" {
-			msg := fmt.Sprintf("Requested role not found in namespace %s", ns)
-			return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: msg}
-		}
-		return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: "Requested role does not exist"}
+		msg := acl.ACLResourceNotExistError("role", args.EnterpriseMeta)
+		return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: msg.Error()}
 	}
 
 	return out.Role, nil
@@ -769,11 +760,8 @@ func (s *HTTPHandlers) ACLBindingRuleRead(resp http.ResponseWriter, req *http.Re
 	if out.BindingRule == nil {
 		// if no error was returned above, the binding rule does not exist
 		resp.WriteHeader(http.StatusNotFound)
-		if ns := args.EnterpriseMeta.NamespaceOrEmpty(); ns != "" {
-			msg := fmt.Sprintf("Requested binding rule not found in namespace %s", ns)
-			return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: msg}
-		}
-		return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: "Requested binding rule does not exist"}
+		msg := acl.ACLResourceNotExistError("binding rule", args.EnterpriseMeta)
+		return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: msg.Error()}
 	}
 
 	return out.BindingRule, nil
@@ -921,11 +909,8 @@ func (s *HTTPHandlers) ACLAuthMethodRead(resp http.ResponseWriter, req *http.Req
 	if out.AuthMethod == nil {
 		// if no error was returned above, the auth method does not exist
 		resp.WriteHeader(http.StatusNotFound)
-		if ns := args.EnterpriseMeta.NamespaceOrEmpty(); ns != "" {
-			msg := fmt.Sprintf("Requested auth method not found in namespace %s", ns)
-			return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: msg}
-		}
-		return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: "Requested auth method does not exist"}
+		msg := acl.ACLResourceNotExistError("auth method", args.EnterpriseMeta)
+		return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: msg.Error()}
 	}
 
 	fixupAuthMethodConfig(out.AuthMethod)

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -2010,7 +2010,8 @@ func TestACLEndpoint_LoginLogout_jwt(t *testing.T) {
 				// make the request
 				_, err = a.srv.ACLTokenCRUD(resp, req)
 				require.Error(t, err)
-				require.Equal(t, acl.ErrNotFound, err)
+				require.ErrorIs(t, err, acl.ErrNotFound)
+				require.ErrorContains(t, err, "token does not exist")
 			})
 		})
 	}

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1845,7 +1845,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCRUD(resp, req)
 			require.Error(t, err)
-			require.ErrorContains(t, err, "Requested token does not exist")
+			require.ErrorContains(t, err, "token does not exist")
 		})
 	})
 }
@@ -2010,7 +2010,7 @@ func TestACLEndpoint_LoginLogout_jwt(t *testing.T) {
 				// make the request
 				_, err = a.srv.ACLTokenCRUD(resp, req)
 				require.Error(t, err)
-				require.ErrorContains(t, err, "Requested token does not exist")
+				require.ErrorContains(t, err, "token does not exist")
 			})
 		})
 	}

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1845,7 +1845,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCRUD(resp, req)
 			require.Error(t, err)
-			require.ErrorContains(t, err, "token does not exist")
+			require.ErrorContains(t, err, acl.ErrNotFound.Error())
 		})
 	})
 }
@@ -2010,7 +2010,7 @@ func TestACLEndpoint_LoginLogout_jwt(t *testing.T) {
 				// make the request
 				_, err = a.srv.ACLTokenCRUD(resp, req)
 				require.Error(t, err)
-				require.ErrorContains(t, err, "token does not exist")
+				require.ErrorContains(t, err, acl.ErrNotFound.Error())
 			})
 		})
 	}

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1845,7 +1845,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLTokenCRUD(resp, req)
 			require.Error(t, err)
-			require.True(t, acl.IsErrNotFound(err), err.Error())
+			require.ErrorContains(t, err, "Requested token does not exist")
 		})
 	})
 }
@@ -2010,8 +2010,7 @@ func TestACLEndpoint_LoginLogout_jwt(t *testing.T) {
 				// make the request
 				_, err = a.srv.ACLTokenCRUD(resp, req)
 				require.Error(t, err)
-				require.ErrorIs(t, err, acl.ErrNotFound)
-				require.ErrorContains(t, err, "token does not exist")
+				require.ErrorContains(t, err, "Requested token does not exist")
 			})
 		})
 	}

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -754,8 +754,8 @@ func TestACLReplication_TokensRedacted(t *testing.T) {
 			QueryOptions: structs.QueryOptions{Token: aclfilter.RedactedToken},
 		}
 		err := s2.RPC(context.Background(), "ACL.TokenRead", &req, &tokenResp)
-		// its not an error for the secret to not be found.
-		require.NoError(r, err)
+		require.Error(r, err)
+		require.ErrorContains(r, err, "token does not exist")
 		require.Nil(r, tokenResp.Token)
 
 		var status structs.ACLReplicationStatus

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -150,7 +150,12 @@ func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdenti
 		return true, aclToken, nil
 	}
 
-	return s.InPrimaryDatacenter() || index > 0, nil, acl.ErrNotFound
+	defaultErr := acl.ErrNotFound
+	canBootstrap, _, _ := s.fsm.State().CanBootstrapACLToken()
+	if canBootstrap {
+		defaultErr = fmt.Errorf("ACL system must be bootstrapped: %w", defaultErr)
+	}
+	return s.InPrimaryDatacenter() || index > 0, nil, defaultErr
 }
 
 func (s *serverACLResolverBackend) ResolvePolicyFromID(policyID string) (bool, *structs.ACLPolicy, error) {

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -153,7 +153,7 @@ func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdenti
 	defaultErr := acl.ErrNotFound
 	canBootstrap, _, _ := s.fsm.State().CanBootstrapACLToken()
 	if canBootstrap {
-		defaultErr = fmt.Errorf("ACL system must be bootstrapped: %w", defaultErr)
+		defaultErr = fmt.Errorf("ACL system must be bootstrapped before making any requests that require authorization: %w", defaultErr)
 	}
 	return s.InPrimaryDatacenter() || index > 0, nil, defaultErr
 }

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -142,7 +142,6 @@ func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdenti
 	if !s.InPrimaryDatacenter() && !s.config.ACLTokenReplication {
 		return false, nil, nil
 	}
-
 	index, aclToken, err := s.fsm.State().ACLTokenGetBySecret(nil, token, nil)
 	if err != nil {
 		return true, nil, err

--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -95,10 +95,9 @@ func (s *Store) ACLBootstrap(idx, resetIndex uint64, token *structs.ACLToken) er
 	if err := aclTokenSetTxn(tx, idx, token, ACLTokenSetOptions{}); err != nil {
 		return fmt.Errorf("failed inserting bootstrap token: %v", err)
 	}
-	// SKP: debug
-	/*	if err := tx.Insert(tableIndex, &IndexEntry{"acl-token-bootstrap", idx}); err != nil {
+	if err := tx.Insert(tableIndex, &IndexEntry{"acl-token-bootstrap", idx}); err != nil {
 		return fmt.Errorf("failed to mark ACL bootstrapping as complete: %v", err)
-	}*/
+	}
 	return tx.Commit()
 }
 

--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -95,9 +95,10 @@ func (s *Store) ACLBootstrap(idx, resetIndex uint64, token *structs.ACLToken) er
 	if err := aclTokenSetTxn(tx, idx, token, ACLTokenSetOptions{}); err != nil {
 		return fmt.Errorf("failed inserting bootstrap token: %v", err)
 	}
-	if err := tx.Insert(tableIndex, &IndexEntry{"acl-token-bootstrap", idx}); err != nil {
+	// SKP: debug
+	/*	if err := tx.Insert(tableIndex, &IndexEntry{"acl-token-bootstrap", idx}); err != nil {
 		return fmt.Errorf("failed to mark ACL bootstrapping as complete: %v", err)
-	}
+	}*/
 	return tx.Commit()
 }
 

--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -289,6 +289,28 @@ func prepTokenPoliciesInPartition(t *testing.T, acl *ACL, partition string) (pol
 	return
 }
 
+func TestAPI_ACLBootstrap(t *testing.T) {
+	t.Parallel()
+	c, s := makeNonBootstrappedACLClient(t)
+	defer s.Stop()
+
+	acl := c.ACL()
+	s.WaitForLeader(t)
+
+	// not bootstrapped
+	_, _, err := acl.TokenList(nil)
+	require.EqualError(t, err, "Unexpected response code: 403 (ACL system must be bootstrapped: ACL not found)")
+	// bootstrap
+	mgmtTok, _, err := acl.Bootstrap()
+	require.NoError(t, err)
+	// bootstrapped
+	acl.c.config.Token = mgmtTok.SecretID
+	toks, _, err := acl.TokenList(nil)
+	require.NoError(t, err)
+	// management and anonymous should be only tokens
+	require.Len(t, toks, 2)
+}
+
 func TestAPI_ACLToken_CreateReadDelete(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)

--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -299,7 +299,7 @@ func TestAPI_ACLBootstrap(t *testing.T) {
 
 	// not bootstrapped
 	_, _, err := acl.TokenList(nil)
-	require.EqualError(t, err, "Unexpected response code: 403 (ACL system must be bootstrapped: ACL not found)")
+	require.EqualError(t, err, "Unexpected response code: 403 (ACL system must be bootstrapped before making any requests that require authorization: ACL not found)")
 	// bootstrap
 	mgmtTok, _, err := acl.Bootstrap()
 	require.NoError(t, err)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -50,6 +50,19 @@ func makeACLClient(t *testing.T) (*Client, *testutil.TestServer) {
 	})
 }
 
+func makeNonBootstrappedACLClient(t *testing.T) (*Client, *testutil.TestServer) {
+	return makeClientWithConfig(t,
+		func(clientConfig *Config) {
+			clientConfig.Token = "root"
+		},
+		func(serverConfig *testutil.TestServerConfig) {
+			serverConfig.PrimaryDatacenter = "dc1"
+			serverConfig.ACL.Enabled = true
+			serverConfig.ACL.DefaultPolicy = "deny"
+			serverConfig.Bootstrap = true
+		})
+}
+
 func makeClientWithCA(t *testing.T) (*Client, *testutil.TestServer) {
 	return makeClientWithConfig(t,
 		func(c *Config) {

--- a/command/acl/acl_helpers.go
+++ b/command/acl/acl_helpers.go
@@ -163,7 +163,7 @@ func GetBindingRuleIDFromPartial(client *api.Client, partialID string) (string, 
 	}
 
 	if ruleID == "" {
-		return "", fmt.Errorf("No such rule ID with prefix: %s", partialID)
+		return "", fmt.Errorf("no such rule ID with prefix: %s: %w", partialID, acl.ErrNotFound)
 	}
 
 	return ruleID, nil

--- a/command/acl/authmethod/delete/authmethod_delete_test.go
+++ b/command/acl/authmethod/delete/authmethod_delete_test.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/consul/agent"
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testrpc"
 
 	// activate testing auth method
 	_ "github.com/hashicorp/consul/agent/consul/authmethod/testauth"
@@ -70,12 +71,11 @@ func TestAuthMethodDeleteCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
-		require.Empty(t, ui.ErrorWriter.String())
+		require.Equal(t, 1, code)
+		require.Contains(t, ui.ErrorWriter.String(), "404 (Cannot find auth method to delete)")
 
 		output := ui.OutputWriter.String()
-		require.Contains(t, output, fmt.Sprintf("deleted successfully"))
-		require.Contains(t, output, "notfound")
+		require.Empty(t, output)
 	})
 
 	createAuthMethod := func(t *testing.T) string {

--- a/command/acl/bindingrule/delete/bindingrule_delete_test.go
+++ b/command/acl/bindingrule/delete/bindingrule_delete_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/require"
 
 	// activate testing auth method
 	_ "github.com/hashicorp/consul/agent/consul/authmethod/testauth"
@@ -179,5 +180,23 @@ func TestBindingRuleDeleteCommand(t *testing.T) {
 		code := cmd.Run(args)
 		require.Equal(t, code, 1)
 		require.Contains(t, ui.ErrorWriter.String(), "Error determining binding rule ID")
+	})
+
+	t.Run("delete notfound", func(t *testing.T) {
+		ui := cli.NewMockUi()
+		cmd := New(ui)
+
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-token=root",
+			"-id=notfound",
+		}
+
+		code := cmd.Run(args)
+		require.Equal(t, 1, code)
+		require.Contains(t, ui.ErrorWriter.String(), "Error determining binding rule ID: no such rule ID with prefix: notfound")
+
+		output := ui.OutputWriter.String()
+		require.Empty(t, output)
 	})
 }

--- a/command/acl/policy/delete/policy_delete_test.go
+++ b/command/acl/policy/delete/policy_delete_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPolicyDeleteCommand_noTabs(t *testing.T) {
@@ -69,5 +70,5 @@ func TestPolicyDeleteCommand(t *testing.T) {
 		policy.ID,
 		&api.QueryOptions{Token: "root"},
 	)
-	assert.EqualError(t, err, "Unexpected response code: 403 (ACL not found)")
+	assert.EqualError(t, err, "Unexpected response code: 404 (Requested policy does not exist)")
 }

--- a/command/acl/policy/delete/policy_delete_test.go
+++ b/command/acl/policy/delete/policy_delete_test.go
@@ -70,5 +70,5 @@ func TestPolicyDeleteCommand(t *testing.T) {
 		policy.ID,
 		&api.QueryOptions{Token: "root"},
 	)
-	assert.EqualError(t, err, "Unexpected response code: 404 (Requested policy does not exist)")
+	assert.EqualError(t, err, "Unexpected response code: 404 (Requested policy does not exist: ACL not found)")
 }

--- a/command/acl/token/delete/token_delete_test.go
+++ b/command/acl/token/delete/token_delete_test.go
@@ -70,5 +70,6 @@ func TestTokenDeleteCommand(t *testing.T) {
 		token.AccessorID,
 		&api.QueryOptions{Token: "root"},
 	)
-	assert.EqualError(t, err, "Unexpected response code: 403 (token does not exist: ACL not found)")
+	assert.ErrorContains(t, err, "Unexpected response code: 403")
+	assert.ErrorContains(t, err, "ACL not found")
 }

--- a/command/acl/token/delete/token_delete_test.go
+++ b/command/acl/token/delete/token_delete_test.go
@@ -70,5 +70,5 @@ func TestTokenDeleteCommand(t *testing.T) {
 		token.AccessorID,
 		&api.QueryOptions{Token: "root"},
 	)
-	assert.EqualError(t, err, "Unexpected response code: 403 (ACL not found)")
+	assert.EqualError(t, err, "Unexpected response code: 403 (token does not exist: ACL not found)")
 }

--- a/command/logout/logout_test.go
+++ b/command/logout/logout_test.go
@@ -55,7 +55,7 @@ func TestLogoutCommand(t *testing.T) {
 
 		code := cmd.Run(args)
 		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
-		require.Contains(t, ui.ErrorWriter.String(), "403 (ACL not found)")
+		require.Contains(t, ui.ErrorWriter.String(), "401 (Token supplied with request not found)")
 	})
 
 	t.Run("logout of deleted token", func(t *testing.T) {
@@ -185,7 +185,7 @@ func TestLogoutCommand_k8s(t *testing.T) {
 
 		code := cmd.Run(args)
 		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
-		require.Contains(t, ui.ErrorWriter.String(), "403 (ACL not found)")
+		require.Contains(t, ui.ErrorWriter.String(), "401 (Token supplied with request not found)")
 	})
 
 	t.Run("logout of deleted token", func(t *testing.T) {

--- a/command/logout/logout_test.go
+++ b/command/logout/logout_test.go
@@ -55,7 +55,7 @@ func TestLogoutCommand(t *testing.T) {
 
 		code := cmd.Run(args)
 		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
-		require.Contains(t, ui.ErrorWriter.String(), "401 (Token supplied with request not found)")
+		require.Contains(t, ui.ErrorWriter.String(), "401 (Supplied token does not exist)")
 	})
 
 	t.Run("logout of deleted token", func(t *testing.T) {
@@ -185,7 +185,7 @@ func TestLogoutCommand_k8s(t *testing.T) {
 
 		code := cmd.Run(args)
 		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
-		require.Contains(t, ui.ErrorWriter.String(), "401 (Token supplied with request not found)")
+		require.Contains(t, ui.ErrorWriter.String(), "401 (Supplied token does not exist)")
 	})
 
 	t.Run("logout of deleted token", func(t *testing.T) {


### PR DESCRIPTION
### Description
These errors provide helpful information in the case where the ACL system has not been bootstrapped, when a token does not exist, or when it does not exist in a particular namespace.

Functionality changes
Useful errors are now returned when:
- trying to get a specific resource (specified by ID) and failing because it does not exist
- trying to delete a resource that does not exist

Table of new API error messages:
| Message | Appears when | Previously |
|----|----|----|
| Requested * not found in namespace *: ACL not found |  ACL * Read / Get (namespace) | No error, return nothing |
| Requested * does not exist: ACL not found | ACL * Read / Get | No error, return nothing |
| Cannot find * to delete | ACL * Delete | Policy / Token: “ACL Not Found”, Role / Rule / AuthMethod: No error, return ok |
| Supplied token does not exist | ACLTokenSelf, ACLLogout | “ACL Not Found” |
| ACL system must be bootstrapped before making any requests that require authorization: ACL not found | ACL Bootstrap | “ACL not found” |

### Testing & Reproduction steps
Locally: spin up consul server cluster with ACLs enabled. 

- Try to interact with ACL system before bootstrapping has completed:
  - sample error, logs: `"leaf cert watch returned an error: rpc error making call: ACL system must be bootstrapped before making any requests that require authorization: ACL not found"`
  - sample error, CLI: `Failed to create new token: Unexpected response code: 403 (ACL system must be bootstrapped before making any requests that require authorization: ACL not found)`

- Delete a token and then try to read/update/clone it:
  - sample error, logs: `[ERROR] agent.http: Request error: method=GET url=/v1/acl/token/XXXX from=address:port error="Permission denied: token does not exist: ACL not found"`
  - sample error, CLI: `Error reading token "XXXXX": Unexpected response code: 401 (Requested token does not exist: ACL not found)`


### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
