### PR TITLE
improvement: prevent filter being added twice from any enovy extension

### DIFF
--- a/agent/envoyextensions/extensioncommon/basic_envoy_extender.go
+++ b/agent/envoyextensions/extensioncommon/basic_envoy_extender.go
@@ -169,11 +169,12 @@ func (b BasicEnvoyExtender) patchTerminatingGatewayListener(config *RuntimeConfi
 			if err != nil {
 				resultErr = multierror.Append(resultErr, fmt.Errorf("error patching listener filter: %w", err))
 				filters = append(filters, filter)
+				continue
 			}
 			if ok {
 				filters = append(filters, newFilter)
 				patched = true
-			} else if err == nil { // NOTE: this is to prevent filter being added twice
+			} else {
 				filters = append(filters, filter)
 			}
 		}
@@ -217,12 +218,13 @@ func (b BasicEnvoyExtender) patchConnectProxyListener(config *RuntimeConfig, l *
 			if err != nil {
 				resultErr = multierror.Append(resultErr, fmt.Errorf("error patching listener filter: %w", err))
 				filters = append(filters, filter)
+				continue
 			}
 
 			if ok {
 				filters = append(filters, newFilter)
 				patched = true
-			} else if err == nil { // NOTE: this is to prevent filter being added twice
+			} else {
 				filters = append(filters, filter)
 			}
 		}
@@ -251,12 +253,13 @@ func (b BasicEnvoyExtender) patchTProxyListener(config *RuntimeConfig, l *envoy_
 			if err != nil {
 				resultErr = multierror.Append(resultErr, fmt.Errorf("error patching listener filter: %w", err))
 				filters = append(filters, filter)
+				continue
 			}
 
 			if ok {
 				filters = append(filters, newFilter)
 				patched = true
-			} else if err == nil { // NOTE: this is to prevent filter being added twice
+			} else {
 				filters = append(filters, filter)
 			}
 		}

--- a/agent/envoyextensions/extensioncommon/basic_envoy_extender.go
+++ b/agent/envoyextensions/extensioncommon/basic_envoy_extender.go
@@ -173,6 +173,8 @@ func (b BasicEnvoyExtender) patchTerminatingGatewayListener(config *RuntimeConfi
 			if ok {
 				filters = append(filters, newFilter)
 				patched = true
+			} else if err == nil { // NOTE: this is to prevent filter being added twice
+				filters = append(filters, filter)
 			}
 		}
 		filterChain.Filters = filters
@@ -220,6 +222,8 @@ func (b BasicEnvoyExtender) patchConnectProxyListener(config *RuntimeConfig, l *
 			if ok {
 				filters = append(filters, newFilter)
 				patched = true
+			} else if err == nil { // NOTE: this is to prevent filter being added twice
+				filters = append(filters, filter)
 			}
 		}
 		filterChain.Filters = filters
@@ -252,6 +256,8 @@ func (b BasicEnvoyExtender) patchTProxyListener(config *RuntimeConfig, l *envoy_
 			if ok {
 				filters = append(filters, newFilter)
 				patched = true
+			} else if err == nil { // NOTE: this is to prevent filter being added twice
+				filters = append(filters, filter)
 			}
 		}
 		filterChain.Filters = filters

--- a/test/integration/connect/envoy/case-lua/setup.sh
+++ b/test/integration/connect/envoy/case-lua/setup.sh
@@ -27,6 +27,31 @@ end
 ]
 '
 
+upsert_config_entry primary '
+Kind = "service-defaults"
+Name = "s1"
+Protocol = "tcp"
+EnvoyExtensions = [
+  {
+    Name = "builtin/lua",
+    Arguments = {
+      ProxyType = "connect-proxy"
+      Listener = "inbound"
+      Script = <<-EOF
+function envoy_on_request(request_handle)
+  meta = request_handle:streamInfo():dynamicMetadata()
+  m = meta:get("consul")
+  request_handle:headers():add("x-consul-service", m["service"])
+  request_handle:headers():add("x-consul-namespace", m["namespace"])
+  request_handle:headers():add("x-consul-datacenter", m["datacenter"])
+  request_handle:headers():add("x-consul-trust-domain", m["trust-domain"])
+end
+      EOF
+    }
+  }
+]
+'
+
 register_services primary
 
 gen_envoy_bootstrap s1 19000 primary

--- a/test/integration/connect/envoy/case-lua/verify.bats
+++ b/test/integration/connect/envoy/case-lua/verify.bats
@@ -37,3 +37,13 @@ load helpers
   echo "$output" | grep -E "X-Consul-Namespace: default"
   echo "$output" | grep -E "X-Consul-Trust-Domain: (\w+-){4}\w+.consul"
 }
+
+@test "s1(tcp) proxy should not be changed by lua extension" {
+  TCP_FILTERS=$(get_envoy_listener_filters localhost:19000)
+  PUB=$(echo "$TCP_FILTERS" | grep -E "^public_listener:" | cut -f 2 -d ' ')
+
+  echo "TCP_FILTERS = $TCP_FILTERS"
+  echo "PUB = $PUB"
+
+  [ "$PUB" = "envoy.filters.network.rbac,envoy.filters.network.tcp_proxy" ]
+}


### PR DESCRIPTION
### Description
This is to prevent any potential bug from any extension 

(1) may add filter twice, e.g., the Patch method of an extension both return some error and `ok = false`. In this case, filter will be added twice.

(2) doesn't change the filter and will result in err == nil and ok == false. In this case, original filter should be added back to the filter chain

### Testing & Reproduction steps

### Links

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
