### PR TITLE
docs(service-defaults): upstream overrides for peered services

### DIFF
--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -317,7 +317,7 @@ Note that the Kubernetes example does not include a `partition` field. Configura
           name: 'namespace',
           enterprise: true,
           description:
-            'Must be set to `default`. If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for additional information.',
+            'Must be set to `default`. If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/consul/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for additional information.',
         },
       ],
       hcl: false,
@@ -326,7 +326,7 @@ Note that the Kubernetes example does not include a `partition` field. Configura
       name: 'TransparentProxy',
       type: 'TransparentProxyConfig: <optional>',
       description:
-        'Controls configuration specific to proxies in `transparent` [mode](/docs/connect/config-entries/service-defaults#mode). Added in v1.10.0.',
+        'Controls configuration specific to proxies in `transparent` [mode](/consul/docs/connect/config-entries/service-defaults#mode). Added in v1.10.0.',
       children: [
         {
           name: 'MeshDestinationsOnly',

--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -317,7 +317,7 @@ Note that the Kubernetes example does not include a `partition` field. Configura
           name: 'namespace',
           enterprise: true,
           description:
-            'Must be set to `default`. If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/consul/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for additional information.',
+            'Must be set to `default`. If running Consul Open Source, the namespace is ignored (see [Kubernetes Namespaces in Consul OSS](/docs/k8s/crds#consul-oss)). If running Consul Enterprise see [Kubernetes Namespaces in Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for additional information.',
         },
       ],
       hcl: false,
@@ -326,7 +326,7 @@ Note that the Kubernetes example does not include a `partition` field. Configura
       name: 'TransparentProxy',
       type: 'TransparentProxyConfig: <optional>',
       description:
-        'Controls configuration specific to proxies in `transparent` [mode](/consul/docs/connect/config-entries/service-defaults#mode). Added in v1.10.0.',
+        'Controls configuration specific to proxies in `transparent` [mode](/docs/connect/config-entries/service-defaults#mode). Added in v1.10.0.',
       children: [
         {
           name: 'MeshDestinationsOnly',

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -425,11 +425,11 @@ represents a location outside the Consul cluster. They can be dialed directly wh
               name: 'Peer',
               type: 'string: ""',
               description: 
-                `The name of the peer containing the upstream. This should not be set to the wildcard specifier \`*\`.<br><br>
-                    NOTE: If the \`peer\` field is not set in any of \`Overrides\`, an override applies to peered services with the same [\`name\`](/consul/docs/connect/config-entries/service-defaults#name) 
-                    regardless if this field is set. This maintains backward compatibility with Consul 1.14.0. 
-                    If any override has the \`peer\` field specified, this compatibility mode is disabled and each peered service must have it's own override.
-                    This compatibility mode will be removed in a future version of Consul.`,
+                `The name of the peer containing the upstream. Do not use a wildcard specifier ( \`*\`).<br><br>
+                    If the \`peer\` field is not set in any \`Overrides\` configuration, then Consul applies overrides to peered services with the same [\`name\`](/consul/docs/connect/config-entries/service-defaults#name). 
+                    This maintains backward compatibility with Consul 1.14.0. 
+                    If the \`peer\` field is specified in any override, then backward compatibility with Consul 1.14.0 is disabled. 
+                    As a result, each peered service must have a separate override configuration if desired.` ,
             },
             {
               name: 'Protocol',

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -426,7 +426,7 @@ represents a location outside the Consul cluster. They can be dialed directly wh
               type: 'string: ""',
               description: 
                 `The name of the peer containing the upstream. This should not be set to the wildcard specifier \`*\`.<br><br>
-                    NOTE: If the \`peer\` field is not set in any of \`Overrides\`, an override applies to peered services with the same [\`name\`](/docs/connect/config-entries/service-defaults#name) 
+                    NOTE: If the \`peer\` field is not set in any of \`Overrides\`, an override applies to peered services with the same [\`name\`](/consul/docs/connect/config-entries/service-defaults#name) 
                     regardless if this field is set. This maintains backward compatibility with Consul 1.14.0. 
                     If any override has the \`peer\` field specified, this compatibility mode is disabled and each peered service must have it's own override.
                     This compatibility mode will be removed in a future version of Consul.`,

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -422,6 +422,16 @@ represents a location outside the Consul cluster. They can be dialed directly wh
                 'The namespace of the upstream. This should not be set to the wildcard specifier `*`.',
             },
             {
+              name: 'Peer',
+              type: 'string: ""',
+              description: 
+                `The name of the peer containing the upstream. This should not be set to the wildcard specifier \`*\`.<br><br>
+                    NOTE: If the \`peer\` field is not set in any of \`Overrides\`, an override applies to peered services with the same [\`name\`](/docs/connect/config-entries/service-defaults#name) 
+                    regardless if this field is set. This maintains backward compatibility with Consul 1.14.0. 
+                    If any override has the \`peer\` field specified, this compatibility mode is disabled and each peered service must have it's own override.
+                    This compatibility mode will be removed in a future version of Consul.`,
+            },
+            {
               name: 'Protocol',
               type: 'string: ""',
               description: `The protocol for the upstream listener.<br><br>
@@ -433,6 +443,8 @@ represents a location outside the Consul cluster. They can be dialed directly wh
                     proxy upstream config will not fully enable some
                     [L7 features](/consul/docs/connect/l7-traffic).
                     It is supported here for backwards compatibility with Consul versions prior to 1.6.0.
+                    In addition, the \`protocol\` of a peered service cannot be overriden. Any value in 
+                    this field is ignored for peered services.
                   `,
             },
             {

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -89,9 +89,8 @@ In Consul v1.15 and higher:
 
 #### `service-defaults` Overrides for Upstream Peered Services
 
-In Consul 1.14.x, `service-defaults` upstream [`overrides`](/consul/docs/connect/config-entries/service-defaults#overrides) would apply to a both local and peered services as long as the `name` field matched.
-Consul 1.15.0 introduces a compatibility mode to maintain this behavior as long as [`peer`](/consul/docs/connect/config-entries/service-defaults#peer) is not set in any override.
-However, starting in Consul 1.16.0, peered services will require explicit overrides in `service-defaults` by specifying the [`peer`](/consul/docs/connect/config-entries/service-defaults#peer) field.
+In Consul 1.14.x, `service-defaults` upstream [`overrides`](/consul/docs/connect/config-entries/service-defaults#overrides) applies to both local and peered services as long as the `name` field matched.
+Consul 1.15.0 is backward compatible with 1.14 if the [`peer`](/consul/docs/connect/config-entries/service-defaults#peer) is not set in any override.
 We recommend converting any upstream peer service overrides as a 1.15.x post-upgrade step.
 
 Before Consul v1.15:

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -89,7 +89,7 @@ In Consul v1.15 and higher:
 
 #### `service-defaults` Overrides for Upstream Peered Services
 
-In Consul 1.14.x, `service-defaults` upstream [`overrides`](/consul/docs/connect/config-entries/service-defaults#overrides) applies to both local and peered services as long as the `name` field matched.
+In Consul 1.14.x, `service-defaults` upstream [`overrides`](/consul/docs/connect/config-entries/service-defaults#overrides) apply to both local and peered services as long as the `name` field matches.
 Consul 1.15.0 is backward compatible with 1.14 if the [`peer`](/consul/docs/connect/config-entries/service-defaults#peer) is not set in any override.
 We recommend converting any upstream peer service overrides as a 1.15.x post-upgrade step.
 

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -89,9 +89,9 @@ In Consul v1.15 and higher:
 
 #### `service-defaults` Overrides for Upstream Peered Services
 
-In Consul 1.14.x, `service-defaults` upstream [`overrides`](/docs/connect/config-entries/service-defaults#overrides) would apply to a both local and peered services as long as the `name` field matched.
-Consul 1.15.0 introduces a compatibility mode to maintain this behavior as long as [`peer`](/docs/connect/config-entries/service-defaults#peer) is not set in any override.
-However, starting in Consul 1.16.0, peered services will require explicit overrides in `service-defaults` by specifying the [`peer`](/docs/connect/config-entries/service-defaults#peer) field.
+In Consul 1.14.x, `service-defaults` upstream [`overrides`](/consul/docs/connect/config-entries/service-defaults#overrides) would apply to a both local and peered services as long as the `name` field matched.
+Consul 1.15.0 introduces a compatibility mode to maintain this behavior as long as [`peer`](/consul/docs/connect/config-entries/service-defaults#peer) is not set in any override.
+However, starting in Consul 1.16.0, peered services will require explicit overrides in `service-defaults` by specifying the [`peer`](/consul/docs/connect/config-entries/service-defaults#peer) field.
 We recommend converting any upstream peer service overrides as a 1.15.x post-upgrade step.
 
 Before Consul v1.15:

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -87,6 +87,55 @@ In Consul v1.15 and higher:
 
    </CodeBlockConfig>
 
+#### `service-defaults` Overrides for Upstream Peered Services
+
+In Consul 1.14.x, `service-defaults` upstream [`overrides`](/docs/connect/config-entries/service-defaults#overrides) would apply to a both local and peered services as long as the `name` field matched.
+Consul 1.15.0 introduces a compatibility mode to maintain this behavior as long as [`peer`](/docs/connect/config-entries/service-defaults#peer) is not set in any override.
+However, starting in Consul 1.16.0, peered services will require explicit overrides in `service-defaults` by specifying the [`peer`](/docs/connect/config-entries/service-defaults#peer) field.
+We recommend converting any upstream peer service overrides as a 1.15.x post-upgrade step.
+
+Before Consul v1.15:
+
+   <CodeBlockConfig>
+
+   ```hcl
+   Kind = "service-defaults"
+   Name = "<SERVICE_NAME>"
+   Protocol  = "http"
+   UpstreamConfig = {
+     Overrides = [
+       {
+          Name = foo      # Applies to local `foo` and any peered service `foo`
+       }
+     ]
+   }
+   ```
+
+   </CodeBlockConfig>
+
+In Consul v1.15 and higher:
+
+   <CodeBlockConfig>
+
+   ```hcl
+   Kind = "service-defaults"
+   Name = "<SERVICE_NAME>"
+   Protocol  = "http"
+   UpstreamConfig = {
+     Overrides = [
+       {
+          Name = foo  # Applies to local service `foo` 
+       },
+       {
+          Name = foo  # Applies to `foo` imported from peered cluster `bar`
+          Peer = bar
+       }
+     ]
+   }
+   ```
+
+   </CodeBlockConfig>
+
 ## Consul 1.14.x
 
 ### Service Mesh Compatibility


### PR DESCRIPTION
### Description
Docs for ##15956. Upstream overrides will require the `peer` field to work for peered services in 1.16. 
