### PR TITLE
Document how numRetries can't be set to 0

### DIFF
--- a/website/content/docs/connect/config-entries/service-router.mdx
+++ b/website/content/docs/connect/config-entries/service-router.mdx
@@ -701,8 +701,8 @@ spec:
       name: 'NumRetries',
       type: 'int: 1',
       description: {
-        hcl: 'The number of times to retry the request when a retryable result occurs. This cannot be set to 0 so if you wish to disable retries, unset all other retry settings (`RetryOnConnectFailure`, `RetryOn`, `RetryOnStatusCodes`)',
-        yaml: 'The number of times to retry the request when a retryable result occurs. This cannot be set to 0 so if you wish to disable retries, unset all other retry settings (`retryOnConnectFailure`, `retryOn`, `retryOnStatusCodes`)',
+        hcl: 'The number of times to retry the request when a retryable result occurs. You cannot set the value to `0`. To disable retries, unset all other retry settings (`RetryOnConnectFailure`, `RetryOn`, `RetryOnStatusCodes`)',
+        yaml: 'The number of times to retry the request when a retryable result occurs. You cannot set the value to `0`. To disable retries, unset all other retry settings (`retryOnConnectFailure`, `retryOn`, `retryOnStatusCodes`)',
       }
     },
     {

--- a/website/content/docs/connect/config-entries/service-router.mdx
+++ b/website/content/docs/connect/config-entries/service-router.mdx
@@ -699,9 +699,11 @@ spec:
     },
     {
       name: 'NumRetries',
-      type: 'int: 0',
-      description:
-        'The number of times to retry the request when a retryable result occurs.',
+      type: 'int: 1',
+      description: {
+        hcl: 'The number of times to retry the request when a retryable result occurs. This cannot be set to 0 so if you wish to disable retries, unset all other retry settings (`RetryOnConnectFailure`, `RetryOn`, `RetryOnStatusCodes`)',
+        yaml: 'The number of times to retry the request when a retryable result occurs. This cannot be set to 0 so if you wish to disable retries, unset all other retry settings (`retryOnConnectFailure`, `retryOn`, `retryOnStatusCodes`)',
+      }
     },
     {
       name: 'RetryOnConnectFailure',


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/11816 and fixes https://github.com/hashicorp/consul/issues/8516. See those issues for more details but tl;dr: envoy defaults num_retries to 1 and so if any other retry configs are set, then you'll get 1 retry. If you try setting our NumRetries to 0 we treat it as the zero value (because our struct doesn't have a pointer for that field) and so we leave it unset in the Envoy config which then results in it defaulting to 1.
