### PR TITLE
Set `codegen-tools` to be a dependency of `deep-copy`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -366,11 +366,7 @@ codegen-tools:
 	@$(SHELL) $(CURDIR)/build-support/scripts/devtools.sh -codegen
 
 .PHONY: deep-copy
-deep-copy:
-	@if [ -z "$(shell which deep-copy)" ]; then \
-		echo "deep-copy not found. Please run 'make codegen-tools' to install it." ; \
-		exit 1 ; \
-	fi
+deep-copy: codegen-tools
 	@$(SHELL) $(CURDIR)/agent/structs/deep-copy.sh
 	@$(SHELL) $(CURDIR)/agent/proxycfg/deep-copy.sh
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -367,6 +367,10 @@ codegen-tools:
 
 .PHONY: deep-copy
 deep-copy:
+	@if [ -z "$(shell which deep-copy)" ]; then \
+		echo "deep-copy not found. Please run 'make codegen-tools' to install it." ; \
+		exit 1 ; \
+	fi
 	@$(SHELL) $(CURDIR)/agent/structs/deep-copy.sh
 	@$(SHELL) $(CURDIR)/agent/proxycfg/deep-copy.sh
 


### PR DESCRIPTION
### Description

I just ran into this when running `deep-copy` for the first time. While it didn't take me too long to figure out, I did spend a minute figuring out what what wrong when the error I got was originally a bit esoteric (raised from the `./agent/structs/deep-copy.sh` script).

I thought I would save future devs the moments of confusion with a helpful error.

### Testing & Reproduction steps

Have `deep-copy` not installed (`rm $(which deep-copy)` works) then run `make deep-copy`.
You will get the error `deep-copy not found. Please run 'make codegen-tools' to install it.`

### PR Checklist

* ~[ ] updated test coverage~
* ~[ ] external facing docs updated~
* ~[ ] not a security concern~
