### PR TITLE
Discovery Chain Merging/Synthesizing for HTTP/TCPRoutes

### DIFF
--- a/agent/consul/discoverychain/gateway.go
+++ b/agent/consul/discoverychain/gateway.go
@@ -1,0 +1,181 @@
+package discoverychain
+
+import (
+	"fmt"
+	"hash/crc32"
+	"sort"
+	"strconv"
+
+	"github.com/hashicorp/consul/agent/configentry"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func hostsKey(hosts ...string) string {
+	sort.Strings(hosts)
+	hostsHash := crc32.NewIEEE()
+	for _, h := range hosts {
+		if _, err := hostsHash.Write([]byte(h)); err != nil {
+			continue
+		}
+	}
+	return strconv.FormatUint(uint64(hostsHash.Sum32()), 16)
+}
+
+type hostnameMatch struct {
+	match    structs.HTTPMatch
+	filters  structs.HTTPFilters
+	services []structs.HTTPService
+}
+
+type GatewayChainSynthesizer struct {
+	datacenter        string
+	gateway           *structs.APIGatewayConfigEntry
+	matchesByHostname map[string][]hostnameMatch
+	tcpRoutes         []structs.TCPRouteConfigEntry
+}
+
+func NewGatewayChainSynthesizer(datacenter string, gateway *structs.APIGatewayConfigEntry) *GatewayChainSynthesizer {
+	return &GatewayChainSynthesizer{
+		datacenter:        datacenter,
+		gateway:           gateway,
+		matchesByHostname: map[string][]hostnameMatch{},
+	}
+}
+
+// AddTCPRoute adds a TCPRoute to use in synthesizing a discovery chain
+func (l *GatewayChainSynthesizer) AddTCPRoute(route structs.TCPRouteConfigEntry) {
+	l.tcpRoutes = append(l.tcpRoutes, route)
+}
+
+// AddHTTPRoute takes a new route and flattens its rule matches out per hostname.
+// This is required since a single route can specify multiple hostnames, and a
+// single hostname can be specified in multiple routes. Routing for a given
+// hostname must behave based on the aggregate of all rules that apply to it.
+func (l *GatewayChainSynthesizer) AddHTTPRoute(route structs.HTTPRouteConfigEntry) {
+	for _, host := range route.Hostnames {
+		matches, ok := l.matchesByHostname[host]
+		if !ok {
+			matches = []hostnameMatch{}
+		}
+
+		for _, rule := range route.Rules {
+			// If a rule has no matches defined, add default match
+			if len(rule.Matches) == 0 {
+				rule.Matches = []structs.HTTPMatch{{
+					Path: structs.HTTPPathMatch{
+						Match: structs.HTTPPathMatchPrefix,
+						Value: "/",
+					},
+				}}
+			}
+
+			// Add all matches for this rule to the list for this hostname
+			for _, match := range rule.Matches {
+				matches = append(matches, hostnameMatch{
+					match:    match,
+					filters:  rule.Filters,
+					services: rule.Services,
+				})
+			}
+		}
+
+		l.matchesByHostname[host] = matches
+	}
+}
+
+// consolidateHTTPRoutes combines all rules into the shortest possible list of routes
+// with one route per hostname containing all rules for that hostname.
+func (l *GatewayChainSynthesizer) consolidateHTTPRoutes() []structs.HTTPRouteConfigEntry {
+	var routes []structs.HTTPRouteConfigEntry
+
+	for hostname, rules := range l.matchesByHostname {
+		// Create route for this hostname
+		route := structs.HTTPRouteConfigEntry{
+			Kind:           structs.HTTPRoute,
+			Name:           fmt.Sprintf("%s-%s", l.gateway.Name, hostsKey(hostname)),
+			Hostnames:      []string{hostname},
+			Rules:          make([]structs.HTTPRouteRule, 0, len(rules)),
+			Meta:           l.gateway.Meta,
+			EnterpriseMeta: l.gateway.EnterpriseMeta,
+		}
+
+		// Sort rules for this hostname in order of precedence
+		sort.SliceStable(rules, func(i, j int) bool {
+			return compareHTTPRules(rules[i].match, rules[j].match)
+		})
+
+		// Add all rules for this hostname
+		for _, rule := range rules {
+			route.Rules = append(route.Rules, structs.HTTPRouteRule{
+				Matches:  []structs.HTTPMatch{rule.match},
+				Filters:  rule.filters,
+				Services: rule.services,
+			})
+		}
+
+		routes = append(routes, route)
+	}
+
+	return routes
+}
+
+func (l *GatewayChainSynthesizer) synthesizeEntries() ([]structs.IngressService, *configentry.DiscoveryChainSet) {
+	services := []structs.IngressService{}
+	entries := configentry.NewDiscoveryChainSet()
+
+	for _, route := range l.consolidateHTTPRoutes() {
+		ingress, router, splitters, defaults := synthesizeHTTPRouteDiscoveryChain(route)
+		entries.AddRouters(router)
+		entries.AddSplitters(splitters...)
+		entries.AddServices(defaults...)
+		services = append(services, ingress)
+	}
+
+	for _, route := range l.tcpRoutes {
+		services = append(services, synthesizeTCPRouteDiscoveryChain(route)...)
+	}
+
+	return services, entries
+}
+
+// Synthesize assembles a synthetic discovery chain from multiple other discovery chains
+// that have StartNodes that are referenced by routers or splitters in the entries for the
+// given CompileRequest.
+//
+// This is currently used to help API gateways masquarade as ingress gateways
+// by providing a set of virtual config entries that change the routing behavior
+// to upstreams referenced in the given HTTPRoutes or TCPRoutes.
+func (l *GatewayChainSynthesizer) Synthesize(chain *structs.CompiledDiscoveryChain, extra ...*structs.CompiledDiscoveryChain) ([]structs.IngressService, *structs.CompiledDiscoveryChain, error) {
+	extra = append([]*structs.CompiledDiscoveryChain{chain}, extra...)
+
+	services, entries := l.synthesizeEntries()
+
+	if entries.IsEmpty() {
+		// we can't actually compile a discovery chain, i.e. we're using a TCPRoute-based listener, instead, just return the ingresses
+		// and the first pre-compiled discovery chain
+		return services, chain, nil
+	}
+
+	compiled, err := Compile(CompileRequest{
+		ServiceName:          l.gateway.Name,
+		EvaluateInNamespace:  l.gateway.NamespaceOrDefault(),
+		EvaluateInPartition:  l.gateway.PartitionOrDefault(),
+		EvaluateInDatacenter: l.datacenter,
+		Entries:              entries,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, c := range extra {
+		for id, target := range c.Targets {
+			compiled.Targets[id] = target
+		}
+		for id, node := range c.Nodes {
+			compiled.Nodes[id] = node
+		}
+		compiled.EnvoyExtensions = append(compiled.EnvoyExtensions, c.EnvoyExtensions...)
+	}
+
+	return services, compiled, nil
+}

--- a/agent/consul/discoverychain/gateway_httproute.go
+++ b/agent/consul/discoverychain/gateway_httproute.go
@@ -1,0 +1,276 @@
+package discoverychain
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// compareHTTPRules implements the non-hostname order of precedence for routes specified by the K8s Gateway API spec.
+// https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteRule
+//
+// Ordering prefers matches based on the largest number of:
+//
+//  1. characters in a matching non-wildcard hostname
+//  2. characters in a matching hostname
+//  3. characters in a matching path
+//  4. header matches
+//  5. query param matches
+//
+// The hostname-specific comparison (1+2) occur in Envoy outside of our control:
+// https://github.com/envoyproxy/envoy/blob/5c4d4bd957f9402eca80bef82e7cc3ae714e04b4/source/common/router/config_impl.cc#L1645-L1682
+func compareHTTPRules(ruleA, ruleB structs.HTTPMatch) bool {
+	if len(ruleA.Path.Value) != len(ruleB.Path.Value) {
+		return len(ruleA.Path.Value) > len(ruleB.Path.Value)
+	}
+	if len(ruleA.Headers) != len(ruleB.Headers) {
+		return len(ruleA.Headers) > len(ruleB.Headers)
+	}
+	return len(ruleA.Query) > len(ruleB.Query)
+}
+
+func httpServiceDefault(entry structs.ConfigEntry, meta map[string]string) *structs.ServiceConfigEntry {
+	return &structs.ServiceConfigEntry{
+		Kind:           structs.ServiceDefaults,
+		Name:           entry.GetName(),
+		Protocol:       "http",
+		Meta:           meta,
+		EnterpriseMeta: *entry.GetEnterpriseMeta(),
+	}
+}
+
+func synthesizeHTTPRouteDiscoveryChain(route structs.HTTPRouteConfigEntry) (structs.IngressService, *structs.ServiceRouterConfigEntry, []*structs.ServiceSplitterConfigEntry, []*structs.ServiceConfigEntry) {
+	meta := route.GetMeta()
+	splitters := []*structs.ServiceSplitterConfigEntry{}
+	defaults := []*structs.ServiceConfigEntry{}
+
+	router, splits := httpRouteToDiscoveryChain(route)
+	serviceDefault := httpServiceDefault(router, meta)
+	defaults = append(defaults, serviceDefault)
+	for _, split := range splits {
+		splitters = append(splitters, split)
+		if split.Name != serviceDefault.Name {
+			defaults = append(defaults, httpServiceDefault(split, meta))
+		}
+	}
+
+	ingress := structs.IngressService{
+		Name:           router.Name,
+		Hosts:          route.Hostnames,
+		Meta:           route.Meta,
+		EnterpriseMeta: route.EnterpriseMeta,
+	}
+
+	return ingress, router, splitters, defaults
+}
+
+func httpRouteToDiscoveryChain(route structs.HTTPRouteConfigEntry) (*structs.ServiceRouterConfigEntry, []*structs.ServiceSplitterConfigEntry) {
+	router := &structs.ServiceRouterConfigEntry{
+		Kind:           structs.ServiceRouter,
+		Name:           route.GetName(),
+		Meta:           route.GetMeta(),
+		EnterpriseMeta: route.EnterpriseMeta,
+	}
+	var splitters []*structs.ServiceSplitterConfigEntry
+
+	for idx, rule := range route.Rules {
+		modifier := httpRouteFiltersToServiceRouteHeaderModifier(rule.Filters.Headers)
+		prefixRewrite := httpRouteFiltersToDestinationPrefixRewrite(rule.Filters.URLRewrites)
+
+		var destination structs.ServiceRouteDestination
+		if len(rule.Services) == 1 {
+			// TODO open question: is there a use case where someone might want to set the rewrite to ""?
+			service := rule.Services[0]
+
+			servicePrefixRewrite := httpRouteFiltersToDestinationPrefixRewrite(service.Filters.URLRewrites)
+			if servicePrefixRewrite == "" {
+				servicePrefixRewrite = prefixRewrite
+			}
+			serviceModifier := httpRouteFiltersToServiceRouteHeaderModifier(service.Filters.Headers)
+			modifier.Add = mergeMaps(modifier.Add, serviceModifier.Add)
+			modifier.Set = mergeMaps(modifier.Set, serviceModifier.Set)
+			modifier.Remove = append(modifier.Remove, serviceModifier.Remove...)
+
+			destination.Service = service.Name
+			destination.Namespace = service.NamespaceOrDefault()
+			destination.Partition = service.PartitionOrDefault()
+			destination.PrefixRewrite = servicePrefixRewrite
+			destination.RequestHeaders = modifier
+		} else {
+			// create a virtual service to split
+			destination.Service = fmt.Sprintf("%s-%d", route.GetName(), idx)
+			destination.Namespace = route.NamespaceOrDefault()
+			destination.Partition = route.PartitionOrDefault()
+			destination.PrefixRewrite = prefixRewrite
+			destination.RequestHeaders = modifier
+
+			splitter := &structs.ServiceSplitterConfigEntry{
+				Kind:           structs.ServiceSplitter,
+				Name:           destination.Service,
+				Splits:         []structs.ServiceSplit{},
+				Meta:           route.GetMeta(),
+				EnterpriseMeta: route.EnterpriseMeta,
+			}
+
+			totalWeight := 0
+			for _, service := range rule.Services {
+				totalWeight += service.Weight
+			}
+
+			for _, service := range rule.Services {
+				if service.Weight == 0 {
+					continue
+				}
+
+				modifier := httpRouteFiltersToServiceRouteHeaderModifier(service.Filters.Headers)
+
+				weightPercentage := float32(service.Weight) / float32(totalWeight)
+				split := structs.ServiceSplit{
+					RequestHeaders: modifier,
+					Weight:         weightPercentage * 100,
+				}
+				split.Service = service.Name
+				split.Namespace = service.NamespaceOrDefault()
+				split.Partition = service.PartitionOrDefault()
+				splitter.Splits = append(splitter.Splits, split)
+			}
+			if len(splitter.Splits) > 0 {
+				splitters = append(splitters, splitter)
+			}
+		}
+
+		// for each match rule a ServiceRoute is created for the service-router
+		// if there are no rules a single route with the destination is set
+		if len(rule.Matches) == 0 {
+			router.Routes = append(router.Routes, structs.ServiceRoute{Destination: &destination})
+		}
+
+		for _, match := range rule.Matches {
+			router.Routes = append(router.Routes, structs.ServiceRoute{
+				Match:       &structs.ServiceRouteMatch{HTTP: httpRouteMatchToServiceRouteHTTPMatch(match)},
+				Destination: &destination,
+			})
+		}
+	}
+
+	return router, splitters
+}
+
+func httpRouteFiltersToDestinationPrefixRewrite(rewrites []structs.URLRewrite) string {
+	for _, rewrite := range rewrites {
+		if rewrite.Path != "" {
+			return rewrite.Path
+		}
+	}
+	return ""
+}
+
+// httpRouteFiltersToServiceRouteHeaderModifier will consolidate a list of HTTP filters
+// into a single set of header modifications for Consul to make as a request passes through.
+func httpRouteFiltersToServiceRouteHeaderModifier(filters []structs.HTTPHeaderFilter) *structs.HTTPHeaderModifiers {
+	modifier := &structs.HTTPHeaderModifiers{
+		Add: make(map[string]string),
+		Set: make(map[string]string),
+	}
+	for _, filter := range filters {
+		// If we have multiple filters specified, then we can potentially clobber
+		// "Add" and "Set" here -- as far as K8S gateway spec is concerned, this
+		// is all implementation-specific behavior and undefined by the spec.
+		modifier.Add = mergeMaps(modifier.Add, filter.Add)
+		modifier.Set = mergeMaps(modifier.Set, filter.Set)
+		modifier.Remove = append(modifier.Remove, filter.Remove...)
+	}
+	return modifier
+}
+
+func mergeMaps(a, b map[string]string) map[string]string {
+	for k, v := range b {
+		a[k] = v
+	}
+	return a
+}
+
+func httpRouteMatchToServiceRouteHTTPMatch(match structs.HTTPMatch) *structs.ServiceRouteHTTPMatch {
+	var consulMatch structs.ServiceRouteHTTPMatch
+	switch match.Path.Match {
+	case structs.HTTPPathMatchExact:
+		consulMatch.PathExact = match.Path.Value
+	case structs.HTTPPathMatchPrefix:
+		consulMatch.PathPrefix = match.Path.Value
+	case structs.HTTPPathMatchRegularExpression:
+		consulMatch.PathRegex = match.Path.Value
+	}
+
+	for _, header := range match.Headers {
+		switch header.Match {
+		case structs.HTTPHeaderMatchExact:
+			consulMatch.Header = append(consulMatch.Header, structs.ServiceRouteHTTPMatchHeader{
+				Name:  header.Name,
+				Exact: header.Value,
+			})
+		case structs.HTTPHeaderMatchPrefix:
+			consulMatch.Header = append(consulMatch.Header, structs.ServiceRouteHTTPMatchHeader{
+				Name:   header.Name,
+				Prefix: header.Value,
+			})
+		case structs.HTTPHeaderMatchSuffix:
+			consulMatch.Header = append(consulMatch.Header, structs.ServiceRouteHTTPMatchHeader{
+				Name:   header.Name,
+				Suffix: header.Value,
+			})
+		case structs.HTTPHeaderMatchPresent:
+			consulMatch.Header = append(consulMatch.Header, structs.ServiceRouteHTTPMatchHeader{
+				Name:    header.Name,
+				Present: true,
+			})
+		case structs.HTTPHeaderMatchRegularExpression:
+			consulMatch.Header = append(consulMatch.Header, structs.ServiceRouteHTTPMatchHeader{
+				Name:  header.Name,
+				Regex: header.Value,
+			})
+		}
+	}
+
+	for _, query := range match.Query {
+		switch query.Match {
+		case structs.HTTPQueryMatchExact:
+			consulMatch.QueryParam = append(consulMatch.QueryParam, structs.ServiceRouteHTTPMatchQueryParam{
+				Name:  query.Name,
+				Exact: query.Value,
+			})
+		case structs.HTTPQueryMatchPresent:
+			consulMatch.QueryParam = append(consulMatch.QueryParam, structs.ServiceRouteHTTPMatchQueryParam{
+				Name:    query.Name,
+				Present: true,
+			})
+		case structs.HTTPQueryMatchRegularExpression:
+			consulMatch.QueryParam = append(consulMatch.QueryParam, structs.ServiceRouteHTTPMatchQueryParam{
+				Name:  query.Name,
+				Regex: query.Value,
+			})
+		}
+	}
+
+	switch match.Method {
+	case structs.HTTPMatchMethodConnect:
+		consulMatch.Methods = append(consulMatch.Methods, "CONNECT")
+	case structs.HTTPMatchMethodDelete:
+		consulMatch.Methods = append(consulMatch.Methods, "DELETE")
+	case structs.HTTPMatchMethodGet:
+		consulMatch.Methods = append(consulMatch.Methods, "GET")
+	case structs.HTTPMatchMethodHead:
+		consulMatch.Methods = append(consulMatch.Methods, "HEAD")
+	case structs.HTTPMatchMethodOptions:
+		consulMatch.Methods = append(consulMatch.Methods, "OPTIONS")
+	case structs.HTTPMatchMethodPatch:
+		consulMatch.Methods = append(consulMatch.Methods, "PATCH")
+	case structs.HTTPMatchMethodPost:
+		consulMatch.Methods = append(consulMatch.Methods, "POST")
+	case structs.HTTPMatchMethodPut:
+		consulMatch.Methods = append(consulMatch.Methods, "PUT")
+	case structs.HTTPMatchMethodTrace:
+		consulMatch.Methods = append(consulMatch.Methods, "TRACE")
+	}
+
+	return &consulMatch
+}

--- a/agent/consul/discoverychain/gateway_tcproute.go
+++ b/agent/consul/discoverychain/gateway_tcproute.go
@@ -1,0 +1,17 @@
+package discoverychain
+
+import "github.com/hashicorp/consul/agent/structs"
+
+func synthesizeTCPRouteDiscoveryChain(route structs.TCPRouteConfigEntry) []structs.IngressService {
+	services := []structs.IngressService{}
+	for _, service := range route.Services {
+		ingress := structs.IngressService{
+			Name:           service.Name,
+			EnterpriseMeta: service.EnterpriseMeta,
+		}
+
+		services = append(services, ingress)
+	}
+
+	return services
+}

--- a/agent/proxycfg/proxycfg.deepcopy.go
+++ b/agent/proxycfg/proxycfg.deepcopy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/proto/pbpeering"
 	"github.com/hashicorp/consul/types"
+	"time"
 )
 
 // DeepCopy generates a deep copy of *ConfigSnapshot
@@ -227,6 +228,44 @@ func (o *configSnapshotAPIGateway) DeepCopy() *configSnapshotAPIGateway {
 	if o.TLSConfig.CipherSuites != nil {
 		cp.TLSConfig.CipherSuites = make([]types.TLSCipherSuite, len(o.TLSConfig.CipherSuites))
 		copy(cp.TLSConfig.CipherSuites, o.TLSConfig.CipherSuites)
+	}
+	if o.APIGatewayConfigEntry != nil {
+		cp.APIGatewayConfigEntry = new(structs.APIGatewayConfigEntry)
+		*cp.APIGatewayConfigEntry = *o.APIGatewayConfigEntry
+		if o.APIGatewayConfigEntry.Listeners != nil {
+			cp.APIGatewayConfigEntry.Listeners = make([]structs.APIGatewayListener, len(o.APIGatewayConfigEntry.Listeners))
+			copy(cp.APIGatewayConfigEntry.Listeners, o.APIGatewayConfigEntry.Listeners)
+			for i4 := range o.APIGatewayConfigEntry.Listeners {
+				if o.APIGatewayConfigEntry.Listeners[i4].TLS.Certificates != nil {
+					cp.APIGatewayConfigEntry.Listeners[i4].TLS.Certificates = make([]structs.ResourceReference, len(o.APIGatewayConfigEntry.Listeners[i4].TLS.Certificates))
+					copy(cp.APIGatewayConfigEntry.Listeners[i4].TLS.Certificates, o.APIGatewayConfigEntry.Listeners[i4].TLS.Certificates)
+				}
+				if o.APIGatewayConfigEntry.Listeners[i4].TLS.CipherSuites != nil {
+					cp.APIGatewayConfigEntry.Listeners[i4].TLS.CipherSuites = make([]types.TLSCipherSuite, len(o.APIGatewayConfigEntry.Listeners[i4].TLS.CipherSuites))
+					copy(cp.APIGatewayConfigEntry.Listeners[i4].TLS.CipherSuites, o.APIGatewayConfigEntry.Listeners[i4].TLS.CipherSuites)
+				}
+			}
+		}
+		if o.APIGatewayConfigEntry.Status.Conditions != nil {
+			cp.APIGatewayConfigEntry.Status.Conditions = make([]structs.Condition, len(o.APIGatewayConfigEntry.Status.Conditions))
+			copy(cp.APIGatewayConfigEntry.Status.Conditions, o.APIGatewayConfigEntry.Status.Conditions)
+			for i5 := range o.APIGatewayConfigEntry.Status.Conditions {
+				if o.APIGatewayConfigEntry.Status.Conditions[i5].Resource != nil {
+					cp.APIGatewayConfigEntry.Status.Conditions[i5].Resource = new(structs.ResourceReference)
+					*cp.APIGatewayConfigEntry.Status.Conditions[i5].Resource = *o.APIGatewayConfigEntry.Status.Conditions[i5].Resource
+				}
+				if o.APIGatewayConfigEntry.Status.Conditions[i5].LastTransitionTime != nil {
+					cp.APIGatewayConfigEntry.Status.Conditions[i5].LastTransitionTime = new(time.Time)
+					*cp.APIGatewayConfigEntry.Status.Conditions[i5].LastTransitionTime = *o.APIGatewayConfigEntry.Status.Conditions[i5].LastTransitionTime
+				}
+			}
+		}
+		if o.APIGatewayConfigEntry.Meta != nil {
+			cp.APIGatewayConfigEntry.Meta = make(map[string]string, len(o.APIGatewayConfigEntry.Meta))
+			for k4, v4 := range o.APIGatewayConfigEntry.Meta {
+				cp.APIGatewayConfigEntry.Meta[k4] = v4
+			}
+		}
 	}
 	if o.Hosts != nil {
 		cp.Hosts = make([]string, len(o.Hosts))

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -2,10 +2,9 @@ package proxycfg
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"hash/crc32"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/consul/acl"
@@ -687,392 +686,15 @@ type configSnapshotAPIGateway struct {
 	//Defaults structs.IngressServiceConfig
 }
 
-func httpRouteToDiscoveryChain(route structs.HTTPRouteConfigEntry) (*structs.ServiceRouterConfigEntry, []*structs.ServiceSplitterConfigEntry) {
-	router := &structs.ServiceRouterConfigEntry{
-		Kind:           structs.ServiceRouter,
-		Name:           route.GetName(),
-		Meta:           route.GetMeta(),
-		EnterpriseMeta: route.EnterpriseMeta,
-	}
-	var splitters []*structs.ServiceSplitterConfigEntry
-
-	for idx, rule := range route.Rules {
-		modifier := httpRouteFiltersToServiceRouteHeaderModifier(rule.Filters.Headers)
-		prefixRewrite := httpRouteFiltersToDestinationPrefixRewrite(rule.Filters.URLRewrites)
-
-		var destination structs.ServiceRouteDestination
-		if len(rule.Services) == 1 {
-			// TODO open question: is there a use case where someone might want to set the rewrite to ""?
-			service := rule.Services[0]
-
-			servicePrefixRewrite := httpRouteFiltersToDestinationPrefixRewrite(service.Filters.URLRewrites)
-			if servicePrefixRewrite == "" {
-				servicePrefixRewrite = prefixRewrite
-			}
-			serviceModifier := httpRouteFiltersToServiceRouteHeaderModifier(service.Filters.Headers)
-			modifier.Add = mergeMaps(modifier.Add, serviceModifier.Add)
-			modifier.Set = mergeMaps(modifier.Set, serviceModifier.Set)
-			modifier.Remove = append(modifier.Remove, serviceModifier.Remove...)
-
-			destination.Service = service.Name
-			destination.Namespace = service.NamespaceOrDefault()
-			destination.Partition = service.PartitionOrDefault()
-			destination.PrefixRewrite = servicePrefixRewrite
-			destination.RequestHeaders = modifier
-		} else {
-			// create a virtual service to split
-			destination.Service = fmt.Sprintf("%s-%d", route.GetName(), idx)
-			destination.Namespace = route.NamespaceOrDefault()
-			destination.Partition = route.PartitionOrDefault()
-			destination.PrefixRewrite = prefixRewrite
-			destination.RequestHeaders = modifier
-
-			splitter := &structs.ServiceSplitterConfigEntry{
-				Kind:           structs.ServiceSplitter,
-				Name:           destination.Service,
-				Splits:         []structs.ServiceSplit{},
-				Meta:           route.GetMeta(),
-				EnterpriseMeta: route.EnterpriseMeta,
-			}
-
-			totalWeight := 0
-			for _, service := range rule.Services {
-				totalWeight += service.Weight
-			}
-
-			for _, service := range rule.Services {
-				if service.Weight == 0 {
-					continue
-				}
-
-				modifier := httpRouteFiltersToServiceRouteHeaderModifier(service.Filters.Headers)
-
-				weightPercentage := float32(service.Weight) / float32(totalWeight)
-				split := structs.ServiceSplit{
-					RequestHeaders: modifier,
-					Weight:         weightPercentage * 100,
-				}
-				split.Service = service.Name
-				split.Namespace = service.NamespaceOrDefault()
-				split.Partition = service.PartitionOrDefault()
-				splitter.Splits = append(splitter.Splits, split)
-			}
-			if len(splitter.Splits) > 0 {
-				splitters = append(splitters, splitter)
-			}
-		}
-
-		// for each match rule a ServiceRoute is created for the service-router
-		// if there are no rules a single route with the destination is set
-		if len(rule.Matches) == 0 {
-			router.Routes = append(router.Routes, structs.ServiceRoute{Destination: &destination})
-		}
-
-		for _, match := range rule.Matches {
-			router.Routes = append(router.Routes, structs.ServiceRoute{
-				Match:       &structs.ServiceRouteMatch{HTTP: httpRouteMatchToServiceRouteHTTPMatch(match)},
-				Destination: &destination,
-			})
-		}
-	}
-
-	return router, splitters
-}
-
-func httpRouteFiltersToDestinationPrefixRewrite(rewrites []structs.URLRewrite) string {
-	for _, rewrite := range rewrites {
-		if rewrite.Path != "" {
-			return rewrite.Path
-		}
-	}
-	return ""
-}
-
-// httpRouteFiltersToServiceRouteHeaderModifier will consolidate a list of HTTP filters
-// into a single set of header modifications for Consul to make as a request passes through.
-func httpRouteFiltersToServiceRouteHeaderModifier(filters []structs.HTTPHeaderFilter) *structs.HTTPHeaderModifiers {
-	modifier := &structs.HTTPHeaderModifiers{
-		Add: make(map[string]string),
-		Set: make(map[string]string),
-	}
-	for _, filter := range filters {
-		// If we have multiple filters specified, then we can potentially clobber
-		// "Add" and "Set" here -- as far as K8S gateway spec is concerned, this
-		// is all implementation-specific behavior and undefined by the spec.
-		modifier.Add = mergeMaps(modifier.Add, filter.Add)
-		modifier.Set = mergeMaps(modifier.Set, filter.Set)
-		modifier.Remove = append(modifier.Remove, filter.Remove...)
-	}
-	return modifier
-}
-
-func mergeMaps(a, b map[string]string) map[string]string {
-	for k, v := range b {
-		a[k] = v
-	}
-	return a
-}
-
-func httpRouteMatchToServiceRouteHTTPMatch(match structs.HTTPMatch) *structs.ServiceRouteHTTPMatch {
-	var consulMatch structs.ServiceRouteHTTPMatch
-	switch match.Path.Match {
-	case structs.HTTPPathMatchExact:
-		consulMatch.PathExact = match.Path.Value
-	case structs.HTTPPathMatchPrefix:
-		consulMatch.PathPrefix = match.Path.Value
-	case structs.HTTPPathMatchRegularExpression:
-		consulMatch.PathRegex = match.Path.Value
-	}
-
-	for _, header := range match.Headers {
-		switch header.Match {
-		case structs.HTTPHeaderMatchExact:
-			consulMatch.Header = append(consulMatch.Header, structs.ServiceRouteHTTPMatchHeader{
-				Name:  header.Name,
-				Exact: header.Value,
-			})
-		case structs.HTTPHeaderMatchPrefix:
-			consulMatch.Header = append(consulMatch.Header, structs.ServiceRouteHTTPMatchHeader{
-				Name:   header.Name,
-				Prefix: header.Value,
-			})
-		case structs.HTTPHeaderMatchSuffix:
-			consulMatch.Header = append(consulMatch.Header, structs.ServiceRouteHTTPMatchHeader{
-				Name:   header.Name,
-				Suffix: header.Value,
-			})
-		case structs.HTTPHeaderMatchPresent:
-			consulMatch.Header = append(consulMatch.Header, structs.ServiceRouteHTTPMatchHeader{
-				Name:    header.Name,
-				Present: true,
-			})
-		case structs.HTTPHeaderMatchRegularExpression:
-			consulMatch.Header = append(consulMatch.Header, structs.ServiceRouteHTTPMatchHeader{
-				Name:  header.Name,
-				Regex: header.Value,
-			})
-		}
-	}
-
-	for _, query := range match.Query {
-		switch query.Match {
-		case structs.HTTPQueryMatchExact:
-			consulMatch.QueryParam = append(consulMatch.QueryParam, structs.ServiceRouteHTTPMatchQueryParam{
-				Name:  query.Name,
-				Exact: query.Value,
-			})
-		case structs.HTTPQueryMatchPresent:
-			consulMatch.QueryParam = append(consulMatch.QueryParam, structs.ServiceRouteHTTPMatchQueryParam{
-				Name:    query.Name,
-				Present: true,
-			})
-		case structs.HTTPQueryMatchRegularExpression:
-			consulMatch.QueryParam = append(consulMatch.QueryParam, structs.ServiceRouteHTTPMatchQueryParam{
-				Name:  query.Name,
-				Regex: query.Value,
-			})
-		}
-	}
-
-	switch match.Method {
-	case structs.HTTPMatchMethodConnect:
-		consulMatch.Methods = append(consulMatch.Methods, "CONNECT")
-	case structs.HTTPMatchMethodDelete:
-		consulMatch.Methods = append(consulMatch.Methods, "DELETE")
-	case structs.HTTPMatchMethodGet:
-		consulMatch.Methods = append(consulMatch.Methods, "GET")
-	case structs.HTTPMatchMethodHead:
-		consulMatch.Methods = append(consulMatch.Methods, "HEAD")
-	case structs.HTTPMatchMethodOptions:
-		consulMatch.Methods = append(consulMatch.Methods, "OPTIONS")
-	case structs.HTTPMatchMethodPatch:
-		consulMatch.Methods = append(consulMatch.Methods, "PATCH")
-	case structs.HTTPMatchMethodPost:
-		consulMatch.Methods = append(consulMatch.Methods, "POST")
-	case structs.HTTPMatchMethodPut:
-		consulMatch.Methods = append(consulMatch.Methods, "PUT")
-	case structs.HTTPMatchMethodTrace:
-		consulMatch.Methods = append(consulMatch.Methods, "TRACE")
-	}
-
-	return &consulMatch
-}
-
-func hostsKey(hosts ...string) string {
-	sort.Strings(hosts)
-	hostsHash := crc32.NewIEEE()
-	for _, h := range hosts {
-		if _, err := hostsHash.Write([]byte(h)); err != nil {
-			continue
-		}
-	}
-	return strconv.FormatUint(uint64(hostsHash.Sum32()), 16)
-}
-
-// compareHTTPRules implements the non-hostname order of precedence for routes specified by the K8s Gateway API spec.
-// https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteRule
-//
-// Ordering prefers matches based on the largest number of:
-//
-//  1. characters in a matching non-wildcard hostname
-//  2. characters in a matching hostname
-//  3. characters in a matching path
-//  4. header matches
-//  5. query param matches
-//
-// The hostname-specific comparison (1+2) occur in Envoy outside of our control:
-// https://github.com/envoyproxy/envoy/blob/5c4d4bd957f9402eca80bef82e7cc3ae714e04b4/source/common/router/config_impl.cc#L1645-L1682
-func compareHTTPRules(ruleA, ruleB structs.HTTPMatch) bool {
-	if len(ruleA.Path.Value) != len(ruleB.Path.Value) {
-		return len(ruleA.Path.Value) > len(ruleB.Path.Value)
-	}
-	if len(ruleA.Headers) != len(ruleB.Headers) {
-		return len(ruleA.Headers) > len(ruleB.Headers)
-	}
-	return len(ruleA.Query) > len(ruleB.Query)
-}
-
-func httpServiceDefault(entry structs.ConfigEntry, meta map[string]string) *structs.ServiceConfigEntry {
-	return &structs.ServiceConfigEntry{
-		Kind:           structs.ServiceDefaults,
-		Name:           entry.GetName(),
-		Protocol:       "http",
-		Meta:           meta,
-		EnterpriseMeta: *entry.GetEnterpriseMeta(),
-	}
-}
-
-type hostnameMatch struct {
-	match    structs.HTTPMatch
-	filters  structs.HTTPFilters
-	services []structs.HTTPService
-}
-
-type routeConsolidator struct {
-	matchesByHostname map[string][]hostnameMatch
-}
-
-func newRouteConsolidator() *routeConsolidator {
-	return &routeConsolidator{
-		matchesByHostname: map[string][]hostnameMatch{},
-	}
-}
-
-// add takes a new route and flattens its rule matches out per hostname.
-// This is required since a single route can specify multiple hostnames, and a
-// single hostname can be specified in multiple routes. Routing for a given
-// hostname must behave based on the aggregate of all rules that apply to it.
-func (f *routeConsolidator) add(route structs.HTTPRouteConfigEntry) {
-	for _, host := range route.Hostnames {
-		matches, ok := f.matchesByHostname[host]
-		if !ok {
-			matches = []hostnameMatch{}
-		}
-
-		for _, rule := range route.Rules {
-			// If a rule has no matches defined, add default match
-			if len(rule.Matches) == 0 {
-				rule.Matches = []structs.HTTPMatch{{
-					Path: structs.HTTPPathMatch{
-						Match: structs.HTTPPathMatchPrefix,
-						Value: "/",
-					},
-				}}
-			}
-
-			// Add all matches for this rule to the list for this hostname
-			for _, match := range rule.Matches {
-				matches = append(matches, hostnameMatch{
-					match:    match,
-					filters:  rule.Filters,
-					services: rule.Services,
-				})
-			}
-		}
-
-		f.matchesByHostname[host] = matches
-	}
-}
-
-// consolidate combines all rules into the shortest possible list of routes
-// with one route per hostname containing all rules for that hostname.
-func (f *routeConsolidator) consolidate(gateway structs.APIGatewayConfigEntry) []structs.HTTPRouteConfigEntry {
-	var routes []structs.HTTPRouteConfigEntry
-
-	for hostname, rules := range f.matchesByHostname {
-		// Create route for this hostname
-		route := structs.HTTPRouteConfigEntry{
-			Kind:           structs.HTTPRoute,
-			Name:           fmt.Sprintf("%s-%s", gateway.Name, hostsKey(hostname)),
-			Hostnames:      []string{hostname},
-			Rules:          make([]structs.HTTPRouteRule, 0, len(rules)),
-			Meta:           gateway.Meta,
-			EnterpriseMeta: gateway.EnterpriseMeta,
-		}
-
-		// Sort rules for this hostname in order of precedence
-		sort.SliceStable(rules, func(i, j int) bool {
-			return compareHTTPRules(rules[i].match, rules[j].match)
-		})
-
-		// Add all rules for this hostname
-		for _, rule := range rules {
-			route.Rules = append(route.Rules, structs.HTTPRouteRule{
-				Matches:  []structs.HTTPMatch{rule.match},
-				Filters:  rule.filters,
-				Services: rule.services,
-			})
-		}
-
-		routes = append(routes, route)
-	}
-
-	return routes
-}
-
-func flattenedHTTPRouteDiscoveryChain(route structs.HTTPRouteConfigEntry) (*structs.IngressService, *structs.ServiceRouterConfigEntry, []*structs.ServiceSplitterConfigEntry, []*structs.ServiceConfigEntry) {
-	meta := route.GetMeta()
-	splitters := []*structs.ServiceSplitterConfigEntry{}
-	defaults := []*structs.ServiceConfigEntry{}
-
-	router, splits := httpRouteToDiscoveryChain(route)
-	serviceDefault := httpServiceDefault(router, meta)
-	defaults = append(defaults, serviceDefault)
-	for _, split := range splits {
-		splitters = append(splitters, split)
-		if split.Name != serviceDefault.Name {
-			defaults = append(defaults, httpServiceDefault(split, meta))
-		}
-	}
-
-	return &structs.IngressService{
-		Name:           router.Name,
-		Hosts:          route.Hostnames,
-		Meta:           route.Meta,
-		EnterpriseMeta: route.EnterpriseMeta,
-	}, router, splitters, defaults
-}
-
-func compileRouteDiscoveryChain(svc *structs.IngressService, route *structs.HTTPRouteConfigEntry, handlerState handlerState) {
-	req := discoverychain.CompileRequest{
-		ServiceName:          svc.Name,
-		EvaluateInNamespace:  route.NamespaceOrDefault(),
-		EvaluateInPartition:  route.PartitionOrDefault(),
-		EvaluateInDatacenter: handlerState.source.Datacenter,
-	}
-
-	discoverychain, _ := discoverychain.Compile(req)
-}
-
 // ToIngress converts a configSnapshotAPIGateway to a configSnapshotIngressGateway.
 // This is temporary, for the sake of re-using existing codepaths when integrating
 // Consul API Gateway into Consul core.
 //
 // FUTURE: Remove when API gateways have custom snapshot generation
-func (c *configSnapshotAPIGateway) ToIngress() configSnapshotIngressGateway {
+func (c *configSnapshotAPIGateway) ToIngress(datacenter string) (configSnapshotIngressGateway, error) {
 	// Convert API Gateway Listeners to Ingress Listeners.
 	ingressListeners := make(map[IngressListenerKey]structs.IngressListener, len(c.Listeners))
-	routers, splitters, serviceDefaults := []*structs.ServiceRouterConfigEntry{}, []*structs.ServiceSplitterConfigEntry{}, []*structs.ServiceConfigEntry{}
+	synthesizedChains := map[UpstreamID]*structs.CompiledDiscoveryChain{}
 	for name, listener := range c.Listeners {
 		boundListener, ok := c.BoundListeners[name]
 		if !ok {
@@ -1083,38 +705,55 @@ func (c *configSnapshotAPIGateway) ToIngress() configSnapshotIngressGateway {
 		ingressListener := structs.IngressListener{
 			Port:     listener.Port,
 			Protocol: string(listener.Protocol),
-			TLS:      nil,
-			Services: make([]structs.IngressService, 0, len(boundListener.Routes)),
+			// TODO TLS
+			TLS: nil,
 		}
 
-		consolidater := newRouteConsolidator()
+		chains := []*structs.CompiledDiscoveryChain{}
+		synthesizer := discoverychain.NewGatewayChainSynthesizer(datacenter, c.APIGatewayConfigEntry)
 		for _, routeRef := range boundListener.Routes {
 			switch routeRef.Kind {
 			case structs.HTTPRoute:
-				httpRoute, ok := c.HTTPRoutes.Get(routeRef)
+				route, ok := c.HTTPRoutes.Get(routeRef)
 				if !ok {
 					continue
 				}
-				consolidater.add(*httpRoute)
+				synthesizer.AddHTTPRoute(*route)
+				for _, service := range route.GetTargets() {
+					id := NewUpstreamIDFromServiceName(structs.NewServiceName(service.Name, &service.EnterpriseMeta))
+					if chain := c.DiscoveryChain[id]; chain != nil {
+						chains = append(chains, chain)
+					}
+				}
 			case structs.TCPRoute:
-				tcpRoute, ok := c.TCPRoutes.Get(routeRef)
+				route, ok := c.TCPRoutes.Get(routeRef)
 				if !ok {
 					continue
 				}
-				fmt.Println(tcpRoute)
-				// TODO return to this
+				synthesizer.AddTCPRoute(*route)
+				for _, service := range route.GetTargets() {
+					id := NewUpstreamIDFromServiceName(structs.NewServiceName(service.Name, &service.EnterpriseMeta))
+					if chain := c.DiscoveryChain[id]; chain != nil {
+						chains = append(chains, chain)
+					}
+				}
 			default:
 				continue
 			}
 		}
 
-		flattenedHTTPRoutes := consolidater.consolidate(*c.APIGatewayConfigEntry)
-		for _, route := range flattenedHTTPRoutes {
-			service, router, splits, svcDefaults := flattenedHTTPRouteDiscoveryChain(route)
-			ingressListener.Services = append(ingressListener.Services, *service)
-			routers = append(routers, router)
-			splitters = append(splitters, splits...)
-			serviceDefaults = append(serviceDefaults, svcDefaults...)
+		if len(chains) == 0 {
+			return configSnapshotIngressGateway{}, errors.New("could not synthesize discovery chain")
+		}
+
+		services, compiled, err := synthesizer.Synthesize(chains[0], chains[1:]...)
+		if err != nil {
+			return configSnapshotIngressGateway{}, err
+		}
+		ingressListener.Services = services
+		for _, service := range services {
+			id := NewUpstreamIDFromServiceName(structs.NewServiceName(service.Name, &service.EnterpriseMeta))
+			synthesizedChains[id] = compiled
 		}
 
 		ingressListeners[IngressListenerKey{
@@ -1122,12 +761,15 @@ func (c *configSnapshotAPIGateway) ToIngress() configSnapshotIngressGateway {
 			Protocol: string(listener.Protocol),
 		}] = ingressListener
 	}
+	upstreams := c.DeepCopy().ConfigSnapshotUpstreams
+	upstreams.DiscoveryChain = synthesizedChains
 
 	return configSnapshotIngressGateway{
-		ConfigSnapshotUpstreams: c.ConfigSnapshotUpstreams,
+		ConfigSnapshotUpstreams: upstreams,
+		GatewayConfigLoaded:     true,
 		Listeners:               ingressListeners,
 		Defaults:                structs.IngressServiceConfig{},
-	}
+	}, nil
 }
 
 type configSnapshotIngressGateway struct {

--- a/agent/structs/config_entry_routes.go
+++ b/agent/structs/config_entry_routes.go
@@ -39,6 +39,16 @@ type HTTPRouteConfigEntry struct {
 	RaftIndex
 }
 
+func (e *HTTPRouteConfigEntry) GetTargets() []HTTPService {
+	targets := []HTTPService{}
+	for _, rule := range e.Rules {
+		for _, service := range rule.Services {
+			targets = append(targets, service)
+		}
+	}
+	return targets
+}
+
 func (e *HTTPRouteConfigEntry) GetKind() string {
 	return HTTPRoute
 }
@@ -267,6 +277,10 @@ type TCPRouteConfigEntry struct {
 	Status             Status
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 	RaftIndex
+}
+
+func (e *TCPRouteConfigEntry) GetTargets() []TCPService {
+	return e.Services
 }
 
 func (e *TCPRouteConfigEntry) GetKind() string {

--- a/agent/structs/structs.deepcopy.go
+++ b/agent/structs/structs.deepcopy.go
@@ -271,10 +271,110 @@ func (o *HTTPHeaderModifiers) DeepCopy() *HTTPHeaderModifiers {
 // DeepCopy generates a deep copy of *HTTPRouteConfigEntry
 func (o *HTTPRouteConfigEntry) DeepCopy() *HTTPRouteConfigEntry {
 	var cp HTTPRouteConfigEntry = *o
+	if o.Parents != nil {
+		cp.Parents = make([]ResourceReference, len(o.Parents))
+		copy(cp.Parents, o.Parents)
+	}
+	if o.Rules != nil {
+		cp.Rules = make([]HTTPRouteRule, len(o.Rules))
+		copy(cp.Rules, o.Rules)
+		for i2 := range o.Rules {
+			if o.Rules[i2].Filters.Headers != nil {
+				cp.Rules[i2].Filters.Headers = make([]HTTPHeaderFilter, len(o.Rules[i2].Filters.Headers))
+				copy(cp.Rules[i2].Filters.Headers, o.Rules[i2].Filters.Headers)
+				for i5 := range o.Rules[i2].Filters.Headers {
+					if o.Rules[i2].Filters.Headers[i5].Add != nil {
+						cp.Rules[i2].Filters.Headers[i5].Add = make(map[string]string, len(o.Rules[i2].Filters.Headers[i5].Add))
+						for k7, v7 := range o.Rules[i2].Filters.Headers[i5].Add {
+							cp.Rules[i2].Filters.Headers[i5].Add[k7] = v7
+						}
+					}
+					if o.Rules[i2].Filters.Headers[i5].Remove != nil {
+						cp.Rules[i2].Filters.Headers[i5].Remove = make([]string, len(o.Rules[i2].Filters.Headers[i5].Remove))
+						copy(cp.Rules[i2].Filters.Headers[i5].Remove, o.Rules[i2].Filters.Headers[i5].Remove)
+					}
+					if o.Rules[i2].Filters.Headers[i5].Set != nil {
+						cp.Rules[i2].Filters.Headers[i5].Set = make(map[string]string, len(o.Rules[i2].Filters.Headers[i5].Set))
+						for k7, v7 := range o.Rules[i2].Filters.Headers[i5].Set {
+							cp.Rules[i2].Filters.Headers[i5].Set[k7] = v7
+						}
+					}
+				}
+			}
+			if o.Rules[i2].Filters.URLRewrites != nil {
+				cp.Rules[i2].Filters.URLRewrites = make([]URLRewrite, len(o.Rules[i2].Filters.URLRewrites))
+				copy(cp.Rules[i2].Filters.URLRewrites, o.Rules[i2].Filters.URLRewrites)
+			}
+			if o.Rules[i2].Matches != nil {
+				cp.Rules[i2].Matches = make([]HTTPMatch, len(o.Rules[i2].Matches))
+				copy(cp.Rules[i2].Matches, o.Rules[i2].Matches)
+				for i4 := range o.Rules[i2].Matches {
+					if o.Rules[i2].Matches[i4].Headers != nil {
+						cp.Rules[i2].Matches[i4].Headers = make([]HTTPHeaderMatch, len(o.Rules[i2].Matches[i4].Headers))
+						copy(cp.Rules[i2].Matches[i4].Headers, o.Rules[i2].Matches[i4].Headers)
+					}
+					if o.Rules[i2].Matches[i4].Query != nil {
+						cp.Rules[i2].Matches[i4].Query = make([]HTTPQueryMatch, len(o.Rules[i2].Matches[i4].Query))
+						copy(cp.Rules[i2].Matches[i4].Query, o.Rules[i2].Matches[i4].Query)
+					}
+				}
+			}
+			if o.Rules[i2].Services != nil {
+				cp.Rules[i2].Services = make([]HTTPService, len(o.Rules[i2].Services))
+				copy(cp.Rules[i2].Services, o.Rules[i2].Services)
+				for i4 := range o.Rules[i2].Services {
+					if o.Rules[i2].Services[i4].Filters.Headers != nil {
+						cp.Rules[i2].Services[i4].Filters.Headers = make([]HTTPHeaderFilter, len(o.Rules[i2].Services[i4].Filters.Headers))
+						copy(cp.Rules[i2].Services[i4].Filters.Headers, o.Rules[i2].Services[i4].Filters.Headers)
+						for i7 := range o.Rules[i2].Services[i4].Filters.Headers {
+							if o.Rules[i2].Services[i4].Filters.Headers[i7].Add != nil {
+								cp.Rules[i2].Services[i4].Filters.Headers[i7].Add = make(map[string]string, len(o.Rules[i2].Services[i4].Filters.Headers[i7].Add))
+								for k9, v9 := range o.Rules[i2].Services[i4].Filters.Headers[i7].Add {
+									cp.Rules[i2].Services[i4].Filters.Headers[i7].Add[k9] = v9
+								}
+							}
+							if o.Rules[i2].Services[i4].Filters.Headers[i7].Remove != nil {
+								cp.Rules[i2].Services[i4].Filters.Headers[i7].Remove = make([]string, len(o.Rules[i2].Services[i4].Filters.Headers[i7].Remove))
+								copy(cp.Rules[i2].Services[i4].Filters.Headers[i7].Remove, o.Rules[i2].Services[i4].Filters.Headers[i7].Remove)
+							}
+							if o.Rules[i2].Services[i4].Filters.Headers[i7].Set != nil {
+								cp.Rules[i2].Services[i4].Filters.Headers[i7].Set = make(map[string]string, len(o.Rules[i2].Services[i4].Filters.Headers[i7].Set))
+								for k9, v9 := range o.Rules[i2].Services[i4].Filters.Headers[i7].Set {
+									cp.Rules[i2].Services[i4].Filters.Headers[i7].Set[k9] = v9
+								}
+							}
+						}
+					}
+					if o.Rules[i2].Services[i4].Filters.URLRewrites != nil {
+						cp.Rules[i2].Services[i4].Filters.URLRewrites = make([]URLRewrite, len(o.Rules[i2].Services[i4].Filters.URLRewrites))
+						copy(cp.Rules[i2].Services[i4].Filters.URLRewrites, o.Rules[i2].Services[i4].Filters.URLRewrites)
+					}
+				}
+			}
+		}
+	}
+	if o.Hostnames != nil {
+		cp.Hostnames = make([]string, len(o.Hostnames))
+		copy(cp.Hostnames, o.Hostnames)
+	}
 	if o.Meta != nil {
 		cp.Meta = make(map[string]string, len(o.Meta))
 		for k2, v2 := range o.Meta {
 			cp.Meta[k2] = v2
+		}
+	}
+	if o.Status.Conditions != nil {
+		cp.Status.Conditions = make([]Condition, len(o.Status.Conditions))
+		copy(cp.Status.Conditions, o.Status.Conditions)
+		for i3 := range o.Status.Conditions {
+			if o.Status.Conditions[i3].Resource != nil {
+				cp.Status.Conditions[i3].Resource = new(ResourceReference)
+				*cp.Status.Conditions[i3].Resource = *o.Status.Conditions[i3].Resource
+			}
+			if o.Status.Conditions[i3].LastTransitionTime != nil {
+				cp.Status.Conditions[i3].LastTransitionTime = new(time.Time)
+				*cp.Status.Conditions[i3].LastTransitionTime = *o.Status.Conditions[i3].LastTransitionTime
+			}
 		}
 	}
 	return &cp


### PR DESCRIPTION
Moves most of the route translation to the discoverychain package and adds the logic for merging in other discovery chains to the one we synthesize for a listener's routes.