### PR TITLE
NET-2087: Restart proxy sidecar during cluster upgrade

### DIFF
--- a/test/integration/consul-container/libs/service/connect.go
+++ b/test/integration/consul-container/libs/service/connect.go
@@ -40,7 +40,24 @@ func (g ConnectContainer) GetAddr() (string, int) {
 }
 
 func (g ConnectContainer) Restart() error {
-	return fmt.Errorf("Restart Unimplemented by ConnectContainer")
+	_, err := g.GetStatus()
+	if err != nil {
+		return fmt.Errorf("error fetching sidecar container state %s", err)
+	}
+
+	fmt.Printf("Stopping container: %s\n", g.GetName())
+	err = g.container.Stop(g.ctx, nil)
+
+	if err != nil {
+		return fmt.Errorf("error stopping sidecar container %s", err)
+	}
+
+	fmt.Printf("Starting container: %s\n", g.GetName())
+	err = g.container.Start(g.ctx)
+	if err != nil {
+		return fmt.Errorf("error starting sidecar container %s", err)
+	}
+	return nil
 }
 
 func (g ConnectContainer) GetLogs() (string, error) {

--- a/test/integration/consul-container/test/upgrade/peer_control_plane_mgw_test.go
+++ b/test/integration/consul-container/test/upgrade/peer_control_plane_mgw_test.go
@@ -90,9 +90,9 @@ func TestPeering_Upgrade_ControlPlane_MGW(t *testing.T) {
 		//  - Register a new static-client service in dialing cluster and
 		//  - set upstream to static-server service in peered cluster
 
-		// Restart the gateway
-		err = dialing.Gateway.Restart()
-		require.NoError(t, err)
+		// Restart the gateway & proxy sidecar
+		require.NoError(t, dialing.Gateway.Restart())
+		require.NoError(t, dialing.Container.Restart())
 
 		// Restarted gateway should not have any measurement on data plane traffic
 		libassert.AssertEnvoyMetricAtMost(t, gatewayAdminPort,
@@ -107,6 +107,7 @@ func TestPeering_Upgrade_ControlPlane_MGW(t *testing.T) {
 		require.NoError(t, err)
 		_, port := clientSidecarService.GetAddr()
 		_, adminPort := clientSidecarService.GetAdminAddr()
+		require.NoError(t, clientSidecarService.Restart())
 		libassert.AssertUpstreamEndpointStatus(t, adminPort, fmt.Sprintf("static-server.default.%s.external", libtopology.DialingPeerName), "HEALTHY", 1)
 		libassert.HTTPServiceEchoes(t, "localhost", port, "")
 	}

--- a/test/integration/consul-container/test/upgrade/peers_http_test.go
+++ b/test/integration/consul-container/test/upgrade/peers_http_test.go
@@ -64,9 +64,10 @@ func TestPeering_UpgradeToTarget_fromLatest(t *testing.T) {
 		//  - Register a new static-client service in dialing cluster and
 		//  - set upstream to static-server service in peered cluster
 
-		// Restart the gateway
-		err = dialing.Gateway.Restart()
-		require.NoError(t, err)
+		// Restart the gateway & proxy sidecar
+		require.NoError(t, dialing.Gateway.Restart())
+		require.NoError(t, dialing.Container.Restart())
+
 		// Restarted gateway should not have any measurement on data plane traffic
 		libassert.AssertEnvoyMetricAtMost(t, gatewayAdminPort,
 			"cluster.static-server.default.default.accepting-to-dialer.external",
@@ -76,6 +77,7 @@ func TestPeering_UpgradeToTarget_fromLatest(t *testing.T) {
 		require.NoError(t, err)
 		_, port := clientSidecarService.GetAddr()
 		_, adminPort := clientSidecarService.GetAdminAddr()
+		require.NoError(t, clientSidecarService.Restart())
 		libassert.AssertUpstreamEndpointStatus(t, adminPort, fmt.Sprintf("static-server.default.%s.external", libtopology.DialingPeerName), "HEALTHY", 1)
 		libassert.HTTPServiceEchoes(t, "localhost", port, "")
 	}


### PR DESCRIPTION
### Description
Updated the `Reset()` method to restart connect-proxy sidecar during upgrade. 
Added the Reset() method to all upgrade tests

### Testing & Reproduction steps

### Links

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
