### PR TITLE
fix goroutine leak in renew testing

### DIFF
--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -305,12 +305,15 @@ func TestVaultCAProvider_RenewTokenStopWatcherOnConfigure(t *testing.T) {
 		"IntermediatePKIPath": "pki-intermediate/",
 	})
 
+	// overwrite stopWatcher to set flag on stop for testing
+	// be sure that original stopWatcher gets called to avoid goroutine leak
 	gotStopped := uint32(0)
 	realStop := provider.stopWatcher
 	provider.stopWatcher = func() {
 		atomic.StoreUint32(&gotStopped, 1)
 		realStop()
 	}
+
 	// Check the last renewal time.
 	secret, err = testVault.client.Auth().Token().Lookup(providerToken)
 	require.NoError(t, err)

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -198,7 +198,6 @@ func TestVaultCAProvider_Configure(t *testing.T) {
 				"IntermediatePKIPath": "pki-intermediate/",
 			},
 			expectedValue: func(t *testing.T, v *VaultProvider) {
-
 				h := v.client.Headers()
 				require.Equal(t, "ns1", h.Get(vaultconst.NamespaceHeaderName))
 			},
@@ -306,11 +305,12 @@ func TestVaultCAProvider_RenewTokenStopWatcherOnConfigure(t *testing.T) {
 		"IntermediatePKIPath": "pki-intermediate/",
 	})
 
-	var gotStopped = uint32(0)
+	gotStopped := uint32(0)
+	realStop := provider.stopWatcher
 	provider.stopWatcher = func() {
 		atomic.StoreUint32(&gotStopped, 1)
+		realStop()
 	}
-
 	// Check the last renewal time.
 	secret, err = testVault.client.Auth().Token().Lookup(providerToken)
 	require.NoError(t, err)


### PR DESCRIPTION
Test overwrote the stopWatcher() function variable for the test without keeping and calling the original value. The original value is the function that stops the goroutine... so it needs to be called.