### PR TITLE
Net 2229/rpc reduce max retries

### DIFF
--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/consul/acl"
+	rpcRate "github.com/hashicorp/consul/agent/consul/rate"
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/structs"
@@ -296,7 +297,18 @@ TRY:
 
 	// Use the zero value for RPCInfo if the request doesn't implement RPCInfo
 	info, _ := args.(structs.RPCInfo)
-	if retry := canRetry(info, rpcErr, firstCheck, c.config); !retry {
+	retryableMessages := []error{
+		// If we are chunking and it doesn't seem to have completed, try again.
+		ErrChunkingResubmit,
+
+		// These rate limit errors are returned before the handler is called, so are
+		// safe to retry.
+		rpcRate.ErrRetryElsewhere,
+
+		rpcRate.ErrRetryLater,
+	}
+
+	if retry := canRetry(info, rpcErr, firstCheck, c.config, retryableMessages); !retry {
 		c.logger.Error("RPC failed to server",
 			"method", method,
 			"server", server.Addr,

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -304,8 +304,6 @@ TRY:
 		// These rate limit errors are returned before the handler is called, so are
 		// safe to retry.
 		rpcRate.ErrRetryElsewhere,
-
-		rpcRate.ErrRetryLater,
 	}
 
 	if retry := canRetry(info, rpcErr, firstCheck, c.config, retryableMessages); !retry {

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -272,8 +272,9 @@ func (c *Client) RPC(ctx context.Context, method string, args interface{}, reply
 	// starting the timer here we won't potentially double up the delay.
 	// TODO (slackpad) Plumb a deadline here with a context.
 	firstCheck := time.Now()
-
+	retryCount := 0
 TRY:
+	retryCount++
 	manager, server := c.router.FindLANRoute()
 	if server == nil {
 		return structs.ErrNoServers
@@ -317,7 +318,8 @@ TRY:
 	}
 
 	// We can wait a bit and retry!
-	jitter := lib.RandomStagger(c.config.RPCHoldTimeout / structs.JitterFraction)
+	// jitter := lib.RandomStagger(c.config.RPCHoldTimeout / structs.JitterFraction)
+	jitter := getWaitTime(c.config, retryCount)
 	select {
 	case <-time.After(jitter):
 		goto TRY

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -316,12 +316,6 @@ TRY:
 		return rpcErr
 	}
 
-	c.logger.Warn("Retrying RPC to server",
-		"method", method,
-		"server", server.Addr,
-		"error", rpcErr,
-	)
-
 	// We can wait a bit and retry!
 	jitter := lib.RandomStagger(c.config.RPCHoldTimeout / structs.JitterFraction)
 	select {

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -273,6 +273,7 @@ func (c *Client) RPC(ctx context.Context, method string, args interface{}, reply
 	// TODO (slackpad) Plumb a deadline here with a context.
 	firstCheck := time.Now()
 	retryCount := 0
+	previousJitter := time.Duration(0)
 TRY:
 	retryCount++
 	manager, server := c.router.FindLANRoute()
@@ -318,8 +319,9 @@ TRY:
 	}
 
 	// We can wait a bit and retry!
-	// jitter := lib.RandomStagger(c.config.RPCHoldTimeout / structs.JitterFraction)
-	jitter := getWaitTime(c.config, retryCount)
+	jitter := getWaitTime(c.config, previousJitter, retryCount)
+	previousJitter = jitter
+
 	select {
 	case <-time.After(jitter):
 		goto TRY

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -562,23 +562,23 @@ func getWaitTime(config *Config, retryCount int) time.Duration {
 	initialBackoffInSeconds := math.Min(1, rpcHoldTimeoutInSeconds/structs.JitterFraction)
 	backoffMultiplierInSeconds := 2.0
 
-	fmt.Println("rpcHoldTimeoutInSeconds: ", rpcHoldTimeoutInSeconds)
+	// fmt.Println("rpcHoldTimeoutInSeconds: ", rpcHoldTimeoutInSeconds)
 
-	fmt.Println("jitter: ", structs.JitterFraction)
+	// fmt.Println("jitter: ", structs.JitterFraction)
 
-	floatJitter := float64(structs.JitterFraction)
+	// floatJitter := float64(structs.JitterFraction)
 
-	fmt.Println("floatjitter: ", float64(structs.JitterFraction))
+	// fmt.Println("floatjitter: ", float64(structs.JitterFraction))
 
-	threshold := rpcHoldTimeoutInSeconds / floatJitter
+	// threshold := rpcHoldTimeoutInSeconds / floatJitter
 
-	fmt.Println("threshold: ", threshold)
+	// fmt.Println("threshold: ", threshold)
 
-	fmt.Println("initialBackoffInSeconds: ", initialBackoffInSeconds)
+	// fmt.Println("initialBackoffInSeconds: ", initialBackoffInSeconds)
 
-	fmt.Println("retryCount: ", retryCount-1)
+	// fmt.Println("retryCount: ", retryCount-1)
 
-	fmt.Println("power: ", math.Pow(backoffMultiplierInSeconds, float64(retryCount-1)))
+	// fmt.Println("power: ", math.Pow(backoffMultiplierInSeconds, float64(retryCount-1)))
 
 	waitTimeInSeconds := initialBackoffInSeconds * math.Pow(backoffMultiplierInSeconds, float64(retryCount-1))
 	// Itr1:
@@ -616,8 +616,8 @@ func getWaitTime(config *Config, retryCount int) time.Duration {
 	// retryCount = 2
 	// waitTimeInSeconds = 0.43 * 2^4 = 6.88s
 
-	fmt.Println("waitTimeInSeconds: ", waitTimeInSeconds)
-	fmt.Println("wait time duration: ", time.Duration(waitTimeInSeconds*float64(time.Second)))
+	// fmt.Println("waitTimeInSeconds: ", waitTimeInSeconds)
+	// fmt.Println("wait time duration: ", time.Duration(waitTimeInSeconds*float64(time.Second)))
 
 	return lib.RandomStagger(time.Duration(waitTimeInSeconds * float64(time.Second))) // TODO:change this to not be between 0 lower limit?
 }

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -557,7 +557,7 @@ func (c *limitedConn) Read(b []byte) (n int, err error) {
 }
 
 // canRetry returns true if the request and error indicate that a retry is safe.
-func canRetry(info structs.RPCInfo, err error, start time.Time, config *Config) bool {
+func canRetry(info structs.RPCInfo, err error, start time.Time, config *Config, retryableMessages []error) bool {
 	if info != nil {
 		timedOut, timeoutError := info.HasTimedOut(start, config.RPCHoldTimeout, config.MaxQueryTime, config.DefaultQueryTime)
 		if timeoutError != nil {
@@ -579,15 +579,6 @@ func canRetry(info structs.RPCInfo, err error, start time.Time, config *Config) 
 		return true
 	}
 
-	retryableMessages := []error{
-		// If we are chunking and it doesn't seem to have completed, try again.
-		ErrChunkingResubmit,
-
-		// These rate limit errors are returned before the handler is called, so are
-		// safe to retry.
-		rate.ErrRetryElsewhere,
-		rate.ErrRetryLater,
-	}
 	for _, m := range retryableMessages {
 		if err != nil && strings.Contains(err.Error(), m.Error()) {
 			return true
@@ -747,7 +738,12 @@ CHECK_LEADER:
 		}
 	}
 
-	if retry := canRetry(info, rpcErr, firstCheck, s.config); retry {
+	retryableMessages := []error{
+		// If we are chunking and it doesn't seem to have completed, try again.
+		ErrChunkingResubmit,
+	}
+
+	if retry := canRetry(info, rpcErr, firstCheck, s.config, retryableMessages); retry {
 		// Gate the request until there is a leader
 		jitter := lib.RandomStagger(s.config.RPCHoldTimeout / structs.JitterFraction)
 		select {

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -560,32 +560,25 @@ func (c *limitedConn) Read(b []byte) (n int, err error) {
 func getWaitTime(config *Config, retryCount int) time.Duration {
 	rpcHoldTimeoutInSeconds := config.RPCHoldTimeout.Seconds() // TODO: define default value on safe side?
 	initialBackoffInSeconds := math.Min(1, rpcHoldTimeoutInSeconds/structs.JitterFraction)
-	backoffMultiplierInSeconds := 2.0 // math.Min(math.Max(rpcHoldTimeout/structs.MaxRetries, 2), 2)
+	backoffMultiplierInSeconds := 2.0
 
-	print("\nrpcHoldTimeoutInSeconds ")
-	print(rpcHoldTimeoutInSeconds)
+	fmt.Println("rpcHoldTimeoutInSeconds: ", rpcHoldTimeoutInSeconds)
 
-	print("\n jitter ")
-	print(structs.JitterFraction)
+	fmt.Println("jitter: ", structs.JitterFraction)
 
 	floatJitter := float64(structs.JitterFraction)
 
-	print("\nfloatJitter ")
-	print(floatJitter)
+	fmt.Println("floatjitter: ", float64(structs.JitterFraction))
 
 	threshold := rpcHoldTimeoutInSeconds / floatJitter
 
-	print("\nthreshold ")
-	print(threshold)
+	fmt.Println("threshold: ", threshold)
 
-	print("\ninitialBackoffInSeconds:::::")
-	print(initialBackoffInSeconds)
+	fmt.Println("initialBackoffInSeconds: ", initialBackoffInSeconds)
 
-	print("\nretryCount:::::")
-	print(float64(retryCount - 1))
+	fmt.Println("retryCount: ", retryCount-1)
 
-	print("\npower:::::")
-	print(math.Pow(backoffMultiplierInSeconds, float64(retryCount-1)))
+	fmt.Println("power: ", math.Pow(backoffMultiplierInSeconds, float64(retryCount-1)))
 
 	waitTimeInSeconds := initialBackoffInSeconds * math.Pow(backoffMultiplierInSeconds, float64(retryCount-1))
 	// Itr1:
@@ -623,10 +616,10 @@ func getWaitTime(config *Config, retryCount int) time.Duration {
 	// retryCount = 2
 	// waitTimeInSeconds = 0.43 * 2^4 = 6.88s
 
-	print("\nwait time:::::")
-	print(waitTimeInSeconds)
+	fmt.Println("waitTimeInSeconds: ", waitTimeInSeconds)
+	fmt.Println("wait time duration: ", time.Duration(waitTimeInSeconds*float64(time.Second)))
 
-	return lib.RandomStagger(time.Duration(waitTimeInSeconds)) // TODO:change this to not be between 0 lower limit?
+	return lib.RandomStagger(time.Duration(waitTimeInSeconds * float64(time.Second))) // TODO:change this to not be between 0 lower limit?
 }
 
 // canRetry returns true if the request and error indicate that a retry is safe.

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -741,6 +741,8 @@ CHECK_LEADER:
 	retryableMessages := []error{
 		// If we are chunking and it doesn't seem to have completed, try again.
 		ErrChunkingResubmit,
+
+		rate.ErrRetryLater,
 	}
 
 	if retry := canRetry(info, rpcErr, firstCheck, s.config, retryableMessages); retry {

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -1629,7 +1629,8 @@ func TestGetWaitTime(t *testing.T) {
 	config := DefaultConfig()
 	config.RPCHoldTimeout = 7 * time.Second
 	run := func(t *testing.T, tc testCase) {
-		require.Equal(t, tc.expected, getWaitTime(config, tc.retryCount))
+		require.GreaterOrEqual(t, getWaitTime(config, tc.retryCount), 0*time.Second)
+		require.LessOrEqual(t, getWaitTime(config, tc.retryCount), tc.expected)
 	}
 
 	var testCases = []testCase{

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -1623,35 +1623,40 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 func TestGetWaitTime(t *testing.T) {
 	type testCase struct {
 		name       string
+		previous   time.Duration
 		expected   time.Duration
 		retryCount int
 	}
 	config := DefaultConfig()
 	config.RPCHoldTimeout = 7 * time.Second
 	run := func(t *testing.T, tc testCase) {
-		require.GreaterOrEqual(t, getWaitTime(config, tc.retryCount), 0*time.Second)
-		require.LessOrEqual(t, getWaitTime(config, tc.retryCount), tc.expected)
+		require.GreaterOrEqual(t, getWaitTime(config, tc.previous, tc.retryCount), tc.previous)
+		require.LessOrEqual(t, getWaitTime(config, tc.previous, tc.retryCount), tc.expected)
 	}
 
 	var testCases = []testCase{
 		{
 			name:       "first attempt",
 			retryCount: 1,
+			previous:   time.Duration(0),
 			expected:   time.Duration(430) * time.Millisecond,
 		},
 		{
 			name:       "second attempt",
 			retryCount: 2,
+			previous:   time.Duration(430) * time.Millisecond,
 			expected:   time.Duration(860) * time.Millisecond,
 		},
 		{
 			name:       "third attempt",
 			retryCount: 3,
+			previous:   time.Duration(860) * time.Millisecond,
 			expected:   time.Duration(1720) * time.Millisecond,
 		},
 		{
 			name:       "fourth attempt",
 			retryCount: 4,
+			previous:   time.Duration(1720) * time.Millisecond,
 			expected:   time.Duration(3440) * time.Millisecond,
 		},
 	}

--- a/lib/cluster.go
+++ b/lib/cluster.go
@@ -45,6 +45,11 @@ func RandomStagger(intv time.Duration) time.Duration {
 	return time.Duration(uint64(rand.Int63()) % uint64(intv))
 }
 
+// RandomStagger returns an interval between min and the max duration
+func RandomStaggerWithRange(min time.Duration, max time.Duration) time.Duration {
+	return RandomStagger(max-min) + min
+}
+
 // RateScaledInterval is used to choose an interval to perform an action in
 // order to target an aggregate number of actions per second across the whole
 // cluster.

--- a/website/content/docs/connect/connect-internals.mdx
+++ b/website/content/docs/connect/connect-internals.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Service Mesh - How it Works
 description: >-
-  Consul's service mesh enforces secure service communication using mutual TLS (mTLS) encryption and explicit authorization. Learn how the service mesh certificate authorities, intentions, and agents work together in the ""Connect"" subsystem to provide Consul’s service mesh capabilities.
+  Consul's service mesh enforces secure service communication using mutual TLS (mTLS) encryption and explicit authorization. Learn how the service mesh certificate authorities, intentions, and agents work together to provide Consul’s service mesh capabilities.
 ---
 
 # How Service Mesh Works
@@ -19,13 +19,13 @@ tutorial.
 
 ## Mutual Transport Layer Security (mTLS)
 
-The core of Connect is based on [mutual TLS](https://en.wikipedia.org/wiki/Mutual_authentication).
+The core of Consul service mesh is based on [mutual TLS](https://en.wikipedia.org/wiki/Mutual_authentication).
 
-Connect provides each service with an identity encoded as a TLS certificate.
+Consul service mesh provides each service with an identity encoded as a TLS certificate.
 This certificate is used to establish and accept connections to and from other
 services. The identity is encoded in the TLS certificate in compliance with
 the [SPIFFE X.509 Identity Document](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md).
-This enables Connect services to establish and accept connections with
+This enables Consul service mesh services to establish and accept connections with
 other SPIFFE-compliant systems.
 
 The client service verifies the destination service certificate
@@ -50,8 +50,8 @@ requires no other dependencies, and
 also ships with built-in support for [Vault](/consul/docs/connect/ca/vault). The PKI system is designed to be pluggable
 and can be extended to support any system by adding additional CA providers.
 
-All APIs required for Connect typically respond in microseconds and impose
-minimal overhead to existing services. To ensure this, Connect-related API calls
+All APIs required for Consul service mesh typically respond in microseconds and impose
+minimal overhead to existing services. To ensure this, Consul service mesh-related API calls
 are all made to the local Consul agent over a loopback interface, and all [agent
 Connect endpoints](/consul/api-docs/agent/connect) implement local caching, background
 updating, and support blocking queries. Most API calls operate on purely local
@@ -60,14 +60,14 @@ in-memory data.
 ## Agent Caching and Performance
 
 To enable fast responses on endpoints such as the [agent Connect
-API](/consul/api-docs/agent/connect), the Consul agent locally caches most Connect-related
+API](/consul/api-docs/agent/connect), the Consul agent locally caches most Consul service mesh-related
 data and sets up background [blocking queries](/consul/api-docs/features/blocking) against
 the server to update the cache in the background. This allows most API calls
 such as retrieving certificates or authorizing connections to use in-memory
 data and respond very quickly.
 
 All data cached locally by the agent is populated on demand. Therefore, if
-Connect is not used at all, the cache does not store any data. On first request,
+Consul service mesh is not used at all, the cache does not store any data. On first request,
 the data is loaded from the server and cached. The set of data cached is: public
 CA root certificates, leaf certificates, intentions, and service discovery
 results for upstreams. For leaf certificates and intentions, only data related
@@ -79,9 +79,9 @@ may see data it shouldn't from the cache. This results in higher memory usage
 for cached data since it is duplicated per ACL token, but with the benefit
 of simplicity and security.
 
-With Connect enabled, you'll likely see increased memory usage by the
+With Consul service mesh enabled, you'll likely see increased memory usage by the
 local Consul agent. The total memory is dependent on the number of intentions
-related to the services registered with the agent accepting Connect-based
+related to the services registered with the agent accepting Consul service mesh-based
 connections. The other data (leaf certificates and public CA certificates)
 is a relatively fixed size per service. In most cases, the overhead per
 service should be relatively small: single digit kilobytes at most.
@@ -116,7 +116,7 @@ be set in the secondary datacenter server's configuration.
 
 ## Certificate Authority Federation
 
-The primary datacenter also acts as the root Certificate Authority (CA) for Connect.
+The primary datacenter also acts as the root Certificate Authority (CA) for Consul service mesh.
 The primary datacenter generates a trust-domain UUID and obtains a root certificate
 from the configured CA provider which defaults to the built-in one.
 
@@ -124,7 +124,7 @@ Secondary datacenters fetch the root CA public key and trust-domain ID from the
 primary and generate their own key and Certificate Signing Request (CSR) for an
 intermediate CA certificate. This CSR is signed by the root in the primary
 datacenter and the certificate is returned. The secondary datacenter can now use
-this intermediate to sign new Connect certificates in the secondary datacenter
+this intermediate to sign new Consul service mesh certificates in the secondary datacenter
 without WAN communication. CA keys are never replicated between datacenters.
 
 The secondary maintains watches on the root CA certificate in the primary. If the


### PR DESCRIPTION
### Description
The retries were too aggressive which compounded rate limiting errors. Hence, implementing an exponential back-off strategy which gives enough time for the server to recover.

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
