### PR TITLE
command: Fix logger not initializing properly in envoy command

### DIFF
--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -235,12 +235,6 @@ func (c *cmd) init() {
 	c.dialFunc = func(network string, address string) (net.Conn, error) {
 		return net.DialTimeout(network, address, 3*time.Second)
 	}
-
-	opts := hclog.LoggerOptions{Level: hclog.Off}
-	if c.enableLogging {
-		opts.Level = hclog.Debug
-	}
-	c.logger = hclog.New(&opts)
 }
 
 // canBindInternal is here mainly so we can unit test this with a constant net.Addr list
@@ -293,13 +287,18 @@ func (c *cmd) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
 		return 1
 	}
-	c.logger.Debug("Initialized API client")
 
 	// TODO: refactor
 	return c.run(c.flags.Args())
 }
 
 func (c *cmd) run(args []string) int {
+	opts := hclog.LoggerOptions{Level: hclog.Off}
+	if c.enableLogging {
+		opts.Level = hclog.Debug
+	}
+	c.logger = hclog.New(&opts)
+	c.logger.Debug("Starting Envoy config generation")
 
 	if c.nodeName != "" && c.proxyID == "" {
 		c.UI.Error("'-node-name' requires '-proxy-id'")


### PR DESCRIPTION
Follow up to (https://github.com/hashicorp/consul/pull/15988). Caught this when backporting - the logger is getting set up in the wrong place (before flags are parsed) so it won't get set to debug properly when the flag is passed in.