### PR TITLE
docs(service-resolver): clarify the default time unit in service-resolver.ConnectTimeout

### DIFF
--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -438,7 +438,7 @@ spec:
       name: 'ConnectTimeout',
       type: 'duration: 0s',
       description:
-        'The timeout for establishing new network connections to this service.',
+        'The timeout for establishing new network connections to this service. If time unit isn't provided, the default unit is nanosecond',
     },
     {
       name: 'DefaultSubset',

--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -438,7 +438,7 @@ spec:
       name: 'ConnectTimeout',
       type: 'duration: 0s',
       description:
-        'The timeout for establishing new network connections to this service. If time unit isn't provided, the default unit is nanosecond',
+        'The timeout for establishing new network connections to this service. The default unit of time is `ns`.',
     },
     {
       name: 'DefaultSubset',


### PR DESCRIPTION
### Description
When timeunit is not provided in `service-resolver.ConnectTimeout`, the default to be used in nanosecond.

### Testing & Reproduction steps

* Use a config entry without time unit


```
{
  "Kind":"service-resolver",
  "Name":"REDACTED",
  "ConnectTimeout":10, 
  "Failover":{
    "*":{
      "Datacenters":["us-east-1","us-west-2"]
      }
  }
}
```

```bash
consul config write resolver.json


consul config read -kind service-resolver -name REDACTED  

{
    "ConnectTimeout": "10ns",
    "Kind": "service-resolver",
    "Name": "REDACTED",
    "Failover": {
        "*": {
            "Datacenters": [
                "us-east-1",
                "us-west-2"
            ]
        }
    },
    "CreateIndex": 23,
    "ModifyIndex": 137
}


```

### Links
https://github.com/hashicorp/consul/issues/16147

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] not a security concern
