### PR TITLE
fix proxy config of service-defaults doesn't override the defaults

### DIFF
--- a/agent/configentry/merge_service_config.go
+++ b/agent/configentry/merge_service_config.go
@@ -109,7 +109,7 @@ func MergeServiceConfig(defaults *structs.ServiceConfigResponse, service *struct
 	// Merge proxy defaults
 	ns := nsRaw.(*structs.NodeService)
 
-	if err := mergo.Merge(&ns.Proxy.Config, defaults.ProxyConfig); err != nil {
+	if err := mergo.Merge(&ns.Proxy.Config, defaults.ProxyConfig, mergo.WithOverride); err != nil {
 		return nil, err
 	}
 	if err := mergo.Merge(&ns.Proxy.Expose, defaults.Expose); err != nil {


### PR DESCRIPTION
### Description
Fix proxy config provided in `service-defaults doesn't override the values if presented in service definition`.

As a user wants to change some proxy config value like `MaxInBoundConnection` or `localRequestTimeoutMs` of all service instances, I want to change the behavior of writing the value to config-entry `service-defaults`. However, the current implementation doesn't allow service-defaults override the defaults if the field name presents.

### Testing & Reproduction steps

1. Register a service with following values in its `sidecar.proxy.config`: `max_inbound_connections = 1024`, `local_idle_timeout_ms `.

2. Submit a `service-defaults` with values to override the defaults, like
```
MaxInboundConnections = 4096 // value different than in the service definition.
```

The observed value will be from the service definitions.

### Links


### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
