### PR TITLE
Net 2229/rpc reduce max retries 2

### DIFF
--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -325,7 +325,7 @@ TRY:
 	)
 
 	// We can wait a bit and retry!
-	jitter := getWaitTime(c.config, previousJitter, retryCount)
+	jitter := lib.RandomStaggerWithRange(previousJitter, getWaitTime(c.config.RPCHoldTimeout, retryCount))
 	previousJitter = jitter
 
 	select {

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -272,8 +272,9 @@ func (c *Client) RPC(ctx context.Context, method string, args interface{}, reply
 	// starting the timer here we won't potentially double up the delay.
 	// TODO (slackpad) Plumb a deadline here with a context.
 	firstCheck := time.Now()
-
+	retryCount := 0
 TRY:
+	retryCount++
 	manager, server := c.router.FindLANRoute()
 	if server == nil {
 		return structs.ErrNoServers
@@ -323,7 +324,8 @@ TRY:
 	)
 
 	// We can wait a bit and retry!
-	jitter := lib.RandomStagger(c.config.RPCHoldTimeout / structs.JitterFraction)
+	// jitter := lib.RandomStagger(c.config.RPCHoldTimeout / structs.JitterFraction)
+	jitter := getWaitTime(c.config, retryCount)
 	select {
 	case <-time.After(jitter):
 		goto TRY

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -273,6 +273,7 @@ func (c *Client) RPC(ctx context.Context, method string, args interface{}, reply
 	// TODO (slackpad) Plumb a deadline here with a context.
 	firstCheck := time.Now()
 	retryCount := 0
+	previousJitter := time.Duration(0)
 TRY:
 	retryCount++
 	manager, server := c.router.FindLANRoute()
@@ -324,8 +325,9 @@ TRY:
 	)
 
 	// We can wait a bit and retry!
-	// jitter := lib.RandomStagger(c.config.RPCHoldTimeout / structs.JitterFraction)
-	jitter := getWaitTime(c.config, retryCount)
+	jitter := getWaitTime(c.config, previousJitter, retryCount)
+	previousJitter = jitter
+
 	select {
 	case <-time.After(jitter):
 		goto TRY

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -558,7 +558,7 @@ func (c *limitedConn) Read(b []byte) (n int, err error) {
 }
 
 func getWaitTime(rpcHoldTimeout time.Duration, retryCount int) time.Duration {
-	const backoffMultiplierInSeconds = 2.0
+	const backoffMultiplier = 2.0
 
 	rpcHoldTimeoutInMilli := int(rpcHoldTimeout.Milliseconds())
 	initialBackoffInMilli := rpcHoldTimeoutInMilli / structs.JitterFraction
@@ -567,9 +567,9 @@ func getWaitTime(rpcHoldTimeout time.Duration, retryCount int) time.Duration {
 		initialBackoffInMilli = 1
 	}
 
-	waitTimeInSeconds := initialBackoffInMilli * int(math.Pow(backoffMultiplierInSeconds, float64(retryCount-1)))
+	waitTimeInMilli := initialBackoffInMilli * int(math.Pow(backoffMultiplier, float64(retryCount-1)))
 
-	return time.Duration(waitTimeInSeconds) * time.Millisecond
+	return time.Duration(waitTimeInMilli) * time.Millisecond
 }
 
 // canRetry returns true if the request and error indicate that a retry is safe.

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -560,32 +560,25 @@ func (c *limitedConn) Read(b []byte) (n int, err error) {
 func getWaitTime(config *Config, retryCount int) time.Duration {
 	rpcHoldTimeoutInSeconds := config.RPCHoldTimeout.Seconds() // TODO: define default value on safe side?
 	initialBackoffInSeconds := math.Min(1, rpcHoldTimeoutInSeconds/structs.JitterFraction)
-	backoffMultiplierInSeconds := 2.0 // math.Min(math.Max(rpcHoldTimeout/structs.MaxRetries, 2), 2)
+	backoffMultiplierInSeconds := 2.0
 
-	print("\nrpcHoldTimeoutInSeconds ")
-	print(rpcHoldTimeoutInSeconds)
+	fmt.Println("rpcHoldTimeoutInSeconds: ", rpcHoldTimeoutInSeconds)
 
-	print("\n jitter ")
-	print(structs.JitterFraction)
+	fmt.Println("jitter: ", structs.JitterFraction)
 
 	floatJitter := float64(structs.JitterFraction)
 
-	print("\nfloatJitter ")
-	print(floatJitter)
+	fmt.Println("floatjitter: ", float64(structs.JitterFraction))
 
 	threshold := rpcHoldTimeoutInSeconds / floatJitter
 
-	print("\nthreshold ")
-	print(threshold)
+	fmt.Println("threshold: ", threshold)
 
-	print("\ninitialBackoffInSeconds:::::")
-	print(initialBackoffInSeconds)
+	fmt.Println("initialBackoffInSeconds: ", initialBackoffInSeconds)
 
-	print("\nretryCount:::::")
-	print(float64(retryCount - 1))
+	fmt.Println("retryCount: ", retryCount-1)
 
-	print("\npower:::::")
-	print(math.Pow(backoffMultiplierInSeconds, float64(retryCount-1)))
+	fmt.Println("power: ", math.Pow(backoffMultiplierInSeconds, float64(retryCount-1)))
 
 	waitTimeInSeconds := initialBackoffInSeconds * math.Pow(backoffMultiplierInSeconds, float64(retryCount-1))
 	// Itr1:
@@ -623,10 +616,10 @@ func getWaitTime(config *Config, retryCount int) time.Duration {
 	// retryCount = 2
 	// waitTimeInSeconds = 0.43 * 2^4 = 6.88s
 
-	print("\nwait time:::::")
-	print(waitTimeInSeconds)
+	fmt.Println("waitTimeInSeconds: ", waitTimeInSeconds)
+	fmt.Println("wait time duration: ", time.Duration(waitTimeInSeconds*float64(time.Second)))
 
-	return lib.RandomStagger(time.Duration(waitTimeInSeconds)) // TODO:change this to not be between 0 lower limit?
+	return lib.RandomStagger(time.Duration(waitTimeInSeconds * float64(time.Second))) // TODO:change this to not be between 0 lower limit?
 }
 
 // canRetry returns true if the request and error indicate that a retry is safe.

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -557,69 +557,14 @@ func (c *limitedConn) Read(b []byte) (n int, err error) {
 	return c.lr.Read(b)
 }
 
-func getWaitTime(config *Config, retryCount int) time.Duration {
-	rpcHoldTimeoutInSeconds := config.RPCHoldTimeout.Seconds() // TODO: define default value on safe side?
+func getWaitTime(config *Config, previousWaitTime time.Duration, retryCount int) time.Duration {
+	rpcHoldTimeoutInSeconds := config.RPCHoldTimeout.Seconds()
 	initialBackoffInSeconds := math.Min(1, rpcHoldTimeoutInSeconds/structs.JitterFraction)
 	backoffMultiplierInSeconds := 2.0
 
-	fmt.Println("rpcHoldTimeoutInSeconds: ", rpcHoldTimeoutInSeconds)
-
-	fmt.Println("jitter: ", structs.JitterFraction)
-
-	floatJitter := float64(structs.JitterFraction)
-
-	fmt.Println("floatjitter: ", float64(structs.JitterFraction))
-
-	threshold := rpcHoldTimeoutInSeconds / floatJitter
-
-	fmt.Println("threshold: ", threshold)
-
-	fmt.Println("initialBackoffInSeconds: ", initialBackoffInSeconds)
-
-	fmt.Println("retryCount: ", retryCount-1)
-
-	fmt.Println("power: ", math.Pow(backoffMultiplierInSeconds, float64(retryCount-1)))
-
 	waitTimeInSeconds := initialBackoffInSeconds * math.Pow(backoffMultiplierInSeconds, float64(retryCount-1))
-	// Itr1:
-	// rpcHoldTimeoutInSeconds = 7s
-	// initialBackoffInSeconds = 7/16 = 0.43s
-	// backoffMultiplierInSeconds = 2
-	// retryCount = 1
-	// waitTimeInSeconds = 0.43 * 2^0 = 0.43s
 
-	// Itr2:
-	// rpcHoldTimeoutInSeconds = 7s
-	// initialBackoffInSeconds = 7/16 = 0.43s
-	// backoffMultiplierInSeconds = 2
-	// retryCount = 2
-	// waitTimeInSeconds = 0.43 * 2^1 = 0.86s
-
-	// Itr3:
-	// rpcHoldTimeoutInSeconds = 7s
-	// initialBackoffInSeconds = 7/16 = 0.43s
-	// backoffMultiplierInSeconds = 2
-	// retryCount = 2
-	// waitTimeInSeconds = 0.43 * 2^2 = 1.72s
-
-	// Itr4:
-	// rpcHoldTimeoutInSeconds = 7s
-	// initialBackoffInSeconds = 7/16 = 0.43s
-	// backoffMultiplierInSeconds = 2
-	// retryCount = 2
-	// waitTimeInSeconds = 0.43 * 2^3 = 3.44s
-
-	// Itr5:
-	// rpcHoldTimeoutInSeconds = 7s
-	// initialBackoffInSeconds = 7/16 = 0.43s
-	// backoffMultiplierInSeconds = 2
-	// retryCount = 2
-	// waitTimeInSeconds = 0.43 * 2^4 = 6.88s
-
-	fmt.Println("waitTimeInSeconds: ", waitTimeInSeconds)
-	fmt.Println("wait time duration: ", time.Duration(waitTimeInSeconds*float64(time.Second)))
-
-	return lib.RandomStagger(time.Duration(waitTimeInSeconds * float64(time.Second))) // TODO:change this to not be between 0 lower limit?
+	return lib.RandomStaggerWithRange(previousWaitTime, time.Duration(waitTimeInSeconds*float64(time.Second)))
 }
 
 // canRetry returns true if the request and error indicate that a retry is safe.
@@ -781,6 +726,7 @@ func (s *Server) canServeReadRequest(info structs.RPCInfo) bool {
 func (s *Server) forwardRequestToLeader(info structs.RPCInfo, forwardToLeader func(leader *metadata.Server) error) (handled bool, err error) {
 	firstCheck := time.Now()
 	retryCount := 0
+	previousJitter := time.Duration(0)
 CHECK_LEADER:
 	retryCount++
 	// Fail fast if we are in the process of leaving
@@ -815,16 +761,9 @@ CHECK_LEADER:
 
 	if retry := canRetry(info, rpcErr, firstCheck, s.config, retryableMessages); retry {
 		// Gate the request until there is a leader
-		// jitter := lib.RandomStagger(s.config.RPCHoldTimeout / structs.JitterFraction)
+		jitter := getWaitTime(s.config, previousJitter, retryCount)
+		previousJitter = jitter
 
-		// 0.43
-		// 0.43 * 2 => 0.86
-		// 0.43 * 4 => 1.72
-		// 0.43 * 8 => 3.44
-		// ------------------
-		// 0.43 * 16 => 7.3 => 7
-
-		jitter := getWaitTime(s.config, retryCount)
 		select {
 		case <-time.After(jitter):
 			goto CHECK_LEADER

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -1629,7 +1629,8 @@ func TestGetWaitTime(t *testing.T) {
 	config := DefaultConfig()
 	config.RPCHoldTimeout = 7 * time.Second
 	run := func(t *testing.T, tc testCase) {
-		require.Equal(t, tc.expected, getWaitTime(config, tc.retryCount))
+		require.GreaterOrEqual(t, getWaitTime(config, tc.retryCount), 0*time.Second)
+		require.LessOrEqual(t, getWaitTime(config, tc.retryCount), tc.expected)
 	}
 
 	var testCases = []testCase{

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -1623,35 +1623,40 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 func TestGetWaitTime(t *testing.T) {
 	type testCase struct {
 		name       string
+		previous   time.Duration
 		expected   time.Duration
 		retryCount int
 	}
 	config := DefaultConfig()
 	config.RPCHoldTimeout = 7 * time.Second
 	run := func(t *testing.T, tc testCase) {
-		require.GreaterOrEqual(t, getWaitTime(config, tc.retryCount), 0*time.Second)
-		require.LessOrEqual(t, getWaitTime(config, tc.retryCount), tc.expected)
+		require.GreaterOrEqual(t, getWaitTime(config, tc.previous, tc.retryCount), tc.previous)
+		require.LessOrEqual(t, getWaitTime(config, tc.previous, tc.retryCount), tc.expected)
 	}
 
 	var testCases = []testCase{
 		{
 			name:       "first attempt",
 			retryCount: 1,
+			previous:   time.Duration(0),
 			expected:   time.Duration(430) * time.Millisecond,
 		},
 		{
 			name:       "second attempt",
 			retryCount: 2,
+			previous:   time.Duration(430) * time.Millisecond,
 			expected:   time.Duration(860) * time.Millisecond,
 		},
 		{
 			name:       "third attempt",
 			retryCount: 3,
+			previous:   time.Duration(860) * time.Millisecond,
 			expected:   time.Duration(1720) * time.Millisecond,
 		},
 		{
 			name:       "fourth attempt",
 			retryCount: 4,
+			previous:   time.Duration(1720) * time.Millisecond,
 			expected:   time.Duration(3440) * time.Millisecond,
 		},
 	}

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -1622,42 +1622,48 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 
 func TestGetWaitTime(t *testing.T) {
 	type testCase struct {
-		name       string
-		previous   time.Duration
-		expected   time.Duration
-		retryCount int
+		name           string
+		RPCHoldTimeout time.Duration
+		expected       time.Duration
+		retryCount     int
 	}
 	config := DefaultConfig()
-	config.RPCHoldTimeout = 7 * time.Second
+
 	run := func(t *testing.T, tc testCase) {
-		require.GreaterOrEqual(t, getWaitTime(config, tc.previous, tc.retryCount), tc.previous)
-		require.LessOrEqual(t, getWaitTime(config, tc.previous, tc.retryCount), tc.expected)
+		config.RPCHoldTimeout = tc.RPCHoldTimeout
+		require.Equal(t, tc.expected, getWaitTime(config.RPCHoldTimeout, tc.retryCount))
 	}
 
 	var testCases = []testCase{
 		{
-			name:       "first attempt",
-			retryCount: 1,
-			previous:   time.Duration(0),
-			expected:   time.Duration(430) * time.Millisecond,
+			name:           "init backoff small",
+			RPCHoldTimeout: 7 * time.Millisecond,
+			retryCount:     1,
+			expected:       1 * time.Millisecond,
 		},
 		{
-			name:       "second attempt",
-			retryCount: 2,
-			previous:   time.Duration(430) * time.Millisecond,
-			expected:   time.Duration(860) * time.Millisecond,
+			name:           "first attempt",
+			RPCHoldTimeout: 7 * time.Second,
+			retryCount:     1,
+			expected:       437 * time.Millisecond,
 		},
 		{
-			name:       "third attempt",
-			retryCount: 3,
-			previous:   time.Duration(860) * time.Millisecond,
-			expected:   time.Duration(1720) * time.Millisecond,
+			name:           "second attempt",
+			RPCHoldTimeout: 7 * time.Second,
+			retryCount:     2,
+			expected:       874 * time.Millisecond,
 		},
 		{
-			name:       "fourth attempt",
-			retryCount: 4,
-			previous:   time.Duration(1720) * time.Millisecond,
-			expected:   time.Duration(3440) * time.Millisecond,
+			name:           "third attempt",
+			RPCHoldTimeout: 7 * time.Second,
+			retryCount:     3,
+			expected:       1748 * time.Millisecond,
+		},
+		{
+			name:           "fourth attempt",
+			RPCHoldTimeout: 7 * time.Second,
+			retryCount:     4,
+			expected:       3496 * time.Millisecond,
 		},
 	}
 

--- a/lib/cluster.go
+++ b/lib/cluster.go
@@ -45,6 +45,11 @@ func RandomStagger(intv time.Duration) time.Duration {
 	return time.Duration(uint64(rand.Int63()) % uint64(intv))
 }
 
+// RandomStagger returns an interval between min and the max duration
+func RandomStaggerWithRange(min time.Duration, max time.Duration) time.Duration {
+	return RandomStagger(max-min) + min
+}
+
 // RateScaledInterval is used to choose an interval to perform an action in
 // order to target an aggregate number of actions per second across the whole
 // cluster.

--- a/lib/cluster.go
+++ b/lib/cluster.go
@@ -45,7 +45,7 @@ func RandomStagger(intv time.Duration) time.Duration {
 	return time.Duration(uint64(rand.Int63()) % uint64(intv))
 }
 
-// RandomStagger returns an interval between min and the max duration
+// RandomStaggerWithRange returns an interval between min and the max duration
 func RandomStaggerWithRange(min time.Duration, max time.Duration) time.Duration {
 	return RandomStagger(max-min) + min
 }

--- a/lib/cluster_test.go
+++ b/lib/cluster_test.go
@@ -1,6 +1,8 @@
 package lib
 
 import (
+	"github.com/stretchr/testify/require"
+	"math"
 	"testing"
 	"time"
 )
@@ -170,5 +172,27 @@ func TestRateScaledInterval(t *testing.T) {
 	}
 	if v := RateScaledInterval(-1, min, 10000); v != min {
 		t.Fatalf("Bad: %v", v)
+	}
+}
+
+func TestRandomStaggerWithRange(t *testing.T) {
+	type args struct {
+		min time.Duration
+		max time.Duration
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"min-max 0", args{time.Duration(0), time.Duration(0)}},
+		{"min-max big", args{time.Duration(math.MaxInt64), time.Duration(math.MaxInt64)}},
+		{"normal case", args{time.Duration(3), time.Duration(7)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RandomStaggerWithRange(tt.args.min, tt.args.max)
+			require.GreaterOrEqual(t, got, tt.args.min)
+			require.LessOrEqual(t, got, tt.args.max)
+		})
 	}
 }


### PR DESCRIPTION
### Description
This is a remake of #16146 


> The retries were too aggressive which compounded rate limiting errors. Hence, implementing an exponential back-off strategy which gives enough time for the server to recover.
