### PR TITLE
docs: refine server TLS Vault PKI role config

### DIFF
--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/server-tls.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/server-tls.mdx
@@ -104,7 +104,6 @@ this is required for the Consul components to communicate with the Consul server
         allow_subdomains=true \
         allow_bare_domains=true \
         allow_localhost=true \
-        generate_lease=true \
         max_ttl="720h"
     ```
 


### PR DESCRIPTION
The generate_lease=true configuration is unnecessary and generates a note about performance implications in Vault logs. Remove this configuration so that the default value of generate_lease=false is used instead.

Follow-up to https://github.com/hashicorp/consul-k8s/pull/1877