### PR TITLE
revert UI acl changes from #15922

### DIFF
--- a/ui/packages/consul-ui/app/abilities/token.js
+++ b/ui/packages/consul-ui/app/abilities/token.js
@@ -1,6 +1,7 @@
 import BaseAbility from './base';
 import { inject as service } from '@ember/service';
 
+import { isLegacy } from 'consul-ui/helpers/token/is-legacy';
 import { isAnonymous } from 'consul-ui/helpers/token/is-anonymous';
 
 export default class TokenAbility extends BaseAbility {
@@ -27,6 +28,6 @@ export default class TokenAbility extends BaseAbility {
   }
 
   get canDuplicate() {
-    return this.env.var('CONSUL_ACLS_ENABLED') && super.canWrite;
+    return this.env.var('CONSUL_ACLS_ENABLED') && !isLegacy([this.item]) && super.canWrite;
   }
 }

--- a/ui/packages/consul-ui/app/models/token.js
+++ b/ui/packages/consul-ui/app/models/token.js
@@ -15,6 +15,7 @@ export default class Token extends Model {
   @attr('string') IDPName;
   @attr('string') SecretID;
 
+  @attr('boolean') Legacy;
   @attr('boolean') Local;
   @attr('string', { defaultValue: () => '' }) Description;
   @attr() meta; // {}
@@ -27,6 +28,12 @@ export default class Token extends Model {
   @attr('string') Hash;
   @attr('number') CreateIndex;
   @attr('number') ModifyIndex;
+
+  // Legacy
+  @attr('string') Type;
+  @attr('string', { defaultValue: () => '' }) Name;
+  @attr('string') Rules;
+  // End Legacy
 
   @computed('Policies.[]')
   get isGlobalManagement() {

--- a/ui/packages/consul-ui/tests/integration/helpers/token/is-legacy-test.js
+++ b/ui/packages/consul-ui/tests/integration/helpers/token/is-legacy-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | token/is-legacy', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function (assert) {
+    this.set('inputValue', {});
+
+    await render(hbs`{{token/is-legacy inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'false');
+  });
+});

--- a/ui/packages/consul-ui/tests/unit/helpers/token/is-legacy-test.js
+++ b/ui/packages/consul-ui/tests/unit/helpers/token/is-legacy-test.js
@@ -1,0 +1,53 @@
+import { isLegacy } from 'consul-ui/helpers/token/is-legacy';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | token/is-legacy', function () {
+  test('it returns true if the token has a Legacy=true', function (assert) {
+    const actual = isLegacy([{ Legacy: true }]);
+    assert.ok(actual);
+  });
+  test('it returns false if the token has a Legacy=false', function (assert) {
+    const actual = isLegacy([{ Legacy: false }]);
+    assert.notOk(actual);
+  });
+  test('it returns true if the token has Rules', function (assert) {
+    const actual = isLegacy([{ Rules: 'some rules' }]);
+    assert.ok(actual);
+  });
+  test('it returns false if the token has Rules but those rules are empty', function (assert) {
+    const actual = isLegacy([{ Rules: '' }]);
+    assert.notOk(actual);
+  });
+  test('it returns false if the token has Rules but those rules is null', function (assert) {
+    const actual = isLegacy([{ Rules: null }]);
+    assert.notOk(actual);
+  });
+  // passing arrays
+  test("it returns false if things don't have Legacy or Rules", function (assert) {
+    const actual = isLegacy([[{}, {}]]);
+    assert.notOk(actual);
+  });
+  test('it returns true if the token has a Legacy=true', function (assert) {
+    const actual = isLegacy([[{}, { Legacy: true }]]);
+    assert.ok(actual);
+  });
+  test('it returns false if the token has a Legacy=false', function (assert) {
+    const actual = isLegacy([[{}, { Legacy: false }]]);
+    assert.notOk(actual);
+  });
+  test('it returns true if one token has Rules', function (assert) {
+    const actual = isLegacy([[{}, { Rules: 'some rules' }]]);
+    assert.ok(actual);
+  });
+  test('it returns false if tokens have no Rules, or has Rules but those rules are empty', function (assert) {
+    const actual = isLegacy([[{}, { Rules: '' }]]);
+    assert.notOk(actual);
+  });
+  test('it returns false if a token is marked as legacy, has Rules but those rules are empty', function (assert) {
+    // this may seem strange, but empty Rules should override Legacy, this only happens
+    // when a legacy token that has already been loaded has its rules wiped out
+    // WITHOUT then the ui refreshing
+    const actual = isLegacy([{ Legacy: true, Rules: '' }]);
+    assert.notOk(actual);
+  });
+});


### PR DESCRIPTION
### Description
Revert ui changes from https://github.com/hashicorp/consul/pull/15922
I had the idea that it might be helpful to remove some no-longer functional legacy acl code from the ui in https://github.com/hashicorp/consul/pull/15922
But this was unwise, and I should not have touched it without fully understanding their tests.
