### PR TITLE
revert method name change in xds server protocol for version compatibility

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -37,7 +37,7 @@ type TestACLAgent struct {
 
 // NewTestACLAgent does just enough so that all the code within agent/acl.go can work
 // Basically it needs a local state for some of the vet* functions, a logger and a delegate.
-// The key is that we are the delegate so we can control the ResolveTokenSecret responses
+// The key is that we are the delegate so we can control the ResolveToken responses
 func NewTestACLAgent(t *testing.T, name string, hcl string, resolveAuthz authzResolver, resolveIdent identResolver) *TestACLAgent {
 	t.Helper()
 
@@ -89,9 +89,9 @@ func NewTestACLAgent(t *testing.T, name string, hcl string, resolveAuthz authzRe
 	return a
 }
 
-func (a *TestACLAgent) ResolveTokenSecret(secretID string) (acl.Authorizer, error) {
+func (a *TestACLAgent) ResolveToken(secretID string) (acl.Authorizer, error) {
 	if a.resolveAuthzFn == nil {
-		return nil, fmt.Errorf("ResolveTokenSecret call is unexpected - no authz resolver callback set")
+		return nil, fmt.Errorf("ResolveToken call is unexpected - no authz resolver callback set")
 	}
 
 	_, authz, err := a.resolveAuthzFn(secretID)
@@ -99,7 +99,7 @@ func (a *TestACLAgent) ResolveTokenSecret(secretID string) (acl.Authorizer, erro
 }
 
 func (a *TestACLAgent) ResolveTokenAndDefaultMeta(secretID string, entMeta *acl.EnterpriseMeta, authzContext *acl.AuthorizerContext) (resolver.Result, error) {
-	authz, err := a.ResolveTokenSecret(secretID)
+	authz, err := a.ResolveToken(secretID)
 	if err != nil {
 		return resolver.Result{}, err
 	}

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -993,10 +993,10 @@ func (r *ACLResolver) resolveLocallyManagedToken(token string) (structs.ACLIdent
 	return r.resolveLocallyManagedEnterpriseToken(token)
 }
 
-// ResolveTokenSecret to an acl.Authorizer and structs.ACLIdentity. The acl.Authorizer
+// ResolveToken to an acl.Authorizer and structs.ACLIdentity. The acl.Authorizer
 // can be used to check permissions granted to the token using its secret, and the
 // ACLIdentity describes the token and any defaults applied to it.
-func (r *ACLResolver) ResolveTokenSecret(tokenSecretID string) (resolver.Result, error) {
+func (r *ACLResolver) ResolveToken(tokenSecretID string) (resolver.Result, error) {
 	if !r.ACLsEnabled() {
 		return resolver.Result{Authorizer: acl.ManageAll()}, nil
 	}
@@ -1078,7 +1078,7 @@ func (r *ACLResolver) ResolveTokenAndDefaultMeta(
 	entMeta *acl.EnterpriseMeta,
 	authzContext *acl.AuthorizerContext,
 ) (resolver.Result, error) {
-	result, err := r.ResolveTokenSecret(tokenSecretID)
+	result, err := r.ResolveToken(tokenSecretID)
 	if err != nil {
 		return resolver.Result{}, err
 	}
@@ -1121,7 +1121,7 @@ func filterACLWithAuthorizer(logger hclog.Logger, authorizer acl.Authorizer, sub
 // not authorized for read access will be removed from subj.
 func filterACL(r *ACLResolver, tokenSecretID string, subj interface{}) error {
 	// Get the ACL from the token
-	authorizer, err := r.ResolveTokenSecret(tokenSecretID)
+	authorizer, err := r.ResolveToken(tokenSecretID)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -703,7 +703,7 @@ func (a *ACL) TokenBatchRead(args *structs.ACLTokenBatchGetRequest, reply *struc
 		return err
 	}
 
-	authz, err := a.srv.ResolveTokenSecret(args.Token)
+	authz, err := a.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -796,7 +796,7 @@ func (a *ACL) PolicyBatchRead(args *structs.ACLPolicyBatchGetRequest, reply *str
 		return err
 	}
 
-	authz, err := a.srv.ResolveTokenSecret(args.Token)
+	authz, err := a.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -1182,7 +1182,7 @@ func (a *ACL) RoleBatchRead(args *structs.ACLRoleBatchGetRequest, reply *structs
 		return err
 	}
 
-	authz, err := a.srv.ResolveTokenSecret(args.Token)
+	authz, err := a.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -2115,7 +2115,7 @@ func (a *ACL) Authorize(args *structs.RemoteACLAuthorizationRequest, reply *[]st
 		return err
 	}
 
-	authz, err := a.srv.ResolveTokenSecret(args.Token)
+	authz, err := a.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -60,7 +60,7 @@ func (s *ConnectCA) ConfigurationGet(
 	}
 
 	// This action requires operator read access.
-	authz, err := s.srv.ResolveTokenSecret(args.Token)
+	authz, err := s.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (s *ConnectCA) ConfigurationSet(
 	}
 
 	// This action requires operator write access.
-	authz, err := s.srv.ResolveTokenSecret(args.Token)
+	authz, err := s.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func (s *ConnectCA) Sign(
 		return err
 	}
 
-	authz, err := s.srv.ResolveTokenSecret(args.Token)
+	authz, err := s.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func (s *ConnectCA) SignIntermediate(
 	}
 
 	// This action requires operator write access.
-	authz, err := s.srv.ResolveTokenSecret(args.Token)
+	authz, err := s.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/federation_state_endpoint.go
+++ b/agent/consul/federation_state_endpoint.go
@@ -58,7 +58,7 @@ func (c *FederationState) Apply(args *structs.FederationStateRequest, reply *boo
 	defer metrics.MeasureSince([]string{"federation_state", "apply"}, time.Now())
 
 	// Fetch the ACL token, if any.
-	authz, err := c.srv.ResolveTokenSecret(args.Token)
+	authz, err := c.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (c *FederationState) Get(args *structs.FederationStateQuery, reply *structs
 	defer metrics.MeasureSince([]string{"federation_state", "get"}, time.Now())
 
 	// Fetch the ACL token, if any.
-	authz, err := c.srv.ResolveTokenSecret(args.Token)
+	authz, err := c.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func (c *FederationState) List(args *structs.DCSpecificRequest, reply *structs.I
 	defer metrics.MeasureSince([]string{"federation_state", "list"}, time.Now())
 
 	// Fetch the ACL token, if any.
-	authz, err := c.srv.ResolveTokenSecret(args.Token)
+	authz, err := c.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -780,7 +780,7 @@ func (m *Internal) KeyringOperation(
 	}
 
 	// Check ACLs
-	authz, err := m.srv.ACLResolver.ResolveTokenSecret(args.Token)
+	authz, err := m.srv.ACLResolver.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/operator_autopilot_endpoint.go
+++ b/agent/consul/operator_autopilot_endpoint.go
@@ -16,7 +16,7 @@ func (op *Operator) AutopilotGetConfiguration(args *structs.DCSpecificRequest, r
 	}
 
 	// This action requires operator read access.
-	authz, err := op.srv.ACLResolver.ResolveTokenSecret(args.Token)
+	authz, err := op.srv.ACLResolver.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 	}
 
 	// This action requires operator write access.
-	authz, err := op.srv.ACLResolver.ResolveTokenSecret(args.Token)
+	authz, err := op.srv.ACLResolver.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (op *Operator) ServerHealth(args *structs.DCSpecificRequest, reply *structs
 	}
 
 	// This action requires operator read access.
-	authz, err := op.srv.ACLResolver.ResolveTokenSecret(args.Token)
+	authz, err := op.srv.ACLResolver.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func (op *Operator) AutopilotState(args *structs.DCSpecificRequest, reply *autop
 	}
 
 	// This action requires operator read access.
-	authz, err := op.srv.ACLResolver.ResolveTokenSecret(args.Token)
+	authz, err := op.srv.ACLResolver.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/operator_raft_endpoint.go
+++ b/agent/consul/operator_raft_endpoint.go
@@ -18,7 +18,7 @@ func (op *Operator) RaftGetConfiguration(args *structs.DCSpecificRequest, reply 
 	}
 
 	// This action requires operator read access.
-	authz, err := op.srv.ResolveTokenSecret(args.Token)
+	authz, err := op.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (op *Operator) RaftRemovePeerByAddress(args *structs.RaftRemovePeerRequest,
 
 	// This is a super dangerous operation that requires operator write
 	// access.
-	authz, err := op.srv.ACLResolver.ResolveTokenSecret(args.Token)
+	authz, err := op.srv.ACLResolver.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (op *Operator) RaftRemovePeerByID(args *structs.RaftRemovePeerRequest, repl
 
 	// This is a super dangerous operation that requires operator write
 	// access.
-	authz, err := op.srv.ACLResolver.ResolveTokenSecret(args.Token)
+	authz, err := op.srv.ACLResolver.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -78,7 +78,7 @@ func (p *PreparedQuery) Apply(args *structs.PreparedQueryRequest, reply *string)
 	*reply = args.Query.ID
 
 	// Get the ACL token for the request for the checks below.
-	authz, err := p.srv.ResolveTokenSecret(args.Token)
+	authz, err := p.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/snapshot_endpoint.go
+++ b/agent/consul/snapshot_endpoint.go
@@ -58,7 +58,7 @@ func (s *Server) dispatchSnapshotRequest(args *structs.SnapshotRequest, in io.Re
 	// Verify token is allowed to operate on snapshots. There's only a
 	// single ACL sense here (not read and write) since reading gets you
 	// all the ACLs and you could escalate from there.
-	if authz, err := s.ResolveTokenSecret(args.Token); err != nil {
+	if authz, err := s.ResolveToken(args.Token); err != nil {
 		return nil, err
 	} else if err := authz.ToAllowAuthorizer().SnapshotAllowed(nil); err != nil {
 		return nil, err

--- a/agent/consul/txn_endpoint.go
+++ b/agent/consul/txn_endpoint.go
@@ -147,7 +147,7 @@ func (t *Txn) Apply(args *structs.TxnRequest, reply *structs.TxnResponse) error 
 	defer metrics.MeasureSince([]string{"txn", "apply"}, time.Now())
 
 	// Run the pre-checks before we send the transaction into Raft.
-	authz, err := t.srv.ResolveTokenSecret(args.Token)
+	authz, err := t.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (t *Txn) Read(args *structs.TxnReadRequest, reply *structs.TxnReadResponse)
 	}
 
 	// Run the pre-checks before we perform the read.
-	authz, err := t.srv.ResolveTokenSecret(args.Token)
+	authz, err := t.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -103,11 +103,11 @@ type ProxyConfigSource interface {
 // A full description of the XDS protocol can be found at
 // https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
 type Server struct {
-	NodeName           string
-	Logger             hclog.Logger
-	CfgSrc             ProxyConfigSource
-	ResolveTokenSecret ACLResolverFunc
-	CfgFetcher         ConfigFetcher
+	NodeName     string
+	Logger       hclog.Logger
+	CfgSrc       ProxyConfigSource
+	ResolveToken ACLResolverFunc
+	CfgFetcher   ConfigFetcher
 
 	// AuthCheckFrequency is how often we should re-check the credentials used
 	// during a long-lived gRPC Stream after it has been initially established.
@@ -164,7 +164,7 @@ func NewServer(
 		NodeName:           nodeName,
 		Logger:             logger,
 		CfgSrc:             cfgMgr,
-		ResolveTokenSecret: resolveTokenSecret,
+		ResolveToken:       resolveTokenSecret,
 		CfgFetcher:         cfgFetcher,
 		AuthCheckFrequency: DefaultAuthCheckFrequency,
 		activeStreams:      &activeStreamCounters{},
@@ -191,7 +191,7 @@ func (s *Server) authenticate(ctx context.Context) (acl.Authorizer, error) {
 		return nil, status.Errorf(codes.Internal, "error fetching options from context: %v", err)
 	}
 
-	authz, err := s.ResolveTokenSecret(options.Token)
+	authz, err := s.ResolveToken(options.Token)
 	if acl.IsErrNotFound(err) {
 		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
 	} else if acl.IsErrPermissionDenied(err) {


### PR DESCRIPTION
### Description
https://github.com/hashicorp/consul/pull/16044 renamed a field in the xds server protocol struct (https://github.com/hashicorp/consul/pull/16044/files#diff-83eb78d94a07420323d5e88be3bc61881c2f6d5724b74a291e9a77a4c5e07995L108) that could cause version compatibility issues during an upgrade. Revert this rename.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
