### PR TITLE
add warning logs for agent token not set

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -6199,11 +6199,11 @@ func TestAgent_TokenTriggersFullSync(t *testing.T) {
 	}{
 		{
 			path:       "acl_agent_token",
-			tokenGetFn: (*token.Store).AgentToken,
+			tokenGetFn: (*token.Store).TokenForAgent,
 		},
 		{
 			path:       "agent",
-			tokenGetFn: (*token.Store).AgentToken,
+			tokenGetFn: (*token.Store).TokenForAgent,
 		},
 		{
 			path:       "acl_token",
@@ -6542,7 +6542,7 @@ func TestAgent_Token(t *testing.T) {
 				return
 			}
 			require.Equal(t, tt.effective.user, a.tokens.UserToken())
-			require.Equal(t, tt.effective.agent, a.tokens.AgentToken())
+			require.Equal(t, tt.effective.agent, a.tokens.TokenForAgent())
 			require.Equal(t, tt.effective.agentRecovery, a.tokens.AgentRecoveryToken())
 			require.Equal(t, tt.effective.repl, a.tokens.ReplicationToken())
 			require.Equal(t, tt.effective.registration, a.tokens.ConfigFileRegistrationToken())

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -234,7 +234,7 @@ func TestAgent_TokenStore(t *testing.T) {
 	if got, want := a.tokens.UserToken(), "user"; got != want {
 		t.Fatalf("got %q want %q", got, want)
 	}
-	if got, want := a.tokens.AgentToken(), "agent"; got != want {
+	if got, want := a.tokens.TokenForAgent(), "agent"; got != want {
 		t.Fatalf("got %q want %q", got, want)
 	}
 	if got, want := a.tokens.IsAgentRecoveryToken("recovery"), true; got != want {
@@ -5258,7 +5258,7 @@ func TestAutoConfig_Integration(t *testing.T) {
 	testrpc.WaitForTestAgent(t, client.RPC, "dc1", testrpc.WithToken(TestDefaultInitialManagementToken))
 
 	// spot check that we now have an ACL token
-	require.NotEmpty(t, client.tokens.AgentToken())
+	require.NotEmpty(t, client.tokens.TokenForAgent())
 
 	// grab the existing cert
 	cert1 := client.Agent.tlsConfigurator.Cert()

--- a/agent/auto-config/auto_config_test.go
+++ b/agent/auto-config/auto_config_test.go
@@ -317,7 +317,7 @@ func TestInitialConfiguration_restored(t *testing.T) {
 	mcfg.tokens.On("UpdateAgentToken", "secret", token.TokenSourceConfig).Return(true).Once()
 
 	// prepopulation is going to grab the token to populate the correct cache key
-	mcfg.tokens.On("AgentToken").Return("secret").Times(0)
+	mcfg.tokens.On("TokenForAgent").Return("secret").Times(0)
 
 	ac, err := New(mcfg.Config)
 	require.NoError(t, err)
@@ -349,7 +349,7 @@ func TestInitialConfiguration_success(t *testing.T) {
 	mcfg.tokens.On("UpdateAgentToken", "secret", token.TokenSourceConfig).Return(true).Once()
 
 	// prepopulation is going to grab the token to populate the correct cache key
-	mcfg.tokens.On("AgentToken").Return("secret").Times(0)
+	mcfg.tokens.On("TokenForAgent").Return("secret").Times(0)
 
 	// no server provider
 	mcfg.serverProvider.On("FindLANServer").Return(nil).Times(0)
@@ -431,7 +431,7 @@ func TestInitialConfiguration_retries(t *testing.T) {
 	mcfg.tokens.On("UpdateAgentToken", "secret", token.TokenSourceConfig).Return(true).Once()
 
 	// prepopulation is going to grab the token to populate the correct cache key
-	mcfg.tokens.On("AgentToken").Return("secret").Times(0)
+	mcfg.tokens.On("TokenForAgent").Return("secret").Times(0)
 
 	// no server provider
 	mcfg.serverProvider.On("FindLANServer").Return(nil).Times(0)
@@ -534,7 +534,7 @@ func TestGoRoutineManagement(t *testing.T) {
 	mcfg.Config.Loader = loader.Load
 
 	// prepopulation is going to grab the token to populate the correct cache key
-	mcfg.tokens.On("AgentToken").Return("secret").Times(0)
+	mcfg.tokens.On("TokenForAgent").Return("secret").Times(0)
 
 	ac, err := New(mcfg.Config)
 	require.NoError(t, err)
@@ -688,13 +688,13 @@ func startedAutoConfig(t *testing.T, autoEncrypt bool) testAutoConfig {
 	// and then again when setting up the cache watch for the leaf cert.
 	// However one of those expectations is setup in the expectInitialTLS
 	// method so we only need one more here
-	mcfg.tokens.On("AgentToken").Return(originalToken).Once()
+	mcfg.tokens.On("TokenForAgent").Return(originalToken).Once()
 
 	if autoEncrypt {
 		// when using AutoEncrypt we also have to grab the token once more
 		// when setting up the initial RPC as the ACL token is what is used
 		// to authorize the request.
-		mcfg.tokens.On("AgentToken").Return(originalToken).Once()
+		mcfg.tokens.On("TokenForAgent").Return(originalToken).Once()
 	}
 
 	// this is called once during Start to initialze the token watches
@@ -889,7 +889,7 @@ func TestTokenUpdate(t *testing.T) {
 	})
 
 	// this will be retrieved once when resetting the leaf cert watch
-	testAC.mcfg.tokens.On("AgentToken").Return(newToken).Once()
+	testAC.mcfg.tokens.On("TokenForAgent").Return(newToken).Once()
 
 	// send the notification about the token update
 	testAC.tokenUpdates <- struct{}{}

--- a/agent/auto-config/auto_encrypt.go
+++ b/agent/auto-config/auto_encrypt.go
@@ -37,7 +37,7 @@ func (ac *AutoConfig) autoEncryptInitialCerts(ctx context.Context) (*structs.Sig
 
 func (ac *AutoConfig) autoEncryptInitialCertsOnce(ctx context.Context, csr, key string) (*structs.SignedResponse, error) {
 	request := structs.CASignRequest{
-		WriteRequest: structs.WriteRequest{Token: ac.acConfig.Tokens.AgentToken()},
+		WriteRequest: structs.WriteRequest{Token: ac.acConfig.Tokens.TokenForAgent()},
 		Datacenter:   ac.config.Datacenter,
 		CSR:          csr,
 	}

--- a/agent/auto-config/auto_encrypt_test.go
+++ b/agent/auto-config/auto_encrypt_test.go
@@ -192,7 +192,7 @@ func TestAutoEncrypt_InitialCerts(t *testing.T) {
 
 	// The following are called once for each round through the auto-encrypt initial certs outer loop
 	// (not the per-host direct rpc attempts but the one involving the RetryWaiter)
-	mcfg.tokens.On("AgentToken").Return(token).Times(2)
+	mcfg.tokens.On("TokenForAgent").Return(token).Times(2)
 	mcfg.serverProvider.On("FindLANServer").Return(nil).Times(2)
 
 	request := structs.CASignRequest{
@@ -281,7 +281,7 @@ func TestAutoEncrypt_InitialConfiguration(t *testing.T) {
 	indexedRoots, cert, extraCerts := mcfg.setupInitialTLS(t, nodeName, datacenter, token)
 
 	// prepopulation is going to grab the token to populate the correct cache key
-	mcfg.tokens.On("AgentToken").Return(token).Times(0)
+	mcfg.tokens.On("TokenForAgent").Return(token).Times(0)
 
 	// no server provider
 	mcfg.serverProvider.On("FindLANServer").Return(&metadata.Server{Addr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8300}}).Times(1)
@@ -361,7 +361,7 @@ func TestAutoEncrypt_TokenUpdate(t *testing.T) {
 	})
 
 	// this will be retrieved once when resetting the leaf cert watch
-	testAC.mcfg.tokens.On("AgentToken").Return(newToken).Once()
+	testAC.mcfg.tokens.On("TokenForAgent").Return(newToken).Once()
 
 	// send the notification about the token update
 	testAC.tokenUpdates <- struct{}{}
@@ -515,7 +515,7 @@ func TestAutoEncrypt_Fallback(t *testing.T) {
 	}
 
 	// the fallback routine to perform auto-encrypt again will need to grab this
-	testAC.mcfg.tokens.On("AgentToken").Return(testAC.originalToken).Once()
+	testAC.mcfg.tokens.On("TokenForAgent").Return(testAC.originalToken).Once()
 
 	testAC.mcfg.directRPC.On(
 		"RPC",

--- a/agent/auto-config/config.go
+++ b/agent/auto-config/config.go
@@ -47,7 +47,7 @@ type TLSConfigurator interface {
 
 // TokenStore is an interface of the methods we will need to use from the token.Store.
 type TokenStore interface {
-	AgentToken() string
+	TokenForAgent() string
 	UpdateAgentToken(secret string, source token.TokenSource) bool
 	Notify(kind token.TokenKind) token.Notifier
 	StopNotify(notifier token.Notifier)

--- a/agent/auto-config/mock_test.go
+++ b/agent/auto-config/mock_test.go
@@ -194,9 +194,14 @@ func newMockTokenStore(t *testing.T) *mockTokenStore {
 	return &m
 }
 
-func (m *mockTokenStore) AgentToken() string {
+func (m *mockTokenStore) TokenForAgent() string {
 	ret := m.Called()
 	return ret.String(0)
+}
+
+func (m *mockTokenStore) AgentOrUserToken() (string, bool) {
+	ret := m.Called()
+	return ret.String(0), true
 }
 
 func (m *mockTokenStore) UpdateAgentToken(secret string, source token.TokenSource) bool {
@@ -338,7 +343,7 @@ func (m *mockedConfig) expectInitialTLS(t *testing.T, agentName, datacenter, tok
 
 	// when prepopulating the cert in the cache we grab the token so
 	// we should expec that here
-	m.tokens.On("AgentToken").Return(token).Once()
+	m.tokens.On("TokenForAgent").Return(token).Once()
 }
 
 func (m *mockedConfig) setupInitialTLS(t *testing.T, agentName, datacenter, token string) (*structs.IndexedCARoots, *structs.IssuedCert, []string) {

--- a/agent/auto-config/tls.go
+++ b/agent/auto-config/tls.go
@@ -197,7 +197,7 @@ func (ac *AutoConfig) leafCertRequest() cachetype.ConnectCALeafRequest {
 		Agent:          ac.config.NodeName,
 		DNSSAN:         ac.getDNSSANs(),
 		IPSAN:          ac.getIPSANs(),
-		Token:          ac.acConfig.Tokens.AgentToken(),
+		Token:          ac.acConfig.Tokens.TokenForAgent(),
 		EnterpriseMeta: *structs.NodeEnterpriseMetaInPartition(ac.config.PartitionOrEmpty()),
 	}
 }

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -348,7 +348,11 @@ func makeConfigRequest(bd BaseDeps, addReq AddServiceRequest) *structs.ServiceCo
 		EnterpriseMeta:       ns.EnterpriseMeta,
 	}
 	if req.QueryOptions.Token == "" {
-		req.QueryOptions.Token = bd.Tokens.AgentToken()
+		tok, isAgentToken := bd.Tokens.AgentOrUserToken()
+		req.QueryOptions.Token = tok
+		if !isAgentToken {
+			bd.Logger.Warn("Agent ACL token has not been set")
+		}
 	}
 	return req
 }

--- a/agent/token/persistence_test.go
+++ b/agent/token/persistence_test.go
@@ -5,9 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 func TestStore_Load(t *testing.T) {
@@ -26,7 +27,7 @@ func TestStore_Load(t *testing.T) {
 			ACLConfigFileRegistrationToken: "echo",
 		}
 		require.NoError(t, store.Load(cfg, logger))
-		require.Equal(t, "alfa", store.AgentToken())
+		require.Equal(t, "alfa", store.TokenForAgent())
 		require.Equal(t, "bravo", store.AgentRecoveryToken())
 		require.Equal(t, "charlie", store.UserToken())
 		require.Equal(t, "delta", store.ReplicationToken())
@@ -45,7 +46,7 @@ func TestStore_Load(t *testing.T) {
 		// ensures no error for missing persisted tokens file
 		require.NoError(t, store.Load(cfg, logger))
 		require.Equal(t, "echo", store.UserToken())
-		require.Equal(t, "foxtrot", store.AgentToken())
+		require.Equal(t, "foxtrot", store.TokenForAgent())
 		require.Equal(t, "golf", store.AgentRecoveryToken())
 		require.Equal(t, "hotel", store.ReplicationToken())
 		require.Equal(t, "india", store.ConfigFileRegistrationToken())
@@ -74,7 +75,7 @@ func TestStore_Load(t *testing.T) {
 
 		// no updates since token persistence is not enabled
 		require.Equal(t, "echo", store.UserToken())
-		require.Equal(t, "foxtrot", store.AgentToken())
+		require.Equal(t, "foxtrot", store.TokenForAgent())
 		require.Equal(t, "golf", store.AgentRecoveryToken())
 		require.Equal(t, "hotel", store.ReplicationToken())
 		require.Equal(t, "delta", store.ConfigFileRegistrationToken())
@@ -82,7 +83,7 @@ func TestStore_Load(t *testing.T) {
 		cfg.EnablePersistence = true
 		require.NoError(t, store.Load(cfg, logger))
 
-		require.Equal(t, "india", store.AgentToken())
+		require.Equal(t, "india", store.TokenForAgent())
 		require.Equal(t, "juliett", store.AgentRecoveryToken())
 		require.Equal(t, "kilo", store.UserToken())
 		require.Equal(t, "lima", store.ReplicationToken())
@@ -128,7 +129,7 @@ func TestStore_Load(t *testing.T) {
 		require.NoError(t, os.WriteFile(tokenFile, []byte(tokens), 0600))
 		require.NoError(t, store.Load(cfg, logger))
 
-		require.Equal(t, "mike", store.AgentToken())
+		require.Equal(t, "mike", store.TokenForAgent())
 		require.Equal(t, "november", store.AgentRecoveryToken())
 		require.Equal(t, "oscar", store.UserToken())
 		require.Equal(t, "papa", store.ReplicationToken())
@@ -154,7 +155,7 @@ func TestStore_Load(t *testing.T) {
 		require.NoError(t, os.WriteFile(tokenFile, []byte(tokens), 0600))
 		require.NoError(t, store.Load(cfg, logger))
 
-		require.Equal(t, "uniform", store.AgentToken())
+		require.Equal(t, "uniform", store.TokenForAgent())
 		require.Equal(t, "victor", store.AgentRecoveryToken())
 		require.Equal(t, "whiskey", store.UserToken())
 		require.Equal(t, "zulu", store.ReplicationToken())
@@ -178,7 +179,7 @@ func TestStore_Load(t *testing.T) {
 		require.Contains(t, err.Error(), "failed to decode tokens file")
 
 		require.Equal(t, "one", store.UserToken())
-		require.Equal(t, "two", store.AgentToken())
+		require.Equal(t, "two", store.TokenForAgent())
 		require.Equal(t, "three", store.AgentRecoveryToken())
 		require.Equal(t, "four", store.ReplicationToken())
 		require.Equal(t, "five", store.ConfigFileRegistrationToken())
@@ -201,7 +202,7 @@ func TestStore_Load(t *testing.T) {
 		require.Contains(t, err.Error(), "failed to decode tokens file")
 
 		require.Equal(t, "alfa", store.UserToken())
-		require.Equal(t, "bravo", store.AgentToken())
+		require.Equal(t, "bravo", store.TokenForAgent())
 		require.Equal(t, "charlie", store.AgentRecoveryToken())
 		require.Equal(t, "foxtrot", store.ReplicationToken())
 		require.Equal(t, "golf", store.ConfigFileRegistrationToken())

--- a/agent/token/store.go
+++ b/agent/token/store.go
@@ -1,9 +1,8 @@
 package token
 
 import (
-	"sync"
-
 	"crypto/subtle"
+	"sync"
 )
 
 type TokenSource bool
@@ -221,19 +220,25 @@ func (t *Store) UserToken() string {
 	return t.userToken
 }
 
-// AgentToken returns the best token to use for internal agent operations.
-func (t *Store) AgentToken() string {
+// AgentOrUserToken returns the best token to use for internal agent operations, and whether that token is the agent token.
+func (t *Store) AgentOrUserToken() (token string, isAgentToken bool) {
 	t.l.RLock()
 	defer t.l.RUnlock()
 
 	if tok := t.enterpriseAgentToken(); tok != "" {
-		return tok
+		return tok, true
 	}
 
 	if t.agentToken != "" {
-		return t.agentToken
+		return t.agentToken, true
 	}
-	return t.userToken
+	return t.userToken, false
+}
+
+// TokenForAgent returns the best token to use for internal agent operations.
+func (t *Store) TokenForAgent() (token string) {
+	tok, _ := t.AgentOrUserToken()
+	return tok
 }
 
 func (t *Store) AgentRecoveryToken() string {

--- a/agent/token/store_test.go
+++ b/agent/token/store_test.go
@@ -130,7 +130,7 @@ func TestStore_RegularTokens(t *testing.T) {
 			require.False(t, s.UpdateConfigFileRegistrationToken(tt.set.registration, tt.set.registrationSource))
 
 			require.Equal(t, tt.effective.user, s.UserToken())
-			require.Equal(t, tt.effective.agent, s.AgentToken())
+			require.Equal(t, tt.effective.agent, s.TokenForAgent())
 			require.Equal(t, tt.effective.recovery, s.AgentRecoveryToken())
 			require.Equal(t, tt.effective.repl, s.ReplicationToken())
 			require.Equal(t, tt.effective.registration, s.ConfigFileRegistrationToken())


### PR DESCRIPTION
### Description
Log when the agent token has not been set

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
