### PR TITLE
troubleshoot: output messages for the troubleshoot proxy command

### DIFF
--- a/command/troubleshoot/proxy/troubleshoot_proxy.go
+++ b/command/troubleshoot/proxy/troubleshoot_proxy.go
@@ -76,14 +76,21 @@ func (c *cmd) Run(args []string) int {
 		c.UI.Error("error generating troubleshoot client: " + err.Error())
 		return 1
 	}
-	output, err := t.RunAllTests(c.upstream)
+	messages, err := t.RunAllTests(c.upstream)
 	if err != nil {
 		c.UI.Error("error running the tests: " + err.Error())
 		return 1
 	}
 
-	for _, o := range output {
-		c.UI.Output(o)
+	for _, o := range messages {
+		if o.Success {
+			c.UI.Output(o.Message)
+		} else {
+			c.UI.Error(o.Message)
+			if o.PossibleActions != "" {
+				c.UI.Output(o.PossibleActions)
+			}
+		}
 	}
 	return 0
 }

--- a/troubleshoot/go.mod
+++ b/troubleshoot/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/consul/api v1.18.0
 	github.com/hashicorp/consul/envoyextensions v0.0.0-00010101000000-000000000000
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
 	google.golang.org/protobuf v1.28.1
 )

--- a/troubleshoot/go.sum
+++ b/troubleshoot/go.sum
@@ -166,6 +166,7 @@ github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144T
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/troubleshoot/proxy/certs.go
+++ b/troubleshoot/proxy/certs.go
@@ -1,43 +1,58 @@
 package troubleshoot
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
 	envoy_admin_v3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
-	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/consul/troubleshoot/validate"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-func (t *Troubleshoot) validateCerts(certs *envoy_admin_v3.Certificates) error {
+func (t *Troubleshoot) validateCerts(certs *envoy_admin_v3.Certificates) validate.Messages {
 
+	var certMessages validate.Messages
 	// TODO: we can probably warn if the expiration date is close
-	var resultErr error
 	now := time.Now()
 
 	if certs == nil {
-		return errors.New("certs object is nil")
+		msg := validate.Message{
+			Success: false,
+			Message: "certificate object is nil in the proxy configuration",
+		}
+		return []validate.Message{msg}
 	}
 
 	if len(certs.GetCertificates()) == 0 {
-		return errors.New("no certificates provided")
+		msg := validate.Message{
+			Success: false,
+			Message: "no certificates found",
+		}
+		return []validate.Message{msg}
 	}
 
 	for _, cert := range certs.GetCertificates() {
 		for _, cacert := range cert.GetCaCert() {
 			if now.After(cacert.GetExpirationTime().AsTime()) {
-				resultErr = multierror.Append(resultErr, fmt.Errorf("Ca cert is expired"))
+				msg := validate.Message{
+					Success: false,
+					Message: "ca certificate is expired",
+				}
+				certMessages = append(certMessages, msg)
 			}
 
 		}
 		for _, cc := range cert.GetCertChain() {
 			if now.After(cc.GetExpirationTime().AsTime()) {
-				resultErr = multierror.Append(resultErr, fmt.Errorf("cert chain is expired"))
+				msg := validate.Message{
+					Success: false,
+					Message: "certificate chain is expired",
+				}
+				certMessages = append(certMessages, msg)
 			}
 		}
 	}
-	return resultErr
+	return certMessages
 }
 
 func (t *Troubleshoot) getEnvoyCerts() (*envoy_admin_v3.Certificates, error) {

--- a/troubleshoot/proxy/utils.go
+++ b/troubleshoot/proxy/utils.go
@@ -54,7 +54,6 @@ func (t *Troubleshoot) GetEnvoyConfigDump() error {
 	if err != nil {
 		return err
 	}
-	// TODO: validate here
 	t.envoyConfigDump = config
 	return nil
 }
@@ -81,10 +80,10 @@ func (t *Troubleshoot) parseClusters(clusters *envoy_admin_v3.Clusters) ([]strin
 	return upstreams, nil
 }
 
-func (t *Troubleshoot) getEnvoyClusters() (*envoy_admin_v3.Clusters, error) {
+func (t *Troubleshoot) getEnvoyClusters() error {
 	clustersRaw, err := t.request("clusters?format=json")
 	if err != nil {
-		return nil, err
+		return err
 	}
 	clusters := &envoy_admin_v3.Clusters{}
 
@@ -93,10 +92,9 @@ func (t *Troubleshoot) getEnvoyClusters() (*envoy_admin_v3.Clusters, error) {
 	}
 	err = unmarshal.Unmarshal(clustersRaw, clusters)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	// TODO: validate here
 	t.envoyClusters = clusters
-	return clusters, nil
+	return nil
 }

--- a/troubleshoot/proxy/validateupstream_test.go
+++ b/troubleshoot/proxy/validateupstream_test.go
@@ -17,8 +17,8 @@ import (
 func TestValidateFromJSON(t *testing.T) {
 	indexedResources := getConfig(t)
 	clusters := getClusters(t)
-	err := Validate(indexedResources, "backend", "", true, clusters)
-	require.NoError(t, err)
+	messages := Validate(indexedResources, "backend", "", true, clusters)
+	require.True(t, messages.Success())
 }
 
 // TODO: Manually inspect the config and clusters files and hardcode the list of expected resource names for higher


### PR DESCRIPTION
Aggregate and log error messages. 

When you compile and run the CLI, you should now see output from all the validations. For example in a success case, here's what the command output looks like:
```
certificates are valid
listener for upstream "backend" found
route for upstream "backend" found
cluster "backend.default.dc1.internal.7838b4bd-58b3-8117-3df1-60584910541b.consul" for upstream "backend" found
healthy endpoints for cluster "backend.default.dc1.internal.7838b4bd-58b3-8117-3df1-60584910541b.consul" for upstream "backend"
cluster "backend2.default.dc1.internal.7838b4bd-58b3-8117-3df1-60584910541b.consul" for upstream "backend" found
healthy endpoints for cluster "backend2.default.dc1.internal.7838b4bd-58b3-8117-3df1-60584910541b.consul" for upstream "backend"
upstream resources are valid
```

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
