### PR TITLE
UI: CC-4033 - Update padding for the content wrapper

### DIFF
--- a/ui/packages/consul-ui/app/styles/layouts/index.scss
+++ b/ui/packages/consul-ui/app/styles/layouts/index.scss
@@ -11,8 +11,8 @@
   max-width: 1260px;
 }
 %viewport-container {
-  padding-left: 25px;
-  padding-right: 25px;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 fieldset [role='group'] {


### PR DESCRIPTION
### Description
Updates the content wrapper padding from 25px to 48px. 

### Screenshots
**Before:**
<img width="2000" alt="Screenshot 2023-02-08 at 1 55 28 PM" src="https://user-images.githubusercontent.com/5448834/217649617-7eca7bea-4ef5-436e-82fb-a888eac201a5.png">

**After:**
<img width="2000" alt="Screenshot 2023-02-08 at 1 55 06 PM" src="https://user-images.githubusercontent.com/5448834/217649601-c0f103e6-f583-4d51-aa71-ff83171ab676.png">


### Links
- [CC-4033](https://hashicorp.atlassian.net/browse/CC-4033)

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern


[CC-4033]: https://hashicorp.atlassian.net/browse/CC-4033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ