### PR TITLE
troubleshoot: handle tproxy dialed directly case

### DIFF
--- a/troubleshoot/validate/validate.go
+++ b/troubleshoot/validate/validate.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"strings"
 
 	envoy_admin_v3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -179,6 +180,16 @@ func (v *Validate) GetMessages(validateEndpoints bool, endpointValidator Endpoin
 				Message: fmt.Sprintf("cluster %q for upstream %q found", sni, upstream),
 				Success: true,
 			})
+		}
+
+		// If the resource is a passthrough cluster, it will not have endpoints, so we need to skip the endpoint
+		// validation.
+		if strings.Contains(sni, "passthrough~") {
+			messages = append(messages, Message{
+				Message: fmt.Sprintf("cluster %q is a passthrough cluster, skipping endpoint healthiness check", sni),
+				Success: true,
+			})
+			continue
 		}
 
 		if validateEndpoints {

--- a/troubleshoot/validate/validate_test.go
+++ b/troubleshoot/validate/validate_test.go
@@ -171,6 +171,28 @@ func TestErrors(t *testing.T) {
 			},
 			err: "no healthy endpoints for aggregate cluster \"db-sni\" for upstream \"db\"",
 		},
+		"success: passthrough cluster doesn't error even though there are zero endpoints": {
+			validate: func() *Validate {
+				return &Validate{
+					envoyID: "db",
+					snis: map[string]struct{}{
+						"passthrough~db-sni": {},
+					},
+					listener: true,
+					usesRDS:  true,
+					route:    true,
+					resources: map[string]*resource{
+						"passthrough~db-sni": {
+							required: true,
+							cluster:  true,
+						},
+					},
+				}
+			},
+			endpointValidator: func(r *resource, s string, clusters *envoy_admin_v3.Clusters) {
+				r.loadAssignment = true
+			},
+		},
 	}
 
 	for n, tc := range cases {


### PR DESCRIPTION
The troubleshoot proxy command validates Envoy config by checking for listeners, routes, clusters, and endpoints. However, if using Tproxy with DialedDirectly, there would be a passthrough cluster for that upstream without any endpoints. We shouldn't error in that case, and should log that it's a passthrough cluster.


### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
