### PR TITLE
Merge pull request #4216 from hashicorp/NET-2252-add-assert-fortioname

### DIFF
--- a/test/integration/consul-container/libs/cluster/container.go
+++ b/test/integration/consul-container/libs/cluster/container.go
@@ -514,8 +514,13 @@ func newContainerRequest(config Config, opts containerOpts) (podRequest, consulR
 
 			"8443/tcp", // Envoy Gateway Listener
 
-			"8079/tcp", // Envoy App Listener
-			"8080/tcp", // Envoy App Listener
+			"8079/tcp", // Envoy App Listener - grpc port used by static-server
+			"8078/tcp", // Envoy App Listener - grpc port used by static-server-v1
+			"8077/tcp", // Envoy App Listener - grpc port used by static-server-v2
+
+			"8080/tcp", // Envoy App Listener - http port used by static-server
+			"8081/tcp", // Envoy App Listener - http port used by static-server-v1
+			"8082/tcp", // Envoy App Listener - http port used by static-server-v2
 			"9998/tcp", // Envoy App Listener
 			"9999/tcp", // Envoy App Listener
 		},

--- a/test/integration/consul-container/libs/topology/peering_topology.go
+++ b/test/integration/consul-container/libs/topology/peering_topology.go
@@ -68,9 +68,11 @@ func BasicPeeringTwoClustersSetup(
 		var err error
 		// Create a service and proxy instance
 		serviceOpts := libservice.ServiceOpts{
-			Name: libservice.StaticServerServiceName,
-			ID:   "static-server",
-			Meta: map[string]string{"version": ""},
+			Name:     libservice.StaticServerServiceName,
+			ID:       "static-server",
+			Meta:     map[string]string{"version": ""},
+			HTTPPort: 8080,
+			GRPCPort: 8079,
 		}
 		serverSidecarService, _, err := libservice.CreateAndRegisterStaticServerAndSidecar(clientNode, &serviceOpts)
 		require.NoError(t, err)
@@ -107,6 +109,7 @@ func BasicPeeringTwoClustersSetup(
 	libassert.AssertUpstreamEndpointStatus(t, adminPort, fmt.Sprintf("static-server.default.%s.external", DialingPeerName), "HEALTHY", 1)
 	_, port := clientSidecarService.GetAddr()
 	libassert.HTTPServiceEchoes(t, "localhost", port, "")
+	libassert.AssertFortioName(t, fmt.Sprintf("http://localhost:%d", port), "static-server")
 
 	return &BuiltCluster{
 			Cluster:   acceptingCluster,

--- a/test/integration/consul-container/test/basic/connect_service_test.go
+++ b/test/integration/consul-container/test/basic/connect_service_test.go
@@ -1,6 +1,7 @@
 package basic
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,6 +34,7 @@ func TestBasicConnectService(t *testing.T) {
 
 	libassert.AssertContainerState(t, clientService, "running")
 	libassert.HTTPServiceEchoes(t, "localhost", port, "")
+	libassert.AssertFortioName(t, fmt.Sprintf("http://localhost:%d", port), "static-server")
 }
 
 func createCluster(t *testing.T) *libcluster.Cluster {
@@ -72,8 +74,10 @@ func createServices(t *testing.T, cluster *libcluster.Cluster) libservice.Servic
 	client := node.GetClient()
 	// Create a service and proxy instance
 	serviceOpts := &libservice.ServiceOpts{
-		Name: libservice.StaticServerServiceName,
-		ID:   "static-server",
+		Name:     libservice.StaticServerServiceName,
+		ID:       "static-server",
+		HTTPPort: 8080,
+		GRPCPort: 8079,
 	}
 
 	// Create a service and proxy instance

--- a/test/integration/consul-container/test/observability/access_logs_test.go
+++ b/test/integration/consul-container/test/observability/access_logs_test.go
@@ -70,6 +70,7 @@ func TestAccessLogs(t *testing.T) {
 	// Validate Custom JSON
 	require.Eventually(t, func() bool {
 		libassert.HTTPServiceEchoes(t, "localhost", port, "banana")
+		libassert.AssertFortioName(t, fmt.Sprintf("http://localhost:%d", port), "static-server")
 		client := libassert.ServiceLogContains(t, clientService, "\"banana_path\":\"/banana\"")
 		server := libassert.ServiceLogContains(t, serverService, "\"banana_path\":\"/banana\"")
 		return client && server
@@ -111,6 +112,7 @@ func TestAccessLogs(t *testing.T) {
 	_, port = clientService.GetAddr()
 	require.Eventually(t, func() bool {
 		libassert.HTTPServiceEchoes(t, "localhost", port, "orange")
+		libassert.AssertFortioName(t, fmt.Sprintf("http://localhost:%d", port), "static-server")
 		client := libassert.ServiceLogContains(t, clientService, "Orange you glad I didn't say banana: /orange, -")
 		server := libassert.ServiceLogContains(t, serverService, "Orange you glad I didn't say banana: /orange, -")
 		return client && server
@@ -137,8 +139,10 @@ func createServices(t *testing.T, cluster *libcluster.Cluster) (libservice.Servi
 
 	// Create a service and proxy instance
 	serviceOpts := &libservice.ServiceOpts{
-		Name: libservice.StaticServerServiceName,
-		ID:   "static-server",
+		Name:     libservice.StaticServerServiceName,
+		ID:       "static-server",
+		HTTPPort: 8080,
+		GRPCPort: 8079,
 	}
 
 	// Create a service and proxy instance

--- a/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
+++ b/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
@@ -3,6 +3,7 @@ package peering
 import (
 	"context"
 	"encoding/pem"
+	"fmt"
 	"testing"
 	"time"
 
@@ -93,6 +94,7 @@ func TestPeering_RotateServerAndCAThenFail_(t *testing.T) {
 
 		_, port := clientSidecarService.GetAddr()
 		libassert.HTTPServiceEchoes(t, "localhost", port, "")
+		libassert.AssertFortioName(t, fmt.Sprintf("http://localhost:%d", port), "static-server")
 	}
 
 	testutil.RunStep(t, "rotate exporting cluster's root CA", func(t *testing.T) {
@@ -142,6 +144,7 @@ func TestPeering_RotateServerAndCAThenFail_(t *testing.T) {
 		// Connectivity should still be contained
 		_, port := clientSidecarService.GetAddr()
 		libassert.HTTPServiceEchoes(t, "localhost", port, "")
+		libassert.AssertFortioName(t, fmt.Sprintf("http://localhost:%d", port), "static-server")
 
 		verifySidecarHasTwoRootCAs(t, clientSidecarService)
 	})
@@ -163,6 +166,7 @@ func TestPeering_RotateServerAndCAThenFail_(t *testing.T) {
 
 		_, port := clientSidecarService.GetAddr()
 		libassert.HTTPServiceEchoes(t, "localhost", port, "")
+		libassert.AssertFortioName(t, fmt.Sprintf("http://localhost:%d", port), "static-server")
 	})
 }
 

--- a/test/integration/consul-container/test/upgrade/peer_control_plane_mgw_test.go
+++ b/test/integration/consul-container/test/upgrade/peer_control_plane_mgw_test.go
@@ -110,6 +110,7 @@ func TestPeering_Upgrade_ControlPlane_MGW(t *testing.T) {
 		require.NoError(t, clientSidecarService.Restart())
 		libassert.AssertUpstreamEndpointStatus(t, adminPort, fmt.Sprintf("static-server.default.%s.external", libtopology.DialingPeerName), "HEALTHY", 1)
 		libassert.HTTPServiceEchoes(t, "localhost", port, "")
+		libassert.AssertFortioName(t, fmt.Sprintf("http://localhost:%d", port), "static-server")
 	}
 
 	for _, tc := range tcs {

--- a/test/integration/consul-container/test/upgrade/peers_http_test.go
+++ b/test/integration/consul-container/test/upgrade/peers_http_test.go
@@ -80,6 +80,7 @@ func TestPeering_UpgradeToTarget_fromLatest(t *testing.T) {
 		require.NoError(t, clientSidecarService.Restart())
 		libassert.AssertUpstreamEndpointStatus(t, adminPort, fmt.Sprintf("static-server.default.%s.external", libtopology.DialingPeerName), "HEALTHY", 1)
 		libassert.HTTPServiceEchoes(t, "localhost", port, "")
+		libassert.AssertFortioName(t, fmt.Sprintf("http://localhost:%d", port), "static-server")
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
NET-2252: integration tests: add assert.FortioName

### Description
Oss split of ent [pr](https://github.com/hashicorp/consul-enterprise/pull/4216)

### Testing & Reproduction steps

### Links


### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
