### PR TITLE
Immediately (mostly) useable ACL tokens: add wait and check call to allow for ACL token replication

### DIFF
--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1752,6 +1752,16 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 
 			idMap["token-test-1"] = token.AccessorID
 			tokenMap[token.AccessorID] = token
+
+			// Immediately try to read the new token and verify it is usable
+			req, _ = http.NewRequest("GET", "/v1/acl/token/"+token.AccessorID, nil)
+			req.Header.Add("X-Consul-Token", "root")
+			resp = httptest.NewRecorder()
+			obj, err = a.srv.ACLTokenCRUD(resp, req)
+			require.NoError(t, err)
+			tok, ok := obj.(*structs.ACLToken)
+			require.True(t, ok)
+			require.Equal(t, token, tok)
 		})
 		t.Run("Create Token 2", func(t *testing.T) {
 			loginInput := &structs.ACLLoginParams{
@@ -1786,6 +1796,16 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 
 			idMap["token-test-2"] = token.AccessorID
 			tokenMap[token.AccessorID] = token
+
+			// Immediately try to read the new token and verify it is usable
+			req, _ = http.NewRequest("GET", "/v1/acl/token/"+token.AccessorID, nil)
+			req.Header.Add("X-Consul-Token", "root")
+			resp = httptest.NewRecorder()
+			obj, err = a.srv.ACLTokenCRUD(resp, req)
+			require.NoError(t, err)
+			tok, ok := obj.(*structs.ACLToken)
+			require.True(t, ok)
+			require.Equal(t, token, tok)
 		})
 
 		t.Run("List Tokens by (incorrect) Method", func(t *testing.T) {
@@ -1828,6 +1848,19 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				}
 				require.True(t, found)
 			}
+		})
+
+		t.Run("Verify token exists", func(t *testing.T) {
+			time.Sleep(6 * time.Second)
+			// try to read the new token and verify it is usable
+			req, _ := http.NewRequest("GET", "/v1/acl/token/"+idMap["token-test-1"], nil)
+			req.Header.Add("X-Consul-Token", "root")
+			resp := httptest.NewRecorder()
+			obj, err := a.srv.ACLTokenCRUD(resp, req)
+			require.NoError(t, err)
+			tok, ok := obj.(*structs.ACLToken)
+			require.True(t, ok)
+			require.Equal(t, idMap["token-test-1"], tok.AccessorID)
 		})
 
 		t.Run("Logout", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/armon/go-metrics v0.4.1
 	github.com/armon/go-radix v1.0.0
 	github.com/aws/aws-sdk-go v1.42.34
+	github.com/cenkalti/backoff/v3 v3.0.0
 	github.com/coredns/coredns v1.6.6
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/docker/go-connections v0.3.0
@@ -133,7 +134,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
-	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible // indirect


### PR DESCRIPTION
### Description
This is a borrowed workaround to allow time for ACL tokens to go through raft so that they can be immediately used after a login / creation request. See code comments for full description.

Original implementation in consul-k8s: https://github.com/hashicorp/consul-k8s/blob/dc7f08965c01d2180813d0d83539a49bcc60a7d3/control-plane/subcommand/common/common.go#L156
Once this PR is merged, a follow up PR will remove this wait from consul-k8s, since this will be moving the retry loop upstream into the consul client API itself. This should address all calls to the underlying token API, removing the need for dependent projects like consul-k8s to determine which calls should be handled with a retry loop.

### Testing & Reproduction steps

Tested with removed consul k8s retry loop.

No k8s retry loop + these changes: 
No k8s retry loop + without these changes:
No k8s retry loop + forced leader change + changes to delay raft write:
VM create at follower + immediate access request  + delay raft write + without these changes:
VM create at follower + immediate access request  + delay raft write + with these changes:

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
