### PR TITLE
[API Gateway] Add integration test for conflicted TCP listeners

### DIFF
--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -705,6 +705,11 @@ func (c *configSnapshotAPIGateway) ToIngress(datacenter string) (configSnapshotI
 			continue
 		}
 
+		if !c.GatewayConfig.ListenerIsReady(name) {
+			// skip any listeners that might be in an invalid state
+			continue
+		}
+
 		ingressListener := structs.IngressListener{
 			Port:     listener.Port,
 			Protocol: string(listener.Protocol),

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -713,6 +713,25 @@ type APIGatewayConfigEntry struct {
 	RaftIndex
 }
 
+func (e *APIGatewayConfigEntry) ListenerIsReady(name string) bool {
+	for _, condition := range e.Status.Conditions {
+		if !condition.Resource.IsSame(&ResourceReference{
+			Kind:           APIGateway,
+			SectionName:    name,
+			Name:           e.Name,
+			EnterpriseMeta: e.EnterpriseMeta,
+		}) {
+			continue
+		}
+
+		if condition.Type == "Conflicted" && condition.Status == "True" {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (e *APIGatewayConfigEntry) GetKind() string {
 	return APIGateway
 }

--- a/test/integration/connect/envoy/case-api-gateway-tcp-conflicted/capture.sh
+++ b/test/integration/connect/envoy/case-api-gateway-tcp-conflicted/capture.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+snapshot_envoy_admin localhost:20000 api-gateway primary || true

--- a/test/integration/connect/envoy/case-api-gateway-tcp-conflicted/service_gateway.hcl
+++ b/test/integration/connect/envoy/case-api-gateway-tcp-conflicted/service_gateway.hcl
@@ -1,0 +1,4 @@
+services {
+  name = "api-gateway"
+  kind = "api-gateway"
+}

--- a/test/integration/connect/envoy/case-api-gateway-tcp-conflicted/setup.sh
+++ b/test/integration/connect/envoy/case-api-gateway-tcp-conflicted/setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -euo pipefail
+
+upsert_config_entry primary '
+kind = "api-gateway"
+name = "api-gateway"
+listeners = [
+  {
+    port = 9999
+    protocol = "tcp"
+  }
+]
+'
+
+upsert_config_entry primary '
+kind = "tcp-route"
+name = "api-gateway-route-1"
+services = [
+  {
+    name = "s1"
+  }
+]
+parents = [
+  {
+    name = "api-gateway"
+  }
+]
+'
+
+upsert_config_entry primary '
+kind = "tcp-route"
+name = "api-gateway-route-2"
+services = [
+  {
+    name = "s2"
+  }
+]
+parents = [
+  {
+    name = "api-gateway"
+  }
+]
+'
+
+register_services primary
+
+gen_envoy_bootstrap api-gateway 20000 primary true
+gen_envoy_bootstrap s1 19000
+gen_envoy_bootstrap s2 19001

--- a/test/integration/connect/envoy/case-api-gateway-tcp-conflicted/vars.sh
+++ b/test/integration/connect/envoy/case-api-gateway-tcp-conflicted/vars.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export REQUIRED_SERVICES="$DEFAULT_REQUIRED_SERVICES api-gateway-primary"

--- a/test/integration/connect/envoy/case-api-gateway-tcp-conflicted/verify.bats
+++ b/test/integration/connect/envoy/case-api-gateway-tcp-conflicted/verify.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "api gateway proxy admin is up on :20000" {
+  retry_default curl -f -s localhost:20000/stats -o /dev/null
+}
+
+@test "api gateway should have a conflicted status" {
+  assert_config_entry_status Accepted True Accepted primary api-gateway api-gateway
+  assert_config_entry_status Conflicted True RouteConflict primary api-gateway api-gateway
+}
+
+@test "api gateway should have no healthy endpoints for s1" {
+  assert_upstream_missing 127.0.0.1:20000 s1
+}
+
+@test "api gateway should have no healthy endpoints for s2" {
+  assert_upstream_missing 127.0.0.1:20000 s2
+}

--- a/test/integration/connect/envoy/case-api-gateway-tcp-simple/verify.bats
+++ b/test/integration/connect/envoy/case-api-gateway-tcp-simple/verify.bats
@@ -6,6 +6,11 @@ load helpers
   retry_default curl -f -s localhost:20000/stats -o /dev/null
 }
 
+@test "api gateway should have be accepted and not conflicted" {
+  assert_config_entry_status Accepted True Accepted primary api-gateway api-gateway
+  assert_config_entry_status Conflicted False NoConflict primary api-gateway api-gateway
+}
+
 @test "api gateway should have healthy endpoints for s1" {
   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s1 HEALTHY 1
 }


### PR DESCRIPTION
### Description
This adds a test to make sure we don't end up creating a listener that's in a conflicted state, previously without the changes here TCP-based listeners were still routing to upstream routes even when the listener was in a conflicted state.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
