### PR TITLE
update the api in envoyextensions and troubleshoot modules

### DIFF
--- a/envoyextensions/go.mod
+++ b/envoyextensions/go.mod
@@ -6,7 +6,7 @@ replace github.com/hashicorp/consul/api => ../api
 
 require (
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1
-	github.com/hashicorp/consul/api v1.18.0
+	github.com/hashicorp/consul/api v1.10.1-0.20230209203402-db2bd404bf72
 	github.com/hashicorp/consul/sdk v0.13.0
 	github.com/hashicorp/go-hclog v1.2.1
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/hashicorp/consul-awsauth v0.0.0-20220713182709-05ac1c5c2706
 	github.com/hashicorp/consul-net-rpc v0.0.0-20221205195236-156cfab66a69
 	github.com/hashicorp/consul/api v1.18.0
-	github.com/hashicorp/consul/envoyextensions v0.0.0-00010101000000-000000000000
+	github.com/hashicorp/consul/envoyextensions v0.0.0-20230209212012-3b9c56956132
 	github.com/hashicorp/consul/proto-public v0.2.1
 	github.com/hashicorp/consul/sdk v0.13.0
 	github.com/hashicorp/consul/troubleshoot v0.0.0-00010101000000-000000000000

--- a/troubleshoot/go.mod
+++ b/troubleshoot/go.mod
@@ -13,10 +13,8 @@ exclude (
 
 require (
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1
-	github.com/hashicorp/consul/api v1.18.0
-	github.com/hashicorp/consul/envoyextensions v0.0.0-00010101000000-000000000000
-	github.com/hashicorp/go-multierror v1.1.1
-	github.com/pkg/errors v0.9.1
+	github.com/hashicorp/consul/api v1.10.1-0.20230209203402-db2bd404bf72
+	github.com/hashicorp/consul/envoyextensions v0.0.0-20230209212012-3b9c56956132
 	github.com/stretchr/testify v1.8.0
 	google.golang.org/protobuf v1.28.1
 )
@@ -36,6 +34,7 @@ require (
 	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-version v1.2.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect

--- a/troubleshoot/go.sum
+++ b/troubleshoot/go.sum
@@ -166,7 +166,6 @@ github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144T
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
point to real sha's for api and envoyextensions so K8s doesn't need replace directives (api will use an actual tag later when it's tagged for the release)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
