### PR TITLE
[API Gateway] Fix missing references to enterprise metadata

### DIFF
--- a/agent/proxycfg/api_gateway.go
+++ b/agent/proxycfg/api_gateway.go
@@ -243,10 +243,10 @@ func (h *handlerAPIGateway) handleInlineCertConfigUpdate(_ context.Context, u Up
 		return fmt.Errorf("invalid type for config entry: %T", resp.Entry)
 	}
 
-	// TODO Consider if unset SectionName and acl.EnterpriseMeta could trip us up
 	ref := structs.ResourceReference{
-		Kind: cfg.GetKind(),
-		Name: cfg.GetName(),
+		Kind:           cfg.GetKind(),
+		Name:           cfg.GetName(),
+		EnterpriseMeta: *cfg.GetEnterpriseMeta(),
 	}
 
 	snap.APIGateway.Certificates.Set(ref, cfg)
@@ -264,10 +264,10 @@ func (h *handlerAPIGateway) handleRouteConfigUpdate(ctx context.Context, u Updat
 		return nil
 	}
 
-	// TODO Consider if unset SectionName and acl.EnterpriseMeta could trip us up
 	ref := structs.ResourceReference{
-		Kind: resp.Entry.GetKind(),
-		Name: resp.Entry.GetName(),
+		Kind:           resp.Entry.GetKind(),
+		Name:           resp.Entry.GetName(),
+		EnterpriseMeta: *resp.Entry.GetEnterpriseMeta(),
 	}
 
 	seenUpstreamIDs := make(map[UpstreamID]struct{})


### PR DESCRIPTION
### Description
Leaving out enterprise metadata here causes our later route lookups to fail due to having enterprise metadata in one place and not another.

### Testing & Reproduction steps
Verified the fix on an enterprise build.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern