### PR TITLE
proxycfg: init WatchedLocalGWEndpoints map for Ingress and API gateways

### DIFF
--- a/agent/proxycfg/api_gateway.go
+++ b/agent/proxycfg/api_gateway.go
@@ -70,6 +70,7 @@ func (h *handlerAPIGateway) initialize(ctx context.Context) (ConfigSnapshot, err
 	snap.APIGateway.WatchedDiscoveryChains = make(map[UpstreamID]context.CancelFunc)
 	snap.APIGateway.WatchedGateways = make(map[UpstreamID]map[string]context.CancelFunc)
 	snap.APIGateway.WatchedGatewayEndpoints = make(map[UpstreamID]map[string]structs.CheckServiceNodes)
+	snap.APIGateway.WatchedLocalGWEndpoints = watch.NewMap[string, structs.CheckServiceNodes]()
 	snap.APIGateway.WatchedUpstreams = make(map[UpstreamID]map[string]context.CancelFunc)
 	snap.APIGateway.WatchedUpstreamEndpoints = make(map[UpstreamID]map[string]structs.CheckServiceNodes)
 

--- a/agent/proxycfg/ingress_gateway.go
+++ b/agent/proxycfg/ingress_gateway.go
@@ -67,6 +67,7 @@ func (s *handlerIngressGateway) initialize(ctx context.Context) (ConfigSnapshot,
 	snap.IngressGateway.WatchedUpstreamEndpoints = make(map[UpstreamID]map[string]structs.CheckServiceNodes)
 	snap.IngressGateway.WatchedGateways = make(map[UpstreamID]map[string]context.CancelFunc)
 	snap.IngressGateway.WatchedGatewayEndpoints = make(map[UpstreamID]map[string]structs.CheckServiceNodes)
+	snap.IngressGateway.WatchedLocalGWEndpoints = watch.NewMap[string, structs.CheckServiceNodes]()
 	snap.IngressGateway.Listeners = make(map[IngressListenerKey]structs.IngressListener)
 	snap.IngressGateway.UpstreamPeerTrustBundles = watch.NewMap[string, *pbpeering.PeeringTrustBundle]()
 	snap.IngressGateway.PeerUpstreamEndpoints = watch.NewMap[UpstreamID, structs.CheckServiceNodes]()


### PR DESCRIPTION
### Description

Initialize the `WatchedLocalGWEndpoints` snapshot map for Ingress and API gateways.

### Testing & Reproduction steps

We don't support setting peer upstreams on Ingress gateways yet, but if an ingress has been configured to point to a service with a cross-peer failover configured, a watch may be attempted to be set up on the local mesh gateway at https://github.com/hashicorp/consul-enterprise/blob/main/agent/proxycfg/upstreams.go#L345, resulting in a panic when https://github.com/hashicorp/consul-enterprise/blob/main/agent/proxycfg/upstreams.go#L622 is called because the map has not been initialized.

This needs testing and this area of the codebase could likely benefit from a panic handler to avoid errors like this from bringing down the server in a state from which it can be difficult to recover.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
