### PR TITLE
add provider ca auth support for kubernetes

### DIFF
--- a/.changelog/16262.txt
+++ b/.changelog/16262.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ca: support Vault agent auto-auth config for Vault CA provider using Kubernetes authentication.
+```

--- a/agent/connect/ca/provider_vault_auth_k8s.go
+++ b/agent/connect/ca/provider_vault_auth_k8s.go
@@ -1,0 +1,47 @@
+package ca
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func NewK8sAuthClient(authMethod *structs.VaultAuthMethod) (*VaultAuthClient, error) {
+	params := authMethod.Params
+	role, ok := params["role"].(string)
+	if !ok || strings.TrimSpace(role) == "" {
+		return nil, fmt.Errorf("missing 'role' value")
+	}
+	// don't check for `token_path` as it is optional
+
+	authClient := NewVaultAPIAuthClient(authMethod, "")
+	// Note the `jwt` can be passed directly in the authMethod as a Param value
+	// is a freeform map in the config where they could hardcode it.
+	if legacyCheck(params, "jwt") {
+		return authClient, nil
+	}
+
+	authClient.LoginDataGen = K8sLoginDataGen
+	return authClient, nil
+}
+
+func K8sLoginDataGen(authMethod *structs.VaultAuthMethod) (map[string]any, error) {
+	params := authMethod.Params
+	role := params["role"].(string)
+
+	// read token from file on path
+	tokenPath, ok := params["token_path"].(string)
+	if !ok || strings.TrimSpace(tokenPath) == "" {
+		tokenPath = defaultK8SServiceAccountTokenPath
+	}
+	rawToken, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"role": role,
+		"jwt":  strings.TrimSpace(string(rawToken)),
+	}, nil
+}

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -113,7 +113,7 @@ func TestVaultCAProvider_configureVaultAuthMethod(t *testing.T) {
 		"gcp":         {expLoginPath: "auth/gcp/login", params: map[string]interface{}{"type": "iam", "role": "test-role"}},
 		"jwt":         {expLoginPath: "auth/jwt/login", params: map[string]any{"role": "test-role", "path": "test-path"}, hasLDG: true},
 		"kerberos":    {expLoginPath: "auth/kerberos/login"},
-		"kubernetes":  {expLoginPath: "auth/kubernetes/login", params: map[string]interface{}{"jwt": "fake"}},
+		"kubernetes":  {expLoginPath: "auth/kubernetes/login", params: map[string]interface{}{"role": "test-role"}, hasLDG: true},
 		"ldap":        {expLoginPath: "auth/ldap/login/foo", params: map[string]interface{}{"username": "foo"}},
 		"oci":         {expLoginPath: "auth/oci/login/foo", params: map[string]interface{}{"role": "foo"}},
 		"okta":        {expLoginPath: "auth/okta/login/foo", params: map[string]interface{}{"username": "foo"}},


### PR DESCRIPTION
Adds support for Kubernetes jwt/token file based auth. Only needs to read the file and save the contents as the jwt/token.

### PR Checklist

* [X] updated test coverage
* [x] external facing docs updated (#16346)
* [X] not a security concern
