### PR TITLE
[OSS] connect: Bump Envoy 1.22.5 to 1.22.7, 1.23.2 to 1.23.4, 1.24.0 to 1.24.2, add 1.25.1, remove 1.21.5

### DIFF
--- a/.changelog/16274.txt
+++ b/.changelog/16274.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Bump Envoy 1.22.5 to 1.22.7, 1.23.2 to 1.23.4, 1.24.0 to 1.24.2, add 1.25.1, remove 1.21.5
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,10 @@ references:
     BASH_ENV: .circleci/bash_env.sh
     GO_VERSION: 1.19.4
   envoy-versions: &supported_envoy_versions
-    - &default_envoy_version "1.21.5"
-    - "1.22.5"
-    - "1.23.2"
-    - "1.24.0"
+    - &default_envoy_version "1.22.7"
+    - "1.23.4"
+    - "1.24.2"
+    - "1.25.1"
   nomad-versions: &supported_nomad_versions
     - &default_nomad_version "1.3.3"
     - "1.2.10"

--- a/envoyextensions/xdscommon/envoy_versioning_test.go
+++ b/envoyextensions/xdscommon/envoy_versioning_test.go
@@ -121,6 +121,7 @@ func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 		"1.18.6": {expectErr: "Envoy 1.18.6 " + errTooOld},
 		"1.19.5": {expectErr: "Envoy 1.19.5 " + errTooOld},
 		"1.20.7": {expectErr: "Envoy 1.20.7 " + errTooOld},
+		"1.21.5": {expectErr: "Envoy 1.21.5 " + errTooOld},
 	}
 
 	// Insert a bunch of valid versions.
@@ -135,10 +136,10 @@ func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 	}
 	*/
 	for _, v := range []string{
-		"1.21.0", "1.21.1", "1.21.2", "1.21.3", "1.21.4", "1.21.5",
 		"1.22.0", "1.22.1", "1.22.2", "1.22.3", "1.22.4", "1.22.5",
-		"1.23.0", "1.23.1", "1.23.2",
-		"1.24.0",
+		"1.23.0", "1.23.1", "1.23.2", "1.23.3", "1.23.4",
+		"1.24.0", "1.24.1", "1.24.2",
+		"1.25.0", "1.25.1",
 	} {
 		cases[v] = testcase{expect: SupportedProxyFeatures{}}
 	}

--- a/envoyextensions/xdscommon/proxysupport.go
+++ b/envoyextensions/xdscommon/proxysupport.go
@@ -9,10 +9,10 @@ import "strings"
 //
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
-	"1.24.0",
-	"1.23.2",
+	"1.25.1",
+	"1.24.2",
+	"1.23.4",
 	"1.22.5",
-	"1.21.5",
 }
 
 // UnsupportedEnvoyVersions lists any unsupported Envoy versions (mainly minor versions) that fall

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -39,6 +39,7 @@ Consul supports **four major Envoy releases** at the beginning of each major Con
 
 | Consul Version      | Compatible Envoy Versions                                                          |
 | ------------------- | -----------------------------------------------------------------------------------|
+| 1.15.x              | 1.25.1, 1.24.2, 1.23.4, 1.22.5                                                     |
 | 1.14.x              | 1.24.0, 1.23.1, 1.22.5, 1.21.5                                                     |
 | 1.13.x              | 1.23.1, 1.22.5, 1.21.5, 1.20.7                                                     |
 | 1.12.x              | 1.22.5, 1.21.5, 1.20.7, 1.19.5                                                     |
@@ -52,6 +53,7 @@ Consul Dataplane is a feature introduced in Consul v1.14. Because each version o
 
 | Consul Version      | Consul Dataplane Version | Bundled Envoy Version  |
 | ------------------- | ------------------------ | ---------------------- |
+| 1.15.x              | 1.1.x                    | 1.25.x                 |
 | 1.14.x              | 1.0.x                    | 1.24.x                 |
 
 ## Getting Started


### PR DESCRIPTION
### Description

    Bump envoy to the latest versions.
    1.22.5 -> 1.22.7
    1.23.2 -> 1.23.4
    1.24.0 -> 1.24.2
    Add 1.25.1
    Remove 1.21.5


### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
