### PR TITLE
Improve ux to help users avoid overwriting fields of ACL tokens, roles and policies

### DIFF
--- a/.changelog/16288.txt
+++ b/.changelog/16288.txt
@@ -1,0 +1,8 @@
+```release-note:deprecation
+cli: Deprecate the `-merge-policies` and `-merge-roles` flags from the `consul token update` command in favour of: `-add-policy-id`, `-add-policy-name`, `-add-role-name`, and `-add-role-id`.
+```
+
+```release-note:improvement
+cli: added `-add-policy-id`, `-add-policy-name`, `-add-role-name`, and `-add-role-id` flags to the `consul token update` command.
+These flags will allow updates to token's policies/roles without having to override them completely.  
+```

--- a/.changelog/16288.txt
+++ b/.changelog/16288.txt
@@ -1,8 +1,8 @@
 ```release-note:deprecation
-cli: Deprecate the `-merge-policies` and `-merge-roles` flags from the `consul token update` command in favour of: `-add-policy-id`, `-add-policy-name`, `-add-role-name`, and `-add-role-id`.
+cli: Deprecate the `-merge-policies` and `-merge-roles` flags from the `consul token update` command in favor of: `-append-policy-id`, `-append-policy-name`, `-append-role-name`, and `-append-role-id`.
 ```
 
 ```release-note:improvement
-cli: added `-add-policy-id`, `-add-policy-name`, `-add-role-name`, and `-add-role-id` flags to the `consul token update` command.
+cli: added `-append-policy-id`, `-append-policy-name`, `-append-role-name`, and `-append-role-id` flags to the `consul token update` command.
 These flags will allow updates to token's policies/roles without having to override them completely.  
 ```

--- a/.changelog/16288.txt
+++ b/.changelog/16288.txt
@@ -4,5 +4,5 @@ cli: Deprecate the `-merge-policies` and `-merge-roles` flags from the `consul t
 
 ```release-note:improvement
 cli: added `-append-policy-id`, `-append-policy-name`, `-append-role-name`, and `-append-role-id` flags to the `consul token update` command.
-These flags will allow updates to token's policies/roles without having to override them completely.  
+These flags allow updates to a token's policies/roles without having to override them completely.  
 ```

--- a/command/acl/token/update/token_update.go
+++ b/command/acl/token/update/token_update.go
@@ -201,10 +201,7 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 
-		if !hasAddPolicyFields {
-			// c.UI.Warn("Overwriting policies with new specified policies")
-			t.Policies = nil
-		} else {
+		if hasAddPolicyFields {
 			for _, addedPolicyName := range c.addPolicyNames {
 				t.Policies = append(t.Policies, &api.ACLTokenPolicyLink{Name: addedPolicyName})
 			}
@@ -217,6 +214,9 @@ func (c *cmd) Run(args []string) int {
 				}
 				t.Policies = append(t.Policies, &api.ACLTokenPolicyLink{ID: policyID})
 			}
+		} else {
+			// c.UI.Warn("Overwriting policies with new specified policies")
+			t.Policies = nil
 		}
 
 		for _, policyName := range c.policyNames {

--- a/command/acl/token/update/token_update.go
+++ b/command/acl/token/update/token_update.go
@@ -215,7 +215,6 @@ func (c *cmd) Run(args []string) int {
 			policyIDs = c.policyIDs
 			policyNames = c.policyNames
 			t.Policies = nil
-			// c.UI.Warn("Overwriting policies with new specified policies")
 		}
 
 		for _, policyName := range policyNames {
@@ -288,7 +287,6 @@ func (c *cmd) Run(args []string) int {
 		if hasRoleFields {
 			roleNames = c.roleNames
 			roleIDs = c.roleIDs
-			// c.UI.Warn("Overwriting policies with new specified policies")
 			t.Roles = nil
 		}
 

--- a/command/acl/token/update/token_update.go
+++ b/command/acl/token/update/token_update.go
@@ -71,7 +71,7 @@ func (c *cmd) init() {
 	c.flags.Var((*flags.AppendSliceValue)(&c.roleIDs), "role-id", "ID of a "+
 		"role to use for this token. Overwrites existing roles. May be specified multiple times")
 	c.flags.Var((*flags.AppendSliceValue)(&c.roleNames), "role-name", "Name of a "+
-		"role to use for this token. Overwrites existing rolees. May be specified multiple times")
+		"role to use for this token. Overwrites existing roles. May be specified multiple times")
 	c.flags.Var((*flags.AppendSliceValue)(&c.appendRoleIDs), "append-role-id", "ID of a "+
 		"role to add to this token. The token retains existing roles. May be specified multiple times")
 	c.flags.Var((*flags.AppendSliceValue)(&c.appendRoleNames), "append-role-name", "Name of a "+

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -122,6 +122,19 @@ func TestTokenUpdateCommand(t *testing.T) {
 		require.Len(t, token.Policies, 1)
 	})
 
+	// update with add-policy-name
+	t.Run("add-policy-name", func(t *testing.T) {
+		token := run(t, []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-accessor-id=" + token.AccessorID,
+			"-token=root",
+			"-add-policy-name=" + policy.Name,
+			"-description=test token",
+		})
+
+		require.Len(t, token.Policies, 1)
+	})
+
 	// update with policy by id
 	t.Run("policy-id", func(t *testing.T) {
 		token := run(t, []string{
@@ -129,6 +142,19 @@ func TestTokenUpdateCommand(t *testing.T) {
 			"-accessor-id=" + token.AccessorID,
 			"-token=root",
 			"-policy-id=" + policy.ID,
+			"-description=test token",
+		})
+
+		require.Len(t, token.Policies, 1)
+	})
+
+	// update with add-policy-id
+	t.Run("add-policy-id", func(t *testing.T) {
+		token := run(t, []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-accessor-id=" + token.AccessorID,
+			"-token=root",
+			"-add-policy-id=" + policy.ID,
 			"-description=test token",
 		})
 

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -190,6 +190,13 @@ func TestTokenUpdateCommandWithAppend(t *testing.T) {
 	)
 	require.NoError(t, policyErr)
 
+	//third policy
+	thirdPolicy, _, policyErr := client.ACL().PolicyCreate(
+		&api.ACLPolicy{Name: "third-policy"},
+		&api.WriteOptions{Token: "root"},
+	)
+	require.NoError(t, policyErr)
+
 	run := func(t *testing.T, args []string) *api.ACLToken {
 		ui := cli.NewMockUi()
 		cmd := New(ui)
@@ -222,11 +229,11 @@ func TestTokenUpdateCommandWithAppend(t *testing.T) {
 			"-http-addr=" + a.HTTPAddr(),
 			"-accessor-id=" + token.AccessorID,
 			"-token=root",
-			"-append-policy-id=" + secondPolicy.ID,
+			"-append-policy-id=" + thirdPolicy.ID,
 			"-description=test token",
 		})
 
-		require.Len(t, token.Policies, 2)
+		require.Len(t, token.Policies, 3)
 	})
 }
 

--- a/website/content/commands/acl/token/update.mdx
+++ b/website/content/commands/acl/token/update.mdx
@@ -38,10 +38,13 @@ Usage: `consul acl token update [options]`
 
 - `-merge-policies` - Deprecated. Merge the new policies with the existing policies.
 
-~> This is deprecated and will be removed in future consul version. Use `add-policy-id` or `add-policy-name`
+~> This is deprecated and will be removed in future Consul version. Use `add-policy-id` or `add-policy-name`
 instead.
 
-- `-merge-roles` - Merge the new roles with the existing roles.
+- `-merge-roles` - Deprecated. Merge the new roles with the existing roles.
+
+~> This is deprecated and will be removed in future Consul version. Use `add-role-id` or `add-role-name`
+instead.
 
 - `-merge-service-identities` - Merge the new service identities with the existing service identities.
 
@@ -56,16 +59,21 @@ instead.
 
 - `-policy-name=<value>` - Name of a policy to use for this token. Overwrites existing policies. May be specified multiple times.
 
-~> `-policy-id` and `-policy-name` will completely overwrite existing policies. Use `-add-policy-id` or `-add-policy-name` if you
-are trying to append more policies to your existing token policies.
+~> `-policy-id` and `-policy-name` will completely overwrite existing token policies. Use `-add-policy-id` or `-add-policy-name` to retain existing policies.
 
-- `-add-policy-id=<value>` - ID of policy to be added for this token. Added to existing policies. May be specified multiple times.
+- `-add-policy-id=<value>` - ID of policy to be added for this token. The token retains existing policies. May be specified multiple times.
 
-- `-add-policy-name=<value>` - Name of a policy to be added for this token. Added to existing policies. May be specified multiple times.
+- `-add-policy-name=<value>` - Name of a policy to be added for this token. The token retains existing policies. May be specified multiple times.
 
-- `-role-id=<value>` - ID of a role to use for this token. May be specified multiple times.
+- `-role-id=<value>` - ID of a role to use for this token. Overwrites existing roles. May be specified multiple times.
 
-- `-role-name=<value>` - Name of a role to use for this token. May be specified multiple times.
+- `-role-name=<value>` - Name of a role to use for this token. Overwrites existing roles. May be specified multiple times.
+
+~> `-role-id` and `-role-name` will completely overwrite existing policies. Use `-add-role-id` or `-add-role-name` to retain the existing roles.
+
+- `-add-role-id=<value>` - ID of a role to add to this token. The token retains existing roles. May be specified multiple times.
+
+- `-add-role-name=<value>` - Name of a role to add to this token. The token retains existing roles. May be specified multiple times.
 
 - `-service-identity=<value>` - Name of a service identity to use for this
   token. May be specified multiple times. Format is the `SERVICENAME` or

--- a/website/content/commands/acl/token/update.mdx
+++ b/website/content/commands/acl/token/update.mdx
@@ -38,12 +38,12 @@ Usage: `consul acl token update [options]`
 
 - `-merge-policies` - Deprecated. Merge the new policies with the existing policies.
 
-~> This is deprecated and will be removed in future Consul version. Use `add-policy-id` or `add-policy-name`
+~> This is deprecated and will be removed in a future Consul version. Use `append-policy-id` or `append-policy-name`
 instead.
 
 - `-merge-roles` - Deprecated. Merge the new roles with the existing roles.
 
-~> This is deprecated and will be removed in future Consul version. Use `add-role-id` or `add-role-name`
+~> This is deprecated and will be removed in a future Consul version. Use `append-role-id` or `append-role-name`
 instead.
 
 - `-merge-service-identities` - Merge the new service identities with the existing service identities.
@@ -59,21 +59,21 @@ instead.
 
 - `-policy-name=<value>` - Name of a policy to use for this token. Overwrites existing policies. May be specified multiple times.
 
-~> `-policy-id` and `-policy-name` will completely overwrite existing token policies. Use `-add-policy-id` or `-add-policy-name` to retain existing policies.
+~> `-policy-id` and `-policy-name` will completely overwrite existing token policies. Use `-append-policy-id` or `-append-policy-name` to retain existing policies.
 
-- `-add-policy-id=<value>` - ID of policy to be added for this token. The token retains existing policies. May be specified multiple times.
+- `-append-policy-id=<value>` - ID of policy to be added for this token. The token retains existing policies. May be specified multiple times.
 
-- `-add-policy-name=<value>` - Name of a policy to be added for this token. The token retains existing policies. May be specified multiple times.
+- `-append-policy-name=<value>` - Name of a policy to be added for this token. The token retains existing policies. May be specified multiple times.
 
 - `-role-id=<value>` - ID of a role to use for this token. Overwrites existing roles. May be specified multiple times.
 
 - `-role-name=<value>` - Name of a role to use for this token. Overwrites existing roles. May be specified multiple times.
 
-~> `-role-id` and `-role-name` will completely overwrite existing policies. Use `-add-role-id` or `-add-role-name` to retain the existing roles.
+~> `-role-id` and `-role-name` will completely overwrite existing roles. Use `-append-role-id` or `-append-role-name` to retain the existing roles.
 
-- `-add-role-id=<value>` - ID of a role to add to this token. The token retains existing roles. May be specified multiple times.
+- `-append-role-id=<value>` - ID of a role to add to this token. The token retains existing roles. May be specified multiple times.
 
-- `-add-role-name=<value>` - Name of a role to add to this token. The token retains existing roles. May be specified multiple times.
+- `-append-role-name=<value>` - Name of a role to add to this token. The token retains existing roles. May be specified multiple times.
 
 - `-service-identity=<value>` - Name of a service identity to use for this
   token. May be specified multiple times. Format is the `SERVICENAME` or

--- a/website/content/commands/acl/token/update.mdx
+++ b/website/content/commands/acl/token/update.mdx
@@ -36,7 +36,10 @@ Usage: `consul acl token update [options]`
 - `merge-node-identities` - Merge the new node identities with the existing node
   identities.
 
-- `-merge-policies` - Merge the new policies with the existing policies.
+- `-merge-policies` - Deprecated. Merge the new policies with the existing policies.
+
+~> This is deprecated and will be removed in future consul version. Use `add-policy-id` or `add-policy-name`
+instead.
 
 - `-merge-roles` - Merge the new roles with the existing roles.
 
@@ -49,9 +52,16 @@ Usage: `consul acl token update [options]`
   be specified multiple times. Format is `NODENAME:DATACENTER`. Added in Consul
   1.8.1.
 
-- `-policy-id=<value>` - ID of a policy to use for this token. May be specified multiple times.
+- `-policy-id=<value>` - ID of a policy to use for this token. Overwrites existing policies. May be specified multiple times.
 
-- `-policy-name=<value>` - Name of a policy to use for this token. May be specified multiple times.
+- `-policy-name=<value>` - Name of a policy to use for this token. Overwrites existing policies. May be specified multiple times.
+
+~> `-policy-id` and `-policy-name` will completely overwrite existing policies. Use `-add-policy-id` or `-add-policy-name` if you
+are trying to append more policies to your existing token policies.
+
+- `add-policy-id=<value>` - ID of policy to be added for this token. Added to existing policies. May be specified multiple times.
+
+- `-add-policy-name=<value>` - Name of a policy to be added for this token. Added to existing policies. May be specified multiple times.
 
 - `-role-id=<value>` - ID of a role to use for this token. May be specified multiple times.
 

--- a/website/content/commands/acl/token/update.mdx
+++ b/website/content/commands/acl/token/update.mdx
@@ -59,7 +59,7 @@ instead.
 ~> `-policy-id` and `-policy-name` will completely overwrite existing policies. Use `-add-policy-id` or `-add-policy-name` if you
 are trying to append more policies to your existing token policies.
 
-- `add-policy-id=<value>` - ID of policy to be added for this token. Added to existing policies. May be specified multiple times.
+- `-add-policy-id=<value>` - ID of policy to be added for this token. Added to existing policies. May be specified multiple times.
 
 - `-add-policy-name=<value>` - Name of a policy to be added for this token. Added to existing policies. May be specified multiple times.
 

--- a/website/content/commands/acl/token/update.mdx
+++ b/website/content/commands/acl/token/update.mdx
@@ -59,7 +59,7 @@ instead.
 
 - `-policy-name=<value>` - Name of a policy to use for this token. Overwrites existing policies. May be specified multiple times.
 
-~> `-policy-id` and `-policy-name` will completely overwrite existing token policies. Use `-append-policy-id` or `-append-policy-name` to retain existing policies.
+~> `-policy-id` and `-policy-name` will overwrite existing token policies. Use `-append-policy-id` or `-append-policy-name` to retain existing policies.
 
 - `-append-policy-id=<value>` - ID of policy to be added for this token. The token retains existing policies. May be specified multiple times.
 
@@ -69,7 +69,7 @@ instead.
 
 - `-role-name=<value>` - Name of a role to use for this token. Overwrites existing roles. May be specified multiple times.
 
-~> `-role-id` and `-role-name` will completely overwrite existing roles. Use `-append-role-id` or `-append-role-name` to retain the existing roles.
+~> `-role-id` and `-role-name` will overwrite existing roles. Use `-append-role-id` or `-append-role-name` to retain the existing roles.
 
 - `-append-role-id=<value>` - ID of a role to add to this token. The token retains existing roles. May be specified multiple times.
 


### PR DESCRIPTION
### Description
- Marking `mergePolicies` for deprecation and encouraging the use of `-append-policy-id` and `-append-policy-name` to reduce the ambiguity when overwriting fields on update 
- Updating docs to clarify that using: `-policy-id` and `-policy-name` will overwrite existing policies
- Marking `mergeRoles` for deprecation and encouraging the use of `-append-role-id` and `-append-role-name` to reduce the ambiguity when overwriting fields on update 
- Updating docs to clarify that using: `-append-role-id` and `-append-role-name` will overwrite existing policies

## TODO

- [x] add tests cases
- [x] update description
- [x] Do exact thing for `-merge-roles` as we did for `-merge-policies`
- [x] add change-log
- [x] de-duplicate all the logics 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
- [current docs](https://developer.hashicorp.com/consul/commands/acl/token/update)

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
