### PR TITLE
Fix up API Gateway go tests

### DIFF
--- a/test/integration/consul-container/libs/cluster/agent.go
+++ b/test/integration/consul-container/libs/cluster/agent.go
@@ -22,6 +22,7 @@ type Agent interface {
 	GetConfig() Config
 	GetInfo() AgentInfo
 	GetDatacenter() string
+	GetNetwork() string
 	IsServer() bool
 	RegisterTermination(func() error)
 	Terminate() error

--- a/test/integration/consul-container/libs/cluster/cluster.go
+++ b/test/integration/consul-container/libs/cluster/cluster.go
@@ -63,7 +63,7 @@ func NewN(t TestingT, conf Config, count int) (*Cluster, error) {
 //
 // The provided TestingT is used to register a cleanup function to terminate
 // the cluster.
-func New(t TestingT, configs []Config) (*Cluster, error) {
+func New(t TestingT, configs []Config, ports ...int) (*Cluster, error) {
 	id, err := shortid.Generate()
 	if err != nil {
 		return nil, fmt.Errorf("could not cluster id: %w", err)
@@ -99,7 +99,7 @@ func New(t TestingT, configs []Config) (*Cluster, error) {
 		_ = cluster.Terminate()
 	})
 
-	if err := cluster.Add(configs, true); err != nil {
+	if err := cluster.Add(configs, true, ports...); err != nil {
 		return nil, fmt.Errorf("could not start or join all agents: %w", err)
 	}
 
@@ -115,7 +115,7 @@ func (c *Cluster) AddN(conf Config, count int, join bool) error {
 }
 
 // Add starts an agent with the given configuration and joins it with the existing cluster
-func (c *Cluster) Add(configs []Config, serfJoin bool) (xe error) {
+func (c *Cluster) Add(configs []Config, serfJoin bool, ports ...int) (xe error) {
 	if c.Index == 0 && !serfJoin {
 		return fmt.Errorf("the first call to Cluster.Add must have serfJoin=true")
 	}
@@ -135,6 +135,7 @@ func (c *Cluster) Add(configs []Config, serfJoin bool) (xe error) {
 			context.Background(),
 			conf,
 			c,
+			ports...,
 		)
 		if err != nil {
 			return fmt.Errorf("could not add container index %d: %w", idx, err)

--- a/test/integration/consul-container/libs/cluster/container.go
+++ b/test/integration/consul-container/libs/cluster/container.go
@@ -72,7 +72,7 @@ func (c *consulContainerNode) ClaimAdminPort() (int, error) {
 }
 
 // NewConsulContainer starts a Consul agent in a container with the given config.
-func NewConsulContainer(ctx context.Context, config Config, cluster *Cluster) (Agent, error) {
+func NewConsulContainer(ctx context.Context, config Config, cluster *Cluster, ports ...int) (Agent, error) {
 	network := cluster.NetworkName
 	index := cluster.Index
 	if config.ScratchDir == "" {
@@ -127,7 +127,7 @@ func NewConsulContainer(ctx context.Context, config Config, cluster *Cluster) (A
 		addtionalNetworks: []string{"bridge", network},
 		hostname:          fmt.Sprintf("agent-%d", index),
 	}
-	podReq, consulReq := newContainerRequest(config, opts)
+	podReq, consulReq := newContainerRequest(config, opts, ports...)
 
 	// Do some trickery to ensure that partial completion is correctly torn
 	// down, but successful execution is not.
@@ -288,6 +288,10 @@ func NewConsulContainer(ctx context.Context, config Config, cluster *Cluster) (A
 	deferClean.Reset()
 
 	return node, nil
+}
+
+func (c *consulContainerNode) GetNetwork() string {
+	return c.network
 }
 
 func (c *consulContainerNode) GetName() string {
@@ -500,7 +504,7 @@ type containerOpts struct {
 	addtionalNetworks []string
 }
 
-func newContainerRequest(config Config, opts containerOpts) (podRequest, consulRequest testcontainers.ContainerRequest) {
+func newContainerRequest(config Config, opts containerOpts, ports ...int) (podRequest, consulRequest testcontainers.ContainerRequest) {
 	skipReaper := isRYUKDisabled()
 
 	pod := testcontainers.ContainerRequest{
@@ -535,6 +539,10 @@ func newContainerRequest(config Config, opts containerOpts) (podRequest, consulR
 	basePort := 19000
 	for i := 0; i < MaxEnvoyOnNode; i++ {
 		pod.ExposedPorts = append(pod.ExposedPorts, fmt.Sprintf("%d/tcp", basePort+i))
+	}
+
+	for _, port := range ports {
+		pod.ExposedPorts = append(pod.ExposedPorts, fmt.Sprintf("%d/tcp", port))
 	}
 
 	// For handshakes like auto-encrypt, it can take 10's of seconds for the agent to become "ready".

--- a/test/integration/consul-container/libs/service/connect.go
+++ b/test/integration/consul-container/libs/service/connect.go
@@ -55,6 +55,10 @@ func (g ConnectContainer) GetAddr() (string, int) {
 	return g.ip, g.appPort
 }
 
+func (g ConnectContainer) GetPort(port int) int {
+	return 0
+}
+
 func (g ConnectContainer) Restart() error {
 	_, err := g.GetStatus()
 	if err != nil {

--- a/test/integration/consul-container/libs/service/examples.go
+++ b/test/integration/consul-container/libs/service/examples.go
@@ -64,6 +64,10 @@ func (g exampleContainer) GetAddr() (string, int) {
 	return g.ip, g.httpPort
 }
 
+func (g exampleContainer) GetPort(port int) int {
+	return 0
+}
+
 func (g exampleContainer) Restart() error {
 	return fmt.Errorf("Restart Unimplemented by ConnectContainer")
 }

--- a/test/integration/consul-container/libs/service/gateway.go
+++ b/test/integration/consul-container/libs/service/gateway.go
@@ -20,12 +20,13 @@ import (
 
 // gatewayContainer
 type gatewayContainer struct {
-	ctx         context.Context
-	container   testcontainers.Container
-	ip          string
-	port        int
-	adminPort   int
-	serviceName string
+	ctx          context.Context
+	container    testcontainers.Container
+	ip           string
+	port         int
+	adminPort    int
+	serviceName  string
+	portMappings map[int]int
 }
 
 var _ Service = (*gatewayContainer)(nil)
@@ -101,6 +102,10 @@ func (g gatewayContainer) GetAdminAddr() (string, int) {
 	return "localhost", g.adminPort
 }
 
+func (g gatewayContainer) GetPort(port int) int {
+	return g.portMappings[port]
+}
+
 func (g gatewayContainer) Restart() error {
 	_, err := g.container.State(g.ctx)
 	if err != nil {
@@ -126,7 +131,7 @@ func (g gatewayContainer) GetStatus() (string, error) {
 	return state.Status, err
 }
 
-func NewGatewayService(ctx context.Context, name string, kind string, node libcluster.Agent) (Service, error) {
+func NewGatewayService(ctx context.Context, name string, kind string, node libcluster.Agent, ports ...int) (Service, error) {
 	nodeConfig := node.GetConfig()
 	if nodeConfig.ScratchDir == "" {
 		return nil, fmt.Errorf("node ScratchDir is required")
@@ -203,21 +208,33 @@ func NewGatewayService(ctx context.Context, name string, kind string, node libcl
 		adminPortStr = strconv.Itoa(adminPort)
 	)
 
-	info, err := cluster.LaunchContainerOnNode(ctx, node, req, []string{
+	extraPorts := []string{}
+	for _, port := range ports {
+		extraPorts = append(extraPorts, strconv.Itoa(port))
+	}
+
+	info, err := cluster.LaunchContainerOnNode(ctx, node, req, append(
+		extraPorts,
 		portStr,
 		adminPortStr,
-	})
+	))
 	if err != nil {
 		return nil, err
 	}
 
+	portMappings := make(map[int]int)
+	for _, port := range ports {
+		portMappings[port] = info.MappedPorts[strconv.Itoa(port)].Int()
+	}
+
 	out := &gatewayContainer{
-		ctx:         ctx,
-		container:   info.Container,
-		ip:          info.IP,
-		port:        info.MappedPorts[portStr].Int(),
-		adminPort:   info.MappedPorts[adminPortStr].Int(),
-		serviceName: name,
+		ctx:          ctx,
+		container:    info.Container,
+		ip:           info.IP,
+		port:         info.MappedPorts[portStr].Int(),
+		adminPort:    info.MappedPorts[adminPortStr].Int(),
+		serviceName:  name,
+		portMappings: portMappings,
 	}
 
 	return out, nil

--- a/test/integration/consul-container/libs/service/service.go
+++ b/test/integration/consul-container/libs/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+
 	"github.com/hashicorp/consul/api"
 )
 
@@ -12,6 +13,7 @@ type Service interface {
 	// Export a service to the peering cluster
 	Export(partition, peer string, client *api.Client) error
 	GetAddr() (string, int)
+	GetPort(port int) int
 	// GetAdminAddr returns the external admin address
 	GetAdminAddr() (string, int)
 	GetLogs() (string, error)


### PR DESCRIPTION
### Description
This adds some optional ports you can pass in to the consul container used for initializing tests so that the ports get forwarded correctly to an upstream gateway so you can check the routing properly. It shouldn't break any existing tests, but adding this functionality to the testing libraries allows us to specify which ports to forward from our testing code.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
