### PR TITLE
fix: add tls config to unix socket when https is used

### DIFF
--- a/.changelog/16301.txt
+++ b/.changelog/16301.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent configuration: Fix issue of using unix socket when https is used.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1051,7 +1051,8 @@ func (a *Agent) listenHTTP() ([]apiServer, error) {
 		for _, l := range listeners {
 			var tlscfg *tls.Config
 			_, isTCP := l.(*tcpKeepAliveListener)
-			if isTCP && proto == "https" {
+			isUnix := l.Addr().Network() == "unix"
+			if (isTCP || isUnix) && proto == "https" {
 				tlscfg = a.tlsConfigurator.IncomingHTTPSConfig()
 				l = tls.NewListener(l, tlscfg)
 			}


### PR DESCRIPTION
### Description
Add tls config to unix socket when https is used

### Testing & Reproduction steps
Manually tested with the following agent config

```
"addresses": {
        "grpc_tls" : "unix://consul/consul_grpc.sock",
        "http" : "unix://consul/consul_http.sock",
        "https" : "unix://consul/consul_https.sock"
    },
```

```
export CONSUL_HTTP_ADDR=unix://consul/consul_https.sock
CONSUL_HTTP_SSL=true consul connect 
```

### Links

fix #16252 

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
