### PR TITLE
Fix panicky xDS test flakes

### DIFF
--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -47,6 +47,13 @@ type ADSDeltaStream = envoy_discovery_v3.AggregatedDiscoveryService_DeltaAggrega
 
 // DeltaAggregatedResources implements envoy_discovery_v3.AggregatedDiscoveryServiceServer
 func (s *Server) DeltaAggregatedResources(stream ADSDeltaStream) error {
+	// this guard is mainly for our tests where we sometimes nil out the
+	// server stream, any use of the stream after we nil it causes
+	// pretty much all of the below code to panic.
+	if stream == nil {
+		return nil
+	}
+
 	defer s.activeStreams.Increment(stream.Context())()
 
 	// a channel for receiving incoming requests

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -47,13 +47,6 @@ type ADSDeltaStream = envoy_discovery_v3.AggregatedDiscoveryService_DeltaAggrega
 
 // DeltaAggregatedResources implements envoy_discovery_v3.AggregatedDiscoveryServiceServer
 func (s *Server) DeltaAggregatedResources(stream ADSDeltaStream) error {
-	// this guard is mainly for our tests where we sometimes nil out the
-	// server stream, any use of the stream after we nil it causes
-	// pretty much all of the below code to panic.
-	if stream == nil {
-		return nil
-	}
-
 	defer s.activeStreams.Increment(stream.Context())()
 
 	// a channel for receiving incoming requests

--- a/agent/xds/testing.go
+++ b/agent/xds/testing.go
@@ -227,6 +227,10 @@ func (e *TestEnvoy) Close() error {
 	// unblock the recv chans to simulate recv errors when client disconnects
 	if e.deltaStream != nil && e.deltaStream.recvCh != nil {
 		close(e.deltaStream.recvCh)
+		// TODO: This is causing a bunch of panics in testing code due to inflight
+		// requests attempting to grab a context from a stream that's nil. Added
+		// some defensive code in the xDS handler, but really, this should get fixed
+		// so we no longer have a data-race
 		e.deltaStream = nil
 	}
 	if e.cancel != nil {

--- a/agent/xds/testing.go
+++ b/agent/xds/testing.go
@@ -85,6 +85,8 @@ type TestEnvoy struct {
 	EnvoyVersion string
 
 	deltaStream *TestADSDeltaStream // Incremental v3
+
+	closed bool
 }
 
 // NewTestEnvoy creates a TestEnvoy instance.
@@ -225,13 +227,9 @@ func (e *TestEnvoy) Close() error {
 	defer e.mu.Unlock()
 
 	// unblock the recv chans to simulate recv errors when client disconnects
-	if e.deltaStream != nil && e.deltaStream.recvCh != nil {
+	if !e.closed && e.deltaStream.recvCh != nil {
 		close(e.deltaStream.recvCh)
-		// TODO: This is causing a bunch of panics in testing code due to inflight
-		// requests attempting to grab a context from a stream that's nil. Added
-		// some defensive code in the xDS handler, but really, this should get fixed
-		// so we no longer have a data-race
-		e.deltaStream = nil
+		e.closed = true
 	}
 	if e.cancel != nil {
 		e.cancel()


### PR DESCRIPTION
### Description
I'm seeing a bunch of panics in some flaky testing code in our xDS package. The relevant stack traces that come up time and again seem to mostly be on ARM (I'm assuming that this is due to some sort of slowness in the test runs that are accentuating race conditions due to additional qemu translation? 🤷):

```
goroutine 353 [running]:
github.com/hashicorp/consul/agent/xds.(*TestADSDeltaStream).Context(0x400009ff48?)
	<autogenerated>:1
github.com/hashicorp/consul/agent/xds.(*Server).DeltaAggregatedResources(0x4001581620, {0x2998370, 0x0})
	/home/circleci/project/agent/xds/delta.go:50 +0x4c
github.com/hashicorp/consul/agent/xds.newTestServerDeltaScenario.func3()
	/home/circleci/project/agent/xds/xds_protocol_helpers_test.go:197 +0x38
created by github.com/hashicorp/consul/agent/xds.newTestServerDeltaScenario
	/home/circleci/project/agent/xds/xds_protocol_helpers_test.go:196 +0x408
```

Notice the `DeltaAggregatedResources(0x4001581620, {0x2998370, 0x0})` -- the first argument should be the pointer address to the xds server itself, the second is the first argument of the `DeltaAggregatedResources` function (`stream ADSDeltaStream`), which, since it's an interface is a tuple of the type information and then the actual pointer to the underlying type, which is `nil`.

We seem to be `nil`ing the argument that gets passed there in our test helpers while cleaning up after a test run, which, if any requests are in flight will pretty much cause any of our handler code to panic and the tests to abort (hence the ridiculous amount of flake).

~~Really we should probably fix the testing code so it doesn't `nil` something that's often unconditionally dereferenced and also potentially used in a multithreaded context (I wouldn't be surprised if there were still panics due to only nil checking once and using it later in the function), but this is a simple attempt to at least make the tests fail less often, and I'd prefer this for now than to potentially heavily refactor the testing code (I'm also not sure what tests rely on the `nil` behavior of the stream).~~

Edit: Introduced a boolean guard in the test code itself that should hopefully fix the panics since we were still hitting them due to this being multithreaded. Doesn't appear like anything relies on the `nil`, so hopefully that should be fine.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
