### PR TITLE
Backport of Fix hostname alignment checks for HTTPRoutes into release/1.15.x

### DIFF
--- a/agent/consul/discoverychain/gateway_test.go
+++ b/agent/consul/discoverychain/gateway_test.go
@@ -459,6 +459,7 @@ func TestGatewayChainSynthesizer_AddHTTPRoute(t *testing.T) {
 
 			gatewayChainSynthesizer := NewGatewayChainSynthesizer(datacenter, "domain", "suffix", gateway)
 
+			gatewayChainSynthesizer.SetHostname("*")
 			gatewayChainSynthesizer.AddHTTPRoute(tc.route)
 
 			require.Equal(t, tc.expectedMatchesByHostname, gatewayChainSynthesizer.matchesByHostname)
@@ -621,6 +622,8 @@ func TestGatewayChainSynthesizer_Synthesize(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			tc.synthesizer.SetHostname("*")
+
 			for _, tcpRoute := range tc.tcpRoutes {
 				tc.synthesizer.AddTCPRoute(*tcpRoute)
 			}

--- a/agent/consul/gateways/controller_gateways.go
+++ b/agent/consul/gateways/controller_gateways.go
@@ -701,6 +701,14 @@ func (g *gatewayMeta) bindRoute(listener *structs.APIGatewayListener, bound *str
 		return false, nil
 	}
 
+	if route, ok := route.(*structs.HTTPRouteConfigEntry); ok {
+		// check our hostnames
+		hostnames := route.FilteredHostnames(listener.GetHostname())
+		if len(hostnames) == 0 {
+			return false, fmt.Errorf("failed to bind route to gateway %s: listener %s is does not have any hostnames that match the route", route.GetName(), g.Gateway.Name)
+		}
+	}
+
 	if listener.Protocol == route.GetProtocol() && bound.BindRoute(structs.ResourceReference{
 		Kind:           route.GetKind(),
 		Name:           route.GetName(),

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -897,6 +897,13 @@ type APIGatewayListener struct {
 	TLS APIGatewayTLSConfiguration
 }
 
+func (l APIGatewayListener) GetHostname() string {
+	if l.Hostname != "" {
+		return l.Hostname
+	}
+	return "*"
+}
+
 // APIGatewayTLSConfiguration specifies the configuration of a listener’s
 // TLS settings.
 type APIGatewayTLSConfiguration struct {

--- a/test/integration/connect/envoy/case-api-gateway-http-hostnames/capture.sh
+++ b/test/integration/connect/envoy/case-api-gateway-http-hostnames/capture.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+snapshot_envoy_admin localhost:20000 api-gateway primary || true

--- a/test/integration/connect/envoy/case-api-gateway-http-hostnames/service_gateway.hcl
+++ b/test/integration/connect/envoy/case-api-gateway-http-hostnames/service_gateway.hcl
@@ -1,0 +1,4 @@
+services {
+  name = "api-gateway"
+  kind = "api-gateway"
+}

--- a/test/integration/connect/envoy/case-api-gateway-http-hostnames/setup.sh
+++ b/test/integration/connect/envoy/case-api-gateway-http-hostnames/setup.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+set -euo pipefail
+
+upsert_config_entry primary '
+kind = "api-gateway"
+name = "api-gateway"
+listeners = [
+  {
+    name = "listener-one"
+    port = 9999
+    protocol = "http"
+    hostname = "*.consul.example"
+  },
+  {
+    name = "listener-two"
+    port = 9998
+    protocol = "http"
+    hostname = "foo.bar.baz"
+  },
+  {
+    name = "listener-three"
+    port = 9997
+    protocol = "http"
+    hostname = "*.consul.example"
+  },
+  {
+    name = "listener-four"
+    port = 9996
+    protocol = "http"
+    hostname = "*.consul.example"
+  },
+  {
+    name = "listener-five"
+    port = 9995
+    protocol = "http"
+    hostname = "foo.bar.baz"
+  }
+]
+'
+
+upsert_config_entry primary '
+Kind      = "proxy-defaults"
+Name      = "global"
+Config {
+  protocol = "http"
+}
+'
+
+upsert_config_entry primary '
+kind = "http-route"
+name = "api-gateway-route-one"
+hostnames = ["test.consul.example"]
+rules = [
+  {
+    services = [
+      {
+        name = "s1"
+      }
+    ]
+  }
+]
+parents = [
+  {
+    name = "api-gateway"
+    sectionName = "listener-one"
+  },
+]
+'
+
+upsert_config_entry primary '
+kind = "http-route"
+name = "api-gateway-route-two"
+hostnames = ["foo.bar.baz"]
+rules = [
+  {
+    services = [
+      {
+        name = "s1"
+      }
+    ]
+  }
+]
+parents = [
+  {
+    name = "api-gateway"
+    sectionName = "listener-two"
+  },
+]
+'
+
+upsert_config_entry primary '
+kind = "http-route"
+name = "api-gateway-route-three"
+hostnames = ["foo.bar.baz"]
+rules = [
+  {
+    services = [
+      {
+        name = "s1"
+      }
+    ]
+  }
+]
+parents = [
+  {
+    name = "api-gateway"
+    sectionName = "listener-three"
+  },
+]
+'
+
+upsert_config_entry primary '
+kind = "http-route"
+name = "api-gateway-route-four"
+rules = [
+  {
+    services = [
+      {
+        name = "s1"
+      }
+    ]
+  }
+]
+parents = [
+  {
+    name = "api-gateway"
+    sectionName = "listener-four"
+  },
+]
+'
+
+upsert_config_entry primary '
+kind = "http-route"
+name = "api-gateway-route-five"
+rules = [
+  {
+    services = [
+      {
+        name = "s1"
+      }
+    ]
+  }
+]
+parents = [
+  {
+    name = "api-gateway"
+    sectionName = "listener-five"
+  },
+]
+'
+
+register_services primary
+
+gen_envoy_bootstrap api-gateway 20000 primary true
+gen_envoy_bootstrap s1 19000

--- a/test/integration/connect/envoy/case-api-gateway-http-hostnames/vars.sh
+++ b/test/integration/connect/envoy/case-api-gateway-http-hostnames/vars.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export REQUIRED_SERVICES="$DEFAULT_REQUIRED_SERVICES api-gateway-primary"

--- a/test/integration/connect/envoy/case-api-gateway-http-hostnames/verify.bats
+++ b/test/integration/connect/envoy/case-api-gateway-http-hostnames/verify.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "api gateway proxy admin is up on :20000" {
+  retry_default curl -f -s localhost:20000/stats -o /dev/null
+}
+
+@test "api gateway should have be accepted and not conflicted" {
+  assert_config_entry_status Accepted True Accepted primary api-gateway api-gateway
+  assert_config_entry_status Conflicted False NoConflict primary api-gateway api-gateway
+}
+
+@test "api gateway should be bound to route one" {
+  assert_config_entry_status Bound True Bound primary http-route api-gateway-route-one
+  assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s1 HEALTHY 1
+}
+
+@test "api gateway should be bound to route two" {
+  assert_config_entry_status Bound True Bound primary http-route api-gateway-route-two
+}
+
+@test "api gateway should be unbound to route three" {
+  assert_config_entry_status Bound False FailedToBind primary http-route api-gateway-route-three
+}
+
+@test "api gateway should be bound to route four" {
+  assert_config_entry_status Bound True Bound primary http-route api-gateway-route-four
+}
+
+@test "api gateway should be bound to route five" {
+  assert_config_entry_status Bound True Bound primary http-route api-gateway-route-five
+}
+
+@test "api gateway should be able to connect to s1 via route one with the proper host" {
+  run retry_long curl -H "Host: test.consul.example" -s -f -d hello localhost:9999
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "api gateway should not be able to connect to s1 via route one with a mismatched host" {
+  run retry_default sh -c "curl -H \"Host: foo.consul.example\" -sI -o /dev/null -w \"%{http_code}\" localhost:9999 | grep 404"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "404" ]]
+}
+
+@test "api gateway should be able to connect to s1 via route two with the proper host" {
+  run retry_long curl -H "Host: foo.bar.baz" -s -f -d hello localhost:9998
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "api gateway should be able to connect to s1 via route four with any subdomain of the listener host" {
+  run retry_long curl -H "Host: test.consul.example" -s -f -d hello localhost:9996
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello"* ]]
+  run retry_long curl -H "Host: foo.consul.example"  -s -f -d hello localhost:9996
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "api gateway should be able to connect to s1 via route five with the proper host" {
+  run retry_long curl -H "Host: foo.bar.baz" -s -f -d hello localhost:9995
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello"* ]]
+}


### PR DESCRIPTION
## Backport

This PR is a manual backport from #16300

The below text is copied from the body of the original PR.

---

### Description
This adds a missing hostname check between listeners and HTTPRoutes. Without it we do no verification of the alignment between route and Listener hostnames and the listener hostnames are essentially unused. In the upstream spec, only http routes that have hostnames matching the listener hostname (or no hostnames specified) can be bound to a listener. We accomplish this by filtering out routes (both in the xDS code and in our controller) based on the listener hostname and then checking to see if there are any valid hosts to bind to.

It's a stacked PR on top of the inline certs PR (#16295), so that should get merged first.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern