### PR TITLE
fix: revert go mod compat for sdk,api to 1.19

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/api
 
-go 1.20
+go 1.19
 
 replace github.com/hashicorp/consul/sdk => ../sdk
 

--- a/envoyextensions/go.mod
+++ b/envoyextensions/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/envoyextensions
 
-go 1.20
+go 1.19
 
 replace github.com/hashicorp/consul/api => ../api
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/sdk
 
-go 1.20
+go 1.19
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/troubleshoot/go.mod
+++ b/troubleshoot/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/troubleshoot
 
-go 1.20
+go 1.19
 
 replace github.com/hashicorp/consul/api => ../api
 


### PR DESCRIPTION
### Description
This reverts changes from #16263 so that consumers of API/SDK modules can still use older, supported versions of Go with those modules.