### PR TITLE
Fix issue with peer services incorrectly appearing as connect-enabled.

### DIFF
--- a/.changelog/16339.txt
+++ b/.changelog/16339.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: Fix bug where services were incorrectly imported as connect-enabled.
+```

--- a/agent/consul/state/peering.go
+++ b/agent/consul/state/peering.go
@@ -770,88 +770,181 @@ func exportedServicesForPeerTxn(
 	maxIdx := peering.ModifyIndex
 
 	entMeta := structs.NodeEnterpriseMetaInPartition(peering.Partition)
-	idx, conf, err := getExportedServicesConfigEntryTxn(tx, ws, nil, entMeta)
+	idx, exportConf, err := getExportedServicesConfigEntryTxn(tx, ws, nil, entMeta)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to fetch exported-services config entry: %w", err)
 	}
 	if idx > maxIdx {
 		maxIdx = idx
 	}
-	if conf == nil {
+	if exportConf == nil {
 		return maxIdx, &structs.ExportedServiceList{}, nil
 	}
 
 	var (
-		normalSet = make(map[structs.ServiceName]struct{})
-		discoSet  = make(map[structs.ServiceName]struct{})
+		// exportedServices will contain the listing of all service names that are being exported
+		// and will need to be queried for connect / discovery chain information.
+		exportedServices = make(map[structs.ServiceName]struct{})
+
+		// exportedConnectServices will contain the listing of all connect service names that are being exported.
+		exportedConnectServices = make(map[structs.ServiceName]struct{})
+
+		// namespaceConnectServices provides a listing of all connect service names for a particular partition+namespace pair.
+		namespaceConnectServices = make(map[acl.EnterpriseMeta]map[string]struct{})
+
+		// namespaceDiscoChains provides a listing of all disco chain names for a particular partition+namespace pair.
+		namespaceDiscoChains = make(map[acl.EnterpriseMeta]map[string]struct{})
 	)
 
-	// At least one of the following should be true for a name for it to
-	// replicate:
-	//
-	// - are a discovery chain by definition (service-router, service-splitter, service-resolver)
-	// - have an explicit sidecar kind=connect-proxy
-	// - use connect native mode
+	// Helper function for inserting data and auto-creating maps.
+	insertEntry := func(m map[acl.EnterpriseMeta]map[string]struct{}, entMeta acl.EnterpriseMeta, name string) {
+		names, ok := m[entMeta]
+		if !ok {
+			names = make(map[string]struct{})
+			m[entMeta] = names
+		}
+		names[name] = struct{}{}
+	}
 
-	for _, svc := range conf.Services {
+	// Build the set of all services that will be exported.
+	// Any possible namespace wildcards or "consul" services should be removed by this step.
+	for _, svc := range exportConf.Services {
 		// Prevent exporting the "consul" service.
 		if svc.Name == structs.ConsulServiceName {
 			continue
 		}
-		svcMeta := acl.NewEnterpriseMetaWithPartition(entMeta.PartitionOrDefault(), svc.Namespace)
+		svcEntMeta := acl.NewEnterpriseMetaWithPartition(entMeta.PartitionOrDefault(), svc.Namespace)
+		svcName := structs.NewServiceName(svc.Name, &svcEntMeta)
 
-		sawPeer := false
+		peerFound := false
 		for _, consumer := range svc.Consumers {
-			name := structs.NewServiceName(svc.Name, &svcMeta)
-
-			if _, ok := normalSet[name]; ok {
-				// Service was covered by a wildcard that was already accounted for
-				continue
+			if consumer.Peer == peering.Name {
+				peerFound = true
+				break
 			}
-			if consumer.Peer != peering.Name {
-				continue
-			}
-			sawPeer = true
+		}
+		// Only look for more information if the matching peer was found.
+		if !peerFound {
+			continue
+		}
 
-			if svc.Name != structs.WildcardSpecifier {
-				normalSet[name] = struct{}{}
+		// If this isn't a wildcard, we can simply add it to the list of services to watch and move to the next entry.
+		if svc.Name != structs.WildcardSpecifier {
+			exportedServices[svcName] = struct{}{}
+			continue
+		}
+
+		// If all services in the namespace are exported by the wildcard, query those service names.
+		idx, typicalServices, err := serviceNamesOfKindTxn(tx, ws, structs.ServiceKindTypical, svcEntMeta)
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to get typical service names: %w", err)
+		}
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+		for _, sn := range typicalServices {
+			// Prevent exporting the "consul" service.
+			if sn.Service.Name != structs.ConsulServiceName {
+				exportedServices[sn.Service] = struct{}{}
 			}
 		}
 
-		// If the target peer is a consumer, and all services in the namespace are exported, query those service names.
-		if sawPeer && svc.Name == structs.WildcardSpecifier {
-			idx, typicalServices, err := serviceNamesOfKindTxn(tx, ws, structs.ServiceKindTypical, svcMeta)
-			if err != nil {
-				return 0, nil, fmt.Errorf("failed to get typical service names: %w", err)
-			}
-			if idx > maxIdx {
-				maxIdx = idx
-			}
-			for _, s := range typicalServices {
-				// Prevent exporting the "consul" service.
-				if s.Service.Name == structs.ConsulServiceName {
-					continue
-				}
-				normalSet[s.Service] = struct{}{}
-			}
-
-			// list all config entries of kind service-resolver, service-router, service-splitter?
-			idx, discoChains, err := listDiscoveryChainNamesTxn(tx, ws, nil, svcMeta)
-			if err != nil {
-				return 0, nil, fmt.Errorf("failed to get discovery chain names: %w", err)
-			}
-			if idx > maxIdx {
-				maxIdx = idx
-			}
-			for _, sn := range discoChains {
-				discoSet[sn] = struct{}{}
+		// List all config entries of kind service-resolver, service-router, service-splitter, because they
+		// will be exported as connect services.
+		idx, discoChains, err := listDiscoveryChainNamesTxn(tx, ws, nil, svcEntMeta)
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to get discovery chain names: %w", err)
+		}
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+		for _, sn := range discoChains {
+			// Prevent exporting the "consul" service.
+			if sn.Name != structs.ConsulServiceName {
+				exportedConnectServices[sn] = struct{}{}
+				insertEntry(namespaceDiscoChains, svcEntMeta, sn.Name)
 			}
 		}
 	}
 
-	normal := maps.SliceOfKeys(normalSet)
-	disco := maps.SliceOfKeys(discoSet)
+	// At least one of the following should be true for a name to replicate it as a *connect* service:
+	// - are a discovery chain by definition (service-router, service-splitter, service-resolver)
+	// - have an explicit sidecar kind=connect-proxy
+	// - use connect native mode
+	// - are registered with a terminating gateway
+	populateConnectService := func(sn structs.ServiceName) error {
+		// Load all disco-chains in this namespace if we haven't already.
+		if _, ok := namespaceDiscoChains[sn.EnterpriseMeta]; !ok {
+			// Check to see if we have a discovery chain with the same name.
+			idx, chains, err := listDiscoveryChainNamesTxn(tx, ws, nil, sn.EnterpriseMeta)
+			if err != nil {
+				return fmt.Errorf("failed to get connect services: %w", err)
+			}
+			if idx > maxIdx {
+				maxIdx = idx
+			}
+			for _, sn := range chains {
+				insertEntry(namespaceDiscoChains, sn.EnterpriseMeta, sn.Name)
+			}
+		}
+		// Check to see if we have the connect service.
+		if _, ok := namespaceDiscoChains[sn.EnterpriseMeta][sn.Name]; ok {
+			exportedConnectServices[sn] = struct{}{}
+			// Do not early return because we have multiple watches that should be established.
+		}
 
+		// Load all services in this namespace if we haven't already.
+		if _, ok := namespaceConnectServices[sn.EnterpriseMeta]; !ok {
+			// This is more efficient than querying the service instance table.
+			idx, connectServices, err := serviceNamesOfKindTxn(tx, ws, structs.ServiceKindConnectEnabled, sn.EnterpriseMeta)
+			if err != nil {
+				return fmt.Errorf("failed to get connect services: %w", err)
+			}
+			if idx > maxIdx {
+				maxIdx = idx
+			}
+			for _, ksn := range connectServices {
+				insertEntry(namespaceConnectServices, sn.EnterpriseMeta, ksn.Service.Name)
+			}
+		}
+		// Check to see if we have the connect service.
+		if _, ok := namespaceConnectServices[sn.EnterpriseMeta][sn.Name]; ok {
+			exportedConnectServices[sn] = struct{}{}
+			// Do not early return because we have multiple watches that should be established.
+		}
+
+		// Check if the service is exposed via terminating gateways.
+		svcGateways, err := tx.Get(tableGatewayServices, indexService, sn)
+		if err != nil {
+			return fmt.Errorf("failed gateway lookup for %q: %w", sn.Name, err)
+		}
+		ws.Add(svcGateways.WatchCh())
+		for svc := svcGateways.Next(); svc != nil; svc = svcGateways.Next() {
+			gs, ok := svc.(*structs.GatewayService)
+			if !ok {
+				return fmt.Errorf("failed converting to GatewayService for %q", sn.Name)
+			}
+			if gs.GatewayKind == structs.ServiceKindTerminatingGateway {
+				exportedConnectServices[sn] = struct{}{}
+				break
+			}
+		}
+
+		return nil
+	}
+
+	// Perform queries and check if each service is connect-enabled.
+	for sn := range exportedServices {
+		// Do not query for data if we already know it's a connect service.
+		if _, ok := exportedConnectServices[sn]; ok {
+			continue
+		}
+		if err := populateConnectService(sn); err != nil {
+			return 0, nil, err
+		}
+	}
+
+	// Fetch the protocol / targets for connect services.
 	chainInfo := make(map[structs.ServiceName]structs.ExportedDiscoveryChainInfo)
 	populateChainInfo := func(svc structs.ServiceName) error {
 		if _, ok := chainInfo[svc]; ok {
@@ -899,21 +992,17 @@ func exportedServicesForPeerTxn(
 		return nil
 	}
 
-	for _, svc := range normal {
-		if err := populateChainInfo(svc); err != nil {
-			return 0, nil, err
-		}
-	}
-	for _, svc := range disco {
+	for svc := range exportedConnectServices {
 		if err := populateChainInfo(svc); err != nil {
 			return 0, nil, err
 		}
 	}
 
-	structs.ServiceList(normal).Sort()
+	sortedServices := maps.SliceOfKeys(exportedServices)
+	structs.ServiceList(sortedServices).Sort()
 
 	list := &structs.ExportedServiceList{
-		Services:    normal,
+		Services:    sortedServices,
 		DiscoChains: chainInfo,
 	}
 

--- a/agent/grpc-external/services/peerstream/subscription_manager.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager.go
@@ -143,7 +143,7 @@ func (m *subscriptionManager) handleEvent(ctx context.Context, state *subscripti
 		pending := &pendingPayload{}
 		m.syncNormalServices(ctx, state, evt.Services)
 		if m.config.ConnectEnabled {
-			m.syncDiscoveryChains(state, pending, evt.ListAllDiscoveryChains())
+			m.syncDiscoveryChains(state, pending, evt.DiscoChains)
 		}
 
 		err := pending.Add(

--- a/agent/grpc-external/services/peerstream/subscription_manager_test.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager_test.go
@@ -472,15 +472,40 @@ func TestSubscriptionManager_InitialSnapshot(t *testing.T) {
 		Node:    &structs.Node{Node: "foo", Address: "10.0.0.1"},
 		Service: &structs.NodeService{ID: "mysql-1", Service: "mysql", Port: 5000},
 	}
+	mysqlSidecar := structs.NodeService{
+		Kind:    structs.ServiceKindConnectProxy,
+		Service: "mysql-sidecar-proxy",
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceName: "mysql",
+		},
+	}
 	backend.ensureNode(t, mysql.Node)
 	backend.ensureService(t, "foo", mysql.Service)
+	backend.ensureService(t, "foo", &mysqlSidecar)
 
 	mongo := &structs.CheckServiceNode{
-		Node:    &structs.Node{Node: "zip", Address: "10.0.0.3"},
-		Service: &structs.NodeService{ID: "mongo-1", Service: "mongo", Port: 5000},
+		Node: &structs.Node{Node: "zip", Address: "10.0.0.3"},
+		Service: &structs.NodeService{
+			ID:      "mongo-1",
+			Service: "mongo",
+			Port:    5000,
+		},
+	}
+	mongoSidecar := structs.NodeService{
+		Kind:    structs.ServiceKindConnectProxy,
+		Service: "mongo-sidecar-proxy",
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceName: "mongo",
+		},
 	}
 	backend.ensureNode(t, mongo.Node)
 	backend.ensureService(t, "zip", mongo.Service)
+	backend.ensureService(t, "zip", &mongoSidecar)
+
+	backend.ensureConfigEntry(t, &structs.ServiceResolverConfigEntry{
+		Kind: structs.ServiceResolver,
+		Name: "chain",
+	})
 
 	var (
 		mysqlCorrID = subExportedService + structs.NewServiceName("mysql", nil).String()

--- a/agent/proxycfg-glue/exported_peered_services_test.go
+++ b/agent/proxycfg-glue/exported_peered_services_test.go
@@ -49,6 +49,14 @@ func TestServerExportedPeeredServices(t *testing.T) {
 		},
 	}))
 
+	// Create resolvers for each of the services so that they are guaranteed to be replicated by the peer stream.
+	for _, s := range []string{"web", "api", "db"} {
+		require.NoError(t, store.EnsureConfigEntry(0, &structs.ServiceResolverConfigEntry{
+			Kind: structs.ServiceResolver,
+			Name: s,
+		}))
+	}
+
 	authz := policyAuthorizer(t, `
 		service "web" { policy = "read" }
 		service "api" { policy = "read" }

--- a/agent/structs/peering.go
+++ b/agent/structs/peering.go
@@ -62,8 +62,7 @@ func (i ExportedDiscoveryChainInfo) Equal(o ExportedDiscoveryChainInfo) bool {
 	return true
 }
 
-// ListAllDiscoveryChains returns all discovery chains (union of Services and
-// DiscoChains).
+// ListAllDiscoveryChains returns all discovery chains (union of Services and DiscoChains).
 func (list *ExportedServiceList) ListAllDiscoveryChains() map[ServiceName]ExportedDiscoveryChainInfo {
 	chainsByName := make(map[ServiceName]ExportedDiscoveryChainInfo)
 	if list == nil {

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1235,6 +1235,12 @@ const (
 	// This service allows external traffic to exit the mesh through a terminating gateway
 	// based on centralized configuration.
 	ServiceKindDestination ServiceKind = "destination"
+
+	// ServiceKindConnectEnabled is used to indicate whether a service is either
+	// connect-native or if the service has a corresponding sidecar. It is used for
+	// internal query purposes and should not be exposed to users as a valid Kind
+	// option.
+	ServiceKindConnectEnabled ServiceKind = "connect-enabled"
 )
 
 // Type to hold a address and port of a service


### PR DESCRIPTION
Prior to this PR, all peer services were transmitted as connect-enabled as long as a one or more mesh-gateways were healthy. With this change, there is now a difference between typical services and connect services transmitted via peering.

A service will be reported as "connect-enabled" as long as any of these conditions are met:

1. a connect-proxy sidecar is registered for the service name.
2. a connect-native instance of the service is registered.
3. a service resolver / splitter / router is registered for the service name.
4. a terminating gateway has registered the service.