### PR TITLE
Dockerfile: bump to alpine:3.17

### DIFF
--- a/.changelog/16349.txt
+++ b/.changelog/16349.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+docker: Bump base image to Alpine 3.17. 
+```

--- a/.changelog/16349.txt
+++ b/.changelog/16349.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-docker: Bump base image to Alpine 3.17. 
+docker: Update alpine to 3.17 in the Docker image.
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # Official docker image that includes binaries from releases.hashicorp.com. This
 # downloads the release from releases.hashicorp.com and therefore requires that
 # the release is published before building the Docker image.
-FROM docker.mirror.hashicorp.services/alpine:3.15 as official
+FROM docker.mirror.hashicorp.services/alpine:3.17 as official
 
 # This is the release of Consul to pull in.
 ARG VERSION
@@ -109,7 +109,7 @@ CMD ["agent", "-dev", "-client", "0.0.0.0"]
 
 # Production docker image that uses CI built binaries.
 # Remember, this image cannot be built locally.
-FROM docker.mirror.hashicorp.services/alpine:3.15 as default
+FROM docker.mirror.hashicorp.services/alpine:3.17 as default
 
 ARG PRODUCT_VERSION
 ARG BIN_NAME


### PR DESCRIPTION
### Description

Bump Consul docker images to the latest version of alpine, 3.17 for all existing Consul versions. 1.15.0, 1.14.x, and 1.13.x.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
