### PR TITLE
[API Gateway] Fix targeting service splitters in HTTPRoutes

### DIFF
--- a/agent/structs/config_entry_routes.go
+++ b/agent/structs/config_entry_routes.go
@@ -79,9 +79,9 @@ func (e *HTTPRouteConfigEntry) Normalize() error {
 	for i, parent := range e.Parents {
 		if parent.Kind == "" {
 			parent.Kind = APIGateway
-			parent.EnterpriseMeta.Normalize()
-			e.Parents[i] = parent
 		}
+		parent.EnterpriseMeta.Normalize()
+		e.Parents[i] = parent
 	}
 
 	for i, rule := range e.Rules {
@@ -505,9 +505,9 @@ func (e *TCPRouteConfigEntry) Normalize() error {
 	for i, parent := range e.Parents {
 		if parent.Kind == "" {
 			parent.Kind = APIGateway
-			parent.EnterpriseMeta.Normalize()
-			e.Parents[i] = parent
 		}
+		parent.EnterpriseMeta.Normalize()
+		e.Parents[i] = parent
 	}
 
 	for i, service := range e.Services {

--- a/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/capture.sh
+++ b/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/capture.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+snapshot_envoy_admin localhost:20000 api-gateway primary || true

--- a/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/service_gateway.hcl
+++ b/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/service_gateway.hcl
@@ -1,0 +1,4 @@
+services {
+  name = "api-gateway"
+  kind = "api-gateway"
+}

--- a/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/service_s3.hcl
+++ b/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/service_s3.hcl
@@ -1,0 +1,9 @@
+services {
+  id   = "s3"
+  name = "s3"
+  port = 8182
+
+  connect {
+    sidecar_service {}
+  }
+}

--- a/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/setup.sh
+++ b/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/setup.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+upsert_config_entry primary '
+kind = "api-gateway"
+name = "api-gateway"
+listeners = [
+  {
+    name = "listener-one"
+    port = 9999
+    protocol = "http"
+  }
+]
+'
+
+upsert_config_entry primary '
+Kind      = "proxy-defaults"
+Name      = "global"
+Config {
+  protocol = "http"
+}
+'
+
+upsert_config_entry primary '
+kind = "http-route"
+name = "api-gateway-route-one"
+rules = [
+  {
+    services = [
+      {
+        name = "splitter-one"
+      }
+    ]
+  }
+]
+parents = [
+  {
+    name = "api-gateway"
+    sectionName = "listener-one"
+  }
+]
+'
+
+upsert_config_entry primary '
+kind = "service-splitter"
+name = "splitter-one"
+splits = [
+  {
+    weight = 50,
+    service = "s1"
+  },
+  {
+    weight = 50,
+    service = "splitter-two"
+  },
+]
+'
+
+upsert_config_entry primary '
+kind = "service-splitter"
+name = "splitter-two"
+splits = [
+  {
+    weight = 50,
+    service = "s2"
+  },
+  {
+    weight = 50,
+    service = "s3"
+  },
+]
+'
+
+register_services primary
+
+gen_envoy_bootstrap api-gateway 20000 primary true
+gen_envoy_bootstrap s1 19000
+gen_envoy_bootstrap s2 19001
+gen_envoy_bootstrap s3 19002

--- a/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/vars.sh
+++ b/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/vars.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export REQUIRED_SERVICES="$DEFAULT_REQUIRED_SERVICES api-gateway-primary"

--- a/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/verify.bats
+++ b/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/verify.bats
@@ -6,7 +6,7 @@ load helpers
   retry_default curl -f -s localhost:20000/stats -o /dev/null
 }
 
-@test "api gateway should have be accepted and not conflicted" {
+@test "api gateway should be accepted and not conflicted" {
   assert_config_entry_status Accepted True Accepted primary api-gateway api-gateway
   assert_config_entry_status Conflicted False NoConflict primary api-gateway api-gateway
 }

--- a/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/verify.bats
+++ b/test/integration/connect/envoy/case-api-gateway-http-splitter-targets/verify.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "api gateway proxy admin is up on :20000" {
+  retry_default curl -f -s localhost:20000/stats -o /dev/null
+}
+
+@test "api gateway should have be accepted and not conflicted" {
+  assert_config_entry_status Accepted True Accepted primary api-gateway api-gateway
+  assert_config_entry_status Conflicted False NoConflict primary api-gateway api-gateway
+}
+
+@test "api gateway should have healthy endpoints for s1" {
+  assert_config_entry_status Bound True Bound primary http-route api-gateway-route-one
+  assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s1 HEALTHY 1
+}
+
+@test "api gateway should be able to connect to s1, s2, and s3 via configured port" {
+  run retry_default assert_expected_fortio_name_pattern ^FORTIO_NAME=s1$
+  run retry_default assert_expected_fortio_name_pattern ^FORTIO_NAME=s2$
+  run retry_default assert_expected_fortio_name_pattern ^FORTIO_NAME=s3$
+}


### PR DESCRIPTION
### Description

Previously when synthesizing an ingress discovery chain from API Gateway primitives, we weren't properly fixing up the discovery chain to allow for targeting service splitters, which we support today in our Kubernetes solution. This fixes this, allowing the use of virtual splitters in a service target inside of an HTTPRoute.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern