### PR TITLE
Update existing docs from Consul API Gateway -> API Gateway for Kubernetes

### DIFF
--- a/website/content/docs/api-gateway/index.mdx
+++ b/website/content/docs/api-gateway/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Consul API Gateway enables external network client access to a service mesh on Kubernetes and forwards requests based on path or header information. Learn about how the k8s Gateway API specification configures Consul API Gateway so you can control access and simplify traffic management.
 ---
 
-# Consul API Gateway Overview
+# API Gateway for Kubernetes Overview
 
 This topic provides an overview of the Consul API Gateway.
 

--- a/website/content/docs/api-gateway/index.mdx
+++ b/website/content/docs/api-gateway/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: docs
-page_title: Consul API Gateway Overview
+page_title: API Gateway for Kubernetes Overview
 description: >-
   Consul API Gateway enables external network client access to a service mesh on Kubernetes and forwards requests based on path or header information. Learn about how the k8s Gateway API specification configures Consul API Gateway so you can control access and simplify traffic management.
 ---

--- a/website/content/docs/api-gateway/install.mdx
+++ b/website/content/docs/api-gateway/install.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: Install Consul API Gateway
+page_title: Install API Gateway for Kubernetes
 description: >-
   Learn how to install custom resource definitions (CRDs) and configure the Helm chart so that you can run Consul API Gateway on your Kubernetes deployment.
 ---
 
-# Install Consul API Gateway
+# Install API Gateway for Kubernetes
 
 This topic describes how to install and configure Consul API Gateway.
 

--- a/website/content/docs/api-gateway/tech-specs.mdx
+++ b/website/content/docs/api-gateway/tech-specs.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: Consul API Gateway Technical Specifications
+page_title: API Gateway for Kubernetes Technical Specifications
 description: >-
   Consul API Gateway is a service mesh add-on for Kubernetes deployments. Learn about its requirements for system resources, ports, and component versions, its Enterprise limitations, and compatible k8s cloud environments.
 ---
 
-# Consul API Gateway Technical Specifications
+# API Gateway for Kubernetes Technical Specifications
 
 This topic describes the technical specifications associated with using Consul API Gateway.
 

--- a/website/content/docs/api-gateway/upgrades.mdx
+++ b/website/content/docs/api-gateway/upgrades.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: Upgrade Consul API Gateway
+page_title: Upgrade API Gateway for Kubernetes
 description: >-
   Upgrade Consul API Gateway to use newly supported features. Learn about the requirements, procedures, and post-configuration changes involved in standard and specific version upgrades.
 ---
 
-# Upgrade Consul API Gateway
+# Upgrade API Gateway for Kubernetes
 
 This topic describes how to upgrade Consul API Gateway.
 

--- a/website/content/docs/api-gateway/usage/usage.mdx
+++ b/website/content/docs/api-gateway/usage/usage.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: Use Consul API Gateway
+page_title: Use API Gateway for Kubernetes
 description: >-
   Learn how to apply a configured Consul API Gateway to your Kubernetes cluster, review the required fields for rerouting HTTP requests, and troubleshoot an error message.
 ---
 
-# Basic Consul API Gateway Usage
+# Deploy API Gateway for Kubernetes
 
 This topic describes how to use Consul API Gateway.
 

--- a/website/content/docs/api-gateway/usage/usage.mdx
+++ b/website/content/docs/api-gateway/usage/usage.mdx
@@ -1,6 +1,6 @@
 ---
 layout: docs
-page_title: Use API Gateway for Kubernetes
+page_title: Deploy API Gateway for Kubernetes
 description: >-
   Learn how to apply a configured Consul API Gateway to your Kubernetes cluster, review the required fields for rerouting HTTP requests, and troubleshoot an error message.
 ---

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -193,7 +193,7 @@
         ]
       },
       {
-        "title": "Consul API Gateway",
+        "title": "API Gateway for Kubernetes",
         "routes": [
           {
             "title": "v0.5.x",
@@ -1293,7 +1293,7 @@
     "divider": true
   },
   {
-    "title": "Consul API Gateway",
+    "title": "API Gateway for Kubernetes",
     "routes": [
       {
         "title": "Overview",

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1315,7 +1315,7 @@
         "title": "Usage",
         "routes": [
           {
-            "title": "Basic Usage",
+            "title": "Deploy",
             "path": "api-gateway/usage/usage"
           },
           {


### PR DESCRIPTION
### Description
As we begin adding in documentation for API Gateway on VMs, the existing documentation will remain for API Gateway on Kubernetes. To avoid confusion, we want to rename the existing docs to reflect the environment that it's intended for.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
