### PR TITLE
envoy ext: move local rate limit after rbac filter

### DIFF
--- a/agent/xds/delta_envoy_extender_oss_test.go
+++ b/agent/xds/delta_envoy_extender_oss_test.go
@@ -217,12 +217,12 @@ end`,
 						{
 							Name: api.BuiltinLocalRatelimitExtension,
 							Arguments: map[string]interface{}{
-								"ProxyType":      "connect-proxy",
-								"MaxTokens":      3,
-								"TokensPerFill":  2,
-								"FillInterval":   10,
-								"FilterEnabled":  100,
-								"FilterEnforced": 100,
+								"ProxyType":             "connect-proxy",
+								"MaxTokens":             3,
+								"TokensPerFill":         2,
+								"FillInterval":          10,
+								"FilterEnabledPercent":  100,
+								"FilterEnforcedPercent": 100,
 							},
 						},
 					}

--- a/agent/xds/testdata/builtin_extension/listeners/http-local-ratelimit-applyto-filter.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/http-local-ratelimit-applyto-filter.latest.golden
@@ -91,6 +91,13 @@
                                 },
                                 "httpFilters": [
                                     {
+                                        "name": "envoy.filters.http.rbac",
+                                        "typedConfig": {
+                                            "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                                            "rules": {}
+                                        }
+                                    },
+                                    {
                                         "name": "envoy.filters.http.local_ratelimit",
                                         "typedConfig": {
                                             "@type": "type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit",
@@ -110,13 +117,6 @@
                                                     "numerator": 100
                                                 }
                                             }
-                                        }
-                                    },
-                                    {
-                                        "name": "envoy.filters.http.rbac",
-                                        "typedConfig": {
-                                            "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                                            "rules": {}
                                         }
                                     },
                                     {

--- a/test/integration/connect/envoy/case-envoyext-ratelimit/setup.sh
+++ b/test/integration/connect/envoy/case-envoyext-ratelimit/setup.sh
@@ -14,8 +14,8 @@ EnvoyExtensions = [
       MaxTokens = 1,
       TokensPerFill = 1,
       FillInterval = 120,
-      FilterEnabled = 100,
-      FilterEnforced = 100,
+      FilterEnabledPercent = 100,
+      FilterEnforcedPercent = 100,
     }
   }
 ]
@@ -33,8 +33,8 @@ EnvoyExtensions = [
       MaxTokens = 1,
       TokensPerFill = 1,
       FillInterval = 120,
-      FilterEnabled = 100,
-      FilterEnforced = 100,
+      FilterEnabledPercent = 100,
+      FilterEnforcedPercent = 100,
     }
   }
 ]


### PR DESCRIPTION
Change to local rate limit
- move local rate limit after rbac filter
- rename FilterEnabled to FilterEnabledPercent FilterEnforced to FilterEnforcedPercent

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
