### PR TITLE
[OSS] set BRANCH_NAME to release-1.15.x

### DIFF
--- a/.github/workflows/nightly-test-1.15.x.yaml
+++ b/.github/workflows/nightly-test-1.15.x.yaml
@@ -7,7 +7,7 @@ on:
 env:
   EMBER_PARTITION_TOTAL: 4      # Has to be changed in tandem with the matrix.partition
   BRANCH: "release/1.15.x"
-  BRANCH_NAME: "release/1.15.x" # Used for naming artifacts
+  BRANCH_NAME: "release-1.15.x" # Used for naming artifacts
 
 jobs:
   frontend-test-workspace-node:


### PR DESCRIPTION
### Description

We had a bug in the github action that is causing frontend-oss-build to fail.

### Testing & Reproduction steps

Builds should pass

### Links



### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
