### PR TITLE
[API Gateway] Fix infinite loop in controller and binding non-accepted routes and gateways

### DIFF
--- a/agent/consul/gateways/controller_gateways_test.go
+++ b/agent/consul/gateways/controller_gateways_test.go
@@ -49,6 +49,11 @@ func TestBoundAPIGatewayBindRoute(t *testing.T) {
 							Protocol: structs.ListenerProtocolTCP,
 						},
 					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().gatewayAccepted(),
+						},
+					},
 				},
 			},
 			route: &structs.TCPRouteConfigEntry{
@@ -59,6 +64,11 @@ func TestBoundAPIGatewayBindRoute(t *testing.T) {
 						Kind:        structs.APIGateway,
 						Name:        "Gateway",
 						SectionName: "Listener",
+					},
+				},
+				Status: structs.Status{
+					Conditions: []structs.Condition{
+						newGatewayConditionGenerator().routeAccepted(),
 					},
 				},
 			},
@@ -116,6 +126,11 @@ func TestBoundAPIGatewayBindRoute(t *testing.T) {
 							Protocol: structs.ListenerProtocolTCP,
 						},
 					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().gatewayAccepted(),
+						},
+					},
 				},
 			},
 			route: &structs.TCPRouteConfigEntry{
@@ -125,6 +140,11 @@ func TestBoundAPIGatewayBindRoute(t *testing.T) {
 					{
 						Kind: structs.APIGateway,
 						Name: "Gateway",
+					},
+				},
+				Status: structs.Status{
+					Conditions: []structs.Condition{
+						newGatewayConditionGenerator().routeAccepted(),
 					},
 				},
 			},
@@ -417,6 +437,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -429,6 +454,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							Name:        "Gateway",
 							Kind:        structs.APIGateway,
 							SectionName: "Listener",
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -521,6 +551,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 				{
@@ -541,6 +576,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -558,6 +598,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							Name:        "Gateway 2",
 							Kind:        structs.APIGateway,
 							SectionName: "Listener",
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -624,6 +669,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -636,6 +686,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							Name:        "Gateway",
 							Kind:        structs.APIGateway,
 							SectionName: "Listener 2",
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -691,6 +746,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -703,6 +763,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							Name:        "Gateway",
 							Kind:        structs.APIGateway,
 							SectionName: "",
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -770,6 +835,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -782,6 +852,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							Name:        "Gateway",
 							Kind:        structs.APIGateway,
 							SectionName: "",
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -843,6 +918,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 				{
@@ -871,6 +951,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -888,6 +973,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							Name:        "Gateway 2",
 							Kind:        structs.APIGateway,
 							SectionName: "Listener 2",
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -968,6 +1058,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -980,6 +1075,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							Name:        "Gateway",
 							Kind:        structs.APIGateway,
 							SectionName: "Listener 2",
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -1027,6 +1127,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 				{
@@ -1047,6 +1152,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -1061,6 +1171,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							SectionName: "Listener 1",
 						},
 					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
+						},
+					},
 				},
 				&structs.TCPRouteConfigEntry{
 					Name: "TCP Route 2",
@@ -1070,6 +1185,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							Name:        "Gateway 2",
 							Kind:        structs.APIGateway,
 							SectionName: "Listener 2",
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -1128,6 +1248,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolHTTP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -1140,6 +1265,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							Name:        "Gateway",
 							Kind:        structs.APIGateway,
 							SectionName: "Listener",
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -1181,6 +1311,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -1193,6 +1328,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 							Name:        "Gateway",
 							Kind:        structs.APIGateway,
 							SectionName: "",
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -1289,6 +1429,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 								Protocol: structs.ListenerProtocolTCP,
 							},
 						},
+						Status: structs.Status{
+							Conditions: []structs.Condition{
+								newGatewayConditionGenerator().gatewayAccepted(),
+							},
+						},
 					},
 				},
 			},
@@ -1300,6 +1445,11 @@ func TestBindRoutesToGateways(t *testing.T) {
 						{
 							Name: "Gateway",
 							Kind: structs.APIGateway,
+						},
+					},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
 						},
 					},
 				},
@@ -1430,7 +1580,7 @@ func TestAPIGatewayController(t *testing.T) {
 				},
 			},
 		},
-		"tcp-route-no-gateways-invalid-targets": {
+		"tcp-route-not-accepted-bind": {
 			requests: []controller.Request{{
 				Kind: structs.TCPRoute,
 				Name: "tcp-route",
@@ -1444,6 +1594,27 @@ func TestAPIGatewayController(t *testing.T) {
 					Services: []structs.TCPService{{
 						Name: "tcp-upstream",
 					}},
+					Parents: []structs.ResourceReference{{
+						Name:           "api-gateway",
+						EnterpriseMeta: *defaultMeta,
+					}},
+				},
+				&structs.APIGatewayConfigEntry{
+					Kind:           structs.APIGateway,
+					Name:           "api-gateway",
+					EnterpriseMeta: *defaultMeta,
+					Listeners: []structs.APIGatewayListener{{
+						Name: "listener",
+						Port: 80,
+					}},
+				},
+				&structs.BoundAPIGatewayConfigEntry{
+					Kind:           structs.BoundAPIGateway,
+					Name:           "api-gateway",
+					EnterpriseMeta: *defaultMeta,
+					Listeners: []structs.BoundAPIGatewayListener{{
+						Name: "listener",
+					}},
 				},
 			},
 			finalEntries: []structs.ConfigEntry{
@@ -1453,9 +1624,40 @@ func TestAPIGatewayController(t *testing.T) {
 					EnterpriseMeta: *defaultMeta,
 					Status: structs.Status{
 						Conditions: []structs.Condition{
-							conditions.routeInvalidDiscoveryChain(errServiceDoesNotExist),
+							conditions.routeAccepted(),
+							conditions.routeUnbound(structs.ResourceReference{
+								Name:           "api-gateway",
+								EnterpriseMeta: *defaultMeta,
+							}, errors.New("failed to bind route to gateway api-gateway: gateway has not been accepted")),
 						},
 					},
+				},
+				&structs.APIGatewayConfigEntry{
+					Kind:           structs.APIGateway,
+					Name:           "api-gateway",
+					EnterpriseMeta: *defaultMeta,
+					Listeners: []structs.APIGatewayListener{{
+						Name: "listener",
+						Port: 80,
+					}},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							conditions.gatewayListenerNoConflicts(structs.ResourceReference{
+								Kind:           structs.APIGateway,
+								Name:           "api-gateway",
+								SectionName:    "listener",
+								EnterpriseMeta: *defaultMeta,
+							}),
+						},
+					},
+				},
+				&structs.BoundAPIGatewayConfigEntry{
+					Kind:           structs.BoundAPIGateway,
+					Name:           "api-gateway",
+					EnterpriseMeta: *defaultMeta,
+					Listeners: []structs.BoundAPIGatewayListener{{
+						Name: "listener",
+					}},
 				},
 			},
 		},
@@ -1748,6 +1950,11 @@ func TestAPIGatewayController(t *testing.T) {
 						Name:           "gateway",
 						EnterpriseMeta: *defaultMeta,
 					}},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
+						},
+					},
 				},
 				&structs.ServiceConfigEntry{
 					Kind:           structs.ServiceDefaults,
@@ -1763,6 +1970,11 @@ func TestAPIGatewayController(t *testing.T) {
 						Protocol: structs.ListenerProtocolTCP,
 						Port:     22,
 					}},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().gatewayAccepted(),
+						},
+					},
 				},
 				&structs.BoundAPIGatewayConfigEntry{
 					Kind:           structs.BoundAPIGateway,
@@ -1840,6 +2052,11 @@ func TestAPIGatewayController(t *testing.T) {
 						Name:           "gateway",
 						EnterpriseMeta: *defaultMeta,
 					}},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
+						},
+					},
 				},
 				&structs.ServiceConfigEntry{
 					Kind:           structs.ServiceDefaults,
@@ -1931,6 +2148,11 @@ func TestAPIGatewayController(t *testing.T) {
 						Name:           "gateway",
 						EnterpriseMeta: *defaultMeta,
 					}},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
+						},
+					},
 				},
 				&structs.TCPRouteConfigEntry{
 					Kind:           structs.TCPRoute,
@@ -1944,6 +2166,11 @@ func TestAPIGatewayController(t *testing.T) {
 						Name:           "gateway",
 						EnterpriseMeta: *defaultMeta,
 					}},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
+						},
+					},
 				},
 				&structs.ServiceConfigEntry{
 					Kind:           structs.ServiceDefaults,
@@ -2061,6 +2288,11 @@ func TestAPIGatewayController(t *testing.T) {
 						Name:           "gateway",
 						EnterpriseMeta: *defaultMeta,
 					}},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
+						},
+					},
 				},
 				&structs.HTTPRouteConfigEntry{
 					Kind:           structs.HTTPRoute,
@@ -2076,6 +2308,11 @@ func TestAPIGatewayController(t *testing.T) {
 						Name:           "gateway",
 						EnterpriseMeta: *defaultMeta,
 					}},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
+						},
+					},
 				},
 				&structs.ServiceConfigEntry{
 					Kind:           structs.ServiceDefaults,
@@ -2173,6 +2410,14 @@ func TestAPIGatewayController(t *testing.T) {
 			}, {
 				Kind: structs.TCPRoute,
 				Name: "tcp-route",
+				Meta: acl.DefaultEnterpriseMeta(),
+			}, {
+				Kind: structs.TCPRoute,
+				Name: "tcp-route",
+				Meta: acl.DefaultEnterpriseMeta(),
+			}, {
+				Kind: structs.HTTPRoute,
+				Name: "http-route",
 				Meta: acl.DefaultEnterpriseMeta(),
 			}, {
 				Kind: structs.HTTPRoute,
@@ -2327,6 +2572,11 @@ func TestAPIGatewayController(t *testing.T) {
 						Name:           "gateway",
 						EnterpriseMeta: *defaultMeta,
 					}},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
+						},
+					},
 				},
 				&structs.TCPRouteConfigEntry{
 					Kind:           structs.TCPRoute,
@@ -2340,6 +2590,11 @@ func TestAPIGatewayController(t *testing.T) {
 						Name:           "gateway",
 						EnterpriseMeta: *defaultMeta,
 					}},
+					Status: structs.Status{
+						Conditions: []structs.Condition{
+							newGatewayConditionGenerator().routeAccepted(),
+						},
+					},
 				},
 				&structs.ServiceConfigEntry{
 					Kind:           structs.ServiceDefaults,

--- a/agent/structs/config_entry_status.go
+++ b/agent/structs/config_entry_status.go
@@ -50,6 +50,16 @@ type Status struct {
 	Conditions []Condition
 }
 
+func (s *Status) MatchesConditionStatus(condition Condition) bool {
+	for _, c := range s.Conditions {
+		if c.IsCondition(&condition) &&
+			c.Status == condition.Status {
+			return true
+		}
+	}
+	return false
+}
+
 func (s Status) SameConditions(other Status) bool {
 	if len(s.Conditions) != len(other.Conditions) {
 		return false


### PR DESCRIPTION
### Description
We were allowing gateways to bind routes that were in a "non-accepted" state in our gateway reconciliation path and not allowing them in the route reconciliation path. Because of the fact that a TCP route being added to a gateway and forcing the gateway into a "conflicted" state causes a status update to the gateway and a status update to the route, we could trigger an infinite loop where the route status was being written as "bound" and the gateway status as "conflicted" when the gateway was reconciled, and then it would trigger a route reconciliation marking the route as "unbound" and the gateway no longer as "conflicted". The mutual status setting would cause reconciliation to be triggered indefinitely.

The fix is to add a check inside of our binding logic that makes sure a route and gateway are both marked as "accepted" prior to binding them. This does mean that on their first pass through the reconciler neither gateways, nor routes will actually bind anything because they aren't considered "accepted" until the end of the reconciliation loop. This is ok, because a second reconciliation run will be triggered when the status gets updated and routes will bind on the second pass.

### Testing & Reproduction steps

Created the config entries in the following order:

Service one defaults - tcp protocol:

```hcl
kind = "service-defaults"
name = "service-one"
protocol = "tcp"
```

Service two defaults - http protocol:

```hcl
kind = "service-defaults"
name = "service-two"
protocol = "http"
```

TCPRoute one (should be valid):

```hcl
kind = "tcp-route"
name = "api-gateway-route-one"
services = [
  {
    name = "service-one"
  }
]

parents = [
  {
    sectionName = "listener-one"
    name = "api-gateway"
  }
]
```

TCPRoute two (should be invalid due to mismatched protocol on the service):

```hcl
kind = "tcp-route"
name = "api-gateway-route-two"
services = [
  {
    name = "service-two"
  }
]

parents = [
  {
    sectionName = "listener-one"
    name = "api-gateway"
  }
]
```

Gateway:

```hcl
kind = "api-gateway"
name = "api-gateway"
listeners = [
  {
    name = "listener-one"
    port     = 9999
    protocol = "tcp"
  }
]
```

The final write for the gateway kicks off the death loop. It binds both TCPRoutes and sets itself in a "conflicted" state because it was ignoring whether or not the route was actually valid. Binding the routes triggers their reconciliation loops since we write to the route bound status. The route reconciliation would then unbind, taking the gateway out of conflicted, and triggering the gateway reconciliation -- this continued on mutually triggering re-reconciliation infinitely.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
