### PR TITLE
upgrade test: peering with resolver and failover

### DIFF
--- a/test/integration/consul-container/test/upgrade/l7_traffic_management/resolver_default_subset_test.go
+++ b/test/integration/consul-container/test/upgrade/l7_traffic_management/resolver_default_subset_test.go
@@ -11,7 +11,6 @@ import (
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	libservice "github.com/hashicorp/consul/test/integration/consul-container/libs/service"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/topology"
-	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 	libutils "github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
@@ -38,11 +37,11 @@ func TestTrafficManagement_ServiceResolverDefaultSubset(t *testing.T) {
 	tcs := []testcase{
 		{
 			oldversion:    "1.13",
-			targetVersion: utils.TargetVersion,
+			targetVersion: libutils.TargetVersion,
 		},
 		{
 			oldversion:    "1.14",
-			targetVersion: utils.TargetVersion,
+			targetVersion: libutils.TargetVersion,
 		},
 	}
 


### PR DESCRIPTION
### Description
oss split of ent [PR](https://github.com/hashicorp/consul-enterprise/pull/4460)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
