### PR TITLE
Fix rendering error on new operator usage docs

### DIFF
--- a/website/content/api-docs/operator/usage.mdx
+++ b/website/content/api-docs/operator/usage.mdx
@@ -49,6 +49,7 @@ $ curl \
 
 <Tabs>
 <Tab heading="OSS">
+
 ```json
 {
   "Usage": {
@@ -74,8 +75,10 @@ $ curl \
   "ResultsFilteredByACLs": false
 }
 ```
+
 </Tab>
 <Tab heading="Enterprise">
+
 ```json
 {
   "Usage": {
@@ -127,6 +130,7 @@ $ curl \
   "ResultsFilteredByACLs": false
 }
 ```
+
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
### Description
#16258 introduced a rendering error impacting Vercel runs on `main` and `release/1.15.x`:
<img width="1238" alt="CleanShot 2023-02-23 at 11 35 20@2x" src="https://user-images.githubusercontent.com/3476400/220971088-b9b8bf6e-5c47-4890-9ec1-f353d6794d36.png">

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links
Example failing Vercel run: https://vercel.com/hashicorp/consul/8vFm4QCA2PWxK87fiV9M1qiEW848
<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
