### PR TITLE
Fix various flaky tests

### DIFF
--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -1252,8 +1252,8 @@ func TestStreamResources_Server_DisconnectsOnHeartbeatTimeout(t *testing.T) {
 	})
 
 	testutil.RunStep(t, "stream is disconnected due to heartbeat timeout", func(t *testing.T) {
-		disconnectTime := ptr(it.FutureNow(1))
 		retry.Run(t, func(r *retry.R) {
+			disconnectTime := ptr(it.StaticNow())
 			status, ok := srv.StreamStatus(testPeerID)
 			require.True(r, ok)
 			require.False(r, status.Connected)
@@ -1423,7 +1423,7 @@ func makeClient(t *testing.T, srv *testServer, peerID string) *MockClient {
 		},
 	}))
 
-	// Receive a services and roots subscription request pair from server
+	// Receive ExportedService, ExportedServiceList, and PeeringTrustBundle subscription requests from server
 	receivedSub1, err := client.Recv()
 	require.NoError(t, err)
 	receivedSub2, err := client.Recv()

--- a/agent/grpc-external/services/peerstream/testing.go
+++ b/agent/grpc-external/services/peerstream/testing.go
@@ -150,6 +150,16 @@ func (t *incrementalTime) Now() time.Time {
 	return t.base.Add(dur)
 }
 
+// StaticNow returns the current internal clock without advancing it.
+func (t *incrementalTime) StaticNow() time.Time {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	dur := time.Duration(t.next) * time.Second
+
+	return t.base.Add(dur)
+}
+
 // FutureNow will return a given future value of the Now() function.
 // The numerical argument indicates which future Now value you wanted. The
 // value must be > 0.

--- a/agent/xds/xds_protocol_helpers_test.go
+++ b/agent/xds/xds_protocol_helpers_test.go
@@ -166,9 +166,6 @@ func newTestServerDeltaScenario(
 ) *testServerScenario {
 	mgr := newTestManager(t)
 	envoy := NewTestEnvoy(t, proxyID, token)
-	t.Cleanup(func() {
-		envoy.Close()
-	})
 
 	sink := metrics.NewInmemSink(1*time.Minute, 1*time.Minute)
 	cfg := metrics.DefaultConfig("consul.xds.test")
@@ -177,6 +174,7 @@ func newTestServerDeltaScenario(
 	metrics.NewGlobal(cfg, sink)
 
 	t.Cleanup(func() {
+		envoy.Close()
 		sink := &metrics.BlackholeSink{}
 		metrics.NewGlobal(cfg, sink)
 	})

--- a/command/debug/debug.go
+++ b/command/debug/debug.go
@@ -270,7 +270,8 @@ func (c *cmd) prepare() (version string, err error) {
 	// If none are specified we will collect information from
 	// all by default
 	if len(c.capture) == 0 {
-		c.capture = defaultTargets
+		c.capture = make([]string, len(defaultTargets))
+		copy(c.capture, defaultTargets)
 	}
 
 	// If EnableDebug is not true, skip collecting pprof


### PR DESCRIPTION
Fixes tests that have high rates of failure in our CI pipeline:
* `TestStreamResources_Server_DisconnectsOnHeartbeatTimeout/stream_is_disconnected_due_to_heartbeat_timeout`
* `TestDebugCommand_DebugDisabled`
* `TestServer_DeltaAggregatedResources_v3_ACLEnforcement` (added retries but not 100% confident in fix)
