### PR TITLE
add missing field to oss struct

### DIFF
--- a/api/operator_license.go
+++ b/api/operator_license.go
@@ -30,6 +30,9 @@ type License struct {
 	// no longer be used in any capacity
 	TerminationTime time.Time `json:"termination_time"`
 
+	// Whether the license will ignore termination
+	IgnoreTermination bool `json:"ignore_termination"`
+
 	// The product the license is valid for
 	Product string `json:"product"`
 


### PR DESCRIPTION
### Description
This struct was missing a new field for licenses. This brings OSS up to parity with ENT.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern

