### PR TITLE
Backport of Native API Gateway Docs (#16365)

### DIFF
--- a/website/content/docs/api-gateway/index.mdx
+++ b/website/content/docs/api-gateway/index.mdx
@@ -5,9 +5,9 @@ description: >-
   Consul API Gateway enables external network client access to a service mesh on Kubernetes and forwards requests based on path or header information. Learn about how the k8s Gateway API specification configures Consul API Gateway so you can control access and simplify traffic management.
 ---
 
-# API Gateway for Kubernetes Overview
+# API Gateway for Kubernetes overview
 
-This topic provides an overview of the Consul API Gateway.
+This topic provides an overview of the Consul API Gateway for deploying on Kubernetes. If you would like to deploy on virtual machines, refer to [API Gateways on Virtual Machines](/consul/docs/connect/gateways/api-gateway/usage).
 
 ## What is Consul API Gateway?
 

--- a/website/content/docs/connect/gateways/api-gateway/configuration/api-gateway.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/api-gateway.mdx
@@ -1,0 +1,331 @@
+---
+layout: docs
+page_title: API Gateway Configuration Entry Reference
+description: Learn how to configure a Consul API Gateway on VMs.
+---
+
+# API gateway configuration entry reference
+
+This topic provides reference information for the API gateway configuration entry that you can deploy to networks in virtual machine (VM) environments. For reference information about configuring Consul API gateways on Kubernetes, refer to [Gateway Resource Configuration](/consul/docs/api-gateway/configuration/gateway).
+
+## Introduction
+
+A gateway is a type of network infrastructure that determines how service traffic should be handled. Gateways contain one or more listeners that bind to a set of hosts and ports. An HTTP Route or TCP Route can then attach to a gateway listener to direct traffic from the gateway to a service.
+
+## Configuration model
+
+The following list outlines field hierarchy, language-specific data types, and requirements in an `api-gateway` configuration entry. Click on a property name to view additional details, including default values.
+
+- [`Kind`](#kind): string | must be `"api-gateway"`
+- [`Name`](#name): string | no default
+- [`Namespace`](#namespace): string | no default <EnterpriseAlert inline />
+- [`Partition`](#partition): string | no default <EnterpriseAlert inline />
+- [`Meta`](#meta): map | no default
+- [`Listeners`](#listeners): list of objects | no default
+  - [`Name`](#listeners-name): string | no default
+  - [`Port`](#listeners-port): number | no default
+  - [`Hostname`](#listeners-hostname): string | `"*"`
+  - [`Protocol`](#listeners-protocol): string | `"tcp"`
+  - [`TLS`](#listeners-tls): map | none
+    - [`MinVersion`](#listeners-tls-minversion): string | no default
+    - [`MaxVersion`](#listeners-tls-maxversion): string | no default
+    - [`CipherSuites`](#listeners-tls-ciphersuites): list of strings | Envoy default cipher suites
+    - [`Certificates`](#listeners-tls-certificates): list of objects | no default
+      - [`Kind`](#listeners-tls-certificates-kind): string | must be `"inline-certificate"`
+      - [`Name`](#listeners-tls-certificates-name): string | no default
+      - [`Namespace`](#listeners-tls-certificates-namespace): string | no default <EnterpriseAlert inline />
+      - [`Partition`](#listeners-tls-certificates-partition): string | no default <EnterpriseAlert inline />
+
+## Complete configuration
+
+When every field is defined, an `api-gateway` configuration entry has the following form:
+
+<CodeTabs>
+
+```hcl
+Kind = "api-gateway"
+Name = "<name of api gateway>"
+Namespace = "<enterprise: namespace of the gateway>"
+Partition = "<enterprise: partition of the gateway>"
+
+Meta = {
+  <any key> = "<any value>"
+}
+
+Listeners = [
+  {
+    Port = <external service port>
+    Name = "<unique name for this listener>"
+    Protocol = "<protocol used by external service>"
+    TLS = {
+      MaxVersion = "<version of TLS>"
+      MinVersion = "<version of TLS>"
+      CipherSuites = [
+        "<cipher suite>"
+      ]
+      Certificates = [
+        {
+          Kind = "inline-certificate"
+          Name = "<name of inline-certificate>"
+          Namespace = "<enterprise: namespace of the certificate>"
+          Partition = "<enterprise: partition of the certificate>"
+        }
+      ]
+    }
+  }
+]
+```
+
+```json
+{
+  "Kind": "api-gateway",
+  "Name": "<name of api gateway>",
+  "Namespace": "<enterprise: namespace of the gateway>",
+  "Partition": "<enterprise: partition of the gateway>",
+  "Meta": {
+    "<any key>": "<any value>"
+  },
+  "Listeners": [
+    {
+      "Name": "<unique name for this listener>",
+      "Port": <external service port>,
+      "Protocol": "<protocol used by external service>",
+      "TLS": {
+        "MaxVersion": "<version of TLS>",
+        "MinVersion": "<version of TLS>",
+        "CipherSuites": [
+          "<cipher suite>"
+        ],
+        "Certificates": [
+          {
+            "Kind": "inline-certificate",
+            "Name": "<name of inline-certificate>",
+            "Namespace": "<enterprise: namespace of the certificate>",
+            "Partition": "<enterprise: partition of the certificate>"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+</CodeTabs>
+
+## Specification
+
+This section provides details about the fields you can configure in the
+`api-gateway` configuration entry.
+
+### `Kind`
+
+Specifies the type of configuration entry to implement. This must be
+`api-gateway`.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string value that must be set to `"api-gateway"`.
+
+### `Name`
+
+Specifies a name for the configuration entry. The name is metadata that you can
+use to reference the configuration entry when performing Consul operations,
+such as applying a configuration entry to a specific cluster.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string
+
+### `Namespace` <EnterpriseAlert inline />
+
+Specifies the Enterprise [namespace](/consul/docs/enterprise/namespaces) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Partition` <EnterpriseAlert inline />
+
+Specifies the Enterprise [admin partition](/consul/docs/enterprise/admin-partitions) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Meta`
+
+Specifies an arbitrary set of key-value pairs to associate with the gateway.
+
+#### Values
+
+- Default: none
+- Data type: map containing one or more keys and string values.
+
+### `Listeners[]`
+
+Specifies a list of listeners that gateway should set up. Listeners are
+uniquely identified by their port number.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: List of maps. Each member of the list contains the following fields:
+  - [`Name`](#listeners-name)
+  - [`Port`](#listeners-port)
+  - [`Hostname`](#listeners-hostname)
+  - [`Protocol`](#listeners-protocol)
+  - [`TLS`](#listeners-tls)
+
+### `Listeners[].Name`
+
+Specifies the unique name for the listener. This field accepts letters, numbers, and hyphens.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string
+
+### `Listeners[].Port`
+
+Specifies the port number that the listener receives traffic on.
+
+#### Values
+
+- Default: `0`
+- This field is required.
+- Data type: integer
+
+### `Listeners[].Hostname`
+
+Specifies the hostname that the listener receives traffic on.
+
+#### Values
+
+- Default: `"*"`
+- This field is optional.
+- Data type: string
+
+### `Listeners[].Protocol`
+
+Specifies the protocol associated with the listener.
+
+#### Values
+
+- Default: none
+- This field is required.
+- The data type is one of the following string values: `"tcp"` or `"http"`.
+
+### `Listeners[].TLS`
+
+Specifies the TLS configurations for the listener.
+
+#### Values
+
+- Default: none
+- Map that contains the following fields:
+  - [`MaxVersion`](#listeners-tls-maxversion)
+  - [`MinVersion`](#listeners-tls-minversion)
+  - [`CipherSuites`](#listeners-tls-ciphersuites)
+  - [`Certificates`](#listeners-tls-certificates)
+
+### `Listeners[].TLS.MaxVersion`
+
+Specifies the maximum TLS version supported for the listener.
+
+#### Values
+
+- Default depends on the version of Envoy:
+  - Envoy 1.22.0 and later default to `TLSv1_2`
+  - Older versions of Envoy default to `TLSv1_0`
+- Data type is one of the following string values:
+  - `TLS_AUTO`
+  - `TLSv1_0`
+  - `TLSv1_1`
+  - `TLSv1_2`
+  - `TLSv1_3`
+
+### `Listeners[].TLS.MinVersion`
+
+Specifies the minimum TLS version supported for the listener.
+
+#### Values
+
+- Default: none
+- Data type is one of the following string values:
+  - `TLS_AUTO`
+  - `TLSv1_0`
+  - `TLSv1_1`
+  - `TLSv1_2`
+  - `TLSv1_3`
+
+### `Listeners[].TLS.CipherSuites[]`
+
+Specifies a list of cipher suites that the listener supports when negotiating connections using TLS 1.2 or older.
+
+#### Values
+
+- Defaults to the ciphers supported by the version of Envoy in use. Refer to the
+  [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites)
+  for details.
+- Data type: List of string values. Refer to the
+  [Consul repository](https://github.com/hashicorp/consul/blob/v1.11.2/types/tls.go#L154-L169)
+  for a list of supported ciphers.
+
+### `Listeners[].TLS.Certificates[]`
+
+The list of references to inline certificates that the listener uses for TLS termination.
+
+#### Values
+
+- Default: None
+- Data type: List of maps. Each member of the list has the following fields:
+  - [`Kind`](#listeners-tls-certificates-kind)
+  - [`Name`](#listeners-tls-certificates-name)
+  - [`Namespace`](#listeners-tls-certificates-namespace) <EnterpriseAlert inline />
+  - [`Partition`](#listeners-tls-certificates-partition) <EnterpriseAlert inline />
+
+### `Listeners[].TLS.Certificates[].Kind`
+
+The list of references to inline-certificates that the listener uses for TLS termination.
+
+#### Values
+
+- Default: None
+- This field is required and must be set to `"inline-certificate"`.
+- Data type: string
+
+### `Listeners[].TLS.Certificates[].Name`
+
+The list of references to inline certificates that the listener uses for TLS termination.
+
+#### Values
+
+- Default: None
+- This field is required.
+- Data type: string
+
+### `Listeners[].TLS.Certificates[].Namespace` <EnterpriseAlert inline />
+
+Specifies the Enterprise [namespace](/consul/docs/enterprise/namespaces) where the certificate can be found.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Listeners[].TLS.Certificates[].Partition` <EnterpriseAlert inline />
+
+Specifies the Enterprise [admin partition](/consul/docs/enterprise/admin-partitions) where the certificate can be found.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string

--- a/website/content/docs/connect/gateways/api-gateway/configuration/http-route.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/http-route.mdx
@@ -1,0 +1,678 @@
+---
+layout: docs
+page_title: HTTP Route Configuration
+description: Learn how to configure an HTTP Route bound to an API Gateway on VMs.
+---
+
+# HTTP route configuration reference
+
+This topic provides reference information for the gateway routes configuration entry. Refer to [Route Resource Configuration](/consul/docs/api-gateway/configuration/routes) for information about configuring API gateway routes in Kubernetes environments.
+
+## Configuration model
+
+The following list outlines field hierarchy, language-specific data types, and
+requirements in an `http-route` configuration entry. Click on a property name
+to view additional details, including default values.
+
+- [`Kind`](#kind): string | must be `http-route`
+- [`Name`](#name): string | no default
+- [`Namespace`](#namespace): string | no default <EnterpriseAlert inline />
+- [`Partition`](#partition): string | no default <EnterpriseAlert inline />
+- [`Meta`](#meta): map | no default
+- [`Hostnames`](#hostnames): list | no default
+- [`Parents`](#parents): list | no default
+  - [`Kind`](#parents-kind): string | must be `api-gateway`
+  - [`Name`](#parents-name): string | no default
+  - [`Namespace`](#parents-namespace): string | no default <EnterpriseAlert inline />
+  - [`Partition`](#parents-partition): string | no default <EnterpriseAlert inline />
+  - [`SectionName`](#parents-sectionname): string | no default
+- [`Rules`](#rules): list | no default
+  - [`Filters`](#rules-filters): map | no default
+    - [`Headers`](#rules-filters-headers): list | no default
+      - [`Add`](#rules-filters-headers-add): map | no default
+      - [`Remove`](#rules-filters-headers-remove): list | no default
+      - [`Set`](#rules-filters-headers-set): map | no default
+    - [`URLRewrite`](#rules-filters-urlrewrite): map | no default
+      - [`Path`](#rules-filters-urlrewrite-path): string | no default
+  - [`Matches`](#rules-matches): list | no default
+    - [`Headers`](#rules-matches-headers): list | no default
+      - [`Match`](#rules-matches-headers-match): string | no default
+      - [`Name`](#rules-matches-headers-name): string | no default
+      - [`Value`](#rules-matches-headers-value): string | no default
+    - [`Method`](#rules-matches-method): string | no default
+    - [`Path`](#rules-matches-path): map | no default
+      - [`Match`](#rules-matches-path-match): string | no default
+      - [`Value`](#rules-matches-path-value): string | no default
+    - [`Query`](#rules-matches-query): list | no default
+      - [`Match`](#rules-matches-query-match): string | no default
+      - [`Name`](#rules-matches-query-name): string | no default
+      - [`Value`](#rules-matches-query-value): string | no default
+  - [`Services`](#rules-services): list | no default
+    - [`Name`](#rules-services-name): string | no default
+    - [`Namespace`](#rules-services-namespace): string <EnterpriseAlert inline />
+    - [`Partition`](#rules-services-partition): string <EnterpriseAlert inline />
+    - [`Weight`](#rules-services-weight): number | `1`
+    - [`Filters`](#rules-services-filters): map | no default
+      - [`Headers`](#rules-services-filters-headers): list | no default
+        - [`Add`](#rules-services-filters-headers-add): map | no default
+        - [`Remove`](#rules-services-filters-headers-remove): list | no default
+        - [`Set`](#rules-services-filters-headers-set): map | no default
+      - [`URLRewrite`](#rules-services-filters-urlrewrite): map | no default
+        - [`Path`](#rules-services-filters-urlrewrite-path): string | no default
+
+## Complete configuration
+
+When every field is defined, an `http-route` configuration entry has the following form:
+
+<CodeTabs>
+
+```hcl
+Kind = "http-route"
+Name = "<name of the route>"
+Namespace = "<enterprise: namespace of the service>"
+Partition = "<enterprise: partition of the service>"
+Meta = {
+  "<any key>" = "<any value>"
+}
+Hostnames = ["<hostnames for which this HTTPRoute should respond to requests>"]
+
+Parents = [
+  {
+    Kind        = "api-gateway"
+    Name        = "<name of the api-gateway to bind to>"
+    Namespace = "<enterprise: namespace of the service>"
+    Partition = "<enterprise: partition of the service>"
+    SectionName = "<optional name of a specific listener on the api-gateway to bind to>"
+  }
+]
+
+Rules = [
+  {
+    Filters = {
+      Headers = [
+        {
+          Add = {
+            "<name of header to add>" = "<value of header to add>"
+          }
+          Remove = [
+            "<name of header to remove from request>"
+          ]
+          Set = {
+            "<name of header to set>" = "<value of header to set>"
+          }
+        }
+      ]
+      URLRewrite = {
+        Path = "<path to rewrite request to>"
+      }
+    }
+    Matches = [
+      {
+        Headers = [
+          {
+            Match = "<type of match: exact, prefix or regex>"
+            Name = "<name of header to match on>"
+            Value = "<value of header to match on>"
+          }
+        ]
+        Method = "<method type to match on>"
+        Path = {
+          Match = "<type of match: exact, prefix or regex>"
+          Value = "<value to match on>"
+        }
+        Query = [
+          {
+            Match = "<type of match: exact, present or regex>"
+            Name = "<name of query parameter to match on>"
+            Value = "<value of query parameter to match on>"
+          }
+        ]
+      }
+    ]
+    Services = [
+      {
+        Name   = "<name of Consul service to route to>"
+        Namespace = "<enterprise: namespace of the service>"
+        Partition = "<enterprise: partition of the service>"
+        Weight = "<number proportional to other weights>"
+        Filters = {
+          Headers = [
+            {
+              Add = {
+                "<name of header to add>" = "<value of header to add>"
+              }
+              Remove = [
+                "<name of header to remove from request>"
+              ]
+              Set = {
+                "<name of header to set>" = "<value of header to set>"
+              }
+            }
+          ]
+          URLRewrite = {
+            Path = "<path to rewrite request to>"
+          }
+        }
+      }
+    ]
+  }
+]
+
+```
+
+```json
+{
+  "Kind": "http-route",
+  "Name": "<name of the route>",
+  "Namespace": "<enterprise: namespace of the route>",
+  "Partition": "<enterprise: partition of the route>",
+  "Meta": {
+    "<any key>": "<any value>"
+  },
+  "Hostnames": [
+    "<hostnames for which this HTTPRoute should respond to requests>"
+  ],
+  "Parents": [
+    {
+      "Kind": "api-gateway",
+      "Name": "<name of the api-gateway to bind to>",
+      "Namespace": "<enterprise: namespace of the route>",
+      "Partition": "<enterprise: partition of the route>",
+      "SectionName": "<optional name of a specific listener on the api-gateway to bind to>"
+    }
+  ],
+  "Rules": [
+    {
+      "Filters": [
+        {
+          "Headers": [
+            {
+              "Add": [
+                {
+                  "<name of header to add>": "<value of header to add>"
+                }
+              ],
+              "Remove": ["<header to remove from request>"],
+              "Set": [
+                {
+                  "<name of header to set>": "<value of header to set>"
+                }
+              ]
+            }
+          ],
+          "URLRewrite": [
+            {
+              "Path": "<path to rewrite request to>"
+            }
+          ]
+        }
+      ],
+      "Matches": [
+        {
+          "Headers": [
+            {
+              "Match": "<type of match: exact, prefix or regex>",
+              "Name": "<name of header to match on>",
+              "Value": "<value of header to match on>"
+            }
+          ],
+          "Method": "<method type to match on>",
+          "Path": [
+            {
+              "Match": "<type of match: exact, prefix or regex>",
+              "Value": "<value to match on>"
+            }
+          ],
+          "Query": [
+            {
+              "Match": "<type of match: exact, present or regex>",
+              "Name": "<name of query parameter to match on>",
+              "Value": "<value of query parameter to match on>"
+            }
+          ]
+        }
+      ],
+      "Services": [
+        {
+          "Name": "<name of Consul service to route to>",
+          "Namespace": "<enterprise: namespace of the route>",
+          "Partition": "<enterprise: partition of the route>",
+          "Weight": "<number proportional to other weights>",
+          "Filters": [
+            {
+              "Headers": [
+                {
+                  "Add": [
+                    {
+                      "<name of header to add": "<value of header to add>"
+                    }
+                  ],
+                  "Remove": ["<header to remove from request>"],
+                  "Set": [
+                    {
+                      "<name of header to set": "<value of header to set>"
+                    }
+                  ]
+                }
+              ],
+              "URLRewrite": [
+                {
+                  "Path": "<path to rewrite request to>"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+</CodeTabs>
+
+## Specification
+
+This section provides details about the fields you can configure in the `http-route` configuration entry.
+
+### `Kind`
+
+Specifies the type of configuration entry to implement. For HTTP routes, this must be `http-route`.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string value that must be set to `"http-route"`.
+
+### `Name`
+
+Specifies a name for the configuration entry. The name is metadata that you can
+use to reference the configuration entry when performing Consul operations,
+such as applying a configuration entry to a specific cluster.
+
+#### Values
+
+- Default: Defaults to the name of the node after writing the entry to the Consul server.
+- This field is required.
+- Data type: string
+
+### `Namespace` <EnterpriseAlert inline />
+
+Specifies the Enterprise [namespace](/consul/docs/enterprise/namespaces) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Partition` <EnterpriseAlert inline />
+
+Specifies the Enterprise [admin partition](/consul/docs/enterprise/admin-partitions) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Meta`
+
+Specifies an arbitrary set of key-value pairs to associate with the route.
+
+#### Values
+
+- Default: none
+- Data type: map containing one or more keys and string values.
+
+### `Parents[]`
+
+Specifies the list of gateways that this route binds to.
+
+#### Values
+
+- Default: none
+- Data type: List of map. Each member of the list contains the following fields:
+  - `Kind`
+  - `Name`
+  - `Namespace` <EnterpriseAlert inline />
+  - `Partition` <EnterpriseAlert inline />
+  - `SectionName`
+
+### `Parents[].Kind`
+
+Specifies the type of resource to bind to. This field is required and must be
+set to `"api-gateway"`
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string value set to `"api-gateway"`
+
+### `Parents[].Name`
+
+Specifies the name of the api-gateway to bind to.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string
+
+### `Parents[].Namespace` <EnterpriseAlert inline />
+
+Specifies the Enterprise [namespace](/consul/docs/enterprise/namespaces) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Parents[].Partition` <EnterpriseAlert inline />
+
+Specifies the Enterprise [admin partition](/consul/docs/enterprise/admin-partitions) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Parents[].SectionName`
+
+Specifies the name of the listener to bind to on the `api-gateway`. If left
+empty, this route binds to _all listeners_ on the parent gateway.
+
+#### Values
+
+- Default: ""
+- Data type: string
+
+### `Rules[]`
+
+Specifies the list of HTTP-based routing rules that this route uses to construct a route table.
+
+#### Values
+
+- Default:
+- Data type: List of maps. Each member of the list contains the following fields:
+  - `Filters`
+  - `Matches`
+  - `Services`
+
+### `Rules[].Filters`
+
+Specifies the list of HTTP-based filters used to modify a request prior to routing it to the upstream service.
+
+#### Values
+
+- Default: none
+- Data type: Map that contains the following fields:
+  - `Headers`
+  - `UrlRewrite`
+
+### `Rules[].Filters.Headers[]`
+
+Defines operations to perform on matching request headers when an incoming request matches the `Rules.Matches` configuration.
+
+#### Values
+
+This field contains the following configuration objects:
+
+| Parameter | Description                                                                                                                                                                                                                                                                                                                                                                                                                                  | Type            |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `set`     | Configure this field to rewrite the HTTP request header. It specifies the name of an HTTP header to overwrite and the new value to set. Any existing values associated with the header name are overwritten. You can specify the following configurations: <ul><li>`name`: Required string that specifies the name of the HTTP header to set.</li><li>`value`: Required string that specifies the value of the HTTP header to set.</li></ul> | List of maps    |
+| `add`     | Configure this field to append the request header with a new value. It specifies the name of an HTTP header to append and the values to add. You can specify the following configurations: <ul><li>`name`: Required string that specifies the name of the HTTP header to append.</li><li>`value`: Required string that specifies the value of the HTTP header to add.</li></ul>                                                              | List of maps    |
+| `remove`  | Configure this field to specify an array of header names to remove from the request header.                                                                                                                                                                                                                                                                                                                                                  | List of strings |
+
+### `Rules[].Filters.URLRewrite`
+
+Specifies rule for rewriting the URL of incoming requests when an incoming request matches the `Rules.Matches` configuration.
+
+#### Values
+
+- Default: none
+- This field is a map that contains a `Path` field.
+
+### Rules[].Filters.URLRewrite.Path
+
+Specifies a path that determines how Consul API Gateway rewrites a URL path. Refer to [Reroute HTTP requests](/consul/docs/api-gateway/usage#reroute-http-requests) for additional information.
+
+#### Values
+
+The following table describes the parameters for `path`:
+
+| Parameter            | Description                                                                                                                                                                                      | Type   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
+| `replacePrefixMatch` | Specifies a value that replaces the path prefix for incoming HTTP requests. The operation only affects the path prefix. The rest of the path is unchanged.                                       | String |
+| `type`               | Specifies the type of replacement to use for the URL path. You can specify the following values: <ul><li>`ReplacePrefixMatch`: Replaces the matched prefix of the URL path (default). </li></ul> | String |
+
+### `Rules[].Matches[]`
+
+Specifies the matching criteria used in the routing table. When an incoming
+request matches the given HTTPMatch configuration, traffic routes to
+services specified in the [`Rules.Services`](#rules-services) field.
+
+#### Values
+
+- Default: none
+- Data type: List containing maps. Each member of the list contains the following fields:
+  - `Headers`
+  - `Method`
+  - `Path`
+  - `Query`
+
+### `Rules[].Matches[].Headers[]`
+
+Specifies rules for matching incoming request headers. You can specify multiple rules in a list, as well as multiple lists of rules. If all rules in a single list are satisfied, then the route forwards the request to the appropriate service defined in the [`Rules.Services`](#rules-services) configuration. You can create multiple `Header[]` lists to create a range of matching criteria. When at least one list of matching rules are satisfied, the route forwards the request to the appropriate service defined in the [`Rules.Services`](#rules-services) configuration.
+
+#### Values
+
+- Default: none
+- Data type: List containing maps with the following fields:
+  - `Match`
+  - `Name`
+  - `Value`
+
+### `Rules.Matches.Headers.Match`
+
+Specifies type of match for headers: `"exact"`, `"prefix"`, or `"regex"`.
+
+#### Values
+
+- Default: none
+- Data type: string
+
+### `Rules.Matches.Headers.Name`
+
+Specifies the name of the header to match.
+
+#### Values
+
+- Default: none
+- Data type: string
+
+### `Rules[].Matches.Headers.Value`
+
+Specifies the value of the header to match.
+
+#### Values
+
+- Default: none
+- Data type: string
+
+### `Rules[].Matches[].Method`
+
+Specifies a list of strings that define matches based on HTTP request method.
+
+#### Values
+
+Specify one of the following string values:
+
+- `HEAD`
+- `POST`
+- `PUT`
+- `PATCH`
+- `GET`
+- `DELETE`
+- `OPTIONS`
+- `TRACE`
+- `CONNECT`
+
+### `Rules[].Matches[].Path`
+
+Specifies the HTTP method to match.
+
+#### Values
+
+- Default: none
+- Data type: map containing the following fields:
+  - `Match`
+  - `Value`
+
+### `Rules[].Matches[].Path.Match`
+
+Specifies type of match for the path: `"exact"`, `"prefix"`, or `"regex"`.
+
+#### Values
+
+- Default: none
+- Data type: string
+
+### `Rules[].Matches[].Path.Value`
+
+Specifies the value of the path to match.
+
+#### Values
+
+- Default: none
+- Data type: string
+
+### `Rules[].Matches[].Query[]`
+
+Specifies how a match is completed on a request’s query parameters.
+
+#### Values
+
+- Default: none
+- Data type: List of map that contains the following fields:
+  - `Match`
+  - `Name`
+  - `Value`
+
+### `Rules[].Matches[].Query[].Match`
+
+Specifies type of match for query parameters: `"exact"`, `"prefix"`, or `"regex"`.
+
+#### Values
+
+- Default: none
+- Data type: string
+
+### `Rules[].Matches[].Query[].Name`
+
+Specifies the name of the query parameter to match.
+
+#### Values
+
+- Default: none
+- Data type: string
+
+### `Rules[].Matches[].Query[].Value`
+
+Specifies the value of the query parameter to match.
+
+#### Values
+
+- Default: none
+- Data type: string
+
+### `Rules[].Services[]`
+
+Specifies the service that the API gateway routes incoming requests to when the
+requests match the `Rules.Matches` configuration.
+
+#### Values
+
+- Default: none
+- This field contains a list of maps. Each member of the list contains the following fields:
+  - `Name`
+  - `Weight`
+  - `Filters`
+  - `Namespace` <EnterpriseAlert inline />
+  - `Partition` <EnterpriseAlert inline />
+
+### `Rules[].Services[].Name`
+
+Specifies the name of an HTTP-based service to route to.
+
+#### Values
+
+- Default: none
+- Data type: string
+
+### `Rules[].Services[].Namespace` <EnterpriseAlert inline />
+
+Specifies the Enterprise [namespace](/consul/docs/enterprise/namespaces) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Rules[].Services.Partition` <EnterpriseAlert inline />
+
+Specifies the Enterprise [admin partition](/consul/docs/enterprise/admin-partitions) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Rules[].Services[].Weight`
+
+Specifies the proportion of requests forwarded to the specified service. The
+proportion is determined by dividing the value of the weight by the sum of all
+weights in the service list. For non-zero values, there may be some deviation
+from the exact proportion depending on the precision an implementation
+supports. Weight is not a percentage and the sum of weights does not need to
+equal 100.
+
+#### Values
+
+- Default: none
+- Data type: integer
+
+### `Rules[].Services[].Filters`
+
+Specifies the list of HTTP-based filters used to modify a request prior to
+routing it to this upstream service.
+
+#### Values
+
+- Default: none
+- Data type: Map that contains the following fields:
+  - `Headers`
+  - `UrlRewrite`
+
+### `Rules[].Services[].Filters.Headers[]`
+
+Defines operations to perform on matching request headers.
+
+#### Values
+
+This field contains the following configuration objects:
+
+| Parameter | Description                                                                                                                                                                                                                                                                                                                                                                                                                                  | Type            |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `set`     | Configure this field to rewrite the HTTP request header. It specifies the name of an HTTP header to overwrite and the new value to set. Any existing values associated with the header name are overwritten. You can specify the following configurations: <ul><li>`name`: Required string that specifies the name of the HTTP header to set.</li><li>`value`: Required string that specifies the value of the HTTP header to set.</li></ul> | List of maps    |
+| `add`     | Configure this field to append the request header with a new value. It specifies the name of an HTTP header to append and the values to add. You can specify the following configurations: <ul><li>`name`: Required string that specifies the name of the HTTP header to append.</li><li>`value`: Required string that specifies the value of the HTTP header to add.</li></ul>                                                              | List of maps    |
+| `remove`  | Configure this field to specify an array of header names to remove from the request header.                                                                                                                                                                                                                                                                                                                                                  | List of strings |
+
+### `Rules[].Services[].Filters.URLRewrite`
+
+Specifies rule for rewriting the URL of incoming requests.
+
+#### Values
+
+- Default: none
+- This field is a map that contains a `Path` field.

--- a/website/content/docs/connect/gateways/api-gateway/configuration/inline-certificate.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/inline-certificate.mdx
@@ -1,0 +1,127 @@
+---
+layout: docs
+page_title: Inline Certificate Configuration Reference
+description: Learn how to configure an inline certificate bound to an API Gateway on VMs.
+---
+
+# Inline certificate configuration reference
+
+This topic provides reference information for the gateway inline certificate
+configuration entry. For information about certificate configuration for Kubernetes environments, refer to [Gateway Resource Configuration](/consul/docs/api-gateway/configuration/gateway).
+
+## Configuration model
+
+The following list outlines field hierarchy, language-specific data types, and
+requirements in an `inline-certificate` configuration entry. Click on a property name
+to view additional details, including default values.
+
+- [`Kind`](#kind): string | must be `"inline-certificate"`
+- [`Name`](#name): string | no default
+- [`Namespace`](#namespace): string | no default <EnterpriseAlert inline />
+- [`Partition`](#partition): string | no default <EnterpriseAlert inline />
+- [`Meta`](#meta): map | no default
+- [`Certificate`](#certificate): string | no default
+- [`PrivateKey`](#privatekey): string | no default
+
+## Complete configuration
+
+When every field is defined, an `inline-certificate` configuration entry has the following form:
+
+<CodeTabs>
+
+```HCL
+Kind = "inline-certificate"
+Name = "<name of certificate>"
+
+Meta = {
+	"<any key>" = "<any value>"
+}
+
+Certificate = "<public certificate>"
+PrivateKey = "<private key>"
+```
+
+```JSON
+{
+	"Kind": "inline-certificate",
+	"Name": "<name of certificate>",
+	"Meta": {
+		"any key": "any value"
+	}
+	"Certificate": "<public certificate>",
+	"PrivateKey": "<private key>"
+}
+```
+
+</CodeTabs>
+
+## Specification
+
+### `Kind`
+
+Specifies the type of configuration entry to implement.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string that must equal `"inline-certificate"`
+
+### `Name`
+
+Specifies a name for the configuration entry. The name is metadata that you can
+use to reference the configuration entry when performing Consul operations, such
+as applying a configuration entry to a specific cluster.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string
+
+### `Namespace` <EnterpriseAlert inline />
+
+Specifies the Enterprise [namespace](/consul/docs/enterprise/namespaces) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Partition` <EnterpriseAlert inline />
+
+Specifies the Enterprise [admin partition](/consul/docs/enterprise/admin-partitions) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Meta`
+
+Specifies an arbitrary set of key-value pairs to associate with the gateway.
+
+#### Values
+
+- Default: none
+- Data type: map containing one or more keys and string values.
+
+### `Certificate`
+
+Specifies the inline public certificate to use for TLS.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string value of the public certificate
+
+### `PrivateKey`
+
+Specifies the inline private key to use for TLS.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string value of the private key

--- a/website/content/docs/connect/gateways/api-gateway/configuration/tcp-route.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/tcp-route.mdx
@@ -1,0 +1,256 @@
+---
+layout: docs
+page_title: TCP Route Configuration Reference
+description: Learn how to configure a TCP Route that is bound to an API gateway on VMs.
+---
+
+# TCP route configuration Reference
+
+This topic provides reference information for the gateway TCP routes configuration
+entry. Refer to [Route Resource Configuration](/consul/docs/api-gateway/configuration/routes) for information
+about configuring API gateways in Kubernetes environments.
+
+## Configuration model
+
+The following list outlines field hierarchy, language-specific data types, and
+requirements in an `tcp-route` configuration entry. Click on a property name to
+view additional details, including default values.
+
+- [`Kind`](#kind): string | must be `"tcp-route"`
+- [`Name`](#name): string | no default
+- [`Namespace`](#namespace): string | no default <EnterpriseAlert inline />
+- [`Partition`](#partition): string | no default <EnterpriseAlert inline />
+- [`Meta`](#meta): map | no default
+- [`Services`](#services): list | no default
+  - [`Name`](#services-name): string | no default
+  - [`Namespace`](#services-namespace): string | no default <EnterpriseAlert inline />
+  - [`Partition`](#services-partition): string | no default <EnterpriseAlert inline />
+- [`Parents`](#parents): list | no default
+  - [`Kind`](#parents-kind): string | must be `"api-gateway"`
+  - [`Name`](#parents-name): string | no default
+  - [`Namespace`](#parents-namespace): string | no default <EnterpriseAlert inline />
+  - [`Partition`](#parents-partition): string | no default <EnterpriseAlert inline />
+  - [`SectionName`](#parents-sectionname): string | no default
+
+## Complete configuration
+
+When every field is defined, a `tcp-route` configuration entry has the following form:
+
+<CodeTabs>
+
+```HCL
+Kind = "tcp-route"
+Name = "<name of the route>"
+Namespace = "<enterprise: namespace of the route>"
+Partition = "<enterprise: partition of the route>"
+
+Meta = {
+  "<any key>" = "<any value>"
+}
+
+Services = [
+  {
+    Name = "<name of service>"
+    Namespace = "<enterprise: namespace of the service>"
+    Partition = "<enterprise: partition of the service>"
+  }
+]
+
+
+Parents = [
+  {
+    Kind = "api-gateway"
+    Name = "<name of the api-gateway to bind to>"
+    Namespace = "<enterprise: namespace of the parent>"
+    Partition = "<enterprise: partition of the parent>"
+    SectionName = "<listener on the api-gateway to bind to>"
+  }
+]
+```
+
+```JSON
+{
+  "Kind": "tcp-route",
+  "Name": "<name of the route>",
+  "Namespace": "<enterprise: namespace of the route>",
+  "Partition": "<enterprise: partition of the route>",
+  "Meta": {
+    "<any key>": "<any value>"
+  },
+  "Services": [
+    {
+      "Name": "<name of service>"
+      "Namespace": "<enterprise: namespace of the service>",
+      "Partition": "<enterprise: partition of the service>",
+    }
+  ],
+  "Parents": [
+    {
+      "Kind": "api-gateway",
+      "Name": "<name of the api-gateway to bind to>",
+      "Namespace": "<enterprise: namespace of the parent>",
+      "Partition": "<enterprise: partition of the parent>",
+      "SectionName": "<listener on the api-gateway to bind to>"
+    }
+  ]
+}
+```
+
+</CodeTabs>
+
+## Specification
+
+This section provides details about the fields you can configure in the
+`tcp-route` configuration entry.
+
+### `Kind`
+
+Specifies the type of configuration entry to implement. This must be set to
+`"tcp-route"`.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string value that must be set to`tcp-route`.
+
+### `Name`
+
+Specifies a name for the configuration entry. The name is metadata that you can
+use to reference the configuration entry when performing Consul operations,
+such as applying a configuration entry to a specific cluster.
+
+#### Values
+
+- Default: Defaults to the name of the node after writing the entry to the Consul server.
+- This field is required.
+- Data type: string
+
+### `Namespace` <EnterpriseAlert inline />
+
+Specifies the Enterprise [namespace](/consul/docs/enterprise/namespaces) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Partition` <EnterpriseAlert inline />
+
+Specifies the Enterprise [admin partition](/consul/docs/enterprise/admin-partitions) to apply to the configuration entry.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Meta`
+
+Specifies an arbitrary set of key-value pairs to associate with the gateway.
+
+#### Values
+
+- Default: none
+- Data type: map containing one or more keys and string values.
+
+### `Services`
+
+Specifies a TCP-based service the API gateway routes incoming requests
+to. You can only specify one service.
+
+#### Values
+
+- Default: none
+- The data type is a list of maps. Each member of the list contains the following fields:
+  - [`Name`](#services-name)
+  - [`Namespace`](#services-namespace) <EnterpriseAlert inline />
+  - [`Partition`](#services-partition) <EnterpriseAlert inline />
+
+### `Services.Name`
+
+Specifies the list of TCP-based services to route to. You can specify a maximum of one service.
+
+#### Values
+
+- Default: none
+- Data type: string
+
+### `Services.Namespace` <EnterpriseAlert inline />
+
+Specifies the Enterprise [namespace](/consul/docs/enterprise/namespaces) where the service is located.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Services.Partition` <EnterpriseAlert inline />
+
+Specifies the Enterprise [admin partition](/consul/docs/enterprise/admin-partitions) where the service is located.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Parents`
+
+Specifies the list of gateways that the route is bound to.
+
+#### Values
+
+- Default: none
+- Data type: List of map. Each member of the list contains the following fields:
+  - [`Kind`](#parents-kind)
+  - [`Name`](#parents-name)
+  - [`Namespace`](#parents-namespace) <EnterpriseAlert inline />
+  - [`Partition`](#parents-partition) <EnterpriseAlert inline />
+  - [`SectionName`](#parents-sectionname)
+
+### `Parents.Kind`
+
+Specifies the type of resource to bind to. This field is required and must be
+set to `"api-gateway"`
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string
+
+### `Parents.Name`
+
+Specifies the name of the API gateway to bind to.
+
+#### Values
+
+- Default: none
+- This field is required.
+- Data type: string
+
+### `Parents.Namespace` <EnterpriseAlert inline />
+
+Specifies the Enterprise [namespace](/consul/docs/enterprise/namespaces) where the parent is located.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Parents.Partition` <EnterpriseAlert inline />
+
+Specifies the Enterprise [admin partition](/consul/docs/enterprise/admin-partitions) where the parent is located.
+
+#### Values
+
+- Default: `"default"` in Enterprise
+- Data type: string
+
+### `Parents.SectionName`
+
+Specifies the name of the listener defined in the [`api-gateway` configuration](/consul/docs/connect/gateways/api-gateway/configuration/api-gateway) that the route binds to. If the field is configured to an empty string, the route binds to all listeners on the parent gateway.
+
+#### Values
+
+- Default: `""`
+- Data type: string

--- a/website/content/docs/connect/gateways/api-gateway/index.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/index.mdx
@@ -1,0 +1,28 @@
+---
+layout: docs
+page_title: API Gateways Overview
+description: API gateways are objects in Consul that enable ingress requests to services in your service mesh. Learn about API gateways for VMs in this overview.
+---
+
+# API gateway overview
+
+API gateways enable external network clients to access applications and services
+running in a Consul datacenter. This type of network traffic is commonly
+called _north-south_ network traffic because it refers to the flow of
+data into and out of a specific environment. API gateways can also forward
+requests from clients to specific destinations based on path or request
+protocol.
+
+API gateways solve the following primary use cases:
+
+- **Control access at the point of entry**: Set the protocols of external connection
+  requests and secure inbound connections with TLS certificates from trusted
+  providers, such as Verisign and Let's Encrypt.
+- **Simplify traffic management**: Load balance requests across services and route
+  traffic to the appropriate service by matching one or more criteria, such as
+  hostname, path, header presence or value, and HTTP method.
+
+Consul supports API
+gateways for virtual machines and Kubernetes networks. Refer to the following documentation for next steps:
+- [API Gateways on VMs](/consul/docs/connect/gateways/api-gateway/usage)
+- [API Gateways for Kubernetes](/consul/docs/api-gateway).

--- a/website/content/docs/connect/gateways/api-gateway/usage.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/usage.mdx
@@ -1,0 +1,211 @@
+---
+layout: docs
+page_title: API Gateways on Virtual Machines
+description: Learn how to configure and Consul API gateways and gateway routes on virtual machines so that you can enable ingress requests to services in your service mesh in VM environments.
+---
+
+# API gateways on virtual machines
+
+This topic describes how to deploy Consul API gateways to networks that operate
+in virtual machine (VM) environments. If you want to implement an API gateway
+in a Kubernetes environment, refer to [API Gateway for Kubernetes](/consul/docs/api-gateway).
+
+## Introduction
+
+Consul API gateways provide a configurable ingress points for requests into a Consul network. Usethe following configuration entries to set up API gateways:
+
+- [API gateway](/consul/docs/connect/gateways/api-gateway/configuration/api-gateway): Provides an endpoint for requests to enter the network. Define listeners that expose ports on the endpoint for ingress.
+- [HTTP routes](/consul/docs/connect/gateways/api-gateway/configuration/http-route) and [TCP routes](/consul/docs/connect/gateways/api-gateway/configuration/tcp-route): The routes attach to listeners defined in the gateway and control how requests route to services in the network.
+- [Inline certificates](/consul/docs/connect/gateways/api-gateway/configuration/inline-certificate): Makes TLS certificates available to gateways so that requests between the user and the gateway endpoint are encrypted.
+
+You can configure and reuse configuration entries separately. You can define and attach routes and inline certificates to multiple gateways.
+
+The following steps describe the general workflow for deploying a Consul API
+gateway to a VM environment:
+
+1. Create an API gateway configuration entry. The configuration entry includes
+   listener configurations and references to TLS certificates.
+1. Deploy the API gateway configuration entry to create the listeners.
+1. Create and deploy routes to bind to the gateway.
+
+Refer to [API Gateway for Kubernetes](/consul/docs/api-gateway) for information
+about using Consul API gateway on Kubernetes.
+
+## Requirements
+
+The following requirements must be satisfied to use API gateways on VMs:
+
+- Consul 1.15 or later
+- A Consul cluster with service mesh enabled. Refer to [`connect`](/consul/docs/agent/config/config-files#connect)
+- Network connectivity between the machine deploying the API Gateway and a
+  Consul cluster agent or server
+
+If ACLs are enabled, you must present a token with the following permissions to
+configure Consul and deploy API gateways:
+
+- `mesh: read`
+- `mesh: write`
+
+Refer [Mesh Rules](/consul/docs/security/acl/acl-rules#mesh-rules) for
+additional information about configuring policies that enable you to interact
+with Consul API gateway configurations.
+
+## Create the API gateway configuration
+
+Create an API gateway configuration that defines listeners and TLS certificates
+in the mesh. In the following example, the API gateway specifies an HTTP
+listener on port `8443` that routes can use to connect external traffic to
+services in the mesh.
+
+```hcl
+Kind = "api-gateway"
+Name = "my-gateway"
+
+// Each listener configures a port which can be used to access the Consul cluster
+Listeners = [
+	{
+		Port = 8443
+		Name = "my-http-listener"
+		Protocol = "http"
+		TLS = {
+			Certificates = [
+				{
+					Kind = "inline-certificate"
+					Name = "my-certificate"
+				}
+			]
+		}
+	}
+]
+```
+
+Refer to [API Gateway Configuration Reference](/consul/docs/connect/gateways/api-gateway/configuration/api-gateway) for
+information about all configuration fields.
+
+Gateways and routes are eventually-consistent objects that provide feedback
+about their current state through a series of status conditions. As a result,
+you must manually check the route status to determine if the route
+bound to the gateway successfully.
+
+## Deploy the API gateway
+
+Use the `consul config write` command to implement the API gateway
+configuration entries. The following command applies the configuration entry
+for the main gateway object:
+
+```shell-session
+$ consul config write gateways.hcl
+```
+
+Run the following command to deploy an API gateway instance:
+
+```shell-session
+$ consul connect envoy -gateway api -register -service my-api-gateway
+```
+
+The command directs Consul to configure Envoy as an API gateway.
+
+## Route requests
+
+Define route configurations and bind them to listeners configured on the
+gateway so that Consul can route incoming requests to services in the mesh.
+Create HTTP or TCP routes by setting the `Kind` parameter to `http-route` or
+`tcp-route` and configuring rules that define request traffic flows.
+
+The following example routes requests from the listener on the API gateway at
+port `8443` to services in Consul based on the path of the request. When an
+incoming request starts at path `/`, Consul forwards 90 percent of the requests
+to the `ui` service and 10 percent to `experimental-ui`. Consul also forwards
+requests starting with `/api` to `api`.
+
+```hcl
+Kind = "http-route"
+Name = "my-http-route"
+
+// Rules define how requests will be routed
+Rules = [
+  // Send all requests to UI services with 10% going to the "experimental" UI
+  {
+    Matches = [
+      {
+        Path = {
+          Match = "prefix"
+          Value = "/"
+        }
+      }
+    ]
+    Services = [
+      {
+        Name = "ui"
+        Weight = 90
+      },
+      {
+        Name = "experimental-ui"
+        Weight = 10
+      }
+    ]
+  },
+  // Send all requests that start with the path `/api` to the API service
+  {
+    Matches = [
+      {
+        Path = {
+          Match = "prefix"
+          Value = "/api"
+        }
+      }
+    ]
+    Services = [
+      {
+        Name = "api"
+      }
+    ]
+  }
+]
+
+Parents = [
+  {
+    Kind = "api-gateway"
+    Name = "my-gateway"
+    SectionName = "my-http-listener"
+  }
+]
+```
+
+Create this configuration by saving it to a file called `my-http-route.hcl` and using the command
+
+```shell-session
+$ consul config write my-http-route.hcl
+```
+
+Refer to [HTTP Route Configuration Entry Reference](/consul/docs/connect/gateways/api-gateway/configuration/http-route)
+and [TCP Route Configuration Entry Reference](/consul/docs/connect/gateways/api-gateway/configuration/tcp-route) for details about route configurations.
+
+## Add a TLS certificate
+
+Define an [`inline-certificate` configuration entry](/consul/docs/connect/gateways/api-gateway/configuration/inline-certificate) with a name matching the name in the [API gateway listener configuration](/consul/docs/connect/gateways/api-gateway/configuration/api-gateway#listeners) to bind the certificate to that listener.  The inline certificate configuration entry takes a public certificate and private key in plaintext.
+
+The following example defines a certificate named `my-certificate`. API gateway configurations that specify `inline-certificate` in the `Certificate.Kind` field and `my-certificate` in the `Certificate.Name` field are able to use the certificate.
+
+```hcl
+Kind = "inline-certificate"
+Name = "my-certificate"
+
+Certificate = <<EOF
+-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----
+EOF
+
+PrivateKey = <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+...
+-----END RSA PRIVATE KEY-----
+EOF
+```
+
+Create this configuration by saving it to a file called `my-certificate.hcl` and using the command
+
+```shell-session
+$ consul config write my-certificate.hcl
+```

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -342,6 +342,42 @@
             "path": "connect/config-entries"
           },
           {
+            "title": "API Gateway",
+            "href": "/consul/docs/connect/gateways/api-gateway/configuration/api-gateway",
+            "badge": {
+              "text": "BETA",
+              "type": "outlined",
+              "color": "neutral"
+            }
+          },
+          {
+            "title": "HTTP Route",
+            "href": "/consul/docs/connect/gateways/api-gateway/configuration/http-route",
+            "badge": {
+              "text": "BETA",
+              "type": "outlined",
+              "color": "neutral"
+            }
+          },
+          {
+            "title": "TCP Route",
+            "href": "/consul/docs/connect/gateways/api-gateway/configuration/tcp-route",
+            "badge": {
+              "text": "BETA",
+              "type": "outlined",
+              "color": "neutral"
+            }
+          },
+          {
+            "title": "Inline Certificate",
+            "href": "/consul/docs/connect/gateways/api-gateway/configuration/inline-certificate",
+            "badge": {
+              "text": "BETA",
+              "type": "outlined",
+              "color": "neutral"
+            }
+          },
+          {
             "title": "Ingress Gateway",
             "path": "connect/config-entries/ingress-gateway"
           },
@@ -482,6 +518,45 @@
           {
             "title": "Overview",
             "path": "connect/gateways"
+          },
+          {
+            "title": "API Gateways",
+            "badge": {
+              "text": "BETA",
+              "type": "outlined",
+              "color": "neutral"
+            },
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "connect/gateways/api-gateway"
+              },
+              {
+                "title": "Usage",
+                "path": "connect/gateways/api-gateway/usage"
+              },
+              {
+                "title": "Configuration",
+                "routes": [
+                  {
+                    "title": "API Gateway",
+                    "path": "connect/gateways/api-gateway/configuration/api-gateway"
+                  },
+                  {
+                    "title": "HTTP Route",
+                    "path": "connect/gateways/api-gateway/configuration/http-route"
+                  },
+                  {
+                    "title": "TCP Route",
+                    "path": "connect/gateways/api-gateway/configuration/tcp-route"
+                  },
+                  {
+                    "title": "Inline Certificate",
+                    "path": "connect/gateways/api-gateway/configuration/inline-certificate"
+                  }
+                ]
+              }
+            ]
           },
           {
             "title": "Mesh Gateways",
@@ -835,7 +910,6 @@
         "title": "Architecture",
         "path": "k8s/architecture"
       },
-
       {
         "title": "Installation",
         "routes": [


### PR DESCRIPTION
This is a manual backport of #16365 due to the failure of the automated backport, #16407 

Note that the diff here is slightly smaller than the original PR due to the fix for `website/content/api-docs/operator/usage.mdx` that has already been backported into this branch via #16399 