### PR TITLE
fix: ui tests run is fixed (applying class attribute twice to the hbs…

### DIFF
--- a/.changelog/16428.txt
+++ b/.changelog/16428.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes ui tests run on CI
+```

--- a/ui/packages/consul-ui/app/components/consul/intention/notice/custom-resource/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/notice/custom-resource/index.hbs
@@ -1,4 +1,4 @@
-<Hds::Alert @type='inline' @color={{or @type "neutral"}} class='mb-2 mt-2' as |A|>
+<Hds::Alert @type='inline' @color={{or @type "neutral"}} class='mb-2 mt-2 consul-intention-notice-custom-resource' as |A|>
   <A.Title>Intention Custom Resource</A.Title>
   <A.Description>Some of your intentions are being managed through an Intention Custom Resource in your Kubernetes cluster. Those managed intentions will be view only in the UI. Any intentions created in the UI will work but will not be synced to the Custom Resource Definition (CRD) datastore.</A.Description>
   <A.Link::Standalone @href="{{env 'CONSUL_DOCS_URL'}}/k8s/crds"

--- a/ui/packages/consul-ui/app/components/consul/node/agentless-notice/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/node/agentless-notice/index.hbs
@@ -1,5 +1,5 @@
 {{#if isVisible}}
-  <Hds::Alert @type="inline" class='mb-3 mt-2' class='agentless-node-notice' data-test-node-agentless-notice as |A|>
+  <Hds::Alert @type="inline" class='mb-3 mt-2 agentless-node-notice' data-test-node-agentless-notice as |A|>
     <A.Title>
       <span>{{t 'routes.dc.nodes.index.agentless.notice.header'}}</span>
       <Hds::Button


### PR DESCRIPTION
… element caused the issue)

### Description
The PR fixes the issue with running ui-tests and lint. When `yarn run test` command executed, console highlights that `class` attribute was applied to hbs elements twice, and it caused the issue with linter. 
Tests `dc / intentions / index` was fixed by adding class name back to the element.

### Links
https://app.circleci.com/pipelines/github/hashicorp/consul/52520/workflows/de1b8654-7f13-48fa-a111-e04fec72295a/jobs/1224681/tests

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
