### PR TITLE
First cluster grpc service should be NodePort for the second cluster to connect

### DIFF
--- a/website/content/docs/k8s/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/deployment-configurations/single-dc-multi-k8s.mdx
@@ -50,6 +50,17 @@ global:
   gossipEncryption:
     secretName: consul-gossip-encryption-key
     secretKey: key
+server:
+  exposeService:
+    enabled: true
+    type: NodePort
+    nodePort:
+      ## all are random nodePorts and you can set your own
+      http: 30010
+      https: 30011
+      serf: 30012
+      rpc: 30013
+      grpc: 30014
 ui:
   service:
     type: NodePort
@@ -64,6 +75,9 @@ that can be used later to verify the connectivity of services across clusters.
 The UI's service type is set to be `NodePort`.
 This is needed to connect to servers from another cluster without using the pod IPs of the servers,
 which are likely going to change.
+
+The other services, especially grpc is also set to be `NodePort` with a random nodePort. Here, it chose 30014.
+This is needed to discover the consul servers using gRPC when connecting from another cluster.
 
 To deploy, first generate the Gossip encryption key and save it as a Kubernetes secret.
 
@@ -123,6 +137,8 @@ externalServers:
   hosts: ["10.0.0.4"]
   # The node port of the UI's NodePort service or the load balancer port.
   httpsPort: 31557
+  # The GRPC port of the Consul servers(first cluster).
+  grpcPort: 30014
   tlsServerName: server.dc1.consul
   # The address of the kube API server of this Kubernetes cluster
   k8sAuthMethodHost: https://kubernetes.example.com:443
@@ -146,6 +162,8 @@ $ kubectl get service cluster1-consul-ui --context cluster1
 NAME                 TYPE       CLUSTER-IP    EXTERNAL-IP   PORT(S)         AGE
 cluster1-consul-ui   NodePort   10.0.240.80   <none>        443:31557/TCP   40h
 ```
+
+The `grpcPort: 30014` refers to the grpc nodePort set in the first cluster.
 
 Set the `externalServer.tlsServerName` to `server.dc1.consul`. This the DNS SAN
 (Subject Alternative Name) that is present in the Consul server's certificate.


### PR DESCRIPTION
This is based on the issue opened here https://github.com/hashicorp/consul-k8s/issues/1903

If you follow the documentation https://developer.hashicorp.com/consul/docs/k8s/deployment-configurations/single-dc-multi-k8s exactly as it is, the first cluster will only create the consul UI service on NodePort but not the rest of the services (including for grpc). By default, from the helm chart, they are created as headless services by setting clusterIP None. This will cause an issue for the second cluster to discover consul server on the first cluster over gRPC as it cannot simply cannot through gRPC default port 8502 and it ends up in an error as shown in the issue https://github.com/hashicorp/consul-k8s/issues/1903

As a solution, the grpc service should be exposed using NodePort (or LoadBalancer). I added those changes required in both cluster1-values.yaml and cluster2-values.yaml, and also a description for those changes for the normal users to understand. Kindly review and I hope this PR will be accepted.

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
