### PR TITLE
Remove private prefix from proto-gen-rpc-glue e2e test

### DIFF
--- a/internal/tools/proto-gen-rpc-glue/e2e/source.pb.go
+++ b/internal/tools/proto-gen-rpc-glue/e2e/source.pb.go
@@ -3,7 +3,7 @@
 
 package e2e
 
-import "github.com/hashicorp/consul/proto/private/pbcommon"
+import "github.com/hashicorp/consul/proto/pbcommon"
 
 // @consul-rpc-glue: WriteRequest,TargetDatacenter
 type ExampleWriteRequest struct {


### PR DESCRIPTION
### Description

In a previous PR I added a "private" directory within Consuls proto directory to prevent proto registry name conflicts. This apparently broke the proto-gen-rpc-glue e2e tests and even go mod tidy within the e2e dir would fail.

This fixes it.

This dir is especially weird because we are importing consul but consul is redefined to the embedded directory within the e2e tests. So global search/replace for imports happens to pick up changes in these files too.

### Testing & Reproduction steps

To reproduce/test run `make go-mod-tidy`
