### PR TITLE
docs: remove extra whitespace in frontmatter

### DIFF
--- a/website/content/docs/connect/config-entries/service-splitter.mdx
+++ b/website/content/docs/connect/config-entries/service-splitter.mdx
@@ -1,4 +1,4 @@
---- 
+---
 layout: docs
 page_title: Service Splitter Configuration Entry Reference
 description: >- 


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Removes a trailing space that is causing frontmatter parsing to break.