### PR TITLE
cli: ensure acl token read -self works

### DIFF
--- a/.changelog/16445.txt
+++ b/.changelog/16445.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: ensure acl token read -self works
+```

--- a/command/acl/token/read/token_read.go
+++ b/command/acl/token/read/token_read.go
@@ -67,17 +67,6 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	tokenAccessor := c.tokenAccessorID
-	if tokenAccessor == "" {
-		if c.tokenID == "" {
-			c.UI.Error("Must specify the -accessor-id parameter")
-			return 1
-		} else {
-			tokenAccessor = c.tokenID
-			c.UI.Warn("Use the -accessor-id parameter to specify token by Accessor ID")
-		}
-	}
-
 	client, err := c.http.APIClient()
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
@@ -87,6 +76,17 @@ func (c *cmd) Run(args []string) int {
 	var t *api.ACLToken
 	var expanded *api.ACLTokenExpanded
 	if !c.self {
+		tokenAccessor := c.tokenAccessorID
+		if tokenAccessor == "" {
+			if c.tokenID == "" {
+				c.UI.Error("Must specify the -accessor-id parameter")
+				return 1
+			} else {
+				tokenAccessor = c.tokenID
+				c.UI.Warn("Use the -accessor-id parameter to specify token by Accessor ID")
+			}
+		}
+
 		tok, err := acl.GetTokenAccessorIDFromPartial(client, tokenAccessor)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error determining token ID: %v", err))

--- a/command/acl/token/read/token_read_test.go
+++ b/command/acl/token/read/token_read_test.go
@@ -116,3 +116,50 @@ func TestTokenReadCommand_JSON(t *testing.T) {
 	err = json.Unmarshal([]byte(ui.OutputWriter.String()), &jsonOutput)
 	require.NoError(t, err, "token unmarshalling error")
 }
+
+func TestTokenReadCommand_Self(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, `
+	primary_datacenter = "dc1"
+	acl {
+		enabled = true
+		tokens {
+			initial_management = "root"
+		}
+	}`)
+
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	ui := cli.NewMockUi()
+	cmd := New(ui)
+
+	// Create a token
+	client := a.Client()
+
+	token, _, err := client.ACL().TokenCreate(
+		&api.ACLToken{Description: "test"},
+		&api.WriteOptions{Token: "root"},
+	)
+	assert.NoError(t, err)
+
+	args := []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-token=" + token.SecretID,
+		"-self",
+	}
+
+	code := cmd.Run(args)
+	assert.Equal(t, code, 0)
+	assert.Empty(t, ui.ErrorWriter.String())
+
+	output := ui.OutputWriter.String()
+	assert.Contains(t, output, fmt.Sprintf("test"))
+	assert.Contains(t, output, token.AccessorID)
+	assert.Contains(t, output, token.SecretID)
+}


### PR DESCRIPTION
### Description

Fixes a regression in #16044

The `consul acl token read -self` cli command should not require an `-accessor-id` because typically the persona invoking this would not already know the accessor id of their own token.
