### PR TITLE
docs: Add backwards compatibility for Consul 1.14.x and consul-dataplane in the Envoy compat matrix

### DIFF
--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -45,7 +45,7 @@ Consul supports **four major Envoy releases** at the beginning of each major Con
 
 ### Envoy and Consul Dataplane
 
-The Consul dataplane was introduced in Consul v1.14 as a way to manage Envoy proxies without the use of Consul clients. Each new minor version of Consul is released with a new minor version of Consul dataplane, which packages both Envoy and the `consul-dataplane` binary in a single container image. For backwards compatability reasons, each new minor version of Consul will also support the previous minor version of Consul dataplane to allow for seamless upgrades. In addition, each minor version of Consul will support the next minor version of Consul dataplane to allow for extended dataplane support via newer versions of Envoy.  
+The Consul dataplane component was introduced in Consul v1.14 as a way to manage Envoy proxies without the use of Consul clients. Each new minor version of Consul is released with a new minor version of Consul dataplane, which packages both Envoy and the `consul-dataplane` binary in a single container image. For backwards compatability reasons, each new minor version of Consul will also support the previous minor version of Consul dataplane to allow for seamless upgrades. In addition, each minor version of Consul will support the next minor version of Consul dataplane to allow for extended dataplane support via newer versions of Envoy.  
 
 | Consul Version      | Consul Dataplane Version (Bundled Envoy Version)  |
 | ------------------- | ------------------------------------------------- |

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -45,12 +45,12 @@ Consul supports **four major Envoy releases** at the beginning of each major Con
 
 ### Envoy and Consul Dataplane
 
-Consul Dataplane is a feature introduced in Consul v1.14. Because each version of Consul Dataplane supports one specific version of Envoy, you must use the following versions of Consul, Consul Dataplane, and Envoy together.
+The Consul dataplane was introduced in Consul v1.14 as a way to manage Envoy proxies without the use of Consul clients. Each new minor version of Consul is released with a new minor version of Consul dataplane, which packages both Envoy and the `consul-dataplane` binary in a single container image. For backwards compatability reasons, each new minor version of Consul will also support the previous minor version of Consul dataplane to allow for seamless upgrades. In addition, each minor version of Consul will support the next minor version of Consul dataplane to allow for extended dataplane support via newer versions of Envoy.  
 
 | Consul Version      | Consul Dataplane Version (Bundled Envoy Version)  |
 | ------------------- | ------------------------------------------------- |
 | 1.15.x              | 1.1.x (Envoy 1.25.x), 1.0.x (Envoy 1.24.x)        |
-| 1.14.x              | 1.0.x (Envoy 1.24.x)                              |
+| 1.14.x              | 1.1.x (Envoy 1.25.x), 1.0.x (Envoy 1.24.x)        |
 
 ## Getting Started
 


### PR DESCRIPTION
### Description

Clarified our support policy around consul-dataplane versions and added consul-datapalane 1.1.0 to the 1.14.0 Envoy matrix. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
