### PR TITLE
cli: remove stray whitespace when loading the consul version from the VERSION file

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ var (
 	//go:embed VERSION
 	fullVersion string
 
-	Version, VersionPrerelease, _ = strings.Cut(fullVersion, "-")
+	Version, VersionPrerelease, _ = strings.Cut(strings.TrimSpace(fullVersion), "-")
 
 	// https://semver.org/#spec-item-10
 	VersionMetadata = ""


### PR DESCRIPTION
Fixes a regression from #15631 in the output of `consul version` from:

    Consul v1.16.0-dev
    +ent
    Revision 56b86acbe5+CHANGES

to

    Consul v1.16.0-dev+ent
    Revision 56b86acbe5+CHANGES
