### PR TITLE
update services nav titles

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -314,43 +314,43 @@
     "title": "Services",
     "routes": [
       {
-        "title": "Services Overview",
+        "title": "Overview",
         "path": "services/services"
       },
       {
-        "title": "Define and Register",
+        "title": "Usage",
         "routes": [
           {
-            "title": "Define Services",
+            "title": "Define services",
             "path": "services/usage/define-services"
           },
           {
-            "title": "Define Health Checks",
+            "title": "Define health checks",
             "path": "services/usage/checks"
           },
           {
-            "title": "Register Services and Health Checks",
+            "title": "Register services and health checks",
             "path": "services/usage/register-services-checks"
           }
         ]
       },
       {
-        "title": "Service Discovery",
+        "title": "Service discovery",
         "routes": [
           {
-            "title": "DNS Usage Overview",
+            "title": "Overview",
             "path": "services/discovery/dns-overview"
           },
           {
-            "title": "Configure Consul DNS Behavior",
+            "title": "Configure DNS behavior",
             "path": "services/discovery/dns-configuration"
           },
           {
-            "title": "Perform Static DNS Lookups",
+            "title": "Perform static DNS lookups",
             "path": "services/discovery/dns-static-lookups"
           },
           {
-            "title": "Enable Dynamic DNS Lookups",
+            "title": "Enable dynamic DNS lookups",
             "path": "services/discovery/dns-dynamic-lookups"
           }
         ]
@@ -359,19 +359,19 @@
         "title": "Configuration",
         "routes": [
           {
-            "title": "Services Configuration Overview",
+            "title": "Overview",
             "path": "services/configuration/services-configuration-overview"
           },
           {
-            "title": "Services Configuration Reference",
+            "title": "Services",
             "path": "services/configuration/services-configuration-reference"
           },
           {
-            "title": "Health Checks Configuration Reference",
+            "title": "Health checks",
             "path": "services/configuration/checks-configuration-reference"
           },
           {
-            "title": "Service Defaults Configuration Reference",
+            "title": "Service defaults",
             "href": "connect/config-entries/service-defaults"
           }
         ]

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -335,7 +335,7 @@
         ]
       },
       {
-        "title": "Service discovery",
+        "title": "Discover services with DNS",
         "routes": [
           {
             "title": "Overview",


### PR DESCRIPTION
### Description

This PR updates the sidebar nav titles for the Services topics. Sidebar titles should start conform to the style guidance about using sentence-style capitalization for all content titles. Additionally, we should use a short form for nav titles, for example, "Services overview" => "Overview", to keep the nav concise. 

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
