### PR TITLE
fix (cli): return error msg if acl policy not found

### DIFF
--- a/.changelog/16485.txt
+++ b/.changelog/16485.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: fix panic read non-existent acl policy
+```

--- a/command/acl/policy/read/policy_read.go
+++ b/command/acl/policy/read/policy_read.go
@@ -92,6 +92,11 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
+	if pol == nil {
+		c.UI.Error(fmt.Sprintf("Error not found policy %s", c.policyName))
+		return 1
+	}
+
 	formatter, err := policy.NewFormatter(c.format, c.showMeta)
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/command/acl/policy/read/policy_read.go
+++ b/command/acl/policy/read/policy_read.go
@@ -93,7 +93,7 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	if pol == nil {
-		c.UI.Error(fmt.Sprintf("Error not found policy %s", c.policyName))
+		c.UI.Error(fmt.Sprintf("Error policy not found: %s", c.policyName))
 		return 1
 	}
 

--- a/command/acl/policy/read/policy_read_test.go
+++ b/command/acl/policy/read/policy_read_test.go
@@ -82,6 +82,17 @@ func TestPolicyReadCommand(t *testing.T) {
 	output = ui.OutputWriter.String()
 	assert.Contains(t, output, fmt.Sprintf("test-policy"))
 	assert.Contains(t, output, policy.ID)
+
+	// Test querying non-existent policy
+	argsName = []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-token=root",
+		"-name=test-policy-not-exist",
+	}
+
+	cmd = New(ui)
+	code = cmd.Run(argsName)
+	assert.Equal(t, code, 1)
 }
 
 func TestPolicyReadCommand_JSON(t *testing.T) {


### PR DESCRIPTION
### Description

Return error message on acl policy not found, instead of panic

### Links
fix #16483

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
