### PR TITLE
Backport #16274

### DIFF
--- a/.changelog/16274.txt
+++ b/.changelog/16274.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Bump Envoy 1.22.5 to 1.22.7, 1.23.2 to 1.23.4, 1.24.0 to 1.24.2, add 1.25.1, remove 1.21.5
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,10 @@ references:
     BASH_ENV: .circleci/bash_env.sh
     GO_VERSION: 1.20.1
   envoy-versions: &supported_envoy_versions
-    - &default_envoy_version "1.21.5"
-    - "1.22.5"
-    - "1.23.2"
-    - "1.24.0"
+    - &default_envoy_version "1.22.7"
+    - "1.23.4"
+    - "1.24.2"
+    - "1.25.1"
   nomad-versions: &supported_nomad_versions
     - &default_nomad_version "1.3.3"
     - "1.2.10"

--- a/envoyextensions/xdscommon/envoy_versioning_test.go
+++ b/envoyextensions/xdscommon/envoy_versioning_test.go
@@ -121,6 +121,7 @@ func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 		"1.18.6": {expectErr: "Envoy 1.18.6 " + errTooOld},
 		"1.19.5": {expectErr: "Envoy 1.19.5 " + errTooOld},
 		"1.20.7": {expectErr: "Envoy 1.20.7 " + errTooOld},
+		"1.21.5": {expectErr: "Envoy 1.21.5 " + errTooOld},
 	}
 
 	// Insert a bunch of valid versions.
@@ -135,10 +136,10 @@ func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 	}
 	*/
 	for _, v := range []string{
-		"1.21.0", "1.21.1", "1.21.2", "1.21.3", "1.21.4", "1.21.5",
 		"1.22.0", "1.22.1", "1.22.2", "1.22.3", "1.22.4", "1.22.5",
-		"1.23.0", "1.23.1", "1.23.2",
-		"1.24.0",
+		"1.23.0", "1.23.1", "1.23.2", "1.23.3", "1.23.4",
+		"1.24.0", "1.24.1", "1.24.2",
+		"1.25.0", "1.25.1",
 	} {
 		cases[v] = testcase{expect: SupportedProxyFeatures{}}
 	}

--- a/envoyextensions/xdscommon/proxysupport.go
+++ b/envoyextensions/xdscommon/proxysupport.go
@@ -9,10 +9,10 @@ import "strings"
 //
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
-	"1.24.0",
-	"1.23.2",
+	"1.25.1",
+	"1.24.2",
+	"1.23.4",
 	"1.22.5",
-	"1.21.5",
 }
 
 // UnsupportedEnvoyVersions lists any unsupported Envoy versions (mainly minor versions) that fall

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -45,7 +45,7 @@ Consul supports **four major Envoy releases** at the beginning of each major Con
 
 ### Envoy and Consul Dataplane
 
-The Consul dataplane component was introduced in Consul v1.14 as a way to manage Envoy proxies without the use of Consul clients. Each new minor version of Consul is released with a new minor version of Consul dataplane, which packages both Envoy and the `consul-dataplane` binary in a single container image. For backwards compatability reasons, each new minor version of Consul will also support the previous minor version of Consul dataplane to allow for seamless upgrades. In addition, each minor version of Consul will support the next minor version of Consul dataplane to allow for extended dataplane support via newer versions of Envoy.  
+The Consul dataplane component was introduced in Consul v1.14 as a way to manage Envoy proxies without the use of Consul clients. Each new minor version of Consul is released with a new minor version of Consul dataplane, which packages both Envoy and the `consul-dataplane` binary in a single container image. For backwards compatability reasons, each new minor version of Consul will also support the previous minor version of Consul dataplane to allow for seamless upgrades. In addition, each minor version of Consul will support the next minor version of Consul dataplane to allow for extended dataplane support via newer versions of Envoy.
 
 | Consul Version      | Consul Dataplane Version (Bundled Envoy Version)  |
 | ------------------- | ------------------------------------------------- |
@@ -124,7 +124,7 @@ Connect to a local Consul client agent and run the [`consul connect envoy` comma
 
 If you experience issues when bootstrapping Envoy proxies from the CLI, use the
 `-enable-config-gen-logging` flag to enable debug message logging. These logs can
-help you troubleshoot issues that occur during the bootstrapping process. 
+help you troubleshoot issues that occur during the bootstrapping process.
 For more information about available flags and parameters, refer to the
 [`consul connect envoy CLI` reference](/consul/commands/connect/envoy).
 
@@ -336,7 +336,7 @@ defaults that are inherited by all services.
 
 - `local_idle_timeout_ms` - In milliseconds, the idle timeout for HTTP requests
   to the local application instance. Applies to HTTP based protocols only. If not
-  specified, inherits the Envoy default for route idle timeouts (15s). A value of 0 
+  specified, inherits the Envoy default for route idle timeouts (15s). A value of 0
   disables request timeouts.
 
 - `max_inbound_connections` - The maximum number of concurrent inbound connections


### PR DESCRIPTION
### Description
#16274 updated the Envoy compatibility list but wasn't backported into `release/1.15.x`. This is causing Consul 1.15.0 to report invalid Envoy version for newer Envoy releases - 1.25.1, for example - that are valid according to the compatibility chart in our docs.

This backport makes it so that our next patch release will accept the newer version of Envoy without warning the user.

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
