### PR TITLE
proxycfg: ensure that an irrecoverable error in proxycfg closes the xds session and triggers a replacement proxycfg watcher

### DIFF
--- a/.changelog/16497.txt
+++ b/.changelog/16497.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+proxycfg: ensure that an irrecoverable error in proxycfg closes the xds session and triggers a replacement proxycfg watcher
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -721,11 +721,12 @@ func (a *Agent) Start(ctx context.Context) error {
 	go localproxycfg.Sync(
 		&lib.StopChannelContext{StopCh: a.shutdownCh},
 		localproxycfg.SyncConfig{
-			Manager:  a.proxyConfig,
-			State:    a.State,
-			Logger:   a.proxyConfig.Logger.Named("agent-state"),
-			Tokens:   a.baseDeps.Tokens,
-			NodeName: a.config.NodeName,
+			Manager:         a.proxyConfig,
+			State:           a.State,
+			Logger:          a.proxyConfig.Logger.Named("agent-state"),
+			Tokens:          a.baseDeps.Tokens,
+			NodeName:        a.config.NodeName,
+			ResyncFrequency: a.config.LocalProxyConfigResyncInterval,
 		},
 	)
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1091,6 +1091,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		Watches:                           c.Watches,
 		XDSUpdateRateLimit:                limitVal(c.XDS.UpdateMaxPerSecond),
 		AutoReloadConfigCoalesceInterval:  1 * time.Second,
+		LocalProxyConfigResyncInterval:    30 * time.Second,
 	}
 
 	rt.TLS, err = b.buildTLSConfig(rt, c.TLS)

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1475,6 +1475,10 @@ type RuntimeConfig struct {
 	// AutoReloadConfigCoalesceInterval Coalesce Interval for auto reload config
 	AutoReloadConfigCoalesceInterval time.Duration
 
+	// LocalProxyConfigResyncInterval is not a user-configurable value and exists
+	// here so that tests can use a smaller value.
+	LocalProxyConfigResyncInterval time.Duration
+
 	EnterpriseRuntimeConfig
 }
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5995,12 +5995,13 @@ func TestLoad_FullConfig(t *testing.T) {
 	nodeEntMeta := structs.NodeEnterpriseMetaInDefaultPartition()
 	expected := &RuntimeConfig{
 		// non-user configurable values
-		AEInterval:                 time.Minute,
-		CheckDeregisterIntervalMin: time.Minute,
-		CheckReapInterval:          30 * time.Second,
-		SegmentNameLimit:           64,
-		SyncCoordinateIntervalMin:  15 * time.Second,
-		SyncCoordinateRateTarget:   64,
+		AEInterval:                     time.Minute,
+		CheckDeregisterIntervalMin:     time.Minute,
+		CheckReapInterval:              30 * time.Second,
+		SegmentNameLimit:               64,
+		SyncCoordinateIntervalMin:      15 * time.Second,
+		SyncCoordinateRateTarget:       64,
+		LocalProxyConfigResyncInterval: 30 * time.Second,
 
 		Revision:          "JNtPSav3",
 		Version:           "R909Hblt",

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -233,6 +233,7 @@
     "KVMaxValueSize": 1234567800000000,
     "LeaveDrainTime": "0s",
     "LeaveOnTerm": false,
+    "LocalProxyConfigResyncInterval": "0s",
     "Logging": {
         "EnableSyslog": false,
         "LogFilePath": "",

--- a/agent/proxycfg-sources/local/sync.go
+++ b/agent/proxycfg-sources/local/sync.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 
@@ -50,12 +51,15 @@ func Sync(ctx context.Context, cfg SyncConfig) {
 	cfg.State.Notify(stateCh)
 	defer cfg.State.StopNotify(stateCh)
 
+	const resyncFrequency = 30 * time.Second
+
 	for {
 		sync(cfg)
 
 		select {
 		case <-stateCh:
 			// Wait for a state change.
+		case <-time.After(resyncFrequency):
 		case <-ctx.Done():
 			return
 		}

--- a/agent/proxycfg-sources/local/sync.go
+++ b/agent/proxycfg-sources/local/sync.go
@@ -68,7 +68,7 @@ func Sync(ctx context.Context, cfg SyncConfig) {
 		select {
 		case <-stateCh:
 			// Wait for a state change.
-		case <-time.After(cfg.ResyncFrequency):
+		case <-resyncCh:
 			resyncCh = nil
 		case <-ctx.Done():
 			return

--- a/agent/proxycfg/manager.go
+++ b/agent/proxycfg/manager.go
@@ -158,7 +158,7 @@ func (m *Manager) Register(id ProxyID, ns *structs.NodeService, source ProxySour
 
 func (m *Manager) register(id ProxyID, ns *structs.NodeService, source ProxySource, token string, overwrite bool) error {
 	state, ok := m.proxies[id]
-	if ok {
+	if ok && !state.stoppedRunning() {
 		if state.source != source && !overwrite {
 			// Registered by a different source, leave as-is.
 			return nil

--- a/agent/proxycfg_test.go
+++ b/agent/proxycfg_test.go
@@ -1,0 +1,154 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/grpc-external/limiter"
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testrpc"
+)
+
+func TestAgent_local_proxycfg(t *testing.T) {
+	a := NewTestAgent(t, TestACLConfig())
+	defer a.Shutdown()
+
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	token := generateUUID()
+
+	svc := &structs.NodeService{
+		ID:             "db",
+		Service:        "db",
+		Port:           5000,
+		EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+	}
+	require.NoError(t, a.State.AddServiceWithChecks(svc, nil, token, true))
+
+	proxy := &structs.NodeService{
+		Kind:    structs.ServiceKindConnectProxy,
+		ID:      "db-sidecar-proxy",
+		Service: "db-sidecar-proxy",
+		Port:    5000,
+		// Set this internal state that we expect sidecar registrations to have.
+		LocallyRegisteredAsSidecar: true,
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceName: "db",
+			Upstreams:              structs.TestUpstreams(t),
+		},
+		EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+	}
+	require.NoError(t, a.State.AddServiceWithChecks(proxy, nil, token, true))
+
+	// This is a little gross, but this gives us the layered pair of
+	// local/catalog sources for now.
+	cfg := a.xdsServer.CfgSrc
+
+	var (
+		timer      = time.After(100 * time.Millisecond)
+		timerFired = false
+		finalTimer <-chan time.Time
+	)
+
+	var (
+		firstTime = true
+		ch        <-chan *proxycfg.ConfigSnapshot
+		stc       limiter.SessionTerminatedChan
+		cancel    proxycfg.CancelFunc
+	)
+	defer func() {
+		if cancel != nil {
+			cancel()
+		}
+	}()
+	for {
+		if ch == nil {
+			// Sign up for a stream of config snapshots, in the same manner as the xds server.
+			sid := proxy.CompoundServiceID()
+
+			if firstTime {
+				firstTime = false
+			} else {
+				t.Logf("re-creating watch")
+			}
+
+			// Prior to fixes in https://github.com/hashicorp/consul/pull/16497
+			// this call to Watch() would deadlock.
+			var err error
+			ch, stc, cancel, err = cfg.Watch(sid, a.config.NodeName, token)
+			require.NoError(t, err)
+		}
+		select {
+		case <-stc:
+			t.Fatal("session unexpectedly terminated")
+		case snap, ok := <-ch:
+			if !ok {
+				t.Logf("channel is closed")
+				cancel()
+				ch, stc, cancel = nil, nil, nil
+				continue
+			}
+			require.NotNil(t, snap)
+			if !timerFired {
+				t.Fatal("should not have gotten snapshot until after we manifested the token")
+			}
+			return
+		case <-timer:
+			timerFired = true
+			finalTimer = time.After(1 * time.Second)
+
+			// This simulates the eventual consistency of a token
+			// showing up on a server after it's creation by
+			// pre-creating the UUID and later using that as the
+			// initial SecretID for a real token.
+			gotToken := testWriteToken(t, a, &api.ACLToken{
+				AccessorID:  generateUUID(),
+				SecretID:    token,
+				Description: "my token",
+				ServiceIdentities: []*api.ACLServiceIdentity{{
+					ServiceName: "db",
+				}},
+			})
+			require.Equal(t, token, gotToken)
+		case <-finalTimer:
+			t.Fatal("did not receive a snapshot after the token manifested")
+		}
+	}
+
+	/*
+		// Register a global proxy and service config
+		testApplyConfigEntries(t, a,
+			&structs.ProxyConfigEntry{
+				Config: map[string]interface{}{
+					"foo": 1,
+				},
+			},
+			&structs.ServiceConfigEntry{
+				Kind:     structs.ServiceDefaults,
+				Name:     "redis",
+				Protocol: "tcp",
+			},
+		)
+	*/
+
+}
+
+func testWriteToken(t *testing.T, a *TestAgent, tok *api.ACLToken) string {
+	req, _ := http.NewRequest("PUT", "/v1/acl/token", jsonReader(tok))
+	req.Header.Add("X-Consul-Token", "root")
+	resp := httptest.NewRecorder()
+	a.srv.h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	dec := json.NewDecoder(resp.Body)
+	aclResp := &structs.ACLToken{}
+	require.NoError(t, dec.Decode(aclResp))
+	return aclResp.SecretID
+}

--- a/agent/proxycfg_test.go
+++ b/agent/proxycfg_test.go
@@ -122,7 +122,6 @@ func TestAgent_local_proxycfg(t *testing.T) {
 		}
 	}
 
-
 }
 
 func testWriteToken(t *testing.T, a *TestAgent, tok *api.ACLToken) string {

--- a/agent/proxycfg_test.go
+++ b/agent/proxycfg_test.go
@@ -122,21 +122,6 @@ func TestAgent_local_proxycfg(t *testing.T) {
 		}
 	}
 
-	/*
-		// Register a global proxy and service config
-		testApplyConfigEntries(t, a,
-			&structs.ProxyConfigEntry{
-				Config: map[string]interface{}{
-					"foo": 1,
-				},
-			},
-			&structs.ServiceConfigEntry{
-				Kind:     structs.ServiceDefaults,
-				Name:     "redis",
-				Protocol: "tcp",
-			},
-		)
-	*/
 
 }
 

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -214,6 +214,9 @@ func (a *TestAgent) Start(t *testing.T) error {
 			// Lower the maximum backoff period of a cache refresh just for
 			// tests see #14956 for more.
 			result.RuntimeConfig.Cache.CacheRefreshMaxWait = 1 * time.Second
+
+			// Lower the resync interval for tests.
+			result.RuntimeConfig.LocalProxyConfigResyncInterval = 250 * time.Millisecond
 		}
 		return result, err
 	}


### PR DESCRIPTION
### Description

Receiving an "acl not found" error from an RPC in the agent cache and the streaming/event components will cause any request loops to cease under the assumption that they will never work again if the token was destroyed. This prevents log spam (https://github.com/hashicorp/consul/pull/14144, https://github.com/hashicorp/consul/pull/9738).

Unfortunately due to things like:
- authz requests going to stale servers that may not have witnessed the token creation yet
- authz requests in a secondary datacenter happening before the tokens get replicated to that datacenter
- authz requests from a primary TO a secondary datacenter happening before the tokens get replicated to that datacenter

The caller will get an "acl not found" *before* the token exists, rather than just after. The machinery added above in the linked PRs will kick in and prevent the request loop from looping around again once the tokens actually exist.

For `consul-dataplane` usages, where xDS is served by the Consul servers rather than the clients ultimately this is not a problem because in that scenario the `agent/proxycfg` machinery is on-demand and launched by a new xDS stream needing data for a specific service in the catalog. If the watching goroutines are terminated it ripples down and terminates the xDS stream, which CDP will eventually re-establish and restart everything.

For Consul client usages, the `agent/proxycfg` machinery is ahead-of-time launched at service registration time (called "local" in some of the proxycfg machinery) so when the xDS stream comes in the data is already ready to go. If the watching goroutines terminate it should terminate the xDS stream, but there's no mechanism to re-spawn the watching goroutines. If the xDS stream reconnects it will see no `ConfigSnapshot` and will not get one again until the client agent is restarted, or the service is re-registered with something changed in it.

This PR fixes a few things in the machinery:
- there was an inadvertent deadlock in fetching snapshot from the proxycfg machinery by xDS, such that when the watching goroutine terminated the snapshots would never be fetched. This caused some of the xDS machinery to get indefinitely paused and not finish the teardown properly.
- Every 30s we now attempt to re-insert all locally registered services into the proxycfg machinery.
- When services are re-inserted into the proxycfg machinery we special case "dead" ones such that we unilaterally replace them rather that doing that conditionally.
