### PR TITLE
Suppress AlreadyRegisteredError to fix test retries

### DIFF
--- a/lib/telemetry.go
+++ b/lib/telemetry.go
@@ -345,7 +345,6 @@ func configureSinks(cfg TelemetryConfig, memSink metrics.MetricSink) (metrics.Fa
 	addSink(statsdSink)
 	addSink(dogstatdSink)
 	addSink(circonusSink)
-	addSink(circonusSink)
 	addSink(prometheusSink)
 
 	if len(sinks) > 0 {

--- a/lib/telemetry.go
+++ b/lib/telemetry.go
@@ -14,6 +14,7 @@ import (
 	"github.com/armon/go-metrics/prometheus"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
+	prometheuscore "github.com/prometheus/client_golang/prometheus"
 
 	"github.com/hashicorp/consul/lib/retry"
 )
@@ -258,7 +259,7 @@ func dogstatdSink(cfg TelemetryConfig, hostname string) (metrics.MetricSink, err
 	return sink, nil
 }
 
-func prometheusSink(cfg TelemetryConfig, hostname string) (metrics.MetricSink, error) {
+func prometheusSink(cfg TelemetryConfig, _ string) (metrics.MetricSink, error) {
 
 	if cfg.PrometheusOpts.Expiration.Nanoseconds() < 1 {
 		return nil, nil
@@ -266,12 +267,19 @@ func prometheusSink(cfg TelemetryConfig, hostname string) (metrics.MetricSink, e
 
 	sink, err := prometheus.NewPrometheusSinkFrom(cfg.PrometheusOpts)
 	if err != nil {
+		// During testing we may try to register the same metrics collector
+		// multiple times in a single run (e.g. a metrics test fails and
+		// we attempt a retry), resulting in an AlreadyRegisteredError.
+		// Suppress this and move on.
+		if errors.As(err, &prometheuscore.AlreadyRegisteredError{}) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return sink, nil
 }
 
-func circonusSink(cfg TelemetryConfig, hostname string) (metrics.MetricSink, error) {
+func circonusSink(cfg TelemetryConfig, _ string) (metrics.MetricSink, error) {
 	token := cfg.CirconusAPIToken
 	url := cfg.CirconusSubmissionURL
 	if token == "" && url == "" {


### PR DESCRIPTION
### Description

There is a new set of tests that have high rates of failure [(example)](https://app.circleci.com/pipelines/github/hashicorp/consul/52978/workflows/c3f09d66-2e45-4fb8-a56d-efca6223b88c/jobs/1235632).

They are labelled "flaky" but in reality are failing deterministically whenever there is a test retry which causes TestAgents to initialize the prometheus collectors more than once in a single runtime.

This PR suppresses [`prometheus.AlreadyRegisteredError`](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#AlreadyRegisteredError) so retries can run properly. This should have no impact on production usage as the metrics initialization happens only once on consul agent startup.

### Testing & Reproduction steps

* Run a test which configures prometheus metrics from `metrics_test.go` like `TestHTTPHandlers_AgentMetrics_WAL_Prometheus` with `-count 2`. Without this patch, the second run should always fail.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
