### PR TITLE
Allow HCP metrics collection for Envoy proxies

### DIFF
--- a/.changelog/16585.txt
+++ b/.changelog/16585.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+xds: Allow for configuring connect proxies to send service mesh telemetry to an HCP metrics collection service.
+```

--- a/agent/proxycfg/connect_proxy.go
+++ b/agent/proxycfg/connect_proxy.go
@@ -3,12 +3,16 @@ package proxycfg
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 
+	"github.com/hashicorp/consul/acl"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/proxycfg/internal/watch"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/proto/private/pbpeering"
+	"github.com/mitchellh/mapstructure"
 )
 
 type handlerConnectProxy struct {
@@ -101,6 +105,10 @@ func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, e
 	}, svcChecksWatchIDPrefix+structs.ServiceIDString(s.proxyCfg.DestinationServiceID, &s.proxyID.EnterpriseMeta), s.ch)
 	if err != nil {
 		return snap, err
+	}
+
+	if err := s.maybeInitializeHCPMetricsWatches(ctx, snap); err != nil {
+		return snap, fmt.Errorf("failed to initialize HCP metrics watches: %w", err)
 	}
 
 	if s.proxyCfg.Mode == structs.ProxyModeTransparent {
@@ -611,6 +619,69 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u UpdateEvent, s
 
 	default:
 		return (*handlerUpstreams)(s).handleUpdateUpstreams(ctx, u, snap)
+	}
+	return nil
+}
+
+// hcpMetricsConfig represents the basic opaque config values for pushing telemetry to HCP.
+type hcpMetricsConfig struct {
+	// HCPMetricsBindSocketDir is a string that configures the directory for a
+	// unix socket where Envoy will forward metrics. These metrics get pushed to
+	// the HCP Metrics collector to show service mesh metrics on HCP.
+	HCPMetricsBindSocketDir string `mapstructure:"envoy_hcp_metrics_bind_socket_dir"`
+}
+
+func parseHCPMetricsConfig(m map[string]interface{}) (hcpMetricsConfig, error) {
+	var cfg hcpMetricsConfig
+	err := mapstructure.WeakDecode(m, &cfg)
+
+	if err != nil {
+		return cfg, fmt.Errorf("failed to decode: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// maybeInitializeHCPMetricsWatches will initialize a synthetic upstream and discovery chain
+// watch for the HCP metrics collector, if metrics collection is enabled on the proxy registration.
+func (s *handlerConnectProxy) maybeInitializeHCPMetricsWatches(ctx context.Context, snap ConfigSnapshot) error {
+	hcpCfg, err := parseHCPMetricsConfig(s.proxyCfg.Config)
+	if err != nil {
+		s.logger.Error("failed to parse connect.proxy.config", "error", err)
+	}
+
+	if hcpCfg.HCPMetricsBindSocketDir == "" {
+		// Metrics collection is not enabled, return early.
+		return nil
+	}
+
+	// The path includes the proxy ID so that when multiple proxies are on the same host
+	// they each have a distinct path to send their metrics.
+	sock := fmt.Sprintf("%s_%s.sock", s.proxyID.NamespaceOrDefault(), s.proxyID.ID)
+	path := path.Join(hcpCfg.HCPMetricsBindSocketDir, sock)
+
+	upstream := structs.Upstream{
+		DestinationNamespace: acl.DefaultNamespaceName,
+		DestinationPartition: s.proxyID.PartitionOrDefault(),
+		DestinationName:      api.HCPMetricsCollectorName,
+		LocalBindSocketPath:  path,
+		Config: map[string]interface{}{
+			"protocol": "grpc",
+		},
+	}
+	uid := NewUpstreamID(&upstream)
+	snap.ConnectProxy.UpstreamConfig[uid] = &upstream
+
+	err = s.dataSources.CompiledDiscoveryChain.Notify(ctx, &structs.DiscoveryChainRequest{
+		Datacenter:           s.source.Datacenter,
+		QueryOptions:         structs.QueryOptions{Token: s.token},
+		Name:                 upstream.DestinationName,
+		EvaluateInDatacenter: s.source.Datacenter,
+		EvaluateInNamespace:  uid.NamespaceOrDefault(),
+		EvaluateInPartition:  uid.PartitionOrDefault(),
+	}, "discovery-chain:"+uid.String(), s.ch)
+	if err != nil {
+		return fmt.Errorf("failed to watch discovery chain for %s: %v", uid.String(), err)
 	}
 	return nil
 }

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -7,14 +7,16 @@ import (
 	"testing"
 	"time"
 
+	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/consul/acl"
-	cachetype "github.com/hashicorp/consul/agent/cache-types"
+
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
+	apimod "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/proto/private/pbpeering"
 	"github.com/hashicorp/consul/proto/private/prototest"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -455,16 +457,18 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 
 	// Used to account for differences in OSS/ent implementations of ServiceID.String()
 	var (
-		db      = structs.NewServiceName("db", nil)
-		billing = structs.NewServiceName("billing", nil)
-		api     = structs.NewServiceName("api", nil)
-		apiA    = structs.NewServiceName("api-a", nil)
+		db           = structs.NewServiceName("db", nil)
+		billing      = structs.NewServiceName("billing", nil)
+		api          = structs.NewServiceName("api", nil)
+		apiA         = structs.NewServiceName("api-a", nil)
+		hcpCollector = structs.NewServiceName(apimod.HCPMetricsCollectorName, nil)
 
-		apiUID    = NewUpstreamIDFromServiceName(api)
-		dbUID     = NewUpstreamIDFromServiceName(db)
-		pqUID     = UpstreamIDFromString("prepared_query:query")
-		extApiUID = NewUpstreamIDFromServiceName(apiA)
-		extDBUID  = NewUpstreamIDFromServiceName(db)
+		apiUID          = NewUpstreamIDFromServiceName(api)
+		dbUID           = NewUpstreamIDFromServiceName(db)
+		pqUID           = UpstreamIDFromString("prepared_query:query")
+		extApiUID       = NewUpstreamIDFromServiceName(apiA)
+		extDBUID        = NewUpstreamIDFromServiceName(db)
+		hcpCollectorUID = NewUpstreamIDFromServiceName(hcpCollector)
 	)
 	// TODO(peering): NewUpstreamIDFromServiceName should take a PeerName
 	extApiUID.Peer = "peer-a"
@@ -3619,6 +3623,164 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						gwEp, _ := snap.ConnectProxy.WatchedLocalGWEndpoints.Get("dc1")
 						require.NotNil(t, gwEp)
 						require.Len(t, gwEp, 1)
+					},
+				},
+			},
+		},
+		"hcp-metrics": {
+			ns: structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				ID:      "web-sidecar-proxy",
+				Service: "web-sidecar-proxy",
+				Address: "10.0.1.1",
+				Port:    443,
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					Config: map[string]interface{}{
+						"envoy_hcp_metrics_bind_socket_dir": "/tmp/consul/hcp-metrics/",
+					},
+				},
+			},
+			sourceDC: "dc1",
+			stages: []verificationStage{
+				{
+					requiredWatches: map[string]verifyWatchRequest{
+						fmt.Sprintf("discovery-chain:%s", hcpCollectorUID.String()): genVerifyDiscoveryChainWatch(&structs.DiscoveryChainRequest{
+							Name:                 hcpCollector.Name,
+							EvaluateInDatacenter: "dc1",
+							EvaluateInNamespace:  "default",
+							EvaluateInPartition:  "default",
+							Datacenter:           "dc1",
+							QueryOptions: structs.QueryOptions{
+								Token: aclToken,
+							},
+						}),
+					},
+					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
+						require.False(t, snap.Valid(), "should not be valid")
+
+						require.Len(t, snap.ConnectProxy.DiscoveryChain, 0, "%+v", snap.ConnectProxy.DiscoveryChain)
+						require.Len(t, snap.ConnectProxy.WatchedDiscoveryChains, 0, "%+v", snap.ConnectProxy.WatchedDiscoveryChains)
+						require.Len(t, snap.ConnectProxy.WatchedUpstreams, 0, "%+v", snap.ConnectProxy.WatchedUpstreams)
+						require.Len(t, snap.ConnectProxy.WatchedUpstreamEndpoints, 0, "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
+					},
+				},
+				{
+					events: []UpdateEvent{
+						rootWatchEvent(),
+						{
+							CorrelationID: peeringTrustBundlesWatchID,
+							Result:        peerTrustBundles,
+						},
+						{
+							CorrelationID: leafWatchID,
+							Result:        issuedCert,
+							Err:           nil,
+						},
+						{
+							CorrelationID: intentionsWatchID,
+							Result:        TestIntentions(),
+							Err:           nil,
+						},
+						{
+							CorrelationID: meshConfigEntryID,
+							Result:        &structs.ConfigEntryResponse{},
+						},
+						{
+							CorrelationID: fmt.Sprintf("discovery-chain:%s", hcpCollectorUID.String()),
+							Result: &structs.DiscoveryChainResponse{
+								Chain: discoverychain.TestCompileConfigEntries(t, hcpCollector.Name, "default", "default", "dc1", "trustdomain.consul", nil),
+							},
+							Err: nil,
+						},
+					},
+					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
+						require.True(t, snap.Valid())
+						require.Equal(t, indexedRoots, snap.Roots)
+						require.Equal(t, issuedCert, snap.ConnectProxy.Leaf)
+
+						// An event was received with the HCP collector's discovery chain, which sets up some bookkeeping in the snapshot.
+						require.Len(t, snap.ConnectProxy.DiscoveryChain, 1, "%+v", snap.ConnectProxy.DiscoveryChain)
+						require.Contains(t, snap.ConnectProxy.DiscoveryChain, hcpCollectorUID)
+
+						require.Len(t, snap.ConnectProxy.WatchedUpstreams, 1, "%+v", snap.ConnectProxy.WatchedUpstreams)
+						require.Len(t, snap.ConnectProxy.WatchedUpstreamEndpoints, 1, "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
+						require.Contains(t, snap.ConnectProxy.WatchedUpstreamEndpoints, hcpCollectorUID)
+
+						expectUpstream := structs.Upstream{
+							DestinationNamespace: "default",
+							DestinationPartition: "default",
+							DestinationName:      apimod.HCPMetricsCollectorName,
+							LocalBindSocketPath:  "/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock",
+							Config: map[string]interface{}{
+								"protocol": "grpc",
+							},
+						}
+						uid := NewUpstreamID(&expectUpstream)
+
+						require.Contains(t, snap.ConnectProxy.UpstreamConfig, uid)
+						require.Equal(t, &expectUpstream, snap.ConnectProxy.UpstreamConfig[uid])
+
+						// No endpoints have arrived yet.
+						require.Len(t, snap.ConnectProxy.WatchedUpstreamEndpoints[hcpCollectorUID], 0, "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
+					},
+				},
+				{
+					requiredWatches: map[string]verifyWatchRequest{
+						fmt.Sprintf("upstream-target:%s.default.default.dc1:", apimod.HCPMetricsCollectorName) + hcpCollectorUID.String(): genVerifyServiceSpecificRequest(apimod.HCPMetricsCollectorName, "", "dc1", true),
+					},
+					events: []UpdateEvent{
+						{
+							CorrelationID: fmt.Sprintf("upstream-target:%s.default.default.dc1:", apimod.HCPMetricsCollectorName) + hcpCollectorUID.String(),
+							Result: &structs.IndexedCheckServiceNodes{
+								Nodes: structs.CheckServiceNodes{
+									{
+										Node: &structs.Node{
+											Node:    "node1",
+											Address: "10.0.0.1",
+										},
+										Service: &structs.NodeService{
+											ID:      apimod.HCPMetricsCollectorName,
+											Service: apimod.HCPMetricsCollectorName,
+											Port:    8080,
+										},
+									},
+								},
+							},
+							Err: nil,
+						},
+					},
+					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
+						require.True(t, snap.Valid())
+						require.Equal(t, indexedRoots, snap.Roots)
+						require.Equal(t, issuedCert, snap.ConnectProxy.Leaf)
+
+						// Discovery chain for the HCP collector should still be stored in the snapshot.
+						require.Len(t, snap.ConnectProxy.DiscoveryChain, 1, "%+v", snap.ConnectProxy.DiscoveryChain)
+						require.Contains(t, snap.ConnectProxy.DiscoveryChain, hcpCollectorUID)
+
+						require.Len(t, snap.ConnectProxy.WatchedUpstreams, 1, "%+v", snap.ConnectProxy.WatchedUpstreams)
+						require.Len(t, snap.ConnectProxy.WatchedUpstreamEndpoints, 1, "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
+						require.Contains(t, snap.ConnectProxy.WatchedUpstreamEndpoints, hcpCollectorUID)
+
+						// An endpoint arrived for the HCP collector, so it should be present in the snapshot.
+						require.Len(t, snap.ConnectProxy.WatchedUpstreamEndpoints[hcpCollectorUID], 1, "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
+
+						nodes := structs.CheckServiceNodes{
+							{
+								Node: &structs.Node{
+									Node:    "node1",
+									Address: "10.0.0.1",
+								},
+								Service: &structs.NodeService{
+									ID:      apimod.HCPMetricsCollectorName,
+									Service: apimod.HCPMetricsCollectorName,
+									Port:    8080,
+								},
+							},
+						}
+						target := fmt.Sprintf("%s.default.default.dc1", apimod.HCPMetricsCollectorName)
+						require.Equal(t, nodes, snap.ConnectProxy.WatchedUpstreamEndpoints[hcpCollectorUID][target])
 					},
 				},
 			},

--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -166,6 +166,10 @@ func TestAllResourcesFromSnapshot(t *testing.T) {
 			name:   "local-mesh-gateway-with-peered-upstreams",
 			create: proxycfg.TestConfigSnapshotPeeringLocalMeshGateway,
 		},
+		{
+			name:   "hcp-metrics",
+			create: proxycfg.TestConfigSnapshotHCPMetrics,
+		},
 	}
 	tests = append(tests, getConnectProxyTransparentProxyGoldenTestCases()...)
 	tests = append(tests, getMeshGatewayPeeringGoldenTestCases()...)

--- a/agent/xds/testdata/clusters/hcp-metrics.latest.golden
+++ b/agent/xds/testdata/clusters/hcp-metrics.latest.golden
@@ -1,0 +1,183 @@
+{
+  "versionInfo":  "00000001",
+  "resources":  [
+    {
+      "@type":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name":  "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "altStatName":  "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type":  "EDS",
+      "edsClusterConfig":  {
+        "edsConfig":  {
+          "ads":  {},
+          "resourceApiVersion":  "V3"
+        }
+      },
+      "connectTimeout":  "5s",
+      "circuitBreakers":  {},
+      "outlierDetection":  {},
+      "commonLbConfig":  {
+        "healthyPanicThreshold":  {}
+      },
+      "transportSocket":  {
+        "name":  "tls",
+        "typedConfig":  {
+          "@type":  "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext":  {
+            "tlsParams":  {},
+            "tlsCertificates":  [
+              {
+                "certificateChain":  {
+                  "inlineString":  "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                },
+                "privateKey":  {
+                  "inlineString":  "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                }
+              }
+            ],
+            "validationContext":  {
+              "trustedCa":  {
+                "inlineString":  "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+              },
+              "matchSubjectAltNames":  [
+                {
+                  "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
+                }
+              ]
+            }
+          },
+          "sni":  "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+        }
+      }
+    },
+    {
+      "@type":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name":  "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "type":  "EDS",
+      "edsClusterConfig":  {
+        "edsConfig":  {
+          "ads":  {},
+          "resourceApiVersion":  "V3"
+        }
+      },
+      "connectTimeout":  "5s",
+      "circuitBreakers":  {},
+      "outlierDetection":  {},
+      "transportSocket":  {
+        "name":  "tls",
+        "typedConfig":  {
+          "@type":  "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext":  {
+            "tlsParams":  {},
+            "tlsCertificates":  [
+              {
+                "certificateChain":  {
+                  "inlineString":  "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                },
+                "privateKey":  {
+                  "inlineString":  "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                }
+              }
+            ],
+            "validationContext":  {
+              "trustedCa":  {
+                "inlineString":  "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+              },
+              "matchSubjectAltNames":  [
+                {
+                  "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
+                }
+              ]
+            }
+          },
+          "sni":  "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+        }
+      }
+    },
+    {
+      "@type":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name":  "hcp-metrics-collector.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "altStatName":  "hcp-metrics-collector.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type":  "EDS",
+      "edsClusterConfig":  {
+        "edsConfig":  {
+          "ads":  {},
+          "resourceApiVersion":  "V3"
+        }
+      },
+      "connectTimeout":  "5s",
+      "circuitBreakers":  {},
+      "typedExtensionProtocolOptions":  {
+        "envoy.extensions.upstreams.http.v3.HttpProtocolOptions":  {
+          "@type":  "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+          "explicitHttpConfig":  {
+            "http2ProtocolOptions":  {}
+          }
+        }
+      },
+      "outlierDetection":  {},
+      "commonLbConfig":  {
+        "healthyPanicThreshold":  {}
+      },
+      "transportSocket":  {
+        "name":  "tls",
+        "typedConfig":  {
+          "@type":  "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext":  {
+            "tlsParams":  {},
+            "tlsCertificates":  [
+              {
+                "certificateChain":  {
+                  "inlineString":  "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                },
+                "privateKey":  {
+                  "inlineString":  "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                }
+              }
+            ],
+            "validationContext":  {
+              "trustedCa":  {
+                "inlineString":  "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+              },
+              "matchSubjectAltNames":  [
+                {
+                  "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hcp-metrics-collector"
+                }
+              ]
+            }
+          },
+          "sni":  "hcp-metrics-collector.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+        }
+      }
+    },
+    {
+      "@type":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name":  "local_app",
+      "type":  "STATIC",
+      "connectTimeout":  "5s",
+      "loadAssignment":  {
+        "clusterName":  "local_app",
+        "endpoints":  [
+          {
+            "lbEndpoints":  [
+              {
+                "endpoint":  {
+                  "address":  {
+                    "socketAddress":  {
+                      "address":  "127.0.0.1",
+                      "portValue":  8080
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "typeUrl":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+  "nonce":  "00000001"
+}

--- a/agent/xds/testdata/endpoints/hcp-metrics.latest.golden
+++ b/agent/xds/testdata/endpoints/hcp-metrics.latest.golden
@@ -1,0 +1,97 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.20.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "hcp-metrics-collector.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "9.9.9.9",
+                    "portValue": 9090
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/hcp-metrics.latest.golden
+++ b/agent/xds/testdata/listeners/hcp-metrics.latest.golden
@@ -1,0 +1,184 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "db:127.0.0.1:9191",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.db.default.default.dc1",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "hcp-metrics-collector:/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock",
+      "address": {
+        "pipe": {
+          "path": "/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock"
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "upstream.hcp-metrics-collector.default.default.dc1",
+                "routeConfig": {
+                  "name": "hcp-metrics-collector",
+                  "virtualHosts": [
+                    {
+                      "name": "hcp-metrics-collector.default.default.dc1",
+                      "domains": [
+                        "*"
+                      ],
+                      "routes": [
+                        {
+                          "match": {
+                            "prefix": "/"
+                          },
+                          "route": {
+                            "cluster": "hcp-metrics-collector.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.grpc_stats",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                      "statsForAllMethods": true
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.grpc_http1_bridge",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_http1_bridge.v3.Config"
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "tracing": {
+                  "randomSampling": {}
+                },
+                "http2ProtocolOptions": {}
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.prepared_query_geo-cache",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "public_listener:0.0.0.0:9999",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {},
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "public_listener",
+                "cluster": "local_app"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {},
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/routes/hcp-metrics.latest.golden
+++ b/agent/xds/testdata/routes/hcp-metrics.latest.golden
@@ -1,0 +1,5 @@
+{
+  "versionInfo":  "00000001",
+  "typeUrl":  "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+  "nonce":  "00000001"
+}

--- a/agent/xds/testdata/secrets/hcp-metrics.latest.golden
+++ b/agent/xds/testdata/secrets/hcp-metrics.latest.golden
@@ -1,0 +1,5 @@
+{
+  "versionInfo":  "00000001",
+  "typeUrl":  "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+  "nonce":  "00000001"
+}

--- a/api/connect.go
+++ b/api/connect.go
@@ -1,5 +1,8 @@
 package api
 
+// HCPMetricsCollectorName is the service name for the HCP Metrics Collector
+const HCPMetricsCollectorName string = "hcp-metrics-collector"
+
 // Connect can be used to work with endpoints related to Connect, the
 // feature for securely connecting services within Consul.
 type Connect struct {

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"text/template"
 
@@ -810,14 +811,10 @@ func (c *BootstrapConfig) generateListenerConfig(args *BootstrapTplArgs, bindAdd
 // appendHCPMetricsConfig generates config to enable a socket at path: <hcpMetricsBindSocketDir>/<namespace>_<proxy_id>.sock
 // or <hcpMetricsBindSocketDir>/<proxy_id>.sock, if namespace is empty.
 func appendHCPMetricsConfig(args *BootstrapTplArgs, hcpMetricsBindSocketDir string) {
-	dir := hcpMetricsBindSocketDir
-	if !strings.HasSuffix(dir, "/") {
-		dir += "/"
-	}
-
 	// Normalize namespace to "default". This ensures we match the namespace behaviour in proxycfg package,
 	// where a dynamic listener will be created at the same socket path via xDS.
-	path := fmt.Sprintf("%s%s_%s.sock", dir, acl.NamespaceOrDefault(args.Namespace), args.ProxyID)
+	sock := fmt.Sprintf("%s_%s.sock", acl.NamespaceOrDefault(args.Namespace), args.ProxyID)
+	path := path.Join(hcpMetricsBindSocketDir, sock)
 
 	if args.StatsSinksJSON != "" {
 		args.StatsSinksJSON += ",\n"

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/api"
 )
 
@@ -814,10 +815,9 @@ func appendHCPMetricsConfig(args *BootstrapTplArgs, hcpMetricsBindSocketDir stri
 		dir += "/"
 	}
 
-	path := fmt.Sprintf("%s%s.sock", dir, args.ProxyID)
-	if args.Namespace != "" {
-		path = fmt.Sprintf("%s%s_%s.sock", dir, args.Namespace, args.ProxyID)
-	}
+	// Normalize namespace to "default". This ensures we match the namespace behaviour in proxycfg package,
+	// where a dynamic listener will be created at the same socket path via xDS.
+	path := fmt.Sprintf("%s%s_%s.sock", dir, acl.NamespaceOrDefault(args.Namespace), args.ProxyID)
 
 	if args.StatsSinksJSON != "" {
 		args.StatsSinksJSON += ",\n"

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -557,13 +557,59 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 			},
 			wantArgs: BootstrapTplArgs{
 				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `[{
+				StatsSinksJSON: `{
 					"name": "envoy.custom_exciting_sink",
 					"config": {
 						"foo": "bar"
 					}
-				}]`,
+				}`,
 			},
+		},
+		{
+			name: "hcp-metrics-sink",
+			input: BootstrapConfig{
+				HCPMetricsBindPort: 3000,
+			},
+			wantArgs: BootstrapTplArgs{
+				StatsConfigJSON: defaultStatsConfigJSON,
+				StatsSinksJSON: `{
+					"name": "envoy.stat_sinks.metrics_service",
+					"typed_config": {
+					  "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
+					  "transport_api_version": "V3",
+					  "grpc_service": {
+						"envoy_grpc": {
+						  "cluster_name": "hcp_metrics_collector"
+						}
+					  }
+					}
+				  }`,
+				StaticClustersJSON: `{
+					"name": "hcp_metrics_collector",
+					"type": "STATIC",
+					"http2_protocol_options": {},
+					"loadAssignment": {
+					  "clusterName": "hcp_metrics_collector",
+					  "endpoints": [
+						{
+						  "lbEndpoints": [
+							{
+							  "endpoint": {
+								"address": {
+								  "socket_address": {
+									"address": "127.0.0.1",
+									"port_value": 3000
+								  }
+								}
+							  }
+							}
+						  ]
+						}
+					  ]
+					}
+				  }`,
+			},
+			wantErr: false,
 		},
 		{
 			name: "simple-statsd-sink",
@@ -572,7 +618,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 			},
 			wantArgs: BootstrapTplArgs{
 				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `[{
+				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.statsd",
 					"typedConfig": {
 						"@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
@@ -583,7 +629,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 							}
 						}
 					}
-				}]`,
+				}`,
 			},
 			wantErr: false,
 		},
@@ -600,7 +646,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 			},
 			wantArgs: BootstrapTplArgs{
 				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `[{
+				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.statsd",
 					"typedConfig": {
 						"@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
@@ -617,7 +663,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 					"config": {
 						"foo": "bar"
 					}
-				}]`,
+				}`,
 			},
 			wantErr: false,
 		},
@@ -629,7 +675,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 			env: []string{"MY_STATSD_URL=udp://127.0.0.1:9125"},
 			wantArgs: BootstrapTplArgs{
 				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `[{
+				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.statsd",
 					"typedConfig": {
 						"@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
@@ -640,7 +686,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 							}
 						}
 					}
-				}]`,
+				}`,
 			},
 			wantErr: false,
 		},
@@ -652,7 +698,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 			env: []string{"HOST_IP=127.0.0.1"},
 			wantArgs: BootstrapTplArgs{
 				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `[{
+				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.statsd",
 					"typedConfig": {
 						"@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
@@ -663,7 +709,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 							}
 						}
 					}
-				}]`,
+				}`,
 			},
 			wantErr: false,
 		},
@@ -685,7 +731,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 			},
 			wantArgs: BootstrapTplArgs{
 				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `[{
+				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.dog_statsd",
 					"typedConfig": {
 						"@type": "type.googleapis.com/envoy.config.metrics.v3.DogStatsdSink",
@@ -696,7 +742,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 							}
 						}
 					}
-				}]`,
+				}`,
 			},
 			wantErr: false,
 		},
@@ -707,7 +753,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 			},
 			wantArgs: BootstrapTplArgs{
 				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `[{
+				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.dog_statsd",
 					"typedConfig": {
 						"@type": "type.googleapis.com/envoy.config.metrics.v3.DogStatsdSink",
@@ -717,7 +763,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 							}
 						}
 					}
-				}]`,
+				}`,
 			},
 			wantErr: false,
 		},
@@ -730,7 +776,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 			env: []string{"MY_STATSD_URL=udp://127.0.0.1:9125"},
 			wantArgs: BootstrapTplArgs{
 				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `[{
+				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.dog_statsd",
 					"typedConfig": {
 						"@type": "type.googleapis.com/envoy.config.metrics.v3.DogStatsdSink",
@@ -741,7 +787,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 							}
 						}
 					}
-				}]`,
+				}`,
 			},
 			wantErr: false,
 		},

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -568,15 +568,13 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 		{
 			name: "hcp-metrics-sink",
 			baseArgs: BootstrapTplArgs{
-				ProxyID:   "web-sidecar-proxy",
-				Namespace: "default",
+				ProxyID: "web-sidecar-proxy",
 			},
 			input: BootstrapConfig{
 				HCPMetricsBindSocketDir: "/tmp/consul/hcp-metrics",
 			},
 			wantArgs: BootstrapTplArgs{
 				ProxyID:         "web-sidecar-proxy",
-				Namespace:       "default",
 				StatsConfigJSON: defaultStatsConfigJSON,
 				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.metrics_service",
@@ -1599,13 +1597,11 @@ func TestAppendHCPMetrics(t *testing.T) {
 	}{
 		"dir-without-trailing-slash": {
 			inputArgs: &BootstrapTplArgs{
-				Namespace: "default",
-				ProxyID:   "web-sidecar-proxy",
+				ProxyID: "web-sidecar-proxy",
 			},
 			bindSocketDir: "/tmp/consul/hcp-metrics",
 			wantArgs: &BootstrapTplArgs{
-				Namespace: "default",
-				ProxyID:   "web-sidecar-proxy",
+				ProxyID: "web-sidecar-proxy",
 				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.metrics_service",
 					"typed_config": {
@@ -1645,13 +1641,11 @@ func TestAppendHCPMetrics(t *testing.T) {
 		},
 		"dir-with-trailing-slash": {
 			inputArgs: &BootstrapTplArgs{
-				Namespace: "default",
-				ProxyID:   "web-sidecar-proxy",
+				ProxyID: "web-sidecar-proxy",
 			},
 			bindSocketDir: "/tmp/consul/hcp-metrics",
 			wantArgs: &BootstrapTplArgs{
-				Namespace: "default",
-				ProxyID:   "web-sidecar-proxy",
+				ProxyID: "web-sidecar-proxy",
 				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.metrics_service",
 					"typed_config": {
@@ -1689,55 +1683,9 @@ func TestAppendHCPMetrics(t *testing.T) {
 				  }`,
 			},
 		},
-		"path-without-namespace": {
-			inputArgs: &BootstrapTplArgs{
-				ProxyID: "web-sidecar-proxy",
-			},
-			bindSocketDir: "/tmp/consul/hcp-metrics",
-			wantArgs: &BootstrapTplArgs{
-				Namespace: "default",
-				ProxyID:   "web-sidecar-proxy",
-				StatsSinksJSON: `{
-					"name": "envoy.stat_sinks.metrics_service",
-					"typed_config": {
-					  "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
-					  "transport_api_version": "V3",
-					  "grpc_service": {
-						"envoy_grpc": {
-						  "cluster_name": "hcp_metrics_collector"
-						}
-					  }
-					}
-				  }`,
-				StaticClustersJSON: `{
-					"name": "hcp_metrics_collector",
-					"type": "STATIC",
-					"http2_protocol_options": {},
-					"loadAssignment": {
-					  "clusterName": "hcp_metrics_collector",
-					  "endpoints": [
-						{
-						  "lbEndpoints": [
-							{
-							  "endpoint": {
-								"address": {
-								  "pipe": {
-									"path": "/tmp/consul/hcp-metrics/web-sidecar-proxy.sock"
-								  }
-								}
-							  }
-							}
-						  ]
-						}
-					  ]
-					}
-				  }`,
-			},
-		},
 		"append-clusters-and-stats-sink": {
 			inputArgs: &BootstrapTplArgs{
-				Namespace: "default",
-				ProxyID:   "web-sidecar-proxy",
+				ProxyID: "web-sidecar-proxy",
 				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.statsd",
 					"typedConfig": {
@@ -1754,8 +1702,7 @@ func TestAppendHCPMetrics(t *testing.T) {
 			},
 			bindSocketDir: "/tmp/consul/hcp-metrics",
 			wantArgs: &BootstrapTplArgs{
-				Namespace: "default",
-				ProxyID:   "web-sidecar-proxy",
+				ProxyID: "web-sidecar-proxy",
 				StatsSinksJSON: `{
 					"name": "envoy.stat_sinks.statsd",
 					"typedConfig": {

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -513,6 +513,56 @@ const (
     }
   ]
 }`
+
+	expectedStatsdSink = `{
+	"name": "envoy.stat_sinks.statsd",
+	"typedConfig": {
+		"@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
+		"address": {
+			"socket_address": {
+				"address": "127.0.0.1",
+				"port_value": 9125
+			}
+		}
+	}
+}`
+
+	expectedHCPMetricsStatsSink = `{
+	"name": "envoy.stat_sinks.metrics_service",
+	"typed_config": {
+	  "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
+	  "transport_api_version": "V3",
+	  "grpc_service": {
+		"envoy_grpc": {
+		  "cluster_name": "hcp_metrics_collector"
+		}
+	  }
+	}
+  }`
+
+	expectedHCPMetricsCluster = `{
+	"name": "hcp_metrics_collector",
+	"type": "STATIC",
+	"http2_protocol_options": {},
+	"loadAssignment": {
+	  "clusterName": "hcp_metrics_collector",
+	  "endpoints": [
+		{
+		  "lbEndpoints": [
+			{
+			  "endpoint": {
+				"address": {
+				  "pipe": {
+					"path": "/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock"
+				  }
+				}
+			  }
+			}
+		  ]
+		}
+	  ]
+	}
+  }`
 )
 
 func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
@@ -621,18 +671,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 			},
 			wantArgs: BootstrapTplArgs{
 				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `{
-					"name": "envoy.stat_sinks.statsd",
-					"typedConfig": {
-						"@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
-						"address": {
-							"socket_address": {
-								"address": "127.0.0.1",
-								"port_value": 9125
-							}
-						}
-					}
-				}`,
+				StatsSinksJSON:  expectedStatsdSink,
 			},
 			wantErr: false,
 		},
@@ -1601,42 +1640,9 @@ func TestAppendHCPMetrics(t *testing.T) {
 			},
 			bindSocketDir: "/tmp/consul/hcp-metrics",
 			wantArgs: &BootstrapTplArgs{
-				ProxyID: "web-sidecar-proxy",
-				StatsSinksJSON: `{
-					"name": "envoy.stat_sinks.metrics_service",
-					"typed_config": {
-					  "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
-					  "transport_api_version": "V3",
-					  "grpc_service": {
-						"envoy_grpc": {
-						  "cluster_name": "hcp_metrics_collector"
-						}
-					  }
-					}
-				  }`,
-				StaticClustersJSON: `{
-					"name": "hcp_metrics_collector",
-					"type": "STATIC",
-					"http2_protocol_options": {},
-					"loadAssignment": {
-					  "clusterName": "hcp_metrics_collector",
-					  "endpoints": [
-						{
-						  "lbEndpoints": [
-							{
-							  "endpoint": {
-								"address": {
-								  "pipe": {
-									"path": "/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock"
-								  }
-								}
-							  }
-							}
-						  ]
-						}
-					  ]
-					}
-				  }`,
+				ProxyID:            "web-sidecar-proxy",
+				StatsSinksJSON:     expectedHCPMetricsStatsSink,
+				StaticClustersJSON: expectedHCPMetricsCluster,
 			},
 		},
 		"dir-with-trailing-slash": {
@@ -1645,111 +1651,22 @@ func TestAppendHCPMetrics(t *testing.T) {
 			},
 			bindSocketDir: "/tmp/consul/hcp-metrics",
 			wantArgs: &BootstrapTplArgs{
-				ProxyID: "web-sidecar-proxy",
-				StatsSinksJSON: `{
-					"name": "envoy.stat_sinks.metrics_service",
-					"typed_config": {
-					  "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
-					  "transport_api_version": "V3",
-					  "grpc_service": {
-						"envoy_grpc": {
-						  "cluster_name": "hcp_metrics_collector"
-						}
-					  }
-					}
-				  }`,
-				StaticClustersJSON: `{
-					"name": "hcp_metrics_collector",
-					"type": "STATIC",
-					"http2_protocol_options": {},
-					"loadAssignment": {
-					  "clusterName": "hcp_metrics_collector",
-					  "endpoints": [
-						{
-						  "lbEndpoints": [
-							{
-							  "endpoint": {
-								"address": {
-								  "pipe": {
-									"path": "/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock"
-								  }
-								}
-							  }
-							}
-						  ]
-						}
-					  ]
-					}
-				  }`,
+				ProxyID:            "web-sidecar-proxy",
+				StatsSinksJSON:     expectedHCPMetricsStatsSink,
+				StaticClustersJSON: expectedHCPMetricsCluster,
 			},
 		},
 		"append-clusters-and-stats-sink": {
 			inputArgs: &BootstrapTplArgs{
-				ProxyID: "web-sidecar-proxy",
-				StatsSinksJSON: `{
-					"name": "envoy.stat_sinks.statsd",
-					"typedConfig": {
-						"@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
-						"address": {
-							"socket_address": {
-								"address": "127.0.0.1",
-								"port_value": 9125
-							}
-						}
-					}
-				}`,
+				ProxyID:            "web-sidecar-proxy",
+				StatsSinksJSON:     expectedStatsdSink,
 				StaticClustersJSON: expectedSelfAdminCluster,
 			},
 			bindSocketDir: "/tmp/consul/hcp-metrics",
 			wantArgs: &BootstrapTplArgs{
-				ProxyID: "web-sidecar-proxy",
-				StatsSinksJSON: `{
-					"name": "envoy.stat_sinks.statsd",
-					"typedConfig": {
-						"@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
-						"address": {
-							"socket_address": {
-								"address": "127.0.0.1",
-								"port_value": 9125
-							}
-						}
-					}
-				},{
-					"name": "envoy.stat_sinks.metrics_service",
-					"typed_config": {
-					  "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
-					  "transport_api_version": "V3",
-					  "grpc_service": {
-						"envoy_grpc": {
-						  "cluster_name": "hcp_metrics_collector"
-						}
-					  }
-					}
-				  }`,
-				StaticClustersJSON: expectedSelfAdminCluster + `,
-				{
-					"name": "hcp_metrics_collector",
-					"type": "STATIC",
-					"http2_protocol_options": {},
-					"loadAssignment": {
-					  "clusterName": "hcp_metrics_collector",
-					  "endpoints": [
-						{
-						  "lbEndpoints": [
-							{
-							  "endpoint": {
-								"address": {
-								  "pipe": {
-									"path": "/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock"
-								  }
-								}
-							  }
-							}
-						  ]
-						}
-					  ]
-					}
-				  }`,
+				ProxyID:            "web-sidecar-proxy",
+				StatsSinksJSON:     expectedStatsdSink + ",\n" + expectedHCPMetricsStatsSink,
+				StaticClustersJSON: expectedSelfAdminCluster + ",\n" + expectedHCPMetricsCluster,
 			},
 		},
 	}

--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -262,7 +262,9 @@ const bootstrapTemplate = `{
     {{- end }}
   },
   {{- if .StatsSinksJSON }}
-  "stats_sinks": {{ .StatsSinksJSON }},
+  "stats_sinks": [
+    {{ .StatsSinksJSON }}
+  ],
   {{- end }}
   {{- if .StatsConfigJSON }}
   "stats_config": {{ .StatsConfigJSON }},

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -744,6 +744,10 @@ func (c *cmd) generateConfig() ([]byte, error) {
 		if err := mapstructure.WeakDecode(svcProxyConfig.Config, &bsCfg); err != nil {
 			return nil, fmt.Errorf("failed parsing Proxy.Config: %s", err)
 		}
+
+		if bsCfg.HCPMetricsBindPort < 0 || bsCfg.HCPMetricsBindPort > 65535 {
+			return nil, fmt.Errorf("failed parsing Proxy.Config: invalid envoy_hcp_metrics_bind_port: %d", bsCfg.HCPMetricsBindPort)
+		}
 	}
 
 	return bsCfg.GenerateJSON(args, c.omitDeprecatedTags)

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -744,10 +744,6 @@ func (c *cmd) generateConfig() ([]byte, error) {
 		if err := mapstructure.WeakDecode(svcProxyConfig.Config, &bsCfg); err != nil {
 			return nil, fmt.Errorf("failed parsing Proxy.Config: %s", err)
 		}
-
-		if bsCfg.HCPMetricsBindPort < 0 || bsCfg.HCPMetricsBindPort > 65535 {
-			return nil, fmt.Errorf("failed parsing Proxy.Config: invalid envoy_hcp_metrics_bind_port: %d", bsCfg.HCPMetricsBindPort)
-		}
 	}
 
 	return bsCfg.GenerateJSON(args, c.omitDeprecatedTags)

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -197,13 +197,14 @@ func TestGenerateConfig(t *testing.T) {
 		},
 		{
 			Name:  "hcp-metrics",
-			Flags: []string{"-proxy-id", "test-proxy"},
+			Flags: []string{"-proxy-id", "test-proxy", "-namespace", "default"},
 			ProxyConfig: map[string]interface{}{
-				"envoy_hcp_metrics_bind_port": 3000,
+				"envoy_hcp_metrics_bind_socket_dir": "/tmp/consul/hcp-metrics",
 			},
 			WantArgs: BootstrapTplArgs{
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				Namespace:    "default",
 				// We don't know this til after the lookup so it will be empty in the
 				// initial args call we are testing here.
 				ProxySourceService: "",
@@ -217,14 +218,6 @@ func TestGenerateConfig(t *testing.T) {
 				LocalAgentClusterName: xds.LocalAgentClusterName,
 				PrometheusScrapePath:  "/metrics",
 			},
-		},
-		{
-			Name:  "hcp-metrics-invalid-port",
-			Flags: []string{"-proxy-id", "test-proxy"},
-			ProxyConfig: map[string]interface{}{
-				"envoy_hcp_metrics_bind_port": 80000,
-			},
-			WantErr: "failed parsing Proxy.Config: invalid envoy_hcp_metrics_bind_port: 80000",
 		},
 		{
 			Name: "prometheus-metrics",

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -196,6 +196,37 @@ func TestGenerateConfig(t *testing.T) {
 			},
 		},
 		{
+			Name:  "hcp-metrics",
+			Flags: []string{"-proxy-id", "test-proxy"},
+			ProxyConfig: map[string]interface{}{
+				"envoy_hcp_metrics_bind_port": 3000,
+			},
+			WantArgs: BootstrapTplArgs{
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502",
+				},
+				AdminAccessLogPath:    "/dev/null",
+				AdminBindAddress:      "127.0.0.1",
+				AdminBindPort:         "19000",
+				LocalAgentClusterName: xds.LocalAgentClusterName,
+				PrometheusScrapePath:  "/metrics",
+			},
+		},
+		{
+			Name:  "hcp-metrics-invalid-port",
+			Flags: []string{"-proxy-id", "test-proxy"},
+			ProxyConfig: map[string]interface{}{
+				"envoy_hcp_metrics_bind_port": 80000,
+			},
+			WantErr: "failed parsing Proxy.Config: invalid envoy_hcp_metrics_bind_port: 80000",
+		},
+		{
 			Name: "prometheus-metrics",
 			Flags: []string{"-proxy-id", "test-proxy",
 				"-prometheus-backend-port", "20100", "-prometheus-scrape-path", "/scrape-path"},

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -197,14 +197,13 @@ func TestGenerateConfig(t *testing.T) {
 		},
 		{
 			Name:  "hcp-metrics",
-			Flags: []string{"-proxy-id", "test-proxy", "-namespace", "default"},
+			Flags: []string{"-proxy-id", "test-proxy"},
 			ProxyConfig: map[string]interface{}{
 				"envoy_hcp_metrics_bind_socket_dir": "/tmp/consul/hcp-metrics",
 			},
 			WantArgs: BootstrapTplArgs{
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
-				Namespace:    "default",
 				// We don't know this til after the lookup so it will be empty in the
 				// initial args call we are testing here.
 				ProxySourceService: "",

--- a/command/connect/envoy/testdata/hcp-metrics.golden
+++ b/command/connect/envoy/testdata/hcp-metrics.golden
@@ -1,0 +1,248 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 19000
+      }
+    }
+  },
+  "node": {
+    "cluster": "test",
+    "id": "test-proxy",
+    "metadata": {
+      "namespace": "default",
+      "partition": "default"
+    }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576
+        }
+      }
+    ]
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "local_agent",
+        "ignore_health_on_host_removal": false,
+        "connect_timeout": "1s",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "loadAssignment": {
+          "clusterName": "local_agent",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8502
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "name": "hcp_metrics_collector",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "loadAssignment": {
+          "clusterName": "hcp_metrics_collector",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 3000
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "stats_sinks": [
+    {
+      "name": "envoy.stat_sinks.metrics_service",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
+        "transport_api_version": "V3",
+        "grpc_service": {
+          "envoy_grpc": {
+            "cluster_name": "hcp_metrics_collector"
+          }
+        }
+      }
+    }
+  ],
+  "stats_config": {
+    "stats_tags": [
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:([^.]+)\\.)?[^.]+\\.internal[^.]*\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.partition"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.internal[^.]*\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.([^.]+\\.(?:[^.]+\\.)?([^.]+)\\.external\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.peer"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream(?:_peered)?\\.(([^.]+)(?:\\.[^.]+)?(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream_peered\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.peer"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream(?:_peered)?\\.([^.]+(?:\\.([^.]+))?(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.partition"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.internal[^.]*\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.full_target"
+      },
+      {
+        "tag_name": "local_cluster",
+        "fixed_value": "test"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
+      }
+    ],
+    "use_all_default_tags": true
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {},
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "ads": {},
+      "resource_api_version": "V3"
+    },
+    "ads_config": {
+      "api_type": "DELTA_GRPC",
+      "transport_api_version": "V3",
+      "grpc_services": {
+        "initial_metadata": [
+          {
+            "key": "x-consul-token",
+            "value": ""
+          }
+        ],
+        "envoy_grpc": {
+          "cluster_name": "local_agent"
+        }
+      }
+    }
+  }
+}
+

--- a/command/connect/envoy/testdata/hcp-metrics.golden
+++ b/command/connect/envoy/testdata/hcp-metrics.golden
@@ -66,9 +66,8 @@
                 {
                   "endpoint": {
                     "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 3000
+                      "pipe": {
+                        "path": "/tmp/consul/hcp-metrics/default_test-proxy.sock"
                       }
                     }
                   }

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -75,6 +75,9 @@ Usage: `consul connect envoy [options] [-- pass-through options]`
   In cases where either assumption is violated this flag will prevent the
   command attempting to resolve config from the local agent.
 
+- `envoy_hcp_metrics_bind_port` - By setting this port, Envoy will be configured to
+  send metrics to an HCP collector. By default, this is disabled.
+
 - `-envoy-ready-bind-address` - By default the proxy does not have a readiness probe
   configured on it. This flag in conjunction with the `envoy-ready-bind-port` flag
   configures where the envoy readiness probe is configured on the proxy. A `/ready` HTTP

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -75,8 +75,9 @@ Usage: `consul connect envoy [options] [-- pass-through options]`
   In cases where either assumption is violated this flag will prevent the
   command attempting to resolve config from the local agent.
 
-- `envoy_hcp_metrics_bind_port` - By setting this port, Envoy will be configured to
-  send metrics to an HCP collector. By default, this is disabled.
+- `envoy_hcp_metrics_bind_socket_dir` - Specifies the directory of a unix socket 
+  for Envoy to send metrics to. HCP collectors can connect to the socket and collect metrics.
+  The socket is not configured by default.
 
 - `-envoy-ready-bind-address` - By default the proxy does not have a readiness probe
   configured on it. This flag in conjunction with the `envoy-ready-bind-port` flag

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -75,8 +75,8 @@ Usage: `consul connect envoy [options] [-- pass-through options]`
   In cases where either assumption is violated this flag will prevent the
   command attempting to resolve config from the local agent.
 
-- `envoy_hcp_metrics_bind_socket_dir` - Specifies the directory of a unix socket 
-  for Envoy to send metrics to. HCP collectors can connect to the socket and collect metrics.
+- `envoy_hcp_metrics_bind_socket_dir` - Specifies the directory where Envoy creates a unix socket. 
+  Envoy sends metrics to the socket so that HCP collectors can connect to collect them." 
   The socket is not configured by default.
 
 - `-envoy-ready-bind-address` - By default the proxy does not have a readiness probe


### PR DESCRIPTION
### Description
Add a new envoy flag: `envoy_hcp_metrics_bind_socket_dir`, a directory where a unix socket will be created with the name `<namespace>_<proxy_id>.sock` to forward Envoy metrics.
If set, this will configure a local `stats_sink` and `STATIC` cluster to forward Envoy metrics to an HCP collector.

The HCP Cloud team is working on enabling observability metrics in HCP. 

There will be a follow-up PR to generate a listener and cluster dynamically that will be listening on this unix socket. 
That listener and cluster will be configured to route to collector instances through the service mesh.

Caveat: we needed to add this local listener indirection as a workaround due to this [issue](https://github.com/envoyproxy/envoy/issues/25700)

### Testing & Reproduction steps

- Added unit tests
- Tested locally by running consul, registering a proxy with the flag configured and starting Envoy with consul connect command.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
