### PR TITLE
modified unsupported envoy version error

### DIFF
--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -1696,50 +1696,65 @@ func TestCheckEnvoyVersionCompatibility(t *testing.T) {
 		name            string
 		envoyVersion    string
 		unsupportedList []string
-		expectedSupport bool
+		expectedCompat  envoyCompat
 		isErrorExpected bool
 	}{
 		{
 			name:            "supported-using-proxy-support-defined",
 			envoyVersion:    xdscommon.EnvoyVersions[1],
 			unsupportedList: xdscommon.UnsupportedEnvoyVersions,
-			expectedSupport: true,
+			expectedCompat: envoyCompat{
+				isCompatible: true,
+			},
 		},
 		{
 			name:            "supported-at-max",
 			envoyVersion:    xdscommon.GetMaxEnvoyMinorVersion(),
 			unsupportedList: xdscommon.UnsupportedEnvoyVersions,
-			expectedSupport: true,
+			expectedCompat: envoyCompat{
+				isCompatible: true,
+			},
 		},
 		{
 			name:            "supported-patch-higher",
 			envoyVersion:    addNPatchVersion(xdscommon.EnvoyVersions[0], 1),
 			unsupportedList: xdscommon.UnsupportedEnvoyVersions,
-			expectedSupport: true,
+			expectedCompat: envoyCompat{
+				isCompatible: true,
+			},
 		},
 		{
 			name:            "not-supported-minor-higher",
 			envoyVersion:    addNMinorVersion(xdscommon.EnvoyVersions[0], 1),
 			unsupportedList: xdscommon.UnsupportedEnvoyVersions,
-			expectedSupport: false,
+			expectedCompat: envoyCompat{
+				isCompatible:        false,
+				versionIncompatible: replacePatchVersionWithX(addNMinorVersion(xdscommon.EnvoyVersions[0], 1)),
+			},
 		},
 		{
 			name:            "not-supported-minor-lower",
 			envoyVersion:    addNMinorVersion(xdscommon.EnvoyVersions[len(xdscommon.EnvoyVersions)-1], -1),
 			unsupportedList: xdscommon.UnsupportedEnvoyVersions,
-			expectedSupport: false,
+			expectedCompat: envoyCompat{
+				isCompatible:        false,
+				versionIncompatible: replacePatchVersionWithX(addNMinorVersion(xdscommon.EnvoyVersions[len(xdscommon.EnvoyVersions)-1], -1)),
+			},
 		},
 		{
 			name:            "not-supported-explicitly-unsupported-version",
 			envoyVersion:    addNPatchVersion(xdscommon.EnvoyVersions[0], 1),
 			unsupportedList: []string{"1.23.1", addNPatchVersion(xdscommon.EnvoyVersions[0], 1)},
-			expectedSupport: false,
+			expectedCompat: envoyCompat{
+				isCompatible:        false,
+				versionIncompatible: addNPatchVersion(xdscommon.EnvoyVersions[0], 1),
+			},
 		},
 		{
 			name:            "error-bad-input",
 			envoyVersion:    "1.abc.3",
 			unsupportedList: xdscommon.UnsupportedEnvoyVersions,
-			expectedSupport: false,
+			expectedCompat:  envoyCompat{},
 			isErrorExpected: true,
 		},
 	}
@@ -1752,7 +1767,7 @@ func TestCheckEnvoyVersionCompatibility(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, tc.expectedSupport, actual)
+			assert.Equal(t, tc.expectedCompat, actual)
 		})
 	}
 }


### PR DESCRIPTION
### Description
- When an envoy version is out of a supported range, we now return the envoy version being used as `major.minor.x` to indicate that it is the minor version at most that is incompatible
- When an envoy version is in the list of unsupported envoy versions we return back the envoy version in the error message as `major.minor.patch` as now the exact version matters.

Note: Currently we do not have any envoy versions in the list of `unsupported` versions but we can support this in the future should the need arise to invalidate a particular major, minor or patch version

### Testing & Reproduction steps

Verified error message with envoy out of bounds:
```shell
dc1svc2    | Envoy version 1.18.x is not supported. If there is a reason you need to use this version of envoy use the ignore-envoy-compatibility flag. Using an unsupported version of Envoy is not recommended and your experience may vary. For more information on compatibility see https://developer.hashicorp.com/consul/docs/connect/proxies/envoy#envoy-and-consul-client-agent
```

Verified error message with envoy in unsupported list:
```shell
dc1svc2    | Envoy version 1.18.3 is not supported. If there is a reason you need to use this version of envoy use the ignore-envoy-compatibility flag. Using an unsupported version of Envoy is not recommended and your experience may vary. For more information on compatibility see https://developer.hashicorp.com/consul/docs/connect/proxies/envoy#envoy-and-consul-client-agent

```


<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
