### PR TITLE
Fix flakey tests related to ACL token updates

### DIFF
--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -50,13 +50,6 @@ func TestTokenUpdateCommand(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// create a token
-	token, _, err := client.ACL().TokenCreate(
-		&api.ACLToken{Description: "test"},
-		&api.WriteOptions{Token: "root"},
-	)
-	require.NoError(t, err)
-
 	run := func(t *testing.T, args []string) *api.ACLToken {
 		ui := cli.NewMockUi()
 		cmd := New(ui)
@@ -72,7 +65,14 @@ func TestTokenUpdateCommand(t *testing.T) {
 
 	// update with node identity
 	t.Run("node-identity", func(t *testing.T) {
-		token := run(t, []string{
+		// create a token
+		token, _, err := client.ACL().TokenCreate(
+			&api.ACLToken{Description: "test"},
+			&api.WriteOptions{Token: "root"},
+		)
+		require.NoError(t, err)
+
+		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-accessor-id=" + token.AccessorID,
 			"-token=root",
@@ -80,13 +80,23 @@ func TestTokenUpdateCommand(t *testing.T) {
 			"-description=test token",
 		})
 
-		require.Len(t, token.NodeIdentities, 1)
-		require.Equal(t, "foo", token.NodeIdentities[0].NodeName)
-		require.Equal(t, "bar", token.NodeIdentities[0].Datacenter)
+		require.Len(t, responseToken.NodeIdentities, 1)
+		require.Equal(t, "foo", responseToken.NodeIdentities[0].NodeName)
+		require.Equal(t, "bar", responseToken.NodeIdentities[0].Datacenter)
 	})
 
 	t.Run("node-identity-merge", func(t *testing.T) {
-		token := run(t, []string{
+		// create a token
+		token, _, err := client.ACL().TokenCreate(
+			&api.ACLToken{
+				Description:    "test",
+				NodeIdentities: []*api.ACLNodeIdentity{{NodeName: "foo", Datacenter: "bar"}},
+			},
+			&api.WriteOptions{Token: "root"},
+		)
+		require.NoError(t, err)
+
+		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-accessor-id=" + token.AccessorID,
 			"-token=root",
@@ -95,7 +105,7 @@ func TestTokenUpdateCommand(t *testing.T) {
 			"-merge-node-identities",
 		})
 
-		require.Len(t, token.NodeIdentities, 2)
+		require.Len(t, responseToken.NodeIdentities, 2)
 		expected := []*api.ACLNodeIdentity{
 			{
 				NodeName:   "foo",
@@ -106,12 +116,19 @@ func TestTokenUpdateCommand(t *testing.T) {
 				Datacenter: "baz",
 			},
 		}
-		require.ElementsMatch(t, expected, token.NodeIdentities)
+		require.ElementsMatch(t, expected, responseToken.NodeIdentities)
 	})
 
 	// update with policy by name
 	t.Run("policy-name", func(t *testing.T) {
-		token := run(t, []string{
+		// create a token
+		token, _, err := client.ACL().TokenCreate(
+			&api.ACLToken{Description: "test"},
+			&api.WriteOptions{Token: "root"},
+		)
+		require.NoError(t, err)
+
+		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-accessor-id=" + token.AccessorID,
 			"-token=root",
@@ -119,12 +136,19 @@ func TestTokenUpdateCommand(t *testing.T) {
 			"-description=test token",
 		})
 
-		require.Len(t, token.Policies, 1)
+		require.Len(t, responseToken.Policies, 1)
 	})
 
 	// update with policy by id
 	t.Run("policy-id", func(t *testing.T) {
-		token := run(t, []string{
+		// create a token
+		token, _, err := client.ACL().TokenCreate(
+			&api.ACLToken{Description: "test"},
+			&api.WriteOptions{Token: "root"},
+		)
+		require.NoError(t, err)
+
+		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-accessor-id=" + token.AccessorID,
 			"-token=root",
@@ -132,12 +156,19 @@ func TestTokenUpdateCommand(t *testing.T) {
 			"-description=test token",
 		})
 
-		require.Len(t, token.Policies, 1)
+		require.Len(t, responseToken.Policies, 1)
 	})
 
 	// update with service-identity
 	t.Run("service-identity", func(t *testing.T) {
-		token := run(t, []string{
+		// create a token
+		token, _, err := client.ACL().TokenCreate(
+			&api.ACLToken{Description: "test"},
+			&api.WriteOptions{Token: "root"},
+		)
+		require.NoError(t, err)
+
+		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-accessor-id=" + token.AccessorID,
 			"-token=root",
@@ -145,20 +176,27 @@ func TestTokenUpdateCommand(t *testing.T) {
 			"-description=test token",
 		})
 
-		require.Len(t, token.ServiceIdentities, 1)
-		require.Equal(t, "service", token.ServiceIdentities[0].ServiceName)
+		require.Len(t, responseToken.ServiceIdentities, 1)
+		require.Equal(t, "service", responseToken.ServiceIdentities[0].ServiceName)
 	})
 
 	// update with no description shouldn't delete the current description
 	t.Run("merge-description", func(t *testing.T) {
-		token := run(t, []string{
+		// create a token
+		token, _, err := client.ACL().TokenCreate(
+			&api.ACLToken{Description: "test token"},
+			&api.WriteOptions{Token: "root"},
+		)
+		require.NoError(t, err)
+
+		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-accessor-id=" + token.AccessorID,
 			"-token=root",
 			"-policy-name=" + policy.Name,
 		})
 
-		require.Equal(t, "test token", token.Description)
+		require.Equal(t, "test token", responseToken.Description)
 	})
 }
 

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -22,6 +22,13 @@ func TestTokenUpdateCommand_noTabs(t *testing.T) {
 	}
 }
 
+func create_token(t *testing.T, client *api.Client, aclToken *api.ACLToken, writeOptions *api.WriteOptions) *api.ACLToken {
+	token, _, err := client.ACL().TokenCreate(aclToken, writeOptions)
+	require.NoError(t, err)
+
+	return token
+}
+
 func TestTokenUpdateCommand(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -65,12 +72,7 @@ func TestTokenUpdateCommand(t *testing.T) {
 
 	// update with node identity
 	t.Run("node-identity", func(t *testing.T) {
-		// create a token
-		token, _, err := client.ACL().TokenCreate(
-			&api.ACLToken{Description: "test"},
-			&api.WriteOptions{Token: "root"},
-		)
-		require.NoError(t, err)
+		token := create_token(t, client, &api.ACLToken{Description: "test"}, &api.WriteOptions{Token: "root"})
 
 		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
@@ -86,15 +88,11 @@ func TestTokenUpdateCommand(t *testing.T) {
 	})
 
 	t.Run("node-identity-merge", func(t *testing.T) {
-		// create a token
-		token, _, err := client.ACL().TokenCreate(
-			&api.ACLToken{
-				Description:    "test",
-				NodeIdentities: []*api.ACLNodeIdentity{{NodeName: "foo", Datacenter: "bar"}},
-			},
+		token := create_token(t,
+			client,
+			&api.ACLToken{Description: "test", NodeIdentities: []*api.ACLNodeIdentity{{NodeName: "foo", Datacenter: "bar"}}},
 			&api.WriteOptions{Token: "root"},
 		)
-		require.NoError(t, err)
 
 		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
@@ -121,12 +119,7 @@ func TestTokenUpdateCommand(t *testing.T) {
 
 	// update with policy by name
 	t.Run("policy-name", func(t *testing.T) {
-		// create a token
-		token, _, err := client.ACL().TokenCreate(
-			&api.ACLToken{Description: "test"},
-			&api.WriteOptions{Token: "root"},
-		)
-		require.NoError(t, err)
+		token := create_token(t, client, &api.ACLToken{Description: "test"}, &api.WriteOptions{Token: "root"})
 
 		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
@@ -141,12 +134,7 @@ func TestTokenUpdateCommand(t *testing.T) {
 
 	// update with policy by id
 	t.Run("policy-id", func(t *testing.T) {
-		// create a token
-		token, _, err := client.ACL().TokenCreate(
-			&api.ACLToken{Description: "test"},
-			&api.WriteOptions{Token: "root"},
-		)
-		require.NoError(t, err)
+		token := create_token(t, client, &api.ACLToken{Description: "test"}, &api.WriteOptions{Token: "root"})
 
 		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
@@ -161,12 +149,7 @@ func TestTokenUpdateCommand(t *testing.T) {
 
 	// update with service-identity
 	t.Run("service-identity", func(t *testing.T) {
-		// create a token
-		token, _, err := client.ACL().TokenCreate(
-			&api.ACLToken{Description: "test"},
-			&api.WriteOptions{Token: "root"},
-		)
-		require.NoError(t, err)
+		token := create_token(t, client, &api.ACLToken{Description: "test"}, &api.WriteOptions{Token: "root"})
 
 		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
@@ -182,12 +165,7 @@ func TestTokenUpdateCommand(t *testing.T) {
 
 	// update with no description shouldn't delete the current description
 	t.Run("merge-description", func(t *testing.T) {
-		// create a token
-		token, _, err := client.ACL().TokenCreate(
-			&api.ACLToken{Description: "test token"},
-			&api.WriteOptions{Token: "root"},
-		)
-		require.NoError(t, err)
+		token := create_token(t, client, &api.ACLToken{Description: "test token"}, &api.WriteOptions{Token: "root"})
 
 		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
@@ -250,12 +228,10 @@ func TestTokenUpdateCommandWithAppend(t *testing.T) {
 
 	// update with append-policy-name
 	t.Run("append-policy-name", func(t *testing.T) {
-		// create a token
-		token, _, err := client.ACL().TokenCreate(
+		token := create_token(t, client,
 			&api.ACLToken{Description: "test", Policies: []*api.ACLTokenPolicyLink{{Name: policy.Name}}},
 			&api.WriteOptions{Token: "root"},
 		)
-		require.NoError(t, err)
 
 		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
@@ -270,12 +246,10 @@ func TestTokenUpdateCommandWithAppend(t *testing.T) {
 
 	// update with append-policy-id
 	t.Run("append-policy-id", func(t *testing.T) {
-		// create a token
-		token, _, err := client.ACL().TokenCreate(
+		token := create_token(t, client,
 			&api.ACLToken{Description: "test", Policies: []*api.ACLTokenPolicyLink{{Name: policy.Name}}},
 			&api.WriteOptions{Token: "root"},
 		)
-		require.NoError(t, err)
 
 		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
@@ -290,8 +264,7 @@ func TestTokenUpdateCommandWithAppend(t *testing.T) {
 
 	// update with append-node-identity
 	t.Run("append-node-identity", func(t *testing.T) {
-		// create a token
-		token, _, err := client.ACL().TokenCreate(
+		token := create_token(t, client,
 			&api.ACLToken{
 				Description:    "test",
 				Policies:       []*api.ACLTokenPolicyLink{{Name: policy.Name}},
@@ -299,7 +272,6 @@ func TestTokenUpdateCommandWithAppend(t *testing.T) {
 			},
 			&api.WriteOptions{Token: "root"},
 		)
-		require.NoError(t, err)
 
 		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
@@ -316,8 +288,7 @@ func TestTokenUpdateCommandWithAppend(t *testing.T) {
 
 	// update with append-service-identity
 	t.Run("append-service-identity", func(t *testing.T) {
-		// create a token
-		token, _, err := client.ACL().TokenCreate(
+		token := create_token(t, client,
 			&api.ACLToken{
 				Description:       "test",
 				Policies:          []*api.ACLTokenPolicyLink{{Name: policy.Name}},
@@ -325,7 +296,6 @@ func TestTokenUpdateCommandWithAppend(t *testing.T) {
 			},
 			&api.WriteOptions{Token: "root"},
 		)
-		require.NoError(t, err)
 
 		responseToken := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
@@ -334,6 +304,7 @@ func TestTokenUpdateCommandWithAppend(t *testing.T) {
 			"-append-service-identity=web",
 			"-description=test token",
 		})
+
 		require.Len(t, responseToken.ServiceIdentities, 2)
 		require.Equal(t, "web", responseToken.ServiceIdentities[1].ServiceName)
 	})
@@ -369,12 +340,7 @@ func TestTokenUpdateCommand_JSON(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// create a token
-	token, _, err := client.ACL().TokenCreate(
-		&api.ACLToken{Description: "test"},
-		&api.WriteOptions{Token: "root"},
-	)
-	require.NoError(t, err)
+	token := create_token(t, client, &api.ACLToken{Description: "test"}, &api.WriteOptions{Token: "root"})
 
 	t.Run("update with policy by name", func(t *testing.T) {
 		cmd := New(ui)


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
The idea is to make sure each test can independently run so this PR reduce the dependency of tests on each other which causes a degree of flakiness. 

- Each tests depended on the same token to run which sometimes meant one test will overwrite changes from the other. So fixing this by allowing each test to create its own individual token that it could update and read to without any interference from other tests. 


### PR Checklist

* [x] updated test coverage
* [ ] ~external facing docs updated~
* [x] not a security concern
