### PR TITLE
docs: Document config entry permissions

### DIFF
--- a/website/content/api-docs/config.mdx
+++ b/website/content/api-docs/config.mdx
@@ -31,24 +31,31 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required                                      |
 | ---------------- | ----------------- | ------------- | ------------------------------------------------- |
-| `NO`             | `none`            | `none`        | `service:write`<br />`operator:write`<sup>1</sup> |
-
-<p>
-  <sup>1</sup> The ACL required depends on the config entry kind being updated:
-</p>
-
-| Config Entry Kind   | Required ACL       |
-| ------------------- | ------------------ |
-| ingress-gateway     | `operator:write`   |
-| proxy-defaults      | `operator:write`   |
-| service-defaults    | `service:write`    |
-| service-intentions  | `intentions:write` |
-| service-resolver    | `service:write`    |
-| service-router      | `service:write`    |
-| service-splitter    | `service:write`    |
-| terminating-gateway | `operator:write`   |
+| `NO`             | `none`            | `none`        | Refer to [Permissions](#permissions)              |
 
 The corresponding CLI command is [`consul config write`](/consul/commands/config/write).
+
+### Permissions
+
+The ACL required depends on the config entry being written:
+
+| Config Entry Kind   | Required ACLs                    |
+| ------------------- | -------------------------------- |
+| api-gateway         | `mesh:write` or `operator:write` |
+| bound-api-gateway   | Not writable.                    |
+| exported-services   | `mesh:write` or `operator:write` |
+| http-route          | `mesh:write` or `operator:write` |
+| ingress-gateway     | `mesh:write` or `operator:write` |
+| inline-certificate  | `mesh:write` or `operator:write` |
+| mesh                | `mesh:write` or `operator:write` |
+| proxy-defaults      | `mesh:write` or `operator:write` |
+| service-defaults    | `service:write`                  |
+| service-intentions  | `intentions:write`               |
+| service-resolver    | `service:write`                  |
+| service-router      | `service:write`                  |
+| service-splitter    | `service:write`                  |
+| tcp-route           | `mesh:write` or `operator:write` |
+| terminating-gateway | `mesh:write` or `operator:write` |
 
 ### Query Parameters
 
@@ -96,24 +103,34 @@ The table below shows this endpoint's support for
 [agent caching](/consul/api-docs/features/caching), and
 [required ACLs](/consul/api-docs/api-structure#authentication).
 
-| Blocking Queries | Consistency Modes | Agent Caching | ACL Required               |
-| ---------------- | ----------------- | ------------- | -------------------------- |
-| `YES`            | `all`             | `none`        | `service:read`<sup>1</sup> |
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required                           |
+| ---------------- | ----------------- | ------------- | -------------------------------------- |
+| `YES`            | `all`             | `none`        | Refer to [Permissions](#permissions-1) |
 
-<sup>1</sup> The ACL required depends on the config entry kind being read:
-
-| Config Entry Kind   | Required ACL      |
-| ------------------- | ----------------- |
-| ingress-gateway     | `service:read`    |
-| proxy-defaults      | `<none>`          |
-| service-defaults    | `service:read`    |
-| service-intentions  | `intentions:read` |
-| service-resolver    | `service:read`    |
-| service-router      | `service:read`    |
-| service-splitter    | `service:read`    |
-| terminating-gateway | `service:read`    |
 
 The corresponding CLI command is [`consul config read`](/consul/commands/config/read).
+
+### Permissions
+
+The ACL required depends on the config entry kind being read:
+
+| Config Entry Kind   | Required ACLs                    |
+| ------------------- | -------------------------------- |
+| api-gateway         | `service:read`                   |
+| bound-api-gateway   | `service:read`                   |
+| exported-services   | `mesh:read` or `operator:read`   |
+| http-route          | `mesh:read` or `operator:read`   |
+| ingress-gateway     | `service:read`                   |
+| inline-certificate  | `mesh:read` or `operator:read`   |
+| mesh                | No ACL required                  |
+| proxy-defaults      | No ACL required                  |
+| service-defaults    | `service:read`                   |
+| service-intentions  | `intentions:read`                |
+| service-resolver    | `service:read`                   |
+| service-router      | `service:read`                   |
+| service-splitter    | `service:read`                   |
+| tcp-route           | `mesh:read` or `operator:read`   |
+| terminating-gateway | `service:read`                   |
 
 ### Path Parameters
 
@@ -167,22 +184,31 @@ The table below shows this endpoint's support for
 [agent caching](/consul/api-docs/features/caching), and
 [required ACLs](/consul/api-docs/api-structure#authentication).
 
-| Blocking Queries | Consistency Modes | Agent Caching | ACL Required               |
-| ---------------- | ----------------- | ------------- | -------------------------- |
-| `YES`            | `all`             | `none`        | `service:read`<sup>1</sup> |
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required                           |
+| ---------------- | ----------------- | ------------- | -------------------------------------- |
+| `YES`            | `all`             | `none`        | Refer to [Permissions](#permissions-2) |
 
-<sup>1</sup> The ACL required depends on the config entry kind being read:
+### Permissions
 
-| Config Entry Kind   | Required ACL      |
-| ------------------- | ----------------- |
-| ingress-gateway     | `service:read`    |
-| proxy-defaults      | `<none>`          |
-| service-defaults    | `service:read`    |
-| service-intentions  | `intentions:read` |
-| service-resolver    | `service:read`    |
-| service-router      | `service:read`    |
-| service-splitter    | `service:read`    |
-| terminating-gateway | `service:read`    |
+The ACL required depends on the config entry kind being read:
+
+| Config Entry Kind   | Required ACLs                    |
+| ------------------- | -------------------------------- |
+| api-gateway         | `service:read`                   |
+| bound-api-gateway   | `service:read`                   |
+| exported-services   | `mesh:read` or `operator:read`   |
+| http-route          | `mesh:read` or `operator:read`   |
+| ingress-gateway     | `service:read`                   |
+| inline-certificate  | `mesh:read` or `operator:read`   |
+| mesh                | No ACL required                  |
+| proxy-defaults      | No ACL required                  |
+| service-defaults    | `service:read`                   |
+| service-intentions  | `intentions:read`                |
+| service-resolver    | `service:read`                   |
+| service-router      | `service:read`                   |
+| service-splitter    | `service:read`                   |
+| tcp-route           | `mesh:read` or `operator:read`   |
+| terminating-gateway | `service:read`                   |
 
 The corresponding CLI command is [`consul config list`](/consul/commands/config/list).
 
@@ -243,20 +269,29 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required                                      |
 | ---------------- | ----------------- | ------------- | ------------------------------------------------- |
-| `NO`             | `none`            | `none`        | `service:write`<br />`operator:write`<sup>1</sup> |
+| `NO`             | `none`            | `none`        | Refer to [Permissions](#permissions-3)            |
 
-<sup>1</sup> The ACL required depends on the config entry kind being deleted:
+### Permissions
 
-| Config Entry Kind   | Required ACL       |
-| ------------------- | ------------------ |
-| ingress-gateway     | `operator:write`   |
-| proxy-defaults      | `operator:write`   |
-| service-defaults    | `service:write`    |
-| service-intentions  | `intentions:write` |
-| service-resolver    | `service:write`    |
-| service-router      | `service:write`    |
-| service-splitter    | `service:write`    |
-| terminating-gateway | `operator:write `  |
+The ACL required depends on the config entry kind being deleted:
+
+| Config Entry Kind   | Required ACLs                    |
+| ------------------- | -------------------------------- |
+| api-gateway         | `mesh:write` or `operator:write` |
+| bound-api-gateway   | Not writable.                    |
+| exported-services   | `mesh:write` or `operator:write` |
+| http-route          | `mesh:write` or `operator:write` |
+| ingress-gateway     | `mesh:write` or `operator:write` |
+| inline-certificate  | `mesh:write` or `operator:write` |
+| mesh                | `mesh:write` or `operator:write` |
+| proxy-defaults      | `mesh:write` or `operator:write` |
+| service-defaults    | `service:write`                  |
+| service-intentions  | `intentions:write`               |
+| service-resolver    | `service:write`                  |
+| service-router      | `service:write`                  |
+| service-splitter    | `service:write`                  |
+| tcp-route           | `mesh:write` or `operator:write` |
+| terminating-gateway | `mesh:write` or `operator:write` |
 
 The corresponding CLI command is [`consul config delete`](/consul/commands/config/delete).
 


### PR DESCRIPTION
### Description

This updates the api docs to include the permissions needed for each kind of config entry.


### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
