### PR TITLE
Manual Backport of Fix resolution of service resolvers with subsets for external upstreams into release/1.13.x

### DIFF
--- a/.changelog/16499.txt
+++ b/.changelog/16499.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+mesh: Fix resolution of service resolvers with subsets for external upstreams
+```

--- a/agent/rpcclient/health/view_test.go
+++ b/agent/rpcclient/health/view_test.go
@@ -944,7 +944,8 @@ func TestNewFilterEvaluator(t *testing.T) {
 
 func TestHealthView_SkipFilteringTerminatingGateways(t *testing.T) {
 	view, err := NewHealthView(structs.ServiceSpecificRequest{
-		ServiceName: "web",
+		ServiceName: "name",
+		Connect:     true,
 		QueryOptions: structs.QueryOptions{
 			Filter: "Service.Meta.version == \"v1\"",
 		},
@@ -959,7 +960,7 @@ func TestHealthView_SkipFilteringTerminatingGateways(t *testing.T) {
 				CheckServiceNode: &pbservice.CheckServiceNode{
 					Service: &pbservice.NodeService{
 						Kind:    structs.TerminatingGateway,
-						Service: "gateway",
+						Service: "name",
 						Address: "127.0.0.1",
 						Port:    8443,
 					},

--- a/agent/rpcclient/health/view_test.go
+++ b/agent/rpcclient/health/view_test.go
@@ -941,3 +941,38 @@ func TestNewFilterEvaluator(t *testing.T) {
 		})
 	}
 }
+
+func TestHealthView_SkipFilteringTerminatingGateways(t *testing.T) {
+	view, err := NewHealthView(structs.ServiceSpecificRequest{
+		ServiceName: "web",
+		QueryOptions: structs.QueryOptions{
+			Filter: "Service.Meta.version == \"v1\"",
+		},
+	})
+	require.NoError(t, err)
+
+	err = view.Update([]*pbsubscribe.Event{{
+		Index: 1,
+		Payload: &pbsubscribe.Event_ServiceHealth{
+			ServiceHealth: &pbsubscribe.ServiceHealthUpdate{
+				Op: pbsubscribe.CatalogOp_Register,
+				CheckServiceNode: &pbservice.CheckServiceNode{
+					Service: &pbservice.NodeService{
+						Kind:    structs.TerminatingGateway,
+						Service: "gateway",
+						Address: "127.0.0.1",
+						Port:    8443,
+					},
+				},
+			},
+		},
+	}})
+	require.NoError(t, err)
+
+	node, ok := (view.Result(1)).(*structs.IndexedCheckServiceNodes)
+	require.True(t, ok)
+
+	require.Len(t, node.Nodes, 1)
+	require.Equal(t, "127.0.0.1", node.Nodes[0].Service.Address)
+	require.Equal(t, 8443, node.Nodes[0].Service.Port)
+}

--- a/test/integration/connect/envoy/case-terminating-gateway-subsets/capture.sh
+++ b/test/integration/connect/envoy/case-terminating-gateway-subsets/capture.sh
@@ -2,3 +2,4 @@
 
 snapshot_envoy_admin localhost:20000 terminating-gateway primary || true
 snapshot_envoy_admin localhost:19000 s1 primary || true
+snapshot_envoy_admin localhost:19001 s3 primary || true

--- a/test/integration/connect/envoy/case-terminating-gateway-subsets/service_s3.hcl
+++ b/test/integration/connect/envoy/case-terminating-gateway-subsets/service_s3.hcl
@@ -1,0 +1,17 @@
+services {
+  id = "s3"
+  name = "s3"
+  port = 8184
+  connect {
+    sidecar_service {
+      proxy {
+        upstreams = [
+          {
+            destination_name = "s2"
+            local_bind_port = 8185
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/integration/connect/envoy/case-terminating-gateway-subsets/setup.sh
+++ b/test/integration/connect/envoy/case-terminating-gateway-subsets/setup.sh
@@ -11,4 +11,5 @@ register_services primary
 
 # terminating gateway will act as s2's proxy
 gen_envoy_bootstrap s1 19000
+gen_envoy_bootstrap s3 19001
 gen_envoy_bootstrap terminating-gateway 20000 primary true

--- a/test/integration/connect/envoy/case-terminating-gateway-subsets/vars.sh
+++ b/test/integration/connect/envoy/case-terminating-gateway-subsets/vars.sh
@@ -4,5 +4,6 @@
 export REQUIRED_SERVICES="
 s1 s1-sidecar-proxy
 s2-v1
+s3 s3-sidecar-proxy
 terminating-gateway-primary
 "

--- a/test/integration/connect/envoy/case-terminating-gateway-subsets/verify.bats
+++ b/test/integration/connect/envoy/case-terminating-gateway-subsets/verify.bats
@@ -38,3 +38,7 @@ load helpers
   assert_envoy_metric_at_least 127.0.0.1:20000 "v1.s2.default.primary.*cx_total" 1
 }
 
+@test "terminating-gateway is used for the upstream connection of the proxy" {
+  # make sure we resolve the terminating gateway as endpoint for the upstream
+  assert_upstream_has_endpoint_port 127.0.0.1:19001 "v1.s2" 8443
+}

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -346,6 +346,49 @@ function get_envoy_metrics {
   get_all_envoy_metrics $HOSTPORT | grep "$METRICS"
 }
 
+function get_upstream_endpoint {
+  local HOSTPORT=$1
+  local CLUSTER_NAME=$2
+  run curl -s -f "http://${HOSTPORT}/clusters?format=json"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq --raw-output "
+.cluster_statuses[]
+| select(.name|startswith(\"${CLUSTER_NAME}\"))"
+}
+
+function get_upstream_endpoint_port {
+  local HOSTPORT=$1
+  local CLUSTER_NAME=$2
+  local PORT_VALUE=$3
+  run curl -s -f "http://${HOSTPORT}/clusters?format=json"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq --raw-output "
+.cluster_statuses[]
+| select(.name|startswith(\"${CLUSTER_NAME}\"))
+| [.host_statuses[].address.socket_address.port_value]
+| [select(.[] == ${PORT_VALUE})]
+| length"
+}
+
+function assert_upstream_has_endpoint_port_once {
+  local HOSTPORT=$1
+  local CLUSTER_NAME=$2
+  local PORT_VALUE=$3
+
+  GOT_COUNT=$(get_upstream_endpoint_port $HOSTPORT $CLUSTER_NAME $PORT_VALUE)
+
+  [ "$GOT_COUNT" -eq 1 ]
+}
+
+function assert_upstream_has_endpoint_port {
+  local HOSTPORT=$1
+  local CLUSTER_NAME=$2
+  local PORT_VALUE=$3
+
+  run retry_long assert_upstream_has_endpoint_port_once $HOSTPORT $CLUSTER_NAME $PORT_VALUE
+  [ "$status" -eq 0 ]
+}
+
 function get_upstream_endpoint_in_status_count {
   local HOSTPORT=$1
   local CLUSTER_NAME=$2


### PR DESCRIPTION
## Backport

Manual backport from #16499 to release/1.13.x.



The below text is copied from the body of the original PR.

---

### Description

While fixing https://github.com/hashicorp/consul/pull/16498 I noticed that applying a `ServiceResolver` with subsets wasn't functional when referencing an external service proxied through a `TerminatingGateway` as an upstream. I'm not too familiar with the way we return service health for external services, but the problem appears to be that in our health check materializer we:

1. Grab the `CheckServiceNode` values from our subscription, and then
2. Apply any filters that were in our initial subscription request

Since we return the gateway associated with the service when we're using external services in conjuction with a `TerminatingGateway`:

https://github.com/hashicorp/consul/blob/21c30958cc89ba4a14a099d758002bc0a0ecc454/agent/consul/state/catalog.go#L2770-L2782

The filter never passes and we are never able to resolve the upstream endpoint properly.

**_I'm not entirely sure whether this is the only change needed, but from what I could tell all of the health checks initiated via `proxycfg` go through this code path since they leverage either the gRPC endpoints or a direct subscription to the in-memory store._**

### Testing & Reproduction steps

Create a set of external services that has a `ServiceResolver` with subsets as in #16498 and a local service that leverages those services as an upstream. Hit the local proxy's admin cluster listing endpoint.

Without the fix (no ip address ever associates with the endpoint):

```bash
➜  ~ curl -s localhost:9092/clusters | grep v1.external | sort | head -n 1
v1.external.default.dc1.internal.cba29ba8-8796-2c26-cacd-0ee5dee70b82.consul::added_via_api::true
```

With the fix (contains terminating gateway ip for its endpoint):

```bash
➜  ~ curl -s localhost:9092/clusters | grep v1.external | sort | head -n 1
v1.external.default.dc1.internal.ea87fe29-2a6c-bd80-e248-5ebdbfed0a7a.consul::127.0.0.1:8443::canary::false
```

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern


---

<details>
<summary> Overview of commits </summary>

  - 892d389d9b177c90ffa886bf3bc5d17a87556cec  - 8a2468d6b541de31d23f6d4d9ba28b4560ceea68  - f56894fdc1ef8cbe824d06ad3aeaf84382822dc0  - ced73fc2ce09a1b488c3744ce96686d2593992d8 

</details>


