### PR TITLE
added a backport-checker GitHub action

### DIFF
--- a/.github/workflows/backport-checker.yml
+++ b/.github/workflows/backport-checker.yml
@@ -1,0 +1,32 @@
+# This workflow checks that there is either a 'pr/no-backport' label applied to a PR
+# or there is a backport/<major>.<minor> label indicating a backport has been set
+
+name: Backport Checker
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+    # Runs on PRs to main and all release branches
+    branches:
+      - main
+      - release/*
+
+jobs:
+  # checks that a backport label is present for a PR
+  backport-check:
+    # If there's a `pr/no-backport` label we ignore this check. Also, we ignore PRs created by the bot assigned to `backport-assistant`
+    if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-backport') || github.event.pull_request.user.login == 'hc-github-team-consul-core' )"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for Backport Label
+        run: |
+          labels="${{join(github.event.pull_request.labels.*.name, ', ') }}"
+          if [[ "$labels" =~ .*"backport/".* ]]; then
+            echo "Found backport label!"
+            exit 0
+          fi
+          # Fail status check when no backport label was found on the PR
+          echo "Did not find a backport label matching the pattern 'backport/*' and the 'pr/no-backport' label was not applied. Reference - https://github.com/hashicorp/consul/pull/16567"
+          exit 1
+

--- a/.github/workflows/backport-checker.yml
+++ b/.github/workflows/backport-checker.yml
@@ -1,5 +1,5 @@
 # This workflow checks that there is either a 'pr/no-backport' label applied to a PR
-# or there is a backport/<major>.<minor> label indicating a backport has been set
+# or there is a backport/* label indicating a backport has been set
 
 name: Backport Checker
 


### PR DESCRIPTION
### Description
- Add a pipeline check for backport labels. This will ensure that developers must either add a backport label or deliberately specify that this pr does not require backporting with the `pr/no-backport` label.
- This check simply checks for the presence of a label matching `backport/*`. It is up to the developer to add the right backport labels as appropriate for a given PR.

How I've tested this PR:

No Backport label and no `pr/no-backport`
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/62034708/223621208-b9c316a4-cfc6-468e-98e0-ab902b1a9bba.png">

With backport label
<img width="998" alt="image" src="https://user-images.githubusercontent.com/62034708/223621492-25cf58f3-3cf8-4d97-b48f-ae67506b69ed.png">

With `pr/no-backport` label
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/62034708/223621333-b91705cf-4f7e-49a8-93bb-1b21f876806d.png">


### PR Checklist

* [n/a] updated test coverage
* [n/a] external facing docs updated
* [x] not a security concern
