### PR TITLE
UI: Fix htmlsafe errors throughout the app

### DIFF
--- a/.changelog/16574.txt
+++ b/.changelog/16574.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix rendering issues on Overview and empty-states by addressing isHTMLSafe errors
+```

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -134,7 +134,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-in-viewport": "^3.8.1",
     "ember-inflector": "^4.0.1",
-    "ember-intl": "^5.5.1",
+    "ember-intl": "^5.7.0",
     "ember-load-initializers": "^2.1.2",
     "ember-math-helpers": "^2.4.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8189,7 +8189,7 @@ ember-auto-import@^2.2.3, ember-auto-import@^2.4.2:
     typescript-memoize "^1.0.0-alpha.3"
     walk-sync "^3.0.0"
 
-ember-basic-dropdown@3.0.21, ember-basic-dropdown@^3.0.16:
+ember-basic-dropdown@^3.0.16:
   version "3.0.21"
   resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.0.21.tgz#5711d071966919c9578d2d5ac2c6dcadbb5ea0e0"
   integrity sha512-Wu9hJWyqorKo+ZT2PMSIO1BxAeAdaiIC2IjSic0+HcKjmMU47botvG0xbxlprimOWaS9vM+nHat6Pt3xPvcB0A==
@@ -9136,10 +9136,10 @@ ember-inflector@^4.0.2:
   dependencies:
     ember-cli-babel "^7.26.5"
 
-ember-intl@^5.5.1:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/ember-intl/-/ember-intl-5.6.2.tgz#ece4820923dfda033c279b7e3920cbbc8b6bde07"
-  integrity sha512-+FfI2udVbnEzueompcRb3ytBWhfnBfVVjAwnCuxwqIyS9ti8lK0ZiYHa5bquNPHjjfBzfFl4x5TlVgDNaCnccg==
+ember-intl@^5.7.0:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/ember-intl/-/ember-intl-5.7.2.tgz#76d933f974f041448b01247888bc3bcc9261e812"
+  integrity sha512-gs17uY1ywzMaUpx1gxfBkFQYRTWTSa/zbkL13MVtffG9aBLP+998MibytZOUxIipMtLCm4sr/g6/1aaKRr9/+g==
   dependencies:
     broccoli-caching-writer "^3.0.3"
     broccoli-funnel "^3.0.3"
@@ -18084,11 +18084,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xmlhttprequest-ssl@^1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
-  integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8189,7 +8189,7 @@ ember-auto-import@^2.2.3, ember-auto-import@^2.4.2:
     typescript-memoize "^1.0.0-alpha.3"
     walk-sync "^3.0.0"
 
-ember-basic-dropdown@^3.0.16:
+ember-basic-dropdown@3.0.21, ember-basic-dropdown@^3.0.16:
   version "3.0.21"
   resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.0.21.tgz#5711d071966919c9578d2d5ac2c6dcadbb5ea0e0"
   integrity sha512-Wu9hJWyqorKo+ZT2PMSIO1BxAeAdaiIC2IjSic0+HcKjmMU47botvG0xbxlprimOWaS9vM+nHat6Pt3xPvcB0A==
@@ -18084,6 +18084,11 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmlhttprequest-ssl@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
+  integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Traced `isHTMLSafe` errors back to `ember-intl` package. There was [minor release that addressed these issues](https://github.com/ember-intl/ember-intl/releases/tag/v5.7.0). Unfortunately, this missed the patch Consul release.

**Before**
<img width="1482" alt="Screenshot 2023-03-08 at 10 25 09 AM" src="https://user-images.githubusercontent.com/5448834/223785407-3925f56d-a8c8-438b-9d41-f6f1aaf55e9a.png">

**After:**
<img width="1482" alt="Screenshot 2023-03-08 at 12 03 28 PM" src="https://user-images.githubusercontent.com/5448834/223811678-83e730c8-298e-417b-8950-6638edb037c4.png">


### Testing & Reproduction steps
1. Checkout `1.15.1` branch
2. run `make ui-docker` to build the ui image
3. run `make dev-docker`
4. clone https://github.com/WenInCode/consul-setup
5. in the consul-setup repo go to the `setups/peering` directory
6. run `docker-compose up`
7. run `yarn setup:peerings`
8. Go to the overview page or any page with an empty state


### Links
- #16444 
- [CC-4450](https://hashicorp.atlassian.net/browse/CC-4450)
- https://github.com/hashicorp/consul/issues/16429

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern


[CC-4450]: https://hashicorp.atlassian.net/browse/CC-4450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ