### PR TITLE
Preserve CARoots when updating Vault CA configuration

### DIFF
--- a/.changelog/16592.txt
+++ b/.changelog/16592.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ca: Fixes a bug where updating Vault CA Provider config would cause TLS issues in the service mesh
+```

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-uuid"
 	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/consul/acl"
@@ -887,6 +887,20 @@ func (c *CAManager) primaryUpdateRootCA(newProvider ca.Provider, args *structs.C
 		return err
 	}
 
+	// TODO: https://github.com/hashicorp/consul/issues/12386
+	intermediate, err := newProvider.ActiveIntermediate()
+	if err != nil {
+		return err
+	}
+	if intermediate == "" {
+		return fmt.Errorf("no active intermediate")
+	}
+	if intermediate != newRootPEM {
+		if err := setLeafSigningCert(newActiveRoot, intermediate); err != nil {
+			return err
+		}
+	}
+
 	// See if the provider needs to persist any state along with the config
 	pState, err := newProvider.State()
 	if err != nil {
@@ -970,19 +984,9 @@ func (c *CAManager) primaryUpdateRootCA(newProvider ca.Provider, args *structs.C
 			}
 
 			// Add the cross signed cert to the new CA's intermediates (to be attached
-			// to leaf certs).
-			newActiveRoot.IntermediateCerts = []string{xcCert}
-		}
-	}
-
-	// TODO: https://github.com/hashicorp/consul/issues/12386
-	intermediate, err := newProvider.GenerateIntermediate()
-	if err != nil {
-		return err
-	}
-	if intermediate != newRootPEM {
-		if err := setLeafSigningCert(newActiveRoot, intermediate); err != nil {
-			return err
+			// to leaf certs). We do not want it to be the last cert if there are any
+			// existing intermediate certs so we push to the front.
+			newActiveRoot.IntermediateCerts = append([]string{xcCert}, newActiveRoot.IntermediateCerts...)
 		}
 	}
 

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -272,7 +272,7 @@ func newCARoot(pemValue, provider, clusterID string) (*structs.CARoot, error) {
 		ExternalTrustDomain: clusterID,
 		NotBefore:           primaryCert.NotBefore,
 		NotAfter:            primaryCert.NotAfter,
-		RootCert:            pemValue,
+		RootCert:            lib.EnsureTrailingNewline(pemValue),
 		PrivateKeyType:      keyType,
 		PrivateKeyBits:      keyBits,
 		Active:              true,

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -890,10 +890,13 @@ func (c *CAManager) primaryUpdateRootCA(newProvider ca.Provider, args *structs.C
 	// TODO: https://github.com/hashicorp/consul/issues/12386
 	intermediate, err := newProvider.ActiveIntermediate()
 	if err != nil {
-		return err
+		return fmt.Errorf("error fetching active intermediate: %w", err)
 	}
 	if intermediate == "" {
-		return fmt.Errorf("no active intermediate")
+		intermediate, err = newProvider.GenerateIntermediate()
+		if err != nil {
+			return fmt.Errorf("error generating intermediate: %w", err)
+		}
 	}
 	if intermediate != newRootPEM {
 		if err := setLeafSigningCert(newActiveRoot, intermediate); err != nil {


### PR DESCRIPTION
### Description

If a CA config update did not cause a root change, the codepath would return early and skip some steps which preserve its intermediate certificates and signing key ID. This commit re-orders some code and prevents updates from unnecessarily generating new intermediate certificates if one exists.

### Testing & Reproduction steps

* Added new testcase which should fail without this PR
* Existing integration tests are passing

### Links
Fixes https://github.com/hashicorp/consul/issues/16580
Fixes https://github.com/hashicorp/consul/issues/14564

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
