### PR TITLE
Create a weekly 404 checker for all Consul docs content

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,0 +1,30 @@
+name: Broken Link Check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 1"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run lychee link checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.6.1
+        with:
+          args: ./docs --base https://developer.hashicorp.com/ --exclude-all-private --exclude .png --exclude .svg --max-concurrency=24 --no-progress --verbose
+          # Fail GitHub action when broken links are found?
+          fail: false
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create GitHub Issue From lychee output file
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
### Description

To address practitioner concerns over broken links, we would like to implement a 404 checker for Consul docs.

The GitHub action utilizes [lychee](https://github.com/lycheeverse/lychee), a popular, open source link-checking utility.

This implementation of the GitHub action would run lychee on a weekly cadence (Mondays) and output the report to a GitHub issue.

The same implementation has been put in place for the tutorials repository:
https://github.com/hashicorp/tutorials/pull/1204

### Testing & Reproduction steps

Feel free to:
1. Download [lychee](https://github.com/lycheeverse/lychee).
2. Clone this repository and `cd` into the directory.
3. Run this command `lychee ./docs --base https://developer.hashicorp.com/ --exclude-all-private --exclude .png --exclude .svg --max-concurrency=24 --no-progress --verbose`

Some output like the following is expected:
```
...
Lots of logging
...
🔍 232 Total ✅ 158 OK 🚫 56 Errors (HTTP:56) 💤 18 Excluded
```

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] not a security concern
