### PR TITLE
fixes for unsupported partitions field in CRD metadata block

### DIFF
--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -88,6 +88,9 @@ spec:
 </Tab>
 
 <Tab heading="Consul Enterprise">
+
+For Kubernetes environments, the CRD inherits the partition from the cluster hosting the pods.
+
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
@@ -117,7 +120,6 @@ kind: IngressGateway
 metadata:
   name: <name for the gateway>
   namespace: <namespace containing the gateway>
-  partition: <partition containing the gateway namespace>
 
 spec:
   listeners:

--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -89,7 +89,7 @@ spec:
 
 <Tab heading="Consul Enterprise">
 
-For Kubernetes environments, the CRD inherits the partition from the cluster hosting the pods.
+For Kubernetes environments, the configuration entry is always created in the same partition as the Kubernetes cluster.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -82,7 +82,6 @@ The following outline shows how to format the service splitter configuration ent
 - [`metadata`](#metadata): map | no default
   - [`name`](#name): string | no default
   - [`namespace`](#namespace): string | no default | <EnterpriseAlert inline /> 
-  - [`partition`](#partition): string | no default | <EnterpriseAlert inline /> 
 - [`spec`](#spec): map | no default
   - [`protocol`](#protocol): string | default: `tcp`
   - [`balanceInboundConnections`](#balanceinboundconnections): string | no default
@@ -239,7 +238,6 @@ kind: ServiceDefaults
 metadata: 
   name: <name of the service you are configuring>
   namespace: <Consul Enterprise namespace>
-  partition: <Consul Enterprise admin partition>
 spec: 
   protocol: tcp
   balanceInboundConnnections: exact_balance
@@ -801,13 +799,6 @@ Specifies the Consul namespace that the configuration entry applies to. Refer to
 
 - Default: `default`
 - Data type: string
-
-### `metadata.partition` <Enterprise/>
-
-Specifies the name of the name of the Consul admin partition that the configuration entry applies to. Refer to [Consul Enterprise](/consul/docs/k8s/crds#consul-enterprise) for information about how Consul Enterprise on Kubernetes. Consul OSS distributions ignore the `metadata.partition` configuration.
-
-- Default: `default`
-- Data type: string  
 
 ### `spec`
 

--- a/website/content/docs/services/usage/define-services.mdx
+++ b/website/content/docs/services/usage/define-services.mdx
@@ -145,7 +145,7 @@ If Consul service mesh is enabled in your network, you can define default values
 
 Create a file for the configuration entry and specify the required fields. If you are authoring `service-defaults` in HCL or JSON, the `Kind` and `Name` fields are required. On Kubernetes, the `apiVersion`, `kind`, and `metadata.name` fields are required. Refer to [Service Defaults Reference](/consul/docs/connect/config-entries/service-defaults) for details about the configuration options.
 
-If you use Consul Enterprise, you can also specify the `Namespace` and `Partition` fields to apply the configuration to services in specific network areas. In Kubernetes environments, For Kubernetes environments, the CRD inherits the partition from the cluster hosting the pods. 
+If you use Consul Enterprise, you can also specify the `Namespace` and `Partition` fields to apply the configuration to services in a specific namespace or partition. For Kubernetes environments, the configuration entry is always created in the same partition as the Kubernetes cluster.
 
 ### Consul OSS example
 The following example instructs services named `counting` to send up to `512` concurrent requests to a mesh gateway: 

--- a/website/content/docs/services/usage/define-services.mdx
+++ b/website/content/docs/services/usage/define-services.mdx
@@ -15,7 +15,7 @@ You must tell Consul about the services deployed to your network if you want the
 
 You can define multiple services individually using `service` blocks or group multiple services into the same `services` configuration block. Refer to [Define multiple services in a single file](#define-multiple-services-in-a-single-file) for additional information.
 
-If Consul service mesh is enabled in your network, you can use the `service-defaults` configuration entry to specify default global values for services. The configuraiton entry lets you define common service parameter, such as upstreams, namespaces, and partitions. Refer to [Define service defaults](#define-service-defaults) for additional information.
+If Consul service mesh is enabled in your network, you can use the [service defaults configuration entry](/consul/docs/connect/config-entries/service-defaults) to specify default global values for services. The configuration entry lets you define common service parameter, such as upstreams, namespaces, and partitions. Refer to [Define service defaults](#define-service-defaults) for additional information.
 
 ## Requirements
 
@@ -145,6 +145,9 @@ If Consul service mesh is enabled in your network, you can define default values
 
 Create a file for the configuration entry and specify the required fields. If you are authoring `service-defaults` in HCL or JSON, the `Kind` and `Name` fields are required. On Kubernetes, the `apiVersion`, `kind`, and `metadata.name` fields are required. Refer to [Service Defaults Reference](/consul/docs/connect/config-entries/service-defaults) for details about the configuration options.
 
+If you use Consul Enterprise, you can also specify the `Namespace` and `Partition` fields to apply the configuration to services in specific network areas. In Kubernetes environments, For Kubernetes environments, the CRD inherits the partition from the cluster hosting the pods. 
+
+### Consul OSS example
 The following example instructs services named `counting` to send up to `512` concurrent requests to a mesh gateway: 
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
@@ -198,6 +201,87 @@ spec:
 {
   "Kind": "service-defaults",
   "Name": "counting",
+  "UpstreamConfig": {
+    "Defaults": {
+      "MeshGateway": {
+        "Mode": "local"
+      },
+      "Limits": {
+        "MaxConnections": 512,
+        "MaxPendingRequests": 512,
+        "MaxConcurrentRequests": 512
+      }
+    },
+    "Overrides": [
+      {
+        "Name": "dashboard",
+        "MeshGateway": {
+          "Mode": "remote"
+        }
+      }
+    ]
+  }
+}
+```
+</CodeTabs>
+
+### Consul Enterprise example
+The following example instructs services named `counting` in the `prod` namespace to send up to `512` concurrent requests to a mesh gateway: 
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind = "service-defaults"
+Name = "counting"
+Namespace = "prod"
+
+UpstreamConfig = {
+  Defaults = {
+    MeshGateway = {
+      Mode = "local"
+    }
+    Limits = {
+      MaxConnections = 512
+      MaxPendingRequests = 512
+      MaxConcurrentRequests = 512
+    }
+  }
+
+  Overrides = [
+    {
+      Name = "dashboard"
+      MeshGateway = {
+        Mode = "remote"
+      }
+    }
+  ]
+}
+```
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: counting
+  namespace: prod
+spec:
+  upstreamConfig:
+    defaults:
+      meshGateway:
+        mode: local
+      limits:
+        maxConnections: 512
+        maxPendingRequests: 512
+        maxConcurrentRequests: 512
+    overrides:
+      - name: dashboard
+        meshGateway:
+          mode: remote
+```
+```json
+{
+  "Kind": "service-defaults",
+  "Name": "counting",
+  "Namespace" : "prod",
   "UpstreamConfig": {
     "Defaults": {
       "MeshGateway": {


### PR DESCRIPTION
### Description
We incorrectly documented that the `metadata.partitions` field is supported for some K8s CRDs. This PR removes the field and, in the appropriate context, explains that the pod inherits the partition configuration. 


### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
