### PR TITLE
Fix issue with trust bundle read ACL check.

### DIFF
--- a/.changelog/_4696.txt
+++ b/.changelog/_4696.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: **(Consul Enterprise only)** Fix issue where connect-enabled services with peer upstreams incorrectly required `service:write` access in the `default` namespace to query data, which was too restrictive. Now having `service:write` to any namespace is sufficient to query the peering data.
+```

--- a/agent/proxycfg-glue/trust_bundle.go
+++ b/agent/proxycfg-glue/trust_bundle.go
@@ -33,12 +33,14 @@ type serverTrustBundle struct {
 }
 
 func (s *serverTrustBundle) Notify(ctx context.Context, req *cachetype.TrustBundleReadRequest, correlationID string, ch chan<- proxycfg.UpdateEvent) error {
-	entMeta := structs.NodeEnterpriseMetaInPartition(req.Request.Partition)
+	// Having the ability to write a service in ANY (at least one) namespace should be
+	// sufficient for reading the trust bundle, which is why we use a wildcard.
+	entMeta := acl.NewEnterpriseMetaWithPartition(req.Request.Partition, acl.WildcardName)
 
 	return watch.ServerLocalNotify(ctx, correlationID, s.deps.GetStore,
 		func(ws memdb.WatchSet, store Store) (uint64, *pbpeering.TrustBundleReadResponse, error) {
 			var authzCtx acl.AuthorizerContext
-			authz, err := s.deps.ACLResolver.ResolveTokenAndDefaultMeta(req.Token, entMeta, &authzCtx)
+			authz, err := s.deps.ACLResolver.ResolveTokenAndDefaultMeta(req.Token, &entMeta, &authzCtx)
 			if err != nil {
 				return 0, nil, err
 			}


### PR DESCRIPTION
This commit fixes an issue where trust bundles could not be read by services in a non-default namespace, unless they had excessive ACL permissions given to them.

Prior to this change, `service:write` was required in the default namespace in order to read the trust bundle. Now, `service:write` to a service in any namespace is sufficient.