### PR TITLE
fix starting consul via systemd unit /etc/consul.d does not contain consul.hcl

### DIFF
--- a/.release/linux/package/usr/lib/systemd/system/consul.service
+++ b/.release/linux/package/usr/lib/systemd/system/consul.service
@@ -3,7 +3,7 @@ Description="HashiCorp Consul - A service mesh solution"
 Documentation=https://www.consul.io/
 Requires=network-online.target
 After=network-online.target
-ConditionFileNotEmpty=/etc/consul.d/consul.hcl
+ConditionDirectoryNotEmpty=/etc/consul.d
 
 [Service]
 EnvironmentFile=-/etc/consul.d/consul.env

--- a/.release/linux/package/usr/lib/systemd/system/consul.service
+++ b/.release/linux/package/usr/lib/systemd/system/consul.service
@@ -18,4 +18,3 @@ LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
### Description

I ran into a problem setting up consul for the first time. I'm using this puppet module to install consul via an RPM from hashicorp:
https://github.com/voxpupuli/puppet-consul

The problem isn't specific to puppet--I only mention puppet to illustrate that this isn't a theoretical issue.

Consul refuses to start; from `sudo systemctl status consul`:
```
Condition: start condition failed at Wed 2023-03-15 00:36:02 UTC; 16s ago
           └─ ConditionFileNotEmpty=/etc/consul.d/consul.hcl was not met
```

This is happening because puppet removes the default package-provided files in `/etc/consul.d/` and creates its own `/etc/consul.d/config.json` file. According to the consul documentation, puppet isn't doing anything wrong here--the check in the systemd unit is overly strict.

I'm not _entirely_ sure that I'm changing the correct file here in order to fix the unit file provided via RPM, but this file was the only such systemd unit file I could find.

### Testing & Reproduction steps

1. Install consul from a package (RPM version 1.15.1-1 tested).
2. Remove the default config files in `/etc/consul.d/`
3. Add your own config file of some other name, e.g. `/etc/consul.d/config.json`
4. Attempt to start consul via `sudo systemctl start consul`.


### Links

https://developer.hashicorp.com/consul/docs/agent/config/cli-flags#_config_dir
https://www.freedesktop.org/software/systemd/man/systemd.unit.html

### PR Checklist

* [N/A] updated test coverage
* [N/A] external facing docs updated
* [X] not a security concern

Thanks,
Corey