### PR TITLE
Add validation for apigw creation with no routes

### DIFF
--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -1,6 +1,7 @@
 package structs
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -769,6 +770,9 @@ func (e *APIGatewayConfigEntry) Validate() error {
 		return err
 	}
 
+	if len(e.Listeners) == 0 {
+		return errors.New("api gateway must have at least one listener")
+	}
 	if err := e.validateListenerNames(); err != nil {
 		return err
 	}

--- a/agent/structs/config_entry_gateways_test.go
+++ b/agent/structs/config_entry_gateways_test.go
@@ -1126,6 +1126,13 @@ func TestGatewayService_Addresses(t *testing.T) {
 
 func TestAPIGateway_Listeners(t *testing.T) {
 	cases := map[string]configEntryTestcase{
+		"no listeners defined": {
+			entry: &APIGatewayConfigEntry{
+				Kind: "api-gateway",
+				Name: "api-gw-one",
+			},
+			validateErr: "api gateway must have at least one listener",
+		},
 		"listener name conflict": {
 			entry: &APIGatewayConfigEntry{
 				Kind: "api-gateway",


### PR DESCRIPTION
### Description

To meet the standard ([Gateways require at least one listener defined](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.Gateway)) we need to add checks in to verify that at least one listener is defined.

### Testing & Reproduction steps
```
make dev-build 
consul agent -dev
```
Open another terminal, create a file called gateway.hcl with the following content:
```
Kind = "api-gateway"
Name = "my-gateway"
```
After creating the file, run the following command in the same terminal:
```
consul config write gateway.hcl
```
This should error out, saying "api gateway must have at least one listener"

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
