### PR TITLE
Backport squash structures for config entries

### DIFF
--- a/agent/structs/config_entry_routes.go
+++ b/agent/structs/config_entry_routes.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/consul/acl"
 	"github.com/miekg/dns"
+
+	"github.com/hashicorp/consul/acl"
 )
 
 // BoundRoute indicates a route that has parent gateways which
@@ -443,7 +444,7 @@ type HTTPService struct {
 	// to routing it to the upstream service
 	Filters HTTPFilters
 
-	acl.EnterpriseMeta
+	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 }
 
 func (s HTTPService) ServiceName() ServiceName {

--- a/agent/structs/config_entry_status.go
+++ b/agent/structs/config_entry_status.go
@@ -22,7 +22,7 @@ type ResourceReference struct {
 	// unused, this should be blank.
 	SectionName string
 
-	acl.EnterpriseMeta
+	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 }
 
 func (r *ResourceReference) String() string {


### PR DESCRIPTION
### Description

Adds `squash` tag for `acl.EnterpriseMeta` so fields can unmarshal correctly in enterprise

### Testing & Reproduction steps

N/A

### Links

N/A

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
