### PR TITLE
Add in query options for catalog service existing in a specific namespace when creating service for tests

### DIFF
--- a/test/integration/consul-container/test/gateways/gateway_endpoint_test.go
+++ b/test/integration/consul-container/test/gateways/gateway_endpoint_test.go
@@ -206,8 +206,8 @@ func createService(t *testing.T, cluster *libcluster.Cluster, serviceOpts *libse
 	service, _, err := libservice.CreateAndRegisterStaticServerAndSidecar(node, serviceOpts, containerArgs...)
 	require.NoError(t, err)
 
-	libassert.CatalogServiceExists(t, client, serviceOpts.Name+"-sidecar-proxy", nil)
-	libassert.CatalogServiceExists(t, client, serviceOpts.Name, nil)
+	libassert.CatalogServiceExists(t, client, serviceOpts.Name+"-sidecar-proxy", &api.QueryOptions{Namespace: serviceOpts.Namespace})
+	libassert.CatalogServiceExists(t, client, serviceOpts.Name, &api.QueryOptions{Namespace: serviceOpts.Namespace})
 
 	return service
 }


### PR DESCRIPTION
### Description

This got dropped in between rebases to keep branch up to date for previous PR https://github.com/hashicorp/consul/pull/16627

### Testing & Reproduction steps

In enterprise change the `getNamespace` function to return a non-empty string, without this change gateway tests will fail.

### Links

https://github.com/hashicorp/consul/pull/16627

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
