### PR TITLE
Update the compatible envoy versions

### DIFF
--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -33,7 +33,7 @@ Envoy must be run with the `--max-obj-name-len` option set to `256` or greater f
 
 The following matrix describes Envoy compatibility for the currently supported **n-2 major Consul releases**. For previous Consul version compatibility please view the respective versioned docs for this page.
 
-The `consul-dataplane` binary automatically upgrades Envoy proxies that are compatible with Consul v1.14 and later. 
+The `consul-dataplane` binary automatically upgrades Envoy proxies that are compatible with Consul v1.14 and later on Kubernetes. This does not apply to non-Kubernetes environments where Consul clients manage Envoy. Compatible Envoy versions will be different from Envoy managed by Consul client agents and Consul dataplane. 
 
 ### Envoy and Consul Client Agent
 
@@ -41,8 +41,8 @@ Consul supports **four major Envoy releases** at the beginning of each major Con
 
 | Consul Version      | Compatible Envoy Versions                                                          |
 | ------------------- | -----------------------------------------------------------------------------------|
-| 1.15.x              | 1.25.x, 1.24.x, 1.23.4, 1.22.5                                                     |
-| 1.14.x              | 1.25.x, 1.24.x, 1.23.1, 1.22.5, 1.21.5                                                     |
+| 1.15.x              | 1.25.1, 1.24.2, 1.23.4, 1.22.5                                                     |
+| 1.14.x              | 1.24.0, 1.23.1, 1.22.5, 1.21.5                                                     |
 | 1.13.x              | 1.23.1, 1.22.5, 1.21.5, 1.20.7                                                     |
 
 ### Envoy and Consul Dataplane

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -33,14 +33,16 @@ Envoy must be run with the `--max-obj-name-len` option set to `256` or greater f
 
 The following matrix describes Envoy compatibility for the currently supported **n-2 major Consul releases**. For previous Consul version compatibility please view the respective versioned docs for this page.
 
+~> **Note:** Starting on Consul v1.14, Consul dataplane was implemented to manage Envoy proxies without the use of Consul clients. This means that compatibile Envoy versions for 1.14+ will be automatically upgraded via the consul-dataplane binary. 
+
 ### Envoy and Consul Client Agent
 
 Consul supports **four major Envoy releases** at the beginning of each major Consul release. Consul maintains compatibility with Envoy patch releases for each major version so that users can benefit from bug and security fixes in Envoy. As a policy, Consul will add support for a new major versions of Envoy in a Consul major release. Support for newer versions of Envoy will not be added to existing releases.
 
 | Consul Version      | Compatible Envoy Versions                                                          |
 | ------------------- | -----------------------------------------------------------------------------------|
-| 1.15.x              | 1.25.1, 1.24.2, 1.23.4, 1.22.5                                                     |
-| 1.14.x              | 1.24.0, 1.23.1, 1.22.5, 1.21.5                                                     |
+| 1.15.x              | 1.25.x, 1.24.x, 1.23.4, 1.22.5                                                     |
+| 1.14.x              | 1.25.x, 1.24.x, 1.23.1, 1.22.5, 1.21.5                                                     |
 | 1.13.x              | 1.23.1, 1.22.5, 1.21.5, 1.20.7                                                     |
 
 ### Envoy and Consul Dataplane

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -33,7 +33,7 @@ Envoy must be run with the `--max-obj-name-len` option set to `256` or greater f
 
 The following matrix describes Envoy compatibility for the currently supported **n-2 major Consul releases**. For previous Consul version compatibility please view the respective versioned docs for this page.
 
-~> **Note:** Starting on Consul v1.14, Consul dataplane was implemented to manage Envoy proxies without the use of Consul clients. This means that compatibile Envoy versions for 1.14+ will be automatically upgraded via the consul-dataplane binary. 
+The `consul-dataplane` binary automatically upgrades Envoy proxies that are compatible with Consul v1.14 and later. 
 
 ### Envoy and Consul Client Agent
 


### PR DESCRIPTION


### Description

Under "Envoy and Consul Client Agent" and "Envoy and Consul Dataplane", there seems to be a discrepancy for the supported envoy versions in 1.14.x and 1.15.x. Initially, 1.14.x under "Envoy and Consul Client Agent" showed **1.24.0** and **1.15.x 1.25.1, 1.24.2**. Since consul dataplane is introduced in 1.14.x, I think the document should be updated to align with the "Envoy and Consul Dataplane" section. This avoids confusion on if customers should be upgrading envoy versions on 1.14+, where consul dataplane automatically does it.

### Testing & Reproduction steps



1. In the consul values file use the following images:
```
image: "hashicorp/consul:1.14.4"
imageK8S: "hashicorp/consul-k8s-control-plane:1.0.0"
imageEnvoy: "envoyproxy/envoy:v1.24.2"
```
2. Describe the connect injector pod. You will see the dataplane(consul-dataplane:1.1.0)
```
kubectl describe pod consul-connect-injector-757cd5d7d9-z9bq5 -n consul

Command:
/bin/sh
-ec
consul-k8s-control-plane inject-connect \
-log-level=info \
-log-json=false \
-default-inject=false \
-consul-image="hashicorp/consul:1.14.4" \
**-consul-dataplane-image="hashicorp/consul-dataplane:1.1.0"** \
-consul-k8s-image="hashicorp/consul-k8s-control-plane:1.0.0" \
-release-name="consul" \
-release-namespace="consul" \
-resource-prefix=consul \
-listen=:8080 \
-default-enable-transparent-proxy=true \
-enable-cni=false \
-transparent-proxy-default-overwrite-probes=true \
-enable-consul-dns=true \
-default-enable-metrics=false \
-enable-gateway-metrics=true \
-default-enable-metrics-merging=false \
-default-merged-metrics-port=20100 \
-default-prometheus-scrape-port=20200 \
-default-prometheus-scrape-path="/metrics" \
-acl-auth-method="consul-k8s-auth-method" \
-allow-k8s-namespace="*" \
-tls-cert-dir=/etc/connect-injector/certs \
-default-envoy-proxy-concurrency=2 \
-init-container-memory-limit=150Mi \
-init-container-memory-request=25Mi \
-init-container-cpu-limit=50m \
-init-container-cpu-request=50m \
-enable-auto-encrypt \

```
3. Create a service like [counting](https://developer.hashicorp.com/consul/tutorials/kubernetes/kubernetes-kind#deploy-two-demo-services). The dashboard service is not needed.
4. Get the envoy config dump for the service:
 kubectl exec pod/(counting-pod-name) -c envoy-sidecar -- wget -O http://localhost:19000/config_dump

5. Look for the envoy version, you'll see 1.25.

```
{
"configs": [
{
"@type": "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump",
"bootstrap": {
"node": {
"id": "counting-7547ff85f7-4w48v-counting-sidecar-proxy",
"cluster": "counting",
"metadata": {
"partition": "default",
"namespace": "default",
"nodename": "ip-172-23-99-908.ec2.internal-virtual" }, "useragentname": "envoy", "useragentbuildversion": {
"version": {
"majornumber": 1, "minornumber": 25,
"patch": 1
},
```

 So regardless of hardcoding the envoy version in the values.yaml file, the dataplane will be managing it. 


### Links



Referring to the following [document](https://developer.hashicorp.com/consul/docs/connect/proxies/envoy#envoy-and-consul-client-agent)



### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
