### PR TITLE
fix: add AccessorID property to PUT token request

### DIFF
--- a/.changelog/16660.txt
+++ b/.changelog/16660.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix PUT token request with adding missed AccessorID property to requestBody
+```

--- a/ui/packages/consul-ui/app/adapters/token.js
+++ b/ui/packages/consul-ui/app/adapters/token.js
@@ -87,6 +87,7 @@ export default class TokenAdapter extends Adapter {
         Description: serialized.Description,
         Policies: serialized.Policies,
         Roles: serialized.Roles,
+        AccessorID: serialized.AccessorID,
         ServiceIdentities: serialized.ServiceIdentities,
         NodeIdentities: serialized.NodeIdentities,
         Local: serialized.Local,

--- a/ui/packages/consul-ui/app/adapters/token.js
+++ b/ui/packages/consul-ui/app/adapters/token.js
@@ -85,9 +85,9 @@ export default class TokenAdapter extends Adapter {
 
       ${{
         Description: serialized.Description,
+        AccessorID: serialized.AccessorID,
         Policies: serialized.Policies,
         Roles: serialized.Roles,
-        AccessorID: serialized.AccessorID,
         ServiceIdentities: serialized.ServiceIdentities,
         NodeIdentities: serialized.NodeIdentities,
         Local: serialized.Local,


### PR DESCRIPTION
### Description
Triggering saving of token responds with 'Token Accessor ID in URL and payload do not match' error. 
The reason is the AccessorID property has not been included to requestBody. there might be some changes on backend side, which updated requestBody structure to include AccessorID for token PUT endpoint. 

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps
https://user-images.githubusercontent.com/10027860/225770124-7b02a50d-6264-4134-a943-8233a9721526.mov

Testing & Reproduction steps
- run `make ui-docker` to build the ui image
- run `make dev-docker`
- clone `https://github.com/WenInCode/consul-setup`
- in the `consul-setup` repo go to the `setups/peering directory`
- run `docker-compose up`
- run `yarn setup:peerings`
- Go to the token details page and press 'Save' button

### Links
https://hashicorp.atlassian.net/browse/CC-4515

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
