### PR TITLE
Fix incorrect links on Envoy extensions documentation

### DIFF
--- a/website/content/docs/connect/proxies/envoy-extensions/index.mdx
+++ b/website/content/docs/connect/proxies/envoy-extensions/index.mdx
@@ -25,8 +25,8 @@ Envoy extensions enable additional service mesh functionality in Consul by chang
 
 ### Lua
 
-The `lua` Envoy extension enables HTTP Lua filters in your Consul Envoy proxies. It allows you to run Lua scripts during Envoy requests and responses from Consul-generated Envoy resources. Refer to the [`lua`](/consul/docs/proxies/envoy-extensions/usage/lua) documentation for more information.
+The `lua` Envoy extension enables HTTP Lua filters in your Consul Envoy proxies. It allows you to run Lua scripts during Envoy requests and responses from Consul-generated Envoy resources. Refer to the [`lua`](/consul/docs/connect/proxies/envoy-extensions/usage/lua) documentation for more information.
 
 ### Lambda
 
-The `lambda` Envoy extension enables services to make requests to AWS Lambda functions through the mesh as if they are a normal part of the Consul catalog. Refer to the [`lambda`](/consul/docs/proxies/envoy-extensions/usage/lambda) documentation for more information.
+The `lambda` Envoy extension enables services to make requests to AWS Lambda functions through the mesh as if they are a normal part of the Consul catalog. Refer to the [`lambda`](/consul/docs/connect/proxies/envoy-extensions/usage/lambda) documentation for more information.


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

Incorrect links to Lua and Lambda extension documentation on Envoy extensions page.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

N/A

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

N/A

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
