### PR TITLE
[release/1.14.x] peering: peering partition failover fixes

### DIFF
--- a/.changelog/16693.txt
+++ b/.changelog/16693.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: Fixes a bug where the importing partition was not added to peered failover targets, which causes issues when the importing partition is a non-default partition.
+```

--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -462,6 +462,9 @@ func (s *handlerUpstreams) watchUpstreamTarget(ctx context.Context, snap *Config
 
 	if opts.peer != "" {
 		uid = NewUpstreamIDFromTargetID(opts.chainID)
+		// chainID has the partition stripped. However, when a target is in a cluster peer, the partition should be set
+		// to the local partition (i.e chain.Partition), since the peered target is imported into the local partition.
+		uid.OverridePartition(opts.entMeta.PartitionOrDefault())
 		correlationID = upstreamPeerWatchIDPrefix + uid.String()
 	}
 


### PR DESCRIPTION
manual release/1.14.x backport due to backport from 1.15 not working

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
