### PR TITLE
Fix 'device' typo in intro doc

### DIFF
--- a/website/content/docs/intro/index.mdx
+++ b/website/content/docs/intro/index.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # What is Consul?
 
-HashiCorp Consul is a service networking solution that enables teams to manage secure network connectivity between services and across on-prem and multi-cloud environments and runtimes. Consul offers service discovery, service mesh, traffic management, and automated updates to network infrastructure device. You can use these features individually or together in a single Consul deployment.
+HashiCorp Consul is a service networking solution that enables teams to manage secure network connectivity between services and across on-prem and multi-cloud environments and runtimes. Consul offers service discovery, service mesh, traffic management, and automated updates to network infrastructure devices. You can use these features individually or together in a single Consul deployment.
 
 > **Hands-on**: Complete the Getting Started tutorials to learn how to deploy Consul:
 - [Get Started on Kubernetes](/consul/tutorials/get-started-kubernetes)


### PR DESCRIPTION
### Description

One-character typo fix in the docs I noticed when reading the intro.
