### PR TITLE
add extra resiliency to snapshot restore test

### DIFF
--- a/test/integration/consul-container/test/snapshot/snapshot_restore_test.go
+++ b/test/integration/consul-container/test/snapshot/snapshot_restore_test.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"fmt"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
 	libtopology "github.com/hashicorp/consul/test/integration/consul-container/libs/topology"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
@@ -79,6 +80,9 @@ func testSnapShotRestoreForLogStore(t *testing.T, logStore libcluster.LogStore) 
 
 	libcluster.WaitForLeader(t, cluster2, client2)
 
+	leader, err := cluster2.Leader()
+	require.NoError(t, err)
+
 	followers, err := cluster2.Followers()
 	require.NoError(t, err)
 	require.Len(t, followers, 2)
@@ -86,6 +90,17 @@ func testSnapShotRestoreForLogStore(t *testing.T, logStore libcluster.LogStore) 
 	// use a follower api client and set `AllowStale` to true
 	// to test the follower snapshot install code path as well.
 	fc := followers[0].GetClient()
+	lc := leader.GetClient()
+
+	retry.Run(t, func(r *retry.R) {
+		self, err := lc.Agent().Self()
+		require.NoError(r, err)
+		LeaderLogIndex := self["Stats"]["raft"].(map[string]interface{})["last_log_index"].(string)
+		self, err = fc.Agent().Self()
+		require.NoError(r, err)
+		followerLogIndex := self["Stats"]["raft"].(map[string]interface{})["last_log_index"].(string)
+		require.Equal(r, LeaderLogIndex, followerLogIndex)
+	})
 
 	for i := 0; i < 100; i++ {
 		kv, _, err := fc.KV().Get(fmt.Sprintf("key-%d", i), &api.QueryOptions{AllowStale: true})


### PR DESCRIPTION
### Description

This add a check before reading the KV entries from the new cluster (restored from a snapshot) in the snapshot restore test. The extra check would verify that the follower is caught up with the leader before reading logs as we would like to read those KV entry performing a stale read from the follower to ensure that the logs were replicated to the follower correctly.

This is to avoid some flakes observed in CI as [this](https://app.circleci.com/pipelines/github/hashicorp/consul/54329/workflows/b15eff84-ef76-48db-ace3-5cbf5ab14c79/jobs/1284077/tests#failed-test-1).

