### PR TITLE
fix: gracefully fail on invalid port number

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -455,6 +455,14 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 	sidecarMaxPort := b.portVal("ports.sidecar_max_port", c.Ports.SidecarMaxPort)
 	exposeMinPort := b.portVal("ports.expose_min_port", c.Ports.ExposeMinPort)
 	exposeMaxPort := b.portVal("ports.expose_max_port", c.Ports.ExposeMaxPort)
+	if serverPort <= 0 {
+		return RuntimeConfig{}, fmt.Errorf(
+			"server-port must be greater than zero")
+	}
+	if serfPortLAN <= 0 {
+		return RuntimeConfig{}, fmt.Errorf(
+			"serf-lan-port must be greater than zero")
+	}
 	if proxyMaxPort < proxyMinPort {
 		return RuntimeConfig{}, fmt.Errorf(
 			"proxy_min_port must be less than proxy_max_port. To disable, set both to zero.")


### PR DESCRIPTION
### Description
Fail gracefully if the server port provided is 0.

Consul allows some ports, like gRPC, https, to be -1, meaning the ports are disabled. However, if the server port (8300) or 
serf port is disabled, consul seems not working properly. So this PR disallows disabling these 2 ports.

### Links
https://github.com/hashicorp/consul/issues/16715

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
