### PR TITLE
Remove version bump from CRT workflow

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -129,21 +129,9 @@ event "post-publish-website" {
     on = "always"
   }
 }
-event "bump-version" {
-  depends = ["post-publish-website"]
-  action "bump-version" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "bump-version"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
 
 event "update-ironbank" {
-  depends = ["bump-version"]
+  depends = ["post-publish-website"]
   action "update-ironbank" {
     organization = "hashicorp"
     repository = "crt-workflows-common"


### PR DESCRIPTION
### Description
This part of the workflow bumps the version to reflect the next patch release ([example](https://github.com/hashicorp/consul/commit/b42941fd5b40da72d121482047bdb0ebcbd1ad91)); however, we use a specific branch for each patch release and so never wind up cutting a release directly from the `release/1.15.x` (for example) where this is intended to work.

The end result is that our `release/1.15.1` branch gets bumped to have a version of `1.15.2` which is non-sensical.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

> Emily Neil
hey Chris and Nathan! yeah the CRT automation for version bumping was designed specifically for a singular release branch system, so it can't really support listening for a release and updating 1.15.x  at the moment unfortunately. I think the best work around for the moment would be to remove the bump-version block in the ci.hcl to turn off that automatic bumping behaviour, and we can cut a ticket to support updating branches like 1.15.x

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
