### PR TITLE
fix: remove unused tenancy category from rate limit spec

### DIFF
--- a/agent/consul/rate/handler.go
+++ b/agent/consul/rate/handler.go
@@ -112,7 +112,6 @@ const (
 	OperationCategoryHealth          OperationCategory = "Health"
 	OperationCategoryIntention       OperationCategory = "Intention"
 	OperationCategoryKV              OperationCategory = "KV"
-	OperationCategoryTenancy         OperationCategory = "Tenancy"
 	OperationCategoryPreparedQuery   OperationCategory = "PreparedQuery"
 	OperationCategorySession         OperationCategory = "Session"
 	OperationCategoryStatus          OperationCategory = "Status"


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
@dhiaayachi  noticed `Tenancy` category is not referred anywhere which prompted me to look into this. 

The only place I found tenancy referred is in gRPC `ResourceService`. Resource category is already added to the relevant proto file and is included in the `OperationCategory` struct hence we don't need Tenancy.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

Resource proto file: https://github.com/hashicorp/consul-enterprise/blob/main/proto-public/pbresource/resource.proto

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [ ] ~not a security concern~
