### PR TITLE
log warning about CA expiring sooner

### DIFF
--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -125,21 +125,25 @@ func (m CertExpirationMonitor) Monitor(ctx context.Context) error {
 		}
 
 		if expiresSoon(lifetime, untilAfter) {
-			key := strings.Join(m.Key, "")
-			rootKey := strings.Join(metricsKeyMeshRootCAExpiry, "")
-			signingKey := strings.Join(metricsKeyMeshActiveSigningCAExpiry, "")
+			key := strings.Join(m.Key, ":")
 			switch key {
-			case rootKey:
+			case "mesh:active-root-ca:expiry":
 				logger.Warn("root certificate will expire soon",
 					"time_to_expiry", untilAfter,
 					"expiration", time.Now().Add(untilAfter),
-					"suggested_action", "rotate the root certificate",
+					"suggested_action", "manually rotate the root certificate",
 				)
-			case signingKey:
+			case "mesh:active-signing-ca:expiry":
 				logger.Warn("signing (intermediate) certificate will expire soon",
 					"time_to_expiry", untilAfter,
 					"expiration", time.Now().Add(untilAfter),
 					"suggested_action", "check consul logs for rotation issues",
+				)
+			case "agent:tls:cert:expiry":
+				logger.Warn("agent TLS certificate will expire soon",
+					"time_to_expiry", untilAfter,
+					"expiration", time.Now().Add(untilAfter),
+					"suggested_action", "manually rotate this agent's certificate",
 				)
 			}
 		}

--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -104,8 +104,10 @@ type CertExpirationMonitor struct {
 	// then the metrics will expire before they are emitted again.
 	Labels []metrics.Label
 	Logger hclog.Logger
-	// Query is called at each interval. It should return the duration until the
-	// certificate expires, or an error if the query failed.
+	// Query is called at each interval. It should return 2 durations, the full
+	// lifespan of the certificate (NotBefore -> NotAfter) and the duration
+	// until the certificate expires (Now -> NotAfter), or an error if the
+	// query failed.
 	Query func() (time.Duration, time.Duration, error)
 }
 

--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -172,8 +172,8 @@ func initLeaderMetrics() {
 
 // expiresSoon checks to see if we are close enough to the cert expiring that
 // we should send out a WARN log message.
-// It defaults to returning true if the cert will expire within 28 days or 40%
-// of the certs total duration, whichever is shorter.
+// It returns true if the cert will expire within 28 days or 40% of the
+// certificate's total duration (whichever is shorter).
 func expiresSoon(lifetime, untilAfter time.Duration) bool {
 	defaultPeriod := 28 * (24 * time.Hour) // 28 days
 	fortyPercent := (lifetime / 10) * 4    // 40% of total duration

--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -119,7 +119,8 @@ func (m CertExpirationMonitor) Monitor(ctx context.Context) error {
 			return
 		}
 
-		if d < 24*time.Hour {
+		thirtyDays := 30 * (24 * time.Hour)
+		if d < thirtyDays {
 			logger.Warn("certificate will expire soon",
 				"time_to_expiry", d, "expiration", time.Now().Add(d))
 		}

--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -125,9 +125,19 @@ func (m CertExpirationMonitor) Monitor(ctx context.Context) error {
 		}
 
 		if expiresSoon(lifetime, notAfter) {
-			logger.Warn("certificate will expire soon",
-				"time_to_expiry", notAfter,
-				"expiration", time.Now().Add(notAfter))
+			key := strings.Join(m.Key, "")
+			rootKey := strings.Join(metricsKeyMeshRootCAExpiry, "")
+			signingKey := strings.Join(metricsKeyMeshActiveSigningCAExpiry, "")
+			switch key {
+			case rootKey:
+				logger.Warn("root certificate will expire soon",
+					"time_to_expiry", notAfter,
+					"expiration", time.Now().Add(notAfter))
+			case signingKey:
+				logger.Warn("signing (intermediate) certificate will expire soon",
+					"time_to_expiry", notAfter,
+					"expiration", time.Now().Add(notAfter))
+			}
 		}
 
 		expiry := notAfter / time.Second

--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -132,11 +132,15 @@ func (m CertExpirationMonitor) Monitor(ctx context.Context) error {
 			case rootKey:
 				logger.Warn("root certificate will expire soon",
 					"time_to_expiry", untilAfter,
-					"expiration", time.Now().Add(untilAfter))
+					"expiration", time.Now().Add(untilAfter),
+					"suggested_action", "rotate the root certificate",
+				)
 			case signingKey:
 				logger.Warn("signing (intermediate) certificate will expire soon",
 					"time_to_expiry", untilAfter,
-					"expiration", time.Now().Add(untilAfter))
+					"expiration", time.Now().Add(untilAfter),
+					"suggested_action", "check consul logs for rotation issues",
+				)
 			}
 		}
 

--- a/agent/consul/leader_metrics_test.go
+++ b/agent/consul/leader_metrics_test.go
@@ -13,25 +13,25 @@ const (
 
 func TestExpiresSoon(t *testing.T) {
 	// ExpiresSoon() should return true if 'notAfter' is <= 28 days
-	// OR if notBefore+notAfter is < 70 days and notAfter <= 40% of that
+	// OR if 40% of lifetime if it is less than 28 days
 	testCases := []struct {
-		name                string
-		notBefore, notAfter time.Duration
-		expiresSoon         bool
+		name               string
+		lifetime, notAfter time.Duration
+		expiresSoon        bool
 	}{
-		{name: "base-pass", notBefore: year, notAfter: year, expiresSoon: false},
-		{name: "base-expire", notBefore: year, notAfter: (day * 27), expiresSoon: true},
-		{name: "expires", notBefore: (day * 50), notAfter: (day * 20), expiresSoon: true},
-		{name: "passes", notBefore: (day * 20), notAfter: (day * 50), expiresSoon: false},
-		{name: "just-expires", notBefore: (day * 43), notAfter: (day * 27), expiresSoon: true},
-		{name: "just-passes", notBefore: (day * 27), notAfter: (day * 43), expiresSoon: false},
-		{name: "40%-expire", notBefore: (day * 20), notAfter: (day * 10), expiresSoon: true},
-		{name: "40%-pass", notBefore: (day * 18), notAfter: (day * 12), expiresSoon: false},
+		{name: "base-pass", lifetime: year, notAfter: year, expiresSoon: false},
+		{name: "base-expire", lifetime: year, notAfter: (day * 27), expiresSoon: true},
+		{name: "expires", lifetime: (day * 70), notAfter: (day * 20), expiresSoon: true},
+		{name: "passes", lifetime: (day * 70), notAfter: (day * 50), expiresSoon: false},
+		{name: "just-expires", lifetime: (day * 70), notAfter: (day * 27), expiresSoon: true},
+		{name: "just-passes", lifetime: (day * 70), notAfter: (day * 43), expiresSoon: false},
+		{name: "40%-expire", lifetime: (day * 30), notAfter: (day * 10), expiresSoon: true},
+		{name: "40%-pass", lifetime: (day * 30), notAfter: (day * 12), expiresSoon: false},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fmt.Print(tc.name + ": ")
-			if expiresSoon(tc.notBefore, tc.notAfter) != tc.expiresSoon {
+			if expiresSoon(tc.lifetime, tc.notAfter) != tc.expiresSoon {
 				t.Errorf("test case failed, should return `%t`", tc.expiresSoon)
 			}
 		})

--- a/agent/consul/leader_metrics_test.go
+++ b/agent/consul/leader_metrics_test.go
@@ -1,0 +1,39 @@
+package consul
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+const (
+	day  = time.Hour * 24
+	year = day * 365
+)
+
+func TestExpiresSoon(t *testing.T) {
+	// ExpiresSoon() should return true if 'after' is <= 28 days
+	// OR if before+after is < 70 days and after <= 40% of that
+	testCases := []struct {
+		name          string
+		before, after time.Duration
+		expiresSoon   bool
+	}{
+		{name: "base-pass", before: year, after: year, expiresSoon: false},
+		{name: "base-expire", before: year, after: (day * 27), expiresSoon: true},
+		{name: "expires", before: (day * 50), after: (day * 20), expiresSoon: true},
+		{name: "passes", before: (day * 20), after: (day * 50), expiresSoon: false},
+		{name: "just-expires", before: (day * 43), after: (day * 27), expiresSoon: true},
+		{name: "just-passes", before: (day * 27), after: (day * 43), expiresSoon: false},
+		{name: "40%-expire", before: (day * 20), after: (day * 10), expiresSoon: true},
+		{name: "40%-pass", before: (day * 18), after: (day * 12), expiresSoon: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fmt.Print(tc.name + ": ")
+			if expiresSoon(tc.before, tc.after) != tc.expiresSoon {
+				t.Errorf("test case failed, should return `%t`", tc.expiresSoon)
+			}
+		})
+	}
+}

--- a/agent/consul/leader_metrics_test.go
+++ b/agent/consul/leader_metrics_test.go
@@ -12,26 +12,26 @@ const (
 )
 
 func TestExpiresSoon(t *testing.T) {
-	// ExpiresSoon() should return true if 'after' is <= 28 days
-	// OR if before+after is < 70 days and after <= 40% of that
+	// ExpiresSoon() should return true if 'notAfter' is <= 28 days
+	// OR if notBefore+notAfter is < 70 days and notAfter <= 40% of that
 	testCases := []struct {
-		name          string
-		before, after time.Duration
-		expiresSoon   bool
+		name                string
+		notBefore, notAfter time.Duration
+		expiresSoon         bool
 	}{
-		{name: "base-pass", before: year, after: year, expiresSoon: false},
-		{name: "base-expire", before: year, after: (day * 27), expiresSoon: true},
-		{name: "expires", before: (day * 50), after: (day * 20), expiresSoon: true},
-		{name: "passes", before: (day * 20), after: (day * 50), expiresSoon: false},
-		{name: "just-expires", before: (day * 43), after: (day * 27), expiresSoon: true},
-		{name: "just-passes", before: (day * 27), after: (day * 43), expiresSoon: false},
-		{name: "40%-expire", before: (day * 20), after: (day * 10), expiresSoon: true},
-		{name: "40%-pass", before: (day * 18), after: (day * 12), expiresSoon: false},
+		{name: "base-pass", notBefore: year, notAfter: year, expiresSoon: false},
+		{name: "base-expire", notBefore: year, notAfter: (day * 27), expiresSoon: true},
+		{name: "expires", notBefore: (day * 50), notAfter: (day * 20), expiresSoon: true},
+		{name: "passes", notBefore: (day * 20), notAfter: (day * 50), expiresSoon: false},
+		{name: "just-expires", notBefore: (day * 43), notAfter: (day * 27), expiresSoon: true},
+		{name: "just-passes", notBefore: (day * 27), notAfter: (day * 43), expiresSoon: false},
+		{name: "40%-expire", notBefore: (day * 20), notAfter: (day * 10), expiresSoon: true},
+		{name: "40%-pass", notBefore: (day * 18), notAfter: (day * 12), expiresSoon: false},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fmt.Print(tc.name + ": ")
-			if expiresSoon(tc.before, tc.after) != tc.expiresSoon {
+			if expiresSoon(tc.notBefore, tc.notAfter) != tc.expiresSoon {
 				t.Errorf("test case failed, should return `%t`", tc.expiresSoon)
 			}
 		})

--- a/agent/consul/leader_metrics_test.go
+++ b/agent/consul/leader_metrics_test.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -30,7 +29,6 @@ func TestExpiresSoon(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fmt.Print(tc.name + ": ")
 			if expiresSoon(tc.lifetime, tc.untilAfter) != tc.expiresSoon {
 				t.Errorf("test case failed, should return `%t`", tc.expiresSoon)
 			}

--- a/agent/consul/leader_metrics_test.go
+++ b/agent/consul/leader_metrics_test.go
@@ -12,26 +12,26 @@ const (
 )
 
 func TestExpiresSoon(t *testing.T) {
-	// ExpiresSoon() should return true if 'notAfter' is <= 28 days
+	// ExpiresSoon() should return true if 'untilAfter' is <= 28 days
 	// OR if 40% of lifetime if it is less than 28 days
 	testCases := []struct {
-		name               string
-		lifetime, notAfter time.Duration
-		expiresSoon        bool
+		name                 string
+		lifetime, untilAfter time.Duration
+		expiresSoon          bool
 	}{
-		{name: "base-pass", lifetime: year, notAfter: year, expiresSoon: false},
-		{name: "base-expire", lifetime: year, notAfter: (day * 27), expiresSoon: true},
-		{name: "expires", lifetime: (day * 70), notAfter: (day * 20), expiresSoon: true},
-		{name: "passes", lifetime: (day * 70), notAfter: (day * 50), expiresSoon: false},
-		{name: "just-expires", lifetime: (day * 70), notAfter: (day * 27), expiresSoon: true},
-		{name: "just-passes", lifetime: (day * 70), notAfter: (day * 43), expiresSoon: false},
-		{name: "40%-expire", lifetime: (day * 30), notAfter: (day * 10), expiresSoon: true},
-		{name: "40%-pass", lifetime: (day * 30), notAfter: (day * 12), expiresSoon: false},
+		{name: "base-pass", lifetime: year, untilAfter: year, expiresSoon: false},
+		{name: "base-expire", lifetime: year, untilAfter: (day * 27), expiresSoon: true},
+		{name: "expires", lifetime: (day * 70), untilAfter: (day * 20), expiresSoon: true},
+		{name: "passes", lifetime: (day * 70), untilAfter: (day * 50), expiresSoon: false},
+		{name: "just-expires", lifetime: (day * 70), untilAfter: (day * 27), expiresSoon: true},
+		{name: "just-passes", lifetime: (day * 70), untilAfter: (day * 43), expiresSoon: false},
+		{name: "40%-expire", lifetime: (day * 30), untilAfter: (day * 10), expiresSoon: true},
+		{name: "40%-pass", lifetime: (day * 30), untilAfter: (day * 12), expiresSoon: false},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fmt.Print(tc.name + ": ")
-			if expiresSoon(tc.lifetime, tc.notAfter) != tc.expiresSoon {
+			if expiresSoon(tc.lifetime, tc.untilAfter) != tc.expiresSoon {
 				t.Errorf("test case failed, should return `%t`", tc.expiresSoon)
 			}
 		})

--- a/agent/metrics.go
+++ b/agent/metrics.go
@@ -30,17 +30,19 @@ func tlsCertExpirationMonitor(c *tlsutil.Configurator, logger hclog.Logger) cons
 	return consul.CertExpirationMonitor{
 		Key:    metricsKeyAgentTLSCertExpiry,
 		Logger: logger,
-		Query: func() (time.Duration, error) {
+		Query: func() (time.Duration, time.Duration, error) {
 			raw := c.Cert()
 			if raw == nil {
-				return 0, fmt.Errorf("tls not enabled")
+				return 0, 0, fmt.Errorf("tls not enabled")
 			}
 
 			cert, err := x509.ParseCertificate(raw.Certificate[0])
 			if err != nil {
-				return 0, fmt.Errorf("failed to parse agent tls cert: %w", err)
+				return 0, 0, fmt.Errorf("failed to parse agent tls cert: %w", err)
 			}
-			return time.Until(cert.NotAfter), nil
+
+			lifetime := time.Since(cert.NotBefore) + time.Until(cert.NotAfter)
+			return lifetime, time.Until(cert.NotAfter), nil
 		},
 	}
 }


### PR DESCRIPTION
The old setting of 24 hours was not enough time to deal with an expiring CA. Changing it to 30 days to give a reasonable amount of time to do the rotation.