### PR TITLE
refactor build workflows to contain universal logic for oss v. ent builds

### DIFF
--- a/.github/workflows/build-distros.yml
+++ b/.github/workflows/build-distros.yml
@@ -8,8 +8,25 @@ permissions:
   contents: read
 
 jobs:
+  setup: # Detect oss v. ent and set runner type
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      runner-standard: ${{ steps.setup-outputs.outputs.runner-standard }}
+    steps:
+    - id: setup-outputs
+      name: Setup outputs
+      run: |
+        github_repository="${{ github.repository }}"
+        if [ "${github_repository##*/}" == "consul-enterprise" ] ; then
+          echo 'runner-standard=["self-hosted","linux"]' >> $GITHUB_OUTPUT
+          echo 'enterprise=1' >> $GITHUB_OUTPUT
+        else
+          echo 'runner-standard=["ubuntu-22.04"]' >> $GITHUB_OUTPUT
+          echo 'enterprise=' >> $GITHUB_OUTPUT
+        fi
   check-go-mod:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(needs.setup.outputs.runner-standard) }}
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # pin@v3.5.0
@@ -27,7 +44,7 @@ jobs:
     needs: check-go-mod
     env:
       XC_OS: "freebsd linux windows"
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(needs.setup.outputs.runner-standard) }}
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # pin@v3.5.0
@@ -43,7 +60,7 @@ jobs:
     needs: check-go-mod
     env:
       XC_OS: "darwin freebsd linux solaris windows"
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(needs.setup.outputs.runner-standard) }}
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # pin@v3.5.0
@@ -57,7 +74,7 @@ jobs:
 
   build-arm:
     needs: check-go-mod
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(needs.setup.outputs.runner-standard) }}
     env:
       CGO_ENABLED: 1
       GOOS: linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,27 @@ env:
   METADATA: oss
 
 jobs:
-  set-product-version:
+  setup: # Detect oss v. ent and set runner type
+    name: Setup
     runs-on: ubuntu-latest
+    outputs:
+      runner-standard: ${{ steps.setup-outputs.outputs.runner-standard }}
+    steps:
+    - id: setup-outputs
+      name: Setup outputs
+      run: |
+        github_repository="${{ github.repository }}"
+        if [ "${github_repository##*/}" == "consul-enterprise" ] ; then
+          echo 'linux-runner-standard=["self-hosted","linux"]' >> $GITHUB_OUTPUT
+          echo 'macos-runner-standard-macos=["self-hosted","ondemand","os=macos"]' >> $GITHUB_OUTPUT
+          echo 'enterprise=1' >> $GITHUB_OUTPUT
+        else
+          echo 'linux-runner-standard=["ubuntu-latest"]' >> $GITHUB_OUTPUT
+          echo 'macos-runner-standard=["macos-latest"]' >> $GITHUB_OUTPUT
+          echo 'enterprise=' >> $GITHUB_OUTPUT
+        fi
+  set-product-version:
+    runs-on: ${{ fromJSON(needs.setup.outputs.linux-runner-standard) }}
     outputs:
       product-version: ${{ steps.set-product-version.outputs.product-version }}
       base-product-version: ${{ steps.set-product-version.outputs.base-product-version }}
@@ -46,7 +65,7 @@ jobs:
           "
   validate-outputs:
     needs: set-product-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.linux-runner-standard) }}
     steps:
       - name: Validate Outputs
         run: |
@@ -58,7 +77,7 @@ jobs:
           echo "Ldflags: ${{ needs.set-product-version.outputs.shared-ldflags }}"
   generate-metadata-file:
     needs: set-product-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.linux-runner-standard) }}
     outputs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
@@ -78,7 +97,7 @@ jobs:
 
   build:
     needs: set-product-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.linux-runner-standard) }}
     strategy:
       matrix:
         include:
@@ -174,7 +193,7 @@ jobs:
 
   build-darwin:
     needs: set-product-version
-    runs-on: macos-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.macos-runner-standard) }}
     strategy:
       matrix:
         goos: [ darwin ]
@@ -226,7 +245,7 @@ jobs:
     needs:
       - set-product-version
       - build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.linux-runner-standard) }}
     strategy:
       matrix:
         arch: ["386", "amd64", "arm", "arm64"]
@@ -263,7 +282,7 @@ jobs:
     needs:
       - set-product-version
       - build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.linux-runner-standard) }}
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.set-product-version.outputs.product-version}}
@@ -283,7 +302,7 @@ jobs:
     needs:
       - set-product-version
       - build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.linux-runner-standard) }}
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.set-product-version.outputs.product-version}}
@@ -315,7 +334,7 @@ jobs:
     needs:
       - set-product-version
       - build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.linux-runner-standard) }}
     strategy:
       matrix:
         arch: ["386", "amd64", "arm", "arm64"]
@@ -347,7 +366,7 @@ jobs:
     needs:
       - set-product-version
       - build-darwin
-    runs-on: macos-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.macos-runner-standard) }}
     strategy:
       fail-fast: true
     env:
@@ -373,7 +392,7 @@ jobs:
     needs:
       - build
       - set-product-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.linux-runner-standard) }}
     strategy:
       matrix:
         arch: ["i386", "amd64", "armhf", "arm64"]
@@ -410,7 +429,7 @@ jobs:
     needs:
       - build
       - set-product-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.linux-runner-standard) }}
     strategy:
       matrix:
         # TODO(eculver): re-enable when there is a smaller verification container available


### PR DESCRIPTION

### Description

As part of our migration effort off of circleci, this adds in workflow logic that detects whether we are working in our OSS or enterprise repos in order to select from the appropriate github runner pools. This allows us to maintain the same workflow code in both repositories, easing automerging between OSS and ent.

