### PR TITLE
add failover policy to ProxyConfigEntry in api

### DIFF
--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -312,15 +312,16 @@ func (s *ServiceConfigEntry) GetModifyIndex() uint64     { return s.ModifyIndex 
 type ProxyConfigEntry struct {
 	Kind             string
 	Name             string
-	Partition        string                  `json:",omitempty"`
-	Namespace        string                  `json:",omitempty"`
-	Mode             ProxyMode               `json:",omitempty"`
-	TransparentProxy *TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
-	Config           map[string]interface{}  `json:",omitempty"`
-	MeshGateway      MeshGatewayConfig       `json:",omitempty" alias:"mesh_gateway"`
-	Expose           ExposeConfig            `json:",omitempty"`
-	AccessLogs       *AccessLogsConfig       `json:",omitempty" alias:"access_logs"`
-	EnvoyExtensions  []EnvoyExtension        `json:",omitempty" alias:"envoy_extensions"`
+	Partition        string                         `json:",omitempty"`
+	Namespace        string                         `json:",omitempty"`
+	Mode             ProxyMode                      `json:",omitempty"`
+	TransparentProxy *TransparentProxyConfig        `json:",omitempty" alias:"transparent_proxy"`
+	Config           map[string]interface{}         `json:",omitempty"`
+	MeshGateway      MeshGatewayConfig              `json:",omitempty" alias:"mesh_gateway"`
+	Expose           ExposeConfig                   `json:",omitempty"`
+	AccessLogs       *AccessLogsConfig              `json:",omitempty" alias:"access_logs"`
+	EnvoyExtensions  []EnvoyExtension               `json:",omitempty" alias:"envoy_extensions"`
+	FailoverPolicy   *ServiceResolverFailoverPolicy `json:",omitempty" alias:"failover_policy"`
 
 	Meta        map[string]string `json:",omitempty"`
 	CreateIndex uint64

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -408,6 +408,9 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"Type": "file",
 					"Path": "/tmp/logs.txt",
 					"TextFormat": "[%START_TIME%]"
+				},
+				"FailoverPolicy": {
+					"Mode": "default"
 				}
 			}
 			`,
@@ -439,6 +442,9 @@ func TestDecodeConfigEntry(t *testing.T) {
 					Type:                FileLogSinkType,
 					Path:                "/tmp/logs.txt",
 					TextFormat:          "[%START_TIME%]",
+				},
+				FailoverPolicy: &ServiceResolverFailoverPolicy{
+					Mode: "default",
 				},
 			},
 		},

--- a/website/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/website/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -473,6 +473,19 @@ spec:
       ],
     },
     {
+      name: 'FailoverPolicy',
+      type: 'ServiceResolverFailoverPolicy: <optional>',
+      description: `Policy specifies the exact mechanism used for failover.
+      Added in v1.16.0.`,
+      children: [
+        {
+          name: 'Mode',
+          type: 'string: ""',
+          description: 'One of `""`, `default`, or `order-by-locality`.',
+        },
+      ],
+    },
+    {
       name: 'AccessLogs',
       type: 'AccessLogsConfig: <optional>',
       description: `Controls the configuration of [Envoy's access logging](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/observability/access_logging.html?highlight=access%20logs)


### PR DESCRIPTION
### Description
add failover policy to ProxyConfigEntry in api to be able to use it in consul-k8s

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
