### PR TITLE
fix: export ReadWriteRatesConfig struct as it needs to referenced from consul-k8s

### DIFF
--- a/api/config_entry_rate_limit_ip.go
+++ b/api/config_entry_rate_limit_ip.go
@@ -1,6 +1,6 @@
 package api
 
-type readWriteRatesConfig struct {
+type ReadWriteRatesConfig struct {
 	ReadRate  float64
 	WriteRate float64
 }
@@ -17,19 +17,19 @@ type RateLimitIPConfigEntry struct {
 	WriteRate float64
 
 	//limits specific to a type of call
-	ACL            *readWriteRatesConfig `json:",omitempty"`
-	Catalog        *readWriteRatesConfig `json:",omitempty"`
-	ConfigEntry    *readWriteRatesConfig `json:",omitempty"`
-	ConnectCA      *readWriteRatesConfig `json:",omitempty"`
-	Coordinate     *readWriteRatesConfig `json:",omitempty"`
-	DiscoveryChain *readWriteRatesConfig `json:",omitempty"`
-	Health         *readWriteRatesConfig `json:",omitempty"`
-	Intention      *readWriteRatesConfig `json:",omitempty"`
-	KV             *readWriteRatesConfig `json:",omitempty"`
-	Tenancy        *readWriteRatesConfig `json:",omitempty"`
-	PreparedQuery  *readWriteRatesConfig `json:",omitempty"`
-	Session        *readWriteRatesConfig `json:",omitempty"`
-	Txn            *readWriteRatesConfig `json:",omitempty"`
+	ACL            *ReadWriteRatesConfig `json:",omitempty"`
+	Catalog        *ReadWriteRatesConfig `json:",omitempty"`
+	ConfigEntry    *ReadWriteRatesConfig `json:",omitempty"`
+	ConnectCA      *ReadWriteRatesConfig `json:",omitempty"`
+	Coordinate     *ReadWriteRatesConfig `json:",omitempty"`
+	DiscoveryChain *ReadWriteRatesConfig `json:",omitempty"`
+	Health         *ReadWriteRatesConfig `json:",omitempty"`
+	Intention      *ReadWriteRatesConfig `json:",omitempty"`
+	KV             *ReadWriteRatesConfig `json:",omitempty"`
+	Tenancy        *ReadWriteRatesConfig `json:",omitempty"`
+	PreparedQuery  *ReadWriteRatesConfig `json:",omitempty"`
+	Session        *ReadWriteRatesConfig `json:",omitempty"`
+	Txn            *ReadWriteRatesConfig `json:",omitempty"`
 
 	// Partition is the partition the config entry is associated with.
 	// Partitioning is a Consul Enterprise feature.


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Exporting `ReadWriteRatesConfig` from the API package that can be referenced in K8s.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [ ] ~not a security concern~
