### PR TITLE
Start using pre-commit to automate things on git commit: goimports

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,8 +10,8 @@ effort. The worst that can happen is that you'll be politely asked to change
 something. We appreciate any sort of contributions, and don't want a wall of
 rules to get in the way of that.
 
-That said, if you want to ensure that a pull request is likely to be merged, 
-talk to us! A great way to do this is in issues themselves. When you want to 
+That said, if you want to ensure that a pull request is likely to be merged,
+talk to us! A great way to do this is in issues themselves. When you want to
 work on an issue, comment on it first and tell us the approach you want to take.
 
 ## Getting Started
@@ -29,20 +29,20 @@ are deployed from this repo.
 
 ### Reporting an Issue
 
->Note: Issues on GitHub for Consul are intended to be related to bugs or feature requests. 
+>Note: Issues on GitHub for Consul are intended to be related to bugs or feature requests.
 >Questions should be directed to other community resources such as the: [Discuss Forum](https://discuss.hashicorp.com/c/consul/29), [FAQ](https://www.consul.io/docs/faq.html), or [Guides](https://www.consul.io/docs/guides/index.html).
 
-* Make sure you test against the latest released version. It is possible we 
-already fixed the bug you're experiencing. However, if you are on an older 
+* Make sure you test against the latest released version. It is possible we
+already fixed the bug you're experiencing. However, if you are on an older
 version of Consul and feel the issue is critical, do let us know.
 
-* Check existing issues (both open and closed) to make sure it has not been 
+* Check existing issues (both open and closed) to make sure it has not been
 reported previously.
 
-* Provide a reproducible test case. If a contributor can't reproduce an issue, 
+* Provide a reproducible test case. If a contributor can't reproduce an issue,
 then it dramatically lowers the chances it'll get fixed.
 
-* Aim to respond promptly to any questions made by the Consul team on your 
+* Aim to respond promptly to any questions made by the Consul team on your
 issue. Stale issues will be closed.
 
 ### Issue Lifecycle
@@ -87,9 +87,9 @@ If you make any changes to the code, run `gofmt -s -w` to automatically format t
 
 ##### Organizing Imports
 
-Group imports using `goimports -local github.com/hashicorp/consul/` to keep [local packages](https://github.com/golang/tools/commit/ed69e84b1518b5857a9f4e01d1f9cefdcc45246e) in their own section.
+Imports are automatically checked and organized on commit by using the go-imports [pre-commit](https://https://pre-commit.com/) hook.
+Local packages (github.com/hashicorp/consul/) do have their own section, but go-imports doesn't enforce moving the section to the end of the import list as shown.
 
-Example: 
 ```
 import (
 	"context"
@@ -156,7 +156,7 @@ When you're ready to submit a pull request:
    if your changes aren't finalized but would benefit from in-process feedback.
 5. If there's any reason Consul users might need to know about this change,
    [add a changelog entry](../docs/contributing/add-a-changelog-entry.md).
-6. Add labels to your pull request. A table of commonly use labels is below. 
+6. Add labels to your pull request. A table of commonly use labels is below.
    If you have any questions about which to apply, feel free to call it out in the PR or comments.
    | Label | When to Use |
    | --- | --- |
@@ -170,9 +170,9 @@ When you're ready to submit a pull request:
 8. After you address Consul maintainer feedback and the PR is approved, a Consul maintainer
    will merge it. Your contribution will be available from the next major release (e.g., 1.x)
    unless explicitly backported to an existing or previous major release by the maintainer.
-9. Any backport labels will generate an additional PR to the targeted release branch. 
+9. Any backport labels will generate an additional PR to the targeted release branch.
    These will be linked in the original PR.
-   Assuming the tests pass, the PR will be merged automatically. 
+   Assuming the tests pass, the PR will be merged automatically.
    If the tests fail, it is you responsibility to resolve the issues with backports and request another reviewer.
 
 #### Checklists

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-added-large-files
+    # TODO(spatel): Consider for future inclusion after verifying changes aren't disruptive
+    # -   id: check-yaml
+    # -   id: check-added-large-files
 -   repo: https://github.com/tekwizely/pre-commit-golang
     rev: v1.0.0-rc.1
     hooks:
     -   id: go-imports
-        args:
-          - "-local github.com/hashicorp/consul/"
+        args: ["-w", "-local", "github.com/hashicorp/consul/"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,9 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+-   repo: https://github.com/tekwizely/pre-commit-golang
+    rev: v1.0.0-rc.1
+    hooks:
+    -   id: go-imports
+        args:
+          - "-local github.com/hashicorp/consul/"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -366,6 +366,10 @@ proto-tools:
 codegen-tools:
 	@$(SHELL) $(CURDIR)/build-support/scripts/devtools.sh -codegen
 
+.PHONY: pre-commit-tools
+pre-commit-tools:
+	@$(SHELL) $(CURDIR)/build-support/scripts/devtools.sh -pre-commit
+
 .PHONY: deep-copy
 deep-copy: codegen-tools
 	@$(SHELL) $(CURDIR)/agent/structs/deep-copy.sh
@@ -376,8 +380,8 @@ deep-copy: codegen-tools
 precommit: pre-commit
 
 .PHONY: pre-commit
-pre-commit:
-	@$(SHELL) $(CURDIR)/build-support/scripts/devtools.sh -pre-commit
+pre-commit: pre-commit-tools
+	pre-commit run
 
 version:
 	@echo -n "Version:                    "

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -188,7 +188,7 @@ remote-docker: check-remote-dev-image-env
 	@echo "Building and Pushing Consul Development container - $(REMOTE_DEV_IMAGE)"
 	@if ! docker buildx inspect consul-builder; then \
 		docker buildx create --name consul-builder --driver docker-container --bootstrap; \
-	fi; 
+	fi;
 	@docker buildx use consul-builder && docker buildx build -t '$(REMOTE_DEV_IMAGE)' \
        --platform linux/amd64,linux/arm64 \
 	   --build-arg CONSUL_IMAGE_VERSION=$(CONSUL_IMAGE_VERSION) \
@@ -371,6 +371,14 @@ deep-copy: codegen-tools
 	@$(SHELL) $(CURDIR)/agent/structs/deep-copy.sh
 	@$(SHELL) $(CURDIR)/agent/proxycfg/deep-copy.sh
 
+# Devs shoudln't have to think about whether there is a hypen or not
+.PHONY: precommit
+precommit: pre-commit
+
+.PHONY: pre-commit
+pre-commit:
+	@$(SHELL) $(CURDIR)/build-support/scripts/devtools.sh -pre-commit
+
 version:
 	@echo -n "Version:                    "
 	@$(SHELL) $(CURDIR)/build-support/scripts/version.sh
@@ -496,7 +504,7 @@ proto-format: proto-tools
 
 .PHONY: proto-lint
 proto-lint: proto-tools
-	@buf lint 
+	@buf lint
 	@for fn in $$(find proto -name '*.proto'); do \
 		if [[ "$$fn" = "proto/private/pbsubscribe/subscribe.proto" ]]; then \
 			continue ; \

--- a/build-support/scripts/devtools.sh
+++ b/build-support/scripts/devtools.sh
@@ -162,8 +162,13 @@ function codegen_install {
 }
 
 function pre_commit_install {
-    # bail if already installed
+    # if already installed make sure the hook is also installed
     if command -v "pre-commit" &>/dev/null; then
+        # Not to be confused with installing the tool, this installs
+        # the git hook locally (.git/hooks/pre-commit) which pre-commit
+        # uses as a vector to run checks on `git commit`. This hook is
+        # generated based on the local environment hence not source
+        # controlled.
         pre-commit install
         return 0
     fi

--- a/build-support/scripts/devtools.sh
+++ b/build-support/scripts/devtools.sh
@@ -22,6 +22,7 @@ Options:
     -protobuf                Just install tools for protobuf.
     -lint                    Just install tools for linting.
     -codegen                 Just install tools for codegen.
+    -pre-commit              Just install pre-commit.
     -h | --help              Print this help text.
 EOF
 }
@@ -46,6 +47,10 @@ function main {
                 ;;
             -codegen )
                 codegen_install
+                return 0
+                ;;
+            -pre-commit )
+                pre_commit_install
                 return 0
                 ;;
             -h | --help )
@@ -156,11 +161,38 @@ function codegen_install {
         'github.com/globusdigital/deep-copy'
 }
 
-function tools_install {
+function pre_commit_install {
+    # bail if already installed
+    if command -v "pre-commit" &>/dev/null; then
+        pre-commit install
+        return 0
+    fi
 
+    # Install options based on https://pre-commit.com/#installation
+    if command -v "brew" &>/dev/null; then
+        brew install pre-commit && pre-commit install
+        return 0
+    fi
+
+    if command -v "pip3" &>/dev/null; then
+        pip3 install pre-commit && pre-commit install
+        return 0
+    fi
+
+    if [[ "$(uname)" == "Darwin" ]]; then
+        echo "ERROR: Install homebrew from https://brew.sh/ so that pre-commit (https://pre-commit.com) can be installed."
+        return 1
+    fi
+
+    echo "ERROR: Install python3 and pip3 so that pre-commit (https://pre-commit.com) can be installed."
+    return 1
+}
+
+function tools_install {
     lint_install
     proto_tools_install
     codegen_install
+    pre_commit_install
 
     return 0
 }


### PR DESCRIPTION
### Description

See [NET-3409](https://hashicorp.atlassian.net/browse/NET-3409) for motivation and acceptance criteria.

[pre-commit](https://pre-commit.com/) is a pretty popular tool in this space and has 10k+ stars on github. 

I'm specifically looking for `git commit` workflows which can possibly fail by introducing this change. The workaround to bypass pre-commit is `git commit --no-verify`.

There is a wrinkle with bootstrapping this functionality. The git hook can't be stored in source control because it is generated and dependent on the local dev environment (where is python installed? etc). So, after a fresh `git clone` it is necessary to run `pre-commit install` to install the git hook. Currently, I have piggybacked this behavior onto `make tools` target to not opt-everyone into this as the experience probably needs refining and some tweaks. One of the things we can do once confidence in this workflow has increased is to just have a raw make target on the `./.git/hooks/pre-commit` file and make it a dependency of the default make target.


### Highlights
- Removes the need for developers to configure `goimports` specifically for this repo 
- Removes the need for developers to have to remember to run `goimports` before they commit code locally
- Provides an avenue to add even more automation around coding standards, conventions, and policies. e.g. linting, protobufs, yaml, hcl, ui stuff, etc.
- Catches automatable fixes locally rather than waiting for CI to catch them post-commit.
 
### Testing & Reproduction steps
- verified on an M1 mac with homebrew
- verified on an M1 mac with python + pip
- verified on a linux VM with python + pip

### Developer experience
- Dev gets a feature branch in shape for commit and stages files
- Dev runs `git commit -m ...`
- All pre-commit hooks (go-imports in this case) are run against staged files
- Changes are written to files by goimports and dev is notified of the failure + changes
- Dev inspects changes which were made
- Dev likes the changes, re-stages files and runs `git commit` again
- All pre-commit hooks are run and this time they pass with a visual green
- The commit operation is successful

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern


[NET-3409]: https://hashicorp.atlassian.net/browse/NET-3409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ