### PR TITLE
Allow dialer to re-establish terminated peering

### DIFF
--- a/.changelog/16776.txt
+++ b/.changelog/16776.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+peering: allow re-establishing terminated peering from new token without deleting existing peering first.
+```

--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -150,8 +150,11 @@ func (b *PeeringBackend) fetchPeerServerAddresses(ws memdb.WatchSet, peerID stri
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch peer %q: %w", peerID, err)
 	}
-	if !peering.IsActive() {
-		return nil, fmt.Errorf("there is no active peering for %q", peerID)
+	if peering == nil {
+		return nil, fmt.Errorf("unknown peering %q", peerID)
+	}
+	if peering.DeletedAt != nil && !structs.IsZeroProtoTime(peering.DeletedAt) {
+		return nil, fmt.Errorf("peering %q was deleted", peerID)
 	}
 	return bufferFromAddresses(peering.GetAddressesToDial())
 }


### PR DESCRIPTION
### Description

Currently, if an acceptor peer deletes a peering the dialer's peering will eventually get to a "terminated" state. If the two clusters need to be re-peered the acceptor will re-generate the token but the dialer will encounter this error on the call to establish:

>failed to get addresses to dial peer: failed to refresh peer server addresses, will continue to use initial addresses: there is no active peering for "<<<ID>>>"

This is because in `exchangeSecret().GetDialAddresses()` we will get an error if fetching addresses for an inactive peering. The peering shows up as inactive at this point because of the existing terminated state.

Rather than checking whether a peering is active we can instead check whether it was deleted. This way users do not need to delete terminated peerings in the dialing cluster before re-establishing them.

### Testing & Reproduction steps
* The `TestLeader_PeeringSync_Lifecycle_ServerDeletion` test updated below shows how to reproduce the issue. It fails without this update.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
