### PR TITLE
Manual Backport: Fix bug in changelog checker where bash variable is not quoted (#16681)

### DIFF
--- a/.github/scripts/changelog_checker.sh
+++ b/.github/scripts/changelog_checker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# check if there is a diff in the .changelog directory
+# for PRs against the main branch, the changelog file name should match the PR number
+if [ "$GITHUB_BASE_REF" = "$GITHUB_DEFAULT_BRANCH" ]; then
+    enforce_matching_pull_request_number="matching this PR number "
+    changelog_file_path=".changelog/(_)?$PR_NUMBER.txt"
+else
+    changelog_file_path=".changelog/[_0-9]*.txt"
+fi
+
+changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/main")" | egrep "${changelog_file_path}")
+
+# If we do not find a file in .changelog/, we fail the check
+if [ -z "$changelog_files" ]; then
+    # Fail status check when no .changelog entry was found on the PR
+    echo "Did not find a .changelog entry ${enforce_matching_pull_request_number}and the 'pr/no-changelog' label was not applied. Reference - https://github.com/hashicorp/consul/pull/8387"
+    exit 1
+else
+    echo "Found .changelog entry in PR!"
+fi

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -13,7 +13,7 @@ jobs:
   # checks that a .changelog entry is present for a PR
   changelog-check:
     # If there  a `pr/no-changelog` label we ignore this check. Also, we ignore PRs created by the bot assigned to `backport-assistant`
-    if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-changelog') || github.event.pull_request.user.login == 'hc-github-team-consul-core' )" 
+    if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-changelog') || github.event.pull_request.user.login == 'hc-github-team-consul-core' )"
     runs-on: ubuntu-latest
 
     steps:
@@ -22,23 +22,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # by default the checkout action doesn't checkout all branches
       - name: Check for changelog entry in diff
-        run: |
-          # check if there is a diff in the .changelog directory
-          # for PRs against the main branch, the changelog file name should match the PR number
-          if [ "${{ github.event.pull_request.base.ref }}" = "${{ github.event.repository.default_branch }}" ]; then
-            enforce_matching_pull_request_number="matching this PR number "
-            changelog_file_path=".changelog/${{ github.event.pull_request.number }}.txt"
-          else
-            changelog_file_path=".changelog/*.txt"
-          fi
-
-          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/main")" -- ${changelog_file_path})
-
-          # If we do not find a file in .changelog/, we fail the check
-          if [ -z "$changelog_files" ]; then
-            # Fail status check when no .changelog entry was found on the PR
-            echo "Did not find a .changelog entry ${enforce_matching_pull_request_number}and the 'pr/no-changelog' label was not applied. Reference - https://github.com/hashicorp/consul/pull/8387"
-            exit 1
-          else
-            echo "Found .changelog entry in PR!"
-          fi
+        run: ./.github/scripts/changelog_checker.sh
+        env:
+          GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Description

Manual backport of https://github.com/hashicorp/consul/pull/16681

### Testing & Reproduction steps

N/A

### Links

N/A

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
