### PR TITLE
Merge Bootstrap Config from CCM

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1496,6 +1496,12 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	cfg.RequestLimitsWriteRate = runtimeCfg.RequestLimitsWriteRate
 	cfg.Locality = runtimeCfg.StructLocality()
 
+	if runtimeCfg.Cloud.ManagementToken != "" {
+		cfg.Cloud = &consul.CloudConfig{
+			ManagementToken: runtimeCfg.Cloud.ManagementToken,
+		}
+	}
+
 	enterpriseConsulConfig(cfg, runtimeCfg)
 	return cfg, nil
 }

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -438,6 +438,8 @@ type Config struct {
 
 	Locality *structs.Locality
 
+	Cloud *CloudConfig
+
 	// Embedded Consul Enterprise specific configuration
 	*EnterpriseConfig
 }

--- a/agent/consul/config_cloud.go
+++ b/agent/consul/config_cloud.go
@@ -1,0 +1,5 @@
+package consul
+
+type CloudConfig struct {
+	ManagementToken string
+}

--- a/agent/hcp/bootstrap/bootstrap_test.go
+++ b/agent/hcp/bootstrap/bootstrap_test.go
@@ -1,0 +1,62 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/agent/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckManagementToken(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		expectedToken   string
+		runtimeConfig   *config.RuntimeConfig
+		bootstrapConfig map[string]interface{}
+	}{
+		{
+			name:          "EmptyRuntimeConfig",
+			expectedToken: "foo",
+			runtimeConfig: &config.RuntimeConfig{},
+			bootstrapConfig: map[string]interface{}{
+				"acl": map[string]interface{}{
+					"tokens": map[string]interface{}{
+						"initial_management": "foo",
+					},
+				},
+			},
+		},
+		{
+			name:          "DeleteBootstrapToken",
+			expectedToken: "",
+			runtimeConfig: &config.RuntimeConfig{
+				ACLInitialManagementToken: "bar",
+			},
+			bootstrapConfig: map[string]interface{}{
+				"acl": map[string]interface{}{
+					"tokens": map[string]interface{}{
+						"initial_management": "foo",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := require.New(t)
+			checkManagementToken(test.runtimeConfig, test.bootstrapConfig)
+
+			acl, ok := test.bootstrapConfig["acl"].(map[string]interface{})
+			if !ok {
+				t.Error("`acl` was not found in bootstrap config")
+			}
+
+			tokens, ok := acl["tokens"].(map[string]interface{})
+			if !ok {
+				t.Error("`acl.tokens` was not found in bootstrap config")
+			}
+
+			bootstrapToken, _ := tokens["initial_management"].(string)
+			r.Equal(test.expectedToken, bootstrapToken)
+		})
+	}
+}

--- a/agent/hcp/config/config.go
+++ b/agent/hcp/config/config.go
@@ -14,6 +14,9 @@ type CloudConfig struct {
 	Hostname     string
 	AuthURL      string
 	ScadaAddress string
+
+	// internal
+	ManagementToken string
 }
 
 func (c *CloudConfig) HCPConfig(opts ...hcpcfg.HCPConfigOption) (hcpcfg.HCPConfig, error) {

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -215,6 +215,14 @@ func TestBadDataDirPermissions(t *testing.T) {
 	}
 }
 
+// func TestConfigLoader(t *testing.T) {
+// 	loader := func(source config.Source) (config.LoadResult, error) {
+// 		return config.LoadResult{}, nil
+// 	}
+// 	bd, _ := agent.NewBaseDeps(loader, nil, nil)
+// 	bd.RuntimeConfig.ACLInitialManagementToken
+// }
+
 type captureUI struct {
 	*mcli.MockUi
 }


### PR DESCRIPTION
### Description

This PR adds an additional field to the internal runtime config which allows for an additional initial management token to be sent from HCP, such that it does override the user-provided initial management token. We also add implementation to merge HTTP response headers into the runtime config from the HCP bootstrap.

### Links

[RFC for CCM Linking Existing Clusters](https://docs.google.com/document/d/1q-cGem9JF4LIuSoD2n_KwRobL0Uf2QWbBqnFj5YcWPM/edit#heading=h.cxaty5xfhqiw)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
