### PR TITLE
[CC-4374] Expose MetricsConfig in Deps for HCP Manager

### DIFF
--- a/agent/consul/options.go
+++ b/agent/consul/options.go
@@ -16,10 +16,12 @@ import (
 	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/rpc/middleware"
 	"github.com/hashicorp/consul/agent/token"
+	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/tlsutil"
 )
 
 type Deps struct {
+	MetricsConfig    *lib.MetricsConfig
 	EventPublisher   *stream.EventPublisher
 	Logger           hclog.InterceptLogger
 	TLSConfigurator  *tlsutil.Configurator

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -51,7 +51,6 @@ type BaseDeps struct {
 	consul.Deps // TODO: un-embed
 
 	RuntimeConfig *config.RuntimeConfig
-	MetricsConfig *lib.MetricsConfig
 	AutoConfig    *autoconf.AutoConfig // TODO: use an interface
 	Cache         *cache.Cache
 	ViewStore     *submatview.Store

--- a/lib/telemetry.go
+++ b/lib/telemetry.go
@@ -216,6 +216,7 @@ type TelemetryConfig struct {
 type MetricsHandler interface {
 	DisplayMetrics(resp http.ResponseWriter, req *http.Request) (interface{}, error)
 	Stream(ctx context.Context, encoder metrics.Encoder)
+	Data() []*metrics.IntervalMetrics
 }
 
 type MetricsConfig struct {


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Change originally authored by @freddygv 

#### Background: HCP Telemetry
TLDR: new feature to ship Server metrics directly to HCP.
- We will be merging these approved changes into **feature/hcp-telemetry**
- That branch will be merged at the end into `main` and backported

This allows us to iteratively improve on this feature over time before 🚢 

In #16797, we use a go metrics sink to fetch data for a new HCP Metrics Reporter.
This PR is a pre-requisite to expose the backend within the HCP manager via `Deps`:
- See this [line of code](https://github.com/hashicorp/consul/pull/16797/files#diff-2cc91c6c9b4a1393e287b185f5e20cde300cbccdddafb199953094e2308d4eb9R501) for initialization in Manager
- See this [line of code](https://github.com/hashicorp/consul/pull/16797/files#diff-52d267da081e83b27274393deb6de37983af468d2131d82e63103983b2e277baR104) for usage of the `Data()` method 

#### Changes

1. Expose the `Data()` method in the `MetricsHandler` interface
2. Expose the Backend in `Deps` instead of BaseDeps (cleanup)

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
