### PR TITLE
Add manual virtual IP support to state store

### DIFF
--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -39,6 +39,7 @@ const (
 	indexUUID        = "uuid"
 	indexMeta        = "meta"
 	indexCounterOnly = "counter"
+	indexManualVIPs  = "manual-vips"
 )
 
 // nodesTableSchema returns a new table schema used for storing struct.Node.
@@ -608,8 +609,9 @@ func (q NodeCheckQuery) PartitionOrDefault() string {
 // ServiceVirtualIP is used to store a virtual IP associated with a service.
 // It is also used to store assigned virtual IPs when a snapshot is created.
 type ServiceVirtualIP struct {
-	Service structs.PeeredServiceName
-	IP      net.IP
+	Service   structs.PeeredServiceName
+	IP        net.IP
+	ManualIPs []string
 
 	structs.RaftIndex
 }
@@ -628,6 +630,33 @@ func counterIndex(obj interface{}) (bool, error) {
 	return false, fmt.Errorf("object is not a virtual IP entry")
 }
 
+type ServiceManualVIPIndex struct{}
+
+func (index *ServiceManualVIPIndex) FromObject(obj interface{}) (bool, []byte, error) {
+	entry, ok := obj.(ServiceVirtualIP)
+	if !ok {
+		return false, nil, fmt.Errorf("object is not a ServiceVirtualIP")
+	}
+
+	// Enforce lowercase and add null character as terminator
+	id := strings.ToLower(entry.Service.ServiceName.PartitionOrDefault()) + "\x00"
+
+	return true, []byte(id), nil
+}
+
+func (index *ServiceManualVIPIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("must provide only a single argument")
+	}
+	arg, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("argument must be a string: %#v", args[0])
+	}
+
+	id := strings.ToLower(arg) + "\x00"
+	return []byte(id), nil
+}
+
 func serviceVirtualIPTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
 		Name: tableServiceVirtualIPs,
@@ -641,6 +670,19 @@ func serviceVirtualIPTableSchema() *memdb.TableSchema {
 					writeIndex: indexFromServiceVirtualIP,
 					// Read all peers in a cluster / partition
 					prefixIndex: prefixIndexFromQueryWithPeerWildcardable,
+				},
+			},
+			indexManualVIPs: {
+				Name:         indexManualVIPs,
+				AllowMissing: true,
+				Unique:       false,
+				Indexer: &memdb.CompoundMultiIndex{
+					Indexes: []memdb.Indexer{
+						&ServiceManualVIPIndex{},
+						&memdb.StringSliceFieldIndex{
+							Field: "ManualIPs",
+						},
+					},
 				},
 			},
 		},

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -88,6 +88,7 @@ const (
 	PeeringSecretsWriteType                     = 40
 	RaftLogVerifierCheckpoint                   = 41 // Only used for log verifier, no-op on FSM.
 	ResourceOperationType                       = 42
+	UpdateVirtualIPRequestType                  = 43
 )
 
 const (
@@ -156,6 +157,7 @@ var requestTypeStrings = map[MessageType]string{
 	PeeringSecretsWriteType:         "PeeringSecret",
 	RaftLogVerifierCheckpoint:       "RaftLogVerifierCheckpoint",
 	ResourceOperationType:           "Resource",
+	UpdateVirtualIPRequestType:      "UpdateManualVirtualIPRequestType",
 }
 
 const (


### PR DESCRIPTION
Follow-up to #16760 - add a manual virtual IPs field that can be used to manually assign multiple virtual IPs to a service, which will be returned through discovery chain lookups by transparent proxies.
