### PR TITLE
Resolves issue-16844 - systemd notify by default

### DIFF
--- a/.changelog/16845.txt
+++ b/.changelog/16845.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+systemd: set service type to notify.
+```

--- a/.release/linux/package/usr/lib/systemd/system/consul.service
+++ b/.release/linux/package/usr/lib/systemd/system/consul.service
@@ -6,6 +6,7 @@ After=network-online.target
 ConditionFileNotEmpty=/etc/consul.d/consul.hcl
 
 [Service]
+Type=notify
 EnvironmentFile=-/etc/consul.d/consul.env
 User=consul
 Group=consul


### PR DESCRIPTION
* updates `consul.service` systemd service unit to use `Type=notify` to resolve issue #16844

### Description

To resolve issue #16844 and switch packaged systemd unit to use systemd's notify mechanism by default.

### Testing & Reproduction steps

See #16844 where the steps to reproduce the current and updated behavior are documented

### Links

https://github.com/hashicorp/consul/issues/2121
https://github.com/hashicorp/consul/commit/31a310f551c36243d2aae9ed80054c200e079b81
https://developer.hashicorp.com/consul/docs/agent#understanding-the-agent-startup-output
https://developer.hashicorp.com/consul/tutorials/production-deploy/deployment-guide#configure-the-consul-process


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
