### PR TITLE
ci: remove verify-ci from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1081,12 +1081,6 @@ jobs:
       - run: "echo ok"
 
 workflows:
-  version: 2
-  # verify-ci is a no-op workflow that must run on every PR. It is used in a
-  # branch protection rule to detect when CI workflows are not running.
-  verify-ci:
-    jobs: [noop]
-
   go-tests:
     jobs:
       - check-go-mod: &filter-ignore-non-go-branches


### PR DESCRIPTION
### Description
This is blocked by the following remaining issues with go-tests on GHA:
- configuring the GHA version as the required github check
