### PR TITLE
fix: metrics labels are prefixed by consul in 1.13.x

### DIFF
--- a/agent/consul/usagemetrics/usagemetrics.go
+++ b/agent/consul/usagemetrics/usagemetrics.go
@@ -53,7 +53,7 @@ var Gauges = []prometheus.GaugeDefinition{
 		Help: "Measures the current number of unique configuration entries registered with Consul, labeled by Kind. It is only emitted by Consul servers. Added in v1.10.4.",
 	},
 	{
-		Name: []string{"state", "billable_service_instances"},
+		Name: []string{"consul", "state", "billable_service_instances"},
 		Help: "Total number of billable service instances in the local datacenter.",
 	},
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
I noticed that all metric labels in 1.13.x are prefixed with consul so matching the pattern


### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [ ] ~not a security concern~
