### PR TITLE
highlight the agent.tls cert metric with CA ones

### DIFF
--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -100,7 +100,7 @@ These are some metrics emitted that can help you understand the health of your c
 ** Why they're important:** Consul Mesh requires a CA to sign all certificates
 used to connect the mesh and the mesh network ceases to work if they expire and
 become invalid. The Root is particularly important to monitor as Consul does
-not automatically rotate it. The third metric is to monitor the certificate
+not automatically rotate it. The TLS certificate metric monitors the certificate
 that the server's agent uses to connect with the other agents in the cluster.
 
 ** What to look for:** The Root CA should be monitored for an approaching

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -93,19 +93,23 @@ These are some metrics emitted that can help you understand the health of your c
 
 | Metric Name                            | Description                                                             | Unit    | Type  |
 | :------------------------- | :---------------------------------------------------------------------------------- | :------ | :---- |
-| `consul.mesh.active-root-ca.expiry`    | The number of seconds until the root CA expires, updated every hour.    | seconds | gauge |
-| `consul.mesh.active-signing-ca.expiry` | The number of seconds until the signing CA expires, updated every hour. | seconds | gauge |
+| `consul.mesh.active-root-ca.expiry`    | The number of seconds until the root CA expires, updated every hour.       | seconds | gauge |
+| `consul.mesh.active-signing-ca.expiry` | The number of seconds until the signing CA expires, updated every hour.    | seconds | gauge |
+| `consul.agent.tls.cert.expiry` | The number of seconds until the Agent TLS certificate expires, updated every hour. | seconds | gauge |
 
 ** Why they're important:** Consul Mesh requires a CA to sign all certificates
 used to connect the mesh and the mesh network ceases to work if they expire and
 become invalid. The Root is particularly important to monitor as Consul does
-not automatically rotate it.
+not automatically rotate it. The third metric is to monitor the certificate
+that the server's agent uses to connect with the other agents in the cluster.
 
 ** What to look for:** The Root CA should be monitored for an approaching
-expiration, to indicate it is time for you to rotate the "root" CA either manually or with external automation.
-The signing (intermediate) certificate should be
-rotated automatically by Consul, but should be monitored in case of rotation isn't working;
-in this scenario, check the server agent logs for messages related to the CA system.
+expiration, to indicate it is time for you to rotate the "root" CA either
+manually or with external automation. The signing (intermediate) certificate
+should be rotated automatically by Consul, but should be monitored in case of
+rotation isn't working; in this scenario, check the server agent logs for
+messages related to the CA system. The agent certificate's rotation handling
+varies based on the configuration.
 
 ### Autopilot
 
@@ -688,7 +692,6 @@ are allowed for <EnterpriseAlert inline />.
 | `consul.catalog.connect.query-tag`     | Increments for each connect-based catalog query for the given service with the given tag.                                                                                                                                                                                                                                                                                                                                          | queries                                 | counter |
 | `consul.catalog.connect.query-tags`    | Increments for each connect-based catalog query for the given service with the given tags.                                                                                                                                                                                                                                                                                                                                         | queries                                 | counter |
 | `consul.catalog.connect.not-found`     | Increments for each connect-based catalog query where the given service could not be found.                                                                                                                                                                                                                                                                                                                                        | queries                                 | counter |
-| `consul.agent.tls.cert.expiry`         | The number of seconds until the Agent TLS certificate expires, updated every hour.                                                                                                                                                                                                                                                                                                                                                 | seconds                                 | gauge   |
 
 ## Connect Built-in Proxy Metrics
 

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -105,10 +105,9 @@ that the server's agent uses to connect with the other agents in the cluster.
 
 ** What to look for:** The Root CA should be monitored for an approaching
 expiration, to indicate it is time for you to rotate the "root" CA either
-manually or with external automation. The signing (intermediate) certificate
-should be rotated automatically by Consul, but should be monitored in case of
-rotation isn't working; in this scenario, check the server agent logs for
-messages related to the CA system. The agent certificate's rotation handling
+manually or with external automation. Consul should rotate the signing (intermediate) certificate
+automatically, but we recommend monitoring the rotation.  When the certificate does not rotate, check the server agent logs for
+messages related to the CA system. The agent TLS certificate's rotation handling
 varies based on the configuration.
 
 ### Autopilot

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -95,7 +95,7 @@ These are some metrics emitted that can help you understand the health of your c
 | :------------------------- | :---------------------------------------------------------------------------------- | :------ | :---- |
 | `consul.mesh.active-root-ca.expiry`    | The number of seconds until the root CA expires, updated every hour.       | seconds | gauge |
 | `consul.mesh.active-signing-ca.expiry` | The number of seconds until the signing CA expires, updated every hour.    | seconds | gauge |
-| `consul.agent.tls.cert.expiry` | The number of seconds until the Agent TLS certificate expires, updated every hour. | seconds | gauge |
+| `consul.agent.tls.cert.expiry` | The number of seconds until the server agent's TLS certificate expires, updated every hour. | seconds | gauge |
 
 ** Why they're important:** Consul Mesh requires a CA to sign all certificates
 used to connect the mesh and the mesh network ceases to work if they expire and


### PR DESCRIPTION
Related to #16747, this adds the agent.tls certificate to the section on important cert's that need monitoring.