### PR TITLE
Omit false positives from 404 checker

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.6.1
         with:
-          args: ./website/content/docs/ --base https://developer.hashicorp.com/ --exclude-all-private --exclude '\.(svg|gif|jpg|png)' --exclude 'manage\.auth0\.com' --max-concurrency=24 --no-progress --verbose
+          args: ./website/content/docs/ --base https://developer.hashicorp.com/ --exclude-all-private --exclude '\.(svg|gif|jpg|png)' --exclude 'manage\.auth0\.com' --accept 403 --max-concurrency=24 --no-progress --verbose
           # Fail GitHub action when broken links are found?
           fail: false
         env:

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -459,7 +459,7 @@ Specifies the default protocol for the service. In service mesh use cases, the `
 - [observability](/consul/docs/connect/observability)
 - [service splitter configuration entry](/consul/docs/connect/config-entries/service-splitter) 
 - [service router configuration entry](/consul/docs/connect/config-entries/service-router) 
-- [L7 intentions](/consul/docs/connect/intentions/index#l7-traffic-intentions)
+- [L7 intentions](/consul/docs/connect/intentions#l7-traffic-intentions)
 
 You can set the global protocol for proxies in the [`proxy-defaults`](/consul/docs/connect/config-entries/proxy-defaults#default-protocol) configuration entry, but the protocol specified in the `service-defaults` configuration entry overrides the `proxy-defaults` configuration.    
 
@@ -831,7 +831,7 @@ Specifies the default protocol for the service. In service service mesh use case
 - [observability](/consul/docs/connect/observability)
 - [`service-splitter` configuration entry](/consul/docs/connect/config-entries/service-splitter) 
 - [`service-router` configuration entry](/consul/docs/connect/config-entries/service-router) 
-- [L7 intentions](/consul/docs/connect/intentions/index#l7-traffic-intentions)
+- [L7 intentions](/consul/docs/connect/intentions#l7-traffic-intentions)
 
 You can set the global protocol for proxies in the [`ProxyDefaults` configuration entry](/consul/docs/connect/config-entries/proxy-defaults#default-protocol), but the protocol specified in the `ServiceDefaults` configuration entry overrides the `ProxyDefaults` configuration.    
 

--- a/website/content/docs/connect/intentions/create-manage-intentions.mdx
+++ b/website/content/docs/connect/intentions/create-manage-intentions.mdx
@@ -11,7 +11,7 @@ This topic describes how to create and manage service intentions, which are conf
 
 ## Overview
 
-You can create single intentions or create them in batches using the Consul API, CLI, or UI. You can also define a service intention configuration entry that sets default intentions for all services in the mesh. Refer to [Service intentions overview](/consul/docs/connnect/intentions/intentions) for additional background information about intentions.
+You can create single intentions or create them in batches using the Consul API, CLI, or UI. You can also define a service intention configuration entry that sets default intentions for all services in the mesh. Refer to [Service intentions overview](/consul/docs/connect/intentions/) for additional background information about intentions.
 
 ## Requirements
 
@@ -76,7 +76,7 @@ For L7 intentions, specify the `Permissions` in the request payload to configure
 
 </CodeBlockConfig>
 
-The `Permissions` object specifies a list of permissions for L7 traffic sources. The list contains one or more actions and a set of match criteria for each action. Refer to the [`Sources[].Permissions[]` parameter](/consul/connect/config-entries/service-intentions#source-permissions) in the service intentions configuration entry reference for configuration details.   
+The `Permissions` object specifies a list of permissions for L7 traffic sources. The list contains one or more actions and a set of match criteria for each action. Refer to the [`Sources[].Permissions[]` parameter](/consul/docs/connect/config-entries/service-intentions#sources-permissions) in the service intentions configuration entry reference for configuration details.   
 
 To apply the intention, call the endpoint and pass the configuration file containing the attributes to the endpoint:
 


### PR DESCRIPTION
### Description

Omit false positives (403 errors) from the 404 checker.

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

1. download lychee
2. cd to consul repo's root folder
3. run the following

`lychee ./website/content/docs/ --base https://developer.hashicorp.com/ --exclude-all-private --exclude '\.(svg|gif|jpg|png)' --exclude 'manage\.auth0\.com' --accept 403 --max-concurrency=24 --no-progress --verbose`

### Links

Notes:
https://github.com/lycheeverse/lychee/blob/master/docs/TROUBLESHOOTING.md#unexpected-status-codes

### PR Checklist

* [x] external facing docs updated
* [x] not a security concern
