### PR TITLE
ci: add test-integrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,6 +346,7 @@ jobs:
             sudo tar -C /usr/local -xzvf go${GO_VERSION}.linux-amd64.tar.gz
           environment:
             <<: *ENVIRONMENT
+      - run: go env
       - run: *install-gotestsum
       - run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile .
       - run:
@@ -409,6 +410,7 @@ jobs:
               sudo tar -C /usr/local -xzvf go${GO_VERSION}.linux-amd64.tar.gz
             environment:
               <<: *ENVIRONMENT
+        - run: go env
         - run: *install-gotestsum
         - run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile .
         - run:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -252,7 +252,7 @@ jobs:
           name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
           path: ${{ env.TEST_RESULTS_DIR }}
 
- compatibility-integration-test:
+  compatibility-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     needs:
       - setup

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -4,7 +4,6 @@
 name: test-integrations
 
 on:
-  push:
   pull_request:
     branches-ignore:
       - stable-website

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -281,6 +281,9 @@ jobs:
         run: docker build -t ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local -f ./build-support/docker/Consul-Dev.dockerfile .
       - name: Compatibility Integration Tests
         run: |
+            cat /etc/hosts && echo "-----------"
+            sudo sed -i 's/::1 *localhost ip6-localhost ip6-loopback/::1 ip6-localhost ip6-loopback/g' /etc/hosts
+            cat /etc/hosts
             mkdir -p "/tmp/test-results"
             cd ./test/integration/consul-container
             docker run --rm ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local consul version
@@ -349,6 +352,9 @@ jobs:
         run: docker build -t ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local -f ./build-support/docker/Consul-Dev.dockerfile .
       - name: Upgrade Integration Tests
         run: |
+          cat /etc/hosts && echo "-----------"
+          sudo sed -i 's/::1 *localhost ip6-localhost ip6-loopback/::1 ip6-localhost ip6-loopback/g' /etc/hosts
+          cat /etc/hosts
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"
           cd ./test/integration/consul-container/test/upgrade
           docker run --rm ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local consul version

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -23,7 +23,7 @@ env:
   GOTESTSUM_VERSION: "1.9.0"
   CONSUL_BINARY_UPLOAD_NAME: consul-bin
   # strip the hashicorp/ off the front of github.repository
-  CONSUL_LATEST_IMAGE_NAME: ${{ endsWith(github.repository, '-enterprise') && 'consul-enterprise' || 'consul' }}
+  CONSUL_LATEST_IMAGE_NAME: consul
 
 jobs:
   setup:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -21,6 +21,7 @@ env:
   GOTAGS: ${{ endsWith(github.repository, '-enterprise') && 'consulent' || '' }}
   GOTESTSUM_VERSION: "1.9.0"
   CONSUL_BINARY_UPLOAD_NAME: consul-bin
+  CONSUL_LATEST_IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   setup:
@@ -251,8 +252,8 @@ jobs:
           name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
           path: ${{ env.TEST_RESULTS_DIR }}
 
-  compatibility-integration-test:
-    runs-on: ubuntu-latest
+ compatibility-integration-test:
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     needs:
       - setup
       - dev-build
@@ -277,12 +278,12 @@ jobs:
         run: chmod +x consul
 
       - name: Build consul:local image
-        run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile .
+        run: docker build -t ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local -f ./build-support/docker/Consul-Dev.dockerfile .
       - name: Compatibility Integration Tests
         run: |
             mkdir -p "/tmp/test-results"
-            cd ./test/integration/consul-container/test
-            docker run --rm consul:local consul version
+            cd ./test/integration/consul-container
+            docker run --rm ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local consul version
             # shellcheck disable=SC2046
             gotestsum \
               --raw-command \
@@ -293,13 +294,13 @@ jobs:
               -- \
               go test \
               -p=4 \
-              -tags "" \
+              -tags "${{ env.GOTAGS }}" \
               -timeout=30m \
               -json \
               $(go list ./... | grep -v upgrade) \
-              --target-image consul \
+              --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
               --target-version local \
-              --latest-image consul \
+              --latest-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
               --latest-version latest
             ls -lrt
         env:
@@ -316,7 +317,7 @@ jobs:
           path: ${{ env.TEST_RESULTS_DIR }}
 
   upgrade-integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     needs:
       - setup
       - dev-build
@@ -345,12 +346,13 @@ jobs:
       - name: restore mode+x
         run: chmod +x consul
       - name: Build consul:local image
-        run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile .
+        run: docker build -t ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local -f ./build-support/docker/Consul-Dev.dockerfile .
       - name: Upgrade Integration Tests
         run: |
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"
           cd ./test/integration/consul-container/test/upgrade
-          docker run --rm consul:local consul version
+          docker run --rm ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local consul version
+          # shellcheck disable=SC2046
           PACKAGE_NAMES=$(go list -tags "${{ env.GOTAGS }}" ./...)
           gotestsum \
             --raw-command \
@@ -365,9 +367,9 @@ jobs:
             -timeout=30m \
             -json \
             ./... \
-            --target-image consul \
+            --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
             --target-version local \
-            --latest-image consul \
+            --latest-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
             --latest-version "${{ env.CONSUL_VERSION }}"
           ls -lrt
         env:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -22,7 +22,8 @@ env:
   GOTAGS: ${{ endsWith(github.repository, '-enterprise') && 'consulent' || '' }}
   GOTESTSUM_VERSION: "1.9.0"
   CONSUL_BINARY_UPLOAD_NAME: consul-bin
-  CONSUL_LATEST_IMAGE_NAME: ${{ github.repository }}
+  # strip the hashicorp/ off the front of github.repository
+  CONSUL_LATEST_IMAGE_NAME: ${{ endsWith(github.repository, '-enterprise') && 'consul-enterprise' || 'consul' }}
 
 jobs:
   setup:
@@ -253,7 +254,7 @@ jobs:
           name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
           path: ${{ env.TEST_RESULTS_DIR }}
 
-generate-compatibility-job-matrices:
+  generate-compatibility-job-matrices:
     needs: [setup]
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
     name: Generate Compatibility Job Matrices

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -253,11 +253,39 @@ jobs:
           name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
           path: ${{ env.TEST_RESULTS_DIR }}
 
+generate-compatibility-job-matrices:
+    needs: [setup]
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+    name: Generate Compatibility Job Matrices
+    outputs:
+      compatibility-matrix: ${{ steps.set-matrix.outputs.compatibility-matrix }}
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - name: Generate Compatibility Job Matrix
+        id: set-matrix
+        env:
+          TOTAL_RUNNERS: 5
+          JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
+        run: |
+          cd ./test/integration/consul-container
+          {
+            echo -n "compatibility-matrix="
+            find ./test -maxdepth 2 -type d -print0 | xargs -0 -n 1 \
+              | grep -v util | grep -v upgrade \
+              | jq --raw-input --argjson runnercount "$TOTAL_RUNNERS" "$JQ_SLICER" \
+              | jq --compact-output 'map(join(" "))'
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
   compatibility-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     needs:
       - setup
       - dev-build
+      - generate-compatibility-job-matrices
+    strategy:
+      fail-fast: false
+      matrix:
+        test-cases: ${{ fromJSON(needs.generate-compatibility-job-matrices.outputs.compatibility-matrix) }}
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
@@ -280,28 +308,32 @@ jobs:
 
       - name: Build consul:local image
         run: docker build -t ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local -f ./build-support/docker/Consul-Dev.dockerfile .
+      - name: Configure GH workaround for ipv6 loopback
+        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        run: |
+          cat /etc/hosts && echo "-----------"
+          sudo sed -i 's/::1 *localhost ip6-localhost ip6-loopback/::1 ip6-localhost ip6-loopback/g' /etc/hosts
+          cat /etc/hosts
       - name: Compatibility Integration Tests
         run: |
-            cat /etc/hosts && echo "-----------"
-            sudo sed -i 's/::1 *localhost ip6-localhost ip6-loopback/::1 ip6-localhost ip6-loopback/g' /etc/hosts
-            cat /etc/hosts
             mkdir -p "/tmp/test-results"
             cd ./test/integration/consul-container
             docker run --rm ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local consul version
-            # shellcheck disable=SC2046
+            echo "Running $(sed 's,|, ,g' <<< "${{ matrix.test-cases }}" |wc -w) subtests"
+            # shellcheck disable=SC2001
+            sed 's,|,\n,g' <<< "${{ matrix.test-cases }}"
             gotestsum \
               --raw-command \
               --format=short-verbose \
               --debug \
               --rerun-fails=3 \
-              --packages="./..." \
               -- \
               go test \
               -p=4 \
               -tags "${{ env.GOTAGS }}" \
               -timeout=30m \
               -json \
-              $(go list ./... | grep -v upgrade) \
+              "${{ matrix.test-cases }}" \
               --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
               --target-version local \
               --latest-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
@@ -320,14 +352,43 @@ jobs:
           name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
           path: ${{ env.TEST_RESULTS_DIR }}
 
+  generate-upgrade-job-matrices:
+    needs: [setup]
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+    name: Generate Upgrade Job Matrices
+    outputs:
+      upgrade-matrix: ${{ steps.set-matrix.outputs.upgrade-matrix }}
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Generate Updgrade Job Matrix
+        id: set-matrix
+        env:
+          TOTAL_RUNNERS: 4
+          JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
+        run: |
+          cd ./test/integration/consul-container/test/upgrade
+          {
+            echo -n "upgrade-matrix="
+            go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | gsub("[\\n\\t]"; "")' \
+            | jq --raw-input --argjson runnercount "$TOTAL_RUNNERS" "$JQ_SLICER" \
+            | jq --compact-output 'map(join("|"))'
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+  
   upgrade-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     needs:
       - setup
       - dev-build
+      - generate-upgrade-job-matrices
     strategy:
+      fail-fast: false
       matrix:
         consul-version: [ "1.14", "1.15"]
+        test-cases: ${{ fromJSON(needs.generate-upgrade-job-matrices.outputs.upgrade-matrix) }}
     env:
       CONSUL_VERSION: ${{ matrix.consul-version }}
     steps:
@@ -351,33 +412,30 @@ jobs:
         run: chmod +x consul
       - name: Build consul:local image
         run: docker build -t ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local -f ./build-support/docker/Consul-Dev.dockerfile .
-      - name: Upgrade Integration Tests
+      - name: Configure GH workaround for ipv6 loopback
+        if: ${{ !endsWith(github.repository, '-enterprise') }}
         run: |
           cat /etc/hosts && echo "-----------"
           sudo sed -i 's/::1 *localhost ip6-localhost ip6-loopback/::1 ip6-localhost ip6-loopback/g' /etc/hosts
           cat /etc/hosts
+      - name: Upgrade Integration Tests
+        run: |
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"
           cd ./test/integration/consul-container/test/upgrade
           docker run --rm ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local consul version
-          # shellcheck disable=SC2046
-          PACKAGE_NAMES=$(go list -tags "${{ env.GOTAGS }}" ./...)
-          gotestsum \
-            --raw-command \
-            --format=short-verbose \
-            --debug \
-            --rerun-fails=3 \
-            --packages="${PACKAGE_NAMES}" \
-            -- \
-            go test \
-            -p=4 \
-            -tags "${{ env.GOTAGS }}" \
-            -timeout=30m \
-            -json \
-            ./... \
-            --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
-            --target-version local \
-            --latest-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
-            --latest-version "${{ env.CONSUL_VERSION }}"
+          echo "Running $(sed 's,|, ,g' <<< "${{ matrix.test-cases }}" |wc -w) subtests"
+          # shellcheck disable=SC2001
+          sed 's,|,\n,g' <<< "${{ matrix.test-cases }}"
+          go test \
+          -p=4 \
+          -tags "${{ env.GOTAGS }}" \
+          -timeout=30m \
+          -json ./... \
+          -run "${{ matrix.test-cases }}" \
+          --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
+          --target-version local \
+          --latest-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
+          --latest-version "${{ env.CONSUL_VERSION }}"
           ls -lrt
         env:
           # this is needed because of incompatibility between RYUK container and circleci
@@ -394,12 +452,14 @@ jobs:
   test-integrations-success:
     needs: 
     - setup
-    - generate-envoy-job-matrices
     - dev-build
     - nomad-integration-test
     - vault-integration-test
+    - generate-envoy-job-matrices
     - envoy-integration-test
+    - generate-compatibility-job-matrices
     - compatibility-integration-test
+    - generate-upgrade-job-matrices
     - upgrade-integration-test
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
     if: |

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -426,16 +426,23 @@ jobs:
           echo "Running $(sed 's,|, ,g' <<< "${{ matrix.test-cases }}" |wc -w) subtests"
           # shellcheck disable=SC2001
           sed 's,|,\n,g' <<< "${{ matrix.test-cases }}"
-          go test \
-          -p=4 \
-          -tags "${{ env.GOTAGS }}" \
-          -timeout=30m \
-          -json ./... \
-          -run "${{ matrix.test-cases }}" \
-          --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
-          --target-version local \
-          --latest-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
-          --latest-version "${{ env.CONSUL_VERSION }}"
+          gotestsum \
+            --raw-command \
+            --format=short-verbose \
+            --debug \
+            --rerun-fails=3 \
+            --packages="./..." \
+            -- \
+            go test \
+            -p=4 \
+            -tags "${{ env.GOTAGS }}" \
+            -timeout=30m \
+            -json ./... \
+            -run "${{ matrix.test-cases }}" \
+            --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
+            --target-version local \
+            --latest-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
+            --latest-version "${{ env.CONSUL_VERSION }}"
           ls -lrt
         env:
           # this is needed because of incompatibility between RYUK container and circleci

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -4,6 +4,7 @@
 name: test-integrations
 
 on:
+  push:
   pull_request:
     branches-ignore:
       - stable-website

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -280,7 +280,7 @@ jobs:
       - name: Compatibility Integration Tests
         run: |
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"
-          cd ./test/integration/consul-container/test/upgrade
+          cd ./test/integration/consul-container
           docker run --rm consul:local consul version
           gotestsum \
             --raw-command \
@@ -291,14 +291,13 @@ jobs:
             -- \
             go test \
             -p=4 \
-            -tags "${{ env.GOTAGS }}" \
             -timeout=30m \
             -json \
-            ./.../upgrade/ \
+            `go list ./... | grep -v upgrade` \
             --target-image consul \
             --target-version local \
             --latest-image consul \
-            --latest-version ${{ env.CONSUL_VERSION }}
+            --latest-version latest
           ls -lrt
         env:
           # this is needed because of incompatibility between RYUK container and circleci

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -252,7 +252,7 @@ jobs:
           path: ${{ env.TEST_RESULTS_DIR }}
 
   compatibility-integration-test:
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    runs-on: ubuntu-latest
     needs:
       - setup
       - dev-build
@@ -316,7 +316,7 @@ jobs:
           path: ${{ env.TEST_RESULTS_DIR }}
 
   upgrade-integration-test:
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    runs-on: ubuntu-latest
     needs:
       - setup
       - dev-build

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -258,7 +258,9 @@ jobs:
       - dev-build
     steps:
       - name: Debug Docker
-        run: docker inspect -f '{{index .Options "com.docker.network.bridge.enable_icc"}}' [network]
+        run: |
+          docker inspect -f '{{index .Options "com.docker.network.bridge.enable_icc"}}' host
+          docker inspect -f '{{index .Options "com.docker.network.bridge.enable_icc"}}' bridge
 
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -145,7 +145,7 @@ jobs:
           # this is further going to multiplied in envoy-integration tests by the 
           # other dimensions in the matrix.  Currently TOTAL_RUNNERS would be
           # multiplied by 8 based on these values:
-          # envoy-version: ["1.22.7", "1.23.4", "1.24.2", "1.25.1"]
+          # envoy-version: ["1.22.11", "1.23.8", "1.24.6", "1.25.4"]
           # xds-target: ["server", "client"]
           TOTAL_RUNNERS: 3 
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
@@ -171,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        envoy-version: ["1.22.7", "1.23.4", "1.24.2", "1.25.1"]
+        envoy-version: ["1.22.11", "1.23.8", "1.24.6", "1.25.4"]
         xds-target: ["server", "client"]
         test-cases: ${{ fromJSON(needs.generate-envoy-job-matrices.outputs.envoy-matrix) }}
     env:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -20,7 +20,7 @@ env:
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
   GOTAGS: ${{ endsWith(github.repository, '-enterprise') && 'consulent' || '' }}
   GOTESTSUM_VERSION: "1.9.0"
-  CONSUL_BINARY_UPLOAD_NAME: gotestsum_version: consul-bin
+  CONSUL_BINARY_UPLOAD_NAME: consul-bin
 
 jobs:
   setup:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -84,7 +84,8 @@ jobs:
 
       - name: Run integration tests
         run: |
-          go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
+          go install gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} && \
+          gotestsum \
             --format=short-verbose \
             --rerun-fails \
             --rerun-fails-report=/tmp/gotestsum-rerun-fails \

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -280,9 +280,8 @@ jobs:
       - name: Compatibility Integration Tests
         run: |
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"
-          cd ./test/integration/consul-container
+          cd ./test/integration/consul-container/test/upgrade
           docker run --rm consul:local consul version
-          # shellcheck disable=SC2046
           gotestsum \
             --raw-command \
             --format=short-verbose \
@@ -295,11 +294,11 @@ jobs:
             -tags "${{ env.GOTAGS }}" \
             -timeout=30m \
             -json \
-            $(go list ./... | grep -v upgrade) \
+            ./.../upgrade/ \
             --target-image consul \
             --target-version local \
             --latest-image consul \
-            --latest-version latest
+            --latest-version ${{ env.CONSUL_VERSION 
           ls -lrt
         env:
           # this is needed because of incompatibility between RYUK container and circleci
@@ -349,23 +348,24 @@ jobs:
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"
           cd ./test/integration/consul-container/test/upgrade
           docker run --rm consul:local consul version
+          PACKAGE_NAMES=$(go list -tags "${{ env.GOTAGS }}" ./...)
           gotestsum \
             --raw-command \
             --format=short-verbose \
             --debug \
             --rerun-fails=3 \
-            --packages="./..." \
+            --packages="${PACKAGE_NAMES}" \
             -- \
             go test \
             -p=4 \
             -tags "${{ env.GOTAGS }}" \
             -timeout=30m \
             -json \
-            ./.../upgrade/ \
+            ./... \
             --target-image consul \
             --target-version local \
             --latest-image consul \
-            --latest-version ${{ env.CONSUL_VERSION }}
+            --latest-version "${{ env.CONSUL_VERSION }}"
           ls -lrt
         env:
           # this is needed because of incompatibility between RYUK container and circleci

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -43,7 +43,7 @@ jobs:
     with:
       runs-on: ${{ needs.setup.outputs.compute-xl }}
       repository-name: ${{ github.repository }}
-      uploaded-binary-name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
+      uploaded-binary-name: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}
     secrets:
       elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 
@@ -298,7 +298,7 @@ jobs:
             --target-image consul \
             --target-version local \
             --latest-image consul \
-            --latest-version ${{ env.CONSUL_VERSION 
+            --latest-version ${{ env.CONSUL_VERSION }}
           ls -lrt
         env:
           # this is needed because of incompatibility between RYUK container and circleci

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -257,6 +257,9 @@ jobs:
       - setup
       - dev-build
     steps:
+      - name: Debug Docker
+        run: docker inspect -f '{{index .Options "com.docker.network.bridge.enable_icc"}}' [network]
+
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -377,3 +377,21 @@ jobs:
         with:
           name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
           path: ${{ env.TEST_RESULTS_DIR }}
+
+  test-integrations-success:
+    needs: 
+    - setup
+    - generate-envoy-job-matrices
+    - dev-build
+    - nomad-integration-test
+    - vault-integration-test
+    - envoy-integration-test
+    - compatibility-integration-test
+    - upgrade-integration-test
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+    if: |
+      (always() && ! cancelled()) &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    steps:
+      - run: echo "test-integrations succeeded"

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -356,7 +356,7 @@ jobs:
             --packages="${PACKAGE_NAMES}" \
             -- \
             go test \
-            -p=8 \
+            -p=4 \
             -tags "${{ env.GOTAGS }}" \
             -timeout=30m \
             -json \
@@ -364,7 +364,7 @@ jobs:
             --target-image consul \
             --target-version local \
             --latest-image consul \
-            --latest-version "$CONSUL_VERSION"
+            --latest-version "${{ env.CONSUL_VERSION }}"
           ls -lrt
         env:
           # this is needed because of incompatibility between RYUK container and circleci

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -127,7 +127,7 @@ jobs:
       - dev-build
     strategy:
       matrix:
-        vault-version: ["1.12.2", "1.11.6", "1.10.9", "1.9.10"]
+        vault-version: ["1.13.1", "1.12.5", "1.11.9", "1.10.11"]
     env:
       VAULT_BINARY_VERSION: ${{ matrix.vault-version }}
     steps:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -19,6 +19,8 @@ env:
   TEST_RESULTS_ARTIFACT_NAME: test-results
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
   GOTAGS: ${{ endsWith(github.repository, '-enterprise') && 'consulent' || '' }}
+  GOTESTSUM_VERSION: "1.9.0"
+  CONSUL_BINARY_UPLOAD_NAME: gotestsum_version: consul-bin
 
 jobs:
   setup:
@@ -35,41 +37,13 @@ jobs:
       - id: runners
         run: .github/scripts/get_runner_classes.sh
 
-  generate-envoy-job-matrices:
-    needs: [setup]
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-    name: Generate Envoy Job Matrices
-    outputs:
-      envoy-matrix: ${{ steps.set-matrix.outputs.envoy-matrix }}
-    steps:
-      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
-      - name: Generate Envoy Job Matrix
-        id: set-matrix
-        env:
-          # this is further going to multiplied in envoy-integration tests by the 
-          # other dimensions in the matrix.  Currently TOTAL_RUNNERS would be
-          # multiplied by 8 based on these values:
-          # envoy-version: ["1.22.7", "1.23.4", "1.24.2", "1.25.1"]
-          # xds-target: ["server", "client"]
-          TOTAL_RUNNERS: 3 
-          JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
-        run: |
-          {
-            echo -n "envoy-matrix="
-            find ./test/integration/connect/envoy -maxdepth 1 -type d -print0 \
-              | xargs -0 -n 1 basename \
-              | jq --raw-input --argjson runnercount "$TOTAL_RUNNERS" "$JQ_SLICER" \
-              | jq --compact-output 'map(join("|"))'
-          } >> "$GITHUB_OUTPUT"
-          cat "$GITHUB_OUTPUT"
-
   dev-build:
     needs: [setup]
     uses: ./.github/workflows/reusable-dev-build.yml
     with:
       runs-on: ${{ needs.setup.outputs.compute-xl }}
       repository-name: ${{ github.repository }}
-      uploaded-binary-name: 'consul-bin'
+      uploaded-binary-name: 'gotestsum_version: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
     secrets:
       elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 
@@ -85,7 +59,7 @@ jobs:
       - name: Setup gotestsum
         uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
         with:
-          gotestsum_version: 1.9.0
+          gotestsum_version: ${{ env.GOTESTSUM_VERSION }}
       - name: Checkout Nomad
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
         with:
@@ -100,7 +74,7 @@ jobs:
       - name: Fetch Consul binary
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: 'consul-bin'
+          name: 'gotestsum_version: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ./bin
       - name: Restore Consul permissions
         run: |
@@ -144,7 +118,7 @@ jobs:
 
       - uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
         with:
-          gotestsum_version: 1.9.0
+          gotestsum_version: ${{ env.GOTESTSUM_VERSION }}
 
       - name: Install Vault
         run: |
@@ -157,6 +131,34 @@ jobs:
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"
           make test-connect-ca-providers
 
+  generate-envoy-job-matrices:
+    needs: [setup]
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+    name: Generate Envoy Job Matrices
+    outputs:
+      envoy-matrix: ${{ steps.set-matrix.outputs.envoy-matrix }}
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - name: Generate Envoy Job Matrix
+        id: set-matrix
+        env:
+          # this is further going to multiplied in envoy-integration tests by the 
+          # other dimensions in the matrix.  Currently TOTAL_RUNNERS would be
+          # multiplied by 8 based on these values:
+          # envoy-version: ["1.22.7", "1.23.4", "1.24.2", "1.25.1"]
+          # xds-target: ["server", "client"]
+          TOTAL_RUNNERS: 3 
+          JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
+        run: |
+          {
+            echo -n "envoy-matrix="
+            find ./test/integration/connect/envoy -maxdepth 1 -type d -print0 \
+              | xargs -0 -n 1 basename \
+              | jq --raw-input --argjson runnercount "$TOTAL_RUNNERS" "$JQ_SLICER" \
+              | jq --compact-output 'map(join("|"))'
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+  
   envoy-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     permissions:
@@ -202,12 +204,12 @@ jobs:
       - name: Setup gotestsum
         uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
         with:
-          gotestsum_version: 1.9.0
+          gotestsum_version: ${{ env.GOTESTSUM_VERSION }}
 
       - name: fetch binary
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: 'consul-bin'
+          name: 'gotestsum_version: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ./bin
       - name: restore mode+x
         run: chmod +x ./bin/consul
@@ -262,13 +264,13 @@ jobs:
       - name: Setup gotestsum
         uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
         with:
-          gotestsum_version: 1.9.0
+          gotestsum_version: ${{ env.GOTESTSUM_VERSION }}
 
       # Build the consul:local image from the already built binary
       - name: fetch binary
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: 'consul-bin'
+          name: 'gotestsum_version: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: .
       - name: restore mode+x
         run: chmod +x consul
@@ -330,13 +332,13 @@ jobs:
       - name: Setup gotestsum
         uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
         with:
-          gotestsum_version: 1.9.0
+          gotestsum_version: ${{ env.GOTESTSUM_VERSION }}
 
       # Get go binary from workspace
       - name: fetch binary
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: 'consul-bin'
+          name: 'gotestsum_version: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: .
       - name: restore mode+x
         run: chmod +x consul

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -21,8 +21,8 @@ env:
   GOTAGS: ${{ endsWith(github.repository, '-enterprise') && 'consulent' || '' }}
   GOTESTSUM_VERSION: "1.9.0"
   CONSUL_BINARY_UPLOAD_NAME: consul-bin
-  # strip the hashicorp/ off the front of github.repository
-  CONSUL_LATEST_IMAGE_NAME: consul
+  # strip the hashicorp/ off the front of github.repository for consul
+  CONSUL_LATEST_IMAGE_NAME: ${{ endsWith(github.repository, '-enterprise') && github.repository || 'consul' }}
 
 jobs:
   setup:
@@ -378,6 +378,9 @@ jobs:
   
   upgrade-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    permissions:
+      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+      contents: read
     needs:
       - setup
       - dev-build
@@ -395,6 +398,33 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: go env
+
+      # NOTE: ENT specific step as we store secrets in Vault.
+      - name: Authenticate to Vault
+        if: ${{ endsWith(github.repository, '-enterprise') }}
+        id: vault-auth
+        run: vault-auth
+
+      # NOTE: ENT specific step as we store secrets in Vault.
+      - name: Fetch Secrets
+        if: ${{ endsWith(github.repository, '-enterprise') }}
+        id: secrets
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets: |
+              kv/data/github/${{ github.repository }}/dockerhub username | DOCKERHUB_USERNAME;
+              kv/data/github/${{ github.repository }}/dockerhub token | DOCKERHUB_TOKEN;
+
+      # NOTE: conditional specific logic as we store secrets in Vault in ENT and use GHA secrets in OSS.
+      - name: Login to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin@v2.1.0
+        with:
+          username: ${{ endsWith(github.repository, '-enterprise') && steps.secrets.outputs.DOCKERHUB_USERNAME || secrets.DOCKERHUB_USERNAME }}
+          password: ${{ endsWith(github.repository, '-enterprise') && steps.secrets.outputs.DOCKERHUB_TOKEN || secrets.DOCKERHUB_TOKEN }}
+
 
       # Get go binary from workspace
       - name: fetch binary

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -85,12 +85,12 @@ jobs:
       - name: Run integration tests
         run: |
           go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
-              --format=short-verbose \
-              --rerun-fails \
-              --rerun-fails-report=/tmp/gotestsum-rerun-fails \
-              --packages="./command/agent/consul" \
-              --junitfile $TEST_RESULTS_DIR/results.xml -- \
-              -run TestConsul
+            --format=short-verbose \
+            --rerun-fails \
+            --rerun-fails-report=/tmp/gotestsum-rerun-fails \
+            --packages="./command/agent/consul" \
+            --junitfile $TEST_RESULTS_DIR/results.xml -- \
+            -run TestConsul
 
   vault-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -1,0 +1,379 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+name: test-integrations
+
+on:
+  pull_request:
+    branches-ignore:
+      - stable-website
+      - 'docs/**'
+      - 'ui/**'
+      - 'mktg-**' # Digital Team Terraform-generated branch prefix
+      - 'backport/docs/**'
+      - 'backport/ui/**'
+      - 'backport/mktg-**'
+
+env:
+  TEST_RESULTS_DIR: /tmp/test-results
+  TEST_RESULTS_ARTIFACT_NAME: test-results
+  CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
+  GOTAGS: ${{ endsWith(github.repository, '-enterprise') && 'consulent' || '' }}
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    name: Setup
+    outputs:
+      compute-small: ${{ steps.runners.outputs.compute-small }}
+      compute-medium: ${{ steps.runners.outputs.compute-medium }}
+      compute-large: ${{ steps.runners.outputs.compute-large }}
+      compute-xl: ${{ steps.runners.outputs.compute-xl }}
+      enterprise: ${{ steps.runners.outputs.enterprise }}
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - id: runners
+        run: .github/scripts/get_runner_classes.sh
+
+  generate-envoy-job-matrices:
+    needs: [setup]
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+    name: Generate Envoy Job Matrices
+    outputs:
+      envoy-matrix: ${{ steps.set-matrix.outputs.envoy-matrix }}
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - name: Generate Envoy Job Matrix
+        id: set-matrix
+        env:
+          # this is further going to multiplied in envoy-integration tests by the 
+          # other dimensions in the matrix.  Currently TOTAL_RUNNERS would be
+          # multiplied by 8 based on these values:
+          # envoy-version: ["1.22.7", "1.23.4", "1.24.2", "1.25.1"]
+          # xds-target: ["server", "client"]
+          TOTAL_RUNNERS: 3 
+          JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
+        run: |
+          {
+            echo -n "envoy-matrix="
+            find ./test/integration/connect/envoy -maxdepth 1 -type d -print0 \
+              | xargs -0 -n 1 basename \
+              | jq --raw-input --argjson runnercount "$TOTAL_RUNNERS" "$JQ_SLICER" \
+              | jq --compact-output 'map(join("|"))'
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+
+  dev-build:
+    needs: [setup]
+    uses: ./.github/workflows/reusable-dev-build.yml
+    with:
+      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      repository-name: ${{ github.repository }}
+      uploaded-binary-name: 'consul-bin'
+    secrets:
+      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+
+  nomad-integration-test:
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
+    needs:
+      - setup
+      - dev-build
+    strategy:
+      matrix:
+        nomad-version: ['v1.3.3', 'v1.2.10', 'v1.1.16']
+    steps:
+      - name: Setup gotestsum
+        uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
+        with:
+          gotestsum_version: 1.9.0
+      - name: Checkout Nomad
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        with:
+          repository: hashicorp/nomad
+          ref: ${{ matrix.nomad-version }}
+
+      - name: Install Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Fetch Consul binary
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: 'consul-bin'
+          path: ./bin
+      - name: Restore Consul permissions
+        run: |
+          chmod +x ./bin/consul
+          echo "$(pwd)/bin" >> $GITHUB_PATH
+
+      - name: Make Nomad dev build
+        run: make pkg/linux_amd64/nomad
+
+      - name: Run integration tests
+        run: |
+          gotestsum \
+              --format=short-verbose \
+              --rerun-fails \
+              --rerun-fails-report=/tmp/gotestsum-rerun-fails \
+              --packages="./command/agent/consul" \
+              --junitfile $TEST_RESULTS_DIR/results.xml -- \
+              -run TestConsul
+
+  vault-integration-test:
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
+    needs:
+      - setup
+      - dev-build
+    strategy:
+      matrix:
+        vault-version: ["1.12.2", "1.11.6", "1.10.9", "1.9.10"]
+    env:
+      VAULT_BINARY_VERSION: ${{ matrix.vault-version }}
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+
+      # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+      - name: Setup Git
+        if: ${{ endsWith(github.repository, '-enterprise') }}
+        run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version-file: 'go.mod'
+
+      - uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
+        with:
+          gotestsum_version: 1.9.0
+
+      - name: Install Vault
+        run: |
+          wget -q -O /tmp/vault.zip "https://releases.hashicorp.com/vault/${{ env.VAULT_BINARY_VERSION }}/vault_${{ env.VAULT_BINARY_VERSION }}_linux_amd64.zip"
+          unzip -d /tmp /tmp/vault.zip
+          echo "/tmp" >> $GITHUB_PATH
+
+      - name: Run Connect CA Provider Tests
+        run: |
+          mkdir -p "${{ env.TEST_RESULTS_DIR }}"
+          make test-connect-ca-providers
+
+  envoy-integration-test:
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    permissions:
+      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+      contents: read
+    needs:
+      - setup
+      - generate-envoy-job-matrices
+      - dev-build
+    strategy:
+      fail-fast: false
+      matrix:
+        envoy-version: ["1.22.7", "1.23.4", "1.24.2", "1.25.1"]
+        xds-target: ["server", "client"]
+        test-cases: ${{ fromJSON(needs.generate-envoy-job-matrices.outputs.envoy-matrix) }}
+    env:
+      ENVOY_VERSION: ${{ matrix.envoy-version }}
+      XDS_TARGET: ${{ matrix.xds-target }}
+      AWS_LAMBDA_REGION: us-west-2
+    steps:
+      # NOTE: ENT specific step as we store secrets in Vault.
+      - name: Authenticate to Vault
+        if: ${{ endsWith(github.repository, '-enterprise') }}
+        id: vault-auth
+        run: vault-auth
+
+      # NOTE: ENT specific step as we store secrets in Vault.
+      - name: Fetch Secrets
+        if: ${{ endsWith(github.repository, '-enterprise') }}
+        id: secrets
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets: |
+            kv/data/github/${{ github.repository }}/aws arn | AWS_ROLE_ARN ;
+
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Setup gotestsum
+        uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
+        with:
+          gotestsum_version: 1.9.0
+
+      - name: fetch binary
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: 'consul-bin'
+          path: ./bin
+      - name: restore mode+x
+        run: chmod +x ./bin/consul
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # v2.4.1
+
+      - name: Docker build
+        run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile ./bin
+
+      - name: Envoy Integration Tests
+        env:
+          GOTESTSUM_JUNITFILE: ${{ env.TEST_RESULTS_DIR }}/results.xml
+          GOTESTSUM_FORMAT: standard-verbose
+          COMPOSE_INTERACTIVE_NO_CLI: 1
+          LAMBDA_TESTS_ENABLED: "true"
+          # tput complains if this isn't set to something.
+          TERM: ansi
+        run: |
+          # shellcheck disable=SC2001
+          echo "Running $(sed 's,|, ,g' <<< "${{ matrix.test-cases }}" |wc -w) subtests"
+          # shellcheck disable=SC2001
+          sed 's,|,\n,g' <<< "${{ matrix.test-cases }}"
+          gotestsum \
+              --debug \
+              --rerun-fails \
+              --rerun-fails-report=/tmp/gotestsum-rerun-fails \
+              --jsonfile /tmp/jsonfile/go-test.log \
+              --packages=./test/integration/connect/envoy \
+              -- -timeout=30m -tags integration -run="TestEnvoy/(${{ matrix.test-cases }})"
+          
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: container-logs
+          path: ./test/integration/connect/envoy/workdir/logs
+
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
+          path: ${{ env.TEST_RESULTS_DIR }}
+
+  compatibility-integration-test:
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    needs:
+      - setup
+      - dev-build
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Setup gotestsum
+        uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
+        with:
+          gotestsum_version: 1.9.0
+
+      # Build the consul:local image from the already built binary
+      - name: fetch binary
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: 'consul-bin'
+          path: .
+      - name: restore mode+x
+        run: chmod +x consul
+
+      - name: Build consul:local image
+        run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile .
+      - name: Compatibility Integration Tests
+        run: |
+          mkdir -p "${{ env.TEST_RESULTS_DIR }}"
+          cd ./test/integration/consul-container
+          docker run --rm consul:local consul version
+          # shellcheck disable=SC2046
+          gotestsum \
+            --raw-command \
+            --format=short-verbose \
+            --debug \
+            --rerun-fails=3 \
+            --packages="./..." \
+            -- \
+            go test \
+            -p=4 \
+            -tags "${{ env.GOTAGS }}" \
+            -timeout=30m \
+            -json \
+            $(go list ./... | grep -v upgrade) \
+            --target-image consul \
+            --target-version local \
+            --latest-image consul \
+            --latest-version latest
+          ls -lrt
+        env:
+          # this is needed because of incompatibility between RYUK container and circleci
+          GOTESTSUM_JUNITFILE: ${{ env.TEST_RESULTS_DIR }}/results.xml
+          GOTESTSUM_FORMAT: standard-verbose
+          COMPOSE_INTERACTIVE_NO_CLI: 1
+          # tput complains if this isn't set to something.
+          TERM: ansi
+
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
+          path: ${{ env.TEST_RESULTS_DIR }}
+
+  upgrade-integration-test:
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    needs:
+      - setup
+      - dev-build
+    strategy:
+      matrix:
+        consul-version: [ "1.14", "1.15"]
+    env:
+      CONSUL_VERSION: ${{ matrix.consul-version }}
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Setup gotestsum
+        uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
+        with:
+          gotestsum_version: 1.9.0
+
+      # Get go binary from workspace
+      - name: fetch binary
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: 'consul-bin'
+          path: .
+      - name: restore mode+x
+        run: chmod +x consul
+      - name: Build consul:local image
+        run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile .
+      - name: Upgrade Integration Tests
+        run: |
+          mkdir -p "${{ env.TEST_RESULTS_DIR }}"
+          cd ./test/integration/consul-container/test/upgrade
+          docker run --rm consul:local consul version
+          PACKAGE_NAMES=$(go list -tags "${{ env.GOTAGS }}" ./...)
+          gotestsum \
+            --raw-command \
+            --format=short-verbose \
+            --debug \
+            --rerun-fails=3 \
+            --packages="${PACKAGE_NAMES}" \
+            -- \
+            go test \
+            -p=8 \
+            -tags "${{ env.GOTAGS }}" \
+            -timeout=30m \
+            -json \
+            ./... \
+            --target-image consul \
+            --target-version local \
+            --latest-image consul \
+            --latest-version "$CONSUL_VERSION"
+          ls -lrt
+        env:
+          # this is needed because of incompatibility between RYUK container and circleci
+          GOTESTSUM_JUNITFILE: ${{ env.TEST_RESULTS_DIR }}/results.xml
+          GOTESTSUM_FORMAT: standard-verbose
+          COMPOSE_INTERACTIVE_NO_CLI: 1
+          # tput complains if this isn't set to something.
+          TERM: ansi
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
+          path: ${{ env.TEST_RESULTS_DIR }}

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -257,11 +257,6 @@ jobs:
       - setup
       - dev-build
     steps:
-      - name: Debug Docker
-        run: |
-          docker inspect -f '{{index .Options "com.docker.network.bridge.enable_icc"}}' host
-          docker inspect -f '{{index .Options "com.docker.network.bridge.enable_icc"}}' bridge
-
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -261,6 +261,7 @@ jobs:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: 'go.mod'
+      - run: go env
       - name: Setup gotestsum
         uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
         with:
@@ -327,6 +328,7 @@ jobs:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: 'go.mod'
+      - run: go env
       - name: Setup gotestsum
         uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
         with:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -43,7 +43,7 @@ jobs:
     with:
       runs-on: ${{ needs.setup.outputs.compute-xl }}
       repository-name: ${{ github.repository }}
-      uploaded-binary-name: 'gotestsum_version: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
+      uploaded-binary-name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
     secrets:
       elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 
@@ -74,7 +74,7 @@ jobs:
       - name: Fetch Consul binary
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: 'gotestsum_version: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
+          name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ./bin
       - name: Restore Consul permissions
         run: |
@@ -209,7 +209,7 @@ jobs:
       - name: fetch binary
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: 'gotestsum_version: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
+          name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ./bin
       - name: restore mode+x
         run: chmod +x ./bin/consul
@@ -270,7 +270,7 @@ jobs:
       - name: fetch binary
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: 'gotestsum_version: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
+          name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: .
       - name: restore mode+x
         run: chmod +x consul
@@ -337,7 +337,7 @@ jobs:
       - name: fetch binary
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: 'gotestsum_version: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
+          name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: .
       - name: restore mode+x
         run: chmod +x consul

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -43,7 +43,7 @@ jobs:
     with:
       runs-on: ${{ needs.setup.outputs.compute-xl }}
       repository-name: ${{ github.repository }}
-      uploaded-binary-name: ${{ env.CONSUL_BINARY_UPLOAD_NAME }}
+      uploaded-binary-name: 'consul-bin'
     secrets:
       elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -281,7 +281,7 @@ jobs:
       - name: Compatibility Integration Tests
         run: |
             mkdir -p "/tmp/test-results"
-            cd ./test/integration/consul-container
+            cd ./test/integration/consul-container/test
             docker run --rm consul:local consul version
             # shellcheck disable=SC2046
             gotestsum \

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -349,24 +349,23 @@ jobs:
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"
           cd ./test/integration/consul-container/test/upgrade
           docker run --rm consul:local consul version
-          PACKAGE_NAMES=$(go list -tags "${{ env.GOTAGS }}" ./...)
           gotestsum \
             --raw-command \
             --format=short-verbose \
             --debug \
             --rerun-fails=3 \
-            --packages="${PACKAGE_NAMES}" \
+            --packages="./..." \
             -- \
             go test \
             -p=4 \
             -tags "${{ env.GOTAGS }}" \
             -timeout=30m \
             -json \
-            ./... \
+            ./.../upgrade/ \
             --target-image consul \
             --target-version local \
             --latest-image consul \
-            --latest-version "${{ env.CONSUL_VERSION }}"
+            --latest-version ${{ env.CONSUL_VERSION }}
           ls -lrt
         env:
           # this is needed because of incompatibility between RYUK container and circleci

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -280,26 +280,28 @@ jobs:
         run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile .
       - name: Compatibility Integration Tests
         run: |
-          mkdir -p "${{ env.TEST_RESULTS_DIR }}"
-          cd ./test/integration/consul-container
-          docker run --rm consul:local consul version
-          gotestsum \
-            --raw-command \
-            --format=short-verbose \
-            --debug \
-            --rerun-fails=3 \
-            --packages="./..." \
-            -- \
-            go test \
-            -p=4 \
-            -timeout=30m \
-            -json \
-            `go list ./... | grep -v upgrade` \
-            --target-image consul \
-            --target-version local \
-            --latest-image consul \
-            --latest-version latest
-          ls -lrt
+            mkdir -p "/tmp/test-results"
+            cd ./test/integration/consul-container
+            docker run --rm consul:local consul version
+            # shellcheck disable=SC2046
+            gotestsum \
+              --raw-command \
+              --format=short-verbose \
+              --debug \
+              --rerun-fails=3 \
+              --packages="./..." \
+              -- \
+              go test \
+              -p=4 \
+              -tags "" \
+              -timeout=30m \
+              -json \
+              $(go list ./... | grep -v upgrade) \
+              --target-image consul \
+              --target-version local \
+              --latest-image consul \
+              --latest-version latest
+            ls -lrt
         env:
           # this is needed because of incompatibility between RYUK container and circleci
           GOTESTSUM_JUNITFILE: ${{ env.TEST_RESULTS_DIR }}/results.xml

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -58,10 +58,6 @@ jobs:
       matrix:
         nomad-version: ['v1.3.3', 'v1.2.10', 'v1.1.16']
     steps:
-      - name: Setup gotestsum
-        uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
-        with:
-          gotestsum_version: ${{ env.GOTESTSUM_VERSION }}
       - name: Checkout Nomad
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
         with:
@@ -88,7 +84,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          gotestsum \
+          go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
               --format=short-verbose \
               --rerun-fails \
               --rerun-fails-report=/tmp/gotestsum-rerun-fails \
@@ -118,10 +114,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
-        with:
-          gotestsum_version: ${{ env.GOTESTSUM_VERSION }}
-
       - name: Install Vault
         run: |
           wget -q -O /tmp/vault.zip "https://releases.hashicorp.com/vault/${{ env.VAULT_BINARY_VERSION }}/vault_${{ env.VAULT_BINARY_VERSION }}_linux_amd64.zip"
@@ -131,7 +123,20 @@ jobs:
       - name: Run Connect CA Provider Tests
         run: |
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"
-          make test-connect-ca-providers
+          go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
+            --format=short-verbose \
+            --junitfile "${{ env.TEST_RESULTS_DIR }}/gotestsum-report.xml" \
+            -- -tags "${{ env.GOTAGS }}" -cover -coverprofile=coverage.txt ./agent/connect/ca
+          # Run leader tests that require Vault
+          go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
+            --format=short-verbose \
+            --junitfile "${{ env.TEST_RESULTS_DIR }}/gotestsum-report-leader.xml" \
+            -- -tags "${{ env.GOTAGS }}" -cover -coverprofile=coverage-leader.txt -run Vault ./agent/consul
+          # Run agent tests that require Vault
+          go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
+            --format=short-verbose \
+            --junitfile "${{ env.TEST_RESULTS_DIR }}/gotestsum-report-agent.xml" \
+            -- -tags "${{ env.GOTAGS }}" -cover -coverprofile=coverage-agent.txt -run Vault ./agent
 
   generate-envoy-job-matrices:
     needs: [setup]
@@ -203,10 +208,6 @@ jobs:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: 'go.mod'
-      - name: Setup gotestsum
-        uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
-        with:
-          gotestsum_version: ${{ env.GOTESTSUM_VERSION }}
 
       - name: fetch binary
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
@@ -235,7 +236,7 @@ jobs:
           echo "Running $(sed 's,|, ,g' <<< "${{ matrix.test-cases }}" |wc -w) subtests"
           # shellcheck disable=SC2001
           sed 's,|,\n,g' <<< "${{ matrix.test-cases }}"
-          gotestsum \
+          go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
               --debug \
               --rerun-fails \
               --rerun-fails-report=/tmp/gotestsum-rerun-fails \
@@ -292,10 +293,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: go env
-      - name: Setup gotestsum
-        uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
-        with:
-          gotestsum_version: ${{ env.GOTESTSUM_VERSION }}
 
       # Build the consul:local image from the already built binary
       - name: fetch binary
@@ -322,7 +319,7 @@ jobs:
             echo "Running $(sed 's,|, ,g' <<< "${{ matrix.test-cases }}" |wc -w) subtests"
             # shellcheck disable=SC2001
             sed 's,|,\n,g' <<< "${{ matrix.test-cases }}"
-            gotestsum \
+            go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
               --raw-command \
               --format=short-verbose \
               --debug \
@@ -397,10 +394,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: go env
-      - name: Setup gotestsum
-        uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # v1.0.0
-        with:
-          gotestsum_version: ${{ env.GOTESTSUM_VERSION }}
 
       # Get go binary from workspace
       - name: fetch binary
@@ -426,7 +419,7 @@ jobs:
           echo "Running $(sed 's,|, ,g' <<< "${{ matrix.test-cases }}" |wc -w) subtests"
           # shellcheck disable=SC2001
           sed 's,|,\n,g' <<< "${{ matrix.test-cases }}"
-          gotestsum \
+          go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
             --raw-command \
             --format=short-verbose \
             --debug \


### PR DESCRIPTION
### Description
This configuration currently works in ENT but fails in OSS.  GitHub is helping us look at it.  The docker based tests in `compatability-tests` and `upgrade-test` fail with intermittent communication failures when docker containers need to talk to each other as is the case for 3 servers joining in a cluster.

As part of troubleshooting that issue, most iteration has been done on [this](https://github.com/hashicorp/consul/tree/jm/hack-int) which comments out all of the envoy, nomad, and vault stuff so that it only runs the two jobs with docker based tests.

### Remaining items Checklist

- [x] get docker based compatibility tests and upgrade tests to pass in OSS.  They currently pass in ENT.
- [x] revisit testsplitting for envoy
- [x] audit commands for GHA vs CircleCI in OSS and ENT
- [x] ensure envoy, nomad, vault versions match CircleCI for OSS and ENT