### PR TITLE
Test: add noCleanup to TestServer stop

### DIFF
--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -357,7 +357,13 @@ func NewTestServerConfigT(t TestingTB, cb ServerConfigCallback) (*TestServer, er
 // Stop stops the test Consul server, and removes the Consul data
 // directory once we are done.
 func (s *TestServer) Stop() error {
-	defer os.RemoveAll(s.tmpdir)
+	defer func() {
+		if noCleanup {
+			fmt.Println("skipping cleanup because TEST_NOCLEANUP was enabled")
+		} else {
+			os.RemoveAll(s.tmpdir)
+		}
+	}()
 
 	// There was no process
 	if s.cmd == nil {


### PR DESCRIPTION
### Description

`noCleanup` exists in the test code to preserve the data after unit test run.

https://github.com/hashicorp/consul/blob/430df05e61a017627f4e5eb5e38513840f6172d1/sdk/testutil/io.go#L12

`noCleanup` has been used in someplace like 

https://github.com/hashicorp/consul/blob/430df05e61a017627f4e5eb5e38513840f6172d1/sdk/testutil/io.go#L18

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
