### PR TITLE
ci: increase ENT runner size for xl to match OSS.  have build-distros use  xl to match CircleCI

### DIFF
--- a/.github/scripts/get_runner_classes.sh
+++ b/.github/scripts/get_runner_classes.sh
@@ -13,7 +13,8 @@ case "$GITHUB_REPOSITORY" in
         echo "compute-small=['self-hosted', 'linux', 'small']" >> "$GITHUB_OUTPUT"
         echo "compute-medium=['self-hosted', 'linux', 'medium']" >> "$GITHUB_OUTPUT"
         echo "compute-large=['self-hosted', 'linux', 'large']" >> "$GITHUB_OUTPUT"
-        echo "compute-xl=['self-hosted', 'ondemand', 'linux', 'type=m5.2xlarge']" >> "$GITHUB_OUTPUT"
+        # m5d.8xlarge is equivalent to our xl custom runner in OSS
+        echo "compute-xl=['self-hosted', 'ondemand', 'linux', 'type=m5d.8xlarge']" >> "$GITHUB_OUTPUT"
         ;;
     *)
         # shellcheck disable=SC2129

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -32,7 +32,7 @@ jobs:
 
   dev-build-push:
     needs: setup
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-medium) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read

--- a/.github/workflows/build-distros.yml
+++ b/.github/workflows/build-distros.yml
@@ -44,7 +44,7 @@ jobs:
     - check-go-mod
     env:
       XC_OS: "freebsd linux windows"
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-medium) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
 
@@ -68,7 +68,7 @@ jobs:
     - check-go-mod
     env:
       XC_OS: "darwin freebsd linux solaris windows"
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-medium) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
 


### PR DESCRIPTION


### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
