### PR TITLE
APIGW: Routes with duplicate parents should be invalid

### DIFF
--- a/agent/structs/config_entry_routes.go
+++ b/agent/structs/config_entry_routes.go
@@ -4,6 +4,7 @@
 package structs
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -143,10 +144,16 @@ func (e *HTTPRouteConfigEntry) Validate() error {
 		APIGateway: true,
 	}
 
+	uniques := make(map[ResourceReference]struct{}, len(e.Parents))
+
 	for _, parent := range e.Parents {
 		if !validParentKinds[parent.Kind] {
 			return fmt.Errorf("unsupported parent kind: %q, must be 'api-gateway'", parent.Kind)
 		}
+		if _, ok := uniques[parent]; ok {
+			return errors.New("route parents must be unique")
+		}
+		uniques[parent] = struct{}{}
 	}
 
 	if err := validateConfigEntryMeta(e.Meta); err != nil {

--- a/agent/structs/config_entry_routes.go
+++ b/agent/structs/config_entry_routes.go
@@ -150,6 +150,7 @@ func (e *HTTPRouteConfigEntry) Validate() error {
 		if !validParentKinds[parent.Kind] {
 			return fmt.Errorf("unsupported parent kind: %q, must be 'api-gateway'", parent.Kind)
 		}
+
 		if _, ok := uniques[parent]; ok {
 			return errors.New("route parents must be unique")
 		}
@@ -541,10 +542,19 @@ func (e *TCPRouteConfigEntry) Validate() error {
 	if len(e.Services) > 1 {
 		return fmt.Errorf("tcp-route currently only supports one service")
 	}
+
+	uniques := make(map[ResourceReference]struct{}, len(e.Parents))
+
 	for _, parent := range e.Parents {
 		if !validParentKinds[parent.Kind] {
 			return fmt.Errorf("unsupported parent kind: %q, must be 'api-gateway'", parent.Kind)
 		}
+
+		if _, ok := uniques[parent]; ok {
+			return errors.New("route parents must be unique")
+		}
+		uniques[parent] = struct{}{}
+
 	}
 
 	if err := validateConfigEntryMeta(e.Meta); err != nil {


### PR DESCRIPTION
### Description

We currently don't validate that routes cannot have duplicate parents. This change introduces validations to ensure parents are unique according to the k8s gateway spec https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.CommonRouteSpec

Of note: we reached out to the k8's sig for clarification on some potential edge cases: https://github.com/kubernetes-sigs/gateway-api/issues/1925
depending on the result of that this code may change in the future.

### Testing & Reproduction steps
Run the `./start.sh` script from here https://github.com/jm96441n/consul-experiments/tree/main/vm/basic-api-gateway (this assumes you have run the `convoy-build` script at the root of the repo and have built a consul image locally). You will see the route be successfully added, rebuild the images with the changes in this branch and you will see the route fail to be entered.

### Links

[k8s parent refs docs](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.CommonRouteSpec)

### PR Checklist

* [X] updated test coverage
* [ ] external facing docs updated
* [X] not a security concern
