### PR TITLE
upgrade test: config nodeName, nodeid, and inherited persistent data for consul container

### DIFF
--- a/test/integration/consul-container/go.mod
+++ b/test/integration/consul-container/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/itchyny/gojq v0.12.9
 	github.com/mitchellh/copystructure v1.2.0
+	github.com/otiai10/copy v1.10.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 	github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569

--- a/test/integration/consul-container/go.sum
+++ b/test/integration/consul-container/go.sum
@@ -641,6 +641,9 @@ github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqi
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
+github.com/otiai10/copy v1.10.0 h1:znyI7l134wNg/wDktoVQPxPkgvhDfGCYUasey+h0rDQ=
+github.com/otiai10/copy v1.10.0/go.mod h1:rSaLseMUsZFFbsFGc7wCJnnkTAvdc5L6VWxPE4308Ww=
+github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/test/integration/consul-container/libs/cluster/agent.go
+++ b/test/integration/consul-container/libs/cluster/agent.go
@@ -40,6 +40,19 @@ type Agent interface {
 //
 // Constructed by (Builder).ToAgentConfig()
 type Config struct {
+	// NodeName is set for the consul agent name and container name
+	// Equivalent to the -node command-line flag.
+	// If empty, a randam name will be generated
+	NodeName string
+	// NodeID is used to configure node_id in agent config file
+	// Equivalent to the -node-id command-line flag.
+	// If empty, a randam name will be generated
+	NodeID string
+
+	// ExternalDataDir is data directory to copy consul data from, if set.
+	// This directory contains subdirectories like raft, serf, services
+	ExternalDataDir string
+
 	ScratchDir    string
 	CertVolume    string
 	CACert        string

--- a/test/integration/consul-container/libs/cluster/builder.go
+++ b/test/integration/consul-container/libs/cluster/builder.go
@@ -273,6 +273,11 @@ func (b *Builder) Peering(enable bool) *Builder {
 	return b
 }
 
+func (b *Builder) NodeID(nodeID string) *Builder {
+	b.conf.Set("node_id", nodeID)
+	return b
+}
+
 func (b *Builder) Partition(name string) *Builder {
 	b.conf.Set("partition", name)
 	return b

--- a/test/integration/consul-container/libs/cluster/container.go
+++ b/test/integration/consul-container/libs/cluster/container.go
@@ -16,6 +16,7 @@ import (
 	goretry "github.com/avast/retry-go"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/hashicorp/go-multierror"
+	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -94,11 +95,15 @@ func NewConsulContainer(ctx context.Context, config Config, cluster *Cluster, po
 		return nil, err
 	}
 
-	consulType := "client"
-	if pc.Server {
-		consulType = "server"
+	name := config.NodeName
+	if name == "" {
+		// Generate a random name for the agent
+		consulType := "client"
+		if pc.Server {
+			consulType = "server"
+		}
+		name = utils.RandName(fmt.Sprintf("%s-consul-%s-%d", pc.Datacenter, consulType, index))
 	}
-	name := utils.RandName(fmt.Sprintf("%s-consul-%s-%d", pc.Datacenter, consulType, index))
 
 	// Inject new Agent name
 	config.Cmd = append(config.Cmd, "-node", name)
@@ -109,6 +114,14 @@ func NewConsulContainer(ctx context.Context, config Config, cluster *Cluster, po
 	}
 	if err := os.Chmod(tmpDirData, 0777); err != nil {
 		return nil, fmt.Errorf("error chowning data directory %s: %w", tmpDirData, err)
+	}
+
+	if config.ExternalDataDir != "" {
+		// copy consul persistent state from an external dir
+		err := copy.Copy(config.ExternalDataDir, tmpDirData)
+		if err != nil {
+			return nil, fmt.Errorf("error copying persistent data from %s: %w", config.ExternalDataDir, err)
+		}
 	}
 
 	var caCertFileForAPI string


### PR DESCRIPTION
### Description
This PR allows configuring Node name, node Id, and external consul data to copy from for the consul container.
With this change, we can do upgrade test if a newer version of consul can use the data generated from an older version of consul.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
