### PR TITLE
Remove deprecated service-defaults upstream behavior.

### DIFF
--- a/.changelog/16957.txt
+++ b/.changelog/16957.txt
@@ -1,0 +1,5 @@
+```release-note:breaking-change
+peering: Removed deprecated backward-compatibility behavior.
+Upstream overrides in service-defaults will now only apply to peer upstreams when the `peer` field is provided.
+Visit the 1.16.x [upgrade instructions](https://developer.hashicorp.com/consul/docs/upgrading/upgrade-specific) for more information.
+```

--- a/agent/configentry/merge_service_config.go
+++ b/agent/configentry/merge_service_config.go
@@ -157,44 +157,20 @@ func MergeServiceConfig(defaults *structs.ServiceConfigResponse, service *struct
 	// remoteUpstreams contains synthetic Upstreams generated from central config (service-defaults.UpstreamConfigs).
 	remoteUpstreams := make(map[structs.PeeredServiceName]structs.Upstream)
 
-	if len(defaults.UpstreamIDConfigs) > 0 {
-		// Handle legacy upstreams. This should be removed in Consul 1.16.
-		for _, us := range defaults.UpstreamIDConfigs {
-			parsed, err := structs.ParseUpstreamConfigNoDefaults(us.Config)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse upstream config map for %s: %v", us.Upstream.String(), err)
-			}
-			psn := structs.PeeredServiceName{
-				Peer:        "",
-				ServiceName: structs.NewServiceName(us.Upstream.ID, &us.Upstream.EnterpriseMeta),
-			}
-
-			remoteUpstreams[psn] = structs.Upstream{
-				DestinationNamespace: us.Upstream.NamespaceOrDefault(),
-				DestinationPartition: us.Upstream.PartitionOrDefault(),
-				DestinationName:      us.Upstream.ID,
-				DestinationPeer:      "",
-				Config:               us.Config,
-				MeshGateway:          parsed.MeshGateway,
-				CentrallyConfigured:  true,
-			}
+	for _, us := range defaults.UpstreamConfigs {
+		parsed, err := structs.ParseUpstreamConfigNoDefaults(us.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse upstream config map for %s: %v", us.Upstream.String(), err)
 		}
-	} else {
-		for _, us := range defaults.UpstreamConfigs {
-			parsed, err := structs.ParseUpstreamConfigNoDefaults(us.Config)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse upstream config map for %s: %v", us.Upstream.String(), err)
-			}
 
-			remoteUpstreams[us.Upstream] = structs.Upstream{
-				DestinationNamespace: us.Upstream.ServiceName.NamespaceOrDefault(),
-				DestinationPartition: us.Upstream.ServiceName.PartitionOrDefault(),
-				DestinationName:      us.Upstream.ServiceName.Name,
-				DestinationPeer:      us.Upstream.Peer,
-				Config:               us.Config,
-				MeshGateway:          parsed.MeshGateway,
-				CentrallyConfigured:  true,
-			}
+		remoteUpstreams[us.Upstream] = structs.Upstream{
+			DestinationNamespace: us.Upstream.ServiceName.NamespaceOrDefault(),
+			DestinationPartition: us.Upstream.ServiceName.PartitionOrDefault(),
+			DestinationName:      us.Upstream.ServiceName.Name,
+			DestinationPeer:      us.Upstream.Peer,
+			Config:               us.Config,
+			MeshGateway:          parsed.MeshGateway,
+			CentrallyConfigured:  true,
 		}
 	}
 

--- a/agent/configentry/resolve.go
+++ b/agent/configentry/resolve.go
@@ -133,7 +133,7 @@ func ComputeResolvedServiceConfig(
 	seenUpstreams := map[structs.PeeredServiceName]struct{}{}
 
 	var (
-		noUpstreamArgs = len(args.UpstreamServiceNames) == 0 && len(args.UpstreamIDs) == 0
+		noUpstreamArgs = len(args.UpstreamServiceNames) == 0
 
 		// Check the args and the resolved value. If it was exclusively set via a config entry, then args.Mode
 		// will never be transparent because the service config request does not use the resolved value.
@@ -152,15 +152,6 @@ func ComputeResolvedServiceConfig(
 		if _, ok := seenUpstreams[psn]; !ok {
 			seenUpstreams[psn] = struct{}{}
 		}
-	}
-	// For 1.14, service-defaults overrides would apply to peer upstreams incorrectly
-	// because the config merging logic was oblivious to the concept of a peer.
-	// We replicate this behavior on legacy calls for backwards-compatibility.
-	for _, sid := range args.UpstreamIDs {
-		psn := structs.PeeredServiceName{
-			ServiceName: structs.NewServiceName(sid.ID, &sid.EnterpriseMeta),
-		}
-		seenUpstreams[psn] = struct{}{}
 	}
 
 	// Then store upstreams inferred from service-defaults and mapify the overrides.
@@ -205,22 +196,6 @@ func ComputeResolvedServiceConfig(
 	if len(wildcardUpstreamDefaults) > 0 {
 		resolvedConfigs[wildcard] = wildcardUpstreamDefaults
 	}
-
-	// For Consul 1.14.x, service-defaults would apply to either local or peer services as long
-	// as the `name` matched. We introduce `legacyUpstreams` as a compatibility mode for:
-	//   1. old agents, that are using the deprecated UpstreamIDs api
-	//   2. Migrations to 1.15 that do not specify the "peer" field. The behavior should remain the same
-	//      until the config entries are updates.
-	//
-	// This should be remove in Consul 1.16
-	var hasPeerUpstream bool
-	for _, override := range upstreamOverrides {
-		if override.Peer != "" {
-			hasPeerUpstream = true
-			break
-		}
-	}
-	legacyUpstreams := len(args.UpstreamIDs) > 0 || !hasPeerUpstream
 
 	for upstream := range seenUpstreams {
 		resolvedCfg := make(map[string]interface{})
@@ -273,16 +248,6 @@ func ComputeResolvedServiceConfig(
 		}
 
 		// Merge in Overrides for the upstream (step 5).
-		// In the legacy case, overrides only match on name. We remove the peer and try to match against
-		// our map of overrides. We still want to check the full PSN in the map in case there is a specific
-		// override that applies to peers.
-		if legacyUpstreams {
-			peerlessUpstream := upstream
-			peerlessUpstream.Peer = ""
-			if upstreamOverrides[peerlessUpstream] != nil {
-				upstreamOverrides[peerlessUpstream].MergeInto(resolvedCfg)
-			}
-		}
 		if upstreamOverrides[upstream] != nil {
 			upstreamOverrides[upstream].MergeInto(resolvedCfg)
 		}
@@ -297,21 +262,11 @@ func ComputeResolvedServiceConfig(
 		return &thisReply, nil
 	}
 
-	if len(args.UpstreamIDs) > 0 {
-		// DEPRECATED: Remove these legacy upstreams in Consul v1.16
-		thisReply.UpstreamIDConfigs = make(structs.OpaqueUpstreamConfigsDeprecated, 0, len(resolvedConfigs))
+	thisReply.UpstreamConfigs = make(structs.OpaqueUpstreamConfigs, 0, len(resolvedConfigs))
 
-		for us, conf := range resolvedConfigs {
-			thisReply.UpstreamIDConfigs = append(thisReply.UpstreamIDConfigs,
-				structs.OpaqueUpstreamConfigDeprecated{Upstream: us.ServiceName.ToServiceID(), Config: conf})
-		}
-	} else {
-		thisReply.UpstreamConfigs = make(structs.OpaqueUpstreamConfigs, 0, len(resolvedConfigs))
-
-		for us, conf := range resolvedConfigs {
-			thisReply.UpstreamConfigs = append(thisReply.UpstreamConfigs,
-				structs.OpaqueUpstreamConfig{Upstream: us, Config: conf})
-		}
+	for us, conf := range resolvedConfigs {
+		thisReply.UpstreamConfigs = append(thisReply.UpstreamConfigs,
+			structs.OpaqueUpstreamConfig{Upstream: us, Config: conf})
 	}
 
 	return &thisReply, nil

--- a/agent/proxycfg-glue/resolved_service_config.go
+++ b/agent/proxycfg-glue/resolved_service_config.go
@@ -5,7 +5,6 @@ package proxycfgglue
 
 import (
 	"context"
-	"errors"
 
 	"github.com/hashicorp/go-memdb"
 
@@ -38,10 +37,6 @@ type serverResolvedServiceConfig struct {
 func (s *serverResolvedServiceConfig) Notify(ctx context.Context, req *structs.ServiceConfigRequest, correlationID string, ch chan<- proxycfg.UpdateEvent) error {
 	if req.Datacenter != s.deps.Datacenter {
 		return s.remoteSource.Notify(ctx, req, correlationID, ch)
-	}
-
-	if len(req.UpstreamIDs) != 0 {
-		return errors.New("ServerResolvedServiceConfig does not support the legacy UpstreamIDs parameter")
 	}
 
 	return watch.ServerLocalNotify(ctx, correlationID, s.deps.GetStore,

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -829,9 +829,6 @@ func fixPersistedServiceConfigForTest(content []byte) ([]byte, error) {
 		return nil, err
 	}
 	// Sort the output, since it's randomized and causes flaky tests otherwise.
-	sort.Slice(parsed.Defaults.UpstreamIDConfigs, func(i, j int) bool {
-		return parsed.Defaults.UpstreamIDConfigs[i].Upstream.ID < parsed.Defaults.UpstreamIDConfigs[j].Upstream.ID
-	})
 	sort.Slice(parsed.Defaults.UpstreamConfigs, func(i, j int) bool {
 		return parsed.Defaults.UpstreamConfigs[i].Upstream.String() < parsed.Defaults.UpstreamConfigs[j].Upstream.String()
 	})

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -2146,13 +2146,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 
 func TestServiceConfigRequest(t *testing.T) {
 
-	makeLegacyUpstreamIDs := func(services ...string) []ServiceID {
-		u := make([]ServiceID, 0, len(services))
-		for _, s := range services {
-			u = append(u, NewServiceID(s, acl.DefaultEnterpriseMeta()))
-		}
-		return u
-	}
 	tests := []struct {
 		name     string
 		req      ServiceConfigRequest
@@ -2183,39 +2176,17 @@ func TestServiceConfigRequest(t *testing.T) {
 			wantSame: false,
 		},
 		{
-			name: "legacy upstreams should be different",
-			req: ServiceConfigRequest{
-				Name:        "web",
-				UpstreamIDs: makeLegacyUpstreamIDs("foo"),
-			},
-			mutate: func(req *ServiceConfigRequest) {
-				req.UpstreamIDs = makeLegacyUpstreamIDs("foo", "bar")
-			},
-			wantSame: false,
-		},
-		{
-			name: "legacy upstreams should not depend on order",
-			req: ServiceConfigRequest{
-				Name:        "web",
-				UpstreamIDs: makeLegacyUpstreamIDs("bar", "foo"),
-			},
-			mutate: func(req *ServiceConfigRequest) {
-				req.UpstreamIDs = makeLegacyUpstreamIDs("foo", "bar")
-			},
-			wantSame: true,
-		},
-		{
 			name: "upstreams should be different",
 			req: ServiceConfigRequest{
 				Name: "web",
-				UpstreamIDs: []ServiceID{
-					NewServiceID("foo", nil),
+				UpstreamServiceNames: []PeeredServiceName{
+					{ServiceName: NewServiceName("foo", nil)},
 				},
 			},
 			mutate: func(req *ServiceConfigRequest) {
-				req.UpstreamIDs = []ServiceID{
-					NewServiceID("foo", nil),
-					NewServiceID("bar", nil),
+				req.UpstreamServiceNames = []PeeredServiceName{
+					{ServiceName: NewServiceName("foo", nil)},
+					{ServiceName: NewServiceName("bar", nil)},
 				}
 			},
 			wantSame: false,
@@ -2224,15 +2195,15 @@ func TestServiceConfigRequest(t *testing.T) {
 			name: "upstreams should not depend on order",
 			req: ServiceConfigRequest{
 				Name: "web",
-				UpstreamIDs: []ServiceID{
-					NewServiceID("bar", nil),
-					NewServiceID("foo", nil),
+				UpstreamServiceNames: []PeeredServiceName{
+					{ServiceName: NewServiceName("foo", nil)},
+					{ServiceName: NewServiceName("bar", nil)},
 				},
 			},
 			mutate: func(req *ServiceConfigRequest) {
-				req.UpstreamIDs = []ServiceID{
-					NewServiceID("foo", nil),
-					NewServiceID("bar", nil),
+				req.UpstreamServiceNames = []PeeredServiceName{
+					{ServiceName: NewServiceName("foo", nil)},
+					{ServiceName: NewServiceName("bar", nil)},
 				}
 			},
 			wantSame: true,

--- a/agent/structs/structs.deepcopy.go
+++ b/agent/structs/structs.deepcopy.go
@@ -783,18 +783,6 @@ func (o *ServiceConfigResponse) DeepCopy() *ServiceConfigResponse {
 			cp.ProxyConfig[k2] = v2
 		}
 	}
-	if o.UpstreamIDConfigs != nil {
-		cp.UpstreamIDConfigs = make([]OpaqueUpstreamConfigDeprecated, len(o.UpstreamIDConfigs))
-		copy(cp.UpstreamIDConfigs, o.UpstreamIDConfigs)
-		for i2 := range o.UpstreamIDConfigs {
-			if o.UpstreamIDConfigs[i2].Config != nil {
-				cp.UpstreamIDConfigs[i2].Config = make(map[string]interface{}, len(o.UpstreamIDConfigs[i2].Config))
-				for k4, v4 := range o.UpstreamIDConfigs[i2].Config {
-					cp.UpstreamIDConfigs[i2].Config[k4] = v4
-				}
-			}
-		}
-	}
 	if o.UpstreamConfigs != nil {
 		cp.UpstreamConfigs = make([]OpaqueUpstreamConfig, len(o.UpstreamConfigs))
 		copy(cp.UpstreamConfigs, o.UpstreamConfigs)

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -16,10 +16,12 @@ upgrade flow.
 
 ## Consul 1.16.x
 
+#### Remove deprecated service-defaults peer upstream override behavior
+
 In Consul 1.16.x, `service-defaults` upstream [`overrides`](/consul/docs/connect/config-entries/service-defaults#overrides)
 will not apply to peer upstreams, unless the [`peer`](/consul/docs/connect/config-entries/service-defaults#peer) field is explicitly provided.
 
-Consul 1.15.x introduced a backward-compatibility behavior to allow for a smoother transition to peer services. This behavior will be removed in Consul 1.16.x.
+Consul 1.15.x introduced a backward-compatibility behavior to allow for a smoother transition during the upgrade. This behavior will be removed in Consul 1.16.x.
 Visit the [upgrade instructions for 1.15.x](#service-defaults-overrides-for-upstream-peered-services) for more info.
 
 ## Consul 1.15.x

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -14,6 +14,14 @@ provided for their upgrades as a result of new features or changed behavior.
 This page is used to document those details separately from the standard
 upgrade flow.
 
+## Consul 1.16.x
+
+In Consul 1.16.x, `service-defaults` upstream [`overrides`](/consul/docs/connect/config-entries/service-defaults#overrides)
+will not apply to peer upstreams, unless the [`peer`](/consul/docs/connect/config-entries/service-defaults#peer) field is explicitly provided.
+
+Consul 1.15.x introduced a backward-compatibility behavior to allow for a smoother transition to peer services. This behavior will be removed in Consul 1.16.x.
+Visit the [upgrade instructions for 1.15.x](#service-defaults-overrides-for-upstream-peered-services) for more info.
+
 ## Consul 1.15.x
 
 #### Service mesh known issue


### PR DESCRIPTION
In 1.14 the service-defaults config entry lacked the `peer` field on upstream overrides and applied the override config purely based on the `name` field matching. For 1.15, we introduced the new `peer` field and also maintained the existing behavior. If `peer` was not specified anywhere in the config entry, we assume it was not peering aware and fell back to the compatibility mode. https://developer.hashicorp.com/consul/docs/upgrading/upgrade-specific#service-defaults-overrides-for-upstream-peered-services

This commit removes that deprecated backwards-compatibility behavior. Now in 1.16, it is necessary to specify the `peer` field in order for upstream overrides to apply to a peer upstream.