### PR TITLE
Backport of feat: add reporting config with reload

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1494,7 +1494,10 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	cfg.RequestLimitsReadRate = runtimeCfg.RequestLimitsReadRate
 	cfg.RequestLimitsWriteRate = runtimeCfg.RequestLimitsWriteRate
 
+	cfg.Reporting.License.Enabled = runtimeCfg.Reporting.License.Enabled
+
 	enterpriseConsulConfig(cfg, runtimeCfg)
+
 	return cfg, nil
 }
 
@@ -4185,6 +4188,11 @@ func (a *Agent) reloadConfigInternal(newCfg *config.RuntimeConfig) error {
 		HeartbeatTimeout:      newCfg.ConsulRaftHeartbeatTimeout,
 		ElectionTimeout:       newCfg.ConsulRaftElectionTimeout,
 		RaftTrailingLogs:      newCfg.RaftTrailingLogs,
+		Reporting: consul.Reporting{
+			License: consul.License{
+				Enabled: newCfg.Reporting.License.Enabled,
+			},
+		},
 	}
 	if err := a.delegate.ReloadConfig(cc); err != nil {
 		return err

--- a/agent/agent_oss_test.go
+++ b/agent/agent_oss_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !consulent
+// +build !consulent
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgent_consulConfig_Reporting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	hcl := `
+		reporting {
+			license {
+				enabled = true
+			}
+		}
+	`
+	a := NewTestAgent(t, hcl)
+	defer a.Shutdown()
+	require.Equal(t, false, a.consulConfig().Reporting.License.Enabled)
+}
+
+func TestAgent_consulConfig_Reporting_Default(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	hcl := `
+		reporting {
+		}
+	`
+	a := NewTestAgent(t, hcl)
+	defer a.Shutdown()
+	require.Equal(t, false, a.consulConfig().Reporting.License.Enabled)
+}

--- a/agent/config/builder_oss.go
+++ b/agent/config/builder_oss.go
@@ -57,6 +57,10 @@ func validateEnterpriseConfigKeys(config *Config) []error {
 		add("license_path")
 		config.LicensePath = nil
 	}
+	if config.Reporting.License.Enabled != nil {
+		add("reporting.license.enabled")
+		config.Reporting.License.Enabled = nil
+	}
 
 	return result
 }

--- a/agent/config/builder_oss_test.go
+++ b/agent/config/builder_oss_test.go
@@ -107,6 +107,19 @@ func TestValidateEnterpriseConfigKeys(t *testing.T) {
 				require.Empty(t, c.LicensePath)
 			},
 		},
+		"reporting.license.enabled": {
+			config: Config{
+				Reporting: Reporting{
+					License: License{
+						Enabled: &boolVal,
+					},
+				},
+			},
+			badKeys: []string{"reporting.license.enabled"},
+			check: func(t *testing.T, c *Config) {
+				require.Nil(t, c.Reporting.License.Enabled)
+			},
+		},
 		"multi": {
 			config: Config{
 				ReadReplica: &boolVal,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -291,6 +291,9 @@ type Config struct {
 	LicensePollMaxTime    *string `mapstructure:"license_poll_max_time" json:"-"`
 	LicenseUpdateBaseTime *string `mapstructure:"license_update_base_time" json:"-"`
 	LicenseUpdateMaxTime  *string `mapstructure:"license_update_max_time" json:"-"`
+
+	// license reporting
+	Reporting Reporting `mapstructure:"reporting" json:"-"`
 }
 
 type GossipLANConfig struct {
@@ -942,4 +945,12 @@ type RaftBoltDBConfigRaw struct {
 
 type RaftWALConfigRaw struct {
 	SegmentSizeMB *int `mapstructure:"segment_size_mb" json:"segment_size_mb,omitempty"`
+}
+
+type License struct {
+	Enabled *bool `mapstructure:"enabled"`
+}
+
+type Reporting struct {
+	License License `mapstructure:"license"`
 }

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1479,7 +1479,17 @@ type RuntimeConfig struct {
 	// here so that tests can use a smaller value.
 	LocalProxyConfigResyncInterval time.Duration
 
+	Reporting ReportingConfig
+
 	EnterpriseRuntimeConfig
+}
+
+type LicenseConfig struct {
+	Enabled bool
+}
+
+type ReportingConfig struct {
+	License LicenseConfig
 }
 
 type AutoConfig struct {

--- a/agent/config/runtime_oss_test.go
+++ b/agent/config/runtime_oss_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 var testRuntimeConfigSanitizeExpectedFilename = "TestRuntimeConfig_Sanitize.golden"
@@ -28,6 +29,7 @@ var enterpriseConfigKeyWarnings = []string{
 	enterpriseConfigKeyError{key: "acl.msp_disable_bootstrap"}.Error(),
 	enterpriseConfigKeyError{key: "acl.tokens.managed_service_provider"}.Error(),
 	enterpriseConfigKeyError{key: "audit"}.Error(),
+	enterpriseConfigKeyError{key: "reporting.license.enabled"}.Error(),
 }
 
 // OSS-only equivalent of TestConfigFlagsAndEdgecases
@@ -83,4 +85,83 @@ func TestLoad_IntegrationWithFlags_OSS(t *testing.T) {
 			t.Run(name, tc.run(format, dataDir))
 		}
 	}
+}
+
+func TestLoad_ReportingConfig(t *testing.T) {
+	dir := testutil.TempDir(t, t.Name())
+
+	t.Run("load from JSON defaults to false", func(t *testing.T) {
+		content := `{
+			"reporting": {}
+		}`
+
+		opts := LoadOpts{
+			FlagValues: FlagValuesTarget{Config: Config{
+				DataDir: &dir,
+			}},
+			Overrides: []Source{
+				FileSource{
+					Name:   "reporting.json",
+					Format: "json",
+					Data:   content,
+				},
+			},
+		}
+		patchLoadOptsShims(&opts)
+		result, err := Load(opts)
+		require.NoError(t, err)
+		require.Len(t, result.Warnings, 0)
+		require.Equal(t, false, result.RuntimeConfig.Reporting.License.Enabled)
+	})
+
+	t.Run("load from HCL defaults to false", func(t *testing.T) {
+		content := `
+		  reporting {}
+		`
+
+		opts := LoadOpts{
+			FlagValues: FlagValuesTarget{Config: Config{
+				DataDir: &dir,
+			}},
+			Overrides: []Source{
+				FileSource{
+					Name:   "reporting.hcl",
+					Format: "hcl",
+					Data:   content,
+				},
+			},
+		}
+		patchLoadOptsShims(&opts)
+		result, err := Load(opts)
+		require.NoError(t, err)
+		require.Len(t, result.Warnings, 0)
+		require.Equal(t, false, result.RuntimeConfig.Reporting.License.Enabled)
+	})
+
+	t.Run("with value set returns warning and defaults to false", func(t *testing.T) {
+		content := `reporting {
+			license {
+			  enabled = true
+			}
+		}`
+
+		opts := LoadOpts{
+			FlagValues: FlagValuesTarget{Config: Config{
+				DataDir: &dir,
+			}},
+			Overrides: []Source{
+				FileSource{
+					Name:   "reporting.hcl",
+					Format: "hcl",
+					Data:   content,
+				},
+			},
+		}
+		patchLoadOptsShims(&opts)
+		result, err := Load(opts)
+		require.NoError(t, err)
+		require.Len(t, result.Warnings, 1)
+		require.Contains(t, result.Warnings[0], "\"reporting.license.enabled\" is a Consul Enterprise configuration and will have no effect")
+		require.Equal(t, false, result.RuntimeConfig.Reporting.License.Enabled)
+	})
 }

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -289,6 +289,11 @@
     "ReconnectTimeoutLAN": "0s",
     "ReconnectTimeoutWAN": "0s",
     "RejoinAfterLeave": false,
+    "Reporting": {
+        "License": {
+            "Enabled": false
+        }
+    },
     "RequestLimitsMode": 0,
     "RequestLimitsReadRate": 0,
     "RequestLimitsWriteRate": 0,

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -372,6 +372,11 @@ reconnect_timeout = "23739s"
 reconnect_timeout_wan = "26694s"
 recursors = [ "63.38.39.58", "92.49.18.18" ]
 rejoin_after_leave = true
+reporting = {
+    license = {
+        enabled = false
+    }
+}
 retry_interval = "8067s"
 retry_interval_wan = "28866s"
 retry_join = [ "pbsSFY7U", "l0qLtWij" ]

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -428,6 +428,11 @@
     "92.49.18.18"
   ],
   "rejoin_after_leave": true,
+  "reporting": {
+    "license": {
+      "enabled": false
+    }
+  },
   "retry_interval": "8067s",
   "retry_interval_wan": "28866s",
   "retry_join": [

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -436,6 +436,8 @@ type Config struct {
 
 	PeeringTestAllowPeerRegistrations bool
 
+	Reporting Reporting
+
 	// Embedded Consul Enterprise specific configuration
 	*EnterpriseConfig
 }
@@ -671,6 +673,7 @@ type ReloadableConfig struct {
 	RaftTrailingLogs      int
 	HeartbeatTimeout      time.Duration
 	ElectionTimeout       time.Duration
+	Reporting             Reporting
 }
 
 type RaftLogStoreConfig struct {
@@ -692,4 +695,12 @@ type RaftBoltDBConfig struct {
 
 type WALConfig struct {
 	SegmentSize int
+}
+
+type License struct {
+	Enabled bool
+}
+
+type Reporting struct {
+	License License
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1746,6 +1746,8 @@ func (s *Server) ReloadConfig(config ReloadableConfig) error {
 		return err
 	}
 
+	s.updateReportingConfig(config)
+
 	s.rpcLimiter.Store(rate.NewLimiter(config.RPCRateLimit, config.RPCMaxBurst))
 
 	if config.RequestLimits != nil {

--- a/agent/consul/server_oss.go
+++ b/agent/consul/server_oss.go
@@ -174,3 +174,7 @@ func addSerfMetricsLabels(conf *serf.Config, wan bool, segment string, partition
 
 	conf.MetricLabels = append(conf.MetricLabels, networkMetric)
 }
+
+func (s *Server) updateReportingConfig(config ReloadableConfig) {
+	// no-op
+}

--- a/agent/consul/server_oss_test.go
+++ b/agent/consul/server_oss_test.go
@@ -1,0 +1,43 @@
+//go:build !consulent
+// +build !consulent
+
+package consul
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/testrpc"
+)
+
+func TestAgent_ReloadConfig_Reporting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+	t.Parallel()
+
+	dir1, s := testServerWithConfig(t, func(c *Config) {
+		c.Reporting.License.Enabled = false
+	})
+	defer os.RemoveAll(dir1)
+	defer s.Shutdown()
+
+	testrpc.WaitForTestAgent(t, s.RPC, "dc1")
+
+	require.Equal(t, false, s.config.Reporting.License.Enabled)
+
+	rc := ReloadableConfig{
+		Reporting: Reporting{
+			License: License{
+				Enabled: true,
+			},
+		},
+	}
+
+	require.NoError(t, s.ReloadConfig(rc))
+
+	// Check config reload is no-op
+	require.Equal(t, false, s.config.Reporting.License.Enabled)
+}


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Manually backporting: https://github.com/hashicorp/consul/pull/16890

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [ ] ~appropriate backport labels added~
* [ ] ~not a security concern~
