### PR TITLE
controller: make the `WorkQueue` generic

### DIFF
--- a/agent/consul/controller/queue/rate.go
+++ b/agent/consul/controller/queue/rate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package controller
+package queue
 
 import (
 	"math"
@@ -14,18 +14,18 @@ import (
 
 // Limiter is an interface for a rate limiter that can limit
 // the number of retries processed in the work queue.
-type Limiter interface {
+type Limiter[T ItemType] interface {
 	// NextRetry returns the remaining time until the queue should
 	// reprocess a Request.
-	NextRetry(request Request) time.Duration
+	NextRetry(request T) time.Duration
 	// Forget causes the Limiter to reset the backoff for the Request.
-	Forget(request Request)
+	Forget(request T)
 }
 
-var _ Limiter = &ratelimiter{}
+var _ Limiter[string] = &ratelimiter[string]{}
 
-type ratelimiter struct {
-	failures map[Request]int
+type ratelimiter[T ItemType] struct {
+	failures map[T]int
 	base     time.Duration
 	max      time.Duration
 	mutex    sync.RWMutex
@@ -33,9 +33,9 @@ type ratelimiter struct {
 
 // NewRateLimiter returns a Limiter that does per-item exponential
 // backoff.
-func NewRateLimiter(base, max time.Duration) Limiter {
-	return &ratelimiter{
-		failures: make(map[Request]int),
+func NewRateLimiter[T ItemType](base, max time.Duration) Limiter[T] {
+	return &ratelimiter[T]{
+		failures: make(map[T]int),
 		base:     base,
 		max:      max,
 	}
@@ -43,7 +43,7 @@ func NewRateLimiter(base, max time.Duration) Limiter {
 
 // NextRetry returns the remaining time until the queue should
 // reprocess a Request.
-func (r *ratelimiter) NextRetry(request Request) time.Duration {
+func (r *ratelimiter[T]) NextRetry(request T) time.Duration {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
@@ -65,7 +65,7 @@ func (r *ratelimiter) NextRetry(request Request) time.Duration {
 }
 
 // Forget causes the Limiter to reset the backoff for the Request.
-func (r *ratelimiter) Forget(request Request) {
+func (r *ratelimiter[T]) Forget(request T) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 

--- a/agent/consul/controller/queue/rate_test.go
+++ b/agent/consul/controller/queue/rate_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package controller
+package queue
 
 import (
 	"testing"
@@ -10,10 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type Request struct{ Kind string }
+
 func TestRateLimiter_Backoff(t *testing.T) {
 	t.Parallel()
 
-	limiter := NewRateLimiter(1*time.Millisecond, 1*time.Second)
+	limiter := NewRateLimiter[Request](1*time.Millisecond, 1*time.Second)
 
 	request := Request{Kind: "one"}
 	require.Equal(t, 1*time.Millisecond, limiter.NextRetry(request))
@@ -33,7 +35,7 @@ func TestRateLimiter_Backoff(t *testing.T) {
 func TestRateLimiter_Overflow(t *testing.T) {
 	t.Parallel()
 
-	limiter := NewRateLimiter(1*time.Millisecond, 1000*time.Second)
+	limiter := NewRateLimiter[Request](1*time.Millisecond, 1000*time.Second)
 
 	request := Request{Kind: "one"}
 	for i := 0; i < 5; i++ {
@@ -49,7 +51,7 @@ func TestRateLimiter_Overflow(t *testing.T) {
 	// make sure we're capped at the passed in max backoff
 	require.Equal(t, 1000*time.Second, limiter.NextRetry(overflow))
 
-	limiter = NewRateLimiter(1*time.Minute, 1000*time.Hour)
+	limiter = NewRateLimiter[Request](1*time.Minute, 1000*time.Hour)
 
 	for i := 0; i < 2; i++ {
 		limiter.NextRetry(request)

--- a/agent/consul/controller/queue_test.go
+++ b/agent/consul/controller/queue_test.go
@@ -6,11 +6,13 @@ package controller
 import (
 	"sync/atomic"
 	"time"
+
+	"github.com/hashicorp/consul/agent/consul/controller/queue"
 )
 
-var _ WorkQueue = &countingWorkQueue{}
+var _ queue.WorkQueue[string] = &countingWorkQueue[string]{}
 
-type countingWorkQueue struct {
+type countingWorkQueue[T queue.ItemType] struct {
 	getCounter            uint64
 	addCounter            uint64
 	addAfterCounter       uint64
@@ -18,16 +20,16 @@ type countingWorkQueue struct {
 	forgetCounter         uint64
 	doneCounter           uint64
 
-	inner WorkQueue
+	inner queue.WorkQueue[T]
 }
 
-func newCountingWorkQueue(inner WorkQueue) *countingWorkQueue {
-	return &countingWorkQueue{
+func newCountingWorkQueue[T queue.ItemType](inner queue.WorkQueue[T]) *countingWorkQueue[T] {
+	return &countingWorkQueue[T]{
 		inner: inner,
 	}
 }
 
-func (c *countingWorkQueue) reset() {
+func (c *countingWorkQueue[T]) reset() {
 	atomic.StoreUint64(&c.getCounter, 0)
 	atomic.StoreUint64(&c.addCounter, 0)
 	atomic.StoreUint64(&c.addAfterCounter, 0)
@@ -36,61 +38,61 @@ func (c *countingWorkQueue) reset() {
 	atomic.StoreUint64(&c.doneCounter, 0)
 }
 
-func (c *countingWorkQueue) requeues() uint64 {
+func (c *countingWorkQueue[T]) requeues() uint64 {
 	return c.addAfters() + c.addRateLimiteds()
 }
 
-func (c *countingWorkQueue) Get() (item Request, shutdown bool) {
+func (c *countingWorkQueue[T]) Get() (item T, shutdown bool) {
 	item, err := c.inner.Get()
 	atomic.AddUint64(&c.getCounter, 1)
 	return item, err
 }
 
-func (c *countingWorkQueue) gets() uint64 {
+func (c *countingWorkQueue[T]) gets() uint64 {
 	return atomic.LoadUint64(&c.getCounter)
 }
 
-func (c *countingWorkQueue) Add(item Request) {
+func (c *countingWorkQueue[T]) Add(item T) {
 	c.inner.Add(item)
 	atomic.AddUint64(&c.addCounter, 1)
 }
 
-func (c *countingWorkQueue) adds() uint64 {
+func (c *countingWorkQueue[T]) adds() uint64 {
 	return atomic.LoadUint64(&c.addCounter)
 }
 
-func (c *countingWorkQueue) AddAfter(item Request, duration time.Duration) {
+func (c *countingWorkQueue[T]) AddAfter(item T, duration time.Duration) {
 	c.inner.AddAfter(item, duration)
 	atomic.AddUint64(&c.addAfterCounter, 1)
 }
 
-func (c *countingWorkQueue) addAfters() uint64 {
+func (c *countingWorkQueue[T]) addAfters() uint64 {
 	return atomic.LoadUint64(&c.addAfterCounter)
 }
 
-func (c *countingWorkQueue) AddRateLimited(item Request) {
+func (c *countingWorkQueue[T]) AddRateLimited(item T) {
 	c.inner.AddRateLimited(item)
 	atomic.AddUint64(&c.addRateLimitedCounter, 1)
 }
 
-func (c *countingWorkQueue) addRateLimiteds() uint64 {
+func (c *countingWorkQueue[T]) addRateLimiteds() uint64 {
 	return atomic.LoadUint64(&c.addRateLimitedCounter)
 }
 
-func (c *countingWorkQueue) Forget(item Request) {
+func (c *countingWorkQueue[T]) Forget(item T) {
 	c.inner.Forget(item)
 	atomic.AddUint64(&c.forgetCounter, 1)
 }
 
-func (c *countingWorkQueue) forgets() uint64 {
+func (c *countingWorkQueue[T]) forgets() uint64 {
 	return atomic.LoadUint64(&c.forgetCounter)
 }
 
-func (c *countingWorkQueue) Done(item Request) {
+func (c *countingWorkQueue[T]) Done(item T) {
 	c.inner.Done(item)
 	atomic.AddUint64(&c.doneCounter, 1)
 }
 
-func (c *countingWorkQueue) dones() uint64 {
+func (c *countingWorkQueue[T]) dones() uint64 {
 	return atomic.LoadUint64(&c.doneCounter)
 }

--- a/agent/consul/gateways/controller_gateways_test.go
+++ b/agent/consul/gateways/controller_gateways_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/controller"
+	"github.com/hashicorp/consul/agent/consul/controller/queue"
 	"github.com/hashicorp/consul/agent/consul/fsm"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/consul/stream"
@@ -3701,7 +3702,7 @@ func (n *noopController) Subscribe(request *stream.SubscribeRequest, transformer
 func (n *noopController) WithBackoff(base, max time.Duration) controller.Controller { return n }
 func (n *noopController) WithLogger(logger hclog.Logger) controller.Controller      { return n }
 func (n *noopController) WithWorkers(i int) controller.Controller                   { return n }
-func (n *noopController) WithQueueFactory(fn func(ctx context.Context, baseBackoff time.Duration, maxBackoff time.Duration) controller.WorkQueue) controller.Controller {
+func (n *noopController) WithQueueFactory(fn func(ctx context.Context, baseBackoff time.Duration, maxBackoff time.Duration) queue.WorkQueue[controller.Request]) controller.Controller {
 	return n
 }
 


### PR DESCRIPTION
### Description

Makes the `WorkQueue` generic (and moves into a `queue` sub-package) so that it can be reused in the new resource-based controller implementation.
