### PR TITLE
upgrade test: fix missing upgrade version 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ references:
     - "1.10.9"
     - "1.9.10"
   consul-versions: &consul_versions
+    - "1.13"
     - "1.14"
     - "1.15"
   images:


### PR DESCRIPTION
### Description
Add the missing upgrade test from version 1.13

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
