### PR TITLE
Don't send updates twice

### DIFF
--- a/agent/hcp/manager_test.go
+++ b/agent/hcp/manager_test.go
@@ -39,7 +39,6 @@ func TestManager_Run(t *testing.T) {
 
 	// Make sure after manager has stopped no more statuses are pushed.
 	cancel()
-	mgr.SendUpdate()
 	client.AssertExpectations(t)
 }
 


### PR DESCRIPTION
Fix test race condition causing test flake.

```
=== RUN   TestManager_SendUpdate
panic: Fail in goroutine after TestManager_Run has completed

exec: go version
goroutine 35 [running]:
testing.(*common).Fail(0xc000484680)
	/home/runner/actions-runner/_work/_tool/go/1.20.3/x64/src/testing/testing.go:933 +0xe5
testing.(*common).Errorf(0xc000484680, {0xc59347?, 0x40fd08?}, {0xc00049cac0?, 0x18?, 0x18?})
	/home/runner/actions-runner/_work/_tool/go/1.20.3/x64/src/testing/testing.go:1050 +0x65
github.com/stretchr/testify/mock.(*Mock).fail(0xc0004ae140, {0xc59347?, 0x4?}, {0xc00049cac0?, 0x2?, 0x2?})
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.8.2/mock/mock.go:330 +0xeb
github.com/stretchr/testify/mock.(*Mock).MethodCalled(0xc0004ae140, {0xe1cbd3, 0x10}, {0xc00061a000, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.8.2/mock/mock.go:472 +0x2ac
github.com/stretchr/testify/mock.(*Mock).Called(0x7fc7b1f76878?, {0xc00061a000, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.8.2/mock/mock.go:456 +0x148
github.com/hashicorp/consul/agent/hcp.(*MockClient).PushServerStatus(0xc0004ae140, {0xd338e8?, 0xc000610000}, 0xc000618000)
	/home/runner/actions-runner/_work/consul-enterprise/consul-enterprise/agent/hcp/mock_Client.go:118 +0xe5
github.com/hashicorp/consul/agent/hcp.(*Manager).sendUpdate(0xc0004a2a10)
	/home/runner/actions-runner/_work/consul-enterprise/consul-enterprise/agent/hcp/manager.go:179 +0x405
github.com/hashicorp/consul/agent/hcp.(*Manager).Run(0xc0004a2a10, {0xd33878, 0xc0004ae190})
	/home/runner/actions-runner/_work/consul-enterprise/consul-enterprise/agent/hcp/manager.go:110 +0x3c8
created by github.com/hashicorp/consul/agent/hcp.TestManager_Run
	/home/runner/actions-runner/_work/consul-enterprise/consul-enterprise/agent/hcp/manager_test.go:33 +0x4cf
FAIL agent/hcp.TestManager_SendUpdate (-1.00s)
```

https://github.com/hashicorp/consul-enterprise/actions/runs/4694345380/jobs/8322458432?pr=5112