### PR TITLE
Add a check for local leader in cluter peering

### DIFF
--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -304,9 +304,8 @@ func (s *ResourceGenerator) endpointsFromSnapshotMeshGateway(cfgSnap *proxycfg.C
 
 		servers, _ := cfgSnap.MeshGateway.WatchedLocalServers.Get(structs.ConsulServiceName)
 		for _, srv := range servers {
-			if isReplica := srv.Service.Meta["read_replica"]; isReplica == "true" {
-				// Peering control-plane traffic can only ever be handled by the local leader.
-				// We avoid routing to read replicas since they will never be Raft voters.
+			isLeader := srv.Service.Meta["leader"] == "true"
+			if !isLeader {
 				continue
 			}
 


### PR DESCRIPTION
### Description

This change adds a check for the leader referring to this issue https://github.com/hashicorp/consul/issues/15338

### Testing & Reproduction steps


Run ./run.sh to set up a peering between two clusters through mesh gateways ([reference repo](https://github.com/DanStough/consul-scenarios/tree/main/scenario-peering-mesh-gw)). You will also need to manually run the commands after the exit 0 in the script to complete the peering connection.
Add two servers:
consul agent -log-level trace -config-file config_dc1-server2.hcl 1>./logs/dc1-server2.log &.
consul agent -log-level trace -config-file config_dc1-server3.hcl 1>./logs/dc1-server3.log &.
Observer the mesh gateway has all server gRPC addresses in its cluster endpoints.
http://localhost:19004/clusters?format=json

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
