### PR TITLE
added missing error message content to troubleshooting

### DIFF
--- a/website/content/docs/troubleshoot/common-errors.mdx
+++ b/website/content/docs/troubleshoot/common-errors.mdx
@@ -5,15 +5,15 @@ description: >-
   Troubleshoot issues based on the error message. Common errors result from failed actions, timeouts, multiple entries, bad and expired certificates, invalid characters, syntax parsing, malformed responses, and exceeded deadlines.
 ---
 
-# Common Error Messages
+# Common error messages
 
-When installing and running Consul, there are some common messages you might see. Usually they indicate an issue in your network or in your server's configuration. Some of the more common errors and their solutions are listed below.
+This topic describes common messages that may appear when installing and running Consul. Errors usually they indicate an issue in your network or in your server's configuration. Refer to the [Troubleshooting Guide][troubleshooting] for help resolving error messages that do not appear on this page.
 
-If you are getting an error message you don't see listed on this page, please consider following our general [Troubleshooting Guide][troubleshooting].
-
-For common errors messages related to Kubernetes, please go to [Common errors on Kubernetes](#common-errors-on-kubernetes).
+For common errors messages related to Kubernetes, refer to [Common errors on Kubernetes](#common-errors-on-kubernetes).
 
 ## Configuration file errors
+
+The following errors are related to misconfigured files.
 
 ### Multiple network interfaces
 
@@ -100,7 +100,7 @@ If a host does not properly implement half-close you may see an error message `[
 
 This has been a [known issue](https://github.com/docker/libnetwork/issues/1204) in Docker, but may manifest in other environments as well.
 
-## ACL Not Found
+## ACL not found
 
 ```text
 RPC error making call: rpc error making call: ACL not found
@@ -108,7 +108,9 @@ RPC error making call: rpc error making call: ACL not found
 
 This indicates that you have ACL enabled in your cluster, but you aren't passing a valid token. Make sure that when creating your tokens that they have the correct permissions set. In addition, you would want to make sure that an agent token is provided on each call.
 
-## TLS and Certificates
+## TLS and certificates
+
+The follow errors are related to TLS and certificate issues.
 
 ### Incorrect certificate or certificate name
 
@@ -150,7 +152,19 @@ You have installed an Enterprise version of Consul. If you are an Enterprise cus
 
 -> **Note:** Enterprise binaries can be identified on our [download site][releases] by the `+ent` suffix.
 
+## Rate limit reached on the server
+
+You may receive a `RESOURCE_EXHAUSTED` error from the Consul server if the maximum number of read or write requests per second have been reached. Refer to [Set a global limit on traffic rates](/consul/docs/agent/set-global-traffic-rate-limits) for additional information. You can retry another server unless the number of retries is exhausted. If the number of retries is exhausted, you should implement an exponential backoff.
+
+The RESOURCE_EXHAUSTED RPC response is translated into a `429 Too Many Requests` error code on the HTTP interface. 
+
+The server may respond as `UNAVAILABLE` if it is the leader node and the global write request rate limit is reached. The solution is to apply an exponential backoff until the leader has capacity to serve those requests. 
+
+The `UNAVAILABLE` RPC response is translated into a `503 Service Unavailable` error code on the  RPC requests sent through HTTP interface.
+
 ## Common errors on Kubernetes
+
+The following error messages are specific to Kubernetes issues.
 
 ### Unable to connect to the Consul client on the same host
 


### PR DESCRIPTION
### Description

This PR adds error messages associated with rate limiting to the troubleshooting page. The content was missing and resulted in bad links on the source page. I also made a few minor changes to the troubleshooting page for style consistency.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
