### PR TITLE
POC: use type to demarcate test phases

### DIFF
--- a/client_server_integration_test/clientserver.go
+++ b/client_server_integration_test/clientserver.go
@@ -18,6 +18,11 @@ func (a *TestServerAdapter) Stop() error {
 	return nil
 }
 
+func (a *TestServerAdapter) Upgrade(t *testing.T) {
+	// TODO: does upgrade invalidate our client?
+	a.cluster.Upgrade(t)
+}
+
 // assert that we fulfill the interface
 var _ TestServerI = &TestServerAdapter{}
 

--- a/client_server_integration_test/health_generated_test.go
+++ b/client_server_integration_test/health_generated_test.go
@@ -7,20 +7,31 @@ import (
 )
 
 func TestAPI_HealthNode_Noncontainerized(t *testing.T) {
+	t.Parallel()
 	c, s := NewClientServer(t)
-	cstestAPI_HealthNode(t, c, s)
+	ts := &cstestAPI_HealthNode{}
+	ts.assemble(t, c, s)
+	ts.act(t, c, s)
+	ts.assert(t, c, s)
 }
 
 func TestAPI_HealthNode_Containerized(t *testing.T) {
+	t.Parallel()
 	c, s := NewClusterTestServerAdapter(t)
-	cstestAPI_HealthNode(t, c, s)
+	ts := &cstestAPI_HealthNode{}
+	ts.assemble(t, c, s)
+	ts.act(t, c, s)
+	ts.assert(t, c, s)
 }
 
-/* TODO
 func TestAPI_HealthNode_ContainerizedUpgrade(t *testing.T) {
-	c, s := topology.NewTestServerAdapter(t)
-	cstestAPI_HealthNode(t, c, s)
+	t.Parallel()
+	c, s := NewClusterTestServerAdapter(t)
+	ts := &cstestAPI_HealthNode{}
+	ts.assemble(t, c, s)
+	ts.act(t, c, s)
+	ts.assert(t, c, s)
 
-	s.StandardUpgrade()
+	s.Upgrade(t)
+	ts.assert(t, c, s)
 }
-*/

--- a/client_server_integration_test/health_test.go
+++ b/client_server_integration_test/health_test.go
@@ -8,10 +8,18 @@ import (
 )
 
 //go:generate cstestgen
-func cstestAPI_HealthNode(t *testing.T, c *api.Client, s TestServerI) {
-	t.Parallel()
-	defer s.Stop()
+type cstestAPI_HealthNode struct {
+}
 
+func (cstest *cstestAPI_HealthNode) assemble(t *testing.T, c *api.Client, s TestServerI) {
+	// nothing
+}
+
+func (cstest *cstestAPI_HealthNode) act(t *testing.T, c *api.Client, s TestServerI) {
+	// nothing
+}
+
+func (cstest *cstestAPI_HealthNode) assert(t *testing.T, c *api.Client, s TestServerI) {
 	agent := c.Agent()
 	health := c.Health()
 

--- a/test/integration/consul-container/libs/cluster/cluster.go
+++ b/test/integration/consul-container/libs/cluster/cluster.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/serf/serf"
 
 	goretry "github.com/avast/retry-go"
+	utils "github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 	"github.com/stretchr/testify/require"
 	"github.com/teris-io/shortid"
 	"github.com/testcontainers/testcontainers-go"
@@ -284,6 +285,11 @@ func (c *Cluster) Remove(n Agent) error {
 
 	c.Agents = append(c.Agents[:foundIdx], c.Agents[foundIdx+1:]...)
 	return nil
+}
+
+// simpler StandardUpgrade
+func (c *Cluster) Upgrade(t *testing.T) {
+	require.NoError(t, c.StandardUpgrade(t, context.Background(), utils.TargetVersion))
 }
 
 // StandardUpgrade upgrades a running consul cluster following the steps from


### PR DESCRIPTION
This allows us to reuse the test with an upgrade + reassert. Need a better example test though; this one doesn't have assemble or act steps.
