### PR TITLE
added an intro statement for the SI conf entry confiration model

### DIFF
--- a/website/content/docs/connect/config-entries/service-intentions.mdx
+++ b/website/content/docs/connect/config-entries/service-intentions.mdx
@@ -92,6 +92,8 @@ The following outline shows how to format the service intentions configuration e
 
 ## Complete configuration
 
+When every field is defined, a service intentions configuration entry has the following form:
+
 <Tabs>
 <Tab heading="HCL" group="hcl">
 
@@ -280,7 +282,7 @@ spec:
 
 ## Specification
 
-This section provides details about the fields you can configure in the service defaults configuration entry.
+This section provides details about the fields you can configure in the service intentions configuration entry.
 
 <Tabs>
 

--- a/website/content/docs/connect/config-entries/service-intentions.mdx
+++ b/website/content/docs/connect/config-entries/service-intentions.mdx
@@ -11,6 +11,8 @@ This topic provides reference information for the service intentions configurati
 
 ## Configuration model
 
+The following outline shows how to format the service intentions configuration entry. Click on a property name to view details about the configuration.
+
 <Tabs>
 
 <Tab heading="HCL and JSON" group="hcl">


### PR DESCRIPTION
### Description

This PR adds an introductory statement to the configuration model section on the service intentions configuration reference page. This is for consistency. 

* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
