### PR TITLE
Add default_intention_policy config

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -997,6 +997,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		DataDir:                                dataDir,
 		Datacenter:                             datacenter,
 		DefaultQueryTime:                       b.durationVal("default_query_time", c.DefaultQueryTime),
+		DefaultIntentionPolicy:                 stringVal(c.DefaultIntentionPolicy),
 		DevMode:                                boolVal(b.opts.DevMode),
 		DisableAnonymousSignature:              boolVal(c.DisableAnonymousSignature),
 		DisableCoordinates:                     boolVal(c.DisableCoordinates),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -165,6 +165,7 @@ type Config struct {
 	DataDir                          *string             `mapstructure:"data_dir" json:"data_dir,omitempty"`
 	Datacenter                       *string             `mapstructure:"datacenter" json:"datacenter,omitempty"`
 	DefaultQueryTime                 *string             `mapstructure:"default_query_time" json:"default_query_time,omitempty"`
+	DefaultIntentionPolicy           *string             `mapstructure:"default_intention_policy" json:"default_intention_policy,omitempty"`
 	DisableAnonymousSignature        *bool               `mapstructure:"disable_anonymous_signature" json:"disable_anonymous_signature,omitempty"`
 	DisableCoordinates               *bool               `mapstructure:"disable_coordinates" json:"disable_coordinates,omitempty"`
 	DisableHostNodeID                *bool               `mapstructure:"disable_host_node_id" json:"disable_host_node_id,omitempty"`

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -565,6 +565,15 @@ type RuntimeConfig struct {
 	// flag: -data-dir string
 	DataDir string
 
+	// DefaultIntentionPolicy is used to define a default intention action for all
+	// sources and destinations. Possible values are "allow", "deny", or "" (blank).
+	// For compatibility, falls back to ACLResolverSettings.ACLDefaultPolicy (which
+	// itself has a default of "allow") if left blank. Future versions of Consul
+	// will default this field to "deny" to be secure by default.
+	//
+	// hcl: default_intention_policy = string
+	DefaultIntentionPolicy string
+
 	// DefaultQueryTime is the amount of time a blocking query will wait before
 	// Consul will force a response. This value can be overridden by the 'wait'
 	// query parameter.

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -217,6 +217,23 @@ type ACLResolverSettings struct {
 	ACLDefaultPolicy string
 }
 
+func (a ACLResolverSettings) CheckACLs() error {
+	switch a.ACLDefaultPolicy {
+	case "allow":
+	case "deny":
+	default:
+		return fmt.Errorf("Unsupported default ACL policy: %s", a.ACLDefaultPolicy)
+	}
+	switch a.ACLDownPolicy {
+	case "allow":
+	case "deny":
+	case "async-cache", "extend-cache":
+	default:
+		return fmt.Errorf("Unsupported down ACL policy: %s", a.ACLDownPolicy)
+	}
+	return nil
+}
+
 // ACLResolver is the type to handle all your token and policy resolution needs.
 //
 // Supports:

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -103,7 +103,7 @@ func NewClient(config *Config, deps Deps) (*Client, error) {
 	if config.DataDir == "" {
 		return nil, fmt.Errorf("Config must provide a DataDir")
 	}
-	if err := config.CheckACL(); err != nil {
+	if err := config.CheckEnumStrings(); err != nil {
 		return nil, err
 	}
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -460,7 +460,7 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server, incom
 	if config.DataDir == "" && !config.DevMode {
 		return nil, fmt.Errorf("Config must provide a DataDir")
 	}
-	if err := config.CheckACL(); err != nil {
+	if err := config.CheckEnumStrings(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
### Description

This is a WIP PR demonstrating the addition of default_intention_policy to agent configuration.

TODO:
* Check all usages of `(Authorizer).IntentionDefaultAllow()` and add branching code to override the decision if `default_intention_policy != ""`

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
