### PR TITLE
hoststats: add package for collecting host statistics including cpu memory and disk usage

### DIFF
--- a/.changelog/17038.txt
+++ b/.changelog/17038.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-agent: add new metrics to track cpu disk and memory usage for server hosts
+agent: add new metrics to track cpu disk and memory usage for server hosts (defaults to: enabled)
 ```

--- a/.changelog/17038.txt
+++ b/.changelog/17038.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: add new metrics to track cpu disk and memory usage for server hosts
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -941,6 +941,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 			CirconusCheckTags:                  stringVal(c.Telemetry.CirconusCheckTags),
 			CirconusSubmissionInterval:         stringVal(c.Telemetry.CirconusSubmissionInterval),
 			CirconusSubmissionURL:              stringVal(c.Telemetry.CirconusSubmissionURL),
+			DisableHostMetrics:                 boolVal(c.Telemetry.DisableHostMetrics),
 			DisableHostname:                    boolVal(c.Telemetry.DisableHostname),
 			DogstatsdAddr:                      stringVal(c.Telemetry.DogstatsdAddr),
 			DogstatsdTags:                      c.Telemetry.DogstatsdTags,

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -941,7 +941,6 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 			CirconusCheckTags:                  stringVal(c.Telemetry.CirconusCheckTags),
 			CirconusSubmissionInterval:         stringVal(c.Telemetry.CirconusSubmissionInterval),
 			CirconusSubmissionURL:              stringVal(c.Telemetry.CirconusSubmissionURL),
-			DisableHostMetrics:                 boolVal(c.Telemetry.DisableHostMetrics),
 			DisableHostname:                    boolVal(c.Telemetry.DisableHostname),
 			DogstatsdAddr:                      stringVal(c.Telemetry.DogstatsdAddr),
 			DogstatsdTags:                      c.Telemetry.DogstatsdTags,
@@ -1106,6 +1105,9 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		AutoReloadConfigCoalesceInterval:  1 * time.Second,
 		LocalProxyConfigResyncInterval:    30 * time.Second,
 	}
+
+	// host metrics are enabled by default if consul is configured with HashiCorp Cloud Platform integration
+	rt.Telemetry.EnableHostMetrics = boolValWithDefault(c.Telemetry.EnableHostMetrics, rt.IsCloudEnabled())
 
 	rt.TLS, err = b.buildTLSConfig(rt, c.TLS)
 	if err != nil {

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -556,3 +556,22 @@ func TestBuilder_parsePrefixFilter(t *testing.T) {
 		}
 	})
 }
+
+func TestBuidler_hostMetricsWithCloud(t *testing.T) {
+	devMode := true
+	builderOpts := LoadOpts{
+		DevMode: &devMode,
+		DefaultConfig: FileSource{
+			Name:   "test",
+			Format: "hcl",
+			Data:   `cloud{ resource_id = "abc" client_id = "abc" client_secret = "abc"}`,
+		},
+	}
+
+	result, err := Load(builderOpts)
+	require.NoError(t, err)
+	require.Empty(t, result.Warnings)
+	cfg := result.RuntimeConfig
+	require.NotNil(t, cfg)
+	require.True(t, cfg.Telemetry.EnableHostMetrics)
+}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -690,6 +690,7 @@ type Telemetry struct {
 	CirconusCheckTags                  *string  `mapstructure:"circonus_check_tags" json:"circonus_check_tags,omitempty"`
 	CirconusSubmissionInterval         *string  `mapstructure:"circonus_submission_interval" json:"circonus_submission_interval,omitempty"`
 	CirconusSubmissionURL              *string  `mapstructure:"circonus_submission_url" json:"circonus_submission_url,omitempty"`
+	DisableHostMetrics                 *bool    `mapstructure:"disable_host_metrics" json:"disable_host_metrics,omitempty"`
 	DisableHostname                    *bool    `mapstructure:"disable_hostname" json:"disable_hostname,omitempty"`
 	DogstatsdAddr                      *string  `mapstructure:"dogstatsd_addr" json:"dogstatsd_addr,omitempty"`
 	DogstatsdTags                      []string `mapstructure:"dogstatsd_tags" json:"dogstatsd_tags,omitempty"`

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -690,8 +690,8 @@ type Telemetry struct {
 	CirconusCheckTags                  *string  `mapstructure:"circonus_check_tags" json:"circonus_check_tags,omitempty"`
 	CirconusSubmissionInterval         *string  `mapstructure:"circonus_submission_interval" json:"circonus_submission_interval,omitempty"`
 	CirconusSubmissionURL              *string  `mapstructure:"circonus_submission_url" json:"circonus_submission_url,omitempty"`
-	DisableHostMetrics                 *bool    `mapstructure:"disable_host_metrics" json:"disable_host_metrics,omitempty"`
 	DisableHostname                    *bool    `mapstructure:"disable_hostname" json:"disable_hostname,omitempty"`
+	EnableHostMetrics                  *bool    `mapstructure:"enable_host_metrics" json:"enable_host_metrics,omitempty"`
 	DogstatsdAddr                      *string  `mapstructure:"dogstatsd_addr" json:"dogstatsd_addr,omitempty"`
 	DogstatsdTags                      []string `mapstructure:"dogstatsd_tags" json:"dogstatsd_tags,omitempty"`
 	RetryFailedConfiguration           *bool    `mapstructure:"retry_failed_connection" json:"retry_failed_connection,omitempty"`

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -6754,6 +6754,7 @@ func TestLoad_FullConfig(t *testing.T) {
 				Expiration: 15 * time.Second,
 				Name:       "ftO6DySn", // notice this is the same as the metrics prefix
 			},
+			DisableHostMetrics: true,
 		},
 		TLS: tlsutil.Config{
 			InternalRPC: tlsutil.ProtocolConfig{

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -6754,7 +6754,7 @@ func TestLoad_FullConfig(t *testing.T) {
 				Expiration: 15 * time.Second,
 				Name:       "ftO6DySn", // notice this is the same as the metrics prefix
 			},
-			DisableHostMetrics: true,
+			EnableHostMetrics: true,
 		},
 		TLS: tlsutil.Config{
 			InternalRPC: tlsutil.ProtocolConfig{

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -462,10 +462,10 @@
         "CirconusSubmissionInterval": "",
         "CirconusSubmissionURL": "",
         "Disable": false,
-        "DisableHostMetrics": false,
         "DisableHostname": false,
         "DogstatsdAddr": "",
         "DogstatsdTags": [],
+        "EnableHostMetrics": false,
         "FilterDefault": false,
         "MetricsPrefix": "",
         "PrometheusOpts": {

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -462,6 +462,7 @@
         "CirconusSubmissionInterval": "",
         "CirconusSubmissionURL": "",
         "Disable": false,
+        "DisableHostMetrics": false,
         "DisableHostname": false,
         "DogstatsdAddr": "",
         "DogstatsdTags": [],

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -690,6 +690,7 @@ telemetry {
     circonus_check_tags = "prvO4uBl"
     circonus_submission_interval = "DolzaflP"
     circonus_submission_url = "gTcbS93G"
+    disable_host_metrics = true
     disable_hostname = true
     dogstatsd_addr = "0wSndumK"
     dogstatsd_tags = [ "3N81zSUB","Xtj8AnXZ" ]

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -690,7 +690,7 @@ telemetry {
     circonus_check_tags = "prvO4uBl"
     circonus_submission_interval = "DolzaflP"
     circonus_submission_url = "gTcbS93G"
-    disable_host_metrics = true
+    enable_host_metrics = true
     disable_hostname = true
     dogstatsd_addr = "0wSndumK"
     dogstatsd_tags = [ "3N81zSUB","Xtj8AnXZ" ]

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -808,6 +808,7 @@
     "circonus_check_tags": "prvO4uBl",
     "circonus_submission_interval": "DolzaflP",
     "circonus_submission_url": "gTcbS93G",
+    "disable_host_metrics": true,
     "disable_hostname": true,
     "dogstatsd_addr": "0wSndumK",
     "dogstatsd_tags": [

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -808,7 +808,7 @@
     "circonus_check_tags": "prvO4uBl",
     "circonus_submission_interval": "DolzaflP",
     "circonus_submission_url": "gTcbS93G",
-    "disable_host_metrics": true,
+    "enable_host_metrics": true,
     "disable_hostname": true,
     "dogstatsd_addr": "0wSndumK",
     "dogstatsd_tags": [

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -119,7 +119,9 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer, providedLogger hcl
 	if err != nil {
 		return d, fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
-	hoststats.NewCollector(context.Background(), d.Logger, cfg.DataDir)
+	if !cfg.Telemetry.DisableHostMetrics {
+		hoststats.NewCollector(context.Background(), d.Logger, cfg.DataDir)
+	}
 
 	d.TLSConfigurator, err = tlsutil.NewConfigurator(cfg.TLS, d.Logger)
 	if err != nil {

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"github.com/hashicorp/consul/lib/hoststats"
 	"github.com/hashicorp/go-hclog"
 	wal "github.com/hashicorp/raft-wal"
 	"github.com/hashicorp/raft-wal/verifier"
@@ -117,6 +119,7 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer, providedLogger hcl
 	if err != nil {
 		return d, fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
+	hoststats.NewCollector(context.Background(), d.Logger, cfg.DataDir)
 
 	d.TLSConfigurator, err = tlsutil.NewConfigurator(cfg.TLS, d.Logger)
 	if err != nil {
@@ -295,6 +298,7 @@ func getPrometheusDefs(cfg *config.RuntimeConfig, isServer bool) ([]prometheus.G
 		Gauges,
 		raftGauges,
 		serverGauges,
+		hoststats.Gauges,
 	}
 
 	// TODO(ffmmm): conditionally add only leader specific metrics to gauges, counters, summaries, etc

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -120,7 +120,7 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer, providedLogger hcl
 	if err != nil {
 		return d, fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
-	if !cfg.Telemetry.Disable && !cfg.Telemetry.DisableHostMetrics {
+	if !cfg.Telemetry.Disable && cfg.Telemetry.EnableHostMetrics {
 		ctx, cancel := context.WithCancel(context.Background())
 		hoststats.NewCollector(ctx, d.Logger, cfg.DataDir)
 		d.stopHostCollector = cancel

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -61,6 +61,7 @@ type BaseDeps struct {
 	WatchedFiles  []string
 
 	deregisterBalancer, deregisterResolver func()
+	stopHostCollector                      func()
 }
 
 type ConfigLoader func(source config.Source) (config.LoadResult, error)
@@ -119,8 +120,10 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer, providedLogger hcl
 	if err != nil {
 		return d, fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
-	if !cfg.Telemetry.DisableHostMetrics {
-		hoststats.NewCollector(context.Background(), d.Logger, cfg.DataDir)
+	if !cfg.Telemetry.Disable && !cfg.Telemetry.DisableHostMetrics {
+		ctx, cancel := context.WithCancel(context.Background())
+		hoststats.NewCollector(ctx, d.Logger, cfg.DataDir)
+		d.stopHostCollector = cancel
 	}
 
 	d.TLSConfigurator, err = tlsutil.NewConfigurator(cfg.TLS, d.Logger)
@@ -219,11 +222,10 @@ func (bd BaseDeps) Close() {
 	bd.AutoConfig.Stop()
 	bd.MetricsConfig.Cancel()
 
-	if fn := bd.deregisterBalancer; fn != nil {
-		fn()
-	}
-	if fn := bd.deregisterResolver; fn != nil {
-		fn()
+	for _, fn := range []func(){bd.deregisterBalancer, bd.deregisterResolver, bd.stopHostCollector} {
+		if fn != nil {
+			fn()
+		}
 	}
 }
 

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -302,7 +302,10 @@ func getPrometheusDefs(cfg *config.RuntimeConfig, isServer bool) ([]prometheus.G
 		Gauges,
 		raftGauges,
 		serverGauges,
-		hoststats.Gauges,
+	}
+
+	if cfg.Telemetry.EnableHostMetrics {
+		gauges = append(gauges, hoststats.Gauges)
 	}
 
 	// TODO(ffmmm): conditionally add only leader specific metrics to gauges, counters, summaries, etc

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
-	"github.com/hashicorp/consul/lib/hoststats"
 	"github.com/hashicorp/go-hclog"
 	wal "github.com/hashicorp/raft-wal"
 	"github.com/hashicorp/raft-wal/verifier"
@@ -43,6 +42,7 @@ import (
 	"github.com/hashicorp/consul/agent/xds"
 	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/lib/hoststats"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/tlsutil"
 )
@@ -61,7 +61,7 @@ type BaseDeps struct {
 	WatchedFiles  []string
 
 	deregisterBalancer, deregisterResolver func()
-	stopHostCollector                      func()
+	stopHostCollector                      context.CancelFunc
 }
 
 type ConfigLoader func(source config.Source) (config.LoadResult, error)

--- a/lib/hoststats/collector.go
+++ b/lib/hoststats/collector.go
@@ -1,0 +1,189 @@
+package hoststats
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-hclog"
+	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/mem"
+)
+
+// Collector collects host resource usage stats
+type Collector struct {
+	numCores      int
+	cpuCalculator map[string]*cpuStatsCalculator
+	hostStats     *HostStats
+	hostStatsLock sync.RWMutex
+	dataDir       string
+
+	metrics    Metrics
+	baseLabels []metrics.Label
+
+	logger hclog.Logger
+}
+
+// NewCollector returns a Collector. The dataDir is passed in
+// so that we can present the disk related statistics for the mountpoint where the dataDir exists
+func NewCollector(ctx context.Context, logger hclog.Logger, dataDir string, opts ...CollectorOption) *Collector {
+	logger = logger.Named("host_stats")
+	collector := initCollector(logger, dataDir)
+	go collector.loop(ctx)
+	return collector
+}
+
+// initCollector initializes the Collector but does not start the collection loop
+func initCollector(logger hclog.Logger, dataDir string, opts ...CollectorOption) *Collector {
+	numCores := runtime.NumCPU()
+	statsCalculator := make(map[string]*cpuStatsCalculator)
+	collector := &Collector{
+		cpuCalculator: statsCalculator,
+		numCores:      numCores,
+		logger:        logger,
+		dataDir:       dataDir,
+	}
+
+	for _, opt := range opts {
+		opt(collector)
+	}
+
+	if collector.metrics == nil {
+		collector.metrics = metrics.Default()
+	}
+	return collector
+}
+
+func (h *Collector) loop(ctx context.Context) {
+	// Start collecting host stats right away and then keep collecting every
+	// collection interval
+	next := time.NewTimer(0)
+	defer next.Stop()
+	for {
+		select {
+		case <-next.C:
+			h.collect()
+			next.Reset(hostStatsCollectionInterval)
+			h.Stats().Emit(h.metrics, h.baseLabels)
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// collect will collect stats related to resource usage of the host
+func (h *Collector) collect() {
+	h.hostStatsLock.Lock()
+	defer h.hostStatsLock.Unlock()
+	hs := &HostStats{Timestamp: time.Now().UTC().UnixNano()}
+
+	// Determine up-time
+	uptime, err := host.Uptime()
+	if err != nil {
+		h.logger.Error("failed to collect uptime stats", "error", err)
+		uptime = 0
+	}
+	hs.Uptime = uptime
+
+	// Collect memory stats
+	mstats, err := h.collectMemoryStats()
+	if err != nil {
+		h.logger.Error("failed to collect memory stats", "error", err)
+		mstats = &MemoryStats{}
+	}
+	hs.Memory = mstats
+
+	// Collect cpu stats
+	cpus, err := h.collectCPUStats()
+	if err != nil {
+		h.logger.Error("failed to collect cpu stats", "error", err)
+		cpus = []*CPUStats{}
+	}
+	hs.CPU = cpus
+
+	// Collect disk stats
+	diskStats, err := h.collectDiskStats(h.dataDir)
+	if err != nil {
+		h.logger.Error("failed to collect dataDir disk stats", "error", err)
+	}
+	hs.DataDirStats = diskStats
+
+	// Update the collected status object.
+	h.hostStats = hs
+}
+
+func (h *Collector) collectDiskStats(dir string) (*DiskStats, error) {
+	usage, err := disk.Usage(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect disk usage stats: %w", err)
+	}
+	return h.toDiskStats(usage), nil
+}
+
+func (h *Collector) collectMemoryStats() (*MemoryStats, error) {
+	memStats, err := mem.VirtualMemory()
+	if err != nil {
+		return nil, err
+	}
+	mem := &MemoryStats{
+		Total:       memStats.Total,
+		Available:   memStats.Available,
+		Used:        memStats.Used,
+		UsedPercent: memStats.UsedPercent,
+		Free:        memStats.Free,
+	}
+
+	return mem, nil
+}
+
+// Stats returns the host stats that has been collected
+func (h *Collector) Stats() *HostStats {
+	h.hostStatsLock.RLock()
+	defer h.hostStatsLock.RUnlock()
+
+	if h.hostStats == nil {
+		return &HostStats{}
+	}
+
+	return h.hostStats.Clone()
+}
+
+// toDiskStats merges UsageStat and PartitionStat to create a DiskStat
+func (h *Collector) toDiskStats(usage *disk.UsageStat) *DiskStats {
+	ds := DiskStats{
+		Size:              usage.Total,
+		Used:              usage.Used,
+		Available:         usage.Free,
+		UsedPercent:       usage.UsedPercent,
+		InodesUsedPercent: usage.InodesUsedPercent,
+		Path:              usage.Path,
+	}
+	if math.IsNaN(ds.UsedPercent) {
+		ds.UsedPercent = 0.0
+	}
+	if math.IsNaN(ds.InodesUsedPercent) {
+		ds.InodesUsedPercent = 0.0
+	}
+
+	return &ds
+}
+
+type CollectorOption func(c *Collector)
+
+func WithMetrics(m *metrics.Metrics) CollectorOption {
+	return func(c *Collector) {
+		c.metrics = m
+	}
+}
+
+func WithBaseLabels(labels []metrics.Label) CollectorOption {
+	return func(c *Collector) {
+		c.baseLabels = labels
+	}
+}

--- a/lib/hoststats/cpu.go
+++ b/lib/hoststats/cpu.go
@@ -1,0 +1,118 @@
+package hoststats
+
+import (
+	"math"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+)
+
+// cpuStatsCalculator calculates cpu usage percentages
+type cpuStatsCalculator struct {
+	prevIdle   float64
+	prevUser   float64
+	prevSystem float64
+	prevBusy   float64
+	prevTotal  float64
+}
+
+// calculate calculates the current cpu usage percentages
+func (h *cpuStatsCalculator) calculate(times cpu.TimesStat) (idle float64, user float64, system float64, total float64) {
+	currentIdle := times.Idle
+	currentUser := times.User
+	currentSystem := times.System
+	currentTotal := times.Total()
+	currentBusy := times.User + times.System + times.Nice + times.Iowait + times.Irq +
+		times.Softirq + times.Steal + times.Guest + times.GuestNice
+
+	deltaTotal := currentTotal - h.prevTotal
+	idle = ((currentIdle - h.prevIdle) / deltaTotal) * 100
+	user = ((currentUser - h.prevUser) / deltaTotal) * 100
+	system = ((currentSystem - h.prevSystem) / deltaTotal) * 100
+	total = ((currentBusy - h.prevBusy) / deltaTotal) * 100
+
+	// Protect against any invalid values
+	if math.IsNaN(idle) || math.IsInf(idle, 0) {
+		idle = 100.0
+	}
+	if math.IsNaN(user) || math.IsInf(user, 0) {
+		user = 0.0
+	}
+	if math.IsNaN(system) || math.IsInf(system, 0) {
+		system = 0.0
+	}
+	if math.IsNaN(total) || math.IsInf(total, 0) {
+		total = 0.0
+	}
+
+	h.prevIdle = currentIdle
+	h.prevUser = currentUser
+	h.prevSystem = currentSystem
+	h.prevTotal = currentTotal
+	h.prevBusy = currentBusy
+	return
+}
+
+// cpuStats calculates cpu usage percentage
+type cpuStats struct {
+	prevCpuTime float64
+	prevTime    time.Time
+
+	totalCpus int
+}
+
+// percent calculates the cpu usage percentage based on the current cpu usage
+// and the previous cpu usage where usage is given as time in nanoseconds spend
+// in the cpu
+func (c *cpuStats) percent(cpuTime float64) float64 {
+	now := time.Now()
+
+	if c.prevCpuTime == 0.0 {
+		// invoked first time
+		c.prevCpuTime = cpuTime
+		c.prevTime = now
+		return 0.0
+	}
+
+	timeDelta := now.Sub(c.prevTime).Nanoseconds()
+	ret := c.calculatePercent(c.prevCpuTime, cpuTime, timeDelta)
+	c.prevCpuTime = cpuTime
+	c.prevTime = now
+	return ret
+}
+
+func (c *cpuStats) calculatePercent(t1, t2 float64, timeDelta int64) float64 {
+	vDelta := t2 - t1
+	if timeDelta <= 0 || vDelta <= 0.0 {
+		return 0.0
+	}
+
+	overall_percent := (vDelta / float64(timeDelta)) * 100.0
+	return overall_percent
+}
+
+func (h *Collector) collectCPUStats() (cpus []*CPUStats, err error) {
+
+	cpuStats, err := cpu.Times(true)
+	if err != nil {
+		return nil, err
+	}
+	cs := make([]*CPUStats, len(cpuStats))
+	for idx, cpuStat := range cpuStats {
+		percentCalculator, ok := h.cpuCalculator[cpuStat.CPU]
+		if !ok {
+			percentCalculator = &cpuStatsCalculator{}
+			h.cpuCalculator[cpuStat.CPU] = percentCalculator
+		}
+		idle, user, system, total := percentCalculator.calculate(cpuStat)
+		cs[idx] = &CPUStats{
+			CPU:    cpuStat.CPU,
+			User:   user,
+			System: system,
+			Idle:   idle,
+			Total:  total,
+		}
+	}
+
+	return cs, nil
+}

--- a/lib/hoststats/cpu.go
+++ b/lib/hoststats/cpu.go
@@ -21,9 +21,9 @@ func (h *cpuStatsCalculator) calculate(times cpu.TimesStat) (idle float64, user 
 	currentIdle := times.Idle
 	currentUser := times.User
 	currentSystem := times.System
-	currentTotal := times.Total()
 	currentBusy := times.User + times.System + times.Nice + times.Iowait + times.Irq +
 		times.Softirq + times.Steal + times.Guest + times.GuestNice
+	currentTotal := currentBusy + currentIdle
 
 	deltaTotal := currentTotal - h.prevTotal
 	idle = ((currentIdle - h.prevIdle) / deltaTotal) * 100

--- a/lib/hoststats/cpu.go
+++ b/lib/hoststats/cpu.go
@@ -2,7 +2,6 @@ package hoststats
 
 import (
 	"math"
-	"time"
 
 	"github.com/shirou/gopsutil/v3/cpu"
 )
@@ -14,17 +13,28 @@ type cpuStatsCalculator struct {
 	prevTotal float64
 }
 
-// calculate calculates the current cpu usage percentages
+// calculate the current cpu usage percentages.
+// Since the cpu.TimesStat captures the total time a cpu spent in various states
+// this function tracks the last seen stat and derives each cpu state's utilization
+// as a percentage of the total change in cpu time between calls.
+// The first time calculate is called CPUStats will report %100 idle
+// usage since there is not a previous value to calculate against
 func (h *cpuStatsCalculator) calculate(times cpu.TimesStat) *CPUStats {
 
+	// sum all none idle counters to get the total busy cpu time
 	currentBusy := times.User + times.System + times.Nice + times.Iowait + times.Irq +
 		times.Softirq + times.Steal + times.Guest + times.GuestNice
+	// sum of the total cpu time
 	currentTotal := currentBusy + times.Idle
 
+	// calculate how much cpu time has passed since last calculation
 	deltaTotal := currentTotal - h.prevTotal
+
 	stats := &CPUStats{
 		CPU: times.CPU,
 
+		// calculate each percentage as the ratio of the change
+		// in each state's time to the total change in cpu time
 		Idle:   ((times.Idle - h.prev.Idle) / deltaTotal) * 100,
 		User:   ((times.User - h.prev.User) / deltaTotal) * 100,
 		System: ((times.System - h.prev.System) / deltaTotal) * 100,
@@ -55,15 +65,7 @@ func (h *cpuStatsCalculator) calculate(times cpu.TimesStat) *CPUStats {
 	return stats
 }
 
-// cpuStats calculates cpu usage percentage
-type cpuStats struct {
-	prevCpuTime float64
-	prevTime    time.Time
-
-	totalCpus int
-}
-
-func (h *Collector) collectCPUStats() (cpus []*CPUStats, err error) {
+func (c *Collector) collectCPUStats() (cpus []*CPUStats, err error) {
 
 	cpuStats, err := cpu.Times(true)
 	if err != nil {
@@ -71,10 +73,10 @@ func (h *Collector) collectCPUStats() (cpus []*CPUStats, err error) {
 	}
 	cs := make([]*CPUStats, len(cpuStats))
 	for idx, cpuStat := range cpuStats {
-		percentCalculator, ok := h.cpuCalculator[cpuStat.CPU]
+		percentCalculator, ok := c.cpuCalculator[cpuStat.CPU]
 		if !ok {
 			percentCalculator = &cpuStatsCalculator{}
-			h.cpuCalculator[cpuStat.CPU] = percentCalculator
+			c.cpuCalculator[cpuStat.CPU] = percentCalculator
 		}
 		cs[idx] = percentCalculator.calculate(cpuStat)
 	}

--- a/lib/hoststats/cpu_test.go
+++ b/lib/hoststats/cpu_test.go
@@ -1,0 +1,77 @@
+package hoststats
+
+import (
+	"math"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCpuStats_percent(t *testing.T) {
+	cs := &cpuStats{
+		totalCpus: runtime.NumCPU(),
+	}
+	cs.percent(79.7)
+	time.Sleep(1 * time.Second)
+	percent := cs.percent(80.69)
+	expectedPercent := 98.00
+	if percent < expectedPercent && percent > (expectedPercent+1.00) {
+		t.Fatalf("expected: %v, actual: %v", expectedPercent, percent)
+	}
+}
+
+func TestHostStats_CPU(t *testing.T) {
+
+	assert := assert.New(t)
+
+	logger := testutil.Logger(t)
+	cwd, err := os.Getwd()
+	assert.Nil(err)
+	hs := initCollector(logger, cwd)
+
+	// Collect twice so we can calculate percents we need to generate some work
+	// so that the cpu values change
+	hs.collect()
+	total := 0
+	for i := 1; i < 1000000000; i++ {
+		total *= i
+		total = total % i
+	}
+	hs.collect()
+	stats := hs.Stats()
+	assert.NotZero(len(stats.CPU))
+
+	for _, cpu := range stats.CPU {
+		assert.False(math.IsNaN(cpu.Idle))
+		assert.False(math.IsNaN(cpu.Total))
+		assert.False(math.IsNaN(cpu.System))
+		assert.False(math.IsNaN(cpu.User))
+
+		assert.False(math.IsInf(cpu.Idle, 0))
+		assert.False(math.IsInf(cpu.Total, 0))
+		assert.False(math.IsInf(cpu.System, 0))
+		assert.False(math.IsInf(cpu.User, 0))
+	}
+}
+
+func TestCpuStatsCalculator_Nan(t *testing.T) {
+	times := cpu.TimesStat{
+		User:   0.0,
+		Idle:   100.0,
+		System: 0.0,
+	}
+
+	calculator := &cpuStatsCalculator{}
+	calculator.calculate(times)
+	idle, user, system, total := calculator.calculate(times)
+	require.Equal(t, 100.0, idle)
+	require.Zero(t, user)
+	require.Zero(t, system)
+	require.Zero(t, total)
+}

--- a/lib/hoststats/cpu_test.go
+++ b/lib/hoststats/cpu_test.go
@@ -27,12 +27,9 @@ func TestCpuStats_percent(t *testing.T) {
 }
 
 func TestHostStats_CPU(t *testing.T) {
-
-	assert := assert.New(t)
-
 	logger := testutil.Logger(t)
 	cwd, err := os.Getwd()
-	assert.Nil(err)
+	assert.Nil(t, err)
 	hs := initCollector(logger, cwd)
 
 	// Collect twice so we can calculate percents we need to generate some work
@@ -45,18 +42,18 @@ func TestHostStats_CPU(t *testing.T) {
 	}
 	hs.collect()
 	stats := hs.Stats()
-	assert.NotZero(len(stats.CPU))
+	assert.NotZero(t, len(stats.CPU))
 
 	for _, cpu := range stats.CPU {
-		assert.False(math.IsNaN(cpu.Idle))
-		assert.False(math.IsNaN(cpu.Total))
-		assert.False(math.IsNaN(cpu.System))
-		assert.False(math.IsNaN(cpu.User))
+		assert.False(t, math.IsNaN(cpu.Idle))
+		assert.False(t, math.IsNaN(cpu.Total))
+		assert.False(t, math.IsNaN(cpu.System))
+		assert.False(t, math.IsNaN(cpu.User))
 
-		assert.False(math.IsInf(cpu.Idle, 0))
-		assert.False(math.IsInf(cpu.Total, 0))
-		assert.False(math.IsInf(cpu.System, 0))
-		assert.False(math.IsInf(cpu.User, 0))
+		assert.False(t, math.IsInf(cpu.Idle, 0))
+		assert.False(t, math.IsInf(cpu.Total, 0))
+		assert.False(t, math.IsInf(cpu.System, 0))
+		assert.False(t, math.IsInf(cpu.User, 0))
 	}
 }
 

--- a/lib/hoststats/cpu_test.go
+++ b/lib/hoststats/cpu_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/shirou/gopsutil/v3/cpu"
@@ -20,10 +21,7 @@ func TestHostStats_CPU(t *testing.T) {
 	// Collect twice so we can calculate percents we need to generate some work
 	// so that the cpu values change
 	hs.collect()
-	total := 0
-	for i := 1; i < 1000000000; i++ {
-		total *= i
-		total = total % i
+	for begin := time.Now(); time.Now().Sub(begin) < 100*time.Millisecond; {
 	}
 	hs.collect()
 	stats := hs.Stats()

--- a/lib/hoststats/cpu_test.go
+++ b/lib/hoststats/cpu_test.go
@@ -3,28 +3,13 @@ package hoststats
 import (
 	"math"
 	"os"
-	"runtime"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestCpuStats_percent(t *testing.T) {
-	cs := &cpuStats{
-		totalCpus: runtime.NumCPU(),
-	}
-	cs.percent(79.7)
-	time.Sleep(1 * time.Second)
-	percent := cs.percent(80.69)
-	expectedPercent := 98.00
-	if percent < expectedPercent && percent > (expectedPercent+1.00) {
-		t.Fatalf("expected: %v, actual: %v", expectedPercent, percent)
-	}
-}
 
 func TestHostStats_CPU(t *testing.T) {
 	logger := testutil.Logger(t)
@@ -66,9 +51,10 @@ func TestCpuStatsCalculator_Nan(t *testing.T) {
 
 	calculator := &cpuStatsCalculator{}
 	calculator.calculate(times)
-	idle, user, system, total := calculator.calculate(times)
-	require.Equal(t, 100.0, idle)
-	require.Zero(t, user)
-	require.Zero(t, system)
-	require.Zero(t, total)
+	stats := calculator.calculate(times)
+	require.Equal(t, 100.0, stats.Idle)
+	require.Zero(t, stats.User)
+	require.Zero(t, stats.System)
+	require.Zero(t, stats.Iowait)
+	require.Zero(t, stats.Total)
 }

--- a/lib/hoststats/host.go
+++ b/lib/hoststats/host.go
@@ -1,0 +1,95 @@
+package hoststats
+
+import (
+	"time"
+
+	"github.com/armon/go-metrics"
+)
+
+var hostStatsCollectionInterval = 10 * time.Second
+
+// HostStats represents resource usage hoststats of the host running a Consul agent
+type HostStats struct {
+	Memory       *MemoryStats
+	CPU          []*CPUStats
+	DataDirStats *DiskStats
+	Uptime       uint64
+	Timestamp    int64
+}
+
+func (hs *HostStats) Clone() *HostStats {
+	clone := *hs
+
+	clone.CPU = make([]*CPUStats, len(hs.CPU))
+	for i := range hs.CPU {
+		cpu := *hs.CPU[i]
+		clone.CPU[i] = &cpu
+	}
+	return &clone
+}
+
+func (hs *HostStats) Emit(sink Metrics, baseLabels []metrics.Label) {
+
+	if hs.Memory != nil {
+		sink.SetGaugeWithLabels([]string{"host", "memory", "total"}, float32(hs.Memory.Total), baseLabels)
+		sink.SetGaugeWithLabels([]string{"host", "memory", "available"}, float32(hs.Memory.Available), baseLabels)
+		sink.SetGaugeWithLabels([]string{"host", "memory", "used"}, float32(hs.Memory.Used), baseLabels)
+		sink.SetGaugeWithLabels([]string{"host", "memory", "used_percent"}, float32(hs.Memory.UsedPercent), baseLabels)
+		sink.SetGaugeWithLabels([]string{"host", "memory", "free"}, float32(hs.Memory.Free), baseLabels)
+	}
+
+	for _, cpu := range hs.CPU {
+		labels := append(baseLabels, metrics.Label{
+			Name:  "cpu",
+			Value: cpu.CPU,
+		})
+
+		sink.SetGaugeWithLabels([]string{"host", "cpu", "total"}, float32(cpu.Total), labels)
+		sink.SetGaugeWithLabels([]string{"host", "cpu", "user"}, float32(cpu.User), labels)
+		sink.SetGaugeWithLabels([]string{"host", "cpu", "idle"}, float32(cpu.Idle), labels)
+		sink.SetGaugeWithLabels([]string{"host", "cpu", "system"}, float32(cpu.System), labels)
+	}
+
+	if hs.DataDirStats != nil {
+		diskLabels := append(baseLabels, metrics.Label{
+			Name:  "path",
+			Value: hs.DataDirStats.Path,
+		})
+
+		sink.SetGaugeWithLabels([]string{"host", "disk", "size"}, float32(hs.DataDirStats.Size), diskLabels)
+		sink.SetGaugeWithLabels([]string{"host", "disk", "used"}, float32(hs.DataDirStats.Used), diskLabels)
+		sink.SetGaugeWithLabels([]string{"host", "disk", "available"}, float32(hs.DataDirStats.Available), diskLabels)
+		sink.SetGaugeWithLabels([]string{"host", "disk", "used_percent"}, float32(hs.DataDirStats.UsedPercent), diskLabels)
+		sink.SetGaugeWithLabels([]string{"host", "disk", "inodes_percent"}, float32(hs.DataDirStats.InodesUsedPercent), diskLabels)
+	}
+
+	sink.SetGaugeWithLabels([]string{"host", "uptime"}, float32(hs.Uptime), baseLabels)
+}
+
+// CPUStats represents hoststats related to cpu usage
+type CPUStats struct {
+	CPU    string
+	User   float64
+	System float64
+	Idle   float64
+	Total  float64
+}
+
+// MemoryStats represents hoststats related to virtual memory usage
+type MemoryStats struct {
+	Total       uint64
+	Available   uint64
+	Used        uint64
+	UsedPercent float64
+	Free        uint64
+}
+
+// DiskStats represents hoststats related to disk usage
+type DiskStats struct {
+	Path              string
+	Size              uint64
+	Used              uint64
+	Available         uint64
+	UsedPercent       float64
+	InodesUsedPercent float64
+}

--- a/lib/hoststats/host.go
+++ b/lib/hoststats/host.go
@@ -18,14 +18,9 @@ type HostStats struct {
 }
 
 func (hs *HostStats) Clone() *HostStats {
-	clone := *hs
-
-	clone.CPU = make([]*CPUStats, len(hs.CPU))
-	for i := range hs.CPU {
-		cpu := *hs.CPU[i]
-		clone.CPU[i] = &cpu
-	}
-	return &clone
+	clone := &HostStats{}
+	*clone = *hs
+	return clone
 }
 
 func (hs *HostStats) Emit(sink Metrics, baseLabels []metrics.Label) {

--- a/lib/hoststats/host.go
+++ b/lib/hoststats/host.go
@@ -47,6 +47,7 @@ func (hs *HostStats) Emit(sink Metrics, baseLabels []metrics.Label) {
 		sink.SetGaugeWithLabels([]string{"host", "cpu", "total"}, float32(cpu.Total), labels)
 		sink.SetGaugeWithLabels([]string{"host", "cpu", "user"}, float32(cpu.User), labels)
 		sink.SetGaugeWithLabels([]string{"host", "cpu", "idle"}, float32(cpu.Idle), labels)
+		sink.SetGaugeWithLabels([]string{"host", "cpu", "iowait"}, float32(cpu.Iowait), labels)
 		sink.SetGaugeWithLabels([]string{"host", "cpu", "system"}, float32(cpu.System), labels)
 	}
 
@@ -72,6 +73,7 @@ type CPUStats struct {
 	User   float64
 	System float64
 	Idle   float64
+	Iowait float64
 	Total  float64
 }
 

--- a/lib/hoststats/metrics.go
+++ b/lib/hoststats/metrics.go
@@ -45,6 +45,10 @@ var Gauges = []prometheus.GaugeDefinition{
 		Help: "Idle cpu utilization",
 	},
 	{
+		Name: []string{"host", "cpu", "iowait"},
+		Help: "Iowait cpu utilization",
+	},
+	{
 		Name: []string{"host", "cpu", "system"},
 		Help: "System cpu utilization",
 	},

--- a/lib/hoststats/metrics.go
+++ b/lib/hoststats/metrics.go
@@ -1,0 +1,75 @@
+package hoststats
+
+import (
+	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/prometheus"
+)
+
+// Metrics defines an interface for the methods used to emit data to the go-metrics library.
+// `metrics.Default()` should always satisfy this interface.
+type Metrics interface {
+	SetGaugeWithLabels(key []string, val float32, labels []metrics.Label)
+}
+
+var Gauges = []prometheus.GaugeDefinition{
+	{
+		Name: []string{"host", "memory", "total"},
+		Help: "Total physical memory in bytes",
+	},
+	{
+		Name: []string{"host", "memory", "available"},
+		Help: "Available physical memory in bytes",
+	},
+	{
+		Name: []string{"host", "memory", "free"},
+		Help: "Free physical memory in bytes",
+	},
+	{
+		Name: []string{"host", "memory", "used"},
+		Help: "Used physical memory in bytes",
+	},
+	{
+		Name: []string{"host", "memory", "used_percent"},
+		Help: "Percentage of physical memory in use",
+	},
+	{
+		Name: []string{"host", "cpu", "total"},
+		Help: "Total cpu utilization",
+	},
+	{
+		Name: []string{"host", "cpu", "user"},
+		Help: "User cpu utilization",
+	},
+	{
+		Name: []string{"host", "cpu", "idle"},
+		Help: "Idle cpu utilization",
+	},
+	{
+		Name: []string{"host", "cpu", "system"},
+		Help: "System cpu utilization",
+	},
+	{
+		Name: []string{"host", "disk", "size"},
+		Help: "Size of disk in bytes",
+	},
+	{
+		Name: []string{"host", "disk", "used"},
+		Help: "Disk usage in bytes",
+	},
+	{
+		Name: []string{"host", "disk", "available"},
+		Help: "Available bytes on disk",
+	},
+	{
+		Name: []string{"host", "disk", "used_percent"},
+		Help: "Percentage of disk space usage",
+	},
+	{
+		Name: []string{"host", "disk", "inodes_percent"},
+		Help: "Percentage of disk inodes usage",
+	},
+	{
+		Name: []string{"host", "uptime"},
+		Help: "System uptime",
+	},
+}

--- a/lib/telemetry.go
+++ b/lib/telemetry.go
@@ -204,17 +204,17 @@ type TelemetryConfig struct {
 	// hcl: telemetry { statsite_address = string }
 	StatsiteAddr string `json:"statsite_address,omitempty" mapstructure:"statsite_address"`
 
+	// EnableHostMetrics will enable metrics collected about the host system such as cpu memory and disk usage.
+	//
+	// hcl: telemetry { enable_host_metrics = (true|false) }
+	EnableHostMetrics bool `json:"enable_host_metrics,omitempty" mapstructure:"enable_host_metrics"`
+
 	// PrometheusOpts provides configuration for the PrometheusSink. Currently the only configuration
 	// we acquire from hcl is the retention time. We also use definition slices that are set in agent setup
 	// before being passed to InitTelemmetry.
 	//
 	// hcl: telemetry { prometheus_retention_time = "duration" }
 	PrometheusOpts prometheus.PrometheusOpts
-
-	// DisableHostMetrics will disable metrics collected about the host system such as cpu memory and disk usage.
-	//
-	// hcl: telemetry { disable_host_metrics = (true|false) }
-	DisableHostMetrics bool
 }
 
 // MetricsHandler provides an http.Handler for displaying metrics.

--- a/lib/telemetry.go
+++ b/lib/telemetry.go
@@ -210,6 +210,11 @@ type TelemetryConfig struct {
 	//
 	// hcl: telemetry { prometheus_retention_time = "duration" }
 	PrometheusOpts prometheus.PrometheusOpts
+
+	// DisableHostMetrics will disable metrics collected about the host system such as cpu memory and disk usage.
+	//
+	// hcl: telemetry { disable_host_metrics = (true|false) }
+	DisableHostMetrics bool
 }
 
 // MetricsHandler provides an http.Handler for displaying metrics.

--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -1817,6 +1817,9 @@ subsystem that provides Consul's service mesh capabilities.
     be used based on **where** this particular instance is running (e.g. a specific
     geo location or datacenter, dc:sfo). By default, this is left blank and not used.
 
+  - `disable_host_metrics` ((#telemetry-disable_host_metrics))
+    This disables reporting of host metrics about system resources, defaults to false.
+
   - `disable_hostname` ((#telemetry-disable_hostname))
     This controls whether or not to prepend runtime telemetry with the machine's
     hostname, defaults to false.

--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -1817,9 +1817,6 @@ subsystem that provides Consul's service mesh capabilities.
     be used based on **where** this particular instance is running (e.g. a specific
     geo location or datacenter, dc:sfo). By default, this is left blank and not used.
 
-  - `disable_host_metrics` ((#telemetry-disable_host_metrics))
-    This disables reporting of host metrics about system resources, defaults to false.
-
   - `disable_hostname` ((#telemetry-disable_hostname))
     This controls whether or not to prepend runtime telemetry with the machine's
     hostname, defaults to false.
@@ -1833,6 +1830,9 @@ subsystem that provides Consul's service mesh capabilities.
   - `dogstatsd_tags` ((#telemetry-dogstatsd_tags)) This provides a list
     of global tags that will be added to all telemetry packets sent to DogStatsD.
     It is a list of strings, where each string looks like "my_tag_name:my_tag_value".
+
+  - `enable_host_metrics` ((#telemetry-enable_host_metrics))
+    This enables reporting of host metrics about system resources, defaults to false.
 
   - `filter_default` ((#telemetry-filter_default))
     This controls whether to allow metrics that have not been specified by the filter.

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -772,6 +772,7 @@ Consul servers report the following metrics about the host's system resources
 | `consul.host.cpu.total`             | The host's total cpu utilization
 | `consul.host.cpu.user`              | The cpu utilization in user space
 | `consul.host.cpu.idle`              | The cpu utilization in idle state
+| `consul.host.cpu.iowait`            | The cpu utilization in iowait state
 | `consul.host.cpu.system`            | The cpu utilization in system space
 | `consul.host.disk.size`             | The size in bytes of the data_dir disk
 | `consul.host.disk.used`             | The number of bytes used on the data_dir disk

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -757,7 +757,8 @@ Consul attaches the following labels to metric values.
 
 ## Server Host Metrics
 
-Consul servers report the following metrics about the host's system resources.
+Consul servers can report the following metrics about the host's system resources.
+This feature must be enabled in the [agent telemetry configuration](/consul/docs/agent/config/config-files#telemetry-enable_host_metrics).
 Note that if the Consul server is operating inside a container these metrics
 still report host resource usage and do not report any resource limits placed
 on the container.  

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -755,3 +755,27 @@ Consul attaches the following labels to metric values.
 | `peer_id`                             | The ID of a peer connected to the reporting cluster or leader.                   | Any UUID                                  |
 | `partition`                           | <EnterpriseAlert inline /> Name of the partition that the peering is created in. | Any defined partition name in the cluster |
 
+## Server Host Metrics
+
+Consul servers report the following metrics about the host's system resources
+
+**Requirements:**
+- Consul 1.15.3+
+
+| Metric                              | Description                                                                                                                                                                                                                                                       | Unit        | Type    |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------- |
+| `consul.host.memory.total`          | The total physical memory in bytes                                                                                                                                                                                                   | mixed       | mixed   |
+| `consul.host.memory.available`      | The available physical memory in bytes                                                                                                                                                                                                   | mixed       | mixed   |
+| `consul.host.memory.free`           | The free physical memory in bytes                                                                                                                                                                                                   | mixed       | mixed   |
+| `consul.host.memory.used`           | The used physical memory in bytes                                                                                                                                                                                                   | mixed       | mixed   |
+| `consul.host.memory.used_percent`   | The used physical memory as a percentage of total physical memory                                                                                                                                                                                                 | mixed       | mixed   |
+| `consul.host.cpu.total`             | The host's total cpu utilization
+| `consul.host.cpu.user`              | The cpu utilization in user space
+| `consul.host.cpu.idle`              | The cpu utilization in idle state
+| `consul.host.cpu.system`            | The cpu utilization in system space
+| `consul.host.disk.size`             | The size in bytes of the data_dir disk
+| `consul.host.disk.used`             | The number of bytes used on the data_dir disk
+| `consul.host.disk.available`        | The number of bytes available on the data_dir disk
+| `consul.host.disk.used_percent`     | The percentage of disk space used on the data_dir disk
+| `consul.host.disk.inodes_percent`   | The percentage of inode usage on the data_dir disk
+| `consul.host.uptime`                | The uptime of the host in seconds

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -757,7 +757,10 @@ Consul attaches the following labels to metric values.
 
 ## Server Host Metrics
 
-Consul servers report the following metrics about the host's system resources
+Consul servers report the following metrics about the host's system resources.
+Note that if the Consul server is operating inside a container these metrics
+still report host resource usage and do not report any resource limits placed
+on the container.  
 
 **Requirements:**
 - Consul 1.15.3+


### PR DESCRIPTION
### Description

This PR adds the ability for Consul to report host statistics through go-metrics. These metrics include cpu utilization by core and in aggregate, system memory usage and disk usage for the disk backing the configured data_dir. 

### Testing & Reproduction steps

Tests were added to assert cpu utilization calculation is performed accurately. Manual testing was performed on linux and darwin to ensure reported host stats values were accurate.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
