### PR TITLE
Avoid decoding nil pointer in map walker

### DIFF
--- a/.changelog/17048.txt
+++ b/.changelog/17048.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix an bug where decoding some Config structs with unset pointer fields could fail with `reflect: call of reflect.Value.Type on zero Value`. 
+```

--- a/lib/map_walker.go
+++ b/lib/map_walker.go
@@ -113,7 +113,7 @@ func (w *mapWalker) MapElem(m, k, v reflect.Value) error {
 		return nil
 	}
 
-	if inner := v.Elem(); inner.Type() == typMapIfaceIface {
+	if inner := v.Elem(); inner.IsValid() && inner.Type() == typMapIfaceIface {
 		// map[interface{}]interface{}, attempt to weakly decode into string keys
 		var target map[string]interface{}
 		if err := mapstructure.WeakDecode(v.Interface(), &target); err != nil {

--- a/lib/map_walker_test.go
+++ b/lib/map_walker_test.go
@@ -41,6 +41,16 @@ func TestMapWalk(t *testing.T) {
 			},
 			unexpected: true,
 		},
+		// ensure we don't panic from trying to call reflect.Value.Type
+		// on a nil pointer
+		"nil pointer": {
+			input: map[string]interface{}{
+				"foo": nil,
+			},
+			expected: map[string]interface{}{
+				"foo": nil,
+			},
+		},
 		// ensure nested maps get processed correctly
 		"nested": {
 			input: map[string]interface{}{


### PR DESCRIPTION
### Description

This PR fixes a bug with the mapwalk decoding logic used on the client agents for things like config entries and resolved service configs. Currently, if there is a struct stored within a `map[string]interface{}`  with at least one field set and one pointer field unset/`nil` (such as `EnforcingConsecutive5xx` in the `PassiveHealthCheck` struct), the mapwalk logic here would attempt to call `reflect.Value.Type()` which is invalid for a nil pointer and we'd get `reflect: call of reflect.Value.Type on zero Value`.

### Testing & Reproduction steps

Replication steps:
1. Set up a server and client agent
2. Register the following service config:
```json
{
    "Kind": "service-defaults",
    "Name": "frontend",
    "Protocol": "http",
    "UpstreamConfig": {
        "Defaults": {
            "ConnectTimeoutMs": 15000,
            "PassiveHealthCheck": {
                "MaxFailures": 1000000
            },
            "MeshGateway": {}
        }
    }
}
```
3. Attempt to register the following service on the client agent:
```json
{
    "id": "frontend",
    "name": "frontend",
    "port": 9090,
    "checks": [
        {
            "Name": "check-9090-is-open",
            "TCP": "127.0.0.1:9090",
            "Interval": "10s"
        }
    ],
    "connect": {
        "sidecar_service": {
            "checks": [
                {
                    "Name": "check-9191-is-open",
                    "TCP": "127.0.0.1:9191",
                    "Interval": "10s"
                }
            ],
            "proxy": {
                "upstreams": [
                    {
                        "destination_name": "backend",
                        "local_bind_port": 9191
                    }
                ]
            }
        }
    }
}
```
4. Registration should fail with `reflect: call of reflect.Value.Type on zero Value`

### PR Checklist

* [x] updated test coverage
* ~~[ ] external facing docs updated~~
* [x] appropriate backport labels added
* [x] not a security concern
