### PR TITLE
testing: `RunResourceService` helper

### DIFF
--- a/agent/grpc-external/services/resource/testing/testing.go
+++ b/agent/grpc-external/services/resource/testing/testing.go
@@ -1,0 +1,58 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/hashicorp/consul/acl/resolver"
+	svc "github.com/hashicorp/consul/agent/grpc-external/services/resource"
+	internal "github.com/hashicorp/consul/agent/grpc-internal"
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/demo"
+	"github.com/hashicorp/consul/internal/storage/inmem"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+// RunResourceService runs a Resource Service for the duration of the test and
+// returns a client to interact with it. ACLs will be disabled.
+func RunResourceService(t *testing.T) pbresource.ResourceServiceClient {
+	t.Helper()
+
+	backend, err := inmem.NewBackend()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go backend.Run(ctx)
+
+	registry := resource.NewRegistry()
+	demo.Register(registry)
+
+	server := grpc.NewServer()
+
+	svc.NewServer(svc.Config{
+		Backend:     backend,
+		Registry:    registry,
+		Logger:      testutil.Logger(t),
+		ACLResolver: resolver.DANGER_NO_AUTH{},
+	}).Register(server)
+
+	pipe := internal.NewPipeListener()
+	go server.Serve(pipe)
+	t.Cleanup(server.Stop)
+
+	conn, err := grpc.Dial("",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(pipe.DialContext),
+		grpc.WithBlock(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return pbresource.NewResourceServiceClient(conn)
+}

--- a/agent/grpc-external/services/resource/testing/testing.go
+++ b/agent/grpc-external/services/resource/testing/testing.go
@@ -12,7 +12,6 @@ import (
 	svc "github.com/hashicorp/consul/agent/grpc-external/services/resource"
 	internal "github.com/hashicorp/consul/agent/grpc-internal"
 	"github.com/hashicorp/consul/internal/resource"
-	"github.com/hashicorp/consul/internal/resource/demo"
 	"github.com/hashicorp/consul/internal/storage/inmem"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -20,7 +19,7 @@ import (
 
 // RunResourceService runs a Resource Service for the duration of the test and
 // returns a client to interact with it. ACLs will be disabled.
-func RunResourceService(t *testing.T) pbresource.ResourceServiceClient {
+func RunResourceService(t *testing.T, registerFns ...func(resource.Registry)) pbresource.ResourceServiceClient {
 	t.Helper()
 
 	backend, err := inmem.NewBackend()
@@ -31,7 +30,9 @@ func RunResourceService(t *testing.T) pbresource.ResourceServiceClient {
 	go backend.Run(ctx)
 
 	registry := resource.NewRegistry()
-	demo.Register(registry)
+	for _, fn := range registerFns {
+		fn(registry)
+	}
 
 	server := grpc.NewServer()
 


### PR DESCRIPTION
### Description

This PR adds a helper method for running a Resource Service for the duration of a test. I'm using it in my WIP controller branch, and I think it'll be what most controller tests will end up using.
