### PR TITLE
Controller Implementation 🏗

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -782,6 +782,17 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server, incom
 	// to enable RPC forwarding.
 	s.grpcHandler = newGRPCHandlerFromConfig(flat, config, s)
 	s.grpcLeaderForwarder = flat.LeaderForwarder
+
+	if err := s.setupInternalResourceService(logger); err != nil {
+		return nil, err
+	}
+	s.controllerManager = controller.NewManager(
+		s.internalResourceServiceClient,
+		logger.Named(logging.ControllerRuntime),
+	)
+	s.registerResources()
+	go s.controllerManager.Run(&lib.StopChannelContext{StopCh: shutdownCh})
+
 	go s.trackLeaderChanges()
 
 	s.xdsCapacityController = xdscapacity.NewController(xdscapacity.Config{
@@ -790,10 +801,6 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server, incom
 		SessionLimiter: flat.XDSStreamLimiter,
 	})
 	go s.xdsCapacityController.Run(&lib.StopChannelContext{StopCh: s.shutdownCh})
-
-	if err := s.setupInternalResourceService(logger); err != nil {
-		return nil, err
-	}
 
 	// Initialize Autopilot. This must happen before starting leadership monitoring
 	// as establishing leadership could attempt to use autopilot and cause a panic.
@@ -830,13 +837,6 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server, incom
 	if err != nil {
 		return nil, err
 	}
-
-	s.controllerManager = controller.NewManager(
-		s.internalResourceServiceClient,
-		logger.Named(logging.ControllerRuntime),
-	)
-	s.registerResources()
-	go s.controllerManager.Run(&lib.StopChannelContext{StopCh: shutdownCh})
 
 	return s, nil
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -507,7 +507,6 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server, incom
 		incomingRPCLimiter:      incomingRPCLimiter,
 		routineManager:          routine.NewManager(logger.Named(logging.ConsulServer)),
 		typeRegistry:            resource.NewRegistry(),
-		controllerManager:       controller.NewManager(logger.Named(logging.ControllerRuntime)),
 	}
 	incomingRPCLimiter.Register(s)
 
@@ -832,6 +831,10 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server, incom
 		return nil, err
 	}
 
+	s.controllerManager = controller.NewManager(
+		s.internalResourceServiceClient,
+		logger.Named(logging.ControllerRuntime),
+	)
 	s.registerResources()
 	go s.controllerManager.Run(&lib.StopChannelContext{StopCh: shutdownCh})
 

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package controller
 
 import (

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -1,12 +1,32 @@
 package controller
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
 // ForType begins building a Controller for the given resource type.
 func ForType(managedType *pbresource.Type) Controller {
 	return Controller{managedType: managedType}
+}
+
+// WithReconciler adds the given reconciler to the controller being built.
+func (c Controller) WithReconciler(reconciler Reconciler) Controller {
+	c.reconciler = reconciler
+	return c
+}
+
+// WithBackoff changes the base and maximum backoff values for the controller's
+// retry rate limiter.
+func (c Controller) WithBackoff(base, max time.Duration) Controller {
+	c.baseBackoff = base
+	c.maxBackoff = max
+	return c
 }
 
 // Controller runs a reconciliation loop to respond to changes in resources and
@@ -17,4 +37,48 @@ func ForType(managedType *pbresource.Type) Controller {
 // a controller, and then pass it to a Manager to be executed.
 type Controller struct {
 	managedType *pbresource.Type
+	reconciler  Reconciler
+
+	baseBackoff, maxBackoff time.Duration
+}
+
+// Request represents a request to reconcile the resource with the given ID.
+type Request struct {
+	// ID of the resource that needs to be reconciled.
+	ID *pbresource.ID
+}
+
+// Runtime contains the dependencies required by reconcilers.
+type Runtime struct {
+	Client pbresource.ResourceServiceClient
+	Logger hclog.Logger
+}
+
+// Reconciler implements the business logic of a controller.
+type Reconciler interface {
+	// Reconcile the resource identified by req.ID.
+	Reconcile(ctx context.Context, rt Runtime, req Request) error
+}
+
+// RequeueAfterError is an error that allows a Reconciler to override the
+// exponential backoff behavior of the Controller, rather than applying
+// the backoff algorithm, returning a RequeueAfterError will cause the
+// Controller to reschedule the Request at a given time in the future.
+type RequeueAfterError time.Duration
+
+// Error implements the error interface.
+func (r RequeueAfterError) Error() string {
+	return fmt.Sprintf("requeue at %s", time.Duration(r))
+}
+
+// RequeueAfter constructs a RequeueAfterError with the given duration
+// setting.
+func RequeueAfter(after time.Duration) error {
+	return RequeueAfterError(after)
+}
+
+// RequeueNow constructs a RequeueAfterError that reschedules the Request
+// immediately.
+func RequeueNow() error {
+	return RequeueAfterError(0)
 }

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -21,6 +21,12 @@ func (c Controller) WithReconciler(reconciler Reconciler) Controller {
 	return c
 }
 
+// WithLogger adds the given logger to the controller being built.
+func (c Controller) WithLogger(logger hclog.Logger) Controller {
+	c.logger = logger
+	return c
+}
+
 // WithBackoff changes the base and maximum backoff values for the controller's
 // retry rate limiter.
 func (c Controller) WithBackoff(base, max time.Duration) Controller {
@@ -38,6 +44,7 @@ func (c Controller) WithBackoff(base, max time.Duration) Controller {
 type Controller struct {
 	managedType *pbresource.Type
 	reconciler  Reconciler
+	logger      hclog.Logger
 
 	baseBackoff, maxBackoff time.Duration
 }

--- a/internal/controller/api_test.go
+++ b/internal/controller/api_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package controller_test
 
 import (

--- a/internal/controller/api_test.go
+++ b/internal/controller/api_test.go
@@ -1,0 +1,159 @@
+package controller_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/resource/demo"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/hashicorp/consul/proto/private/prototest"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+func TestControllerAPI(t *testing.T) {
+	rec := newTestReconciler()
+	client := svctest.RunResourceService(t, demo.RegisterTypes)
+
+	ctrl := controller.
+		ForType(demo.TypeV2Artist).
+		WithBackoff(10*time.Millisecond, 100*time.Millisecond).
+		WithReconciler(rec)
+
+	mgr := controller.NewManager(client, testutil.Logger(t))
+	mgr.Register(ctrl)
+	mgr.SetRaftLeader(true)
+	go mgr.Run(testContext(t))
+
+	t.Run("basic", func(t *testing.T) {
+		res, err := demo.GenerateV2Artist()
+		require.NoError(t, err)
+
+		rsp, err := client.Write(testContext(t), &pbresource.WriteRequest{Resource: res})
+		require.NoError(t, err)
+
+		req := rec.wait(t)
+		prototest.AssertDeepEqual(t, rsp.Resource.Id, req.ID)
+
+		rec.expectNoRequest(t, 1*time.Second)
+	})
+
+	t.Run("error retries", func(t *testing.T) {
+		rec.failNext(errors.New("KABOOM"))
+
+		res, err := demo.GenerateV2Artist()
+		require.NoError(t, err)
+
+		rsp, err := client.Write(testContext(t), &pbresource.WriteRequest{Resource: res})
+		require.NoError(t, err)
+
+		req := rec.wait(t)
+		prototest.AssertDeepEqual(t, rsp.Resource.Id, req.ID)
+
+		// Reconciler should be called with the same request again.
+		req = rec.wait(t)
+		prototest.AssertDeepEqual(t, rsp.Resource.Id, req.ID)
+	})
+
+	t.Run("panic retries", func(t *testing.T) {
+		rec.panicNext("KABOOM")
+
+		res, err := demo.GenerateV2Artist()
+		require.NoError(t, err)
+
+		rsp, err := client.Write(testContext(t), &pbresource.WriteRequest{Resource: res})
+		require.NoError(t, err)
+
+		req := rec.wait(t)
+		prototest.AssertDeepEqual(t, rsp.Resource.Id, req.ID)
+
+		// Reconciler should be called with the same request again.
+		req = rec.wait(t)
+		prototest.AssertDeepEqual(t, rsp.Resource.Id, req.ID)
+	})
+
+	t.Run("defer", func(t *testing.T) {
+		rec.failNext(controller.RequeueAfter(1 * time.Second))
+
+		res, err := demo.GenerateV2Artist()
+		require.NoError(t, err)
+
+		rsp, err := client.Write(testContext(t), &pbresource.WriteRequest{Resource: res})
+		require.NoError(t, err)
+
+		req := rec.wait(t)
+		prototest.AssertDeepEqual(t, rsp.Resource.Id, req.ID)
+
+		rec.expectNoRequest(t, 750*time.Millisecond)
+
+		req = rec.wait(t)
+		prototest.AssertDeepEqual(t, rsp.Resource.Id, req.ID)
+	})
+}
+
+func newTestReconciler() *testReconciler {
+	return &testReconciler{
+		calls:  make(chan controller.Request),
+		errors: make(chan error, 1),
+		panics: make(chan any, 1),
+	}
+}
+
+type testReconciler struct {
+	calls  chan controller.Request
+	errors chan error
+	panics chan any
+}
+
+func (r *testReconciler) Reconcile(_ context.Context, _ controller.Runtime, req controller.Request) error {
+	r.calls <- req
+
+	select {
+	case err := <-r.errors:
+		return err
+	case p := <-r.panics:
+		panic(p)
+	default:
+		return nil
+	}
+}
+
+func (r *testReconciler) failNext(err error) { r.errors <- err }
+func (r *testReconciler) panicNext(p any)    { r.panics <- p }
+
+func (r *testReconciler) expectNoRequest(t *testing.T, duration time.Duration) {
+	t.Helper()
+
+	started := time.Now()
+	select {
+	case req := <-r.calls:
+		t.Fatalf("expected no request for %s, but got: %s after %s", duration, req.ID, time.Since(started))
+	case <-time.After(duration):
+	}
+}
+
+func (r *testReconciler) wait(t *testing.T) controller.Request {
+	t.Helper()
+
+	var req controller.Request
+	select {
+	case req = <-r.calls:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Reconcile was not called after 500ms")
+	}
+	return req
+}
+
+func testContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	return ctx
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package controller
 
 import (

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -62,17 +62,8 @@ func (c *controllerRunner) run(ctx context.Context) error {
 }
 
 func runQueue[T queue.ItemType](ctx context.Context, ctrl Controller) queue.WorkQueue[T] {
-	baseBackoff := ctrl.baseBackoff
-	if baseBackoff == 0 {
-		baseBackoff = 5 * time.Millisecond
-	}
-
-	maxBackoff := ctrl.maxBackoff
-	if maxBackoff == 0 {
-		maxBackoff = 1000 * time.Second
-	}
-
-	return queue.RunWorkQueue[T](ctx, baseBackoff, maxBackoff)
+	base, max := ctrl.backoff()
+	return queue.RunWorkQueue[T](ctx, base, max)
 }
 
 func (c *controllerRunner) watch(ctx context.Context, typ *pbresource.Type, add func(*pbresource.Resource)) error {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -2,14 +2,23 @@ package controller
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/hashicorp/consul/agent/consul/controller/queue"
+	"github.com/hashicorp/consul/internal/storage"
+	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
 // controllerRunner contains the actual implementation of running a controller
 // including creating watches, calling the reconciler, handling retries, etc.
 type controllerRunner struct {
 	ctrl   Controller
+	client pbresource.ResourceServiceClient
 	logger hclog.Logger
 }
 
@@ -17,6 +26,93 @@ func (c *controllerRunner) run(ctx context.Context) error {
 	c.logger.Debug("controller running")
 	defer c.logger.Debug("controller stopping")
 
-	<-ctx.Done()
-	return ctx.Err()
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	queue := c.runQueue(groupCtx)
+	group.Go(func() error { return c.watchManagedType(groupCtx, queue) })
+	group.Go(func() error { return c.runReconciler(groupCtx, queue) })
+
+	return group.Wait()
+}
+
+type workQueue queue.WorkQueue[Request]
+
+func (c *controllerRunner) runQueue(ctx context.Context) workQueue {
+	baseBackoff := c.ctrl.baseBackoff
+	if baseBackoff == 0 {
+		baseBackoff = 5 * time.Millisecond
+	}
+
+	maxBackoff := c.ctrl.maxBackoff
+	if maxBackoff == 0 {
+		maxBackoff = 1000 * time.Second
+	}
+
+	return queue.RunWorkQueue[Request](ctx, baseBackoff, maxBackoff)
+}
+
+func (c *controllerRunner) watchManagedType(ctx context.Context, queue workQueue) error {
+	watch, err := c.client.WatchList(ctx, &pbresource.WatchListRequest{
+		Type: c.ctrl.managedType,
+		Tenancy: &pbresource.Tenancy{
+			Partition: storage.Wildcard,
+			PeerName:  storage.Wildcard,
+			Namespace: storage.Wildcard,
+		},
+	})
+	if err != nil {
+		c.logger.Error("failed to create watch on managed resource type", "error", err)
+		return err
+	}
+
+	for {
+		event, err := watch.Recv()
+		if err != nil {
+			c.logger.Warn("error received from watch", "error", err)
+			return err
+		}
+		queue.Add(Request{ID: event.Resource.Id})
+	}
+}
+
+func (c *controllerRunner) runReconciler(ctx context.Context, queue workQueue) error {
+	for {
+		req, shutdown := queue.Get()
+		if shutdown {
+			return nil
+		}
+
+		c.logger.Trace("handling request", "request", req)
+		if err := c.reconcile(ctx, req); err == nil {
+			queue.Forget(req)
+		} else {
+			var requeueAfter RequeueAfterError
+			if errors.As(err, &requeueAfter) {
+				queue.Forget(req)
+				queue.AddAfter(req, time.Duration(requeueAfter))
+			} else {
+				queue.AddRateLimited(req)
+			}
+		}
+		queue.Done(req)
+	}
+}
+
+func (c *controllerRunner) reconcile(ctx context.Context, req Request) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := hclog.Stacktrace()
+			c.logger.Error("panic from controller reconciler",
+				"panic", r,
+				"stack", stack,
+			)
+			err = fmt.Errorf("panic [recovered]: %v", r)
+			return
+		}
+	}()
+
+	return c.ctrl.reconciler.Reconcile(ctx, Runtime{
+		Client: c.client,
+		Logger: c.logger,
+	}, req)
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/hashicorp/consul/agent/consul/controller/queue"
+	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/storage"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
@@ -27,33 +29,55 @@ func (c *controllerRunner) run(ctx context.Context) error {
 	defer c.logger.Debug("controller stopping")
 
 	group, groupCtx := errgroup.WithContext(ctx)
+	recQueue := runQueue[Request](groupCtx, c.ctrl)
 
-	queue := c.runQueue(groupCtx)
-	group.Go(func() error { return c.watchManagedType(groupCtx, queue) })
-	group.Go(func() error { return c.runReconciler(groupCtx, queue) })
+	// Managed Type Events → Reconciliation Queue
+	group.Go(func() error {
+		return c.watch(groupCtx, c.ctrl.managedType, func(res *pbresource.Resource) {
+			recQueue.Add(Request{ID: res.Id})
+		})
+	})
+
+	for _, watch := range c.ctrl.watches {
+		watch := watch
+		mapQueue := runQueue[*pbresource.Resource](groupCtx, c.ctrl)
+
+		// Watched Type Events → Mapper Queue
+		group.Go(func() error {
+			return c.watch(groupCtx, watch.watchedType, mapQueue.Add)
+		})
+
+		// Mapper Queue → Mapper → Reconciliation Queue
+		group.Go(func() error {
+			return c.runMapper(groupCtx, watch, mapQueue, recQueue)
+		})
+	}
+
+	// Reconciliation Queue → Reconciler
+	group.Go(func() error {
+		return c.runReconciler(groupCtx, recQueue)
+	})
 
 	return group.Wait()
 }
 
-type workQueue queue.WorkQueue[Request]
-
-func (c *controllerRunner) runQueue(ctx context.Context) workQueue {
-	baseBackoff := c.ctrl.baseBackoff
+func runQueue[T queue.ItemType](ctx context.Context, ctrl Controller) queue.WorkQueue[T] {
+	baseBackoff := ctrl.baseBackoff
 	if baseBackoff == 0 {
 		baseBackoff = 5 * time.Millisecond
 	}
 
-	maxBackoff := c.ctrl.maxBackoff
+	maxBackoff := ctrl.maxBackoff
 	if maxBackoff == 0 {
 		maxBackoff = 1000 * time.Second
 	}
 
-	return queue.RunWorkQueue[Request](ctx, baseBackoff, maxBackoff)
+	return queue.RunWorkQueue[T](ctx, baseBackoff, maxBackoff)
 }
 
-func (c *controllerRunner) watchManagedType(ctx context.Context, queue workQueue) error {
+func (c *controllerRunner) watch(ctx context.Context, typ *pbresource.Type, add func(*pbresource.Resource)) error {
 	watch, err := c.client.WatchList(ctx, &pbresource.WatchListRequest{
-		Type: c.ctrl.managedType,
+		Type: typ,
 		Tenancy: &pbresource.Tenancy{
 			Partition: storage.Wildcard,
 			PeerName:  storage.Wildcard,
@@ -61,7 +85,7 @@ func (c *controllerRunner) watchManagedType(ctx context.Context, queue workQueue
 		},
 	})
 	if err != nil {
-		c.logger.Error("failed to create watch on managed resource type", "error", err)
+		c.logger.Error("failed to create watch", "error", err)
 		return err
 	}
 
@@ -71,11 +95,48 @@ func (c *controllerRunner) watchManagedType(ctx context.Context, queue workQueue
 			c.logger.Warn("error received from watch", "error", err)
 			return err
 		}
-		queue.Add(Request{ID: event.Resource.Id})
+		add(event.Resource)
 	}
 }
 
-func (c *controllerRunner) runReconciler(ctx context.Context, queue workQueue) error {
+func (c *controllerRunner) runMapper(
+	ctx context.Context,
+	w watch,
+	from queue.WorkQueue[*pbresource.Resource],
+	to queue.WorkQueue[Request],
+) error {
+	logger := c.logger.With("watched_resource_type", resource.ToGVK(w.watchedType))
+
+	for {
+		res, shutdown := from.Get()
+		if shutdown {
+			return nil
+		}
+
+		reqs, err := w.mapper(ctx, c.runtime(), res)
+		if err != nil {
+			from.AddRateLimited(res)
+			from.Done(res)
+			continue
+		}
+
+		for _, r := range reqs {
+			if !proto.Equal(r.ID.Type, c.ctrl.managedType) {
+				logger.Error("dependency mapper returned request for a resource of the wrong type",
+					"type_expected", resource.ToGVK(c.ctrl.managedType),
+					"type_got", resource.ToGVK(r.ID.Type),
+				)
+				continue
+			}
+			to.Add(r)
+		}
+
+		from.Forget(res)
+		from.Done(res)
+	}
+}
+
+func (c *controllerRunner) runReconciler(ctx context.Context, queue queue.WorkQueue[Request]) error {
 	for {
 		req, shutdown := queue.Get()
 		if shutdown {
@@ -111,8 +172,12 @@ func (c *controllerRunner) reconcile(ctx context.Context, req Request) (err erro
 		}
 	}()
 
-	return c.ctrl.reconciler.Reconcile(ctx, Runtime{
+	return c.ctrl.reconciler.Reconcile(ctx, c.runtime(), req)
+}
+
+func (c *controllerRunner) runtime() Runtime {
+	return Runtime{
 		Client: c.client,
 		Logger: c.logger,
-	}, req)
+	}
 }

--- a/internal/controller/doc.go
+++ b/internal/controller/doc.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package controller provides an API for implementing control loops on top of
+// Consul resources. It is heavily inspired by [Kubebuilder] and the Kubernetes
+// [controller runtime].
+//
+// [Kubebuilder]: https://github.com/kubernetes-sigs/kubebuilder
+// [controller runtime]: https://github.com/kubernetes-sigs/controller-runtime
+package controller

--- a/internal/controller/lease.go
+++ b/internal/controller/lease.go
@@ -22,3 +22,8 @@ type raftLease struct {
 
 func (l *raftLease) Held() bool               { return l.m.raftLeader.Load() }
 func (l *raftLease) Changed() <-chan struct{} { return l.ch }
+
+type eternalLease struct{}
+
+func (eternalLease) Held() bool               { return true }
+func (eternalLease) Changed() <-chan struct{} { return nil }

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -58,10 +58,15 @@ func (m *Manager) Run(ctx context.Context) {
 	m.running = true
 
 	for _, desc := range m.controllers {
+		logger := desc.logger
+		if logger == nil {
+			logger = m.logger.With("managed_type", resource.ToGVK(desc.managedType))
+		}
+
 		runner := &controllerRunner{
 			ctrl:   desc,
 			client: m.client,
-			logger: m.logger.With("managed_type", resource.ToGVK(desc.managedType)),
+			logger: logger,
 		}
 		go newSupervisor(runner.run, m.newLeaseLocked()).run(ctx)
 	}

--- a/internal/resource/demo/controller.go
+++ b/internal/resource/demo/controller.go
@@ -23,6 +23,7 @@ func RegisterControllers(mgr *controller.Manager) {
 
 func artistController() controller.Controller {
 	return controller.ForType(TypeV2Artist).
+		WithWatch(TypeV2Album, controller.MapOwner).
 		WithReconciler(&artistReconciler{})
 }
 

--- a/internal/resource/demo/controller.go
+++ b/internal/resource/demo/controller.go
@@ -1,6 +1,19 @@
 package demo
 
-import "github.com/hashicorp/consul/internal/controller"
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	pbdemov2 "github.com/hashicorp/consul/proto/private/pbdemo/v2"
+)
+
+const statusKeyArtistController = "consul.io/artist-controller"
 
 // RegisterControllers registers controllers for the demo types. Should only be
 // called in dev mode.
@@ -9,5 +22,48 @@ func RegisterControllers(mgr *controller.Manager) {
 }
 
 func artistController() controller.Controller {
-	return controller.ForType(TypeV2Artist)
+	return controller.ForType(TypeV2Artist).
+		WithReconciler(&artistReconciler{})
+}
+
+type artistReconciler struct{}
+
+func (r *artistReconciler) Reconcile(ctx context.Context, rt controller.Runtime, req controller.Request) error {
+	rsp, err := rt.Client.Read(ctx, &pbresource.ReadRequest{Id: req.ID})
+	switch {
+	case status.Code(err) == codes.NotFound:
+		return nil
+	case err != nil:
+		return err
+	}
+
+	res := rsp.Resource
+
+	var artist pbdemov2.Artist
+	if err := res.Data.UnmarshalTo(&artist); err != nil {
+		return err
+	}
+
+	newStatus := &pbresource.Status{
+		ObservedGeneration: res.Generation,
+		Conditions: []*pbresource.Condition{
+			{
+				Type:    "Accepted",
+				State:   pbresource.Condition_STATE_TRUE,
+				Reason:  "Accepted",
+				Message: fmt.Sprintf("Artist '%s' accepted", artist.Name),
+			},
+		},
+	}
+
+	if proto.Equal(res.Status[statusKeyArtistController], newStatus) {
+		return nil
+	}
+
+	_, err = rt.Client.WriteStatus(ctx, &pbresource.WriteStatusRequest{
+		Id:     res.Id,
+		Key:    statusKeyArtistController,
+		Status: newStatus,
+	})
+	return err
 }

--- a/internal/resource/demo/controller.go
+++ b/internal/resource/demo/controller.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package demo
 
 import (

--- a/internal/resource/demo/controller.go
+++ b/internal/resource/demo/controller.go
@@ -3,12 +3,15 @@ package demo
 import (
 	"context"
 	"fmt"
+	"math/rand"
 
+	"github.com/oklog/ulid/v2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	pbdemov2 "github.com/hashicorp/consul/proto/private/pbdemo/v2"
 )
@@ -37,24 +40,72 @@ func (r *artistReconciler) Reconcile(ctx context.Context, rt controller.Runtime,
 	case err != nil:
 		return err
 	}
-
 	res := rsp.Resource
 
 	var artist pbdemov2.Artist
 	if err := res.Data.UnmarshalTo(&artist); err != nil {
 		return err
 	}
+	conditions := []*pbresource.Condition{
+		{
+			Type:    "Accepted",
+			State:   pbresource.Condition_STATE_TRUE,
+			Reason:  "Accepted",
+			Message: fmt.Sprintf("Artist '%s' accepted", artist.Name),
+		},
+	}
+
+	numAlbums := 3
+	if artist.Genre == pbdemov2.Genre_GENRE_BLUES {
+		numAlbums = 10
+	}
+
+	desiredAlbums, err := generateV2AlbumsDeterministic(res.Id, numAlbums)
+	if err != nil {
+		return err
+	}
+
+	actualAlbums, err := rt.Client.List(ctx, &pbresource.ListRequest{
+		Type:       TypeV2Album,
+		Tenancy:    res.Id.Tenancy,
+		NamePrefix: fmt.Sprintf("%s/", res.Id.Name),
+	})
+	if err != nil {
+		return err
+	}
+
+	writes, deletions, err := diffAlbums(desiredAlbums, actualAlbums.Resources)
+	if err != nil {
+		return err
+	}
+	for _, w := range writes {
+		if _, err := rt.Client.Write(ctx, &pbresource.WriteRequest{Resource: w}); err != nil {
+			return err
+		}
+	}
+	for _, d := range deletions {
+		if _, err := rt.Client.Delete(ctx, &pbresource.DeleteRequest{Id: d}); err != nil {
+			return err
+		}
+	}
+
+	for _, want := range desiredAlbums {
+		var album pbdemov2.Album
+		if err := want.Data.UnmarshalTo(&album); err != nil {
+			return err
+		}
+		conditions = append(conditions, &pbresource.Condition{
+			Type:     "AlbumCreated",
+			State:    pbresource.Condition_STATE_TRUE,
+			Reason:   "AlbumCreated",
+			Message:  fmt.Sprintf("Album '%s' created for artist '%s'", album.Title, artist.Name),
+			Resource: resource.Reference(want.Id, ""),
+		})
+	}
 
 	newStatus := &pbresource.Status{
 		ObservedGeneration: res.Generation,
-		Conditions: []*pbresource.Condition{
-			{
-				Type:    "Accepted",
-				State:   pbresource.Condition_STATE_TRUE,
-				Reason:  "Accepted",
-				Message: fmt.Sprintf("Artist '%s' accepted", artist.Name),
-			},
-		},
+		Conditions:         conditions,
 	}
 
 	if proto.Equal(res.Status[statusKeyArtistController], newStatus) {
@@ -67,4 +118,65 @@ func (r *artistReconciler) Reconcile(ctx context.Context, rt controller.Runtime,
 		Status: newStatus,
 	})
 	return err
+}
+
+func diffAlbums(want, have []*pbresource.Resource) ([]*pbresource.Resource, []*pbresource.ID, error) {
+	haveMap := make(map[string]*pbresource.Resource, len(have))
+	for _, r := range have {
+		haveMap[r.Id.Name] = r
+	}
+
+	wantMap := make(map[string]struct{}, len(want))
+	for _, r := range want {
+		wantMap[r.Id.Name] = struct{}{}
+	}
+
+	writes := make([]*pbresource.Resource, 0)
+	for _, w := range want {
+		h, ok := haveMap[w.Id.Name]
+		if ok {
+			var wd, hd pbdemov2.Album
+			if err := w.Data.UnmarshalTo(&wd); err != nil {
+				return nil, nil, err
+			}
+			if err := h.Data.UnmarshalTo(&hd); err != nil {
+				return nil, nil, err
+			}
+			if proto.Equal(&wd, &hd) {
+				continue
+			}
+		}
+
+		writes = append(writes, w)
+	}
+
+	deletions := make([]*pbresource.ID, 0)
+	for _, h := range have {
+		if _, ok := wantMap[h.Id.Name]; ok {
+			continue
+		}
+		deletions = append(deletions, h.Id)
+	}
+
+	return writes, deletions, nil
+}
+
+func generateV2AlbumsDeterministic(artistID *pbresource.ID, count int) ([]*pbresource.Resource, error) {
+	uid, err := ulid.Parse(artistID.Uid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Uid: %w", err)
+	}
+	rand := rand.New(rand.NewSource(int64(uid.Time())))
+
+	albums := make([]*pbresource.Resource, count)
+	for i := 0; i < count; i++ {
+		album, err := generateV2Album(artistID, rand)
+		if err != nil {
+			return nil, err
+		}
+		// Add suffix to avoid collisions.
+		album.Id.Name = fmt.Sprintf("%s-%d", album.Id.Name, i)
+		albums[i] = album
+	}
+	return albums, nil
 }

--- a/internal/resource/demo/controller_test.go
+++ b/internal/resource/demo/controller_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package demo
 
 import (

--- a/internal/resource/demo/controller_test.go
+++ b/internal/resource/demo/controller_test.go
@@ -1,0 +1,99 @@
+package demo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	pbdemov2 "github.com/hashicorp/consul/proto/private/pbdemo/v2"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+func TestArtistReconciler(t *testing.T) {
+	client := svctest.RunResourceService(t, RegisterTypes)
+
+	// Seed the database with an artist.
+	res, err := GenerateV2Artist()
+	require.NoError(t, err)
+
+	// Set the genre to BLUES to ensure there are 10 albums.
+	var artist pbdemov2.Artist
+	require.NoError(t, res.Data.UnmarshalTo(&artist))
+	artist.Genre = pbdemov2.Genre_GENRE_BLUES
+	require.NoError(t, res.Data.MarshalFrom(&artist))
+
+	ctx := testutil.TestContext(t)
+	writeRsp, err := client.Write(ctx, &pbresource.WriteRequest{Resource: res})
+	require.NoError(t, err)
+
+	// Call the reconciler for that artist.
+	var rec artistReconciler
+	runtime := controller.Runtime{
+		Client: client,
+		Logger: testutil.Logger(t),
+	}
+	req := controller.Request{
+		ID: writeRsp.Resource.Id,
+	}
+	require.NoError(t, rec.Reconcile(ctx, runtime, req))
+
+	// Check the status was updated.
+	readRsp, err := client.Read(ctx, &pbresource.ReadRequest{Id: writeRsp.Resource.Id})
+	require.NoError(t, err)
+	require.Contains(t, readRsp.Resource.Status, "consul.io/artist-controller")
+
+	status := readRsp.Resource.Status["consul.io/artist-controller"]
+	require.Equal(t, writeRsp.Resource.Generation, status.ObservedGeneration)
+	require.Len(t, status.Conditions, 11)
+	require.Equal(t, "Accepted", status.Conditions[0].Type)
+	require.Equal(t, "AlbumCreated", status.Conditions[1].Type)
+
+	// Check the albums were created.
+	listRsp, err := client.List(ctx, &pbresource.ListRequest{
+		Type:    TypeV2Album,
+		Tenancy: readRsp.Resource.Id.Tenancy,
+	})
+	require.NoError(t, err)
+	require.Len(t, listRsp.Resources, 10)
+
+	// Delete an album.
+	_, err = client.Delete(ctx, &pbresource.DeleteRequest{Id: listRsp.Resources[0].Id})
+	require.NoError(t, err)
+
+	// Call the reconciler again.
+	require.NoError(t, rec.Reconcile(ctx, runtime, req))
+
+	// Check the album was recreated.
+	listRsp, err = client.List(ctx, &pbresource.ListRequest{
+		Type:    TypeV2Album,
+		Tenancy: readRsp.Resource.Id.Tenancy,
+	})
+	require.NoError(t, err)
+	require.Len(t, listRsp.Resources, 10)
+
+	// Set the genre to DISCO.
+	readRsp, err = client.Read(ctx, &pbresource.ReadRequest{Id: writeRsp.Resource.Id})
+	require.NoError(t, err)
+
+	res = readRsp.Resource
+	require.NoError(t, res.Data.UnmarshalTo(&artist))
+	artist.Genre = pbdemov2.Genre_GENRE_DISCO
+	require.NoError(t, res.Data.MarshalFrom(&artist))
+
+	_, err = client.Write(ctx, &pbresource.WriteRequest{Resource: res})
+	require.NoError(t, err)
+
+	// Call the reconciler again.
+	require.NoError(t, rec.Reconcile(ctx, runtime, req))
+
+	// Check there are only 3 albums now.
+	listRsp, err = client.List(ctx, &pbresource.ListRequest{
+		Type:    TypeV2Album,
+		Tenancy: readRsp.Resource.Id.Tenancy,
+	})
+	require.NoError(t, err)
+	require.Len(t, listRsp.Resources, 3)
+}

--- a/internal/resource/demo/demo.go
+++ b/internal/resource/demo/demo.go
@@ -204,6 +204,10 @@ func GenerateV2Artist() (*pbresource.Resource, error) {
 // GenerateV2Album generates a random Album resource, owned by the Artist with
 // the given ID.
 func GenerateV2Album(artistID *pbresource.ID) (*pbresource.Resource, error) {
+	return generateV2Album(artistID, rand.New(rand.NewSource(time.Now().UnixNano())))
+}
+
+func generateV2Album(artistID *pbresource.ID, rand *rand.Rand) (*pbresource.Resource, error) {
 	adjective := adjectives[rand.Intn(len(adjectives))]
 	noun := nouns[rand.Intn(len(nouns))]
 


### PR DESCRIPTION
### Description

Introduces the new controller runtime for resources 🎉 

The API is pretty heavily inspired by [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder), and it leans on the awesome work the API GW folks did to support config entry-based controllers (hat tip @andrewstucki @mikemorris @nathancoleman @t-eckert @sarahalsmiller), including reusing the queue implementation.

### Testing

There are unit tests! There's also a controller for our dummy `demo.v2.artist` resource type that you can see in-action if you spin up a server in dev mode and poke it with `grpcurl`.

```shell
$ grpcurl -d @ \
  -plaintext \
  -import-path proto-public \
  -import-path proto/private \
  -proto proto/private/pbdemo/v2/demo.proto \
  -proto proto-public/pbresource/resource.proto \
  127.0.0.1:8502 \
  hashicorp.consul.resource.ResourceService.Write \
<<EOF
  {
    "resource": {
      "id": {
        "type": {
          "group": "demo",
          "group_version": "v2",
          "kind": "artist"
        },
        "tenancy": {
          "partition": "default",
          "peer_name": "local",
          "namespace": "default"
        },
        "name": "korn"
      },
      "data": {
        "@type": "types.googleapis.com/hashicorp.consul.internal.demo.v2.Artist",
        "name": "Korn",
        "genre": "GENRE_METAL"
      }
    }
  }
EOF
```

```shell
$ grpcurl -d @ \
  -plaintext \
  -import-path proto-public \
  -import-path proto/private \
  -proto proto/private/pbdemo/v2/demo.proto \
  -proto proto-public/pbresource/resource.proto \
  127.0.0.1:8502 \
  hashicorp.consul.resource.ResourceService.List \
<<EOF
  {
      "type": {
        "group": "demo",
        "group_version": "v2",
        "kind": "album"
      },
      "tenancy": {
        "partition": "default",
        "peer_name": "local",
        "namespace": "default"
      }
  }
EOF
```