### PR TITLE
fix the linter

### DIFF
--- a/test/integration/consul-container/test/consul_envoy_version/consul_envoy_version.go
+++ b/test/integration/consul-container/test/consul_envoy_version/consul_envoy_version.go
@@ -34,7 +34,7 @@ func main() {
 	sort.Sort(sort.Reverse(sort.StringSlice(cev.EnvoyVersions)))
 
 	ceVersions := consulEnvoyVersions{
-		ConsulVersion: string(cVersion),
+		ConsulVersion: cVersion,
 		EnvoyVersions: cev.EnvoyVersions,
 	}
 	output, err := json.Marshal(ceVersions)


### PR DESCRIPTION
This fixes an unnecessary string conversion linter failure introduced in https://github.com/hashicorp/consul/pull/17060

```
$ golangci-lint run -v
INFO [config_reader] Config search paths: [./ /home/rboyer/src/consul/test/integration/consul-container /home/rboyer/src/consul/test/integration /home/rboyer/src/consul/test /home/rboyer/src/consul /home/rboyer/src /home/rboyer /home /]
INFO [config_reader] Used config file ../../../.golangci.yml
INFO [lintersdb] Active 9 linters: [depguard forbidigo gofmt gomodguard govet ineffassign staticcheck unconvert unparam]
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|name|exports_file|files|imports|types_sizes) took 166.718028ms
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 2.455952ms
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 2, after processing: 1
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 2/2, skip_dirs: 2/2, max_per_file_from_linter: 1/1, max_same_issues: 1/1, autogenerated_exclude: 2/2, path_shortener: 1/1, path_prefixer: 1/1, nolint: 1/1, uniq_by_line: 1/1, max_from_linter: 1/1, source_code: 1/1, exclude: 2/2, exclude-rules: 1/2, diff: 1/1, severity-rules: 1/1, cgo: 2/2, path_prettifier: 2/2, skip_files: 2/2, identifier_marker: 2/2, sort_results: 1/1
INFO [runner] processing took 226.611µs with stages: nolint: 90.899µs, path_prettifier: 40.696µs, autogenerated_exclude: 34.826µs, identifier_marker: 19.63µs, skip_dirs: 18.836µs, source_code: 9.493µs, exclude-rules: 7.025µs, max_same_issues: 946ns, cgo: 872ns, uniq_by_line: 726ns, max_from_linter: 530ns, filename_unadjuster: 458ns, path_shortener: 413ns, max_per_file_from_linter: 362ns, skip_files: 274ns, exclude: 176ns, severity-rules: 174ns, sort_results: 108ns, diff: 96ns, path_prefixer: 71ns
INFO [runner] linters took 63.209522ms with stages: goanalysis_metalinter: 62.905768ms
test/consul_envoy_version/consul_envoy_version.go:37:24: unnecessary conversion (unconvert)
		ConsulVersion: string(cVersion),
		                     ^
INFO File cache stats: 1 entries of total size 893B
INFO Memory: 4 samples, avg is 39.0MB, max is 51.1MB
INFO Execution took 235.570507ms
```