### PR TITLE
Fix a bug with sameness group disco chain config entry fetching

### DIFF
--- a/agent/structs/config_entry_sameness_group.go
+++ b/agent/structs/config_entry_sameness_group.go
@@ -71,6 +71,6 @@ func (s *SamenessGroupConfigEntry) MarshalJSON() ([]byte, error) {
 }
 
 type SamenessGroupMember struct {
-	Partition string
-	Peer      string
+	Partition string `json:",omitempty"`
+	Peer      string `json:",omitempty"`
 }

--- a/api/config_entry_sameness_group.go
+++ b/api/config_entry_sameness_group.go
@@ -16,8 +16,8 @@ type SamenessGroupConfigEntry struct {
 }
 
 type SamenessGroupMember struct {
-	Partition string
-	Peer      string
+	Partition string `json:",omitempty"`
+	Peer      string `json:",omitempty"`
 }
 
 func (s *SamenessGroupConfigEntry) GetKind() string            { return s.Kind }


### PR DESCRIPTION
Before this change, we were not fetching service resolvers (and therefore service defaults) configuration entries for services on members of sameness groups.