### PR TITLE
ci: fix test splits that have less test packages than runner count from hanging

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -4,7 +4,6 @@
 name: test-integrations
 
 on:
-  push:
   pull_request:
     branches-ignore:
       - stable-website

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -168,6 +168,7 @@ jobs:
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
           NUM_RUNNERS=$(($NUM_RUNNERS))-1
+          echo "NUM_RUNNERS: $NUM_RUNNERS"
           {
             echo -n "envoy-matrix="
             find ./test/integration/connect/envoy -maxdepth 1 -type d -print0 \
@@ -284,6 +285,7 @@ jobs:
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
           NUM_RUNNERS=$(($NUM_RUNNERS))-1
+          echo "NUM_RUNNERS: $NUM_RUNNERS"
           {
             echo -n "compatibility-matrix="
             find ./test -maxdepth 2 -type d -print0 | xargs -0 -n 1 \
@@ -391,6 +393,7 @@ jobs:
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
           NUM_RUNNERS=$(($NUM_RUNNERS))-1
+          echo "NUM_RUNNERS: $NUM_RUNNERS"
           {
             echo -n "upgrade-matrix="
             go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | gsub("[\\n\\t]"; "")' \

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -156,7 +156,7 @@ jobs:
           # multiplied by 8 based on these values:
           # envoy-version: ["1.22.11", "1.23.8", "1.24.6", "1.25.4"]
           # xds-target: ["server", "client"]
-          TOTAL_RUNNERS: 700 
+          TOTAL_RUNNERS: 4 
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
         run: |
           NUM_RUNNERS=$TOTAL_RUNNERS
@@ -168,7 +168,6 @@ jobs:
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
           NUM_RUNNERS=$(($NUM_RUNNERS-1))
-          echo "NUM_RUNNERS: $NUM_RUNNERS"
           {
             echo -n "envoy-matrix="
             find ./test/integration/connect/envoy -maxdepth 1 -type d -print0 \
@@ -285,7 +284,6 @@ jobs:
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
           NUM_RUNNERS=$(($NUM_RUNNERS-1))
-          echo "NUM_RUNNERS: $NUM_RUNNERS"
           {
             echo -n "compatibility-matrix="
             find ./test -maxdepth 2 -type d -print0 | xargs -0 -n 1 \
@@ -393,7 +391,6 @@ jobs:
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
           NUM_RUNNERS=$(($NUM_RUNNERS-1))
-          echo "NUM_RUNNERS: $NUM_RUNNERS"
           {
             echo -n "upgrade-matrix="
             go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | gsub("[\\n\\t]"; "")' \

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -275,15 +275,15 @@ jobs:
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
         run: |
           cd ./test/integration/consul-container
-          export NUM_RUNNERS=$TOTAL_RUNNERS
-          export NUM_DIRS=$(find ./test -maxdepth 2 -type d | wc -l)
+          NUM_RUNNERS=$TOTAL_RUNNERS
+          NUM_DIRS=$(find ./test -maxdepth 2 -type d | wc -l)
           if [ $NUM_DIRS -lt $NUM_RUNNERS ]
           then
             echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
             $NUM_RUNNERS = $NUM_DIRS
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          $NUM_RUNNERS = $NUM_RUNNERS - 1
+          NUM_RUNNERS = $(($NUM_RUNNERS)) - 1
           {
             echo -n "compatibility-matrix="
             find ./test -maxdepth 2 -type d -print0 | xargs -0 -n 1 \

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -175,7 +175,6 @@ jobs:
               | jq --raw-input --argjson runnercount "$NUM_RUNNERS" "$JQ_SLICER" \
               | jq --compact-output 'map(join("|"))'
           } >> "$GITHUB_OUTPUT"
-          cat "$GITHUB_OUTPUT"
   
   envoy-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
@@ -291,7 +290,6 @@ jobs:
               | jq --raw-input --argjson runnercount "$NUM_RUNNERS" "$JQ_SLICER" \
               | jq --compact-output 'map(join(" "))'
           } >> "$GITHUB_OUTPUT"
-          cat "$GITHUB_OUTPUT"
   compatibility-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     needs:
@@ -397,7 +395,6 @@ jobs:
             | jq --raw-input --argjson runnercount "$NUM_RUNNERS" "$JQ_SLICER" \
             | jq --compact-output 'map(join("|"))'
           } >> "$GITHUB_OUTPUT"
-          cat "$GITHUB_OUTPUT"
   
   upgrade-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -161,13 +161,12 @@ jobs:
         run: |
           NUM_RUNNERS=$TOTAL_RUNNERS
           NUM_DIRS=$(find ./test/integration/connect/envoy -maxdepth 1 -type d | wc -l)
-          if [ $NUM_DIRS -lt $NUM_RUNNERS ]
-          then
+          if [ "$NUM_DIRS" -lt "$NUM_RUNNERS" ]; then
             echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
             NUM_RUNNERS=$NUM_DIRS
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          NUM_RUNNERS=$(($NUM_RUNNERS-1))
+          NUM_RUNNERS=$((NUM_RUNNERS-1))
           {
             echo -n "envoy-matrix="
             find ./test/integration/connect/envoy -maxdepth 1 -type d -print0 \
@@ -276,13 +275,12 @@ jobs:
           cd ./test/integration/consul-container
           NUM_RUNNERS=$TOTAL_RUNNERS
           NUM_DIRS=$(find ./test -maxdepth 2 -type d | wc -l)
-          if [ $NUM_DIRS -lt $NUM_RUNNERS ]
-          then
+          if [ "$NUM_DIRS" -lt "$NUM_RUNNERS" ]; then
             echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
             NUM_RUNNERS=$NUM_DIRS
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          NUM_RUNNERS=$(($NUM_RUNNERS-1))
+          NUM_RUNNERS=$((NUM_RUNNERS-1))
           {
             echo -n "compatibility-matrix="
             find ./test -maxdepth 2 -type d -print0 | xargs -0 -n 1 \
@@ -382,13 +380,12 @@ jobs:
           cd ./test/integration/consul-container/test/upgrade
           NUM_RUNNERS=$TOTAL_RUNNERS
           NUM_DIRS=$(go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | gsub("[\\n\\t]"; "")' | wc -l)
-          if [ $NUM_DIRS -lt $NUM_RUNNERS ]
-          then
+          if [ "$NUM_DIRS" -lt "$NUM_RUNNERS" ]; then
             echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
             NUM_RUNNERS=$NUM_DIRS
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          NUM_RUNNERS=$(($NUM_RUNNERS-1))
+          NUM_RUNNERS=$((NUM_RUNNERS-1))
           {
             echo -n "upgrade-matrix="
             go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | gsub("[\\n\\t]"; "")' \

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -156,7 +156,7 @@ jobs:
           # multiplied by 8 based on these values:
           # envoy-version: ["1.22.11", "1.23.8", "1.24.6", "1.25.4"]
           # xds-target: ["server", "client"]
-          TOTAL_RUNNERS: 4 
+          TOTAL_RUNNERS: 700 
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
         run: |
           NUM_RUNNERS=$TOTAL_RUNNERS

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -383,7 +383,7 @@ jobs:
         run: |
           cd ./test/integration/consul-container/test/upgrade
           NUM_RUNNERS=$TOTAL_RUNNERS
-          NUM_DIRS=$(go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | wc -l)
+          NUM_DIRS=$(go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | gsub("[\\n\\t]"; "")' | wc -l)
           if [ $NUM_DIRS -lt $NUM_RUNNERS ]
           then
             echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -159,15 +159,15 @@ jobs:
           TOTAL_RUNNERS: 4 
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
         run: |
-          export NUM_RUNNERS=$TOTAL_RUNNERS
-          export NUM_DIRS=$(find ./test/integration/connect/envoy -maxdepth 1 -type d | wc -l)
+          NUM_RUNNERS=$TOTAL_RUNNERS
+          NUM_DIRS=$(find ./test/integration/connect/envoy -maxdepth 1 -type d | wc -l)
           if [ $NUM_DIRS -lt $NUM_RUNNERS ]
           then
             echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
-            $num_runners = $NUM_DIRS
+            NUM_RUNNERS=$NUM_DIRS
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          $NUM_RUNNERS = $NUM_RUNNERS - 1
+          NUM_RUNNERS=$(($NUM_RUNNERS))-1
           {
             echo -n "envoy-matrix="
             find ./test/integration/connect/envoy -maxdepth 1 -type d -print0 \
@@ -280,10 +280,10 @@ jobs:
           if [ $NUM_DIRS -lt $NUM_RUNNERS ]
           then
             echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
-            $NUM_RUNNERS = $NUM_DIRS
+            NUM_RUNNERS=$NUM_DIRS
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          NUM_RUNNERS = $(($NUM_RUNNERS)) - 1
+          NUM_RUNNERS=$(($NUM_RUNNERS))-1
           {
             echo -n "compatibility-matrix="
             find ./test -maxdepth 2 -type d -print0 | xargs -0 -n 1 \
@@ -382,15 +382,15 @@ jobs:
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
         run: |
           cd ./test/integration/consul-container/test/upgrade
-          export NUM_RUNNERS=$TOTAL_RUNNERS
-          export NUM_DIRS=$(go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | wc -l)
+          NUM_RUNNERS=$TOTAL_RUNNERS
+          NUM_DIRS=$(go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | wc -l)
           if [ $NUM_DIRS -lt $NUM_RUNNERS ]
           then
             echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
-            $NUM_RUNNERS = $NUM_DIRS
+            NUM_RUNNERS=$NUM_DIRS
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          $NUM_RUNNERS = $NUM_RUNNERS - 1
+          NUM_RUNNERS=$(($NUM_RUNNERS))-1
           {
             echo -n "upgrade-matrix="
             go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | gsub("[\\n\\t]"; "")' \

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -4,6 +4,7 @@
 name: test-integrations
 
 on:
+  push:
   pull_request:
     branches-ignore:
       - stable-website
@@ -155,14 +156,23 @@ jobs:
           # multiplied by 8 based on these values:
           # envoy-version: ["1.22.11", "1.23.8", "1.24.6", "1.25.4"]
           # xds-target: ["server", "client"]
-          TOTAL_RUNNERS: 3 
+          TOTAL_RUNNERS: 4 
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
         run: |
+          export NUM_RUNNERS=$TOTAL_RUNNERS
+          export NUM_DIRS=$(find ./test/integration/connect/envoy -maxdepth 1 -type d | wc -l)
+          if [ $NUM_DIRS -lt $NUM_RUNNERS ]
+          then
+            echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
+            $num_runners = $NUM_DIRS
+          fi
+          # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
+          $NUM_RUNNERS = $NUM_RUNNERS - 1
           {
             echo -n "envoy-matrix="
             find ./test/integration/connect/envoy -maxdepth 1 -type d -print0 \
               | xargs -0 -n 1 basename \
-              | jq --raw-input --argjson runnercount "$TOTAL_RUNNERS" "$JQ_SLICER" \
+              | jq --raw-input --argjson runnercount "$NUM_RUNNERS" "$JQ_SLICER" \
               | jq --compact-output 'map(join("|"))'
           } >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
@@ -261,15 +271,24 @@ jobs:
       - name: Generate Compatibility Job Matrix
         id: set-matrix
         env:
-          TOTAL_RUNNERS: 5
+          TOTAL_RUNNERS: 6
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
         run: |
           cd ./test/integration/consul-container
+          export NUM_RUNNERS=$TOTAL_RUNNERS
+          export NUM_DIRS=$(find ./test -maxdepth 2 -type d | wc -l)
+          if [ $NUM_DIRS -lt $NUM_RUNNERS ]
+          then
+            echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
+            $NUM_RUNNERS = $NUM_DIRS
+          fi
+          # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
+          $NUM_RUNNERS = $NUM_RUNNERS - 1
           {
             echo -n "compatibility-matrix="
             find ./test -maxdepth 2 -type d -print0 | xargs -0 -n 1 \
               | grep -v util | grep -v upgrade \
-              | jq --raw-input --argjson runnercount "$TOTAL_RUNNERS" "$JQ_SLICER" \
+              | jq --raw-input --argjson runnercount "$NUM_RUNNERS" "$JQ_SLICER" \
               | jq --compact-output 'map(join(" "))'
           } >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
@@ -359,14 +378,23 @@ jobs:
       - name: Generate Updgrade Job Matrix
         id: set-matrix
         env:
-          TOTAL_RUNNERS: 4
+          TOTAL_RUNNERS: 5
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
         run: |
           cd ./test/integration/consul-container/test/upgrade
+          export NUM_RUNNERS=$TOTAL_RUNNERS
+          export NUM_DIRS=$(go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | wc -l)
+          if [ $NUM_DIRS -lt $NUM_RUNNERS ]
+          then
+            echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
+            $NUM_RUNNERS = $NUM_DIRS
+          fi
+          # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
+          $NUM_RUNNERS = $NUM_RUNNERS - 1
           {
             echo -n "upgrade-matrix="
             go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | gsub("[\\n\\t]"; "")' \
-            | jq --raw-input --argjson runnercount "$TOTAL_RUNNERS" "$JQ_SLICER" \
+            | jq --raw-input --argjson runnercount "$NUM_RUNNERS" "$JQ_SLICER" \
             | jq --compact-output 'map(join("|"))'
           } >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -167,7 +167,7 @@ jobs:
             NUM_RUNNERS=$NUM_DIRS
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          NUM_RUNNERS=$(($NUM_RUNNERS))-1
+          NUM_RUNNERS=$(($NUM_RUNNERS-1))
           echo "NUM_RUNNERS: $NUM_RUNNERS"
           {
             echo -n "envoy-matrix="
@@ -284,7 +284,7 @@ jobs:
             NUM_RUNNERS=$NUM_DIRS
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          NUM_RUNNERS=$(($NUM_RUNNERS))-1
+          NUM_RUNNERS=$(($NUM_RUNNERS-1))
           echo "NUM_RUNNERS: $NUM_RUNNERS"
           {
             echo -n "compatibility-matrix="
@@ -392,7 +392,7 @@ jobs:
             NUM_RUNNERS=$NUM_DIRS
           fi
           # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          NUM_RUNNERS=$(($NUM_RUNNERS))-1
+          NUM_RUNNERS=$(($NUM_RUNNERS-1))
           echo "NUM_RUNNERS: $NUM_RUNNERS"
           {
             echo -n "upgrade-matrix="


### PR DESCRIPTION
### Description
In 1.13, there are only two compatibility test packages.  So when a generate matrix job has a TOTAL_RUNNERS of 5 but there are only 2 packages, the process hangs.  This PR changes the runner count to 2 in this case.  

Another issue that occurs that is fixed in this PR is that when you specify TOTAL_RUNNERS = 4, you will actually split across 5 runners.  (The same occurs with any number you set TOTAL_RUNNERS to.  You will actually get 1 greater.)

