### PR TITLE
Clarify OpenTelemetry support for tracing

### DIFF
--- a/website/content/docs/connect/distributed-tracing.mdx
+++ b/website/content/docs/connect/distributed-tracing.mdx
@@ -234,8 +234,11 @@ config to take effect.
 1. Requests through [Ingress Gateways](/consul/docs/connect/gateways/ingress-gateway) will not be traced unless the header
    `x-client-trace-id: 1` is set (see [hashicorp/consul#6645](https://github.com/hashicorp/consul/issues/6645)).
 
-1. Consul does not currently support interoperation with [OpenTelemetry](https://opentelemetry.io/) libraries due to
-   Envoy not yet having support.
+1. Consul's proxies do not currently support [OpenTelemetry](https://opentelemetry.io/) spans, as Envoy has not
+   [fully implemented](https://github.com/envoyproxy/envoy/issues/9958) it. Instead, you can add
+   OpenTelemetry libraries to your application to emit spans for other
+   [tracing protocols](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/observability/tracing)
+   supported by Envoy, such as Zipkin or Jaeger.
 
 1. Tracing is only supported with Envoy proxies, not the built-in proxy.
 


### PR DESCRIPTION
### Description

Request for clarification of tracing documentation for Consul around OpenTelemetry. You can use the libraries, the proxies do not emit OTLP spans until Envoy fully supports it.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
