### PR TITLE
Add ACLs Enabled field to consul agent startup status message

### DIFF
--- a/.changelog/17086.txt
+++ b/.changelog/17086.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command: Adds ACL enabled to status output on agent startup.
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -230,6 +230,7 @@ func (c *cmd) run(args []string) int {
 		config.SerfPortLAN, config.SerfPortWAN))
 	ui.Info(fmt.Sprintf("Gossip Encryption: %t", config.EncryptKey != ""))
 	ui.Info(fmt.Sprintf(" Auto-Encrypt-TLS: %t", config.AutoEncryptTLS || config.AutoEncryptAllowTLS))
+	ui.Info(fmt.Sprintf("     ACLs Enabled: %t", config.ACLsEnabled))
 	ui.Info(fmt.Sprintf("        HTTPS TLS: Verify Incoming: %t, Verify Outgoing: %t, Min Version: %s",
 		config.TLS.HTTPS.VerifyIncoming, config.TLS.HTTPS.VerifyOutgoing, config.TLS.HTTPS.TLSMinVersion))
 	ui.Info(fmt.Sprintf("         gRPC TLS: Verify Incoming: %t, Min Version: %s", config.TLS.GRPC.VerifyIncoming, config.TLS.GRPC.TLSMinVersion))

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -19,10 +19,9 @@ import (
 	"github.com/hashicorp/go-hclog"
 	mcli "github.com/mitchellh/cli"
 
-	"github.com/hashicorp/consul/agent/hcp"
-
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/config"
+	"github.com/hashicorp/consul/agent/hcp"
 	hcpbootstrap "github.com/hashicorp/consul/agent/hcp/bootstrap"
 	"github.com/hashicorp/consul/command/cli"
 	"github.com/hashicorp/consul/command/flags"

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -15,10 +15,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hashicorp/consul/agent/hcp"
 	"github.com/hashicorp/go-checkpoint"
 	"github.com/hashicorp/go-hclog"
 	mcli "github.com/mitchellh/cli"
+
+	"github.com/hashicorp/consul/agent/hcp"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/config"
@@ -212,29 +213,30 @@ func (c *cmd) run(args []string) int {
 	if config.ServerMode {
 		segment = "<all>"
 	}
-	ui.Info(fmt.Sprintf("          Version: '%s'", c.versionHuman))
+	ui.Info(fmt.Sprintf("           Version: '%s'", c.versionHuman))
 	if strings.Contains(c.versionHuman, "dev") {
-		ui.Info(fmt.Sprintf("         Revision: '%s'", c.revision))
+		ui.Info(fmt.Sprintf("          Revision: '%s'", c.revision))
 	}
-	ui.Info(fmt.Sprintf("       Build Date: '%s'", c.buildDate))
-	ui.Info(fmt.Sprintf("          Node ID: '%s'", config.NodeID))
-	ui.Info(fmt.Sprintf("        Node name: '%s'", config.NodeName))
+	ui.Info(fmt.Sprintf("        Build Date: '%s'", c.buildDate))
+	ui.Info(fmt.Sprintf("           Node ID: '%s'", config.NodeID))
+	ui.Info(fmt.Sprintf("         Node name: '%s'", config.NodeName))
 	if ap := config.PartitionOrEmpty(); ap != "" {
-		ui.Info(fmt.Sprintf("        Partition: '%s'", ap))
+		ui.Info(fmt.Sprintf("         Partition: '%s'", ap))
 	}
-	ui.Info(fmt.Sprintf("       Datacenter: '%s' (Segment: '%s')", config.Datacenter, segment))
-	ui.Info(fmt.Sprintf("           Server: %v (Bootstrap: %v)", config.ServerMode, config.Bootstrap))
-	ui.Info(fmt.Sprintf("      Client Addr: %v (HTTP: %d, HTTPS: %d, gRPC: %d, gRPC-TLS: %d, DNS: %d)", config.ClientAddrs,
+	ui.Info(fmt.Sprintf("        Datacenter: '%s' (Segment: '%s')", config.Datacenter, segment))
+	ui.Info(fmt.Sprintf("            Server: %v (Bootstrap: %v)", config.ServerMode, config.Bootstrap))
+	ui.Info(fmt.Sprintf("       Client Addr: %v (HTTP: %d, HTTPS: %d, gRPC: %d, gRPC-TLS: %d, DNS: %d)", config.ClientAddrs,
 		config.HTTPPort, config.HTTPSPort, config.GRPCPort, config.GRPCTLSPort, config.DNSPort))
-	ui.Info(fmt.Sprintf("     Cluster Addr: %v (LAN: %d, WAN: %d)", config.AdvertiseAddrLAN,
+	ui.Info(fmt.Sprintf("      Cluster Addr: %v (LAN: %d, WAN: %d)", config.AdvertiseAddrLAN,
 		config.SerfPortLAN, config.SerfPortWAN))
-	ui.Info(fmt.Sprintf("Gossip Encryption: %t", config.EncryptKey != ""))
-	ui.Info(fmt.Sprintf(" Auto-Encrypt-TLS: %t", config.AutoEncryptTLS || config.AutoEncryptAllowTLS))
-	ui.Info(fmt.Sprintf("     ACLs Enabled: %t", config.ACLsEnabled))
-	ui.Info(fmt.Sprintf("        HTTPS TLS: Verify Incoming: %t, Verify Outgoing: %t, Min Version: %s",
+	ui.Info(fmt.Sprintf(" Gossip Encryption: %t", config.EncryptKey != ""))
+	ui.Info(fmt.Sprintf("  Auto-Encrypt-TLS: %t", config.AutoEncryptTLS || config.AutoEncryptAllowTLS))
+	ui.Info(fmt.Sprintf("       ACL Enabled: %t", config.ACLsEnabled))
+	ui.Info(fmt.Sprintf("ACL Default Policy: %s", config.ACLResolverSettings.ACLDefaultPolicy))
+	ui.Info(fmt.Sprintf("         HTTPS TLS: Verify Incoming: %t, Verify Outgoing: %t, Min Version: %s",
 		config.TLS.HTTPS.VerifyIncoming, config.TLS.HTTPS.VerifyOutgoing, config.TLS.HTTPS.TLSMinVersion))
-	ui.Info(fmt.Sprintf("         gRPC TLS: Verify Incoming: %t, Min Version: %s", config.TLS.GRPC.VerifyIncoming, config.TLS.GRPC.TLSMinVersion))
-	ui.Info(fmt.Sprintf(" Internal RPC TLS: Verify Incoming: %t, Verify Outgoing: %t (Verify Hostname: %t), Min Version: %s",
+	ui.Info(fmt.Sprintf("          gRPC TLS: Verify Incoming: %t, Min Version: %s", config.TLS.GRPC.VerifyIncoming, config.TLS.GRPC.TLSMinVersion))
+	ui.Info(fmt.Sprintf("  Internal RPC TLS: Verify Incoming: %t, Verify Outgoing: %t (Verify Hostname: %t), Min Version: %s",
 		config.TLS.InternalRPC.VerifyIncoming, config.TLS.InternalRPC.VerifyOutgoing, config.TLS.InternalRPC.VerifyServerHostname, config.TLS.InternalRPC.TLSMinVersion))
 	// Enable log streaming
 	ui.Output("")


### PR DESCRIPTION
### Description

When starting the consul agent, we output a status message which shows various parts of the configuration including `Gossip Encryption` and `Auto-Encrypt-TLS` configurations. 

This adds another field to the status showing whether or not ACLs are enabled.

### Testing & Reproduction steps

```
make dev
./bin/consul agent -dev
```


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
