### PR TITLE
TProxy integration test

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -309,7 +309,7 @@ jobs:
             docker run --rm ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local consul version
             echo "Running $(sed 's,|, ,g' <<< "${{ matrix.test-cases }}" |wc -w) subtests"
             # shellcheck disable=SC2001
-            sed 's,|,\n,g' <<< "${{ matrix.test-cases }}"
+            sed 's, ,\n,g' <<< "${{ matrix.test-cases }}"
             go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
               --raw-command \
               --format=short-verbose \
@@ -321,7 +321,7 @@ jobs:
               -tags "${{ env.GOTAGS }}" \
               -timeout=30m \
               -json \
-              "${{ matrix.test-cases }}" \
+              ${{ matrix.test-cases }} \
               --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
               --target-version local \
               --latest-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \

--- a/test/integration/consul-container/libs/cluster/app.go
+++ b/test/integration/consul-container/libs/cluster/app.go
@@ -58,6 +58,7 @@ func LaunchContainerOnNode(
 	launchCtx, cancel := context.WithTimeout(ctx, time.Second*40)
 	defer cancel()
 
+	req.PrintBuildLog = true
 	container, err := testcontainers.GenericContainer(launchCtx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,

--- a/test/integration/consul-container/libs/cluster/app.go
+++ b/test/integration/consul-container/libs/cluster/app.go
@@ -58,7 +58,6 @@ func LaunchContainerOnNode(
 	launchCtx, cancel := context.WithTimeout(ctx, time.Second*40)
 	defer cancel()
 
-	req.PrintBuildLog = true
 	container, err := testcontainers.GenericContainer(launchCtx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,

--- a/test/integration/consul-container/libs/service/assets/Dockerfile-consul-envoy
+++ b/test/integration/consul-container/libs/service/assets/Dockerfile-consul-envoy
@@ -5,4 +5,18 @@ ARG ENVOY_VERSION
 FROM ${CONSUL_IMAGE} as consul
 
 FROM docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}
+
+# Install iptables and sudo, needed for tproxy.
+RUN apt update -y \
+	&& apt install -y iptables sudo curl jq dnsutils iproute2 \
+	&& adduser envoy sudo \
+	&& chsh -s /bin/sh envoy \
+	&& echo 'envoy ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+COPY tproxy-startup.sh /bin/tproxy-startup.sh
+RUN chmod +x /bin/tproxy-startup.sh \
+	&& chown envoy:envoy /bin/tproxy-startup.sh
+
 COPY --from=consul /bin/consul /bin/consul
+
+USER envoy

--- a/test/integration/consul-container/libs/service/assets/Dockerfile-consul-envoy
+++ b/test/integration/consul-container/libs/service/assets/Dockerfile-consul-envoy
@@ -8,9 +8,8 @@ FROM docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}
 
 # Install iptables and sudo, needed for tproxy.
 RUN apt update -y \
-	&& apt install -y iptables sudo curl jq dnsutils iproute2 \
+	&& apt install -y iptables sudo curl dnsutils \
 	&& adduser envoy sudo \
-	&& chsh -s /bin/sh envoy \
 	&& echo 'envoy ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 COPY tproxy-startup.sh /bin/tproxy-startup.sh

--- a/test/integration/consul-container/libs/service/assets/tproxy-startup.sh
+++ b/test/integration/consul-container/libs/service/assets/tproxy-startup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+set -ex
+
+# HACK: UID of consul in the consul-client container
+# This is conveniently also the UID of apt in the envoy container
+CONSUL_UID=100
+ENVOY_UID=$(id -u)
+
+sudo consul connect redirect-traffic \
+    -proxy-uid $ENVOY_UID \
+    -exclude-uid $CONSUL_UID \
+    $REDIRECT_TRAFFIC_ARGS
+
+exec "$@"

--- a/test/integration/consul-container/libs/service/helpers.go
+++ b/test/integration/consul-container/libs/service/helpers.go
@@ -27,7 +27,12 @@ type Checks struct {
 }
 
 type SidecarService struct {
-	Port int
+	Port  int
+	Proxy ConnectProxy
+}
+
+type ConnectProxy struct {
+	Mode string
 }
 
 type ServiceOpts struct {
@@ -63,9 +68,10 @@ func createAndRegisterStaticServerAndSidecar(node libcluster.Agent, httpPort int
 		_ = serverService.Terminate()
 	})
 	sidecarCfg := SidecarConfig{
-		Name:      fmt.Sprintf("%s-sidecar", svc.ID),
-		ServiceID: svc.ID,
-		Namespace: svc.Namespace,
+		Name:         fmt.Sprintf("%s-sidecar", svc.ID),
+		ServiceID:    svc.ID,
+		Namespace:    svc.Namespace,
+		EnableTProxy: svc.Proxy != nil && svc.Proxy.Mode == "transparent",
 	}
 	serverConnectProxy, err := NewConnectService(context.Background(), sidecarCfg, []int{svc.Port}, node) // bindPort not used
 	if err != nil {
@@ -102,7 +108,9 @@ func CreateAndRegisterStaticServerAndSidecar(node libcluster.Agent, serviceOpts 
 		Port: p,
 		Connect: &api.AgentServiceConnect{
 			SidecarService: &api.AgentServiceRegistration{
-				Proxy: &api.AgentServiceConnectProxyConfig{},
+				Proxy: &api.AgentServiceConnectProxyConfig{
+					Mode: api.ProxyMode(serviceOpts.Connect.Proxy.Mode),
+				},
 			},
 		},
 		Namespace: serviceOpts.Namespace,
@@ -141,15 +149,34 @@ func CreateAndRegisterStaticClientSidecar(
 	node libcluster.Agent,
 	peerName string,
 	localMeshGateway bool,
+	enableTProxy bool,
 ) (*ConnectContainer, error) {
 	// Do some trickery to ensure that partial completion is correctly torn
 	// down, but successful execution is not.
 	var deferClean utils.ResettableDefer
 	defer deferClean.Execute()
 
-	mgwMode := api.MeshGatewayModeRemote
-	if localMeshGateway {
-		mgwMode = api.MeshGatewayModeLocal
+	var proxy *api.AgentServiceConnectProxyConfig
+	if enableTProxy {
+		proxy = &api.AgentServiceConnectProxyConfig{
+			Mode: "transparent",
+		}
+	} else {
+		mgwMode := api.MeshGatewayModeRemote
+		if localMeshGateway {
+			mgwMode = api.MeshGatewayModeLocal
+		}
+		proxy = &api.AgentServiceConnectProxyConfig{
+			Upstreams: []api.Upstream{{
+				DestinationName:  StaticServerServiceName,
+				DestinationPeer:  peerName,
+				LocalBindAddress: "0.0.0.0",
+				LocalBindPort:    libcluster.ServiceUpstreamLocalBindPort,
+				MeshGateway: api.MeshGatewayConfig{
+					Mode: mgwMode,
+				},
+			}},
+		}
 	}
 
 	// Register the static-client service and sidecar first to prevent race with sidecar
@@ -159,17 +186,7 @@ func CreateAndRegisterStaticClientSidecar(
 		Port: 8080,
 		Connect: &api.AgentServiceConnect{
 			SidecarService: &api.AgentServiceRegistration{
-				Proxy: &api.AgentServiceConnectProxyConfig{
-					Upstreams: []api.Upstream{{
-						DestinationName:  StaticServerServiceName,
-						DestinationPeer:  peerName,
-						LocalBindAddress: "0.0.0.0",
-						LocalBindPort:    libcluster.ServiceUpstreamLocalBindPort,
-						MeshGateway: api.MeshGatewayConfig{
-							Mode: mgwMode,
-						},
-					}},
-				},
+				Proxy: proxy,
 			},
 		},
 	}
@@ -180,8 +197,9 @@ func CreateAndRegisterStaticClientSidecar(
 
 	// Create a service and proxy instance
 	sidecarCfg := SidecarConfig{
-		Name:      fmt.Sprintf("%s-sidecar", StaticClientServiceName),
-		ServiceID: StaticClientServiceName,
+		Name:         fmt.Sprintf("%s-sidecar", StaticClientServiceName),
+		ServiceID:    StaticClientServiceName,
+		EnableTProxy: enableTProxy,
 	}
 
 	clientConnectProxy, err := NewConnectService(context.Background(), sidecarCfg, []int{libcluster.ServiceUpstreamLocalBindPort}, node)

--- a/test/integration/consul-container/libs/topology/peering_topology.go
+++ b/test/integration/consul-container/libs/topology/peering_topology.go
@@ -140,7 +140,7 @@ func BasicPeeringTwoClustersSetup(
 
 		// Create a service and proxy instance
 		var err error
-		clientSidecarService, err = libservice.CreateAndRegisterStaticClientSidecar(clientNode, DialingPeerName, true)
+		clientSidecarService, err = libservice.CreateAndRegisterStaticClientSidecar(clientNode, DialingPeerName, true, false)
 		require.NoError(t, err)
 
 		libassert.CatalogServiceExists(t, dialingClient, "static-client-sidecar-proxy", nil)

--- a/test/integration/consul-container/libs/topology/service_topology.go
+++ b/test/integration/consul-container/libs/topology/service_topology.go
@@ -45,7 +45,7 @@ func CreateServices(t *testing.T, cluster *libcluster.Cluster) (libservice.Servi
 	libassert.CatalogServiceExists(t, client, libservice.StaticServerServiceName, nil)
 
 	// Create a client proxy instance with the server as an upstream
-	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false)
+	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false)
 	require.NoError(t, err)
 
 	libassert.CatalogServiceExists(t, client, fmt.Sprintf("%s-sidecar-proxy", libservice.StaticClientServiceName), nil)

--- a/test/integration/consul-container/test/basic/connect_service_test.go
+++ b/test/integration/consul-container/test/basic/connect_service_test.go
@@ -71,7 +71,7 @@ func createServices(t *testing.T, cluster *libcluster.Cluster) libservice.Servic
 	libassert.CatalogServiceExists(t, client, libservice.StaticServerServiceName, nil)
 
 	// Create a client proxy instance with the server as an upstream
-	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false)
+	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false)
 	require.NoError(t, err)
 
 	libassert.CatalogServiceExists(t, client, "static-client-sidecar-proxy", nil)

--- a/test/integration/consul-container/test/tproxy/tproxy_test.go
+++ b/test/integration/consul-container/test/tproxy/tproxy_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package basic
+package tproxy
 
 import (
 	"context"

--- a/test/integration/consul-container/test/tproxy/tproxy_test.go
+++ b/test/integration/consul-container/test/tproxy/tproxy_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package basic
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
+	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
+	libservice "github.com/hashicorp/consul/test/integration/consul-container/libs/service"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/topology"
+)
+
+// TestTProxyService
+// This test makes sure two services in the same datacenter have connectivity
+// with transparent proxy enabled.
+//
+// Steps:
+//   - Create a single agent cluster.
+//   - Create the example static-server and sidecar containers, then register them both with Consul
+//   - Create an example static-client sidecar, then register both the service and sidecar with Consul
+//   - Make sure a call to the client sidecar local bind port returns a response from the upstream, static-server
+func TestTProxyService(t *testing.T) {
+	t.Parallel()
+
+	cluster, _, _ := topology.NewCluster(t, &topology.ClusterConfig{
+		NumServers:                1,
+		NumClients:                2,
+		ApplyDefaultProxySettings: true,
+		BuildOpts: &libcluster.BuildOptions{
+			Datacenter:             "dc1",
+			InjectAutoEncryption:   true,
+			InjectGossipEncryption: true,
+			// TODO(rb): fix the test to not need the service/envoy stack to use :8500
+			AllowHTTPAnyway: true,
+		},
+	})
+
+	clientService := createServices(t, cluster)
+	_, port := clientService.GetAddr()
+	_, adminPort := clientService.GetAdminAddr()
+
+	fmt.Printf("client app test addr = localhost:%d", port)
+
+	libassert.AssertUpstreamEndpointStatus(t, adminPort, "static-server.default", "HEALTHY", 1)
+	libassert.AssertContainerState(t, clientService, "running")
+
+	// Test that we can make a request to the virtual ip to reach the upstream.
+	//
+	// This uses a workaround for DNS because I had trouble modifying
+	// /etc/resolv.conf. There is a --dns option to docker run, but it
+	// didn't seem to be exposed via testcontainers. I'm not sure if it would
+	// do what I want. In any case, Docker sets up /etc/resolv.conf for certain
+	// functionality so it seems better to leave this alone.
+	//
+	// But, that means DNS queries aren't redirected to Consul out of the box.
+	// As a workaround, we `dig @localhost:53` which is iptables-redirected to
+	// localhost:8600 where the Consul client responds with the virtual ip.
+	//
+	// In tproxy tests, Envoy is not configured with a unique listener for each
+	// upstreams. This means the usual approach for non-tproxy tests doesn't
+	// work - where we send the request to a host address mapped in to Envoy's
+	// upstream listener. Instead, we exec into the container.
+	//
+	// We must make this request with a non-envoy user. The envoy and consul
+	// users are excluded from traffic redirection rules, so instead we
+	// make the request as root.
+	out, err := clientService.Exec(
+		context.Background(),
+		[]string{"sudo", "sh", "-c", `
+		set -e
+		VIRTUAL=$(dig @localhost +short static-server.virtual.consul)
+		echo "Virtual IP: $VIRTUAL"
+		curl -o /dev/null -s -w 'Response code: %{http_code}' $VIRTUAL
+		`,
+		},
+	)
+	t.Logf("curl upstream\nerr = %s\nout = %s", err, out)
+	require.NoError(t, err)
+	require.Regexp(t, `Virtual IP: 240.0.0.\d+`, out)
+	require.Contains(t, out, "Response code: 200")
+}
+
+func createServices(t *testing.T, cluster *libcluster.Cluster) libservice.Service {
+	{
+		node := cluster.Agents[1]
+		t.Logf("createServices: node for static-server = %v", node)
+		client := node.GetClient()
+		// Create a service and proxy instance
+		serviceOpts := &libservice.ServiceOpts{
+			Name:     libservice.StaticServerServiceName,
+			ID:       "static-server",
+			HTTPPort: 8080,
+			GRPCPort: 8079,
+			Connect: libservice.SidecarService{
+				Proxy: libservice.ConnectProxy{
+					Mode: "transparent",
+				},
+			},
+		}
+
+		// Create a service and proxy instance
+		_, _, err := libservice.CreateAndRegisterStaticServerAndSidecar(node, serviceOpts)
+		require.NoError(t, err)
+
+		libassert.CatalogServiceExists(t, client, "static-server-sidecar-proxy", nil)
+		libassert.CatalogServiceExists(t, client, libservice.StaticServerServiceName, nil)
+	}
+
+	{
+		node := cluster.Agents[2]
+		t.Logf("createServices: node for static-server = %v", node)
+		client := node.GetClient()
+
+		// Create a client proxy instance with the server as an upstream
+		clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, true)
+		require.NoError(t, err)
+
+		libassert.CatalogServiceExists(t, client, "static-client-sidecar-proxy", nil)
+		return clientConnectProxy
+	}
+}

--- a/test/integration/consul-container/test/upgrade/ingress_gateway_grpc_test.go
+++ b/test/integration/consul-container/test/upgrade/ingress_gateway_grpc_test.go
@@ -91,7 +91,7 @@ func TestIngressGateway_GRPC_UpgradeToTarget_fromLatest(t *testing.T) {
 	serverNodes := cluster.Servers()
 	require.NoError(t, err)
 	require.True(t, len(serverNodes) > 0)
-	staticClientSvcSidecar, err := libservice.CreateAndRegisterStaticClientSidecar(serverNodes[0], "", true)
+	staticClientSvcSidecar, err := libservice.CreateAndRegisterStaticClientSidecar(serverNodes[0], "", true, false)
 	require.NoError(t, err)
 
 	tests := func(t *testing.T) {

--- a/test/integration/consul-container/test/upgrade/l7_traffic_management/resolver_default_subset_test.go
+++ b/test/integration/consul-container/test/upgrade/l7_traffic_management/resolver_default_subset_test.go
@@ -344,7 +344,7 @@ func setup(t *testing.T) (*libcluster.Cluster, libservice.Service, libservice.Se
 	require.NoError(t, err)
 
 	// Create a client proxy instance with the server as an upstream
-	staticClientProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false)
+	staticClientProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false)
 	require.NoError(t, err)
 
 	require.NoError(t, err)

--- a/test/integration/consul-container/test/upgrade/peering_control_plane_mgw_test.go
+++ b/test/integration/consul-container/test/upgrade/peering_control_plane_mgw_test.go
@@ -80,7 +80,7 @@ func TestPeering_ControlPlaneMGW(t *testing.T) {
 		"upstream_cx_total", 1)
 	require.NoError(t, accepting.Gateway.Start())
 
-	clientSidecarService, err := libservice.CreateAndRegisterStaticClientSidecar(dialingCluster.Servers()[0], libtopology.DialingPeerName, true)
+	clientSidecarService, err := libservice.CreateAndRegisterStaticClientSidecar(dialingCluster.Servers()[0], libtopology.DialingPeerName, true, false)
 	require.NoError(t, err)
 	_, port := clientSidecarService.GetAddr()
 	_, adminPort := clientSidecarService.GetAdminAddr()

--- a/test/integration/consul-container/test/upgrade/peering_http_test.go
+++ b/test/integration/consul-container/test/upgrade/peering_http_test.go
@@ -324,7 +324,7 @@ func peeringUpgrade(t *testing.T, accepting, dialing *libtopology.BuiltCluster, 
 func peeringPostUpgradeValidation(t *testing.T, dialing *libtopology.BuiltCluster) {
 	t.Helper()
 
-	clientSidecarService, err := libservice.CreateAndRegisterStaticClientSidecar(dialing.Cluster.Servers()[0], libtopology.DialingPeerName, true)
+	clientSidecarService, err := libservice.CreateAndRegisterStaticClientSidecar(dialing.Cluster.Servers()[0], libtopology.DialingPeerName, true, false)
 	require.NoError(t, err)
 	_, port := clientSidecarService.GetAddr()
 	_, adminPort := clientSidecarService.GetAdminAddr()

--- a/test/integration/consul-container/test/wanfed/wanfed_peering_test.go
+++ b/test/integration/consul-container/test/wanfed/wanfed_peering_test.go
@@ -57,7 +57,7 @@ func TestPeering_WanFedSecondaryDC(t *testing.T) {
 		require.NoError(t, service.Export("default", "alpha-to-secondary", c3Agent.GetClient()))
 
 		// Create a testing sidecar to proxy requests through
-		clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(c2Agent, "secondary-to-alpha", false)
+		clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(c2Agent, "secondary-to-alpha", false, false)
 		require.NoError(t, err)
 		libassert.CatalogServiceExists(t, c2Agent.GetClient(), "static-client-sidecar-proxy", nil)
 


### PR DESCRIPTION
### Description

This is a basic integration test for TProxy:

* Create 2 "client" pods for the static-client / static-server. Separate pods are needed because iptables rules apply for the network namespace
* Configure the test container with necessary permission for the iptables command:
  * NET_ADMIN container capability. Required to run iptables in a container.
  * sudo, so that the envoy user can run iptables commands
  * A tproxy-startup.sh script that runs the `consul connect redirect-traffic` command to apply iptables rules

This took some fiddling to setup, so there are some workarounds for the moment:

* DNS queries don't automatically redirect to Consul DNS (on my machine)
* Because the Consul client and envoy share a network namespace, the Consul inbound ports and the Consul user id are excluded from traffic redirection.

### Testing & Reproduction steps

```
cd ./test/integration/consul-container
go test -v -timeout=30m ./test/tproxy/ \
    -run 'TestTProxyService' \
    --target-image consul --target-version local \
    --latest-image consul --latest-version latest
```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
