### PR TITLE
remove envoy endpoint flag from k8s docs

### DIFF
--- a/website/content/docs/k8s/k8s-cli.mdx
+++ b/website/content/docs/k8s/k8s-cli.mdx
@@ -794,7 +794,6 @@ $ consul-k8s troubleshoot upstreams -pod <pod> <OPTIONS>
 | Flag                                 | Description                                           | Default                                                                                                                |
 | ------------------------------------ | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | <nobr>`-namespace`, `-n`</nobr>      | `String` The Kubernetes namespace to list proxies in. | Current [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) namespace. |
-| <nobr>`-envoy-admin-endpoint`</nobr> | `String` Envoy sidecar address and port               | `127.0.0.1:19000`                                                                                                      |
 
 #### Example Commands
 
@@ -839,7 +838,6 @@ $ consul-k8s troubleshoot proxy -pod <pod> -upstream-envoy-id <envoy-id> <OPTION
 | Flag                                 | Description                                           | Default                                                                                                                |
 | ------------------------------------ | ----------------------------------------------------------| ---------------------------------------------------------------------------------------------------------------------- |
 | <nobr>`-namespace`, `-n`</nobr>      | `String` The Kubernetes namespace to list proxies in.     | Current [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) namespace. |
-| <nobr>`-envoy-admin-endpoint`</nobr> | `String` Envoy sidecar address and port                   | `127.0.0.1:19000`                                                                                                               |
 | <nobr>`-upstream-ip`</nobr>          | `String` The IP address of the upstream transparent proxy |                                                                                                                |
 | <nobr>`-upstream-envoy-id`</nobr>    | `String` The Envoy identifier of the upstream             |                                                                                                                |
 


### PR DESCRIPTION
### Description
Envoy endpoint is not a flag in k8s but was added in documentation. 
Enterprise PR: https://github.com/hashicorp/consul-enterprise/pull/5228

### PR Checklist

* NA updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
