### PR TITLE
api: ensure empty locality field is not transmitted to Consul

### DIFF
--- a/.changelog/17137.txt
+++ b/.changelog/17137.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-api: ensure empty locality field is not transmitted to Consul
-```

--- a/.changelog/17137.txt
+++ b/.changelog/17137.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: ensure empty locality field is not transmitted to Consul
+```

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -78,8 +78,8 @@ type CatalogRegistration struct {
 	Check           *AgentCheck
 	Checks          HealthChecks
 	SkipNodeUpdate  bool
-	Partition       string `json:",omitempty"`
-	Locality        *Locality
+	Partition       string    `json:",omitempty"`
+	Locality        *Locality `json:",omitempty"`
 }
 
 type CatalogDeregistration struct {

--- a/api/peering.go
+++ b/api/peering.go
@@ -47,7 +47,7 @@ type PeeringRemoteInfo struct {
 	Partition string
 	// Datacenter is the remote peer's datacenter.
 	Datacenter string
-	Locality   *Locality
+	Locality   *Locality `json:",omitempty"`
 }
 
 // Locality identifies where a given entity is running.


### PR DESCRIPTION
### Description

When the current `api` client is used for two endpoints (catalog register, peering) it sends a stray `{... "Locality": "", ...}` to a Consul server because the field is not marked `omitempty`.

If this lands on an older Consul server or client it will reject the request completely because of the unknown field.

Regressed in : https://github.com/hashicorp/consul/pull/16581

