### PR TITLE
enable auto-tidy expired issuers in vault (as CA)

### DIFF
--- a/.changelog/17138.txt
+++ b/.changelog/17138.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+ca: automatically set up Vault's auto-tidy setting for tidy_expired_issuers when using Vault as a CA provider.
+```
+

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -882,7 +882,7 @@ func (v *VaultProvider) autotidyIssuers(path string) (bool, string) {
 		case strings.Contains(errStr, "400"):
 			errStr = "vault versions < 1.13 don't support the tidy_expired_issuers field"
 		case strings.Contains(errStr, "403"):
-			errStr = "permission denied setting auto-tidy in vault"
+			errStr = "permission denied on auto-tidy path in vault"
 		}
 		v.logger.Info("Unable to enable Vault's auto-tidy feature for expired issuers", "reason", errStr, "path", path)
 		return false, errStr

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -880,7 +880,7 @@ func (v *VaultProvider) autotidyIssuers(path string) (bool, string) {
 		case strings.Contains(errStr, "404"):
 			errStr = "vault versions < 1.12 don't support auto-tidy"
 		case strings.Contains(errStr, "400"):
-			errStr = "vault versions < 1.13 don't support tidy_expired_issuers"
+			errStr = "vault versions < 1.13 don't support the tidy_expired_issuers field"
 		case strings.Contains(errStr, "403"):
 			errStr = "permission denied setting auto-tidy in vault"
 		}

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -866,7 +866,7 @@ func (v *VaultProvider) setNamespace(namespace string) func() {
 
 // autotidyIssuers sets Vault's auto-tidy to remove expired issuers
 // Returns a boolean on success for testing (as there is no post-facto way of
-// checking if it is set). Logs warnings on failure to set and why, returning the
+// checking if it is set). Logs at info level on failure to set and why, returning the
 // log message for test purposes as well.
 func (v *VaultProvider) autotidyIssuers(path string) (bool, string) {
 	s, err := v.client.Logical().Write(path+"/config/auto-tidy",

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -884,7 +884,7 @@ func (v *VaultProvider) autotidyIssuers(path string) (bool, string) {
 		case strings.Contains(errStr, "403"):
 			errStr = "permission denied setting auto-tidy in vault"
 		}
-		v.logger.Info("Unable to enable Vault's auto-tidy feature for expired issuers", "error", errStr, "path", path)
+		v.logger.Info("Unable to enable Vault's auto-tidy feature for expired issuers", "reason", errStr, "path", path)
 		return false, errStr
 	}
 	tidySet := false

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -617,7 +617,7 @@ func (v *VaultProvider) GenerateLeafSigningCert() (string, error) {
 			return "", fmt.Errorf("failed to update default intermediate issuer: %w", err)
 		}
 	}
-
+	v.autotidyIssuers(v.config.IntermediatePKIPath)
 	return v.ActiveLeafSigningCert()
 }
 
@@ -829,6 +829,35 @@ func (v *VaultProvider) Stop() {
 func (v *VaultProvider) mountNamespaced(namespace, path string, mountInfo *vaultapi.MountInput) error {
 	defer v.setNamespace(namespace)()
 	return v.client.Sys().Mount(path, mountInfo)
+}
+
+// autotidyIssuers sets Vault's auto-tidy to remove expired issuers
+// returns a boolean on success for testing (as there is no post-facto way of
+// checking if it is set). Logs warnings on failure to set and why.
+func (v *VaultProvider) autotidyIssuers(path string) bool {
+	s, err := v.client.Logical().Write(path+"/config/auto-tidy",
+		map[string]interface{}{
+			"enabled":              true,
+			"tidy_expired_issuers": true,
+		})
+	if err != nil {
+		errStr := err.Error()
+		switch {
+		case strings.Contains(errStr, "404"):
+			errStr = "vault versions < 1.12 don't support auto-tidy"
+		case strings.Contains(errStr, "400"):
+			errStr = "vault versions < 1.13 don't support tidy_expired_issuers"
+		case strings.Contains(errStr, "403"):
+			errStr = "permission denied setting auto-tidy in vault"
+		}
+		v.logger.Info("Unable to enable Vault's auto-tidy feature for expired issuers", "error", errStr, "path", path)
+		return false
+	}
+	tidySet := false
+	if tei, ok := s.Data["tidy_expired_issuers"]; ok {
+		tidySet, _ = tei.(bool)
+	}
+	return tidySet
 }
 
 func (v *VaultProvider) tuneMountNamespaced(namespace, path string, mountConfig *vaultapi.MountConfigInput) error {

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -438,6 +438,9 @@ func (v *VaultProvider) setupIntermediatePKIPath() error {
 		"require_cn":       false,
 	})
 
+	// enable auto-tidy with tidy_expired_issuers
+	v.autotidyIssuers(v.config.IntermediatePKIPath)
+
 	return err
 }
 
@@ -617,7 +620,6 @@ func (v *VaultProvider) GenerateLeafSigningCert() (string, error) {
 			return "", fmt.Errorf("failed to update default intermediate issuer: %w", err)
 		}
 	}
-	v.autotidyIssuers(v.config.IntermediatePKIPath)
 	return v.ActiveLeafSigningCert()
 }
 

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -1130,6 +1130,15 @@ func TestVaultCAProvider_GenerateIntermediate(t *testing.T) {
 	orig, err := provider.ActiveLeafSigningCert()
 	require.NoError(t, err)
 
+	// Check that setting auto-tidy works. It must be run as the only way to
+	// check it is set is by checking the returned value of the write call.
+	if ok := provider.autotidyIssuers("pki-intermediate/"); !ok {
+		t.Error("setting auto-tidy on pki-intermediate/ failed")
+	}
+	if ok := provider.autotidyIssuers("no-perm-pki/"); ok {
+		t.Error("setting auto-tidy on no-perm-pki/ should have failed")
+	}
+
 	// This test was created to ensure that our calls to Vault
 	// returns a new Intermediate certificate and further calls
 	// to ActiveLeafSigningCert return the same new cert.

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -1147,29 +1147,21 @@ func TestVaultCAProvider_GenerateIntermediate(t *testing.T) {
 
 func TestVaultCAProvider_AutoTidyExpiredIssuers(t *testing.T) {
 	SkipIfVaultNotPresent(t)
-
 	t.Parallel()
 
 	testVault := NewTestVaultServer(t)
-
 	attr := &VaultTokenAttributes{
 		RootPath:         "pki-root",
 		IntermediatePath: "pki-intermediate",
 		ConsulManaged:    true,
 	}
 	token := CreateVaultTokenWithAttrs(t, testVault.client, attr)
+	provider := createVaultProvider(t, true, testVault.Addr, token,
+		map[string]any{
+			"RootPKIPath":         "pki-root/",
+			"IntermediatePKIPath": "pki-intermediate/",
+		})
 
-	provider := createVaultProvider(t, true, testVault.Addr, token, map[string]any{
-		"RootPKIPath":         "pki-root/",
-		"IntermediatePKIPath": "pki-intermediate/",
-	})
-
-	// this runs the auto-tidy config call but we can't test that as there
-	// is no way to check. so we re-set it again below checking that it works.
-	_, err := provider.ActiveLeafSigningCert()
-	require.NoError(t, err)
-
-	fmt.Println("vaultTestVersion:", vaultTestVersion)
 	version := strings.Split(vaultTestVersion, ".")
 	require.Len(t, version, 3)
 	minorVersion, err := strconv.Atoi(version[1])

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -1178,10 +1178,10 @@ func TestVaultCAProvider_AutoTidyExpiredIssuers(t *testing.T) {
 	switch {
 	case minorVersion <= 11:
 		require.False(t, expIssSet)
-		require.Contains(t, errStr, "don't support auto-tidy")
+		require.Contains(t, errStr, "auto-tidy")
 	case minorVersion == 12:
 		require.False(t, expIssSet)
-		require.Contains(t, errStr, "don't support tidy_expired_issuers")
+		require.Contains(t, errStr, "tidy_expired_issuers")
 	default: // Consul 1.13+
 		require.True(t, expIssSet)
 	}

--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -184,6 +184,7 @@ type TestVaultServer struct {
 }
 
 var printedVaultVersion sync.Once
+var vaultTestVersion string
 
 func (v *TestVaultServer) Client() *vaultapi.Client {
 	return v.client
@@ -205,6 +206,7 @@ func (v *TestVaultServer) WaitUntilReady(t testing.T) {
 		version = resp.Version
 	})
 	printedVaultVersion.Do(func() {
+		vaultTestVersion = version
 		fmt.Fprintf(os.Stderr, "[INFO] agent/connect/ca: testing with vault server version: %s\n", version)
 	})
 }


### PR DESCRIPTION
When using vault as a CA and generating the local signing cert, try to enable the pki endpoint's auto-tidy feature with it set to tidy expired issuers.