### PR TITLE
[CC-4519] Include Consul NodeID in Envoy bootstrap metadata

### DIFF
--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -17,6 +17,9 @@ type BootstrapTplArgs struct {
 	// the agent to deliver the correct configuration.
 	ProxyID string
 
+	// NodeID is the ID of the node on which the proxy service instance is registered.
+	NodeID string
+
 	// NodeName is the name of the node on which the proxy service instance is registered.
 	NodeName string
 
@@ -184,6 +187,7 @@ const bootstrapTemplate = `{
       {{- if .NodeName }}
       "node_name": "{{ .NodeName }}",
       {{- end }}
+      "node_id": "{{ .NodeID }}",
       "namespace": "{{if ne .Namespace ""}}{{ .Namespace }}{{else}}default{{end}}",
       "partition": "{{if ne .Partition ""}}{{ .Partition }}{{else}}default{{end}}"
     }

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -722,6 +722,12 @@ func (c *cmd) generateConfig() ([]byte, error) {
 		args.Datacenter = datacenter
 	}
 
+	info, err := c.client.Agent().Self()
+	if err != nil {
+		return nil, err
+	}
+	args.NodeID, _ = info["Config"]["NodeID"].(string)
+
 	if err := generateAccessLogs(c, args); err != nil {
 		return nil, err
 	}

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -1691,6 +1691,7 @@ func testMockAgentSelf(
 		resp := agent.Self{
 			Config: map[string]interface{}{
 				"Datacenter": "dc1",
+				"NodeID":     "7cbef9fc-4fb1-4c84-b100-689db9755449",
 			},
 		}
 

--- a/command/connect/envoy/testdata/CONSUL_GRPC_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_GRPC_ADDR-with-https-scheme-enables-tls.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-does-not-affect-grpc-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-does-not-affect-grpc-tls.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/access-logs-enabled-custom.golden
+++ b/command/connect/envoy/testdata/access-logs-enabled-custom.golden
@@ -25,6 +25,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/access-logs-enabled.golden
+++ b/command/connect/envoy/testdata/access-logs-enabled.golden
@@ -47,6 +47,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/acl-enabled-and-token.golden
+++ b/command/connect/envoy/testdata/acl-enabled-and-token.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/acl-enabled-but-no-token.golden
+++ b/command/connect/envoy/testdata/acl-enabled-but-no-token.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-PLAIN-and-CONSUL_GRPC_ADDR-TLS-is-tls.golden
+++ b/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-PLAIN-and-CONSUL_GRPC_ADDR-TLS-is-tls.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-TLS-and-CONSUL_GRPC_ADDR-PLAIN-is-plain.golden
+++ b/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-TLS-and-CONSUL_GRPC_ADDR-PLAIN-is-plain.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/defaults-nodemeta.golden
+++ b/command/connect/envoy/testdata/defaults-nodemeta.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "node_name": "test-node",
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/envoy-readiness-probe.golden
+++ b/command/connect/envoy/testdata/envoy-readiness-probe.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/existing-ca-path.golden
+++ b/command/connect/envoy/testdata/existing-ca-path.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/grpc-addr-unix-with-tls.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix-with-tls.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/grpc-tls-addr-config.golden
+++ b/command/connect/envoy/testdata/grpc-tls-addr-config.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/hcp-metrics.golden
+++ b/command/connect/envoy/testdata/hcp-metrics.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
@@ -12,6 +12,7 @@
     "cluster": "ingress-gateway",
     "id": "ingress-gateway",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
@@ -12,6 +12,7 @@
     "cluster": "ingress-gateway",
     "id": "ingress-gateway",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/ingress-gateway-nodemeta.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-nodemeta.golden
@@ -13,6 +13,7 @@
     "id": "ingress-gateway-1",
     "metadata": {
       "node_name": "test-node",
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
@@ -12,6 +12,7 @@
     "cluster": "my-gateway-123",
     "id": "my-gateway-123",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
@@ -12,6 +12,7 @@
     "cluster": "my-gateway",
     "id": "my-gateway",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/ingress-gateway.golden
+++ b/command/connect/envoy/testdata/ingress-gateway.golden
@@ -12,6 +12,7 @@
     "cluster": "ingress-gateway-1",
     "id": "ingress-gateway-1",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/prometheus-metrics-tls-ca-file.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics-tls-ca-file.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/prometheus-metrics-tls-ca-path.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics-tls-ca-path.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/prometheus-metrics.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/stats-config-override.golden
+++ b/command/connect/envoy/testdata/stats-config-override.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/xds-addr-config.golden
+++ b/command/connect/envoy/testdata/xds-addr-config.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_id": "7cbef9fc-4fb1-4c84-b100-689db9755449",
       "namespace": "default",
       "partition": "default"
     }


### PR DESCRIPTION
### Description

This is being added so that metrics sent to HCP can be augmented with the source node's ID.

Opting not to add this to stats_tag out of caution, since it would increase the cardinality of metrics emitted by Envoy for all users.

There is no functional impact to Envoy expected from this change.

### Testing & Reproduction steps

Added unit tests and also did the following manual test:

Ran a single dev agent with `consul agent -dev` and registered the following service with a sidecar:
```hcl
{
  "service": {
    "name": "counting",
    "port": 8181,
    "connect": {
      "sidecar_service": {}
    }
  }
}
```

Ran Envoy:

```
consul connect envoy -sidecar-for counting
```

Compared the node ID in Envoy's config to the ID in the catalog:
```
curl -s localhost:19000/config_dump | jq '.configs[0].bootstrap.node.metadata.node_id'
curl -s localhost:8500/v1/catalog/nodes | jq '.[0].ID' 
```

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
