### PR TITLE
Fix `api` package Locality Backward Compatability Bug

### DIFF
--- a/api/catalog.go
+++ b/api/catalog.go
@@ -78,8 +78,8 @@ type CatalogRegistration struct {
 	Check           *AgentCheck
 	Checks          HealthChecks
 	SkipNodeUpdate  bool
-	Partition       string `json:",omitempty"`
-	Locality        *Locality
+	Partition       string    `json:",omitempty"`
+	Locality        *Locality `json:",omitempty"`
 }
 
 type CatalogDeregistration struct {

--- a/api/peering.go
+++ b/api/peering.go
@@ -47,7 +47,7 @@ type PeeringRemoteInfo struct {
 	Partition string
 	// Datacenter is the remote peer's datacenter.
 	Datacenter string
-	Locality   *Locality
+	Locality   *Locality `json:",omitempty"`
 }
 
 // Locality identifies where a given entity is running.


### PR DESCRIPTION
Fix backward compat issue caused by localities being set to `null` when they are unset.