### PR TITLE
Fix a bug that wrongly trims domains when there is an overlap with DC name

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -1048,8 +1048,8 @@ func (d *DNSServer) dispatch(remoteAddr net.Addr, req, resp *dns.Msg, maxRecursi
 }
 
 func (d *DNSServer) trimDomain(query string) string {
-	longer := d.domain
-	shorter := d.altDomain
+	longer := "." + strings.TrimLeft(d.domain, ".")
+	shorter := "." + strings.TrimLeft(d.altDomain, ".")
 
 	if len(shorter) > len(longer) {
 		longer, shorter = shorter, longer

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -7071,6 +7071,45 @@ func TestDNS_AltDomains_Overlap(t *testing.T) {
 	}
 }
 
+func TestDNS_AltDomain_DCName_Overlap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	// this tests the DC name overlap with the consul domain/alt-domain
+	// we should get response when DC suffix is a prefix of consul alt-domain
+	t.Parallel()
+	a := NewTestAgent(t, `
+		datacenter = "dc-test"
+		node_name = "test-node"
+		alt_domain = "test.consul."
+	`)
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc-test")
+
+	questions := []string{
+		"test-node.node.dc-test.consul.",
+		"test-node.node.dc-test.test.consul.",
+	}
+
+	for _, question := range questions {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeA)
+
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m, a.DNSAddr())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		require.Len(t, in.Answer, 1)
+
+		aRec, ok := in.Answer[0].(*dns.A)
+		require.True(t, ok)
+		require.Equal(t, aRec.A.To4().String(), "127.0.0.1")
+	}
+}
+
 func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")


### PR DESCRIPTION
Before this change, when DC name and domain/alt-domain overlap, the domain name incorrectly trimmed from the query.

Example:

Given: datacenter = dc-test, alt-domain = test.consul.
Querying for "test-node.node.dc-test.consul" will faile, because the
code was trimming "test.consul" instead of just ".consul"

This change, fixes the issue by adding dot (.) before trimming
