### PR TITLE
peering: ensure that merged central configs of peered upstreams for partitioned downstreams work

### DIFF
--- a/.changelog/17179.txt
+++ b/.changelog/17179.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: ensure that merged central configs of peered upstreams for partitioned downstreams work
+```


### PR DESCRIPTION
### Description

Partitioned downstreams with peered upstreams could not properly merge central config info (i.e. `proxy-defaults` and `service-defaults` things like mesh gateway modes) if the upstream had an empty `DestinationPartition` field in Enterprise.

Due to data flow, if this setup is done using Consul client agents the field is never empty and thus does not experience the bug.

When a service is registered directly to the catalog as is the case for `consul-dataplane` use this field may be empty and and the internal machinery of the merging function doesn't handle this well.

This PR ensure the internal machinery of that function is referentially self-consistent.

The easy way to observe the breakage is arrange for:

* peering with at least the calling side being in a non-default partition
* one server in each cluster
* one mesh gateway in each cluster (in the non-default partition of choice)
* the calling side should use `consul-dataplane`
* the registration done to the catalog should leave the `DestinationPartition` field empty
* create a partitioned `proxy-defaults` with `meshgateway.mode="local"`
* have one mesh 

After bringing everything up, the cluster to reach the upstream from the calling sidecar should point to the local cluster's mesh gateway address (local mode) and not the remote peer's mesh gateway (remote mode).

Needs manual backporting to at least 1.15 (1.14 is very different in this area and may not be applicable).
