### PR TITLE
Sync .golangci.yml from ENT

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,29 +23,14 @@ issues:
     # Temp Ignore SA9004: only the first constant in this group has an explicit type
     # https://staticcheck.io/docs/checks#SA9004
     - linters: [staticcheck]
-      text: 'SA9004:'
-
-    - linters: [staticcheck]
-      text: 'SA1019: "github.com/golang/protobuf/jsonpb" is deprecated: Use the "google.golang.org/protobuf/encoding/protojson" package instead.'
-
-    - linters: [staticcheck]
-      text: 'SA1019: "github.com/golang/protobuf/proto" is deprecated: Use the "google.golang.org/protobuf/proto" package instead.'
-
-    - linters: [staticcheck]
-      text: 'SA1019: ptypes.MarshalAny is deprecated'
-
-    - linters: [staticcheck]
-      text: 'SA1019: ptypes.UnmarshalAny is deprecated'
-
-    - linters: [staticcheck]
-      text: 'SA1019: "github.com/golang/protobuf/ptypes" is deprecated: Well-known types have specialized functionality directly injected into the generated packages for each message type. See the deprecation notice for each function for the suggested alternative.'
+      text: "SA9004:"
 
     - linters: [staticcheck]
       text: 'SA1019: "io/ioutil" has been deprecated since Go 1.16'
 
     # An argument that always receives the same value is often not a problem.
     - linters: [unparam]
-      text: 'always receives'
+      text: "always receives"
 
     # Often functions will implement an interface that returns an error without
     # needing to return an error. Sometimes the error return value is unnecessary
@@ -59,18 +44,18 @@ issues:
     # self-documentation than a single underscore by itself.  Underscore arguments
     # should generally only be used when a function is implementing an interface.
     - linters: [unparam]
-      text: '`_[^`]*` is unused'
+      text: "`_[^`]*` is unused"
 
     # Temp ignore some common unused parameters so that unparam can be added
     # incrementally.
     - linters: [unparam]
-      text: '`(t|resp|req|entMeta)` is unused'
+      text: "`(t|resp|req|entMeta)` is unused"
 
     # Temp ignore everything in _oss(_test).go and _ent(_test).go. Many of these
     # could use underscore to ignore the unused arguments, but the "always returns"
     # issue will likely remain in oss, and will need to be excluded.
     - linters: [unparam]
-      path: '(_oss.go|_oss_test.go|_ent.go|_ent_test.go)'
+      path: "(_oss.go|_oss_test.go|_ent.go|_ent_test.go)"
 
 linters-settings:
   govet:
@@ -115,7 +100,7 @@ linters-settings:
     # Specify an error message to output when a denied package is used.
     # Default: []
     packages-with-error-message:
-      - net/rpc: 'only use forked copy in github.com/hashicorp/consul-net-rpc/net/rpc'
+      - net/rpc: "only use forked copy in github.com/hashicorp/consul-net-rpc/net/rpc"
 
 run:
   timeout: 10m

--- a/agent/grpc-external/services/resource/delete.go
+++ b/agent/grpc-external/services/resource/delete.go
@@ -9,10 +9,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/hashicorp/consul/acl"


### PR DESCRIPTION
Syncs `.golangci.yml` file missed in the original protobuf modernization from [ENT](https://github.com/hashicorp/consul-enterprise/pull/4033/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
