### PR TITLE
fix panic in `injectSANMatcher` when `tlsContext` is `nil`

### DIFF
--- a/.changelog/17185.txt
+++ b/.changelog/17185.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: Fix possible panic that can when generating clusters before the root certificates have been fetched.
+```

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -1427,6 +1427,10 @@ func (s *ResourceGenerator) makeExportedUpstreamClustersForMeshGateway(cfgSnap *
 
 // injectSANMatcher updates a TLS context so that it verifies the upstream SAN.
 func injectSANMatcher(tlsContext *envoy_tls_v3.CommonTlsContext, matchStrings ...string) error {
+	if tlsContext == nil {
+		return fmt.Errorf("invalid type: expected CommonTlsContext_ValidationContext not to be nil")
+	}
+
 	validationCtx, ok := tlsContext.ValidationContextType.(*envoy_tls_v3.CommonTlsContext_ValidationContext)
 	if !ok {
 		return fmt.Errorf("invalid type: expected CommonTlsContext_ValidationContext, got %T",


### PR DESCRIPTION
### Description

We frequently call `injectSANMatcher` [like this](https://github.com/hashicorp/consul/blob/main/agent/xds/clusters.go#L317-L322). The code panics when `commonTLSContext` is `nil` inside `injectSANMatcher` [here](https://github.com/hashicorp/consul/blob/main/agent/xds/clusters.go#L1430). `makeCommonTLSContext` returns `nil` [when it isn't passed root pems](https://github.com/hashicorp/consul/blob/main/agent/xds/listeners.go#L2629-L2631).