### PR TITLE
upgrade test: use docker.mirror.hashicorp.services to avoid docker login

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -376,9 +376,6 @@ jobs:
   
   upgrade-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
     needs:
       - setup
       - dev-build
@@ -396,33 +393,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: go env
-
-      # NOTE: ENT specific step as we store secrets in Vault.
-      - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
-        id: vault-auth
-        run: vault-auth
-
-      # NOTE: ENT specific step as we store secrets in Vault.
-      - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
-        id: secrets
-        uses: hashicorp/vault-action@v2.5.0
-        with:
-          url: ${{ steps.vault-auth.outputs.addr }}
-          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
-          token: ${{ steps.vault-auth.outputs.token }}
-          secrets: |
-              kv/data/github/${{ github.repository }}/dockerhub username | DOCKERHUB_USERNAME;
-              kv/data/github/${{ github.repository }}/dockerhub token | DOCKERHUB_TOKEN;
-
-      # NOTE: conditional specific logic as we store secrets in Vault in ENT and use GHA secrets in OSS.
-      - name: Login to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin@v2.1.0
-        with:
-          username: ${{ endsWith(github.repository, '-enterprise') && steps.secrets.outputs.DOCKERHUB_USERNAME || secrets.DOCKERHUB_USERNAME }}
-          password: ${{ endsWith(github.repository, '-enterprise') && steps.secrets.outputs.DOCKERHUB_TOKEN || secrets.DOCKERHUB_TOKEN }}
-
 
       # Get go binary from workspace
       - name: fetch binary

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -324,7 +324,7 @@ jobs:
               ${{ matrix.test-cases }} \
               --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
               --target-version local \
-              --latest-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
+              --latest-image docker.mirror.hashicorp.services/${{ env.CONSUL_LATEST_IMAGE_NAME }} \
               --latest-version latest
             ls -lrt
         env:


### PR DESCRIPTION
### Description
Use docker image from `docker.mirror.hashicorp.services` to avoid docker login in GHA

Also add image name as parameter to `cluster.StandardUpgrade(utils.GetTargetImageName(), tc.targetVersion)`, because the image we upgrade to is `consul:locally`, which is different than the latest image `docker.mirror.hashicorp.services/docker:1.15` for example.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
