### PR TITLE
Post a PR comment if the backport runner fails

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -28,3 +28,16 @@ jobs:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  handle-failure:
+    needs:
+      - backport
+    if: always() && needs.backport.result == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on PR
+        run: |
+          github_message="Backport failed @${{ github.event.sender.login }}. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -s -H "Authorization: token ${{ secrets.PR_COMMENT_TOKEN }}" \
+            -X POST \
+            -d "{ \"body\": \"${github_message}\"}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pull/${{ github.event.pull_request.number }}/comments"


### PR DESCRIPTION
### Description
Based on:
* Nomad's implementation: https://github.com/hashicorp/nomad/blob/main/.github/workflows/backport.yml#L32-L71
* Backport reminder: https://github.com/hashicorp/consul/blob/ef5d54fd4cca8c2d64506308a3ed6a82955f4470/.github/workflows/backport-reminder.yml

Currently when the backport runner fails it fails silently. This commit adds a step to comment on the PR so that the author can know it failed.

Opted not to post to a Slack channel because not everyone is in the GH/CI feed channels, and it could be too noisy for #team-consul. 

I'm not sure about how to test that this works, open to suggestions!