### PR TITLE
Hash namespace+proxy ID when creating socket path

### DIFF
--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -3722,7 +3722,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							DestinationNamespace: "default",
 							DestinationPartition: "default",
 							DestinationName:      apimod.HCPMetricsCollectorName,
-							LocalBindSocketPath:  "/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock",
+							LocalBindSocketPath:  "/tmp/consul/hcp-metrics/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock",
 							Config: map[string]interface{}{
 								"protocol": "grpc",
 							},

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -3261,6 +3261,15 @@ func TestProxyConfigEntry(t *testing.T) {
 				EnterpriseMeta: *acl.DefaultEnterpriseMeta(),
 			},
 		},
+		"proxy config entry has invalid opaque config": {
+			entry: &ProxyConfigEntry{
+				Name: "global",
+				Config: map[string]interface{}{
+					"envoy_hcp_metrics_bind_socket_dir": "/Consul/is/a/networking/platform/that/enables/securing/your/networking/",
+				},
+			},
+			validateErr: "Config: envoy_hcp_metrics_bind_socket_dir length 71 exceeds max",
+		},
 		"proxy config has invalid failover policy": {
 			entry: &ProxyConfigEntry{
 				Name:           "global",
@@ -3444,4 +3453,34 @@ func uintPointer(v uint32) *uint32 {
 
 func durationPointer(d time.Duration) *time.Duration {
 	return &d
+}
+
+func TestValidateOpaqueConfigMap(t *testing.T) {
+	tt := map[string]struct {
+		input     map[string]interface{}
+		expectErr string
+	}{
+		"hcp metrics socket dir is valid": {
+			input: map[string]interface{}{
+				"envoy_hcp_metrics_bind_socket_dir": "/etc/consul.d/hcp"},
+			expectErr: "",
+		},
+		"hcp metrics socket dir is too long": {
+			input: map[string]interface{}{
+				"envoy_hcp_metrics_bind_socket_dir": "/Consul/is/a/networking/platform/that/enables/securing/your/networking/",
+			},
+			expectErr: "envoy_hcp_metrics_bind_socket_dir length 71 exceeds max 70",
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			err := validateOpaqueProxyConfig(tc.input)
+			if tc.expectErr != "" {
+				require.ErrorContains(t, err, tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1508,6 +1508,10 @@ func (s *NodeService) ValidateForAgent() error {
 				"A Proxy cannot also be Connect Native, only typical services"))
 		}
 
+		if err := validateOpaqueProxyConfig(s.Proxy.Config); err != nil {
+			result = multierror.Append(result, fmt.Errorf("Proxy.Config: %w", err))
+		}
+
 		// ensure we don't have multiple upstreams for the same service
 		var (
 			upstreamKeys = make(map[UpstreamKey]struct{})

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -827,6 +827,16 @@ func TestStructs_NodeService_ValidateConnectProxy(t *testing.T) {
 		},
 
 		{
+			"connect-proxy: invalid opaque config",
+			func(x *NodeService) {
+				x.Proxy.Config = map[string]interface{}{
+					"envoy_hcp_metrics_bind_socket_dir": "/Consul/is/a/networking/platform/that/enables/securing/your/networking/",
+				}
+			},
+			"Proxy.Config: envoy_hcp_metrics_bind_socket_dir length 71 exceeds max",
+		},
+
+		{
 			"connect-proxy: no Proxy.DestinationServiceName",
 			func(x *NodeService) { x.Proxy.DestinationServiceName = "" },
 			"Proxy.DestinationServiceName must be",

--- a/agent/xds/testdata/listeners/hcp-metrics.latest.golden
+++ b/agent/xds/testdata/listeners/hcp-metrics.latest.golden
@@ -1,184 +1,184 @@
 {
-  "versionInfo": "00000001",
-  "resources": [
+  "versionInfo":  "00000001",
+  "resources":  [
     {
-      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name": "db:127.0.0.1:9191",
-      "address": {
-        "socketAddress": {
-          "address": "127.0.0.1",
-          "portValue": 9191
+      "@type":  "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name":  "db:127.0.0.1:9191",
+      "address":  {
+        "socketAddress":  {
+          "address":  "127.0.0.1",
+          "portValue":  9191
         }
       },
-      "filterChains": [
+      "filterChains":  [
         {
-          "filters": [
+          "filters":  [
             {
-              "name": "envoy.filters.network.tcp_proxy",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.db.default.default.dc1",
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              "name":  "envoy.filters.network.tcp_proxy",
+              "typedConfig":  {
+                "@type":  "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix":  "upstream.db.default.default.dc1",
+                "cluster":  "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]
         }
       ],
-      "trafficDirection": "OUTBOUND"
+      "trafficDirection":  "OUTBOUND"
     },
     {
-      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name": "hcp-metrics-collector:/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock",
-      "address": {
-        "pipe": {
-          "path": "/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock"
+      "@type":  "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name":  "hcp-metrics-collector:/tmp/consul/hcp-metrics/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock",
+      "address":  {
+        "pipe":  {
+          "path":  "/tmp/consul/hcp-metrics/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock"
         }
       },
-      "filterChains": [
+      "filterChains":  [
         {
-          "filters": [
+          "filters":  [
             {
-              "name": "envoy.filters.network.http_connection_manager",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix": "upstream.hcp-metrics-collector.default.default.dc1",
-                "routeConfig": {
-                  "name": "hcp-metrics-collector",
-                  "virtualHosts": [
+              "name":  "envoy.filters.network.http_connection_manager",
+              "typedConfig":  {
+                "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix":  "upstream.hcp-metrics-collector.default.default.dc1",
+                "routeConfig":  {
+                  "name":  "hcp-metrics-collector",
+                  "virtualHosts":  [
                     {
-                      "name": "hcp-metrics-collector.default.default.dc1",
-                      "domains": [
+                      "name":  "hcp-metrics-collector.default.default.dc1",
+                      "domains":  [
                         "*"
                       ],
-                      "routes": [
+                      "routes":  [
                         {
-                          "match": {
-                            "prefix": "/"
+                          "match":  {
+                            "prefix":  "/"
                           },
-                          "route": {
-                            "cluster": "hcp-metrics-collector.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                          "route":  {
+                            "cluster":  "hcp-metrics-collector.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                           }
                         }
                       ]
                     }
                   ]
                 },
-                "httpFilters": [
+                "httpFilters":  [
                   {
-                    "name": "envoy.filters.http.grpc_stats",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                      "statsForAllMethods": true
+                    "name":  "envoy.filters.http.grpc_stats",
+                    "typedConfig":  {
+                      "@type":  "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                      "statsForAllMethods":  true
                     }
                   },
                   {
-                    "name": "envoy.filters.http.grpc_http1_bridge",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_http1_bridge.v3.Config"
+                    "name":  "envoy.filters.http.grpc_http1_bridge",
+                    "typedConfig":  {
+                      "@type":  "type.googleapis.com/envoy.extensions.filters.http.grpc_http1_bridge.v3.Config"
                     }
                   },
                   {
-                    "name": "envoy.filters.http.router",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    "name":  "envoy.filters.http.router",
+                    "typedConfig":  {
+                      "@type":  "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
                     }
                   }
                 ],
-                "tracing": {
-                  "randomSampling": {}
+                "tracing":  {
+                  "randomSampling":  {}
                 },
-                "http2ProtocolOptions": {}
+                "http2ProtocolOptions":  {}
               }
             }
           ]
         }
       ],
-      "trafficDirection": "OUTBOUND"
+      "trafficDirection":  "OUTBOUND"
     },
     {
-      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name": "prepared_query:geo-cache:127.10.10.10:8181",
-      "address": {
-        "socketAddress": {
-          "address": "127.10.10.10",
-          "portValue": 8181
+      "@type":  "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name":  "prepared_query:geo-cache:127.10.10.10:8181",
+      "address":  {
+        "socketAddress":  {
+          "address":  "127.10.10.10",
+          "portValue":  8181
         }
       },
-      "filterChains": [
+      "filterChains":  [
         {
-          "filters": [
+          "filters":  [
             {
-              "name": "envoy.filters.network.tcp_proxy",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.prepared_query_geo-cache",
-                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              "name":  "envoy.filters.network.tcp_proxy",
+              "typedConfig":  {
+                "@type":  "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix":  "upstream.prepared_query_geo-cache",
+                "cluster":  "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]
         }
       ],
-      "trafficDirection": "OUTBOUND"
+      "trafficDirection":  "OUTBOUND"
     },
     {
-      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name": "public_listener:0.0.0.0:9999",
-      "address": {
-        "socketAddress": {
-          "address": "0.0.0.0",
-          "portValue": 9999
+      "@type":  "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name":  "public_listener:0.0.0.0:9999",
+      "address":  {
+        "socketAddress":  {
+          "address":  "0.0.0.0",
+          "portValue":  9999
         }
       },
-      "filterChains": [
+      "filterChains":  [
         {
-          "filters": [
+          "filters":  [
             {
-              "name": "envoy.filters.network.rbac",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                "rules": {},
-                "statPrefix": "connect_authz"
+              "name":  "envoy.filters.network.rbac",
+              "typedConfig":  {
+                "@type":  "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules":  {},
+                "statPrefix":  "connect_authz"
               }
             },
             {
-              "name": "envoy.filters.network.tcp_proxy",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "public_listener",
-                "cluster": "local_app"
+              "name":  "envoy.filters.network.tcp_proxy",
+              "typedConfig":  {
+                "@type":  "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix":  "public_listener",
+                "cluster":  "local_app"
               }
             }
           ],
-          "transportSocket": {
-            "name": "tls",
-            "typedConfig": {
-              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
-              "commonTlsContext": {
-                "tlsParams": {},
-                "tlsCertificates": [
+          "transportSocket":  {
+            "name":  "tls",
+            "typedConfig":  {
+              "@type":  "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext":  {
+                "tlsParams":  {},
+                "tlsCertificates":  [
                   {
-                    "certificateChain": {
-                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    "certificateChain":  {
+                      "inlineString":  "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
                     },
-                    "privateKey": {
-                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    "privateKey":  {
+                      "inlineString":  "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
                     }
                   }
                 ],
-                "validationContext": {
-                  "trustedCa": {
-                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                "validationContext":  {
+                  "trustedCa":  {
+                    "inlineString":  "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
                   }
                 }
               },
-              "requireClientCertificate": true
+              "requireClientCertificate":  true
             }
           }
         }
       ],
-      "trafficDirection": "INBOUND"
+      "trafficDirection":  "INBOUND"
     }
   ],
-  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
-  "nonce": "00000001"
+  "typeUrl":  "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce":  "00000001"
 }

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -556,7 +556,7 @@ const (
 			  "endpoint": {
 				"address": {
 				  "pipe": {
-					"path": "/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock"
+					"path": "/tmp/consul/hcp-metrics/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock"
 				  }
 				}
 			  }
@@ -654,7 +654,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 							  "endpoint": {
 								"address": {
 								  "pipe": {
-									"path": "/tmp/consul/hcp-metrics/default_web-sidecar-proxy.sock"
+									"path": "/tmp/consul/hcp-metrics/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock"
 								  }
 								}
 							  }

--- a/command/connect/envoy/testdata/hcp-metrics.golden
+++ b/command/connect/envoy/testdata/hcp-metrics.golden
@@ -68,7 +68,7 @@
                   "endpoint": {
                     "address": {
                       "pipe": {
-                        "path": "/tmp/consul/hcp-metrics/default_test-proxy.sock"
+                        "path": "/tmp/consul/hcp-metrics/k3bWnyJyKvjUYXrBdOX2nXzSSCQ.sock"
                       }
                     }
                   }


### PR DESCRIPTION
### Description

UNIX domain socket paths are limited to 104-108 characters depending on the OS. This limit was quite easy to exceed when testing the feature on Kubernetes, due to how proxy IDs encode the Pod ID eg:
`metrics-collector-59467bcb9b-fkkzl-hcp-metrics-collector-sidecar-proxy`

To ensure we stay under the lower 104 character limit this commit makes a couple changes:
- Use a b64 encoded SHA1 hash of the namespace + proxy ID to create a short and deterministic socket file name.
- Add validation to proxy registrations and proxy-defaults to enforce a limit on the socket directory length.

### Testing & Reproduction steps

* Added unit tests
* Manual testing with long socket path at and above limit

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
