### PR TITLE
resource: add missing validation to the `List` and `WatchList` endpoints

### DIFF
--- a/agent/grpc-external/services/resource/list.go
+++ b/agent/grpc-external/services/resource/list.go
@@ -15,6 +15,10 @@ import (
 )
 
 func (s *Server) List(ctx context.Context, req *pbresource.ListRequest) (*pbresource.ListResponse, error) {
+	if err := validateListRequest(req); err != nil {
+		return nil, err
+	}
+
 	// check type
 	reg, err := s.resolveType(req.Type)
 	if err != nil {
@@ -64,4 +68,17 @@ func (s *Server) List(ctx context.Context, req *pbresource.ListRequest) (*pbreso
 		result = append(result, resource)
 	}
 	return &pbresource.ListResponse{Resources: result}, nil
+}
+
+func validateListRequest(req *pbresource.ListRequest) error {
+	var field string
+	switch {
+	case req.Type == nil:
+		field = "type"
+	case req.Tenancy == nil:
+		field = "tenancy"
+	default:
+		return nil
+	}
+	return status.Errorf(codes.InvalidArgument, "%s is required", field)
 }

--- a/agent/grpc-external/services/resource/watch.go
+++ b/agent/grpc-external/services/resource/watch.go
@@ -13,6 +13,10 @@ import (
 )
 
 func (s *Server) WatchList(req *pbresource.WatchListRequest, stream pbresource.ResourceService_WatchListServer) error {
+	if err := validateWatchListRequest(req); err != nil {
+		return err
+	}
+
 	// check type exists
 	reg, err := s.resolveType(req.Type)
 	if err != nil {
@@ -69,4 +73,17 @@ func (s *Server) WatchList(req *pbresource.WatchListRequest, stream pbresource.R
 			return err
 		}
 	}
+}
+
+func validateWatchListRequest(req *pbresource.WatchListRequest) error {
+	var field string
+	switch {
+	case req.Type == nil:
+		field = "type"
+	case req.Tenancy == nil:
+		field = "tenancy"
+	default:
+		return nil
+	}
+	return status.Errorf(codes.InvalidArgument, "%s is required", field)
 }

--- a/agent/grpc-external/services/resource/watch_test.go
+++ b/agent/grpc-external/services/resource/watch_test.go
@@ -22,6 +22,34 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+func TestWatchList_InputValidation(t *testing.T) {
+	server := testServer(t)
+	client := testClient(t, server)
+
+	demo.RegisterTypes(server.Registry)
+
+	testCases := map[string]func(*pbresource.WatchListRequest){
+		"no type":    func(req *pbresource.WatchListRequest) { req.Type = nil },
+		"no tenancy": func(req *pbresource.WatchListRequest) { req.Tenancy = nil },
+	}
+	for desc, modFn := range testCases {
+		t.Run(desc, func(t *testing.T) {
+			req := &pbresource.WatchListRequest{
+				Type:    demo.TypeV2Album,
+				Tenancy: demo.TenancyDefault,
+			}
+			modFn(req)
+
+			stream, err := client.WatchList(testContext(t), req)
+			require.NoError(t, err)
+
+			_, err = stream.Recv()
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument.String(), status.Code(err).String())
+		})
+	}
+}
+
 func TestWatchList_TypeNotFound(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description

Prevents panics when clients don't send the `Type` and `Tenancy` parameters.
