### PR TITLE
Register new catalog & mesh protobuf types with the resource registry

### DIFF
--- a/internal/catalog/exports.go
+++ b/internal/catalog/exports.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package catalog
+
+import (
+	"github.com/hashicorp/consul/internal/catalog/internal/types"
+	"github.com/hashicorp/consul/internal/resource"
+)
+
+var (
+	// API Group Information
+
+	APIGroup        = types.GroupName
+	VersionV1Alpha1 = types.VersionV1Alpha1
+	CurrentVersion  = types.CurrentVersion
+
+	// Resource Kind Names.
+
+	WorkloadKind         = types.WorkloadKind
+	ServiceKind          = types.ServiceKind
+	ServiceEndpointsKind = types.ServiceEndpointsKind
+	VirtualIPsKind       = types.VirtualIPsKind
+	NodeKind             = types.NodeKind
+	HealthStatusKind     = types.HealthStatusKind
+	HealthChecksKind     = types.HealthChecksKind
+	DNSPolicyKind        = types.DNSPolicyKind
+
+	// Resource Types for the v1alpha1 version.
+
+	WorkloadV1Alpha1Type         = types.WorkloadV1Alpha1Type
+	ServiceV1Alpha1Type          = types.ServiceV1Alpha1Type
+	ServiceEndpointsV1Alpha1Type = types.ServiceEndpointsV1Alpha1Type
+	VirtualIPsV1Alpha1Type       = types.VirtualIPsV1Alpha1Type
+	NodeV1Alpha1Type             = types.NodeV1Alpha1Type
+	HealthStatusV1Alpha1Type     = types.HealthStatusV1Alpha1Type
+	HealthChecksV1Alpha1Type     = types.HealthChecksV1Alpha1Type
+	DNSPolicyV1Alpha1Type        = types.DNSPolicyV1Alpha1Type
+)
+
+// RegisterTypes adds all resource types within the "catalog" API group
+// to the given type registry
+func RegisterTypes(r resource.Registry) {
+	types.Register(r)
+}

--- a/internal/catalog/internal/types/dns_policy.go
+++ b/internal/catalog/internal/types/dns_policy.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	DNSPolicyKind = "DNSPolicy"
+)
+
+var (
+	DNSPolicyV1Alpha1Type = &pbresource.Type{
+		Group:        GroupName,
+		GroupVersion: VersionV1Alpha1,
+		Kind:         DNSPolicyKind,
+	}
+
+	DNSPolicyType = DNSPolicyV1Alpha1Type
+)
+
+func RegisterDNSPolicy(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     DNSPolicyV1Alpha1Type,
+		Proto:    &pbcatalog.DNSPolicy{},
+		Validate: nil,
+	})
+}

--- a/internal/catalog/internal/types/health_checks.go
+++ b/internal/catalog/internal/types/health_checks.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	HealthChecksKind = "HealthChecks"
+)
+
+var (
+	HealthChecksV1Alpha1Type = &pbresource.Type{
+		Group:        GroupName,
+		GroupVersion: VersionV1Alpha1,
+		Kind:         HealthChecksKind,
+	}
+
+	HealthChecksType = HealthChecksV1Alpha1Type
+)
+
+func RegisterHealthChecks(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     HealthChecksV1Alpha1Type,
+		Proto:    &pbcatalog.HealthChecks{},
+		Validate: nil,
+	})
+}

--- a/internal/catalog/internal/types/health_status.go
+++ b/internal/catalog/internal/types/health_status.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	HealthStatusKind = "HealthStatus"
+)
+
+var (
+	HealthStatusV1Alpha1Type = &pbresource.Type{
+		Group:        GroupName,
+		GroupVersion: VersionV1Alpha1,
+		Kind:         HealthStatusKind,
+	}
+
+	HealthStatusType = HealthStatusV1Alpha1Type
+)
+
+func RegisterHealthStatus(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     HealthStatusV1Alpha1Type,
+		Proto:    &pbcatalog.HealthStatus{},
+		Validate: nil,
+	})
+}

--- a/internal/catalog/internal/types/node.go
+++ b/internal/catalog/internal/types/node.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	NodeKind = "Node"
+)
+
+var (
+	NodeV1Alpha1Type = &pbresource.Type{
+		Group:        GroupName,
+		GroupVersion: VersionV1Alpha1,
+		Kind:         NodeKind,
+	}
+
+	NodeType = NodeV1Alpha1Type
+)
+
+func RegisterNode(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     NodeV1Alpha1Type,
+		Proto:    &pbcatalog.Node{},
+		Validate: nil,
+	})
+}

--- a/internal/catalog/internal/types/service.go
+++ b/internal/catalog/internal/types/service.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	ServiceKind = "Service"
+)
+
+var (
+	ServiceV1Alpha1Type = &pbresource.Type{
+		Group:        GroupName,
+		GroupVersion: VersionV1Alpha1,
+		Kind:         ServiceKind,
+	}
+
+	ServiceType = ServiceV1Alpha1Type
+)
+
+func RegisterService(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     ServiceV1Alpha1Type,
+		Proto:    &pbcatalog.Service{},
+		Validate: nil,
+	})
+}

--- a/internal/catalog/internal/types/service_endpoints.go
+++ b/internal/catalog/internal/types/service_endpoints.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	ServiceEndpointsKind = "ServiceEndpoints"
+)
+
+var (
+	ServiceEndpointsV1Alpha1Type = &pbresource.Type{
+		Group:        GroupName,
+		GroupVersion: VersionV1Alpha1,
+		Kind:         ServiceEndpointsKind,
+	}
+
+	ServiceEndpointsType = ServiceEndpointsV1Alpha1Type
+)
+
+func RegisterServiceEndpoints(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     ServiceEndpointsV1Alpha1Type,
+		Proto:    &pbcatalog.ServiceEndpoints{},
+		Validate: nil,
+	})
+}

--- a/internal/catalog/internal/types/types.go
+++ b/internal/catalog/internal/types/types.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+)
+
+const (
+	GroupName       = "catalog"
+	VersionV1Alpha1 = "v1alpha1"
+	CurrentVersion  = VersionV1Alpha1
+)
+
+func Register(r resource.Registry) {
+	RegisterWorkload(r)
+	RegisterService(r)
+	RegisterServiceEndpoints(r)
+	RegisterNode(r)
+	RegisterHealthStatus(r)
+	RegisterHealthChecks(r)
+	RegisterDNSPolicy(r)
+	RegisterVirtualIPs(r)
+}

--- a/internal/catalog/internal/types/types_test.go
+++ b/internal/catalog/internal/types/types_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeRegistration(t *testing.T) {
+	// This test will ensure that all the required types have been registered
+	// It is not trying to determine whether the settings for the registrations
+	// are correct as that would amount more or less to hardcoding structs
+	// from types.go a second time here.
+	requiredKinds := []string{
+		WorkloadKind,
+		ServiceKind,
+		ServiceEndpointsKind,
+		VirtualIPsKind,
+		NodeKind,
+		HealthStatusKind,
+		HealthChecksKind,
+		DNSPolicyKind,
+	}
+
+	r := resource.NewRegistry()
+	Register(r)
+
+	for _, kind := range requiredKinds {
+		t.Run(kind, func(t *testing.T) {
+			registration, ok := r.Resolve(&pbresource.Type{
+				Group:        GroupName,
+				GroupVersion: CurrentVersion,
+				Kind:         kind,
+			})
+
+			require.True(t, ok, "Resource kind %s has not been registered to the type registry", kind)
+			require.NotNil(t, registration, "Registration for %s was found but is nil", kind)
+		})
+	}
+}

--- a/internal/catalog/internal/types/virtual_ips.go
+++ b/internal/catalog/internal/types/virtual_ips.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	VirtualIPsKind = "VirtualIPs"
+)
+
+var (
+	VirtualIPsV1Alpha1Type = &pbresource.Type{
+		Group:        GroupName,
+		GroupVersion: VersionV1Alpha1,
+		Kind:         VirtualIPsKind,
+	}
+
+	VirtualIPsType = VirtualIPsV1Alpha1Type
+)
+
+func RegisterVirtualIPs(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     VirtualIPsV1Alpha1Type,
+		Proto:    &pbcatalog.VirtualIPs{},
+		Validate: nil,
+	})
+}

--- a/internal/catalog/internal/types/workload.go
+++ b/internal/catalog/internal/types/workload.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	WorkloadKind = "Workload"
+)
+
+var (
+	WorkloadV1Alpha1Type = &pbresource.Type{
+		Group:        GroupName,
+		GroupVersion: VersionV1Alpha1,
+		Kind:         WorkloadKind,
+	}
+
+	WorkloadType = WorkloadV1Alpha1Type
+)
+
+func RegisterWorkload(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     WorkloadV1Alpha1Type,
+		Proto:    &pbcatalog.Workload{},
+		Validate: nil,
+	})
+}

--- a/internal/mesh/exports.go
+++ b/internal/mesh/exports.go
@@ -1,0 +1,33 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package mesh
+
+import (
+	"github.com/hashicorp/consul/internal/mesh/internal/types"
+	"github.com/hashicorp/consul/internal/resource"
+)
+
+var (
+	// API Group Information
+
+	APIGroup        = types.GroupName
+	VersionV1Alpha1 = types.VersionV1Alpha1
+	CurrentVersion  = types.CurrentVersion
+
+	// Resource Kind Names.
+
+	ProxyConfigurationKind = types.ProxyConfigurationKind
+	UpstreamsKind          = types.UpstreamsKind
+
+	// Resource Types for the v1alpha1 version.
+
+	ProxyConfigurationV1Alpha1Type = types.ProxyConfigurationV1Alpha1Type
+	UpstreamsV1Alpha1Type          = types.UpstreamsV1Alpha1Type
+)
+
+// RegisterTypes adds all resource types within the "catalog" API group
+// to the given type registry
+func RegisterTypes(r resource.Registry) {
+	types.Register(r)
+}

--- a/internal/mesh/internal/types/proxy_configuration.go
+++ b/internal/mesh/internal/types/proxy_configuration.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	ProxyConfigurationKind = "ProxyConfiguration"
+)
+
+var (
+	ProxyConfigurationV1Alpha1Type = &pbresource.Type{
+		Group:        GroupName,
+		GroupVersion: CurrentVersion,
+		Kind:         ProxyConfigurationKind,
+	}
+
+	ProxyConfigurationType = ProxyConfigurationV1Alpha1Type
+)
+
+func RegisterProxyConfiguration(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     ProxyConfigurationV1Alpha1Type,
+		Proto:    &pbmesh.ProxyConfiguration{},
+		Validate: nil,
+	})
+}

--- a/internal/mesh/internal/types/types.go
+++ b/internal/mesh/internal/types/types.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+)
+
+const (
+	GroupName       = "mesh"
+	VersionV1Alpha1 = "v1alpha1"
+	CurrentVersion  = VersionV1Alpha1
+)
+
+func Register(r resource.Registry) {
+	RegisterProxyConfiguration(r)
+	RegisterUpstreams(r)
+}

--- a/internal/mesh/internal/types/types_test.go
+++ b/internal/mesh/internal/types/types_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeRegistration(t *testing.T) {
+	// This test will ensure that all the required types have been registered
+	// It is not trying to determine whether the settings for the registrations
+	// are correct as that would amount more or less to hardcoding structs
+	// from types.go a second time here.
+	requiredKinds := []string{
+		ProxyConfigurationKind,
+		UpstreamsKind,
+	}
+
+	r := resource.NewRegistry()
+	Register(r)
+
+	for _, kind := range requiredKinds {
+		t.Run(kind, func(t *testing.T) {
+			registration, ok := r.Resolve(&pbresource.Type{
+				Group:        GroupName,
+				GroupVersion: CurrentVersion,
+				Kind:         kind,
+			})
+
+			require.True(t, ok, "Resource kind %s has not been registered to the type registry", kind)
+			require.NotNil(t, registration, "Registration for %s was found but is nil", kind)
+		})
+	}
+}

--- a/internal/mesh/internal/types/upstreams.go
+++ b/internal/mesh/internal/types/upstreams.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	UpstreamsKind = "Upstreams"
+)
+
+var (
+	UpstreamsV1Alpha1Type = &pbresource.Type{
+		Group:        GroupName,
+		GroupVersion: CurrentVersion,
+		Kind:         UpstreamsKind,
+	}
+
+	UpstreamsType = UpstreamsV1Alpha1Type
+)
+
+func RegisterUpstreams(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     UpstreamsV1Alpha1Type,
+		Proto:    &pbmesh.Upstreams{},
+		Validate: nil,
+	})
+}


### PR DESCRIPTION
### Description

This PR takes the protobuf type definitions for catalog and mesh resources from #17123 and causes them to be registered with the resource services type registry. In particular the following new resource types are being added:

* `catalog.v1alpha1.workload`
* `catalog.v1alpha1.service`
* `catalog.v1alpha1.serviceendpoints`
* `catalog.v1alpha1.virtualips`
* `catalog.v1alpha1.node`
* `catalog.v1alpha1.healthstatus`
* `catalog.v1alpha1.healthchecks`
* `catalog.v1alpha1.dnspolicy`
* `mesh.v1alpha1.proxyconfiguration`
* `mesh.v1alpha1.upstreams`

### Future PRs

* Code to perform validation at admission time of the new resources.
* Code to authorize the use of the new resources
* Integration tests to ensure that the new types are properly registered with a real Consul server.

### Testing & Reproduction steps

Some additional unit tests were added to ensure that the required types are being registered.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
