### PR TITLE
cli: consistently name Consul service mesh

### DIFF
--- a/command/connect/ca/ca.go
+++ b/command/connect/ca/ca.go
@@ -26,11 +26,11 @@ func (c *cmd) Help() string {
 	return flags.Usage(help, nil)
 }
 
-const synopsis = "Interact with the Consul Connect Certificate Authority (CA)"
+const synopsis = "Interact with the service mesh Certificate Authority (CA)"
 const help = `
 Usage: consul connect ca <subcommand> [options] [args]
 
-  This command has subcommands for interacting with Consul Connect's 
+  This command has subcommands for interacting with the service mesh's
   Certificate Authority (CA).
 
   Here are some simple examples, and more detailed examples are available

--- a/command/connect/ca/get/connect_ca_get.go
+++ b/command/connect/ca/get/connect_ca_get.go
@@ -76,9 +76,9 @@ func (c *cmd) Help() string {
 	return c.help
 }
 
-const synopsis = "Display the current Connect Certificate Authority (CA) configuration"
+const synopsis = "Display the current service mesh Certificate Authority (CA) configuration"
 const help = `
 Usage: consul connect ca get-config [options]
 
-  Displays the current Connect Certificate Authority (CA) configuration.
+  Displays the current service mesh Certificate Authority (CA) configuration.
 `

--- a/command/connect/ca/set/connect_ca_set.go
+++ b/command/connect/ca/set/connect_ca_set.go
@@ -99,9 +99,9 @@ func (c *cmd) Help() string {
 	return c.help
 }
 
-const synopsis = "Modify the current Connect CA configuration"
+const synopsis = "Modify the current service mesh CA configuration"
 const help = `
 Usage: consul connect ca set-config [options]
 
-  Modifies the current Connect Certificate Authority (CA) configuration.
+  Modifies the current service mesh Certificate Authority (CA) configuration.
 `

--- a/command/connect/connect.go
+++ b/command/connect/connect.go
@@ -26,18 +26,18 @@ func (c *cmd) Help() string {
 	return flags.Usage(help, nil)
 }
 
-const synopsis = "Interact with Consul Connect"
+const synopsis = "Interact with Consul service mesh functionality"
 const help = `
 Usage: consul connect <subcommand> [options] [args]
 
-  This command has subcommands for interacting with Consul Connect.
+  This command has subcommands for interacting with Consul service mesh.
 
   Here are some simple examples, and more detailed examples are available
   in the subcommands or the documentation.
 
-  Run the built-in Connect mTLS proxy
+  Run the production service mesh proxy
 
-      $ consul connect proxy
+      $ consul connect envoy
 
   For more examples, ask for subcommand help or view the documentation.
 `

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -959,13 +959,14 @@ func (c *cmd) Help() string {
 }
 
 const (
-	synopsis = "Runs or Configures Envoy as a Connect proxy"
+	synopsis = "Runs or configures Envoy as a service mesh proxy"
 	help     = `
 Usage: consul connect envoy [options] [-- pass-through options]
 
   Generates the bootstrap configuration needed to start an Envoy proxy instance
-  for use as a Connect sidecar for a particular service instance. By default it
-  will generate the config and then exec Envoy directly until it exits normally.
+  for use as a service mesh sidecar for a particular service instance. By
+  default it will generate the config and then exec Envoy directly until it
+  exits normally.
 
   It will search $PATH for the envoy binary but this can be overridden with
   -envoy-binary.

--- a/command/connect/expose/expose.go
+++ b/command/connect/expose/expose.go
@@ -244,10 +244,10 @@ func (c *cmd) Help() string {
 	return c.help
 }
 
-const synopsis = "Expose a Connect-enabled service through an Ingress gateway"
+const synopsis = "Expose a mesh-enabled service through an Ingress gateway"
 const help = `
 Usage: consul connect expose [options]
 
-  Exposes a Connect-enabled service through the given ingress gateway, using the
+  Exposes a mesh-enabled service through the given ingress gateway, using the
   given protocol and port.
 `

--- a/command/connect/proxy/proxy.go
+++ b/command/connect/proxy/proxy.go
@@ -167,7 +167,7 @@ func (c *cmd) Run(args []string) int {
 
 	// Output this first since the config watcher below will output
 	// other information.
-	c.UI.Output("Consul Connect proxy starting...")
+	c.UI.Output("Consul service mesh built-in proxy starting...")
 
 	// Get the proper configuration watcher
 	cfgWatcher, err := c.configWatcher(client)
@@ -211,7 +211,7 @@ func (c *cmd) Run(args []string) int {
 		}
 	}
 
-	c.UI.Output("Consul Connect proxy shutdown")
+	c.UI.Output("Consul service mesh built-in proxy shutdown")
 	return 0
 }
 
@@ -405,14 +405,16 @@ func (c *cmd) Help() string {
 	return c.help
 }
 
-const synopsis = "Runs a Consul Connect proxy"
+const synopsis = "Runs a non-production, built-in service mesh sidecar proxy"
 const help = `
 Usage: consul connect proxy [options]
 
-  Starts a Consul Connect proxy and runs until an interrupt is received.
+  Starts a non-production, built-in proxy as a Consul service mesh sidecar
+  and runs until an interrupt is received.
+
   The proxy can be used to accept inbound connections for a service,
   wrap outbound connections to upstream services, or both. This enables
-  a non-Connect-aware application to use Connect.
+  a non-mesh-aware application to use Consul service mesh.
 
   The proxy requires service:write permissions for the service it represents.
   The token may be passed via the CLI or the CONSUL_HTTP_TOKEN environment

--- a/command/intention/intention.go
+++ b/command/intention/intention.go
@@ -26,7 +26,7 @@ func (c *cmd) Help() string {
 	return flags.Usage(help, nil)
 }
 
-const synopsis = "Interact with Connect service intentions"
+const synopsis = "Interact with service mesh intentions"
 const help = `
 Usage: consul intention <subcommand> [options] [args]
 

--- a/command/operator/usage/instances/usage_instances.go
+++ b/command/operator/usage/instances/usage_instances.go
@@ -38,7 +38,7 @@ func (c *cmd) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
 	c.flags.BoolVar(&c.onlyBillable, "billable", false, "Display only billable service info. "+
 		"Cannot be used with -connect.")
-	c.flags.BoolVar(&c.onlyConnect, "connect", false, "Display only Connect service info."+
+	c.flags.BoolVar(&c.onlyConnect, "connect", false, "Display only Consul service mesh component info."+
 		"Cannot be used with -billable.")
 	c.flags.BoolVar(&c.allDatacenters, "all-datacenters", false, "Display service counts from "+
 		"all datacenters.")
@@ -242,7 +242,7 @@ Usage: consul operator usage instances [options]
 
       $ consul operator usage instances -billable
 
-  To show only connect service instance counts:
+  To show only service instance counts for service mesh components:
 
       $ consul operator usage instances -connect
 


### PR DESCRIPTION
Remove outdated usage of "Consul Connect" instead of Consul service mesh.

The connect subsystem in Consul provides Consul's service mesh capabilities. However, the term "Consul Connect" should not be used as an alternative to the name "Consul service mesh".

This commit modifies CLI help text for commands and variables. It does not change any functionality.

This PR is a follow up for the docs changes made in #17222.