### PR TITLE
snapshot: some improvments to the snapshot process

### DIFF
--- a/.changelog/17236.txt
+++ b/.changelog/17236.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+logging: change snapshot log header from `agent.server.snapshot` to `agent.server.raft.snapshot`
+```

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1054,7 +1054,7 @@ func (s *Server) setupRaft() error {
 		log = cacheStore
 
 		// Create the snapshot store.
-		snapshots, err := raft.NewFileSnapshotStoreWithLogger(path, snapshotsRetained, s.logger.Named("snapshot"))
+		snapshots, err := raft.NewFileSnapshotStoreWithLogger(path, snapshotsRetained, s.logger.Named("raft.snapshot"))
 		if err != nil {
 			return err
 		}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -53,7 +53,7 @@ func New(logger hclog.Logger, r *raft.Raft) (*Snapshot, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create snapshot file: %v", err)
 	}
-	logger.Info("creating temporary file of snapshot", "path", archive.Name())
+	logger.Debug("creating temporary file of snapshot", "path", archive.Name())
 
 	// If anything goes wrong after this point, we will attempt to clean up
 	// the temp file. The happy path will disarm this.

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -53,6 +53,7 @@ func New(logger hclog.Logger, r *raft.Raft) (*Snapshot, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create snapshot file: %v", err)
 	}
+	logger.Info("creating temporary file of snapshot", "path", archive.Name())
 
 	// If anything goes wrong after this point, we will attempt to clean up
 	// the temp file. The happy path will disarm this.
@@ -112,7 +113,7 @@ func (s *Snapshot) Read(p []byte) (n int, err error) {
 }
 
 // Close closes the snapshot and removes any temporary storage associated with
-// it. You must arrange to call this whenever NewSnapshot() has been called
+// it. You must arrange to call this whenever New() has been called
 // successfully. This is safe to call on a nil snapshot.
 func (s *Snapshot) Close() error {
 	if s == nil {

--- a/website/content/commands/snapshot/save.mdx
+++ b/website/content/commands/snapshot/save.mdx
@@ -29,8 +29,7 @@ variable for the Consul server processes. Keep in mind that setting the environm
 the CLI client attempting to perform a snapshot save will have no effect. It _must_ be set in
 the context of the server process. If you're using Systemd to manage your Consul server
 processes, then adding `Environment=TMPDIR=/path/to/dir` to your Consul unit file will work.
-Another side effect is that one snapshot file is also taken at `data_dir/raft/snapshots`,
-resulting from Raft snapshot.
+As a result of the Raft snapshot, Consul also saves one snapshot file at `data_dir/raft/snapshots`.
 
 The table below shows this command's [required ACLs](/consul/api-docs/api-structure#authentication). Configuration of
 [blocking queries](/consul/api-docs/features/blocking) and [agent caching](/consul/api-docs/features/caching)

--- a/website/content/commands/snapshot/save.mdx
+++ b/website/content/commands/snapshot/save.mdx
@@ -29,7 +29,7 @@ variable for the Consul server processes. Keep in mind that setting the environm
 the CLI client attempting to perform a snapshot save will have no effect. It _must_ be set in
 the context of the server process. If you're using Systemd to manage your Consul server
 processes, then adding `Environment=TMPDIR=/path/to/dir` to your Consul unit file will work.
-Another side effect is that one snapshot file is also taken at `data_dir/raft/snapshops`,
+Another side effect is that one snapshot file is also taken at `data_dir/raft/snapshots`,
 resulting from Raft snapshot.
 
 The table below shows this command's [required ACLs](/consul/api-docs/api-structure#authentication). Configuration of

--- a/website/content/commands/snapshot/save.mdx
+++ b/website/content/commands/snapshot/save.mdx
@@ -20,7 +20,8 @@ If ACLs are enabled, a management token must be supplied in order to perform
 a snapshot save.
 
 -> Note that saving a snapshot involves the server process writing the snapshot to a
-temporary file on-disk before sending that file to the CLI client. The default location
+temporary file on-disk before sending that file to the CLI client. Upon successful completion,
+the temporary file will be removed. The default location of the temporary file
 can vary depending on operating system, but typically is `/tmp`. You can get more detailed
 information on default locations in the Go documentation for [os.TempDir](https://golang.org/pkg/os/#TempDir).
 If you need to change this location, you can do so by setting the `TMPDIR` environment
@@ -28,6 +29,8 @@ variable for the Consul server processes. Keep in mind that setting the environm
 the CLI client attempting to perform a snapshot save will have no effect. It _must_ be set in
 the context of the server process. If you're using Systemd to manage your Consul server
 processes, then adding `Environment=TMPDIR=/path/to/dir` to your Consul unit file will work.
+Another side effect is that one snapshot file is also taken at `data_dir/raft/snapshops`,
+resulting from Raft snapshot.
 
 The table below shows this command's [required ACLs](/consul/api-docs/api-structure#authentication). Configuration of
 [blocking queries](/consul/api-docs/features/blocking) and [agent caching](/consul/api-docs/features/caching)

--- a/website/content/commands/snapshot/save.mdx
+++ b/website/content/commands/snapshot/save.mdx
@@ -21,7 +21,7 @@ a snapshot save.
 
 -> Note that saving a snapshot involves the server process writing the snapshot to a
 temporary file on-disk before sending that file to the CLI client. Upon successful completion,
-the temporary file will be removed. The default location of the temporary file
+Consul removes the temporary file. The default location of the temporary file
 can vary depending on operating system, but typically is `/tmp`. You can get more detailed
 information on default locations in the Go documentation for [os.TempDir](https://golang.org/pkg/os/#TempDir).
 If you need to change this location, you can do so by setting the `TMPDIR` environment


### PR DESCRIPTION
### Description

snapshot: some improvments to the snapshot process

- Add `raft` to the snapshot logger because the log messages are from raft package, making it consistent with other snapshot logs like `starting snapshot up to`, which are from the raft package as well. Also it allows users know where to search for the logger message

```
// before
2023-05-08T10:10:19.954-0400 [INFO]  agent.server.raft: starting snapshot up to: index=30
2023-05-08T10:10:19.954-0400 [INFO]  agent.server.snapshot: creating new snapshot: path=/tmp/dc-2-consul-server-1/raft/snapshots/3-30-1683555019954.tmp
2023-05-08T10:10:19.967-0400 [INFO]  agent.server.raft: snapshot complete up to: index=30

// after
2023-05-08T10:04:20.361-0400 [INFO]  agent.server.raft: starting snapshot up to: index=25
2023-05-08T10:04:20.361-0400 [INFO]  agent.server.raft.snapshot: creating new snapshot: path=/tmp/dc-2-consul-server-1/raft/snapshots/2-25-1683554660361.tmp
2023-05-08T10:04:20.382-0400 [INFO]  agent.server.raft: snapshot complete up to: index=25
2023-05-08T10:04:20.382-0400 [INFO]  agent.server: creating temporary file of snapshot: path=/var/folders/c0/0_4qftyd47g8bkq_4_5dpw4m0000gn/T/snapshot3125735996
```

- Print out the path of the temp snapshot file for trouble shooting

- Update the doc a bit

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
