### PR TITLE
chore(ci): fix backport assistant branch creation race

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -19,7 +19,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.0
+    container: hashicorpdev/backport-assistant:0.3.3
     steps:
       - name: Run Backport Assistant for release branches
         run: |


### PR DESCRIPTION
### Description

A new patch for `backport-assistant` was released to deal with a race in creating the new branch and pushing the PR. For a single PR, this may appear as an error pushing a reference that doesn't exist. For multiple backports, I suspect that it manifests itself as applying the cherry-picked commits on top of the previously checked-out branch.

