### PR TITLE
proto: clear out old ratelimit.tmp files before making new ones

### DIFF
--- a/build-support/scripts/protobuf.sh
+++ b/build-support/scripts/protobuf.sh
@@ -45,6 +45,9 @@ function main {
         esac
     done
 
+    # clear old ratelimit.tmp files
+    find . -name .ratelimit.tmp -delete
+
     local mods=$(find . -name 'buf.gen.yaml' -exec dirname {} \; | sort)
     for mod in $mods
     do


### PR DESCRIPTION
### Description

This will ensure that we don't use stale `.ratelimit.tmp` files from prior runs or branches.
