### PR TITLE
fix(connect envoy): set initial_fetch_timeout to wait for initial xDS…

### DIFF
--- a/.changelog/17317.txt
+++ b/.changelog/17317.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: fix bug with Envoy starting with partial configuration by wait indefinitely for complete, initial xDS configuration.
+```

--- a/.changelog/17317.txt
+++ b/.changelog/17317.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-connect: fix bug with Envoy starting with partial configuration by wait indefinitely for complete, initial xDS configuration.
+connect: fix a bug with Envoy potentially starting with incomplete configuration by not waiting enough for initial xDS configuration.
 ```

--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -281,10 +281,12 @@ const bootstrapTemplate = `{
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/CONSUL_GRPC_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_GRPC_ADDR-with-https-scheme-enables-tls.golden
@@ -197,10 +197,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-does-not-affect-grpc-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-does-not-affect-grpc-tls.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/access-logs-enabled-custom.golden
+++ b/command/connect/envoy/testdata/access-logs-enabled-custom.golden
@@ -197,10 +197,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/access-logs-enabled.golden
+++ b/command/connect/envoy/testdata/access-logs-enabled.golden
@@ -219,10 +219,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/acl-enabled-and-token.golden
+++ b/command/connect/envoy/testdata/acl-enabled-and-token.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/acl-enabled-but-no-token.golden
+++ b/command/connect/envoy/testdata/acl-enabled-but-no-token.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-PLAIN-and-CONSUL_GRPC_ADDR-TLS-is-tls.golden
+++ b/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-PLAIN-and-CONSUL_GRPC_ADDR-TLS-is-tls.golden
@@ -197,10 +197,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-TLS-and-CONSUL_GRPC_ADDR-PLAIN-is-plain.golden
+++ b/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-TLS-and-CONSUL_GRPC_ADDR-PLAIN-is-plain.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/defaults-nodemeta.golden
+++ b/command/connect/envoy/testdata/defaults-nodemeta.golden
@@ -185,10 +185,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/envoy-readiness-probe.golden
+++ b/command/connect/envoy/testdata/envoy-readiness-probe.golden
@@ -273,10 +273,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -197,10 +197,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/existing-ca-path.golden
+++ b/command/connect/envoy/testdata/existing-ca-path.golden
@@ -197,10 +197,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -206,10 +206,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -197,10 +197,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/grpc-addr-unix-with-tls.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix-with-tls.golden
@@ -196,10 +196,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -183,10 +183,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/grpc-tls-addr-config.golden
+++ b/command/connect/envoy/testdata/grpc-tls-addr-config.golden
@@ -197,10 +197,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/hcp-metrics.golden
+++ b/command/connect/envoy/testdata/hcp-metrics.golden
@@ -221,10 +221,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
@@ -273,10 +273,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
@@ -273,10 +273,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/ingress-gateway-nodemeta.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-nodemeta.golden
@@ -274,10 +274,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
@@ -273,10 +273,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
@@ -273,10 +273,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/ingress-gateway.golden
+++ b/command/connect/envoy/testdata/ingress-gateway.golden
@@ -273,10 +273,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/prometheus-metrics-tls-ca-file.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics-tls-ca-file.golden
@@ -310,10 +310,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/prometheus-metrics-tls-ca-path.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics-tls-ca-path.golden
@@ -310,10 +310,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/prometheus-metrics.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics.golden
@@ -273,10 +273,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/stats-config-override.golden
+++ b/command/connect/envoy/testdata/stats-config-override.golden
@@ -62,10 +62,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/xds-addr-config.golden
+++ b/command/connect/envoy/testdata/xds-addr-config.golden
@@ -184,10 +184,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -217,10 +217,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {


### PR DESCRIPTION
### Description

Consul updates for #17283. Consul dataplane updates to follow.

This changes the time Envoy waits for the initial xDS configuration from the default (15s) to indefinitely. This prevents Envoy from starting with only a partial list of listeners/clusters.

### Testing & Reproduction steps

Goldenfile tests have been updated since this affects Envoy's bootstrap configuration.

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] appropriate backport labels added
* [X] not a security concern
