### PR TITLE
upgrade test: fix on-the-fly-image build and downsize runner

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -514,7 +514,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
   
   upgrade-integration-test:
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
     needs:
       - setup
       - dev-build
@@ -548,6 +548,8 @@ jobs:
         run: docker build -t consul-envoy:latest-version --build-arg CONSUL_IMAGE=docker.mirror.hashicorp.services/${{ env.CONSUL_LATEST_IMAGE_NAME }}:${{ env.CONSUL_LATEST_VERSION }} --build-arg ENVOY_VERSION=${{ env.ENVOY_VERSION }} -f ./test/integration/consul-container/assets/Dockerfile-consul-envoy ./test/integration/consul-container/assets
       - name: Build consul-envoy:target-version image
         run: docker build -t consul-envoy:target-version --build-arg CONSUL_IMAGE=${{ env.CONSUL_LATEST_IMAGE_NAME }}:local --build-arg ENVOY_VERSION=${{ env.ENVOY_VERSION }} -f ./test/integration/consul-container/assets/Dockerfile-consul-envoy ./test/integration/consul-container/assets
+      - name: Build sds image
+        run: docker build -t consul-sds-server ./test/integration/connect/envoy/test-sds-server/
       - name: Configure GH workaround for ipv6 loopback
         if: ${{ !endsWith(github.repository, '-enterprise') }}
         run: |
@@ -566,7 +568,7 @@ jobs:
             --raw-command \
             --format=short-verbose \
             --debug \
-            --rerun-fails=3 \
+            --rerun-fails=2 \
             --packages="./..." \
             -- \
             go test \

--- a/test/integration/consul-container/test/upgrade/ingress_gateway_sds_test.go
+++ b/test/integration/consul-container/test/upgrade/ingress_gateway_sds_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 const sdsServerPort = 1234
@@ -313,10 +314,8 @@ func createSDSServer(t *testing.T, cluster *libcluster.Cluster) (containerName s
 	_, err = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		Started: true,
 		ContainerRequest: testcontainers.ContainerRequest{
-			FromDockerfile: testcontainers.FromDockerfile{
-				Context: sdsServerFilesPath,
-			},
-			Name: containerName,
+			Image: "consul-sds-server",
+			Name:  containerName,
 			Networks: []string{
 				cluster.NetworkName,
 			},
@@ -332,6 +331,7 @@ func createSDSServer(t *testing.T, cluster *libcluster.Cluster) (containerName s
 					ReadOnly: true,
 				},
 			},
+			WaitingFor: wait.ForLog("").WithStartupTimeout(60 * time.Second),
 		},
 	})
 	require.NoError(t, err, "create SDS server container")


### PR DESCRIPTION
### Description

Fix another on-the-fly image build in integ test and downsize the runner.

Since we change the image in integ test, the change is needed for the GHA config.


### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
