### PR TITLE
Move envoy_hcp_metrics_bind_socket_dir to proxies docs

### DIFF
--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -75,10 +75,6 @@ Usage: `consul connect envoy [options] [-- pass-through options]`
   In cases where either assumption is violated this flag will prevent the
   command attempting to resolve config from the local agent.
 
-- `-envoy_hcp_metrics_bind_socket_dir` - Specifies the directory where Envoy creates a unix socket. 
-  Envoy sends metrics to the socket so connected HCP collectors can collect them. 
-  The socket is not configured by default.
-
 - `-envoy-ready-bind-address` - By default the proxy does not have a readiness probe
   configured on it. This flag in conjunction with the `envoy-ready-bind-port` flag
   configures where the envoy readiness probe is configured on the proxy. A `/ready` HTTP

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -75,8 +75,8 @@ Usage: `consul connect envoy [options] [-- pass-through options]`
   In cases where either assumption is violated this flag will prevent the
   command attempting to resolve config from the local agent.
 
-- `envoy_hcp_metrics_bind_socket_dir` - Specifies the directory where Envoy creates a unix socket. 
-  Envoy sends metrics to the socket so that HCP collectors can connect to collect them." 
+- `-envoy_hcp_metrics_bind_socket_dir` - Specifies the directory where Envoy creates a unix socket. 
+  Envoy sends metrics to the socket so connected HCP collectors can collect them. 
   The socket is not configured by default.
 
 - `-envoy-ready-bind-address` - By default the proxy does not have a readiness probe

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -170,6 +170,10 @@ the [`sidecar_service`](/consul/docs/connect/registration/sidecar-service) block
   - As well as `udp://`, a `unix://` URL may be specified if your agent can
     listen on a unix socket (e.g. the dogstatsd agent).
 
+- `envoy_hcp_metrics_bind_socket_dir` - Specifies the directory where Envoy creates a unix socket. 
+  Envoy sends metrics to the socket from which HCP collectors collect them. 
+  The socket is not configured by default.
+
 - `envoy_prometheus_bind_addr` - Specifies that the proxy should expose a Prometheus
   metrics endpoint to the _public_ network. It must be supplied in the form
   `ip:port` and port and the ip/port combination must be free within the network


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

This moves the `envoy_hcp_metrics_bind_socket_dir` docs into the proxy config section from the `consul envoy connect` docs.

From:https://developer.hashicorp.com/consul/commands/connect/envoy#envoy_hcp_metrics_bind_socket_dir

To: https://developer.hashicorp.com/consul/docs/connect/proxies/envoy#control-bootstrap-configuration-from-proxy-configuration

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
