### PR TITLE
Pull virtual IPs for filter chains from discovery chains

### DIFF
--- a/agent/proxycfg/testing_tproxy.go
+++ b/agent/proxycfg/testing_tproxy.go
@@ -22,7 +22,16 @@ func TestConfigSnapshotTransparentProxy(t testing.T) *ConfigSnapshot {
 	var (
 		google      = structs.NewServiceName("google", nil)
 		googleUID   = NewUpstreamIDFromServiceName(google)
-		googleChain = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", nil, nil)
+		googleChain = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", func(req *discoverychain.CompileRequest) {
+			req.AutoVirtualIPs = []string{"240.0.0.1"}
+			req.ManualVirtualIPs = []string{"10.0.0.1"}
+		}, nil)
+
+		googleV2      = structs.NewServiceName("google-v2", nil)
+		googleUIDV2   = NewUpstreamIDFromServiceName(googleV2)
+		googleChainV2 = discoverychain.TestCompileConfigEntries(t, "google-v2", "default", "default", "dc1", connect.TestClusterID+".consul", func(req *discoverychain.CompileRequest) {
+			req.ManualVirtualIPs = []string{"10.10.10.10"}
+		}, nil)
 
 		noEndpoints      = structs.NewServiceName("no-endpoints", nil)
 		noEndpointsUID   = NewUpstreamIDFromServiceName(noEndpoints)
@@ -60,6 +69,12 @@ func TestConfigSnapshotTransparentProxy(t testing.T) *ConfigSnapshot {
 			},
 		},
 		{
+			CorrelationID: "discovery-chain:" + googleUIDV2.String(),
+			Result: &structs.DiscoveryChainResponse{
+				Chain: googleChainV2,
+			},
+		},
+		{
 			CorrelationID: "discovery-chain:" + noEndpointsUID.String(),
 			Result: &structs.DiscoveryChainResponse{
 				Chain: noEndpointsChain,
@@ -78,10 +93,6 @@ func TestConfigSnapshotTransparentProxy(t testing.T) *ConfigSnapshot {
 							Service: "google",
 							Address: "9.9.9.9",
 							Port:    9090,
-							TaggedAddresses: map[string]structs.ServiceAddress{
-								"virtual":                      {Address: "10.0.0.1"},
-								structs.TaggedAddressVirtualIP: {Address: "240.0.0.1"},
-							},
 						},
 					},
 				},
@@ -100,9 +111,6 @@ func TestConfigSnapshotTransparentProxy(t testing.T) *ConfigSnapshot {
 						},
 						Service: &structs.NodeService{
 							Service: "google-v2",
-							TaggedAddresses: map[string]structs.ServiceAddress{
-								"virtual": {Address: "10.10.10.10"},
-							},
 						},
 					},
 				},
@@ -255,7 +263,9 @@ func TestConfigSnapshotTransparentProxyCatalogDestinationsOnly(t testing.T) *Con
 	var (
 		google      = structs.NewServiceName("google", nil)
 		googleUID   = NewUpstreamIDFromServiceName(google)
-		googleChain = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", nil, nil)
+		googleChain = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", func(req *discoverychain.CompileRequest) {
+			req.ManualVirtualIPs = []string{"10.0.0.1"}
+		}, nil)
 
 		noEndpoints      = structs.NewServiceName("no-endpoints", nil)
 		noEndpointsUID   = NewUpstreamIDFromServiceName(noEndpoints)
@@ -315,9 +325,6 @@ func TestConfigSnapshotTransparentProxyCatalogDestinationsOnly(t testing.T) *Con
 							Service: "google",
 							Address: "9.9.9.9",
 							Port:    9090,
-							TaggedAddresses: map[string]structs.ServiceAddress{
-								"virtual": {Address: "10.0.0.1"},
-							},
 						},
 					},
 				},
@@ -352,7 +359,9 @@ func TestConfigSnapshotTransparentProxyDialDirectly(t testing.T) *ConfigSnapshot
 
 		mongo      = structs.NewServiceName("mongo", nil)
 		mongoUID   = NewUpstreamIDFromServiceName(mongo)
-		mongoChain = discoverychain.TestCompileConfigEntries(t, "mongo", "default", "default", "dc1", connect.TestClusterID+".consul", nil, set)
+		mongoChain = discoverychain.TestCompileConfigEntries(t, "mongo", "default", "default", "dc1", connect.TestClusterID+".consul", func(req *discoverychain.CompileRequest) {
+			req.ManualVirtualIPs = []string{"6.6.6.6"}
+		}, set)
 
 		db = structs.NewServiceName("db", nil)
 	)
@@ -404,9 +413,6 @@ func TestConfigSnapshotTransparentProxyDialDirectly(t testing.T) *ConfigSnapshot
 							Service: "mongo",
 							Address: "10.10.10.10",
 							Port:    27017,
-							TaggedAddresses: map[string]structs.ServiceAddress{
-								"virtual": {Address: "6.6.6.6"},
-							},
 							Proxy: structs.ConnectProxyConfig{
 								TransparentProxy: structs.TransparentProxyConfig{
 									DialedDirectly: true,
@@ -422,9 +428,6 @@ func TestConfigSnapshotTransparentProxyDialDirectly(t testing.T) *ConfigSnapshot
 							Service: "mongo",
 							Address: "10.10.10.12",
 							Port:    27017,
-							TaggedAddresses: map[string]structs.ServiceAddress{
-								"virtual": {Address: "6.6.6.6"},
-							},
 							Proxy: structs.ConnectProxyConfig{
 								TransparentProxy: structs.TransparentProxyConfig{
 									DialedDirectly: true,
@@ -477,7 +480,10 @@ func TestConfigSnapshotTransparentProxyResolverRedirectUpstream(t testing.T) *Co
 
 		google      = structs.NewServiceName("google", nil)
 		googleUID   = NewUpstreamIDFromServiceName(google)
-		googleChain = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", nil, nil)
+		googleChain = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", func(req *discoverychain.CompileRequest) {
+			req.AutoVirtualIPs = []string{"240.0.0.1"}
+			req.ManualVirtualIPs = []string{"10.0.0.1"}
+		}, nil)
 	)
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
@@ -517,10 +523,6 @@ func TestConfigSnapshotTransparentProxyResolverRedirectUpstream(t testing.T) *Co
 							Service: "google",
 							Address: "9.9.9.9",
 							Port:    9090,
-							TaggedAddresses: map[string]structs.ServiceAddress{
-								"virtual":                      {Address: "10.0.0.1"},
-								structs.TaggedAddressVirtualIP: {Address: "240.0.0.1"},
-							},
 						},
 					},
 				},
@@ -535,11 +537,15 @@ func TestConfigSnapshotTransparentProxyTerminatingGatewayCatalogDestinationsOnly
 	var (
 		google      = structs.NewServiceName("google", nil)
 		googleUID   = NewUpstreamIDFromServiceName(google)
-		googleChain = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", nil, nil)
+		googleChain = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", func(req *discoverychain.CompileRequest) {
+			req.ManualVirtualIPs = []string{"10.0.0.1"}
+		}, nil)
 
 		kafka      = structs.NewServiceName("kafka", nil)
 		kafkaUID   = NewUpstreamIDFromServiceName(kafka)
-		kafkaChain = discoverychain.TestCompileConfigEntries(t, "kafka", "default", "default", "dc1", connect.TestClusterID+".consul", nil, nil)
+		kafkaChain = discoverychain.TestCompileConfigEntries(t, "kafka", "default", "default", "dc1", connect.TestClusterID+".consul", func(req *discoverychain.CompileRequest) {
+			req.ManualVirtualIPs = []string{"10.0.0.2"}
+		}, nil)
 
 		db = structs.NewServiceName("db", nil)
 	)
@@ -557,8 +563,6 @@ func TestConfigSnapshotTransparentProxyTerminatingGatewayCatalogDestinationsOnly
 			Address: "9.9.9.9",
 			Port:    9090,
 			TaggedAddresses: map[string]structs.ServiceAddress{
-				structs.ServiceGatewayVirtualIPTag(google): {Address: "10.0.0.1"},
-				structs.ServiceGatewayVirtualIPTag(kafka):  {Address: "10.0.0.2"},
 				"virtual": {Address: "6.6.6.6"},
 			},
 		},

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -228,6 +228,15 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		endpoints := cfgSnap.ConnectProxy.WatchedUpstreamEndpoints[uid][chain.ID()]
 		uniqueAddrs := make(map[string]struct{})
 
+		if chain.Partition == cfgSnap.ProxyID.PartitionOrDefault() {
+			for _, ip := range chain.AutoVirtualIPs {
+				uniqueAddrs[ip] = struct{}{}
+			}
+			for _, ip := range chain.ManualVirtualIPs {
+				uniqueAddrs[ip] = struct{}{}
+			}
+		}
+
 		// Match on the virtual IP for the upstream service (identified by the chain's ID).
 		// We do not match on all endpoints here since it would lead to load balancing across
 		// all instances when any instance address is dialed.

--- a/agent/xds/testdata/listeners/transparent-proxy-with-resolver-redirect-upstream.latest.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-with-resolver-redirect-upstream.latest.golden
@@ -124,9 +124,7 @@
               "name": "envoy.filters.network.rbac",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                "rules": {
-
-                },
+                "rules": {},
                 "statPrefix": "connect_authz"
               }
             },
@@ -144,9 +142,7 @@
             "typedConfig": {
               "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
               "commonTlsContext": {
-                "tlsParams": {
-
-                },
+                "tlsParams": {},
                 "tlsCertificates": [
                   {
                     "certificateChain": {


### PR DESCRIPTION
This PR is a follow-up to previous work that adds logic in `xds` to pull virtual IPs from discovery chains - including both auto-assigned and manually set (such as cluster IPs via kubernetes).