### PR TITLE
resource: add `AuthorizerContext` helper method

### DIFF
--- a/internal/resource/authz_oss.go
+++ b/internal/resource/authz_oss.go
@@ -1,0 +1,17 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !consulent
+// +build !consulent
+
+package resource
+
+import (
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+// AuthorizerContext builds an ACL AuthorizerContext for the given tenancy.
+func AuthorizerContext(t *pbresource.Tenancy) *acl.AuthorizerContext {
+	return &acl.AuthorizerContext{Peer: t.PeerName}
+}


### PR DESCRIPTION
### Description

While writing up a developer guide for resources/controllers, I realised that it'd be helpful to have an easy way to construct an `AuthorizerContext` for use in ACL hooks - particularly as this struct is different in the OSS and Enterprise repositories.
