### PR TITLE
updates to links in services overview description paragraph

### DIFF
--- a/website/content/docs/services/services.mdx
+++ b/website/content/docs/services/services.mdx
@@ -6,14 +6,20 @@ description: >-
 ---
 
 # Services overview
-This topic provides overview information about services and how to make them discoverable in Consul when your network operates on virtual machines. If service mesh is enabled in your network, refer to the topics in [Consul service mesh](/consul/docs/connect/). If your network is running in Kubernetes, refer to the topics in [Consul on Kubernetes](/consul/docs/k8s). 
+
+This topic provides overview information about services and how to make them discoverable in Consul when your network operates on virtual machines. If service mesh is enabled in your network, refer to the following articles for additional information about connecting services in a mesh:
+
+- [How Service Mesh Works](/consul/docs/connect/connect-internals) 
+- [How Consul Service Mesh Works on Kubernetes](/consul/docs/k8s/connect)
 
 ## Introduction
+
 A _service_ is an entity in your network that performs a specialized operation or set of related operations. In many contexts, a service is software that you want to make available to users or other programs with access to your network. Services can also refer to native Consul functionality, such as _service mesh proxies_ and _gateways_, that enable you to establish connections between different parts of your network. 
 
 You can define and register services with Consul, which makes them discoverable to other services in the network. You can also define various types of health checks that perform several safety functions, such as allowing a web balancer to gracefully remove failing nodes and allowing a database to replace a failed secondary.
 
 ## Workflow
+
 For service discovery, the core Consul workflow for services consists of three stages:
 
 1. **Define services and health checks**: A service definition lets you define various aspects of the service, including how it is discovered by other services in the network. You can define health checks in the service definitions to verify the health of the service. Refer to [Define Services](/consul/docs/services/usage/define-services) and [Define Health Checks](/consul/docs/services/usage/checks) for additional information.
@@ -24,16 +30,20 @@ For service discovery, the core Consul workflow for services consists of three s
 
 
 ## Service mesh use cases
+
 Consul redirects service traffic through sidecar proxies if you use Consul service mesh. As a result, you must specify upstream configurations in service definitions. The service mesh experience is different for virtual machine (VM) and Kubernetes environments.
 
 ### Virtual machines
+
 You must define upstream services in the service definition. Consul uses the upstream configuration to bind the service with its upstreams. After registering the service, you must start a sidecar proxy on the VM to enable mesh connectivity. Refer to [Register a Service Mesh Proxy in a Service Registration](/consul/docs/connect/registration/sidecar-service) for details.
 
 ### Kubernetes 
+
 If you use Consul on Kubernetes, enable the service mesh injector in your Consul Helm chart and Consul automatically adds a sidecar to each of your pods using the Kubernetes `Service` definition as a reference. You can specify upstream annotations in the `Deployment` definition to bind upstream services to the pods.
 Refer to [`connectInject`](/consul/docs/k8s/connect#installation-and-configuration) and [the upstreams annotation documentation](/consul/docs/k8s/annotations-and-labels#consul-hashicorp-com-connect-service-upstreams) for additional information.
 
 ### Multiple services
+
 You can define common characteristics for services in your mesh, such as the admin partition, namespace, or upstreams, by creating and applying a `service-defaults` configuration entry. You can also define override configurations for specific upstreams or service instances. To use `service-defaults` configuraiton entries, you must enable Consul service mesh in your network.
 
 Refer to [Define Service Defaults](/consul/docs/services/usage/define-services#define-service-defaults) for additional information.


### PR DESCRIPTION
### Description

Small tweaks to the description block on the _Services overview_ page. The description now points to additional overview information about how services work in SM and SM on K8s.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
