### PR TITLE
Allow resource updates to omit an owner refs UID

### DIFF
--- a/agent/grpc-external/services/resource/write_test.go
+++ b/agent/grpc-external/services/resource/write_test.go
@@ -571,6 +571,25 @@ func TestWrite_Owner_Uid(t *testing.T) {
 		require.NotEmpty(t, rsp2.Resource.Owner.Uid)
 		require.Equal(t, artist.Id.Uid, rsp2.Resource.Owner.Uid)
 	})
+
+	t.Run("no-uid - update auto resolve", func(t *testing.T) {
+		artist, err := demo.GenerateV2Artist()
+		require.NoError(t, err)
+
+		uid := ulid.Make().String()
+		album, err := demo.GenerateV2Album(artist.Id)
+		require.NoError(t, err)
+		album.Owner.Uid = uid
+
+		_, err = client.Write(testContext(t), &pbresource.WriteRequest{Resource: album})
+		require.NoError(t, err)
+
+		// unset the uid and rewrite the resource
+		album.Owner.Uid = ""
+		rsp, err := client.Write(testContext(t), &pbresource.WriteRequest{Resource: album})
+		require.NoError(t, err)
+		require.Equal(t, uid, rsp.GetResource().GetOwner().GetUid())
+	})
 }
 
 type blockOnceBackend struct {


### PR DESCRIPTION
### Description

This change enables workflows where you are reapplying a resource that should have an owner ref to publish modifications to the resources data without performing a read to figure out the current owner resource incarnations UID.

Basically we want workflows similar to `kubectl apply` or `consul config write` to be able to work seamlessly even for owned resources.

In these cases the users intention is to have the resource owned by the “current” incarnation of the owner resource.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
