### PR TITLE
[Release/1.15.x] net 3914 gha consul container test no splitting

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -343,50 +343,16 @@ jobs:
           DD_ENV: ci
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" $TEST_RESULTS_DIR/results.xml
 
-  generate-compatibility-job-matrices:
-    needs: [setup]
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-    name: Generate Compatibility Job Matrices
-    outputs:
-      compatibility-matrix: ${{ steps.set-matrix.outputs.compatibility-matrix }}
-    steps:
-      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
-      - name: Generate Compatibility Job Matrix
-        id: set-matrix
-        env:
-          TOTAL_RUNNERS: 6
-          JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
-        run: |
-          cd ./test/integration/consul-container
-          NUM_RUNNERS=$TOTAL_RUNNERS
-          NUM_DIRS=$(find ./test -mindepth 1 -maxdepth 2 -type d | wc -l)
-
-          if [ "$NUM_DIRS" -lt "$NUM_RUNNERS" ]; then
-            echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
-            NUM_RUNNERS=$((NUM_DIRS-1))
-          fi
-          # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          NUM_RUNNERS=$((NUM_RUNNERS-1))
-          {
-            echo -n "compatibility-matrix="
-            find ./test -maxdepth 2 -type d -print0 | xargs -0 -n 1 \
-              | grep -v util | grep -v upgrade \
-              | jq --raw-input --argjson runnercount "$NUM_RUNNERS" "$JQ_SLICER" \
-              | jq --compact-output 'map(join(" "))'
-          } >> "$GITHUB_OUTPUT"
   compatibility-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     needs:
       - setup
       - dev-build
-      - generate-compatibility-job-matrices
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        test-cases: ${{ fromJSON(needs.generate-compatibility-job-matrices.outputs.compatibility-matrix) }}
+    env:
+      ENVOY_VERSION: "1.24.6"
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
@@ -402,7 +368,6 @@ jobs:
           path: .
       - name: restore mode+x
         run: chmod +x consul
-
       - name: Build consul:local image
         run: docker build -t ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local -f ./build-support/docker/Consul-Dev.dockerfile .
       - name: Configure GH workaround for ipv6 loopback
@@ -416,21 +381,18 @@ jobs:
             mkdir -p "/tmp/test-results"
             cd ./test/integration/consul-container
             docker run --rm ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local consul version
-            echo "Running $(sed 's,|, ,g' <<< "${{ matrix.test-cases }}" |wc -w) subtests"
-            # shellcheck disable=SC2001
-            sed 's, ,\n,g' <<< "${{ matrix.test-cases }}"
             go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
               --raw-command \
-              --format=short-verbose \
+              --format=standard-verbose \
               --debug \
               --rerun-fails=3 \
               -- \
               go test \
-              -p=4 \
+              -p=6 \
               -tags "${{ env.GOTAGS }}" \
               -timeout=30m \
               -json \
-              ${{ matrix.test-cases }} \
+              `go list ./... | grep -v upgrade` \
               --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
               --target-version local \
               --latest-image docker.mirror.hashicorp.services/${{ env.CONSUL_LATEST_IMAGE_NAME }} \
@@ -474,53 +436,19 @@ jobs:
           DD_ENV: ci
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" $TEST_RESULTS_DIR/results.xml
 
-  generate-upgrade-job-matrices:
-    needs: [setup]
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-    name: Generate Upgrade Job Matrices
-    outputs:
-      upgrade-matrix: ${{ steps.set-matrix.outputs.upgrade-matrix }}
-    steps:
-      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
-      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version-file: 'go.mod'
-      - name: Generate Updgrade Job Matrix
-        id: set-matrix
-        env:
-          TOTAL_RUNNERS: 5
-          JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
-        run: |
-          cd ./test/integration/consul-container/test/upgrade
-          NUM_RUNNERS=$TOTAL_RUNNERS
-          NUM_DIRS=$(go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | gsub("[\\n\\t]"; "")' | wc -l)
-          
-          if [ "$NUM_DIRS" -lt "$NUM_RUNNERS" ]; then
-            echo "TOTAL_RUNNERS is larger than the number of tests/packages to split."
-            NUM_RUNNERS=$((NUM_DIRS-1))
-          fi
-          # fix issue where test splitting calculation generates 1 more split than TOTAL_RUNNERS.
-          NUM_RUNNERS=$((NUM_RUNNERS-1))
-          {
-            echo -n "upgrade-matrix="
-            go test ./...  -list=. -json | jq -r '.Output | select (. !=null) |  select(. | startswith("Test")) | gsub("[\\n\\t]"; "")' \
-            | jq --raw-input --argjson runnercount "$NUM_RUNNERS" "$JQ_SLICER" \
-            | jq --compact-output 'map(join("|"))'
-          } >> "$GITHUB_OUTPUT"
   
   upgrade-integration-test:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     needs:
       - setup
       - dev-build
-      - generate-upgrade-job-matrices
     strategy:
       fail-fast: false
       matrix:
         consul-version: [ "1.14", "1.15"]
-        test-cases: ${{ fromJSON(needs.generate-upgrade-job-matrices.outputs.upgrade-matrix) }}
     env:
-      CONSUL_VERSION: ${{ matrix.consul-version }}
+      CONSUL_LATEST_VERSION: ${{ matrix.consul-version }}
+      ENVOY_VERSION: "1.24.6"
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
@@ -549,9 +477,6 @@ jobs:
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"
           cd ./test/integration/consul-container/test/upgrade
           docker run --rm ${{ env.CONSUL_LATEST_IMAGE_NAME }}:local consul version
-          echo "Running $(sed 's,|, ,g' <<< "${{ matrix.test-cases }}" |wc -w) subtests"
-          # shellcheck disable=SC2001
-          sed 's,|,\n,g' <<< "${{ matrix.test-cases }}"
           go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
             --raw-command \
             --format=short-verbose \
@@ -564,11 +489,10 @@ jobs:
             -tags "${{ env.GOTAGS }}" \
             -timeout=30m \
             -json ./... \
-            -run "${{ matrix.test-cases }}" \
             --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
             --target-version local \
-            --latest-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
-            --latest-version "${{ env.CONSUL_VERSION }}"
+            --latest-image docker.mirror.hashicorp.services/${{ env.CONSUL_LATEST_IMAGE_NAME }} \
+            --latest-version "${{ env.CONSUL_LATEST_VERSION }}"
           ls -lrt
         env:
           # this is needed because of incompatibility between RYUK container and GHA
@@ -590,9 +514,7 @@ jobs:
     - vault-integration-test
     - generate-envoy-job-matrices
     - envoy-integration-test
-    - generate-compatibility-job-matrices
     - compatibility-integration-test
-    - generate-upgrade-job-matrices
     - upgrade-integration-test
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
     if: ${{ always() }}

--- a/test/integration/consul-container/libs/service/connect.go
+++ b/test/integration/consul-container/libs/service/connect.go
@@ -182,7 +182,7 @@ func NewConnectService(ctx context.Context, sidecarCfg SidecarConfig, serviceBin
 
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: dockerfileCtx,
-		WaitingFor:     wait.ForLog("").WithStartupTimeout(10 * time.Second),
+		WaitingFor:     wait.ForLog("").WithStartupTimeout(100 * time.Second),
 		AutoRemove:     false,
 		Name:           containerName,
 		Cmd: []string{

--- a/test/integration/consul-container/libs/service/examples.go
+++ b/test/integration/consul-container/libs/service/examples.go
@@ -150,7 +150,7 @@ func NewExampleService(ctx context.Context, name string, httpPort int, grpcPort 
 
 	req := testcontainers.ContainerRequest{
 		Image:      hashicorpDockerProxy + "/fortio/fortio",
-		WaitingFor: wait.ForLog("").WithStartupTimeout(10 * time.Second),
+		WaitingFor: wait.ForLog("").WithStartupTimeout(100 * time.Second),
 		AutoRemove: false,
 		Name:       containerName,
 		Cmd:        command,

--- a/test/integration/consul-container/libs/service/gateway.go
+++ b/test/integration/consul-container/libs/service/gateway.go
@@ -174,7 +174,7 @@ func NewGatewayService(ctx context.Context, gwCfg GatewayConfig, node libcluster
 
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: dockerfileCtx,
-		WaitingFor:     wait.ForLog("").WithStartupTimeout(10 * time.Second),
+		WaitingFor:     wait.ForLog("").WithStartupTimeout(100 * time.Second),
 		AutoRemove:     false,
 		Name:           containerName,
 		Cmd: []string{

--- a/test/integration/consul-container/libs/topology/peering_topology.go
+++ b/test/integration/consul-container/libs/topology/peering_topology.go
@@ -29,6 +29,13 @@ type BuiltCluster struct {
 	Gateway   libservice.Service
 }
 
+type PeeringClusterSize struct {
+	AcceptingNumServers int
+	AcceptingNumClients int
+	DialingNumServers   int
+	DialingNumClients   int
+}
+
 // BasicPeeringTwoClustersSetup sets up a scenario for testing peering, which consists of
 //
 //   - an accepting cluster with 3 servers and 1 client agent. The client should be used to
@@ -43,11 +50,12 @@ func BasicPeeringTwoClustersSetup(
 	t *testing.T,
 	consulImage string,
 	consulVersion string,
+	pcs PeeringClusterSize,
 	peeringThroughMeshgateway bool,
 ) (*BuiltCluster, *BuiltCluster) {
 	acceptingCluster, acceptingCtx, acceptingClient := NewCluster(t, &ClusterConfig{
-		NumServers: 3,
-		NumClients: 1,
+		NumServers: pcs.AcceptingNumServers,
+		NumClients: pcs.AcceptingNumClients,
 		BuildOpts: &libcluster.BuildOptions{
 			Datacenter:           "dc1",
 			ConsulImageName:      consulImage,
@@ -58,8 +66,8 @@ func BasicPeeringTwoClustersSetup(
 	})
 
 	dialingCluster, dialingCtx, dialingClient := NewCluster(t, &ClusterConfig{
-		NumServers: 1,
-		NumClients: 1,
+		NumServers: pcs.DialingNumServers,
+		NumClients: pcs.DialingNumClients,
 		BuildOpts: &libcluster.BuildOptions{
 			Datacenter:           "dc2",
 			ConsulImageName:      consulImage,

--- a/test/integration/consul-container/libs/utils/version.go
+++ b/test/integration/consul-container/libs/utils/version.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"flag"
+	"strings"
 
 	"github.com/hashicorp/go-version"
 )
@@ -43,7 +44,7 @@ func GetLatestImageName() string {
 
 func DockerImage(image, version string) string {
 	v := image + ":" + version
-	if image == DefaultImageNameENT && isSemVer(version) {
+	if strings.Contains(image, DefaultImageNameENT) && isSemVer(version) {
 		// Enterprise versions get a suffix.
 		v += ImageVersionSuffixENT
 	}

--- a/test/integration/consul-container/test/gateways/http_route_test.go
+++ b/test/integration/consul-container/test/gateways/http_route_test.go
@@ -504,8 +504,6 @@ func TestHTTPRouteParentRefChange(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	t.Parallel()
-
 	// infrastructure set up
 	address := "localhost"
 

--- a/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
+++ b/test/integration/consul-container/test/peering/rotate_server_and_ca_then_fail_test.go
@@ -50,7 +50,13 @@ import (
 func TestPeering_RotateServerAndCAThenFail_(t *testing.T) {
 	t.Parallel()
 
-	accepting, dialing := libtopology.BasicPeeringTwoClustersSetup(t, utils.GetTargetImageName(), utils.TargetVersion, false)
+	accepting, dialing := libtopology.BasicPeeringTwoClustersSetup(t, utils.GetTargetImageName(), utils.TargetVersion,
+		libtopology.PeeringClusterSize{
+			AcceptingNumServers: 3,
+			AcceptingNumClients: 1,
+			DialingNumServers:   1,
+			DialingNumClients:   1,
+		}, false)
 	var (
 		acceptingCluster     = accepting.Cluster
 		dialingCluster       = dialing.Cluster

--- a/test/integration/consul-container/test/upgrade/common.go
+++ b/test/integration/consul-container/test/upgrade/common.go
@@ -1,0 +1,81 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
+	libservice "github.com/hashicorp/consul/test/integration/consul-container/libs/service"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+)
+
+// CreateAndRegisterStaticClientSidecarWith2Upstreams creates a static-client that
+// has two upstreams connecting to destinationNames: local bind addresses are 5000
+// and 5001.
+// - crossCluster: true if upstream is in another cluster
+func CreateAndRegisterStaticClientSidecarWith2Upstreams(c *cluster.Cluster, destinationNames []string, crossCluster bool) (*libservice.ConnectContainer, error) {
+	// Do some trickery to ensure that partial completion is correctly torn
+	// down, but successful execution is not.
+	var deferClean utils.ResettableDefer
+	defer deferClean.Execute()
+
+	node := c.Servers()[0]
+	mgwMode := api.MeshGatewayModeLocal
+
+	// Register the static-client service and sidecar first to prevent race with sidecar
+	// trying to get xDS before it's ready
+	req := &api.AgentServiceRegistration{
+		Name: libservice.StaticClientServiceName,
+		Port: 8080,
+		Connect: &api.AgentServiceConnect{
+			SidecarService: &api.AgentServiceRegistration{
+				Proxy: &api.AgentServiceConnectProxyConfig{
+					Upstreams: []api.Upstream{
+						{
+							DestinationName:  destinationNames[0],
+							LocalBindAddress: "0.0.0.0",
+							LocalBindPort:    cluster.ServiceUpstreamLocalBindPort,
+						},
+						{
+							DestinationName:  destinationNames[1],
+							LocalBindAddress: "0.0.0.0",
+							LocalBindPort:    cluster.ServiceUpstreamLocalBindPort2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if crossCluster {
+		for _, upstream := range req.Connect.SidecarService.Proxy.Upstreams {
+			upstream.MeshGateway = api.MeshGatewayConfig{
+				Mode: mgwMode,
+			}
+		}
+	}
+
+	if err := node.GetClient().Agent().ServiceRegister(req); err != nil {
+		return nil, err
+	}
+
+	// Create a service and proxy instance
+	sidecarCfg := libservice.SidecarConfig{
+		Name:      fmt.Sprintf("%s-sidecar", libservice.StaticClientServiceName),
+		ServiceID: libservice.StaticClientServiceName,
+	}
+
+	clientConnectProxy, err := libservice.NewConnectService(context.Background(), sidecarCfg, []int{cluster.ServiceUpstreamLocalBindPort, cluster.ServiceUpstreamLocalBindPort2}, node)
+	if err != nil {
+		return nil, err
+	}
+	deferClean.Add(func() {
+		_ = clientConnectProxy.Terminate()
+	})
+
+	// disable cleanup functions now that we have an object with a Terminate() function
+	deferClean.Reset()
+
+	return clientConnectProxy, nil
+}

--- a/test/integration/consul-container/test/upgrade/fullstopupgrade_test.go
+++ b/test/integration/consul-container/test/upgrade/fullstopupgrade_test.go
@@ -16,7 +16,6 @@ import (
 
 // Test upgrade a cluster of latest version to the target version
 func TestStandardUpgradeToTarget_fromLatest(t *testing.T) {
-	t.Parallel()
 
 	type testcase struct {
 		oldversion    string

--- a/test/integration/consul-container/test/upgrade/peering/peering_control_plane_mgw_test.go
+++ b/test/integration/consul-container/test/upgrade/peering/peering_control_plane_mgw_test.go
@@ -1,4 +1,4 @@
-package upgrade
+package peering
 
 import (
 	"context"
@@ -42,7 +42,14 @@ func TestPeering_Upgrade_ControlPlane_MGW(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testcase) {
-		accepting, dialing := libtopology.BasicPeeringTwoClustersSetup(t, utils.GetLatestImageName(), tc.oldversion, true)
+		accepting, dialing := libtopology.BasicPeeringTwoClustersSetup(t, utils.GetLatestImageName(), utils.LatestVersion,
+			libtopology.PeeringClusterSize{
+				AcceptingNumServers: 1,
+				AcceptingNumClients: 1,
+				DialingNumServers:   1,
+				DialingNumClients:   1,
+			},
+			true)
 		var (
 			acceptingCluster = accepting.Cluster
 			dialingCluster   = dialing.Cluster


### PR DESCRIPTION
### Description
Manually backport https://github.com/hashicorp/consul/pull/17394 to remove test splitting for container integ tests

- no test splitting
- integ tests on a single runner

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
