### PR TITLE
Use original_dst filter instead of use_original_dst field

### DIFF
--- a/agent/xds/testdata/listeners/connect-proxy-with-tproxy-and-permissive-mtls.latest.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tproxy-and-permissive-mtls.latest.golden
@@ -153,7 +153,14 @@
           ]
         }
       ],
-      "useOriginalDst": true,
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.original_dst",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst"
+          }
+        }
+      ],
       "trafficDirection": "INBOUND"
     }
   ],


### PR DESCRIPTION
### Description

This switches to using the `original_dst` listener filter when permissive mTLS is configured. Envoy's `use_original_dst` field was [previously deprecated](https://github.com/envoyproxy/envoy/issues/5355) so we should avoid using it.

Also, only add the "permissive listener filter" when transparent proxy is enabled. Previously, the filter would be configured when transparent proxy was not enabled, and would simply have no effect without traffic redirection (iptables rules) in place. This ensures the filter is not configured unless tproxy is enabled.

### Testing & Reproduction steps

* Updated unit tests
* Run the Permissive mTLS integration test:

  ```shell
  $ make test-compat-integ-setup
  $ cd test/integration/consul-container
  $ go test -v -timeout=30m ./test/tproxy/ \
    -follow-log true \
    -target-image consul -target-version local \
    -latest-image consul -latest-version latest
  ```

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
