### PR TITLE
extract some config entry helpers into package

### DIFF
--- a/agent/configentry/compare.go
+++ b/agent/configentry/compare.go
@@ -1,0 +1,37 @@
+package configentry
+
+import (
+	"sort"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func SortSlice(configs []structs.ConfigEntry) {
+	sort.SliceStable(configs, func(i, j int) bool {
+		return Less(configs[i], configs[j])
+	})
+}
+
+func Less(first structs.ConfigEntry, second structs.ConfigEntry) bool {
+	if first.GetKind() < second.GetKind() {
+		return true
+	}
+	if first.GetKind() > second.GetKind() {
+		return false
+	}
+
+	if first.GetEnterpriseMeta().LessThan(second.GetEnterpriseMeta()) {
+		return true
+	}
+	if second.GetEnterpriseMeta().LessThan(first.GetEnterpriseMeta()) {
+		return false
+	}
+
+	return first.GetName() < second.GetName()
+}
+
+func EqualID(e1, e2 structs.ConfigEntry) bool {
+	return e1.GetKind() == e2.GetKind() &&
+		e1.GetEnterpriseMeta().IsSame(e2.GetEnterpriseMeta()) &&
+		e1.GetName() == e2.GetName()
+}

--- a/agent/configentry/compare_test.go
+++ b/agent/configentry/compare_test.go
@@ -1,0 +1,89 @@
+package configentry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func TestSortSlice(t *testing.T) {
+	newDefaults := func(name, protocol string) *structs.ServiceConfigEntry {
+		return &structs.ServiceConfigEntry{
+			Kind:     structs.ServiceDefaults,
+			Name:     name,
+			Protocol: protocol,
+		}
+	}
+	newResolver := func(name string, timeout time.Duration) *structs.ServiceResolverConfigEntry {
+		return &structs.ServiceResolverConfigEntry{
+			Kind:           structs.ServiceResolver,
+			Name:           name,
+			ConnectTimeout: timeout,
+		}
+	}
+
+	type testcase struct {
+		configs []structs.ConfigEntry
+		expect  []structs.ConfigEntry
+	}
+
+	cases := map[string]testcase{
+		"none": {},
+		"one": {
+			configs: []structs.ConfigEntry{
+				newDefaults("web", "grpc"),
+			},
+			expect: []structs.ConfigEntry{
+				newDefaults("web", "grpc"),
+			},
+		},
+		"just kinds": {
+			configs: []structs.ConfigEntry{
+				newResolver("web", 33*time.Second),
+				newDefaults("web", "grpc"),
+			},
+			expect: []structs.ConfigEntry{
+				newDefaults("web", "grpc"),
+				newResolver("web", 33*time.Second),
+			},
+		},
+		"just names": {
+			configs: []structs.ConfigEntry{
+				newDefaults("db", "grpc"),
+				newDefaults("api", "http2"),
+			},
+			expect: []structs.ConfigEntry{
+				newDefaults("api", "http2"),
+				newDefaults("db", "grpc"),
+			},
+		},
+		"all": {
+			configs: []structs.ConfigEntry{
+				newResolver("web", 33*time.Second),
+				newDefaults("web", "grpc"),
+				newDefaults("db", "grpc"),
+				newDefaults("api", "http2"),
+			},
+			expect: []structs.ConfigEntry{
+				newDefaults("api", "http2"),
+				newDefaults("db", "grpc"),
+				newDefaults("web", "grpc"),
+				newResolver("web", 33*time.Second),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			SortSlice(tc.configs)
+			require.Equal(t, tc.expect, tc.configs)
+			// and it should be stable
+			SortSlice(tc.configs)
+			require.Equal(t, tc.expect, tc.configs)
+		})
+	}
+}

--- a/agent/consul/config_replication_test.go
+++ b/agent/consul/config_replication_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -16,85 +15,6 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 )
-
-func TestReplication_ConfigSort(t *testing.T) {
-	newDefaults := func(name, protocol string) *structs.ServiceConfigEntry {
-		return &structs.ServiceConfigEntry{
-			Kind:     structs.ServiceDefaults,
-			Name:     name,
-			Protocol: protocol,
-		}
-	}
-	newResolver := func(name string, timeout time.Duration) *structs.ServiceResolverConfigEntry {
-		return &structs.ServiceResolverConfigEntry{
-			Kind:           structs.ServiceResolver,
-			Name:           name,
-			ConnectTimeout: timeout,
-		}
-	}
-
-	type testcase struct {
-		configs []structs.ConfigEntry
-		expect  []structs.ConfigEntry
-	}
-
-	cases := map[string]testcase{
-		"none": {},
-		"one": {
-			configs: []structs.ConfigEntry{
-				newDefaults("web", "grpc"),
-			},
-			expect: []structs.ConfigEntry{
-				newDefaults("web", "grpc"),
-			},
-		},
-		"just kinds": {
-			configs: []structs.ConfigEntry{
-				newResolver("web", 33*time.Second),
-				newDefaults("web", "grpc"),
-			},
-			expect: []structs.ConfigEntry{
-				newDefaults("web", "grpc"),
-				newResolver("web", 33*time.Second),
-			},
-		},
-		"just names": {
-			configs: []structs.ConfigEntry{
-				newDefaults("db", "grpc"),
-				newDefaults("api", "http2"),
-			},
-			expect: []structs.ConfigEntry{
-				newDefaults("api", "http2"),
-				newDefaults("db", "grpc"),
-			},
-		},
-		"all": {
-			configs: []structs.ConfigEntry{
-				newResolver("web", 33*time.Second),
-				newDefaults("web", "grpc"),
-				newDefaults("db", "grpc"),
-				newDefaults("api", "http2"),
-			},
-			expect: []structs.ConfigEntry{
-				newDefaults("api", "http2"),
-				newDefaults("db", "grpc"),
-				newDefaults("web", "grpc"),
-				newResolver("web", 33*time.Second),
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			configSort(tc.configs)
-			require.Equal(t, tc.expect, tc.configs)
-			// and it should be stable
-			configSort(tc.configs)
-			require.Equal(t, tc.expect, tc.configs)
-		})
-	}
-}
 
 func TestReplication_ConfigEntries(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
### Description

Directly lift a few generic config entry helper functions out of `agent/consul` into `agent/configentry` to be used elsewhere later.
