### PR TITLE
This fixes an issue where TCP services that are exported cannot be configured to failover

### DIFF
--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -776,8 +776,8 @@ func (s *ResourceGenerator) makeExportedUpstreamEndpointsForMeshGateway(cfgSnap 
 
 		chainEndpoints := make(map[string]structs.CheckServiceNodes)
 		for _, target := range chain.Targets {
-			if !cfgSnap.Locality.Matches(target.Datacenter, target.Partition) {
-				s.Logger.Warn("ignoring discovery chain target that crosses a datacenter or partition boundary in a mesh gateway",
+			if !cfgSnap.Locality.Matches(target.Datacenter, target.Partition) || target.Peer != "" {
+				s.Logger.Warn("ignoring discovery chain target that crosses a datacenter, peer, or partition boundary in a mesh gateway",
 					"target", target,
 					"gatewayLocality", cfgSnap.Locality,
 				)


### PR DESCRIPTION
### Description

This fixes an issue where TCP services that are exported cannot be configured to failover. This happened because there was a validation that exported services cannot add additional discovery chain targets. Relaxing this constraint is harmless for failover because xds/endpoints excludes cross partition and peer endpoints.

This also adds a bunch of missing tests for existing validations.

This PR has more background on why some disco chain changes are restricted https://github.com/hashicorp/consul/pull/13727.