### PR TITLE
Change `Consul Service Mesh` doc title to uppercase

### DIFF
--- a/website/content/docs/connect/index.mdx
+++ b/website/content/docs/connect/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Consul’s service mesh makes application and microservice networking secure and observable with identity-based authentication, mutual TLS (mTLS) encryption, and explicit service-to-service authorization enforced by sidecar proxies. Learn how Consul’s service mesh works and get started on VMs or Kubernetes.
 ---
 
-# Consul service mesh
+# Consul Service Mesh
 
 Consul service mesh provides service-to-service connection authorization and
 encryption using mutual Transport Layer Security (TLS).


### PR DESCRIPTION
### Description

This is a small docs change. It might be pedantic, and if it's not helpful, a swift close is fine.

I opened the following pages at the same time:

- https://developer.hashicorp.com/nomad/docs/integrations/consul-connect
- https://developer.hashicorp.com/consul/docs/connect

The inconsistency of the identical titles on the two separate projects stood out to me:

![image](https://github.com/hashicorp/consul/assets/14791619/366335c0-6254-43e0-bd96-514c6b0f8b74)

![image](https://github.com/hashicorp/consul/assets/14791619/b7ab5d09-6425-4eac-8e4e-7a28a8666252)

This PR just changes to an uppercase title on the Consul docs.