### PR TITLE
fix: stop peering delete routine on leader loss

### DIFF
--- a/.changelog/17483.txt
+++ b/.changelog/17483.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+peering: Fix a bug that caused server agents to continue cleaning up peering resources even after loss of leadership.
+```

--- a/.changelog/_5614.txt
+++ b/.changelog/_5614.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+namespaces: **(Enterprise only)** fixes a bug where namespaces are stuck in a deferred deletion state indefinitely under some conditions.
+Also fixes the Consul query metadata present in the HTTP headers of the namespace read and list endpoints.
+```

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -364,6 +364,8 @@ func (s *Server) revokeLeadership() {
 
 	s.revokeEnterpriseLeadership()
 
+	s.stopDeferredDeletion()
+
 	s.stopFederationStateAntiEntropy()
 
 	s.stopFederationStateReplication()


### PR DESCRIPTION
### Description

This complements an enterprise PR that resolves an issue with namespaces but also affects the leader routine. When we lose leadership, we clean up the peering deferred deletion routine.


### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [X] appropriate backport labels added
* [ ] not a security concern
