### PR TITLE
Remove replica tag

### DIFF
--- a/agent/hcp/client/client.go
+++ b/agent/hcp/client/client.go
@@ -300,8 +300,7 @@ func (t *TelemetryConfig) Enabled() (string, bool) {
 // DefaultLabels returns a set of <key, value> string pairs that must be added as attributes to all exported telemetry data.
 func (t *TelemetryConfig) DefaultLabels(nodeID string) map[string]string {
 	labels := map[string]string{
-		"__replica__": nodeID, // used for Cortex HA-metrics (deduplication)
-		"node_id":     nodeID, // used to delineate Consul nodes in graphs
+		"node_id": nodeID, // used to delineate Consul nodes in graphs
 	}
 
 	for k, v := range t.Labels {


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

> In Cortex we make sure we only ingest from one of T1.a and T1.b, and only from one of T2.a and T2.b. We do this by electing a leader replica for each cluster of Prometheus. For example, in the case of T1, let it be T1.a. As long as T1.a is the leader, we drop the samples sent by T1.b. And if Cortex sees no new samples from T1.a for a short period (30s by default), it’ll switch the leader to be T1.b.

docs: https://cortexmetrics.io/docs/guides/ha-pair-handling/

Having __replica__ will prevent ingestion of metrics from multiple proxies because one will be elected leader. It's not deduplication of metrics from a single replica, it's deduplication of samples across all replicas

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

Deploy `feature/hcp-telemetry` and push to a Cortex or Cortex-like Prometheus database that has HA-availability metrics ingress.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
