### PR TITLE
ci: update backport assistant to 0.3.4

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -19,7 +19,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.3
+    container: hashicorpdev/backport-assistant:0.3.4
     steps:
       - name: Run Backport Assistant for release branches
         run: |


### PR DESCRIPTION
### Description

Updating backport assistant to 0.3.4 so that backports will be assigned to the merge-by user.