### PR TITLE
[HCP Observability] Turn off retries for now until dynamically configurable

### DIFF
--- a/agent/hcp/client/metrics_client.go
+++ b/agent/hcp/client/metrics_client.go
@@ -24,10 +24,12 @@ const (
 	defaultStreamTimeout = 15 * time.Second
 
 	// Retry config
-	// TODO: Evenutally, we'd like to configure these values dynamically.
+	// TODO: Eventually, we'd like to configure these values dynamically.
 	defaultRetryWaitMin = 1 * time.Second
 	defaultRetryWaitMax = 15 * time.Second
-	defaultRetryMax     = 4
+	// defaultRetryMax is set to 0 to turn off retry functionality, until dynamic configuration is possible.
+	// This reduces load on the Telemetry Gateway for now.
+	defaultRetryMax = 0
 )
 
 // MetricsClient exports Consul metrics in OTLP format to the HCP Telemetry Gateway.

--- a/agent/hcp/client/metrics_client.go
+++ b/agent/hcp/client/metrics_client.go
@@ -28,7 +28,7 @@ const (
 	defaultRetryWaitMin = 1 * time.Second
 	defaultRetryWaitMax = 15 * time.Second
 	// defaultRetryMax is set to 0 to turn off retry functionality, until dynamic configuration is possible.
-	// This reduces load on the Telemetry Gateway for now.
+	// This is to circumvent any spikes in load that may cause or exacerbate server-side issues for now.
 	defaultRetryMax = 0
 )
 


### PR DESCRIPTION
### Description

Turn off retries by setting `defaultRetryMax` to 0 in MetricsClient


Why?
- Avoid retry storm if CTGW is down for lack of capacity in the OTLP service
- For GA, we can add this back in as we'll be able to dynamically update the retry with configuration changes.

### Testing & Reproduction steps
I tested this change end to end with a mock endpoint that returns `status.ServiceUnavailable`, and the retry does not kick off unlike on the feature/hcp-telemetry branch.
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
