### PR TITLE
build(deps): update UBI base image to 9.2

### DIFF
--- a/.changelog/17513.txt
+++ b/.changelog/17513.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Update to UBI base image to 9.2. 
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -201,7 +201,7 @@ CMD ["agent", "-dev", "-client", "0.0.0.0"]
 
 # Red Hat UBI-based image
 # This target is used to build a Consul image for use on OpenShift.
-FROM registry.access.redhat.com/ubi9-minimal:9.1.0 as ubi
+FROM registry.access.redhat.com/ubi9-minimal:9.2 as ubi
 
 ARG PRODUCT_NAME
 ARG PRODUCT_VERSION


### PR DESCRIPTION
### Description
Update UBI base image to 9.2, which has an active support window.
