### PR TITLE
ip rate limiting: adding missing API funcitonality

### DIFF
--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -736,6 +736,8 @@ func MakeConfigEntry(kind, name string) (ConfigEntry, error) {
 		return &HTTPRouteConfigEntry{Name: name}, nil
 	case TCPRoute:
 		return &TCPRouteConfigEntry{Name: name}, nil
+	case RateLimitIPConfig:
+		return &RateLimitIPConfigEntry{Name: name}, nil
 	case JWTProvider:
 		return &JWTProviderConfigEntry{Name: name}, nil
 	default:

--- a/agent/structs/config_entry_rate_limit_ip.go
+++ b/agent/structs/config_entry_rate_limit_ip.go
@@ -1,0 +1,117 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package structs
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/consul/acl"
+)
+
+type ReadWriteRatesConfig struct {
+	ReadRate  float64
+	WriteRate float64
+}
+
+type RateLimitIPConfigEntry struct {
+	// Kind is the kind of configuration entry and must be "jwt-provider".
+	Kind string `json:",omitempty"`
+
+	// Name is the name of the provider being configured.
+	Name               string            `json:",omitempty"`
+	Meta               map[string]string `json:",omitempty"`
+	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
+	Mode               string // {permissive, enforcing, disabled}
+
+	// overall limits
+	ReadRate  float64
+	WriteRate float64
+	//limits specific to a type of call
+	ACL            *ReadWriteRatesConfig `json:",omitempty"`
+	Catalog        *ReadWriteRatesConfig `json:",omitempty"`
+	ConfigEntry    *ReadWriteRatesConfig `json:",omitempty"`
+	ConnectCA      *ReadWriteRatesConfig `json:",omitempty"`
+	Coordinate     *ReadWriteRatesConfig `json:",omitempty"`
+	DiscoveryChain *ReadWriteRatesConfig `json:",omitempty"`
+	Health         *ReadWriteRatesConfig `json:",omitempty"`
+	Intention      *ReadWriteRatesConfig `json:",omitempty"`
+	KV             *ReadWriteRatesConfig `json:",omitempty"`
+	Tenancy        *ReadWriteRatesConfig `json:",omitempty"`
+	PreparedQuery  *ReadWriteRatesConfig `json:",omitempty"`
+	Session        *ReadWriteRatesConfig `json:",omitempty"`
+	Txn            *ReadWriteRatesConfig `json:",omitempty"`
+
+	// Partition is the partition the config entry is associated with.
+	// Partitioning is a Consul Enterprise feature.
+	Partition string `json:",omitempty"`
+
+	// Namespace is the namespace the config entry is associated with.
+	// Namespacing is a Consul Enterprise feature.
+	Namespace string `json:",omitempty"`
+
+	// CreateIndex is the Raft index this entry was created at. This is a
+	// read-only field.
+	CreateIndex uint64
+
+	// ModifyIndex is used for the Check-And-Set operations and can also be fed
+	// back into the WaitIndex of the QueryOptions in order to perform blocking
+	// queries.
+	ModifyIndex uint64
+	RaftIndex
+}
+
+func (r *RateLimitIPConfigEntry) GetKind() string            { return RateLimitIPConfig }
+func (r *RateLimitIPConfigEntry) GetName() string            { return r.Name }
+func (r *RateLimitIPConfigEntry) GetMeta() map[string]string { return r.Meta }
+func (r *RateLimitIPConfigEntry) GetCreateIndex() uint64     { return r.CreateIndex }
+func (r *RateLimitIPConfigEntry) GetModifyIndex() uint64     { return r.ModifyIndex }
+
+func (r *RateLimitIPConfigEntry) GetRaftIndex() *RaftIndex {
+	if r == nil {
+		return &RaftIndex{}
+	}
+	return &r.RaftIndex
+}
+
+func (r *RateLimitIPConfigEntry) GetEnterpriseMeta() *acl.EnterpriseMeta {
+	if r == nil {
+		return nil
+	}
+	return &r.EnterpriseMeta
+}
+
+func (r *RateLimitIPConfigEntry) Normalize() error {
+	if r == nil {
+		return fmt.Errorf("config entry is nil")
+	}
+	r.EnterpriseMeta.Normalize()
+	return nil
+}
+
+func (r *RateLimitIPConfigEntry) CanRead(authz acl.Authorizer) error {
+	return nil
+}
+
+func (r *RateLimitIPConfigEntry) CanWrite(authz acl.Authorizer) error {
+	var authzContext acl.AuthorizerContext
+	r.FillAuthzContext(&authzContext)
+	return authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext)
+}
+
+func (r *RateLimitIPConfigEntry) Validate() error {
+	return nil
+}
+
+func (r *RateLimitIPConfigEntry) MarshalJSON() ([]byte, error) {
+	type Alias RateLimitIPConfigEntry
+	source := &struct {
+		Kind string
+		*Alias
+	}{
+		Kind:  RateLimitIPConfig,
+		Alias: (*Alias)(r),
+	}
+	return json.Marshal(source)
+}

--- a/agent/structs/config_entry_rate_limit_ip.go
+++ b/agent/structs/config_entry_rate_limit_ip.go
@@ -97,7 +97,9 @@ func (r *RateLimitIPConfigEntry) CanRead(authz acl.Authorizer) error {
 func (r *RateLimitIPConfigEntry) CanWrite(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	r.FillAuthzContext(&authzContext)
-	return authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext)
+	// TODO: Implement
+	// return authz.ToAllowAuthorizer().RateLimitIPAllowed(&authzContext)
+	return nil
 }
 
 func (r *RateLimitIPConfigEntry) Validate() error {


### PR DESCRIPTION
### Description
I found this functionality to be missing when I was fixing [unit tests](https://github.com/hashicorp/consul-k8s/pull/2166/files) for the consul-k8s integration of this feature.

Server IP Rate limiting is missing from the config entry API as well as the backing ACL permissions.

### To Do
- [x] Implement basic functionality to allow this to work via config entry api route.
- [ ] Double check struct in agent/structs/config_entry_rate_limit_ip.go and add in missing functionality
  - [ ]  Add functionality to Validate()
- [ ] Add tests for agent/structs/config_entry_rate_limit_ip.go
- [ ] Add in ACL authorization code and tests
- [ ] Ensure this works in `consul-k8s`

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
