### PR TITLE
Accept ap, datacenter, and namespace query params

### DIFF
--- a/.changelog/17525.txt
+++ b/.changelog/17525.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+http: accept query parameters `datacenter`, `ap` (enterprise-only), and `namespace` (enterprise-only). Both short-hand and long-hand forms of these query params are now supported via the HTTP API (dc/datacenter, ap/partition, ns/namespace).
+```

--- a/agent/http.go
+++ b/agent/http.go
@@ -983,9 +983,12 @@ func parseConsistencyReadRequest(resp http.ResponseWriter, req *http.Request, b 
 	}
 }
 
-// parseDC is used to parse the ?dc query param
+// parseDC is used to parse the datacenter from the query params.
+// ?datacenter has precedence over ?dc.
 func (s *HTTPHandlers) parseDC(req *http.Request, dc *string) {
-	if other := req.URL.Query().Get("dc"); other != "" {
+	if other := req.URL.Query().Get("datacenter"); other != "" {
+		*dc = other
+	} else if other = req.URL.Query().Get("dc"); other != "" {
 		*dc = other
 	} else if *dc == "" {
 		*dc = s.agent.config.Datacenter

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -881,6 +881,15 @@ func TestParseSource(t *testing.T) {
 		t.Fatalf("bad: %v", source)
 	}
 
+	// We should follow whatever datacenter parameter was given so that the node is
+	// looked up correctly on the receiving end.
+	req, _ = http.NewRequest("GET", "/v1/catalog/nodes?near=bob&datacenter=foo", nil)
+	source = structs.QuerySource{}
+	a.srv.parseSource(req, &source)
+	if source.Datacenter != "foo" || source.Node != "bob" {
+		t.Fatalf("bad: %v", source)
+	}
+
 	// The magic "_agent" node name will use the agent's local node name.
 	req, _ = http.NewRequest("GET", "/v1/catalog/nodes?near=_agent", nil)
 	source = structs.QuerySource{}

--- a/api/api.go
+++ b/api/api.go
@@ -836,12 +836,21 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 		return
 	}
 	if q.Namespace != "" {
+		// For backwards-compatibility with existing tests,
+		// use the short-hand query param name "ns"
+		// rather than the alternative long-hand "namespace"
 		r.params.Set("ns", q.Namespace)
 	}
 	if q.Partition != "" {
+		// For backwards-compatibility with existing tests,
+		// use the long-hand query param name "partition"
+		// rather than the alternative short-hand "ap"
 		r.params.Set("partition", q.Partition)
 	}
 	if q.Datacenter != "" {
+		// For backwards-compatibility with existing tests,
+		// use the short-hand query param name "dc"
+		// rather than the alternative long-hand "datacenter"
 		r.params.Set("dc", q.Datacenter)
 	}
 	if q.Peer != "" {
@@ -949,12 +958,16 @@ func (r *request) setWriteOptions(q *WriteOptions) {
 	if q == nil {
 		return
 	}
+	// For backwards-compatibility, continue to use the shorthand "ns"
+	// rather than "namespace"
 	if q.Namespace != "" {
 		r.params.Set("ns", q.Namespace)
 	}
 	if q.Partition != "" {
 		r.params.Set("partition", q.Partition)
 	}
+	// For backwards-compatibility, continue to use the shorthand "dc"
+	// rather than "datacenter"
 	if q.Datacenter != "" {
 		r.params.Set("dc", q.Datacenter)
 	}

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -1466,6 +1466,9 @@ func testMockAgentGatewayConfig(namespacesEnabled bool) http.HandlerFunc {
 func namespaceFromQuery(r *http.Request) string {
 	// Use the namespace in the request if there is one, otherwise
 	// use-default.
+	if queryNamespace := r.URL.Query().Get("namespace"); queryNamespace != "" {
+		return queryNamespace
+	}
 	if queryNs := r.URL.Query().Get("ns"); queryNs != "" {
 		return queryNs
 	}
@@ -1475,8 +1478,11 @@ func namespaceFromQuery(r *http.Request) string {
 func partitionFromQuery(r *http.Request) string {
 	// Use the partition in the request if there is one, otherwise
 	// use-default.
-	if queryAP := r.URL.Query().Get("partition"); queryAP != "" {
-		return queryAP
+	if queryPartition := r.URL.Query().Get("partition"); queryPartition != "" {
+		return queryPartition
+	}
+	if queryAp := r.URL.Query().Get("ap"); queryAp != "" {
+		return queryAp
 	}
 	return "default"
 }


### PR DESCRIPTION
This commit only contains the OSS PR (datacenter query param support). A separate enterprise PR adds support for ap and namespace query params.

Resources in Consul can exists within scopes such as datacenters, cluster peers, admin partitions, and namespaces. You can refer to those resources from interfaces such as the CLI, HTTP API, DNS, and configuration files.

Some scope levels have consistent naming: cluster peers are always referred to as "peer".

Other scope levels use a short-hand in DNS lookups...
- "ns" for namespace
- "ap" for admin partition
- "dc" for datacenter

...But use long-hand in CLI commands:
- "namespace" for namespace
- "partition" for admin partition
- and "datacenter"

However, HTTP API query parameters do not follow a consistent pattern, supporting short-hand for some scopes but long-hand for others:
- "ns" for namespace
- "partition" for admin partition
- and "dc" for datacenter.

This inconsistency is confusing, especially for users who have been exposed to providing scope names through another interface such as CLI or DNS queries.

This commit improves UX by consistently supporting both short-hand and long-hand forms of the namespace, partition, and datacenter scopes in HTTP API query parameters.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated - will do in a separate PR post code freeze
* [x] appropriate backport labels added
* [x] not a security concern

