### PR TITLE
Fix tproxy failover issue with sameness groups

### DIFF
--- a/agent/consul/fsm/snapshot_test.go
+++ b/agent/consul/fsm/snapshot_test.go
@@ -44,6 +44,8 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 		StorageBackend: storageBackend,
 	})
 
+	fsm.state.SystemMetadataSet(10, &structs.SystemMetadataEntry{Key: structs.SystemMetadataVirtualIPsEnabled, Value: "true"})
+
 	// Add some state
 	node1 := &structs.Node{
 		ID:         "610918a6-464f-fa9b-1a95-03bd6e88ed92",
@@ -79,8 +81,14 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 		Connect: connectConf,
 	})
 
+	psn := structs.PeeredServiceName{ServiceName: structs.NewServiceName("web", nil)}
+	vip, err := fsm.state.VirtualIPForService(psn)
+	require.NoError(t, err)
+	require.Equal(t, vip, "240.0.0.1")
+
 	fsm.state.EnsureService(4, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "127.0.0.1", Port: 5000})
 	fsm.state.EnsureService(5, "baz", &structs.NodeService{ID: "web", Service: "web", Tags: nil, Address: "127.0.0.2", Port: 80})
+
 	fsm.state.EnsureService(6, "baz", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"secondary"}, Address: "127.0.0.2", Port: 5000})
 	fsm.state.EnsureCheck(7, &structs.HealthCheck{
 		Node:      "foo",
@@ -442,6 +450,10 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 		},
 	}
 	require.NoError(t, fsm.state.EnsureConfigEntry(26, serviceIxn))
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("foo", nil)}
+	vip, err = fsm.state.VirtualIPForService(psn)
+	require.NoError(t, err)
+	require.Equal(t, vip, "240.0.0.2")
 
 	// mesh config entry
 	meshConfig := &structs.MeshConfigEntry{
@@ -465,10 +477,10 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 		Port:    8000,
 		Connect: connectConf,
 	})
-	psn := structs.PeeredServiceName{ServiceName: structs.NewServiceName("frontend", nil)}
-	vip, err := fsm.state.VirtualIPForService(psn)
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("frontend", nil)}
+	vip, err = fsm.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.1")
+	require.Equal(t, vip, "240.0.0.3")
 
 	fsm.state.EnsureService(30, "foo", &structs.NodeService{
 		ID:      "backend",
@@ -480,7 +492,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("backend", nil)}
 	vip, err = fsm.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.2")
+	require.Equal(t, vip, "240.0.0.4")
 
 	_, serviceNames, err := fsm.state.ServiceNamesOfKind(nil, structs.ServiceKindTypical)
 	require.NoError(t, err)
@@ -534,15 +546,15 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 		},
 	}))
 
-	// Add a service-resolver entry to get a virtual IP for service foo
+	// Add a service-resolver entry to get a virtual IP for service goo
 	resolverEntry := &structs.ServiceResolverConfigEntry{
 		Kind: structs.ServiceResolver,
-		Name: "foo",
+		Name: "goo",
 	}
 	require.NoError(t, fsm.state.EnsureConfigEntry(34, resolverEntry))
-	vip, err = fsm.state.VirtualIPForService(structs.PeeredServiceName{ServiceName: structs.NewServiceName("foo", nil)})
+	vip, err = fsm.state.VirtualIPForService(structs.PeeredServiceName{ServiceName: structs.NewServiceName("goo", nil)})
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.3")
+	require.Equal(t, vip, "240.0.0.5")
 
 	// Resources
 	resource, err := storageBackend.WriteCAS(context.Background(), &pbresource.Resource{
@@ -665,18 +677,26 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	require.Equal(t, uint64(25), checks[0].ModifyIndex)
 
 	// Verify virtual IPs are consistent.
-	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("frontend", nil)}
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("web", nil)}
 	vip, err = fsm2.state.VirtualIPForService(psn)
 	require.NoError(t, err)
 	require.Equal(t, vip, "240.0.0.1")
-	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("backend", nil)}
-	vip, err = fsm2.state.VirtualIPForService(psn)
-	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.2")
 	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("foo", nil)}
 	vip, err = fsm2.state.VirtualIPForService(psn)
 	require.NoError(t, err)
+	require.Equal(t, vip, "240.0.0.2")
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("frontend", nil)}
+	vip, err = fsm2.state.VirtualIPForService(psn)
+	require.NoError(t, err)
 	require.Equal(t, vip, "240.0.0.3")
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("backend", nil)}
+	vip, err = fsm2.state.VirtualIPForService(psn)
+	require.NoError(t, err)
+	require.Equal(t, vip, "240.0.0.4")
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("goo", nil)}
+	vip, err = fsm2.state.VirtualIPForService(psn)
+	require.NoError(t, err)
+	require.Equal(t, vip, "240.0.0.5")
 
 	// Verify key is set
 	_, d, err := fsm2.state.KVSGet(nil, "/test", nil)

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -1106,7 +1106,7 @@ func (s *Store) intentionTopologyTxn(
 			// We only need to do this for upstreams currently, so that tproxy can find which discovery chains should be
 			// contacted for failover scenarios. Virtual services technically don't need to be considered as downstreams,
 			// because they will take on the identity of the calling service, rather than the chain itself.
-			vipIndex, vipServices, err := servicesVirtualIPsTxn(tx)
+			vipIndex, vipServices, err := servicesVirtualIPsTxn(tx, ws)
 			if err != nil {
 				return index, nil, fmt.Errorf("failed to list service virtual IPs: %v", err)
 			}


### PR DESCRIPTION
Sameness groups with default-for-failover enabled did not function properly with tproxy whenever all instances of the service disappeared from the local cluster. This occured, because there were no corresponding resolvers (due to the implicit failover policy) which caused VIPs to be deallocated.

This ticket expands upon the VIP allocations so that both service-defaults and service-intentions (without destination wildcards) will ensure that the virtual IP exists.