### PR TITLE
Avoid unnecessary health check flapping for sidecar services

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -716,8 +716,7 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	// Load checks/services/metadata.
-	emptyCheckSnapshot := map[structs.CheckID]*structs.HealthCheck{}
-	if err := a.loadServices(c, emptyCheckSnapshot); err != nil {
+	if err := a.loadServices(c, nil); err != nil {
 		return err
 	}
 	if err := a.loadChecks(c, nil); err != nil {
@@ -4189,7 +4188,7 @@ func (a *Agent) reloadConfigInternal(newCfg *config.RuntimeConfig) error {
 	}
 
 	// Reload service/check definitions and metadata.
-	if err := a.loadServices(newCfg, snap); err != nil {
+	if err := a.loadServices(newCfg, nil); err != nil {
 		return fmt.Errorf("Failed reloading services: %s", err)
 	}
 	if err := a.loadChecks(newCfg, snap); err != nil {


### PR DESCRIPTION
Commit f34703fc63c introduced a regression, such that it passes an empty map as the check snapshot on startup:

    	emptyCheckSnapshot := map[structs.CheckID]*structs.HealthCheck{}
    	if err := a.loadServices(c, emptyCheckSnapshot); err != nil {

If there is no `consul reload`, this empty map will be used for comparison indefinitely, such that the following if-block will never be executed:

       		// Restore the fields from the snapshot.
       		prev, ok := req.checkStateSnapshot[cid]
       		if ok {
       			check.Output = prev.Output
       			check.Status = prev.Status
       		}

Subsequently, every time `handleUpdate` in agent/service_manager.go is triggered, the health checks for sidecar services will flap to critical for several seconds.

If there has been a `consul reload`, and it happened while the health checks were still critical (e.g. shortly after agent startup), then the flapping will also happen, as the check snapshot with critical status will be used for comparison indefinitely.

This commit fixes the issue by always passing nil as the check snapshot.

Note that `handleUpdate` can happen once every 10 minutes even though there is no config change for a specific service, as long as there is any config entries modification within the 10 minutes. As such, on systems with Consul agents >= 1.10, after applying this fix, there should be a significant decrease in `Synced check` log lines, `Catalog.Register` RPC calls, and also disk writes on Consul servers.

Fixes #16663

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
