### PR TITLE
Fix up case where subscription is terminated due to ACLs changing or a snapshot restore occurring

### DIFF
--- a/.changelog/17566.txt
+++ b/.changelog/17566.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: Fixed a bug where modifying ACLs on a token being actively used for an xDS connection caused all xDS updates to fail.
+```

--- a/agent/proxycfg-glue/glue.go
+++ b/agent/proxycfg-glue/glue.go
@@ -141,6 +141,12 @@ func newUpdateEvent(correlationID string, result any, err error) proxycfg.Update
 	if acl.IsErrNotFound(err) {
 		err = proxycfg.TerminalError(err)
 	}
+	// these are also errors where we should mark them
+	// as terminal for the sake of proxycfg, since they require
+	// a resubscribe.
+	if err == stream.ErrSubForceClosed || err == stream.ErrShuttingDown {
+		err = proxycfg.TerminalError(err)
+	}
 	return proxycfg.UpdateEvent{
 		CorrelationID: correlationID,
 		Result:        result,

--- a/agent/proxycfg-glue/glue.go
+++ b/agent/proxycfg-glue/glue.go
@@ -5,6 +5,7 @@ package proxycfgglue
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -144,7 +145,7 @@ func newUpdateEvent(correlationID string, result any, err error) proxycfg.Update
 	// these are also errors where we should mark them
 	// as terminal for the sake of proxycfg, since they require
 	// a resubscribe.
-	if err == stream.ErrSubForceClosed || err == stream.ErrShuttingDown {
+	if errors.Is(err, stream.ErrSubForceClosed) || errors.Is(err, stream.ErrShuttingDown) {
 		err = proxycfg.TerminalError(err)
 	}
 	return proxycfg.UpdateEvent{


### PR DESCRIPTION
### Description

Due to swallowing and only logging xDS errors here:

https://github.com/hashicorp/consul/blob/88951bfafaa969f52235dc5b443cb64ba329660c/agent/proxycfg/state.go#L375-L386

We were getting into a state where if ACLs were modified while connected to xDS, the stream wasn't properly being re-established and instead the Consul logs were filling up with error logs such as:

> Failed to handle update from watch: kind=api-gateway proxy=default/default/gateway-d6b4d69c-krz5b service_id=default/default/gateway-d6b4d69c-krz5b id=gateway-config error="error filling agent cache: subscription closed by server, client must reset state and resubscribe"

Basically we were missing some casing for marking certain errors as `TerminalError`s in proxycfg-glue, this fixes that.

### Testing & Reproduction steps

Get a proxy and/or gateway to connect up to xDS and then modify the token ACLs that are associated with it, you should see a bunch of these in the logs.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
