### PR TITLE
Add Prop Override Envoy extension integration test

### DIFF
--- a/test/integration/connect/envoy/case-property-override/capture.sh
+++ b/test/integration/connect/envoy/case-property-override/capture.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+
+snapshot_envoy_admin localhost:19000 s1 primary || true
+snapshot_envoy_admin localhost:19001 s2 primary || true

--- a/test/integration/connect/envoy/case-property-override/service_s1.hcl
+++ b/test/integration/connect/envoy/case-property-override/service_s1.hcl
@@ -1,0 +1,19 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+services {
+  name = "s1"
+  port = 8080
+  connect {
+    sidecar_service {
+      proxy {
+        upstreams = [
+          {
+            destination_name = "s2"
+            local_bind_port = 5000
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/integration/connect/envoy/case-property-override/service_s2.hcl
+++ b/test/integration/connect/envoy/case-property-override/service_s2.hcl
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+services {
+  name = "s2"
+  port = 8181
+  connect { sidecar_service {} }
+}

--- a/test/integration/connect/envoy/case-property-override/setup.sh
+++ b/test/integration/connect/envoy/case-property-override/setup.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+
+set -eEuo pipefail
+
+upsert_config_entry primary '
+Kind = "service-defaults"
+Name = "s2"
+Protocol = "http"
+EnvoyExtensions = [
+  {
+    Name = "builtin/property-override"
+    Arguments = {
+      ProxyType = "connect-proxy"
+      Patches = [{
+        ResourceFilter = {
+          ResourceType = "listener"
+          TrafficDirection = "inbound"
+        }
+        Op = "add"
+        Path = "/stat_prefix"
+        Value = "custom.stats.s2"
+      }]
+    }
+  }
+]
+'
+
+upsert_config_entry primary '
+Kind = "service-defaults"
+Name = "s1"
+Protocol = "http"
+EnvoyExtensions = [
+  {
+    Name = "builtin/property-override"
+    Arguments = {
+      ProxyType = "connect-proxy"
+      Patches = [{
+          ResourceFilter = {
+            ResourceType = "cluster"
+            TrafficDirection = "outbound"
+          }
+          Op = "add"
+          Path = "/upstream_connection_options/tcp_keepalive/keepalive_probes"
+          Value = 1234
+      }]
+    }
+  }
+]
+'
+
+register_services primary
+
+gen_envoy_bootstrap s1 19000 primary
+gen_envoy_bootstrap s2 19001 primary

--- a/test/integration/connect/envoy/case-property-override/vars.sh
+++ b/test/integration/connect/envoy/case-property-override/vars.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+
+export REQUIRED_SERVICES="s1 s1-sidecar-proxy s2 s2-sidecar-proxy"

--- a/test/integration/connect/envoy/case-property-override/verify.bats
+++ b/test/integration/connect/envoy/case-property-override/verify.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "s1 proxy admin is up on :19000" {
+  retry_default curl -f -s localhost:19000/stats -o /dev/null
+}
+
+@test "s2 proxy admin is up on :19001" {
+  retry_default curl -f -s localhost:19001/stats -o /dev/null
+}
+
+@test "s1 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21000 s1
+}
+
+@test "s1 proxy is configured with the expected envoy patches" {
+  run get_envoy_cluster_config localhost:19000 s2
+  [ "$status" == 0 ]
+
+  [ "$(echo "$output" | jq -r '.upstream_connection_options.tcp_keepalive.keepalive_probes')" == "1234" ]
+}
+
+@test "s2 proxy is configured with the expected envoy patches" {
+  run get_envoy_public_listener_once localhost:19001
+  [ "$status" == 0 ]
+  
+  [ "$(echo "$output" | jq -r '.active_state.listener.stat_prefix')" == "custom.stats.s2" ]
+}

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -228,6 +228,13 @@ function get_envoy_expose_checks_listener_once {
   echo "$output" | jq --raw-output '.configs[] | select(.["@type"] == "type.googleapis.com/envoy.admin.v3.ListenersConfigDump") | .dynamic_listeners[] | select(.name | startswith("exposed_path_"))'
 }
 
+function get_envoy_public_listener_once {
+  local HOSTPORT=$1
+  run curl -s -f $HOSTPORT/config_dump
+  [ "$status" -eq 0 ]
+  echo "$output" | jq --raw-output '.configs[] | select(.["@type"] == "type.googleapis.com/envoy.admin.v3.ListenersConfigDump") | .dynamic_listeners[] | select(.name | startswith("public_listener:"))'
+}
+
 function assert_envoy_http_rbac_policy_count {
   local HOSTPORT=$1
   local EXPECT_COUNT=$2


### PR DESCRIPTION
### Description

Add integration test for Property Override extension that patches two different proxies.

Follow-up changes will ensure that we parse single- and multi-value array config fields appropriately; initial testing shows we may still have a bug there, so committing this simple test for now.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated - N/A
* [x] appropriate backport labels added
* [x] not a security concern
