### PR TITLE
Disable terminating-gateway for property-override

### DIFF
--- a/agent/envoyextensions/builtin/property-override/property_override.go
+++ b/agent/envoyextensions/builtin/property-override/property_override.go
@@ -106,8 +106,8 @@ var Ops = extensioncommon.StringSet{string(OpAdd): {}, string(OpRemove): {}}
 
 // validProxyTypes is the set of supported proxy types for this extension.
 var validProxyTypes = extensioncommon.StringSet{
-	string(api.ServiceKindConnectProxy):       struct{}{},
-	string(api.ServiceKindTerminatingGateway): struct{}{},
+	// For now, we only support `connect-proxy`.
+	string(api.ServiceKindConnectProxy): struct{}{},
 }
 
 // Patch describes a single patch operation to modify the specific field of matching

--- a/agent/envoyextensions/builtin/property-override/property_override_test.go
+++ b/agent/envoyextensions/builtin/property-override/property_override_test.go
@@ -618,7 +618,7 @@ func TestCanApply(t *testing.T) {
 		},
 		"invalid proxy type": {
 			ext: &propertyOverride{
-				ProxyType: api.ServiceKindTerminatingGateway,
+				ProxyType: api.ServiceKindConnectProxy,
 			},
 			conf: &extensioncommon.RuntimeConfig{
 				Kind: api.ServiceKindMeshGateway,


### PR DESCRIPTION
More validation is needed to ensure this behaves as expected; in the meantime, align with docs and disable this proxy type.

### Description

Disable configuring `terminating-gateway` in the `property-override` builtin Envoy extension.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated - separate change
* [x] appropriate backport labels added
* [x] not a security concern
