### PR TITLE
[API Gateway] Fix trust domain for external peered services in synthesis code

### DIFF
--- a/.changelog/17609.txt
+++ b/.changelog/17609.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+gateways: Fixed a bug in API gateways where binding a route that only targets a service imported from a peer results
+in the programmed gateway having no routes.
+```


### PR DESCRIPTION
### Description
This bug was found in writing this test on k8s: https://github.com/hashicorp/consul-k8s/pull/2306

I would like to circle around and write an acceptance-level test in core, but think that might likely have to wait a few weeks given some time constraints, and any behavior that this breaks (v. fixing) should already be covered by tests.

### Testing & Reproduction steps

Ran k8s acceptance test and would not pass until these changes were introduced.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
