### PR TITLE
resource: enforce consistent naming of resource types

### DIFF
--- a/agent/grpc-external/services/resource/list_by_owner_test.go
+++ b/agent/grpc-external/services/resource/list_by_owner_test.go
@@ -74,7 +74,7 @@ func TestListByOwner_TypeNotRegistered(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument.String(), status.Code(err).String())
-	require.Contains(t, err.Error(), "resource type demo.v2.artist not registered")
+	require.Contains(t, err.Error(), "resource type demo.v2.Artist not registered")
 }
 
 func TestListByOwner_Empty(t *testing.T) {
@@ -126,7 +126,7 @@ func TestListByOwner_Many(t *testing.T) {
 }
 
 func TestListByOwner_ACL_PerTypeDenied(t *testing.T) {
-	authz := AuthorizerFrom(t, `key_prefix "resource/demo.v2.album/" { policy = "deny" }`)
+	authz := AuthorizerFrom(t, `key_prefix "resource/demo.v2.Album/" { policy = "deny" }`)
 	_, rsp, err := roundTripListByOwner(t, authz)
 
 	// verify resource filtered out, hence no results
@@ -135,7 +135,7 @@ func TestListByOwner_ACL_PerTypeDenied(t *testing.T) {
 }
 
 func TestListByOwner_ACL_PerTypeAllowed(t *testing.T) {
-	authz := AuthorizerFrom(t, `key_prefix "resource/demo.v2.album/" { policy = "read" }`)
+	authz := AuthorizerFrom(t, `key_prefix "resource/demo.v2.Album/" { policy = "read" }`)
 	album, rsp, err := roundTripListByOwner(t, authz)
 
 	// verify resource not filtered out

--- a/agent/grpc-external/services/resource/list_test.go
+++ b/agent/grpc-external/services/resource/list_test.go
@@ -58,7 +58,7 @@ func TestList_TypeNotFound(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument.String(), status.Code(err).String())
-	require.Contains(t, err.Error(), "resource type demo.v2.artist not registered")
+	require.Contains(t, err.Error(), "resource type demo.v2.Artist not registered")
 }
 
 func TestList_Empty(t *testing.T) {
@@ -178,7 +178,7 @@ func TestList_ACL_ListAllowed_ReadDenied(t *testing.T) {
 
 	// allow list, deny read
 	authz := AuthorizerFrom(t, demo.ArtistV2ListPolicy,
-		`key_prefix "resource/demo.v2.artist/" { policy = "deny" }`)
+		`key_prefix "resource/demo.v2.Artist/" { policy = "deny" }`)
 	_, rsp, err := roundTripList(t, authz)
 
 	// verify resource filtered out by key:read denied hence no results

--- a/agent/grpc-external/services/resource/read_test.go
+++ b/agent/grpc-external/services/resource/read_test.go
@@ -71,7 +71,7 @@ func TestRead_TypeNotFound(t *testing.T) {
 	_, err = client.Read(context.Background(), &pbresource.ReadRequest{Id: artist.Id})
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument.String(), status.Code(err).String())
-	require.Contains(t, err.Error(), "resource type demo.v2.artist not registered")
+	require.Contains(t, err.Error(), "resource type demo.v2.Artist not registered")
 }
 
 func TestRead_ResourceNotFound(t *testing.T) {

--- a/agent/grpc-external/services/resource/watch_test.go
+++ b/agent/grpc-external/services/resource/watch_test.go
@@ -66,7 +66,7 @@ func TestWatchList_TypeNotFound(t *testing.T) {
 
 	err = mustGetError(t, rspCh)
 	require.Equal(t, codes.InvalidArgument.String(), status.Code(err).String())
-	require.Contains(t, err.Error(), "resource type demo.v2.artist not registered")
+	require.Contains(t, err.Error(), "resource type demo.v2.Artist not registered")
 }
 
 func TestWatchList_GroupVersionMatches(t *testing.T) {
@@ -172,7 +172,7 @@ func TestWatchList_ACL_ListAllowed_ReadDenied(t *testing.T) {
 	// allow list, deny read
 	authz := AuthorizerFrom(t, `
 		key_prefix "resource/" { policy = "list" }
-		key_prefix "resource/demo.v2.artist/" { policy = "deny" }
+		key_prefix "resource/demo.v2.Artist/" { policy = "deny" }
 		`)
 	rspCh, _ := roundTripACL(t, authz)
 
@@ -187,7 +187,7 @@ func TestWatchList_ACL_ListAllowed_ReadAllowed(t *testing.T) {
 	// allow list, allow read
 	authz := AuthorizerFrom(t, `
 		key_prefix "resource/" { policy = "list" }
-		key_prefix "resource/demo.v2.artist/" { policy = "read" }
+		key_prefix "resource/demo.v2.Artist/" { policy = "read" }
 	`)
 	rspCh, artist := roundTripACL(t, authz)
 

--- a/agent/grpc-external/services/resource/write_status_test.go
+++ b/agent/grpc-external/services/resource/write_status_test.go
@@ -180,7 +180,7 @@ func TestWriteStatus_TypeNotFound(t *testing.T) {
 	_, err = client.WriteStatus(testContext(t), validWriteStatusRequest(t, res))
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument.String(), status.Code(err).String())
-	require.Contains(t, err.Error(), "resource type demo.v2.artist not registered")
+	require.Contains(t, err.Error(), "resource type demo.v2.Artist not registered")
 }
 
 func TestWriteStatus_ResourceNotFound(t *testing.T) {

--- a/agent/grpc-external/services/resource/write_test.go
+++ b/agent/grpc-external/services/resource/write_test.go
@@ -151,7 +151,7 @@ func TestWrite_TypeNotFound(t *testing.T) {
 	_, err = client.Write(testContext(t), &pbresource.WriteRequest{Resource: res})
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument.String(), status.Code(err).String())
-	require.Contains(t, err.Error(), "resource type demo.v2.artist not registered")
+	require.Contains(t, err.Error(), "resource type demo.v2.Artist not registered")
 }
 
 func TestWrite_ACLs(t *testing.T) {

--- a/internal/controller/api_test.go
+++ b/internal/controller/api_test.go
@@ -191,7 +191,7 @@ func TestController_String(t *testing.T) {
 		WithPlacement(controller.PlacementEachServer)
 
 	require.Equal(t,
-		`<Controller managed_type="demo.v2.artist", watched_types=["demo.v2.album"], backoff=<base="5s", max="1h0m0s">, placement="each-server">`,
+		`<Controller managed_type="demo.v2.Artist", watched_types=["demo.v2.Album"], backoff=<base="5s", max="1h0m0s">, placement="each-server">`,
 		ctrl.String(),
 	)
 }
@@ -202,7 +202,7 @@ func TestController_NoReconciler(t *testing.T) {
 
 	ctrl := controller.ForType(demo.TypeV2Artist)
 	require.PanicsWithValue(t,
-		`cannot register controller without a reconciler <Controller managed_type="demo.v2.artist", watched_types=[], backoff=<base="5ms", max="16m40s">, placement="singleton">`,
+		`cannot register controller without a reconciler <Controller managed_type="demo.v2.Artist", watched_types=[], backoff=<base="5ms", max="16m40s">, placement="singleton">`,
 		func() { mgr.Register(ctrl) })
 }
 

--- a/internal/resource/demo/demo.go
+++ b/internal/resource/demo/demo.go
@@ -33,36 +33,36 @@ var (
 	TypeV1Artist = &pbresource.Type{
 		Group:        "demo",
 		GroupVersion: "v1",
-		Kind:         "artist",
+		Kind:         "Artist",
 	}
 
 	// TypeV1Album represents a collection of an artist's songs.
 	TypeV1Album = &pbresource.Type{
 		Group:        "demo",
 		GroupVersion: "v1",
-		Kind:         "album",
+		Kind:         "Album",
 	}
 
 	// TypeV2Artist represents a musician or group of musicians.
 	TypeV2Artist = &pbresource.Type{
 		Group:        "demo",
 		GroupVersion: "v2",
-		Kind:         "artist",
+		Kind:         "Artist",
 	}
 
 	// TypeV2Album represents a collection of an artist's songs.
 	TypeV2Album = &pbresource.Type{
 		Group:        "demo",
 		GroupVersion: "v2",
-		Kind:         "album",
+		Kind:         "Album",
 	}
 )
 
 const (
-	ArtistV1ReadPolicy  = `key_prefix "resource/demo.v1.artist/" { policy = "read" }`
-	ArtistV1WritePolicy = `key_prefix "resource/demo.v1.artist/" { policy = "write" }`
-	ArtistV2ReadPolicy  = `key_prefix "resource/demo.v2.artist/" { policy = "read" }`
-	ArtistV2WritePolicy = `key_prefix "resource/demo.v2.artist/" { policy = "write" }`
+	ArtistV1ReadPolicy  = `key_prefix "resource/demo.v1.Artist/" { policy = "read" }`
+	ArtistV1WritePolicy = `key_prefix "resource/demo.v1.Artist/" { policy = "write" }`
+	ArtistV2ReadPolicy  = `key_prefix "resource/demo.v2.Artist/" { policy = "read" }`
+	ArtistV2WritePolicy = `key_prefix "resource/demo.v2.Artist/" { policy = "write" }`
 	ArtistV2ListPolicy  = `key_prefix "resource/" { policy = "list" }`
 )
 

--- a/internal/resource/tombstone.go
+++ b/internal/resource/tombstone.go
@@ -6,6 +6,6 @@ var (
 	TypeV1Tombstone = &pbresource.Type{
 		Group:        "internal",
 		GroupVersion: "v1",
-		Kind:         "tombstone",
+		Kind:         "Tombstone",
 	}
 )


### PR DESCRIPTION
### Description

For consistency, resource type names must follow these rules:

- `Group` must be snake case, and in most cases a single word.
- `GroupVersion` must be lowercase, start with a "v" and end with a number.
- `Kind` must be pascal case.

These were chosen because they map to our protobuf type naming conventions.
