### PR TITLE
backport ent changes to oss

### DIFF
--- a/.changelog/_5669.txt
+++ b/.changelog/_5669.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit-logging: (Enterprise only) enable error response and request body logging
+```

--- a/.changelog/_5669.txt
+++ b/.changelog/_5669.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-audit-logging: (Enterprise only) enable error response and request body logging
+audit-logging: **(Enterprise only)** enable error response and request body logging
 ```

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -53,6 +53,22 @@ func makeACLClient(t *testing.T) (*Client, *testutil.TestServer) {
 	})
 }
 
+// Makes a client with Audit enabled, it requires ACLs
+func makeAuditClient(t *testing.T) (*Client, *testutil.TestServer) {
+	return makeClientWithConfig(t, func(clientConfig *Config) {
+		clientConfig.Token = "root"
+	}, func(serverConfig *testutil.TestServerConfig) {
+		serverConfig.PrimaryDatacenter = "dc1"
+		serverConfig.ACL.Tokens.InitialManagement = "root"
+		serverConfig.ACL.Tokens.Agent = "root"
+		serverConfig.ACL.Enabled = true
+		serverConfig.ACL.DefaultPolicy = "deny"
+		serverConfig.Audit = &testutil.TestAuditConfig{
+			Enabled: true,
+		}
+	})
+}
+
 func makeNonBootstrappedACLClient(t *testing.T, defaultPolicy string) (*Client, *testutil.TestServer) {
 	return makeClientWithConfig(t,
 		func(clientConfig *Config) {

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -75,6 +75,11 @@ type TestNetworkSegment struct {
 	Advertise string `json:"advertise"`
 }
 
+// TestAudigConfig contains the configuration for Audit
+type TestAuditConfig struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
 // Locality is used as the TestServerConfig's Locality.
 type Locality struct {
 	Region string `json:"region"`
@@ -124,6 +129,7 @@ type TestServerConfig struct {
 	Stderr              io.Writer              `json:"-"`
 	Args                []string               `json:"-"`
 	ReturnPorts         func()                 `json:"-"`
+	Audit               *TestAuditConfig       `json:"audit,omitempty"`
 }
 
 type TestACLs struct {


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

- Fixing disparities between ent repo and oss repos 
- Drift will be caught in the future by this work: 🤞🏾 https://github.com/hashicorp/consul-enterprise/pull/5781