### PR TITLE
api-gateway: stop adding all header filters to virtual host when generating xDS

### DIFF
--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -415,6 +415,19 @@ func getAPIGatewayGoldenTestCases(t *testing.T) []goldenTestCase {
 						Kind: structs.HTTPRoute,
 						Name: "route",
 						Rules: []structs.HTTPRouteRule{{
+							Filters: structs.HTTPFilters{
+								Headers: []structs.HTTPHeaderFilter{
+									{
+										Add: map[string]string{
+											"X-Header-Add": "added",
+										},
+										Set: map[string]string{
+											"X-Header-Set": "set",
+										},
+										Remove: []string{"X-Header-Remove"},
+									},
+								},
+							},
 							Services: []structs.HTTPService{{
 								Name: "service",
 							}},

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -477,8 +477,6 @@ func (s *ResourceGenerator) routesForAPIGateway(cfgSnap *proxycfg.ConfigSnapshot
 				return nil, err
 			}
 
-			addHeaderFiltersToVirtualHost(&reformatedRoute, virtualHost)
-
 			defaultRoute.VirtualHosts = append(defaultRoute.VirtualHosts, virtualHost)
 		}
 
@@ -1095,16 +1093,6 @@ func injectHeaderManipToRoute(dest *structs.ServiceRouteDestination, r *envoy_ro
 		)
 	}
 	return nil
-}
-
-func addHeaderFiltersToVirtualHost(dest *structs.HTTPRouteConfigEntry, vh *envoy_route_v3.VirtualHost) {
-	for _, rule := range dest.Rules {
-		for _, header := range rule.Filters.Headers {
-			vh.RequestHeadersToAdd = append(vh.RequestHeadersToAdd, makeHeadersValueOptions(header.Add, true)...)
-			vh.RequestHeadersToAdd = append(vh.RequestHeadersToAdd, makeHeadersValueOptions(header.Set, false)...)
-			vh.RequestHeadersToRemove = append(vh.RequestHeadersToRemove, header.Remove...)
-		}
-	}
 }
 
 func injectHeaderManipToVirtualHost(dest *structs.IngressService, vh *envoy_route_v3.VirtualHost) error {

--- a/agent/xds/testdata/routes/api-gateway-with-http-route-and-inline-certificate.latest.golden
+++ b/agent/xds/testdata/routes/api-gateway-with-http-route-and-inline-certificate.latest.golden
@@ -18,8 +18,46 @@
               },
               "route":  {
                 "cluster":  "service.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
-              }
+              },
+              "requestHeadersToAdd":  [
+                {
+                  "header":  {
+                    "key":  "X-Header-Add",
+                    "value":  "added"
+                  },
+                  "append":  true
+                },
+                {
+                  "header":  {
+                    "key":  "X-Header-Set",
+                    "value":  "set"
+                  },
+                  "append":  false
+                }
+              ],
+              "requestHeadersToRemove":  [
+                "X-Header-Remove"
+              ]
             }
+          ],
+          "requestHeadersToAdd":  [
+            {
+              "header":  {
+                "key":  "X-Header-Add",
+                "value":  "added"
+              },
+              "append":  true
+            },
+            {
+              "header":  {
+                "key":  "X-Header-Set",
+                "value":  "set"
+              },
+              "append":  false
+            }
+          ],
+          "requestHeadersToRemove":  [
+            "X-Header-Remove"
           ]
         }
       ],

--- a/agent/xds/testdata/routes/api-gateway-with-http-route-and-inline-certificate.latest.golden
+++ b/agent/xds/testdata/routes/api-gateway-with-http-route-and-inline-certificate.latest.golden
@@ -1,69 +1,50 @@
 {
-  "versionInfo":  "00000001",
-  "resources":  [
+  "versionInfo": "00000001",
+  "resources": [
     {
-      "@type":  "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
-      "name":  "8080",
-      "virtualHosts":  [
+      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+      "name": "8080",
+      "virtualHosts": [
         {
-          "name":  "api-gateway-listener-9b9265b",
-          "domains":  [
+          "name": "api-gateway-listener-9b9265b",
+          "domains": [
             "*",
             "*:8080"
           ],
-          "routes":  [
+          "routes": [
             {
-              "match":  {
-                "prefix":  "/"
+              "match": {
+                "prefix": "/"
               },
-              "route":  {
-                "cluster":  "service.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              "route": {
+                "cluster": "service.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               },
-              "requestHeadersToAdd":  [
+              "requestHeadersToAdd": [
                 {
-                  "header":  {
-                    "key":  "X-Header-Add",
-                    "value":  "added"
+                  "header": {
+                    "key": "X-Header-Add",
+                    "value": "added"
                   },
-                  "append":  true
+                  "append": true
                 },
                 {
-                  "header":  {
-                    "key":  "X-Header-Set",
-                    "value":  "set"
+                  "header": {
+                    "key": "X-Header-Set",
+                    "value": "set"
                   },
-                  "append":  false
+                  "append": false
                 }
               ],
-              "requestHeadersToRemove":  [
+              "requestHeadersToRemove": [
                 "X-Header-Remove"
               ]
             }
-          ],
-          "requestHeadersToAdd":  [
-            {
-              "header":  {
-                "key":  "X-Header-Add",
-                "value":  "added"
-              },
-              "append":  true
-            },
-            {
-              "header":  {
-                "key":  "X-Header-Set",
-                "value":  "set"
-              },
-              "append":  false
-            }
-          ],
-          "requestHeadersToRemove":  [
-            "X-Header-Remove"
           ]
         }
       ],
-      "validateClusters":  true
+      "validateClusters": true
     }
   ],
-  "typeUrl":  "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
-  "nonce":  "00000001"
+  "typeUrl": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+  "nonce": "00000001"
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Header filters on http-route rules are being added to the virtual host _and_ the route when generating xDS.
This is demonstrated by stepping through the commits in this PR:
1. The first commit demonstrates the xDS that _was_ being generated, which includes the header modifications on both the virtual host and the routes
2. The second commit includes the fix to stop adding all header filters to the virtual host
3. The third commit updates the golden file containing the generated xDS, so this is what we're generating after the fix

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
- This PR adds a test verifying that this bug existed and is now fixed
- The kubernetes-sigs/gateway-api conformance tests exercise this functionality, which is how I identified this bug

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

<!-- Addresses NET-4422 -->