### PR TITLE
ENT backport for ext-authz extension updates

### DIFF
--- a/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-local-grpc-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-local-grpc-service.latest.golden
@@ -91,20 +91,6 @@
                 },
                 "httpFilters": [
                   {
-                    "name": "envoy.filters.http.ext_authz",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
-                      "grpcService": {
-                        "envoyGrpc": {
-                          "clusterName": "local_ext_authz"
-                        }
-                      },
-                      "transportApiVersion": "V3",
-                      "failureModeAllow": true,
-                      "statPrefix": "response"
-                    }
-                  },
-                  {
                     "name": "envoy.filters.http.rbac",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
@@ -187,6 +173,23 @@
                           }
                         }
                       ]
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.ext_authz",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
+                      "grpcService": {
+                        "envoyGrpc": {
+                          "clusterName": "local_ext_authz"
+                        }
+                      },
+                      "transportApiVersion": "V3",
+                      "failureModeAllow": true,
+                      "metadataContextNamespaces": [
+                        "consul"
+                      ],
+                      "statPrefix": "response"
                     }
                   },
                   {

--- a/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-local-http-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-local-http-service.latest.golden
@@ -187,6 +187,9 @@
                       },
                       "transportApiVersion": "V3",
                       "failureModeAllow": true,
+                      "metadataContextNamespaces": [
+                        "consul"
+                      ],
                       "statPrefix": "response"
                     }
                   },

--- a/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-upstream-grpc-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-upstream-grpc-service.latest.golden
@@ -208,7 +208,8 @@
                       },
                       "metadataContextNamespaces": [
                         "test-ns-1",
-                        "test-ns-2"
+                        "test-ns-2",
+                        "consul"
                       ],
                       "includePeerCertificate": true,
                       "statPrefix": "ext_authz_stats",

--- a/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-upstream-http-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-upstream-http-service.latest.golden
@@ -206,7 +206,8 @@
                       },
                       "metadataContextNamespaces": [
                         "test-ns-1",
-                        "test-ns-2"
+                        "test-ns-2",
+                        "consul"
                       ],
                       "includePeerCertificate": true,
                       "statPrefix": "ext_authz_stats",

--- a/agent/xds/testdata/builtin_extension/listeners/ext-authz-tcp-local-grpc-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/ext-authz-tcp-local-grpc-service.latest.golden
@@ -64,6 +64,14 @@
         {
           "filters": [
             {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {},
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
               "name": "envoy.filters.network.ext_authz",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.ext_authz.v3.ExtAuthz",
@@ -75,14 +83,6 @@
                 },
                 "failureModeAllow": true,
                 "transportApiVersion": "V3"
-              }
-            },
-            {
-              "name": "envoy.filters.network.rbac",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                "rules": {},
-                "statPrefix": "connect_authz"
               }
             },
             {


### PR DESCRIPTION
### Description

This PR merges some minor updates for the `builtin/ext-authz` Envoy extension.

### Testing & Reproduction steps

- `ext-authz` unit tests all pass
- Golden `xds` tests have been updated.

### Links

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
