### PR TITLE
add enterprise notes for IP-based rate limits

### DIFF
--- a/website/content/docs/agent/limits/index.mdx
+++ b/website/content/docs/agent/limits/index.mdx
@@ -21,7 +21,7 @@ You can set global limits on the rate of read and write requests that affect ind
 
 1. Monitor the metrics and logs and readjust the initial configurations as necessary. Refer to [Monitor rate limit data](/consul/docs/agent/limits/usage/monitor-rate-limit-data)  
 
-1. Define your final operational limits based on your observations. If you are defining global rate limits, refer to [Set global traffic rate limits](/consul/docs/agent/limits/usage/set-global-rate-limits) for additional information. For information about setting limits based on source IP, refer to [Limit traffic rates for a source IP](/consul/docs/agent/limits/usage/set-source-ip-rate-limits).
+1. Define your final operational limits based on your observations. If you are defining global rate limits, refer to [Set global traffic rate limits](/consul/docs/agent/limits/usage/set-global-rate-limits) for additional information. For information about setting limits per source IP address, refer to [Limit traffic rates for a source IP](/consul/docs/agent/limits/usage/set-source-ip-rate-limits). Note that setting limits per source IP requires Consul Enterprise.
 
 ### Order of operations
 

--- a/website/content/docs/agent/limits/usage/limit-request-rates-from-ips.mdx
+++ b/website/content/docs/agent/limits/usage/limit-request-rates-from-ips.mdx
@@ -8,6 +8,12 @@ description: Learn how to set read and request rate limits on RPC and gRPC traff
 
 This topic describes how to configure RPC and gRPC traffic rate limits for source IP addresses. This enables you to specify a budget for read and write requests to prevent any single source IP from overwhelming the Consul server and negatively affecting the network. For information about setting global traffic rate limits, refer to [Set a global limit on traffic rates](/consul/docs/agent/limits/usage/set-glogal-traffic-rate-limits). For an overview of Consul's server rate limiting capabilities, refer to [Limit traffic rates overview](/consul/docs/agent/limits/overview). 
 
+<EnterpriseAlert>
+
+This feature requires Consul Enterprise. Refer to the [feature compatibility matrix](/consul/docs/v1.16.x/enterprise#consul-enterprise-feature-availability) for additional information.
+
+</EnterpriseAlert>
+
 ## Overview
 
 You can set limits on the rate of read and write requests from source IP addresses to specific resources, which mitigates the risks to Consul servers when consul clients send excessive requests to a specific resource type. Before configuring traffic rate limits, you should complete the initialization process to understand normal traffic loads in your network. Refer to [Initialize rate limit settings](/consul/docs/agent/limits/init-rate-limits) for additional information.
@@ -22,7 +28,7 @@ You should also monitor read and write rate activity and make any necessary adju
 
 ## Define rate limits
 
-Create a control plane request limit configuration entry in the `default` partition. The configuration entry applies to all client requests targeting any partition. Refer to the [control plane request limit configuration entry](/consul/docs/connect/config-entries/control-plan-request-limit) reference documentation for details about the available configuration parameters. 
+Create a control plane request limit configuration entry in the `default` partition. The configuration entry applies to all client requests targeting any partition. Refer to the [control plane request limit configuration entry](/consul/docs/connect/config-entries/control-plane-request-limit) reference documentation for details about the available configuration parameters. 
 
 Specify the following parameters:
 

--- a/website/content/docs/agent/limits/usage/limit-request-rates-from-ips.mdx
+++ b/website/content/docs/agent/limits/usage/limit-request-rates-from-ips.mdx
@@ -10,7 +10,7 @@ This topic describes how to configure RPC and gRPC traffic rate limits for sourc
 
 <EnterpriseAlert>
 
-This feature requires Consul Enterprise. Refer to the [feature compatibility matrix](/consul/docs/v1.16.x/enterprise#consul-enterprise-feature-availability) for additional information.
+This feature requires Consul Enterprise. Refer to the [feature compatibility matrix](/consul/docs/enterprise#consul-enterprise-feature-availability) for additional information.
 
 </EnterpriseAlert>
 

--- a/website/content/docs/connect/config-entries/control-plane-request-limit.mdx
+++ b/website/content/docs/connect/config-entries/control-plane-request-limit.mdx
@@ -10,7 +10,7 @@ This topic describes the configuration options for the `control-plane-request-li
 
 <EnterpriseAlert>
 
-This feature requires Consul Enterprise. Refer to the [feature compatibility matrix](/consul/docs/v1.16.x/enterprise#consul-enterprise-feature-availability) for additional information.
+This feature requires Consul Enterprise. Refer to the [feature compatibility matrix](/consul/docs/enterprise#consul-enterprise-feature-availability) for additional information.
 
 </EnterpriseAlert>
 

--- a/website/content/docs/connect/config-entries/control-plane-request-limit.mdx
+++ b/website/content/docs/connect/config-entries/control-plane-request-limit.mdx
@@ -8,6 +8,12 @@ description:  Learn how to configure the control-plane-request-limit configurati
 
 This topic describes the configuration options for the `control-plane-request-limit` configuration entry. You can only write the `control-plane-request-limit` configuration entry to the `default` partition, but the configuration entry applies to all client requests that target any partition. 
 
+<EnterpriseAlert>
+
+This feature requires Consul Enterprise. Refer to the [feature compatibility matrix](/consul/docs/v1.16.x/enterprise#consul-enterprise-feature-availability) for additional information.
+
+</EnterpriseAlert>
+
 ## Configuration model
 
 The following list outlines field hierarchy, language-specific data types, and requirements in a control plane request limit configuration entry. Click on a property name to view additional details, including default values.

--- a/website/content/docs/enterprise/index.mdx
+++ b/website/content/docs/enterprise/index.mdx
@@ -86,7 +86,7 @@ Available Enterprise features per Consul form and license include:
 | [Redundancy Zones](/consul/docs/enterprise/redundancy)          | Not applicable                          | Yes                 | With Global Visibility, Routing, and Scale module |
 | [Sameness Groups](/consul/docs/connect/config-entries/samenes-group) | No | Yes | N/A |
 | [Sentinel for KV](/consul/docs/enterprise/sentinel)             | All tiers                               | Yes                 | With Governance and Policy module                 |
-| [Server request rate limits per source IP](/consul/docs/v1.16.x/agent/limits/usage/limit-request-rates-from-ips) | All tiers | Yes | With Governance and Policy module |
+| [Server request rate limits per source IP](/consul/docs/agent/limits/usage/limit-request-rates-from-ips) | All tiers | Yes | With Governance and Policy module |
 
 
 [HashiCorp Cloud Platform (HCP) Consul]: https://cloud.hashicorp.com/products/consul
@@ -114,7 +114,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Redundancy Zones](/consul/docs/enterprise/redundancy)                  |  &#9989;  |  &#9989;   |   &#9989;  |
 | [Sameness Groups](/consul/docs/connect/config-entries/samenes-group)    |  &#9989;  |  &#9989;   |   &#9989;  |
 | [Sentinel ](/consul/docs/enterprise/sentinel)                           |  &#9989;  |  &#9989;   |   &#9989;  |
-| [Server request rate limits per source IP](/consul/docs/v1.16.x/agent/limits/usage/limit-request-rates-from-ips) | &#9989; | &#9989; | &#9989; |
+| [Server request rate limits per source IP](/consul/docs/agent/limits/usage/limit-request-rates-from-ips) | &#9989; | &#9989; | &#9989; |
 
 </Tab>
 
@@ -134,7 +134,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Redundancy Zones](/consul/docs/enterprise/redundancy)                  |  &#10060; |  &#10060;  |  &#10060;  |
 | [Sameness Groups](/consul/docs/connect/config-entries/samenes-group)    |  &#9989;  |  &#9989;   |   &#9989;  |
 | [Sentinel ](/consul/docs/enterprise/sentinel)                           |  &#9989;  |  &#9989;   |  &#9989;  |
-| [Server request rate limits per source IP](/consul/docs/v1.16.x/agent/limits/usage/limit-request-rates-from-ips) | &#9989; | &#9989; | &#9989; |
+| [Server request rate limits per source IP](/consul/docs/agent/limits/usage/limit-request-rates-from-ips) | &#9989; | &#9989; | &#9989; |
 
 </Tab>
 
@@ -154,7 +154,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Redundancy Zones](/consul/docs/enterprise/redundancy)                  |  n/a      |  n/a       |  n/a       |
 | [Sameness Groups](/consul/docs/connect/config-entries/samenes-group)    |  &#9989;  |  &#9989;   |   &#9989;  |
 | [Sentinel ](/consul/docs/enterprise/sentinel)                           |  &#9989;  |  &#9989;   |   &#9989;  |
-| [Server request rate limits per source IP](/consul/docs/v1.16.x/agent/limits/usage/limit-request-rates-from-ips) | &#9989; | &#9989; | &#9989; |
+| [Server request rate limits per source IP](/consul/docs/agent/limits/usage/limit-request-rates-from-ips) | &#9989; | &#9989; | &#9989; |
 
 </Tab>
 </Tabs>

--- a/website/content/docs/enterprise/index.mdx
+++ b/website/content/docs/enterprise/index.mdx
@@ -86,6 +86,8 @@ Available Enterprise features per Consul form and license include:
 | [Redundancy Zones](/consul/docs/enterprise/redundancy)          | Not applicable                          | Yes                 | With Global Visibility, Routing, and Scale module |
 | [Sameness Groups](/consul/docs/connect/config-entries/samenes-group) | No | Yes | N/A |
 | [Sentinel for KV](/consul/docs/enterprise/sentinel)             | All tiers                               | Yes                 | With Governance and Policy module                 |
+| [Server request rate limits per source IP](/consul/docs/v1.16.x/agent/limits/usage/limit-request-rates-from-ips) | All tiers | Yes | With Governance and Policy module |
+
 
 [HashiCorp Cloud Platform (HCP) Consul]: https://cloud.hashicorp.com/products/consul
 [Consul Enterprise]: https://www.hashicorp.com/products/consul/
@@ -112,6 +114,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Redundancy Zones](/consul/docs/enterprise/redundancy)                  |  &#9989;  |  &#9989;   |   &#9989;  |
 | [Sameness Groups](/consul/docs/connect/config-entries/samenes-group)    |  &#9989;  |  &#9989;   |   &#9989;  |
 | [Sentinel ](/consul/docs/enterprise/sentinel)                           |  &#9989;  |  &#9989;   |   &#9989;  |
+| [Server request rate limits per source IP](/consul/docs/v1.16.x/agent/limits/usage/limit-request-rates-from-ips) | &#9989; | &#9989; | &#9989; |
 
 </Tab>
 
@@ -131,6 +134,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Redundancy Zones](/consul/docs/enterprise/redundancy)                  |  &#10060; |  &#10060;  |  &#10060;  |
 | [Sameness Groups](/consul/docs/connect/config-entries/samenes-group)    |  &#9989;  |  &#9989;   |   &#9989;  |
 | [Sentinel ](/consul/docs/enterprise/sentinel)                           |  &#9989;  |  &#9989;   |  &#9989;  |
+| [Server request rate limits per source IP](/consul/docs/v1.16.x/agent/limits/usage/limit-request-rates-from-ips) | &#9989; | &#9989; | &#9989; |
 
 </Tab>
 
@@ -150,6 +154,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Redundancy Zones](/consul/docs/enterprise/redundancy)                  |  n/a      |  n/a       |  n/a       |
 | [Sameness Groups](/consul/docs/connect/config-entries/samenes-group)    |  &#9989;  |  &#9989;   |   &#9989;  |
 | [Sentinel ](/consul/docs/enterprise/sentinel)                           |  &#9989;  |  &#9989;   |   &#9989;  |
+| [Server request rate limits per source IP](/consul/docs/v1.16.x/agent/limits/usage/limit-request-rates-from-ips) | &#9989; | &#9989; | &#9989; |
 
 </Tab>
 </Tabs>

--- a/website/content/docs/release-notes/consul/v1_16_x.mdx
+++ b/website/content/docs/release-notes/consul/v1_16_x.mdx
@@ -23,7 +23,7 @@ We are pleased to announce the following Consul updates.
     - [Route traffic to virtual services](/consul/docs/k8s/l7-traffic/route-to-virtual-services)
     - [Configure failover services](/consul/docs/k8s/l7-traffic/failover-tproxy).
 
-- **Granular server-side rate limits:** You can now set limits per source IP address. The following steps describe the general process for setting global read and write rate limits:
+- **Granular server-side rate limits:** You can now set limits per source IP address in Consul Enterprise. The following steps describe the general process for setting global read and write rate limits:
 
     1. Set arbitrary limits to begin understanding the upper boundary of RPC and gRPC loads in your network. Refer to [Initialize rate limit settings](/consul/docs/agent/limits/usage/init-rate-limits) for additional information.
     1. Monitor the metrics and logs and readjust the initial configurations as necessary. Refer to [Monitor rate limit data](/consul/docs/agent/limits/usage/monitor-rate-limits)

--- a/website/content/docs/release-notes/consul/v1_16_x.mdx
+++ b/website/content/docs/release-notes/consul/v1_16_x.mdx
@@ -11,9 +11,9 @@ We are pleased to announce the following Consul updates.
 
 ## Release Highlights
 
-- **Sameness groups:** Sameness groups are a user-defined set of partitions that Consul uses to identify services in different administrative partitions with the same name as being the same services. You can use sameness groups to create a blanket failover policy for deployments with cluster peering connections. Refer to the [Sameness groups overview](/consul/docs/connect/cluster-peering/usage/create-sameness-groups) for more information.
+- **Sameness groups (Enterprise):** Sameness groups are a user-defined set of partitions that Consul uses to identify services in different administrative partitions with the same name as being the same services. You can use sameness groups to create a blanket failover policy for deployments with cluster peering connections. Refer to the [Sameness groups overview](/consul/docs/connect/cluster-peering/usage/create-sameness-groups) for more information.
 
-   <Note> Sameness groups is currently a "Beta" feature in Consul v1.16.0 and is an Enterprise feature. </Note>
+   <Note> Sameness groups is currently a _beta_ feature in Consul Enterprise v1.16.0. </Note>
 
 - **Permissive mTLS:** You can enable the `permissive` mTLS mode to enable sidecar proxies to accept both mTLS and non-mTLS traffic. Using this mode enables you to onboard services without downtime and without reconfiguring or redeploying your application. Refer to the [Onboard services while in transparent proxy mode](/consul/docs/k8s/connect/onboarding-tproxy-mode) for more information on how to use permissive mTLS to onboard services to Consul.
 
@@ -39,11 +39,11 @@ We are pleased to announce the following Consul updates.
 
 - **Simplified API Gateway installation for Consul on Kubernetes:** API Gateway is now built into Consul. This enables a simplified installation and configuration process for Consul on Kubernetes. Refer to the [API Gateway installation](/consul/docs/api-gateway/install) for more information on the simplified native installation method. 
 
-- **FIPS compliance:** Consul Enterprise now offers FIPS 140-2 compliant builds that meet the security needs of federal agencies protecting sensitive, unclassified information with approved cryptographic measures. These builds use certified cryptographic modules and restrict configuration settings to comply with FIPS 140-2 Level 1 requirements, enabling compliant Consul deployments. Refer to the [Consul Enterprise FIPS](/consul/docs/enterprise/fips) for more information on FIPS compliance.
+- **FIPS compliance (Enterprise):** HashiCorp now offers FIPS 140-2 compliant builds of Consul Enterprise that meet the security needs of federal agencies protecting sensitive, unclassified information with approved cryptographic measures. These builds use certified cryptographic modules and restrict configuration settings to comply with FIPS 140-2 Level 1 requirements, enabling compliant Consul deployments. Refer to the [Consul Enterprise FIPS](/consul/docs/enterprise/fips) for more information on FIPS compliance.
 
 - **JWT Authorization with service intentions:** Consul can now authorize connections based on claims present in JSON Web Token (JWT). You can configure Consul to use one or more JWT providers, which lets you control access to services and specific HTTP paths based on the validity of JWT claims embedded in the service traffic. This ensures a uniform and low latency mechanism to validate and authorize communication based on JWT claims across all services in a diverse service-oriented architecture. Refer to the [Use JWT authorization with service intentions](/consul/docs/connect/intentions/jwt-authorization) for more information.
 
-- **Automated license utilization reporting:** Consul Enteprise now provides automated license utilization reporting, which sends minimal product-license metering data to HashiCorp. You can use these reports to understand how much more you can deploy under your current contract, which can help you protect against overutilization and budget for predicted consumption. Refer to the [Automated license utilization reporting documentation](/consul/docs/enterprise/license/utilization-reporting) for more information. 
+- **Automated license utilization reporting (Enterprise):** Consul Enteprise now provides automated license utilization reporting, which sends minimal product-license metering data to HashiCorp. You can use these reports to understand how much more you can deploy under your current contract, which can help you protect against overutilization and budget for predicted consumption. Refer to the [Automated license utilization reporting documentation](/consul/docs/enterprise/license/utilization-reporting) for more information. 
 
 ## Upgrading
 

--- a/website/content/docs/release-notes/consul/v1_16_x.mdx
+++ b/website/content/docs/release-notes/consul/v1_16_x.mdx
@@ -23,7 +23,7 @@ We are pleased to announce the following Consul updates.
     - [Route traffic to virtual services](/consul/docs/k8s/l7-traffic/route-to-virtual-services)
     - [Configure failover services](/consul/docs/k8s/l7-traffic/failover-tproxy).
 
-- **Granular server-side rate limits:** You can now set limits per source IP address in Consul Enterprise. The following steps describe the general process for setting global read and write rate limits:
+- **Granular server-side rate limits (Enterprise):** You can now set limits per source IP address. The following steps describe the general process for setting global read and write rate limits:
 
     1. Set arbitrary limits to begin understanding the upper boundary of RPC and gRPC loads in your network. Refer to [Initialize rate limit settings](/consul/docs/agent/limits/usage/init-rate-limits) for additional information.
     1. Monitor the metrics and logs and readjust the initial configurations as necessary. Refer to [Monitor rate limit data](/consul/docs/agent/limits/usage/monitor-rate-limits)


### PR DESCRIPTION
### Description

This PR flags the IP-based request rate limiting functionality as Consul Enterprise. The usage docs, configuration entry, and CE matrix have been updated.

### PR Checklist

* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
