### PR TITLE
Remove extraneous version info for Config entries

### DIFF
--- a/website/content/docs/connect/config-entries/exported-services.mdx
+++ b/website/content/docs/connect/config-entries/exported-services.mdx
@@ -9,8 +9,6 @@ description: >-
 
 This topic describes the `exported-services` configuration entry type. The `exported-services` configuration entry enables Consul to export service instances to other clusters from a single file and connect services across clusters. For additional information, refer to [Cluster Peering](/consul/docs/connect/cluster-peering) and [Admin Partitions](/consul/docs/enterprise/admin-partitions).
 
--> **v1.11.0+:** This config entry is supported in Consul versions 1.11.0+.
-
 ## Introduction
 
 To configure Consul to export services contained in a Consul Enterprise admin partition or Consul OSS datacenter to one or more additional clusters, create a new configuration entry and declare `exported-services` in the `kind` field. This configuration entry enables you to route traffic between services in different clusters.

--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -7,8 +7,6 @@ description: >-
 
 # Mesh Configuration Entry
 
--> **v1.10.0+:** This configuration entry is supported in Consul versions 1.10.0+.
-
 The `mesh` configuration entry allows you to define a global default configuration that applies to all service mesh proxies.
 Settings in this config entry apply across all namespaces and federated datacenters.
 

--- a/website/content/docs/connect/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/connect/config-entries/terminating-gateway.mdx
@@ -7,9 +7,6 @@ description: >-
 
 # Terminating Gateway Configuration Entry
 
--> **v1.8.4+:** On Kubernetes, the `TerminatingGateway` custom resource is supported in Consul versions 1.8.4+.<br />
-**v1.8.0+:** On other platforms, this config entry is supported in Consul versions 1.8.0+.
-
 The `terminating-gateway` config entry kind (`TerminatingGateway` on Kubernetes) allows you to configure terminating gateways
 to proxy traffic from services in the Consul service mesh to services registered with Consul that do not have a
 [service mesh sidecar proxy](/consul/docs/connect/proxies). The configuration is associated with the name of a gateway service


### PR DESCRIPTION
### Description

Now that 1.14-1.16 will be the versions that will actively maintained, we should remove these mentions of old versions from our config entries. Users can still see this in previous versions of our docs due to versioned docs support. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
