### PR TITLE
Disable peering queries by default in proxycfg

### DIFF
--- a/.changelog/17731.txt
+++ b/.changelog/17731.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+connect: Disable peering by default in connect proxies for Consul 1.13. This change was made to prevent inefficient polling
+queries from having a negative impact on server performance. Peering in Consul 1.13 is an experimental feature and is not
+recommended for use in production environments. If you still wish to use the experimental peering feature, ensure
+[`peering.enabled = true`](https://developer.hashicorp.com/consul/docs/v1.13.x/agent/config/config-files#peering_enabled)
+is set on all clients and servers.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -646,6 +646,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		},
 		TLSConfigurator:       a.tlsConfigurator,
 		IntentionDefaultAllow: intentionDefaultAllow,
+		PeeringEnabled:        a.config.PeeringEnabled,
 	})
 	if err != nil {
 		return err

--- a/agent/proxycfg/manager.go
+++ b/agent/proxycfg/manager.go
@@ -75,6 +75,8 @@ type ManagerConfig struct {
 	// information to proxies that need to make intention decisions on their
 	// own.
 	IntentionDefaultAllow bool
+
+	PeeringEnabled bool
 }
 
 // NewManager constructs a Manager.
@@ -137,6 +139,7 @@ func (m *Manager) Register(id ProxyID, ns *structs.NodeService, source ProxySour
 		source:                m.Source,
 		dnsConfig:             m.DNSConfig,
 		intentionDefaultAllow: m.IntentionDefaultAllow,
+		peeringEnabled:        m.PeeringEnabled,
 	}
 	if m.TLSConfigurator != nil {
 		stateConfig.serverSNIFn = m.TLSConfigurator.ServerSNI

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -54,6 +54,7 @@ type stateConfig struct {
 	dnsConfig             DNSConfig
 	serverSNIFn           ServerSNIFunc
 	intentionDefaultAllow bool
+	peeringEnabled        bool
 }
 
 // state holds all the state needed to maintain the config for a registered

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -441,9 +441,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 	type testCase struct {
 		// the state to operate on. the logger, source, cache,
 		// ctx and cancel fields will be filled in by the test
-		ns       structs.NodeService
-		sourceDC string
-		stages   []verificationStage
+		ns             structs.NodeService
+		sourceDC       string
+		stages         []verificationStage
+		peeringEnabled bool
 	}
 
 	newConnectProxyCase := func(meshGatewayProxyConfigValue structs.MeshGatewayMode) testCase {
@@ -747,7 +748,6 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						rootsWatchID:               genVerifyDCSpecificWatch("dc1"),
 						exportedServiceListWatchID: genVerifyDCSpecificWatch("dc1"),
 						meshConfigEntryID:          genVerifyMeshConfigWatch("dc1"),
-						peeringTrustBundlesWatchID: genVerifyTrustBundleListWatchForMeshGateway(""),
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.False(t, snap.Valid(), "gateway without root is not valid")
@@ -827,7 +827,6 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						rootsWatchID:               genVerifyDCSpecificWatch("dc1"),
 						exportedServiceListWatchID: genVerifyDCSpecificWatch("dc1"),
 						meshConfigEntryID:          genVerifyMeshConfigWatch("dc1"),
-						peeringTrustBundlesWatchID: genVerifyTrustBundleListWatchForMeshGateway(""),
 					},
 					events: []UpdateEvent{
 						rootWatchEvent(),
@@ -2715,6 +2714,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 			},
 		},
 		"transparent-proxy-initial-with-peers": {
+			peeringEnabled: true,
 			ns: structs.NodeService{
 				Kind:    structs.ServiceKindConnectProxy,
 				ID:      "api-proxy",
@@ -2964,6 +2964,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 		"connect-proxy":                    newConnectProxyCase(structs.MeshGatewayModeDefault),
 		"connect-proxy-mesh-gateway-local": newConnectProxyCase(structs.MeshGatewayModeLocal),
 		"connect-proxy-with-peers": {
+			peeringEnabled: true,
 			ns: structs.NodeService{
 				Kind:    structs.ServiceKindConnectProxy,
 				ID:      "web-sidecar-proxy",
@@ -3141,6 +3142,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					Domain:    "consul.",
 					AltDomain: "alt.consul.",
 				},
+				peeringEnabled: tc.peeringEnabled,
 			}
 			wr := recordWatches(&sc)
 

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -719,6 +719,7 @@ func testConfigSnapshotFixture(
 	nsFn func(ns *structs.NodeService),
 	serverSNIFn ServerSNIFunc,
 	updates []UpdateEvent,
+	peeringEnabled bool,
 ) *ConfigSnapshot {
 	const token = ""
 
@@ -761,6 +762,7 @@ func testConfigSnapshotFixture(
 		},
 		serverSNIFn:           serverSNIFn,
 		intentionDefaultAllow: false, // TODO: make configurable
+		peeringEnabled:        peeringEnabled,
 	}
 	testConfigSnapshotFixtureEnterprise(&config)
 	s, err := newServiceInstanceFromNodeService(ProxyID{ServiceID: ns.CompoundServiceID()}, ns, token)

--- a/agent/proxycfg/testing_connect_proxy.go
+++ b/agent/proxycfg/testing_connect_proxy.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestConfigSnapshot returns a fully populated snapshot
-func TestConfigSnapshot(t testing.T, nsFn func(ns *structs.NodeService), extraUpdates []UpdateEvent) *ConfigSnapshot {
+func TestConfigSnapshot(t testing.T, nsFn func(ns *structs.NodeService), extraUpdates []UpdateEvent, peeringEnabled bool) *ConfigSnapshot {
 	roots, leaf := TestCerts(t)
 
 	// no entries implies we'll get a default chain
@@ -84,7 +84,7 @@ func TestConfigSnapshot(t testing.T, nsFn func(ns *structs.NodeService), extraUp
 		},
 		Meta:            nil,
 		TaggedAddresses: nil,
-	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates))
+	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates), peeringEnabled)
 }
 
 // TestConfigSnapshotDiscoveryChain returns a fully populated snapshot using a discovery chain
@@ -155,7 +155,7 @@ func TestConfigSnapshotDiscoveryChain(
 		},
 		Meta:            nil,
 		TaggedAddresses: nil,
-	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates))
+	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates), false)
 }
 
 func TestConfigSnapshotExposeConfig(t testing.T, nsFn func(ns *structs.NodeService)) *ConfigSnapshot {
@@ -210,7 +210,7 @@ func TestConfigSnapshotExposeConfig(t testing.T, nsFn func(ns *structs.NodeServi
 		},
 		Meta:            nil,
 		TaggedAddresses: nil,
-	}, nsFn, nil, baseEvents)
+	}, nsFn, nil, baseEvents, false)
 }
 
 func TestConfigSnapshotExposeChecks(t testing.T) *ConfigSnapshot {
@@ -237,7 +237,7 @@ func TestConfigSnapshotExposeChecks(t testing.T) *ConfigSnapshot {
 				}},
 			},
 		},
-	)
+		false)
 }
 
 func TestConfigSnapshotGRPCExposeHTTP1(t testing.T) *ConfigSnapshot {
@@ -286,5 +286,5 @@ func TestConfigSnapshotGRPCExposeHTTP1(t testing.T) *ConfigSnapshot {
 			CorrelationID: svcChecksWatchIDPrefix + structs.ServiceIDString("grpc", nil),
 			Result:        []structs.CheckType{},
 		},
-	})
+	}, false)
 }

--- a/agent/proxycfg/testing_ingress_gateway.go
+++ b/agent/proxycfg/testing_ingress_gateway.go
@@ -99,7 +99,7 @@ func TestConfigSnapshotIngressGateway(
 		Address:         "1.2.3.4",
 		Meta:            nil,
 		TaggedAddresses: nil,
-	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates))
+	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates), true)
 }
 
 func TestConfigSnapshotIngressGatewaySDS_GatewayLevel_MixedTLS(t testing.T) *ConfigSnapshot {

--- a/agent/proxycfg/testing_mesh_gateway.go
+++ b/agent/proxycfg/testing_mesh_gateway.go
@@ -461,7 +461,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 				Port:    443,
 			},
 		},
-	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates))
+	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates), false)
 }
 
 func TestConfigSnapshotPeeredMeshGateway(t testing.T, variant string, nsFn func(ns *structs.NodeService), extraUpdates []UpdateEvent) *ConfigSnapshot {
@@ -737,5 +737,5 @@ func TestConfigSnapshotPeeredMeshGateway(t testing.T, variant string, nsFn func(
 				Port:    443,
 			},
 		},
-	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates))
+	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates), true)
 }

--- a/agent/proxycfg/testing_peering.go
+++ b/agent/proxycfg/testing_peering.go
@@ -106,7 +106,7 @@ func TestConfigSnapshotPeering(t testing.T) *ConfigSnapshot {
 				},
 			},
 		},
-	})
+	}, true)
 }
 
 func TestConfigSnapshotPeeringTProxy(t testing.T) *ConfigSnapshot {
@@ -247,5 +247,5 @@ func TestConfigSnapshotPeeringTProxy(t testing.T) *ConfigSnapshot {
 				},
 			},
 		},
-	})
+	}, true)
 }

--- a/agent/proxycfg/testing_terminating_gateway.go
+++ b/agent/proxycfg/testing_terminating_gateway.go
@@ -321,7 +321,7 @@ func TestConfigSnapshotTerminatingGateway(t testing.T, populateServices bool, ns
 				Port:    443,
 			},
 		},
-	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates))
+	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates), false)
 }
 
 func TestConfigSnapshotTerminatingGatewayDestinations(t testing.T, populateDestinations bool, extraUpdates []UpdateEvent) *ConfigSnapshot {
@@ -520,7 +520,7 @@ func TestConfigSnapshotTerminatingGatewayDestinations(t testing.T, populateDesti
 				Port:    443,
 			},
 		},
-	}, nil, nil, testSpliceEvents(baseEvents, extraUpdates))
+	}, nil, nil, testSpliceEvents(baseEvents, extraUpdates), false)
 }
 
 func TestConfigSnapshotTerminatingGatewayServiceSubsets(t testing.T) *ConfigSnapshot {

--- a/agent/proxycfg/testing_tproxy.go
+++ b/agent/proxycfg/testing_tproxy.go
@@ -113,7 +113,7 @@ func TestConfigSnapshotTransparentProxy(t testing.T) *ConfigSnapshot {
 				Nodes: []structs.CheckServiceNode{},
 			},
 		},
-	})
+	}, false)
 }
 
 func TestConfigSnapshotTransparentProxyHTTPUpstream(t testing.T) *ConfigSnapshot {
@@ -226,7 +226,7 @@ func TestConfigSnapshotTransparentProxyHTTPUpstream(t testing.T) *ConfigSnapshot
 				Nodes: []structs.CheckServiceNode{},
 			},
 		},
-	})
+	}, false)
 }
 
 func TestConfigSnapshotTransparentProxyCatalogDestinationsOnly(t testing.T) *ConfigSnapshot {
@@ -312,7 +312,7 @@ func TestConfigSnapshotTransparentProxyCatalogDestinationsOnly(t testing.T) *Con
 				Nodes: []structs.CheckServiceNode{},
 			},
 		},
-	})
+	}, false)
 }
 
 func TestConfigSnapshotTransparentProxyDialDirectly(t testing.T) *ConfigSnapshot {
@@ -434,7 +434,7 @@ func TestConfigSnapshotTransparentProxyDialDirectly(t testing.T) *ConfigSnapshot
 				},
 			},
 		},
-	})
+	}, false)
 }
 
 func TestConfigSnapshotTransparentProxyResolverRedirectUpstream(t testing.T) *ConfigSnapshot {
@@ -503,7 +503,7 @@ func TestConfigSnapshotTransparentProxyResolverRedirectUpstream(t testing.T) *Co
 				},
 			},
 		},
-	})
+	}, false)
 }
 
 func TestConfigSnapshotTransparentProxyTerminatingGatewayCatalogDestinationsOnly(t testing.T) *ConfigSnapshot {
@@ -591,7 +591,7 @@ func TestConfigSnapshotTransparentProxyTerminatingGatewayCatalogDestinationsOnly
 				Nodes: []structs.CheckServiceNode{tgate},
 			},
 		},
-	})
+	}, false)
 }
 
 func TestConfigSnapshotTransparentProxyDestination(t testing.T) *ConfigSnapshot {
@@ -698,7 +698,7 @@ func TestConfigSnapshotTransparentProxyDestination(t testing.T) *ConfigSnapshot 
 				Nodes: serviceNodes,
 			},
 		},
-	})
+	}, false)
 }
 
 func TestConfigSnapshotTransparentProxyDestinationHTTP(t testing.T) *ConfigSnapshot {
@@ -804,5 +804,5 @@ func TestConfigSnapshotTransparentProxyDestinationHTTP(t testing.T) *ConfigSnaps
 				Nodes: serviceNodes,
 			},
 		},
-	})
+	}, false)
 }

--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -89,7 +89,7 @@ func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u UpdateEv
 			return err
 		}
 
-	case strings.HasPrefix(u.CorrelationID, upstreamPeerWatchIDPrefix):
+	case strings.HasPrefix(u.CorrelationID, upstreamPeerWatchIDPrefix) && s.peeringEnabled:
 		resp, ok := u.Result.(*structs.IndexedCheckServiceNodes)
 		if !ok {
 			return fmt.Errorf("invalid type for response: %T", u.Result)

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -50,7 +50,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							},
 						},
 					},
-				})
+				}, false)
 			},
 		},
 		{
@@ -69,7 +69,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							},
 						},
 					},
-				})
+				}, false)
 			},
 		},
 		{
@@ -88,7 +88,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							},
 						},
 					},
-				})
+				}, false)
 			},
 		},
 		{
@@ -110,7 +110,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							},
 						},
 					},
-				})
+				}, false)
 			},
 		},
 		{
@@ -121,7 +121,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 						customAppClusterJSON(t, customClusterJSONOptions{
 							Name: "mylocal",
 						})
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 						customAppClusterJSON(t, customClusterJSONOptions{
 							Name: "myservice",
 						})
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -157,7 +157,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							// Attempt to override the TLS context should be ignored
 							TLSContext: `"allowRenegotiation": false`,
 						})
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -166,7 +166,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["local_connect_timeout_ms"] = 1234
 					ns.Proxy.Upstreams[0].Config["connect_timeout_ms"] = 2345
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -178,7 +178,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 						"max_failures":              float64(5),
 						"interval":                  float64(10),
 					}
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -186,7 +186,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["max_inbound_connections"] = 3456
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -206,7 +206,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							"max_connections": 500,
 						}
 					}
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -224,7 +224,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							"max_concurrent_requests": 0,
 						}
 					}
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -242,7 +242,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							"max_concurrent_requests": 700,
 						}
 					}
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -344,7 +344,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 					ns.Proxy.LocalServiceAddress = ""
 					ns.Proxy.LocalServicePort = 0
 					ns.Proxy.LocalServiceSocketPath = "/tmp/downstream_proxy.sock"
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -53,7 +53,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 							},
 						},
 					},
-				})
+				}, false)
 			},
 		},
 		{
@@ -72,7 +72,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 							},
 						},
 					},
-				})
+				}, false)
 			},
 		},
 		{
@@ -91,7 +91,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 							},
 						},
 					},
-				})
+				}, false)
 			},
 		},
 		{
@@ -113,7 +113,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 							},
 						},
 					},
-				})
+				}, false)
 			},
 		},
 		{
@@ -121,7 +121,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["bind_address"] = "127.0.0.2"
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -129,7 +129,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["bind_port"] = 8888
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -138,7 +138,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["bind_address"] = "127.0.0.2"
 					ns.Proxy.Config["bind_port"] = 8888
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -149,7 +149,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 					ns.Proxy.Upstreams[0].LocalBindPort = 0
 					ns.Proxy.Upstreams[0].LocalBindSocketPath = "/tmp/service-mesh/client-1/grpc-employee-server"
 					ns.Proxy.Upstreams[0].LocalBindSocketMode = "0640"
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -157,7 +157,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["max_inbound_connections"] = 222
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -165,7 +165,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["protocol"] = "http"
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -186,7 +186,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 								},
 							},
 						},
-					})
+					}, false)
 			},
 		},
 		{
@@ -196,7 +196,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 					ns.Proxy.Config["protocol"] = "http"
 					ns.Proxy.Config["local_connect_timeout_ms"] = 1234
 					ns.Proxy.Config["local_request_timeout_ms"] = 2345
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -204,7 +204,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Upstreams[0].Config["protocol"] = "http"
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -215,7 +215,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 						customListenerJSON(t, customListenerJSONOptions{
 							Name: "custom-public-listen",
 						})
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -227,7 +227,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 						customHTTPListenerJSON(t, customHTTPListenerJSONOptions{
 							Name: "custom-public-listen",
 						})
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -240,7 +240,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 							Name:                      "custom-public-listen",
 							HTTPConnectionManagerName: httpConnectionManagerNewName,
 						})
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -252,7 +252,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 						customListenerJSON(t, customListenerJSONOptions{
 							Name: "custom-public-listen",
 						})
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -266,7 +266,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 							// Attempt to override the TLS context should be ignored
 							TLSContext: `"allowRenegotiation": false`,
 						})
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -288,7 +288,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 								Name: uid.EnvoyID() + ":custom-upstream",
 							})
 					}
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -406,7 +406,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 						v.DestinationNamespace = structs.WildcardSpecifier
 						v.DestinationName = structs.WildcardSpecifier
 					}
-				}, nil)
+				}, nil, false)
 			},
 		},
 		{
@@ -782,7 +782,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["protocol"] = "http"
 					ns.Proxy.Config["envoy_listener_tracing_json"] = customTraceJSON(t)
-				}, nil)
+				}, nil, false)
 			},
 		},
 	}

--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -126,7 +126,7 @@ func TestAllResourcesFromSnapshot(t *testing.T) {
 		{
 			name: "defaults",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, nil)
+				return proxycfg.TestConfigSnapshot(t, nil, nil, false)
 			},
 		},
 		{
@@ -141,7 +141,7 @@ func TestAllResourcesFromSnapshot(t *testing.T) {
 						CorrelationID: "peering-trust-bundles",
 						Result:        proxycfg.TestPeerTrustBundles(t),
 					},
-				})
+				}, true)
 			},
 		},
 		{


### PR DESCRIPTION
This PR disables peering functionality in proxycfg by default, unless `peering.enabled = true` is explicitly set in the agent config.

This change was necessary to prevent expensive polling watch queries (that were introduced for peer upstreams) from impacting users that do not wish to leverage peering features. While this is technically a breaking change, the 1.13 implementation of peering is considered to be experimental and not production ready. After this PR is merged, any users that wish to use peering in conjunction with mesh will need to enable peering on each agent and server.