### PR TITLE
fixes #17732 - AccessorID in request body should be optional when updating ACL token

### DIFF
--- a/.changelog/17739.txt
+++ b/.changelog/17739.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+http: fixed API endpoint `PUT /acl/token/:AccessorID` (update token), no longer requires `AccessorID` in the request body. Web UI can now update tokens.
+ ```

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -441,8 +441,16 @@ func (s *HTTPHandlers) aclTokenSetInternal(req *http.Request, tokenAccessorID st
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Token decoding failed: %v", err)}
 	}
 
-	if !create && args.ACLToken.AccessorID != tokenAccessorID {
-		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: "Token Accessor ID in URL and payload do not match"}
+	if !create {
+		// NOTE: AccessorID in the request body is optional not creating a new token.
+		// If not present in the body and only in the URL then it will be filled in by Consul.
+		if args.ACLToken.AccessorID == "" {
+			args.ACLToken.AccessorID = tokenAccessorID
+		}
+
+		if args.ACLToken.AccessorID != tokenAccessorID {
+			return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: "Token Accessor ID in URL and payload do not match"}
+		}
 	}
 
 	var out structs.ACLToken

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -442,7 +442,7 @@ func (s *HTTPHandlers) aclTokenSetInternal(req *http.Request, tokenAccessorID st
 	}
 
 	if !create {
-		// NOTE: AccessorID in the request body is optional not creating a new token.
+		// NOTE: AccessorID in the request body is optional when not creating a new token.
 		// If not present in the body and only in the URL then it will be filled in by Consul.
 		if args.ACLToken.AccessorID == "" {
 			args.ACLToken.AccessorID = tokenAccessorID

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -907,6 +907,48 @@ func TestACL_HTTP(t *testing.T) {
 			tokenMap[token.AccessorID] = token
 		})
 
+		t.Run("Update without AccessorID in request body", func(t *testing.T) {
+			originalToken := tokenMap[idMap["token-cloned"]]
+
+			// Secret will be filled in
+			tokenInput := &structs.ACLToken{
+				Description: "Better description for this cloned token",
+				Policies: []structs.ACLTokenPolicyLink{
+					{
+						ID:   idMap["policy-read-all-nodes"],
+						Name: policyMap[idMap["policy-read-all-nodes"]].Name,
+					},
+				},
+				NodeIdentities: []*structs.ACLNodeIdentity{
+					{
+						NodeName:   "foo",
+						Datacenter: "bar",
+					},
+				},
+			}
+
+			req, _ := http.NewRequest("PUT", "/v1/acl/token/"+originalToken.AccessorID, jsonBody(tokenInput))
+			req.Header.Add("X-Consul-Token", "root")
+			resp := httptest.NewRecorder()
+			obj, err := a.srv.ACLTokenCRUD(resp, req)
+			require.NoError(t, err)
+			token, ok := obj.(*structs.ACLToken)
+			require.True(t, ok)
+
+			require.Equal(t, originalToken.AccessorID, token.AccessorID)
+			require.Equal(t, originalToken.SecretID, token.SecretID)
+			require.Equal(t, tokenInput.Description, token.Description)
+			require.Equal(t, tokenInput.Policies, token.Policies)
+			require.Equal(t, tokenInput.NodeIdentities, token.NodeIdentities)
+			require.True(t, token.CreateIndex > 0)
+			require.True(t, token.CreateIndex < token.ModifyIndex)
+			require.NotNil(t, token.Hash)
+			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, token.Hash, originalToken.Hash)
+
+			tokenMap[token.AccessorID] = token
+		})
+
 		t.Run("CRUD Missing Token Accessor ID", func(t *testing.T) {
 			req, _ := http.NewRequest("GET", "/v1/acl/token/", nil)
 			req.Header.Add("X-Consul-Token", "root")

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -912,7 +912,7 @@ func TestACL_HTTP(t *testing.T) {
 
 			// Secret will be filled in
 			tokenInput := &structs.ACLToken{
-				Description: "Better description for this cloned token",
+				Description: "Even Better description for this cloned token",
 				Policies: []structs.ACLTokenPolicyLink{
 					{
 						ID:   idMap["policy-read-all-nodes"],


### PR DESCRIPTION
### Description

see #17732

### Links

https://developer.hashicorp.com/consul/api-docs/acl/tokens#update-a-token

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated (not required)
* [ ] appropriate backport labels added
* [x] not a security concern
