### PR TITLE
Improve Transparent Proxy Virtual Services and Failovers

### DIFF
--- a/.changelog/17757.txt
+++ b/.changelog/17757.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Improve transparent proxy support for virtual services and failovers.
+```


### PR DESCRIPTION
This PR is intended to document some of the transparent proxy enhancements that were made for the 1.16 release.

Prior to these changes, transparent proxy deployments would not function properly for several failover scenarios. Most notably, when the number of service instances reached zero, the discovery chain watch would disappear for the corresponding service, causing the resolver to also disappear from proxycfg. This would result in the failover not applying.

With these changes, discovery chains will now continue to exist in the proxy configuration as long as one of the following config entry types also exists and shares a name with the targeted upstream service:

- service-resolver
- service-router
- service-splitter
- service-defaults
- service-intentions

For example, when the following service-resolver exists:

```
  kind: ServiceResolver
  metadata:
    name: my-primary-svc
  spec:
    failover:
      '*':
        target:
          - service: my-failover-svc
```

It can be called via `http://my-primary-svc.virtual.consul` via tproxy. Traffic will be routed to `my-failover-svc` during failures, even when the number of `my-primary-svc` instances is zero.

Virtual services are now better supported as well:

```
  kind: ServiceResolver
  metadata:
    name: my-virtual-svc
  spec:
    redirect:
      service: my-svc
```

In the above example, calls to `http://my-virtual-svc.virtual.consul` will redirect to the `my-svc` service (provided an intention exists that allows access from the calling service source to the destination `my-virtual-svc`).

Related issues:
https://github.com/hashicorp/consul/pull/17375
https://github.com/hashicorp/consul/pull/17099
https://github.com/hashicorp/consul/pull/17533