### PR TITLE
watch: support -tags for watch checks

### DIFF
--- a/api/watch/funcs.go
+++ b/api/watch/funcs.go
@@ -189,6 +189,13 @@ func checksWatch(params map[string]interface{}) (WatcherFunc, error) {
 		state = "any"
 	}
 
+	var (
+		tags []string
+	)
+	if err := assignValueStringSlice(params, "tag", &tags); err != nil {
+		return nil, err
+	}
+
 	fn := func(p *Plan) (BlockingParamVal, interface{}, error) {
 		health := p.client.Health()
 		opts := makeQueryOptionsWithContext(p, stale)
@@ -204,9 +211,39 @@ func checksWatch(params map[string]interface{}) (WatcherFunc, error) {
 		if err != nil {
 			return nil, nil, err
 		}
+		if len(tags) > 0 {
+			checks = filterChecksByTags(checks, tags)
+		}
+
 		return WaitIndexVal(meta.LastIndex), checks, err
 	}
 	return fn, nil
+}
+
+// filterChecksByTags filters HealthChecks by the tags
+func filterChecksByTags(checks consulapi.HealthChecks, tags []string) consulapi.HealthChecks {
+	filteredChecks := consulapi.HealthChecks{}
+
+	for _, check := range checks {
+		// the check is appended to the filteredChecks if its tags
+		// contain every tag in tags
+		svcTagMap := map[string]struct{}{}
+		for _, svcTag := range check.ServiceTags {
+			svcTagMap[svcTag] = struct{}{}
+		}
+
+		count := 0
+		for _, tag := range tags {
+			if _, ok := svcTagMap[tag]; ok {
+				count++
+			}
+
+			if count == len(tags) {
+				filteredChecks = append(filteredChecks, check)
+			}
+		}
+	}
+	return filteredChecks
 }
 
 // eventWatch is used to watch for events, optionally filtering on name

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -772,6 +772,110 @@ func TestChecksWatch_Service(t *testing.T) {
 	}
 }
 
+func TestChecksWatch_Service_Tags(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
+
+	var (
+		wakeups  [][]*api.HealthCheck
+		notifyCh = make(chan struct{})
+	)
+
+	plan := mustParse(t, `{"type":"checks", "tag":["a", "b"]}`)
+	plan.Handler = func(idx uint64, raw interface{}) {
+		if raw == nil {
+			return // ignore
+		}
+		v, ok := raw.([]*api.HealthCheck)
+		if !ok {
+			return // ignore
+		}
+		wakeups = append(wakeups, v)
+		notifyCh <- struct{}{}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := plan.Run(s.HTTPAddr); err != nil {
+			t.Errorf("err: %v", err)
+		}
+	}()
+	defer plan.Stop()
+
+	// Wait for first wakeup.
+	<-notifyCh
+	{
+		catalog := c.Catalog()
+
+		// we don't want to find this one
+		reg := &api.CatalogRegistration{
+			Node:       "foo",
+			Address:    "1.1.1.1",
+			Datacenter: "dc1",
+			Service: &api.AgentService{
+				ID:      "foo",
+				Service: "foo",
+				Tags:    []string{"a"},
+			},
+			Check: &api.AgentCheck{
+				Node:      "foo",
+				CheckID:   "foo",
+				Name:      "foo",
+				Status:    api.HealthPassing,
+				ServiceID: "foo",
+			},
+		}
+		if _, err := catalog.Register(reg, nil); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// we want to find this one
+		reg = &api.CatalogRegistration{
+			Node:       "bar",
+			Address:    "2.2.2.2",
+			Datacenter: "dc1",
+			Service: &api.AgentService{
+				ID:      "bar",
+				Service: "bar",
+				Tags:    []string{"a", "b"},
+			},
+			Check: &api.AgentCheck{
+				Node:      "bar",
+				CheckID:   "bar",
+				Name:      "bar",
+				Status:    api.HealthPassing,
+				ServiceID: "bar",
+			},
+		}
+		if _, err := catalog.Register(reg, nil); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	// Wait for second wakeup.
+	<-notifyCh
+
+	plan.Stop()
+	wg.Wait()
+
+	require.Len(t, wakeups, 2)
+
+	{
+		v := wakeups[0]
+		require.Len(t, v, 0)
+	}
+	{
+		v := wakeups[1]
+		require.Len(t, v, 1)
+		require.Equal(t, "bar", v[0].CheckID)
+	}
+}
+
 func TestEventWatch(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)


### PR DESCRIPTION
### Description

- Support tags for `watch -type=checks` (see use case in https://github.com/hashicorp/consul/issues/17642)

Before: 

```
consul watch -type=checks -state=critical  -tag=test
Invalid parameters: [tag]
```

After

```
onsul watch -type=checks -tag="a"  
[
    {
        "Node": "server-1",
        "CheckID": "fake-backend-check",
        "Name": "Service 'fake-backend' check",
        "Notes": "",
        "Output": "",
        "ServiceID": "fake-backend",
        "ServiceName": "fake-backend",
        "ServiceTags": [
            "a"
        ],

```

- Unit test is added

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

https://github.com/hashicorp/consul/issues/17642

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
