### PR TITLE
Add jwt-authn metrics to jwt-provider docs

### DIFF
--- a/website/content/docs/connect/config-entries/jwt-provider.mdx
+++ b/website/content/docs/connect/config-entries/jwt-provider.mdx
@@ -954,7 +954,7 @@ Defines behavior for caching the validation result of previously encountered JWT
 
 ## Metrics
 
-The following `envoy` metrics can be used to track jwt authentication details. 
+The following `envoy` metrics can be used to track JWT authentication details. 
 
 ~> **Note:** Envoy does not currently provide any documentation on these metrics.
 

--- a/website/content/docs/connect/config-entries/jwt-provider.mdx
+++ b/website/content/docs/connect/config-entries/jwt-provider.mdx
@@ -954,9 +954,7 @@ Defines behavior for caching the validation result of previously encountered JWT
 
 ## Metrics
 
-The following `envoy` metrics can be used to track JWT authentication details. 
-
-~> **Note:** Envoy does not currently provide any documentation on these metrics.
+Envoy proxies expose metrics that can track JWT authentication details. Use the following Envoy metrics:
 
 ```yaml
 http.public_listener.jwt_authn.allowed
@@ -967,6 +965,8 @@ http.public_listener.jwt_authn.jwks_fetch_success
 http.public_listener.jwt_authn.jwt_cache_hit
 http.public_listener.jwt_authn.jwt_cache_miss
 ```
+
+~> **Note:** Currently, Envoy does not reference these metrics in their documentation. Refer to [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/) for more information about exposed metrics.
 
 ## Examples
 

--- a/website/content/docs/connect/config-entries/jwt-provider.mdx
+++ b/website/content/docs/connect/config-entries/jwt-provider.mdx
@@ -959,13 +959,13 @@ The following `envoy` metrics can be used to track jwt authentication details.
 ~> **Note:** Envoy does not currently provide any documentation on these metrics.
 
 ```yaml
-http.ingress_http.jwt_authn.allowed
-http.ingress_http.jwt_authn.cors_preflight_bypassed
-http.ingress_http.jwt_authn.denied
-http.ingress_http.jwt_authn.jwks_fetch_failed
-http.ingress_http.jwt_authn.jwks_fetch_success
-http.ingress_http.jwt_authn.jwt_cache_hit
-http.ingress_http.jwt_authn.jwt_cache_miss
+http.public_listener.jwt_authn.allowed
+http.public_listener.jwt_authn.cors_preflight_bypassed
+http.public_listener.jwt_authn.denied
+http.public_listener.jwt_authn.jwks_fetch_failed
+http.public_listener.jwt_authn.jwks_fetch_success
+http.public_listener.jwt_authn.jwt_cache_hit
+http.public_listener.jwt_authn.jwt_cache_miss
 ```
 
 ## Examples

--- a/website/content/docs/connect/config-entries/jwt-provider.mdx
+++ b/website/content/docs/connect/config-entries/jwt-provider.mdx
@@ -952,6 +952,22 @@ Defines behavior for caching the validation result of previously encountered JWT
 </Tab>
 </Tabs>
 
+## Metrics
+
+The following `envoy` metrics can be used to track jwt authentication details. 
+
+~> **Note:** Envoy does not currently provide any documentation on these metrics.
+
+```yaml
+http.ingress_http.jwt_authn.allowed
+http.ingress_http.jwt_authn.cors_preflight_bypassed
+http.ingress_http.jwt_authn.denied
+http.ingress_http.jwt_authn.jwks_fetch_failed
+http.ingress_http.jwt_authn.jwks_fetch_success
+http.ingress_http.jwt_authn.jwt_cache_hit
+http.ingress_http.jwt_authn.jwt_cache_miss
+```
+
 ## Examples
 
 The following examples demonstrate common JWT provider configuration patterns for specific use cases.


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
- Adding jwt authn docs to jwt provider page 

**NOTE**: we can't provide much more details about these metrics as envoy doesn't provide any details. I did log an issue for them to address this: https://github.com/envoyproxy/envoy/issues/28051

### Docs Preview

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

<img width="1081" alt="Screen Shot 2023-06-20 at 12 45 45 PM" src="https://github.com/hashicorp/consul/assets/7438896/621594be-f759-4557-9546-fd188de0aa02">

