### PR TITLE
Set GOPRIVATE for all hashicorp repos in CI

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  GOPRIVATE: github.com/hashicorp
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   setup:

--- a/.github/workflows/build-distros.yml
+++ b/.github/workflows/build-distros.yml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   GOTAGS: ${{ endsWith(github.repository, '-enterprise') && 'consulent' || '' }}
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   setup:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ on:
 env:
   PKG_NAME: consul
   METADATA: oss
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   set-product-version:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -21,6 +21,7 @@ permissions:
 
 env:
   TEST_RESULTS: /tmp/test-results
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   setup:

--- a/.github/workflows/nightly-test-1.13.x.yaml
+++ b/.github/workflows/nightly-test-1.13.x.yaml
@@ -8,9 +8,10 @@ on:
   workflow_dispatch: {}
 
 env:
-  EMBER_PARTITION_TOTAL: 4      # Has to be changed in tandem with the matrix.partition
+  EMBER_PARTITION_TOTAL: 4        # Has to be changed in tandem with the matrix.partition
   BRANCH: "release/1.13.x"
-  BRANCH_NAME: "release-1.13.x" # Used for naming artifacts
+  BRANCH_NAME: "release-1.13.x"   # Used for naming artifacts
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   frontend-test-workspace-node:

--- a/.github/workflows/nightly-test-1.14.x.yaml
+++ b/.github/workflows/nightly-test-1.14.x.yaml
@@ -8,9 +8,10 @@ on:
   workflow_dispatch: {}
 
 env:
-  EMBER_PARTITION_TOTAL: 4      # Has to be changed in tandem with the matrix.partition
+  EMBER_PARTITION_TOTAL: 4        # Has to be changed in tandem with the matrix.partition
   BRANCH: "release/1.14.x"
-  BRANCH_NAME: "release-1.14.x" # Used for naming artifacts
+  BRANCH_NAME: "release-1.14.x"   # Used for naming artifacts
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   frontend-test-workspace-node:

--- a/.github/workflows/nightly-test-1.15.x.yaml
+++ b/.github/workflows/nightly-test-1.15.x.yaml
@@ -8,9 +8,10 @@ on:
   workflow_dispatch: {}
 
 env:
-  EMBER_PARTITION_TOTAL: 4      # Has to be changed in tandem with the matrix.partition
+  EMBER_PARTITION_TOTAL: 4        # Has to be changed in tandem with the matrix.partition
   BRANCH: "release/1.15.x"
-  BRANCH_NAME: "release-1.15.x" # Used for naming artifacts
+  BRANCH_NAME: "release-1.15.x"   # Used for naming artifacts
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   frontend-test-workspace-node:

--- a/.github/workflows/nightly-test-1.16.x.yaml
+++ b/.github/workflows/nightly-test-1.16.x.yaml
@@ -8,9 +8,10 @@ on:
   workflow_dispatch: {}
 
 env:
-  EMBER_PARTITION_TOTAL: 4      # Has to be changed in tandem with the matrix.partition
+  EMBER_PARTITION_TOTAL: 4        # Has to be changed in tandem with the matrix.partition
   BRANCH: "release/1.16.x"
-  BRANCH_NAME: "release-1.16.x" # Used for naming artifacts
+  BRANCH_NAME: "release-1.16.x"   # Used for naming artifacts
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   frontend-test-workspace-node:

--- a/.github/workflows/nightly-test-main.yaml
+++ b/.github/workflows/nightly-test-main.yaml
@@ -8,9 +8,10 @@ on:
   workflow_dispatch: {}
 
 env:
-  EMBER_PARTITION_TOTAL: 4      # Has to be changed in tandem with the matrix.partition
+  EMBER_PARTITION_TOTAL: 4        # Has to be changed in tandem with the matrix.partition
   BRANCH: "main"
-  BRANCH_NAME: "main"           # Used for naming artifacts
+  BRANCH_NAME: "main"             # Used for naming artifacts
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   frontend-test-workspace-node:

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -20,6 +20,7 @@ on:
 env:
   GOTAGS: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
   GOARCH: ${{inputs.go-arch}}
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   lint:

--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -51,6 +51,7 @@ env:
   TOTAL_RUNNERS: ${{inputs.runner-count}}
   CONSUL_LICENSE: ${{secrets.consul-license}}
   GOTAGS: ${{ inputs.go-tags}}
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
   DATADOG_API_KEY: ${{secrets.datadog-api-key}}
   
 jobs:

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -46,6 +46,7 @@ env:
   GOARCH: ${{inputs.go-arch}}
   CONSUL_LICENSE: ${{secrets.consul-license}}
   GOTAGS: ${{ inputs.go-tags}}
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
   DATADOG_API_KEY: ${{secrets.datadog-api-key}}
   
 jobs:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -23,6 +23,7 @@ env:
   CONSUL_BINARY_UPLOAD_NAME: consul-bin
   # strip the hashicorp/ off the front of github.repository for consul
   CONSUL_LATEST_IMAGE_NAME: ${{ endsWith(github.repository, '-enterprise') && github.repository || 'consul' }}
+  GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
   setup:


### PR DESCRIPTION
Consistently set `GOPRIVATE` to include all `hashicorp` repos, s.t. private modules are successfully pulled in enterprise CI.

### Description

This prevents issues resulting from private indirect dependencies appearing in `go.mod` preventing successful builds.

We [already set `GOPRIVATE` in build-artifacts.yml](https://github.com/hashicorp/consul/blob/e4c9793ee2015bcda2af790d318b1b3f5b48a5bf/.github/workflows/build-artifacts.yml#L16) but do not do it consistently in all places where code is built.

I'm skipping backporting this for now as the instigating change (https://github.com/hashicorp/consul/pull/17674) was not backported.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
