### PR TITLE
ext-authz Envoy extension: support `localhost` as a valid target URI.

### DIFF
--- a/agent/envoyextensions/builtin/ext-authz/ext_authz_test.go
+++ b/agent/envoyextensions/builtin/ext-authz/ext_authz_test.go
@@ -59,7 +59,7 @@ func TestConstructor(t *testing.T) {
 					},
 				},
 			},
-			errMsg: `invalid host for Target.URI "foo.bar.com:9191": expected 'localhost' or '127.0.0.1'`,
+			errMsg: `invalid host for Target.URI "foo.bar.com:9191": expected "localhost", "127.0.0.1", or "::1"`,
 		},
 		"non-loopback address": {
 			args: map[string]any{
@@ -72,7 +72,34 @@ func TestConstructor(t *testing.T) {
 					},
 				},
 			},
-			errMsg: `invalid host for Target.URI "10.0.0.1:9191": expected 'localhost' or '127.0.0.1'`,
+			errMsg: `invalid host for Target.URI "10.0.0.1:9191": expected "localhost", "127.0.0.1", or "::1"`,
+		},
+		"invalid target port": {
+			args: map[string]any{
+				"ProxyType": "connect-proxy",
+				"Config": map[string]any{
+					"GrpcService": map[string]any{
+						"Target": map[string]any{
+							"URI": "localhost:zero",
+						},
+					},
+				},
+			},
+			errMsg: `invalid format for Target.URI "localhost:zero": expected host:port`,
+		},
+		"invalid target timeout": {
+			args: map[string]any{
+				"ProxyType": "connect-proxy",
+				"Config": map[string]any{
+					"GrpcService": map[string]any{
+						"Target": map[string]any{
+							"URI":     "localhost:9191",
+							"Timeout": "one",
+						},
+					},
+				},
+			},
+			errMsg: `failed to parse Target.Timeout "one" as a duration`,
 		},
 		"no uri or service target": {
 			args: map[string]any{

--- a/agent/envoyextensions/builtin/ext-authz/structs.go
+++ b/agent/envoyextensions/builtin/ext-authz/structs.go
@@ -34,6 +34,9 @@ const (
 	defaultMetadataNS    = "consul"
 	defaultStatPrefix    = "response"
 	defaultStatusOnError = 403
+	localhost            = "localhost"
+	localhostIPv4        = "127.0.0.1"
+	localhostIPv6        = "::1"
 )
 
 type extAuthzConfig struct {
@@ -185,6 +188,12 @@ func (c *extAuthzConfig) toEnvoyCluster(_ *cmn.RuntimeConfig) (*envoy_cluster_v3
 		return nil, err
 	}
 
+	clusterType := &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_STATIC}
+	if host == localhost {
+		// If the host is "localhost" use a STRICT_DNS cluster type to perform DNS lookup.
+		clusterType = &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_STRICT_DNS}
+	}
+
 	var typedExtProtoOpts map[string]*anypb.Any
 	if c.isGRPC() {
 		// By default HTTP/1.1 is used for the transport protocol. gRPC requires that we explicitly configure HTTP/2
@@ -205,7 +214,7 @@ func (c *extAuthzConfig) toEnvoyCluster(_ *cmn.RuntimeConfig) (*envoy_cluster_v3
 
 	return &envoy_cluster_v3.Cluster{
 		Name:                 LocalExtAuthzClusterName,
-		ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_STATIC},
+		ClusterDiscoveryType: clusterType,
 		ConnectTimeout:       target.timeoutDurationPB(),
 		LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
 			ClusterName: LocalExtAuthzClusterName,
@@ -645,21 +654,13 @@ func (t *Target) validate() error {
 	}
 
 	if t.isURI() {
-		// Strip the protocol if one was provided
-		if _, addr, hasProto := strings.Cut(t.URI, "://"); hasProto {
-			t.URI = addr
-		}
-		addr := strings.Split(t.URI, ":")
-		if len(addr) == 2 {
-			t.host = addr[0]
-			if t.host == "localhost" || t.host == "127.0.0.1" {
-				// Always use the IP address form.
-				t.host = "127.0.0.1"
-			} else {
-				resultErr = multierror.Append(resultErr, fmt.Errorf("invalid host for Target.URI %q: expected 'localhost' or '127.0.0.1'", t.URI))
-			}
-			if t.port, err = strconv.Atoi(addr[1]); err != nil {
-				resultErr = multierror.Append(resultErr, fmt.Errorf("invalid port for Target.URI %q", addr[1]))
+		t.host, t.port, err = parseAddr(t.URI)
+		if err == nil {
+			switch t.host {
+			case localhost, localhostIPv4, localhostIPv6:
+			default:
+				resultErr = multierror.Append(resultErr,
+					fmt.Errorf("invalid host for Target.URI %q: expected %q, %q, or %q", t.URI, localhost, localhostIPv4, localhostIPv6))
 			}
 		} else {
 			resultErr = multierror.Append(resultErr, fmt.Errorf("invalid format for Target.URI %q: expected host:port", t.URI))
@@ -674,4 +675,23 @@ func (t *Target) validate() error {
 		}
 	}
 	return resultErr
+}
+
+func parseAddr(s string) (host string, port int, err error) {
+	// Strip the protocol if one was provided
+	if _, addr, hasProto := strings.Cut(s, "://"); hasProto {
+		s = addr
+	}
+	idx := strings.LastIndex(s, ":")
+	switch idx {
+	case -1, len(s) - 1:
+		err = fmt.Errorf("invalid input format %q: expected host:port", s)
+	case 0:
+		host = localhost
+		port, err = strconv.Atoi(s[idx+1:])
+	default:
+		host = s[:idx]
+		port, err = strconv.Atoi(s[idx+1:])
+	}
+	return
 }

--- a/agent/envoyextensions/builtin/ext-authz/structs.go
+++ b/agent/envoyextensions/builtin/ext-authz/structs.go
@@ -652,7 +652,10 @@ func (t *Target) validate() error {
 		addr := strings.Split(t.URI, ":")
 		if len(addr) == 2 {
 			t.host = addr[0]
-			if t.host != "localhost" && t.host != "127.0.0.1" {
+			if t.host == "localhost" || t.host == "127.0.0.1" {
+				// Always use the IP address form.
+				t.host = "127.0.0.1"
+			} else {
 				resultErr = multierror.Append(resultErr, fmt.Errorf("invalid host for Target.URI %q: expected 'localhost' or '127.0.0.1'", t.URI))
 			}
 			if t.port, err = strconv.Atoi(addr[1]); err != nil {

--- a/agent/xds/delta_envoy_extender_oss_test.go
+++ b/agent/xds/delta_envoy_extender_oss_test.go
@@ -676,6 +676,7 @@ end`,
 					ns.Proxy.EnvoyExtensions = makeExtAuthzEnvoyExtension(
 						"http",
 						"dest=local",
+						"target-uri=localhost:9191",
 						"insert=AfterLastMatch:envoy.filters.http.header_to_metadata",
 					)
 				}, nil)

--- a/agent/xds/delta_envoy_extender_test.go
+++ b/agent/xds/delta_envoy_extender_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func makeExtAuthzEnvoyExtension(svc string, opts ...string) []structs.EnvoyExtension {
-	target := map[string]any{"URI": "127.0.0.1:9191"}
+	target := map[string]any{"URI": "localhost:9191"}
 	insertOptions := map[string]any{}
 	required := false
 	ent := false

--- a/agent/xds/delta_envoy_extender_test.go
+++ b/agent/xds/delta_envoy_extender_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func makeExtAuthzEnvoyExtension(svc string, opts ...string) []structs.EnvoyExtension {
-	target := map[string]any{"URI": "localhost:9191"}
+	target := map[string]any{"URI": "127.0.0.1:9191"}
 	insertOptions := map[string]any{}
 	required := false
 	ent := false
@@ -49,6 +49,13 @@ func makeExtAuthzEnvoyExtension(svc string, opts ...string) []structs.EnvoyExten
 						"Location":   location,
 						"FilterName": filterName,
 					}
+				}
+			case "target-uri":
+				target = map[string]any{"URI": v}
+				configMap = map[string]any{
+					serviceKey: map[string]any{
+						"Target": target,
+					},
 				}
 			case "config-type":
 				if v == "full" {

--- a/agent/xds/testdata/builtin_extension/clusters/ext-authz-http-local-http-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/ext-authz-http-local-http-service.latest.golden
@@ -142,7 +142,7 @@
     {
       "@type":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
       "name":  "local_ext_authz",
-      "type":  "STATIC",
+      "type":  "STRICT_DNS",
       "loadAssignment":  {
         "clusterName":  "local_ext_authz",
         "endpoints":  [
@@ -152,7 +152,7 @@
                 "endpoint":  {
                   "address":  {
                     "socketAddress":  {
-                      "address":  "127.0.0.1",
+                      "address":  "localhost",
                       "portValue":  9191
                     }
                   }

--- a/website/content/docs/connect/proxies/envoy-extensions/configuration/ext-authz.mdx
+++ b/website/content/docs/connect/proxies/envoy-extensions/configuration/ext-authz.mdx
@@ -348,7 +348,7 @@ The following table describes how to configure parameters for the `Service` fiel
 
 ### `Arguments.Config.GrpcService.Target.Uri`
 
-Specifies the URI of the external authorization service. Configure this field when you must provide an explicit URI to the external authorization service, such as cases in which the authorization service is running on the same host or pod. If set, the value of this field must be either `localhost:<port>` or `127.0.0.1:<port>`
+Specifies the URI of the external authorization service. Configure this field when you must provide an explicit URI to the external authorization service, such as cases in which the authorization service is running on the same host or pod. If set, the value of this field must be one of `localhost:<port>`, `127.0.0.1:<port>`, or `::1:<port>`.
 
 Configure either the `Uri` field or the [`Service`](#arguments-config-grpcservice-target-service) field, but not both. 
  
@@ -434,7 +434,7 @@ The following table describes how to configure parameters for the `Service` fiel
 
 ### `Arguments{}.Config{}.HttpService{}.Target{}.Uri`
 
-Specifies the URI of the external authorization service. Configure this field when you must provide an explicit URI to the external authorization service, such as cases in which the authorization service is running on the same host or pod. 
+Specifies the URI of the external authorization service. Configure this field when you must provide an explicit URI to the external authorization service, such as cases in which the authorization service is running on the same host or pod. If set, the value of this field must be one of `localhost:<port>`, `127.0.0.1:<port>`, or `::1:<port>`.
 
 Configure either the `Uri` field or the [`Service`](#arguments-config-httpservice-target-service) field, but not both. 
  

--- a/website/content/docs/connect/proxies/envoy-extensions/usage/ext-authz.mdx
+++ b/website/content/docs/connect/proxies/envoy-extensions/usage/ext-authz.mdx
@@ -115,7 +115,7 @@ The following Envoy configurations are not supported:
 | `failure_mode_allow` | Set the `EnvoyExtension.Required` field to `true` in the [service defaults configuration entry](/consul/docs/connect/config-entries/service-defaults#envoyextensions) or [proxy defaults configuration entry](/consul/docs/connect/config-entries/proxy-defaults#envoyextensions). |
 | `filter_enabled` | Set the `EnvoyExtension.Required` field to `true` in the [service defaults configuration entry](/consul/docs/connect/config-entries/service-defaults#envoyextensions) or [proxy defaults configuration entry](/consul/docs/connect/config-entries/proxy-defaults#envoyextensions). |
 | `filter_enabled_metadata` | Set the `EnvoyExtension.Required` field to `true` in the [service defaults configuration entry](/consul/docs/connect/config-entries/service-defaults#envoyextensions) or [proxy defaults configuration entry](/consul/docs/connect/config-entries/proxy-defaults#envoyextensions). |
-| `transport_api_version` | Consul only supports v3 of the transport API. As a result, there is no workaround for implement the behavior of this field. |
+| `transport_api_version` | Consul only supports v3 of the transport API. As a result, there is no workaround for implementing the behavior of this field. |
 
 ## Apply the configuration entry
 


### PR DESCRIPTION
### Description

This PR fixes a bug in the `builtin/ext-authz` extension when using `localhost` as the target URI. When using an upstream on the localhost network we configure a `STATIC` cluster type that requires using an IP address. The extension was configuring the cluster with the `localhost` hostname, which caused Envoy to reject the xDS configuration update with an error similar to:

```log
2023-06-20T16:27:39.907Z [ERROR] agent.envoy.xds: got error response from envoy proxy: service_id=default/default/api-5f54fbf97-vkpgr-api-sidecar-proxy typeUrl=type.googleapis.com/envoy.config.cluster.v3.Cluster xdsVersion=v3 nonce=00000006 error="rpc error: code = Internal desc = Error adding/updating cluster(s) local_ext_authz: malformed IP address: localhost. Consider setting resolver_name or setting cluster type to 'STRICT_DNS' or 'LOGICAL_DNS'"
```

### Testing & Reproduction steps

- I found this testing the ext_authz extension using Consul on k8s.
  - I tested the fix successfully in this same environment
- I've updated the `agent/xds` golden tests to ensure that IP addresses result in a `STATIC` cluster type and that `localhost` results in a `STRICT_DNS` cluster type, when creating the cluster definition.
- Added some additional unit tests to the `ext-authz` extension to cover some additional error cases.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
