### PR TITLE
Change URLs for redirects from RC to default latest

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -38,19 +38,19 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/consul/docs/v1.16.x/connect/transparent-proxy',
-    destination: '/consul/docs/v1.16.x/k8s/connect/transparent-proxy',
+    source: '/consul/docs/connect/transparent-proxy',
+    destination: '/consul/docs/k8s/connect/transparent-proxy',
     permanent: true,
   },
   {
-    source: '/consul/docs/1.16.x/agent/limits/init-rate-limits',
-    destination: '/consul/docs/1.16.x/agent/limits/usage/init-rate-limits',
+    source: '/consul/docs/agent/limits/init-rate-limits',
+    destination: '/consul/docs/agent/limits/usage/init-rate-limits',
     permanent: true,
   },
   {
-    source: '/consul/docs/1.16.x/agent/limits/set-global-traffic-rate-limits',
+    source: '/consul/docs/agent/limits/set-global-traffic-rate-limits',
     destination:
-      '/consul/docs/1.16.x/agent/limits/usage/set-global-traffic-rate-limits',
+      '/consul/docs/agent/limits/usage/set-global-traffic-rate-limits',
     permanent: true,
   },
   {


### PR DESCRIPTION
### Description

This PR updates the redirects implemented for the 1.16-RC version of the docs so that they use the _latest_ paths.

### PR Checklist

* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
