### PR TITLE
Backport of [NET-3865] [Supportability] Additional Information in the output - in 1.14.x

### DIFF
--- a/.changelog/17582.txt
+++ b/.changelog/17582.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: `consul operator raft list-peers` command shows the number of commits each follower is trailing the leader by to aid in troubleshooting.
+```

--- a/agent/consul/operator_raft_endpoint.go
+++ b/agent/consul/operator_raft_endpoint.go
@@ -45,6 +45,12 @@ func (op *Operator) RaftGetConfiguration(args *structs.DCSpecificRequest, reply 
 		serverMap[raft.ServerAddress(addr)] = member
 	}
 
+	serverIDLastIndexMap := make(map[raft.ServerID]uint64)
+
+	for _, serverState := range op.srv.autopilot.GetState().Servers {
+		serverIDLastIndexMap[serverState.Server.ID] = serverState.Stats.LastIndex
+	}
+
 	// Fill out the reply.
 	leader := op.srv.raft.Leader()
 	reply.Index = future.Index()
@@ -63,6 +69,7 @@ func (op *Operator) RaftGetConfiguration(args *structs.DCSpecificRequest, reply 
 			Leader:          server.Address == leader,
 			Voter:           server.Suffrage == raft.Voter,
 			ProtocolVersion: raftProtocolVersion,
+			LastIndex:       serverIDLastIndexMap[server.ID],
 		}
 		reply.Servers = append(reply.Servers, entry)
 	}

--- a/agent/consul/operator_raft_endpoint_test.go
+++ b/agent/consul/operator_raft_endpoint_test.go
@@ -47,6 +47,13 @@ func TestOperator_RaftGetConfiguration(t *testing.T) {
 	if len(future.Configuration().Servers) != 1 {
 		t.Fatalf("bad: %v", future.Configuration().Servers)
 	}
+
+	serverIDLastIndexMap := make(map[raft.ServerID]uint64)
+
+	for _, serverState := range s1.autopilot.GetState().Servers {
+		serverIDLastIndexMap[serverState.Server.ID] = serverState.Stats.LastIndex
+	}
+
 	me := future.Configuration().Servers[0]
 	expected := structs.RaftConfigurationResponse{
 		Servers: []*structs.RaftServer{
@@ -57,6 +64,7 @@ func TestOperator_RaftGetConfiguration(t *testing.T) {
 				Leader:          true,
 				Voter:           true,
 				ProtocolVersion: "3",
+				LastIndex:       serverIDLastIndexMap[me.ID],
 			},
 		},
 		Index: future.Index(),
@@ -110,6 +118,10 @@ func TestOperator_RaftGetConfiguration_ACLDeny(t *testing.T) {
 	if len(future.Configuration().Servers) != 1 {
 		t.Fatalf("bad: %v", future.Configuration().Servers)
 	}
+	serverIDLastIndexMap := make(map[raft.ServerID]uint64)
+	for _, serverState := range s1.autopilot.GetState().Servers {
+		serverIDLastIndexMap[serverState.Server.ID] = serverState.Stats.LastIndex
+	}
 	me := future.Configuration().Servers[0]
 	expected := structs.RaftConfigurationResponse{
 		Servers: []*structs.RaftServer{
@@ -120,6 +132,7 @@ func TestOperator_RaftGetConfiguration_ACLDeny(t *testing.T) {
 				Leader:          true,
 				Voter:           true,
 				ProtocolVersion: "3",
+				LastIndex:       serverIDLastIndexMap[me.ID],
 			},
 		},
 		Index: future.Index(),

--- a/agent/structs/operator.go
+++ b/agent/structs/operator.go
@@ -31,6 +31,9 @@ type RaftServer struct {
 	// it's a non-voting server, which will be added in a future release of
 	// Consul.
 	Voter bool
+
+	// LastIndex is the last log index this server has a record of in its Raft log.
+	LastIndex uint64
 }
 
 // RaftConfigurationResponse is returned when querying for the current Raft

--- a/api/operator_raft.go
+++ b/api/operator_raft.go
@@ -25,6 +25,9 @@ type RaftServer struct {
 	// it's a non-voting server, which will be added in a future release of
 	// Consul.
 	Voter bool
+
+	// LastIndex is the last log index this server has a record of in its Raft log.
+	LastIndex uint64
 }
 
 // RaftConfiguration is returned when querying for the current Raft configuration.

--- a/command/operator/raft/listpeers/operator_raft_list_test.go
+++ b/command/operator/raft/listpeers/operator_raft_list_test.go
@@ -25,7 +25,7 @@ func TestOperatorRaftListPeersCommand(t *testing.T) {
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
-	expected := fmt.Sprintf("%s  %s  127.0.0.1:%d  leader  true   3",
+	expected := fmt.Sprintf("%s  %s  127.0.0.1:%d  leader  true   3             1             -",
 		a.Config.NodeName, a.Config.NodeID, a.Config.ServerPort)
 
 	// Test the list-peers subcommand directly

--- a/website/content/commands/operator/raft.mdx
+++ b/website/content/commands/operator/raft.mdx
@@ -46,10 +46,10 @@ Usage: `consul operator raft list-peers -stale=[true|false]`
 The output looks like this:
 
 ```text
-Node     ID              Address         State     Voter  RaftProtocol
-alice    127.0.0.1:8300  127.0.0.1:8300  follower  true   2
-bob      127.0.0.2:8300  127.0.0.2:8300  leader    true   3
-carol    127.0.0.3:8300  127.0.0.3:8300  follower  true   2
+Node     ID              Address         State     Voter  RaftProtocol  Commit Index Trails Leader By
+alice    127.0.0.1:8300  127.0.0.1:8300  follower  true   2             1167         0 commits
+bob      127.0.0.2:8300  127.0.0.2:8300  leader    true   3             1167         -
+carol    127.0.0.3:8300  127.0.0.3:8300  follower  true   2             1159         8 commits
 ```
 
 `Node` is the node name of the server, as known to Consul, or "(unknown)" if
@@ -70,7 +70,7 @@ configuration.
 
 - `-stale` - Enables non-leader servers to provide cluster state information.
   If the cluster is in an outage state without a leader,
-  we recommend setting this option to `true.
+  we recommend setting this option to `true`.
   Default is `false`.
 
 ## remove-peer


### PR DESCRIPTION
### Description

As per requirement of [NET - 3865](https://hashicorp.atlassian.net/browse/NET-3865), We want to have the 'commit_index' to be included in the output of 'consul operator raft list-peers -detailed'. This feature specifically useful in the cases where Consul is being upgraded to determine the replication rate and intervene as needed.

I have implemented it by calling a API `/v1/operator/autopilot/health`, storing the response in a map -> [server id, OperatorHealthReply]. Then this data is used to print the Commit Index by matching the id of server from this to server id in RaftGetConfiguration.

### Testing 

Create a consul cluster by following this [tutorial](https://developer.hashicorp.com/consul/tutorials/kubernetes/kubernetes-windows-nodes).
`kubectl exec -it consul-server-0 -n consul -- /bin/sh` in one terminal
`kubectl exec -it consul-server-1 -n consul -- /bin/sh` in other terminal
do a ps and kill `consul agent` in the second terminal.
Run command `consul operator raft list-peers`

* execute the following command when agent is running
* `consul operator raft list-peers`
* Output - 

![Screenshot 2023-06-08 at 10 36 07 PM](https://github.com/hashicorp/consul/assets/134911583/196abd1c-6f00-4dbc-9045-3d9acea23e4e)


### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
