### PR TITLE
Bump check-generated-protobuf runner size to medium

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -50,7 +50,7 @@ jobs:
   check-generated-protobuf:
     needs: 
     - setup   
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-medium) }}
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
     # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.


### PR DESCRIPTION
### Description

The check-generated-protobuf job now uses a medium sized runner instead of a small. This change was prompted by seeing this job fail a number of times when the runner became disconnected from GitHub and presuming that it was a resource contention issue. Things are working again with the medium runner.

### Testing & Reproduction steps

CI passes.

### Links

[Change from original PR](https://github.com/hashicorp/consul/pull/17834/files#diff-5a1bcf51eaa62614197dde8c00207b1c6a3c91d08241b0953e600baa7b66f6d7)
