### PR TITLE
Fixes Secondary ConnectCA update

### DIFF
--- a/.changelog/17846.txt
+++ b/.changelog/17846.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-connect/ca: Fixes a bug that caused the ConnectCA configuration in secondary DC not persist after initial configuration.
+connect/ca: Fixes a bug preventing CA configuration updates in secondary datacenters
 ```

--- a/.changelog/17846.txt
+++ b/.changelog/17846.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect/ca: Fixes a bug that caused the ConnectCA configuration in secondary DC not persist after initial configuration.
+```

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -736,7 +736,7 @@ func shouldPersistNewRootAndConfig(newActiveRoot *structs.CARoot, oldConfig, new
 		return false
 	}
 
-	// Need not persist when the provider, old and new config is the same
+	// Do not persist if the new provider and config are the same as the old
 	return !(newConfig.Provider == oldConfig.Provider && reflect.DeepEqual(newConfig.Config, oldConfig.Config))
 }
 

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -735,7 +735,9 @@ func shouldPersistNewRootAndConfig(newActiveRoot *structs.CARoot, oldConfig, new
 	if newConfig == nil {
 		return false
 	}
-	return newConfig.Provider == oldConfig.Provider && reflect.DeepEqual(newConfig.Config, oldConfig.Config)
+
+	// Need not persist when the provider, old and new config is the same
+	return !(newConfig.Provider == oldConfig.Provider && reflect.DeepEqual(newConfig.Config, oldConfig.Config))
 }
 
 func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/11363

### Description

This fixes a bug that was identified, which resulted in subsequent ConnectCA configuration updates in secondary DC's not persisting in the cluster.

### Testing & Reproduction steps

Details in NET-4540

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
