### PR TITLE
Trigger OSS => ENT merge for all release branches

### DIFF
--- a/.github/workflows/oss-merge-trigger.yml
+++ b/.github/workflows/oss-merge-trigger.yml
@@ -8,7 +8,7 @@ on:
       - closed
     branches:
       - main
-      - 'release/*.*.x'
+      - release/**
 
 jobs:
   trigger-oss-merge:


### PR DESCRIPTION
### Description
Previously, this only triggered for `release/*.*.x` branches; however, our release process involves cutting a `release/1.16.0` branch, for example, at time of code freeze these days. Any PRs to that branch after code freeze today do not make their way to consul-enterprise. This will make behavior for a .0 branch consistent with current behavior for a .x branch.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
