### PR TITLE
docs: add note about path prefix matching behavior for HTTPRoute config

### DIFF
--- a/website/content/docs/connect/gateways/api-gateway/configuration/http-route.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/http-route.mdx
@@ -533,9 +533,10 @@ Specifies the HTTP method to match.
 
 Specifies type of match for the path: `"exact"`, `"prefix"`, or `"regex"`.
 
--> **Note:** Prefix matching uses simple string matching when comparing to the path. This differs slightly from the
-[Kubernetes Gateway API specification](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.PathMatchType)
-which declares that path prefix matching is done on a path element by element basis.
+If set to `prefix`, Consul uses simple string matching to identify incoming request prefixes. For example, if the route is configured to match incoming requests to services prefixed with `/dev`, then the gateway would match requests to `/dev-` and `/deviate` and route to the upstream.  
+
+This deviates from the
+[Kubernetes Gateway API specification](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.PathMatchType), which matches on full path elements. In the previous example, _only_ requests to `/dev` or `/dev/` would match. 
 
 #### Values
 

--- a/website/content/docs/connect/gateways/api-gateway/configuration/http-route.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/http-route.mdx
@@ -533,6 +533,10 @@ Specifies the HTTP method to match.
 
 Specifies type of match for the path: `"exact"`, `"prefix"`, or `"regex"`.
 
+-> **Note:** Prefix matching uses simple string matching when comparing to the path. This differs slightly from the
+[Kubernetes Gateway API specification](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.PathMatchType)
+which declares that path prefix matching is done on a path element by element basis.
+
 #### Values
 
 - Default: none


### PR DESCRIPTION
### Description
The Gateway API spec says the following about path prefix route matches ([source](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.PathMatchType)):

> Matches based on a URL path prefix split by /. Matching is case sensitive and done on a path element by element basis. A path element refers to the list of labels in the path split by the / separator. When specified, a trailing / is ignored.
> 
> For example, the paths `/abc`, `/abc/`, and `/abc/def` would all match the prefix `/abc`, but the path `/abcd` would not.


Consul API Gateway does simple string prefix comparison today, which is the same thing that the rest of Consul does. The result is that, contrary to the specification above, we do match `/abcd`. This is because Consul uses `RouteMatch_Prefix` across the board for prefix matching when generating xDS instead of `RouteMatch_PathSeparatedPrefix`.

This PR just calls out that difference in the docs so we don't surprise anyone as much as we can help it.

### Testing & Reproduction steps
N/A

### Links

[Vercel preview of added note](https://consul-kpax35h44-hashicorp.vercel.app/consul/docs/connect/gateways/api-gateway/configuration/http-route#rules-matches-path-match)
<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
