### PR TITLE
docs: add note about path prefix matching behavior for HTTPRoute config

### DIFF
--- a/website/content/docs/connect/gateways/api-gateway/configuration/http-route.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/http-route.mdx
@@ -533,6 +533,11 @@ Specifies the HTTP method to match.
 
 Specifies type of match for the path: `"exact"`, `"prefix"`, or `"regex"`.
 
+If set to `prefix`, Consul uses simple string matching to identify incoming request prefixes. For example, if the route is configured to match incoming requests to services prefixed with `/dev`, then the gateway would match requests to `/dev-` and `/deviate` and route to the upstream.  
+
+This deviates from the
+[Kubernetes Gateway API specification](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.PathMatchType), which matches on full path elements. In the previous example, _only_ requests to `/dev` or `/dev/` would match. 
+
 #### Values
 
 - Default: none


### PR DESCRIPTION
### Description
This is a docs-only manual backport of https://github.com/hashicorp/consul/pull/17860 targeting 1.16.0

### Testing & Reproduction steps
N/A (docs-only)
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
