### PR TITLE
api-gateway: add step to upgrade instructions for creating intentions

### DIFF
--- a/website/content/docs/api-gateway/upgrades.mdx
+++ b/website/content/docs/api-gateway/upgrades.mdx
@@ -65,6 +65,8 @@ If you are able to tolerate downtime for your applications, you should delete pr
   $ kubectl apply -f apigw-installation.yaml
   ```
 
+1. Create `ServiceIntentions` allowing `Gateways` to communicate with any backend services that they route to. Refer to [Service intentions configuration entry reference](/consul/docs/connect/config-entries/service-intentions) for additional information.
+
 1. Change any existing `Gateways` to reference the new `GatewayClass` `consul`. Refer to [gatewayClass](/consul/docs/api-gateway/configuration/gateway#gatewayclassname) for additional information.
 
 1. After updating all of your `gateway` configurations to use the new controller, you can complete the upgrade again and completely remove the `apiGateway` block to remove the old controller. 
@@ -98,6 +100,8 @@ If you are unable to tolerate any downtime, you can complete the following steps
   ```shell-session
   $ kubectl apply -f apigw-installation.yaml
   ```
+
+1. Create `ServiceIntentions` allowing `Gateways` to communicate with any backend services that they route to. Refer to [Service intentions configuration entry reference](/consul/docs/connect/config-entries/service-intentions) for additional information.
 
 1. Change any existing `Gateways` to reference the new `GatewayClass` `consul`. Refer to [gatewayClass](/consul/docs/api-gateway/configuration/gateway#gatewayclassname) for additional information.
 


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
The upgrade docs for migrating to the new native api-gateway solution should include a step for creating intentions that allow the gateway to communicate with the backend services that it’s routing to. This is important if a user does not have allow-all in place since the Gateway would be unable to communicate with the service backends post-upgrade.

In the legacy api-gateway solution, we created these intentions automatically; however, we intentionally stopped doing this with our new implementation.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

Follow upgrade instructions.

### Links

https://consul-asgedpqp3-hashicorp.vercel.app/consul/docs/api-gateway/upgrades#upgrade-to-native-consul-api-gateway

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
