### PR TITLE
Passes configured role name to Vault for AWS auth in Connect CA

### DIFF
--- a/.changelog/17885.txt
+++ b/.changelog/17885.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+ca: Fixed a bug where the Vault provider was not passing the configured role param for AWS auth

--- a/agent/connect/ca/provider_vault_auth_aws.go
+++ b/agent/connect/ca/provider_vault_auth_aws.go
@@ -72,9 +72,6 @@ func (g *AWSLoginDataGenerator) GenerateLoginData(authMethod *structs.VaultAuthM
 	if err != nil {
 		return nil, fmt.Errorf("aws auth failed to generate login data: %w", err)
 	}
-	if loginData == nil {
-		return nil, fmt.Errorf("got nil response from GenerateLoginData")
-	}
 
 	// If a Vault role name is specified, we need to manually add this
 	role, ok := authMethod.Params["role"]

--- a/agent/connect/ca/provider_vault_auth_aws.go
+++ b/agent/connect/ca/provider_vault_auth_aws.go
@@ -72,6 +72,16 @@ func (g *AWSLoginDataGenerator) GenerateLoginData(authMethod *structs.VaultAuthM
 	if err != nil {
 		return nil, fmt.Errorf("aws auth failed to generate login data: %w", err)
 	}
+	if loginData == nil {
+		return nil, fmt.Errorf("got nil response from GenerateLoginData")
+	}
+
+	// If a Vault role name is specified, we need to manually add this
+	role, ok := authMethod.Params["role"]
+	if ok {
+		loginData["role"] = role
+	}
+
 	return loginData, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/17887.

### Description

When using Connect, with Vault CA, with AWS auth - this change ensures that the `role` name (if configured) is passed as part of the login request. Prior to this change, Consul did not respect this parameter and therefore always falls back to the default Vault behaviour of using the instance AWS IAM role name, even if `role` was specified in `params`.

### Testing & Reproduction steps

 - Added additional coverage to the existing `TestVaultCAProvider_AWSLoginDataGenerator`  tests.

#### To reproduce original bug

  1. Create a file with CA configuration, e.g.

   ```
   {
     "Provider": "vault",
     "Config": {
       "Address": "https://my.vault.server:8200",
       "IntermediatePKIPath": "pki_int",
       "RootPKIPath": "pki",
       "AuthMethod": {
         "Type": "aws",
         "MountPath": "aws",
         "Params": {
           "role": "configured-role-name"
         }
       }
     }
   }
   ```
 2. Set CA configuration
   ```
   consul connect ca set-config -config-file ca.conf
   ```
 3. Observe that `role` is not sent to Vault, Vault will attempt to use the IAM instance role name and fail if this does not exist as a Vault role.

### Links

 - Vault AWS auth method login request params
   https://developer.hashicorp.com/vault/api-docs/auth/aws#login
 - Vault CLI implementation of AWS auth
   https://github.com/hashicorp/vault/blob/f381fba4a6468921c4d7d90e04db7bfb9bef4f52/builtin/credential/aws/cli.go#L67
 - https://github.com/hashicorp/consul/issues/17887
 - Support ticket: 115239
<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] ~external facing docs updated~ (Not applicable)
* [x] appropriate backport labels added
* [x] not a security concern
