### PR TITLE
Add emit_tags_as_labels to envoy bootstrap config when using Consul Telemetry Collector

### DIFF
--- a/.changelog/17888.txt
+++ b/.changelog/17888.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Add capture group labels from Envoy cluster FQDNs to Envoy exported metric labels
+```

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -847,7 +847,8 @@ func appendTelemetryCollectorConfig(args *BootstrapTplArgs, telemetryCollectorBi
 			"envoy_grpc": {
 			  "cluster_name": "consul_telemetry_collector_loopback"
 			}
-		  }
+		  },
+		  "emit_tags_as_labels": true
 		}
 	  }`
 

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -539,7 +539,8 @@ const (
 		"envoy_grpc": {
 		  "cluster_name": "consul_telemetry_collector_loopback"
 		}
-	  }
+	  },
+	  "emit_tags_as_labels": true
 	}
   }`
 
@@ -638,7 +639,8 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 						"envoy_grpc": {
 						  "cluster_name": "consul_telemetry_collector_loopback"
 						}
-					  }
+					  },
+					  "emit_tags_as_labels": true
 					}
 				  }`,
 				StaticClustersJSON: `{

--- a/command/connect/envoy/testdata/telemetry-collector.golden
+++ b/command/connect/envoy/testdata/telemetry-collector.golden
@@ -89,7 +89,8 @@
           "envoy_grpc": {
             "cluster_name": "consul_telemetry_collector_loopback"
           }
-        }
+        },
+        "emit_tags_as_labels": true
       }
     }
   ],


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

This flips an Envoy flag on so metrics sent to the [Consul Telemetry Collector](https://github.com/hashicorp/consul-telemetry-collector) get all the tags that we create via regexes: https://github.com/hashicorp/consul/blob/94584cf5402c11e5a3c93467d43a8ad97af8d6b3/command/connect/envoy/bootstrap_config.go#L352

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

I made this [change directly to `consul-dataplane`](https://github.com/hashicorp/consul-dataplane/blob/main/internal/bootstrap/bootstrap_config.go#L848), deployed it to a personal Docker Hub repo, and ran `consul-k8s install` with it:

```bash
consul-k8s install -preset cloud -hcp-resource-id "$HCP_RESOURCE_ID" -demo \
    --set="global.enterpriseLicense.secretKey=key" \
    --set="global.enterpriseLicense.secretName=consul-license" \
    --set="global.logLevel=debug" \
    --set="global.imageConsulDataplane=jjtimmons/consul-dataplane:latest" \
    --set="metrics.enableTelemetryCollector=true" \
    --set="peering.enabled=true" \
    --set="server.replicas=3"
```

Checked Prometheus and we're getting all the labels:

> {__name__="http_downstream_rq_active", cluster="josh-test-envoy-emit-tags-labels", consul_source_datacenter="josh-test-envoy-emit-tags-labels", consul_source_namespace="default", consul_source_partition="default", consul_source_service="frontend", consul_upstream_datacenter="josh-test-envoy-emit-tags-labels", consul_upstream_namespace="default", consul_upstream_partition="default", consul_upstream_service="consul-telemetry-collector", envoy_cluster="frontend", envoy_http_conn_manager_prefix="upstream", hcp_internal_id="00000000-e387-6f3e-286b-bc6f1e1b4f84", hcp_organization_id="00000000-06f2-45b3-96ba-e4b0ced62717", hcp_project_id="0000000-0087-4a1b-a9d6-b6030d55ea5c", local_cluster="frontend", namespace="default", node_id="frontend-f74f5f4d4-cw72z-frontend-sidecar-proxy", partition="default"}

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

Envoy docs: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/metrics/v3/metrics_service.proto

>  If true, metrics will have their tags emitted as labels on the metrics objects sent to the MetricsService, and the tag extracted name will be used instead of the full name, which may contain values used by the tag extractor or additional tags added during stats creation.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
