### PR TITLE
Allow service identity tokens the ability to read jwt-providers

### DIFF
--- a/agent/structs/config_entry_jwt_provider.go
+++ b/agent/structs/config_entry_jwt_provider.go
@@ -316,6 +316,15 @@ func (e *JWTProviderConfigEntry) GetRaftIndex() *RaftIndex               { retur
 func (e *JWTProviderConfigEntry) CanRead(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
+
+	// allow service-identity tokens the ability to read jwt-providers
+	// this is a workaround to allow sidecar proxies to read the jwt-providers
+	// see issue: https://github.com/hashicorp/consul/issues/17886 for more details
+	err := authz.ToAllowAuthorizer().ServiceWriteAnyAllowed(&authzContext)
+	if err == nil {
+		return err
+	}
+
 	return authz.ToAllowAuthorizer().MeshReadAllowed(&authzContext)
 }
 

--- a/agent/structs/config_entry_jwt_provider_test.go
+++ b/agent/structs/config_entry_jwt_provider_test.go
@@ -339,8 +339,14 @@ func TestJWTProviderConfigEntry_ACLs(t *testing.T) {
 					canWrite:   false,
 				},
 				{
-					name:       "jwt-provider: service write",
+					name:       "jwt-provider: any service write",
 					authorizer: newTestAuthz(t, `service "" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+				{
+					name:       "jwt-provider: specific service write",
+					authorizer: newTestAuthz(t, `service "web" { policy = "write" }`),
 					canRead:    true,
 					canWrite:   false,
 				},

--- a/agent/structs/config_entry_jwt_provider_test.go
+++ b/agent/structs/config_entry_jwt_provider_test.go
@@ -351,6 +351,12 @@ func TestJWTProviderConfigEntry_ACLs(t *testing.T) {
 					canWrite:   false,
 				},
 				{
+					name:       "jwt-provider: any service prefix write",
+					authorizer: newTestAuthz(t, `service_prefix "" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+				{
 					name:       "jwt-provider: mesh read",
 					authorizer: newTestAuthz(t, `mesh = "read"`),
 					canRead:    true,

--- a/agent/structs/config_entry_jwt_provider_test.go
+++ b/agent/structs/config_entry_jwt_provider_test.go
@@ -339,6 +339,12 @@ func TestJWTProviderConfigEntry_ACLs(t *testing.T) {
 					canWrite:   false,
 				},
 				{
+					name:       "jwt-provider: service write",
+					authorizer: newTestAuthz(t, `service "" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+				{
 					name:       "jwt-provider: mesh read",
 					authorizer: newTestAuthz(t, `mesh = "read"`),
 					canRead:    true,


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

- This PR allows service identity tokens the ability to read jwt providers. This is necessary because before writing an intention that referenced a jwt-provider, there is a validation to ensure that jwt-provider exist. 
- Prior to this PR, if the token didn't have `mesh:read` permission, it will not be able to access the provider hence failing to write any intentions referencing jwt providers due to the validation mentioned above 

