### PR TITLE
Reference hashicorp/consul instead of consul for Docker image

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -171,7 +171,7 @@ dev-build:
 
 dev-docker-dbg: dev-docker
 	@echo "Pulling consul container image - $(CONSUL_IMAGE_VERSION)"
-	@docker pull consul:$(CONSUL_IMAGE_VERSION) >/dev/null
+	@docker pull hashicorp/consul:$(CONSUL_IMAGE_VERSION) >/dev/null
 	@echo "Building Consul Development container - $(CONSUL_DEV_IMAGE)"
 	@#  'consul-dbg:local' tag is needed to run the integration tests
 	@#  'consul-dev:latest' is needed by older workflows
@@ -183,7 +183,7 @@ dev-docker-dbg: dev-docker
 
 dev-docker: linux dev-build
 	@echo "Pulling consul container image - $(CONSUL_IMAGE_VERSION)"
-	@docker pull consul:$(CONSUL_IMAGE_VERSION) >/dev/null
+	@docker pull hashicorp/consul:$(CONSUL_IMAGE_VERSION) >/dev/null
 	@echo "Building Consul Development container - $(CONSUL_DEV_IMAGE)"
 	@#  'consul:local' tag is needed to run the integration tests
 	@#  'consul-dev:latest' is needed by older workflows
@@ -205,7 +205,7 @@ remote-docker: check-remote-dev-image-env
 	$(MAKE) GOARCH=amd64 linux
 	$(MAKE) GOARCH=arm64 linux
 	@echo "Pulling consul container image - $(CONSUL_IMAGE_VERSION)"
-	@docker pull consul:$(CONSUL_IMAGE_VERSION) >/dev/null
+	@docker pull hashicorp/consul:$(CONSUL_IMAGE_VERSION) >/dev/null
 	@echo "Building and Pushing Consul Development container - $(REMOTE_DEV_IMAGE)"
 	@if ! docker buildx inspect consul-builder; then \
 		docker buildx create --name consul-builder --driver docker-container --bootstrap; \
@@ -222,7 +222,7 @@ remote-docker: check-remote-dev-image-env
 # should only run in CI and not locally.
 ci.dev-docker:
 	@echo "Pulling consul container image - $(CONSUL_IMAGE_VERSION)"
-	@docker pull consul:$(CONSUL_IMAGE_VERSION) >/dev/null
+	@docker pull hashicorp/consul:$(CONSUL_IMAGE_VERSION) >/dev/null
 	@echo "Building Consul Development container - $(CI_DEV_DOCKER_IMAGE_NAME)"
 	@docker build $(NOCACHE) $(QUIET) -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)' \
 	--build-arg CONSUL_IMAGE_VERSION=$(CONSUL_IMAGE_VERSION) \

--- a/build-support/docker/Consul-Dev-Multiarch.dockerfile
+++ b/build-support/docker/Consul-Dev-Multiarch.dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 ARG CONSUL_IMAGE_VERSION=latest
-FROM consul:${CONSUL_IMAGE_VERSION}
+FROM hashicorp/consul:${CONSUL_IMAGE_VERSION}
 RUN apk update && apk add iptables
 ARG TARGETARCH
 COPY linux_${TARGETARCH}/consul /bin/consul

--- a/build-support/docker/Consul-Dev.dockerfile
+++ b/build-support/docker/Consul-Dev.dockerfile
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 ARG CONSUL_IMAGE_VERSION=latest
-FROM consul:${CONSUL_IMAGE_VERSION}
+FROM hashicorp/consul:${CONSUL_IMAGE_VERSION}
 RUN apk update && apk add iptables
 COPY consul /bin/consul

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -308,7 +308,7 @@ metadata:
 spec:
   containers:
     - name: example
-      image: 'consul:latest'
+      image: 'hashicorp/consul:latest'
       env:
         - name: HOST_IP
           valueFrom:
@@ -345,7 +345,7 @@ spec:
     spec:
       containers:
         - name: example
-          image: 'consul:latest'
+          image: 'hashicorp/consul:latest'
           env:
             - name: HOST_IP
               valueFrom:


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
`consul:latest` no longer exists. We should instead reference `hashicorp/consul:latest` (or whichever other tag we're using).

Prior to this PR, our integration tests are broken due to the above ([example](https://github.com/hashicorp/consul/actions/runs/5395205237/jobs/9797421738)).

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
Our own integration tests exercise the modified Dockerfiles. They should pass on this PR.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
