### PR TITLE
Add dashes (-) for sameness group

### DIFF
--- a/website/content/docs/connect/config-entries/sameness-group.mdx
+++ b/website/content/docs/connect/config-entries/sameness-group.mdx
@@ -101,8 +101,8 @@ metadata:
 spec:
   defaultForFailover: false
   members:                                        # required
-    partition: <partitionWithServicesInGroup>
-    peer: <clusterPeerWithServicesInGroup>
+    - partition: <partitionWithServicesInGroup>
+    - peer: <clusterPeerWithServicesInGroup>
 ```
 
 </Tab>
@@ -365,10 +365,10 @@ metadata:
 spec:
   defaultForFailover: true
   members:                                   
-    partition: store-east
-    partition: inventory-east
-    peer: dc2-store-west
-    peer: dc2-inventory-west
+    - partition: store-east
+    - partition: inventory-east
+    - peer: dc2-store-west
+    - peer: dc2-inventory-west
 ```
 
 </Tab>


### PR DESCRIPTION
### Description

Dashes were missing for sameness groups causing errors like so 

```
Error from server (BadRequest): error when creating "./kube/configs/dc3/sameness-groups/sameness-group-unicorn.yaml": SamenessGroup in version "v1alpha1" cannot be handled as a SamenessGroup: strict decoding error: unknown field "spec.members.partition", unknown field "spec.members.peer"
```


### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
