### PR TITLE
Update Consul K8s Upgrade Doc Updates

### DIFF
--- a/website/content/docs/k8s/upgrade/index.mdx
+++ b/website/content/docs/k8s/upgrade/index.mdx
@@ -240,7 +240,7 @@ Note that you must remove the token manually after completing the migration.
   kubectl patch deploy $INJECTOR_DEPLOYMENT --type='json' -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/lifecycle"}]'
   ```
 
-1. Follow our [recommended procedures to upgrade servers](#upgrade-consul-servers) on Kubernetes deployments to upgrade Helm values for the new version of Consul.
+1. Follow our [recommended procedures to upgrade servers](#upgrade-consul-servers) on Kubernetes deployments to upgrade Helm values for the new version of Consul. The latest version of consul-k8s components may be in a CrashLoopBackoff state during the performance of the server upgrade from versions <1.14.x until all Consul servers are on versions >=1.14.x. Components in CrashLoopBackoff will not negatively affect the cluster because older versioned components will still be operating. Once all servers have been fully upgraded, the latest consul-k8s components will automatically restore from CrashLoopBackoff and older component versions will be spun down.
 
 1. Run `kubectl rollout restart` to restart your service mesh applications. Restarting service mesh application causes Kubernetes to re-inject them with the webhook for dataplanes.
 


### PR DESCRIPTION
### Description

Updating upgrade procedures to encompass expected CrashLoopBackOff  during upgrade process from v1.13.x to v1.14.x.

### Testing & Reproduction steps

Spun up single consul-k8s on KinD cluster at:
hashicorp/consul-enterprise:1.13.8-ent
hashicorp/consul-k8s-control-plane:0.49.5
envoyproxy/envoy:v1.23.2

Upgraded cluster to:
hashicorp/consul-enterprise:1.14.7-ent
hashicorp/consul-k8s-control-plane:1.0.7
envoyproxy/envoy:v1.24.7
hashicorp/consul-dataplane:1.0.2

### Links
Followed: https://developer.hashicorp.com/consul/docs/k8s/upgrade

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
