### PR TITLE
docs: Deprecations for connect-native SDK and specific connect native APIs

### DIFF
--- a/website/content/docs/connect/native/go.mdx
+++ b/website/content/docs/connect/native/go.mdx
@@ -10,7 +10,7 @@ description: >-
 <Note>
 
 The Connect Native golang SDK is currently deprecated and will be removed in a future Consul release.
-The eventual removal of the SDK is dependent on the delivery of proxyless GRPC via XDS which is tracked on [GH-10339](https://github.com/hashicorp/consul/issues/10339).
+The SDK will be removed when the long term replacement to native application integration (such as a proxyless gRPC service mesh integration) is delivered. Refer to [GH-10339](https://github.com/hashicorp/consul/issues/10339) for additional information and to track progress toward one potential solution that is tracked as replacement functionality.
 
 </Note>
 

--- a/website/content/docs/connect/native/go.mdx
+++ b/website/content/docs/connect/native/go.mdx
@@ -7,8 +7,10 @@ description: >-
 
 # Service Mesh Native Integration for Go Applications
 
--> **Note:** The Connect Native golang SDK is currently deprecated and will be removed in a future Consul release.
+<Note>
+The Connect Native golang SDK is currently deprecated and will be removed in a future Consul release.
 The eventual removal of the SDK is dependent on the delivery of proxyless GRPC via XDS which is tracked on [GH-10339](https://github.com/hashicorp/consul/issues/10339).
+</Note>
 
 We provide a library that makes it drop-in simple to integrate Consul service mesh
 with most [Go](https://golang.org/) applications. This page shows examples

--- a/website/content/docs/connect/native/go.mdx
+++ b/website/content/docs/connect/native/go.mdx
@@ -8,8 +8,10 @@ description: >-
 # Service Mesh Native Integration for Go Applications
 
 <Note>
+
 The Connect Native golang SDK is currently deprecated and will be removed in a future Consul release.
 The eventual removal of the SDK is dependent on the delivery of proxyless GRPC via XDS which is tracked on [GH-10339](https://github.com/hashicorp/consul/issues/10339).
+
 </Note>
 
 We provide a library that makes it drop-in simple to integrate Consul service mesh

--- a/website/content/docs/connect/native/go.mdx
+++ b/website/content/docs/connect/native/go.mdx
@@ -7,6 +7,9 @@ description: >-
 
 # Service Mesh Native Integration for Go Applications
 
+-> **Note:** The Connect Native golang SDK is currently deprecated and will be removed in a future Consul release.
+The eventual removal of the SDK is dependent on the delivery of proxyless GRPC via XDS which is tracked on [GH-10339](https://github.com/hashicorp/consul/issues/10339).
+
 We provide a library that makes it drop-in simple to integrate Consul service mesh
 with most [Go](https://golang.org/) applications. This page shows examples
 of integrating this library for accepting or establishing mesh-based

--- a/website/content/docs/connect/native/index.mdx
+++ b/website/content/docs/connect/native/index.mdx
@@ -9,12 +9,10 @@ description: >-
 
 ~> **Note:** The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
 and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
-is still supported we discourage new users from adopting this feature at this time, as we plan to remove the feature
+will still operate as designed, we discourage new users from adopting this feature at this time, as we plan to remove the feature
 when a future long term replacement such as proxyless GRPC via XDS is delivered (see [GH-10339](https://github.com/hashicorp/consul/issues/10339)).
- The Native App Integration does not support many of the Consul's service
-mesh features, and is not under active development.
-The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production
-environments. 
+The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
+The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production environments. 
 
 Applications can natively integrate with Consul's service mesh API to support accepting
 and establishing connections to other mesh services without the overhead of a

--- a/website/content/docs/connect/native/index.mdx
+++ b/website/content/docs/connect/native/index.mdx
@@ -7,13 +7,16 @@ description: >-
 
 # Service Mesh Native App Integration Overview
 
-~> **Note:** The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
-and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
-will still operate as designed, we discourage new users from adopting this feature at this time, as we plan to remove the feature
-when a future long term replacement such as proxyless GRPC via XDS is delivered (see [GH-10339](https://github.com/hashicorp/consul/issues/10339)).
+<Note>
 
-~> **Note:** The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
+The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
+and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
+will still operate as designed, we do not recommend leveraging this feature because it is deprecated and will be removed when the long term replacement, proxy-less gRPC connections to Consul xDS, is delivered. Refer to [GH-10339](https://github.com/hashicorp/consul/issues/10339) for additional information and to track progress toward the replacement functionality.
+
+The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
 The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production environments. 
+
+</Note>
 
 Applications can natively integrate with Consul's service mesh API to support accepting
 and establishing connections to other mesh services without the overhead of a

--- a/website/content/docs/connect/native/index.mdx
+++ b/website/content/docs/connect/native/index.mdx
@@ -11,7 +11,8 @@ description: >-
 
 The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
 and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
-will still operate as designed, we do not recommend leveraging this feature because it is deprecated and will be removed when the long term replacement, proxy-less gRPC connections to Consul xDS, is delivered. Refer to [GH-10339](https://github.com/hashicorp/consul/issues/10339) for additional information and to track progress toward the replacement functionality.
+will still operate as designed, we do not recommend leveraging this feature because it is deprecated and will be removed 
+removed when the long term replacement to native application integration (such as a proxyless gRPC service mesh integration) is delivered. Refer to [GH-10339](https://github.com/hashicorp/consul/issues/10339) for additional information and to track progress toward one potential solution that is tracked as replacement functionality.
 
 The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
 The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production environments. 

--- a/website/content/docs/connect/native/index.mdx
+++ b/website/content/docs/connect/native/index.mdx
@@ -10,7 +10,10 @@ description: >-
 ~> **Note:** The Native App Integration does not support many of the Consul's service
 mesh features, and is not under active development.
 The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production
-environments.
+environments. The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
+and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
+is still supported we discourage new users from adopting this feature at this time, as we plan to remove the feature
+when a future long term replacement such as proxyless GRPC via XDS is delivered (see [GH-10339](https://github.com/hashicorp/consul/issues/10339)).
 
 Applications can natively integrate with Consul's service mesh API to support accepting
 and establishing connections to other mesh services without the overhead of a

--- a/website/content/docs/connect/native/index.mdx
+++ b/website/content/docs/connect/native/index.mdx
@@ -7,13 +7,14 @@ description: >-
 
 # Service Mesh Native App Integration Overview
 
-~> **Note:** The Native App Integration does not support many of the Consul's service
-mesh features, and is not under active development.
-The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production
-environments. The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
+~> **Note:** The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
 and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
 is still supported we discourage new users from adopting this feature at this time, as we plan to remove the feature
 when a future long term replacement such as proxyless GRPC via XDS is delivered (see [GH-10339](https://github.com/hashicorp/consul/issues/10339)).
+ The Native App Integration does not support many of the Consul's service
+mesh features, and is not under active development.
+The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production
+environments. 
 
 Applications can natively integrate with Consul's service mesh API to support accepting
 and establishing connections to other mesh services without the overhead of a

--- a/website/content/docs/connect/native/index.mdx
+++ b/website/content/docs/connect/native/index.mdx
@@ -11,7 +11,8 @@ description: >-
 and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
 will still operate as designed, we discourage new users from adopting this feature at this time, as we plan to remove the feature
 when a future long term replacement such as proxyless GRPC via XDS is delivered (see [GH-10339](https://github.com/hashicorp/consul/issues/10339)).
-The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
+
+~> **Note:** The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
 The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production environments. 
 
 Applications can natively integrate with Consul's service mesh API to support accepting

--- a/website/content/docs/connect/proxies/integrate.mdx
+++ b/website/content/docs/connect/proxies/integrate.mdx
@@ -11,7 +11,7 @@ description: >-
 
  The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
  and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
- will still operate as designed, we do not recommend leveraging this feature because it is deprecated and will be removed when the long term replacement, proxy-less gRPC connections to Consul xDS, is delivered. Refer to [GH-10339](https://github.com/hashicorp/consul/issues/10339) for additional information and to track progress toward the replacement functionality.
+ will still operate as designed, we do not recommend leveraging this feature because it is deprecated and will be removed when the long term replacement to native application integration (such as a proxyless gRPC service mesh integration) is delivered. Refer to [GH-10339](https://github.com/hashicorp/consul/issues/10339) for additional information and to track progress toward one potential solution that is tracked as replacement functionality.
 
  The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
  The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production environments. 

--- a/website/content/docs/connect/proxies/integrate.mdx
+++ b/website/content/docs/connect/proxies/integrate.mdx
@@ -9,10 +9,10 @@ description: >-
 
 ~> **Note:** The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
  and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
- is still supported we discourage new users from adopting this feature at this time, as we plan to remove the feature
+ will still operate as designed, we discourage new users from adopting this feature at this time, as we plan to remove the feature
  when a future long term replacement such as proxyless GRPC via XDS is delivered (see [GH-10339](https://github.com/hashicorp/consul/issues/10339)).
 
- The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
+~> **Note:** The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
  The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production environments. 
 
 This topic describes the process and API endpoints you can use to extend proxies for integration with Consul.

--- a/website/content/docs/connect/proxies/integrate.mdx
+++ b/website/content/docs/connect/proxies/integrate.mdx
@@ -7,13 +7,16 @@ description: >-
 
 # Custom Proxy Configuration for Service Mesh
 
-~> **Note:** The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
- and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
- will still operate as designed, we discourage new users from adopting this feature at this time, as we plan to remove the feature
- when a future long term replacement such as proxyless GRPC via XDS is delivered (see [GH-10339](https://github.com/hashicorp/consul/issues/10339)).
+<Note>
 
-~> **Note:** The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
+ The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
+ and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
+ will still operate as designed, we do not recommend leveraging this feature because it is deprecated and will be removed when the long term replacement, proxy-less gRPC connections to Consul xDS, is delivered. Refer to [GH-10339](https://github.com/hashicorp/consul/issues/10339) for additional information and to track progress toward the replacement functionality.
+
+ The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
  The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production environments. 
+
+</Note>
 
 This topic describes the process and API endpoints you can use to extend proxies for integration with Consul.
 

--- a/website/content/docs/connect/proxies/integrate.mdx
+++ b/website/content/docs/connect/proxies/integrate.mdx
@@ -7,13 +7,13 @@ description: >-
 
 # Custom Proxy Configuration for Service Mesh
 
-~> **Note:** The Native App Integration does not support many of the Consul's service
- mesh features, and is not under active development.
- The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production
- environments. The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
+~> **Note:** The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
  and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
  is still supported we discourage new users from adopting this feature at this time, as we plan to remove the feature
  when a future long term replacement such as proxyless GRPC via XDS is delivered (see [GH-10339](https://github.com/hashicorp/consul/issues/10339)).
+
+ The Native App Integration does not support many of the Consul's service mesh features, and is not under active development.
+ The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production environments. 
 
 This topic describes the process and API endpoints you can use to extend proxies for integration with Consul.
 

--- a/website/content/docs/connect/proxies/integrate.mdx
+++ b/website/content/docs/connect/proxies/integrate.mdx
@@ -7,6 +7,14 @@ description: >-
 
 # Custom Proxy Configuration for Service Mesh
 
+~> **Note:** The Native App Integration does not support many of the Consul's service
+ mesh features, and is not under active development.
+ The [Envoy proxy](/consul/docs/connect/proxies/envoy) should be used for most production
+ environments. The Connect Native Golang SDK and `v1/agent/connect/authorize`, `v1/agent/connect/ca/leaf`, 
+ and `v1/agent/connect/ca/roots` APIs are deprecated and will be removed in a future release. Although Connect Native 
+ is still supported we discourage new users from adopting this feature at this time, as we plan to remove the feature
+ when a future long term replacement such as proxyless GRPC via XDS is delivered (see [GH-10339](https://github.com/hashicorp/consul/issues/10339)).
+
 This topic describes the process and API endpoints you can use to extend proxies for integration with Consul.
 
 ## Overview

--- a/website/content/docs/release-notes/consul/v1_16_x.mdx
+++ b/website/content/docs/release-notes/consul/v1_16_x.mdx
@@ -58,7 +58,7 @@ We are pleased to announce the following Consul updates.
   - `v1/agent/connect/ca/leaf` - used by the SDK to get a leaf cert for a locally registered service
   - `v1/agent/connect/ca/roots` - use to retrieved cached CA roots form the local client agent
   
-  Currently both `v1/agent/connect/authorize` and `v1/agent/connect/ca/leaf` have corresponding gRPC APIs. Removal of these APIs will be dependent on delivering the gRPC API for `v1/agent/connect/ca/roots` and HTTP endpoints for all three APIs for easier consumption by users. 
+  The `v1/agent/connect/authorize` and `v1/agent/connect/ca/leaf` endpoints have corresponding gRPC APIs. We will remove these APIs when the gRPC API for `v1/agent/connect/ca/roots` and HTTP endpoints for all three APIs are available. 
 
 ## Upgrading
 

--- a/website/content/docs/release-notes/consul/v1_16_x.mdx
+++ b/website/content/docs/release-notes/consul/v1_16_x.mdx
@@ -51,7 +51,7 @@ We are pleased to announce the following Consul updates.
 
   Consul's API gateway is the recommended alternative to ingress gateway. For ingress gateway features not currently supported by API gateway, equivalent functionality will be added to API gateway over the next several releases of Consul.
 
-- **Connect Native Golang SDK:** The Connect Native [golang SDK](https://github.com/hashicorp/consul/tree/main/connect) is deprecated and will be removed in a future release. No further enhancements or maintenance is expected in the future releases. The eventual removal of the SDK is dependent on the delivery of proxyless GRPC via XDS which is tracked on [GH-10339](https://github.com/hashicorp/consul/issues/10339). 
+- **Connect Native Golang SDK:** The Connect Native [Golang SDK](https://github.com/hashicorp/consul/tree/main/connect) is deprecated and will be removed in a future release. No further enhancements or maintenance is expected in the future releases. The eventual removal of the SDK is dependent on the delivery of proxyless GRPC via XDS which is tracked on [GH-10339](https://github.com/hashicorp/consul/issues/10339). 
 
 - **Connect Native APIs:** The following APIs for Connect Native are deprecated: 
   - `v1/agent/connect/authorize` - used by the SDK to perform intention based authorization checks

--- a/website/content/docs/release-notes/consul/v1_16_x.mdx
+++ b/website/content/docs/release-notes/consul/v1_16_x.mdx
@@ -51,6 +51,15 @@ We are pleased to announce the following Consul updates.
 
   Consul's API gateway is the recommended alternative to ingress gateway. For ingress gateway features not currently supported by API gateway, equivalent functionality will be added to API gateway over the next several releases of Consul.
 
+- **Connect Native Golang SDK:** The Connect Native golang SDK ([github](https://github.com/hashicorp/consul/tree/main/connect) is deprecated and will be removed in a future release. No further enhancements or maintenance is expected in the future releases. The eventual removal of the SDK is dependent on the delivery of proxyless GRPC via XDS which is tracked on [GH-10339](https://github.com/hashicorp/consul/issues/10339). 
+
+- **Connect Native APIs:** The following APIs for Connect Native are deprecated: 
+  - `v1/agent/connect/authorize` - used by the SDK to perform intention based authorization checks
+  - `v1/agent/connect/ca/leaf` - used by the SDK to get a leaf cert for a locally registered service
+  - `v1/agent/connect/ca/roots` - use to retrieved cached CA roots form the local client agent
+  
+  Currently both `v1/agent/connect/authorize` and `v1/agent/connect/ca/leaf` have corresponding gRPC APIs. Removal of these APIs will be dependent on delivering the gRPC API for `v1/agent/connect/ca/roots` and HTTP endpoints for all three APIs for easier consumption by users. 
+
 ## Upgrading
 
 For more detailed information, please refer to the [upgrade details page](/consul/docs/upgrading/upgrade-specific) and the changelogs.

--- a/website/content/docs/release-notes/consul/v1_16_x.mdx
+++ b/website/content/docs/release-notes/consul/v1_16_x.mdx
@@ -51,7 +51,7 @@ We are pleased to announce the following Consul updates.
 
   Consul's API gateway is the recommended alternative to ingress gateway. For ingress gateway features not currently supported by API gateway, equivalent functionality will be added to API gateway over the next several releases of Consul.
 
-- **Connect Native Golang SDK:** The Connect Native [Golang SDK](https://github.com/hashicorp/consul/tree/main/connect) is deprecated and will be removed in a future release. No further enhancements or maintenance is expected in the future releases. The eventual removal of the SDK is dependent on the delivery of proxyless GRPC via XDS which is tracked on [GH-10339](https://github.com/hashicorp/consul/issues/10339). 
+- **Connect Native Golang SDK:** The Connect Native [Golang SDK](https://github.com/hashicorp/consul/tree/main/connect) is deprecated and will be removed in a future release. No further enhancements or maintenance is expected in the future releases. We will remove the SDK when the long term replacement, proxy-less gRPC connections to Consul xDS, is delivered. Refer to [GH-10339](https://github.com/hashicorp/consul/issues/10339) for additional information and to track progress toward the replacement functionality. 
 
 - **Connect Native APIs:** The following APIs for Connect Native are deprecated: 
   - `v1/agent/connect/authorize` - used by the SDK to perform intention based authorization checks

--- a/website/content/docs/release-notes/consul/v1_16_x.mdx
+++ b/website/content/docs/release-notes/consul/v1_16_x.mdx
@@ -51,7 +51,7 @@ We are pleased to announce the following Consul updates.
 
   Consul's API gateway is the recommended alternative to ingress gateway. For ingress gateway features not currently supported by API gateway, equivalent functionality will be added to API gateway over the next several releases of Consul.
 
-- **Connect Native Golang SDK:** The Connect Native [Golang SDK](https://github.com/hashicorp/consul/tree/main/connect) is deprecated and will be removed in a future release. No further enhancements or maintenance is expected in the future releases. We will remove the SDK when the long term replacement, proxy-less gRPC connections to Consul xDS, is delivered. Refer to [GH-10339](https://github.com/hashicorp/consul/issues/10339) for additional information and to track progress toward the replacement functionality. 
+- **Connect Native Golang SDK:** The Connect Native [Golang SDK](https://github.com/hashicorp/consul/tree/main/connect) is deprecated and will be removed in a future release. No further enhancements or maintenance is expected in the future releases. We will remove the SDK when the long term replacement to native application integration (such as a proxyless gRPC service mesh integration) is delivered. Refer to [GH-10339](https://github.com/hashicorp/consul/issues/10339) for additional information and to track progress toward one potential solution that is tracked as replacement functionality.
 
 - **Connect Native APIs:** The following APIs for Connect Native are deprecated: 
   - `v1/agent/connect/authorize` - used by the SDK to perform intention based authorization checks

--- a/website/content/docs/release-notes/consul/v1_16_x.mdx
+++ b/website/content/docs/release-notes/consul/v1_16_x.mdx
@@ -51,7 +51,7 @@ We are pleased to announce the following Consul updates.
 
   Consul's API gateway is the recommended alternative to ingress gateway. For ingress gateway features not currently supported by API gateway, equivalent functionality will be added to API gateway over the next several releases of Consul.
 
-- **Connect Native Golang SDK:** The Connect Native golang SDK ([github](https://github.com/hashicorp/consul/tree/main/connect) is deprecated and will be removed in a future release. No further enhancements or maintenance is expected in the future releases. The eventual removal of the SDK is dependent on the delivery of proxyless GRPC via XDS which is tracked on [GH-10339](https://github.com/hashicorp/consul/issues/10339). 
+- **Connect Native Golang SDK:** The Connect Native [golang SDK](https://github.com/hashicorp/consul/tree/main/connect) is deprecated and will be removed in a future release. No further enhancements or maintenance is expected in the future releases. The eventual removal of the SDK is dependent on the delivery of proxyless GRPC via XDS which is tracked on [GH-10339](https://github.com/hashicorp/consul/issues/10339). 
 
 - **Connect Native APIs:** The following APIs for Connect Native are deprecated: 
   - `v1/agent/connect/authorize` - used by the SDK to perform intention based authorization checks


### PR DESCRIPTION
### Description

Deprecation of connect native SDK and specific connect native APIs to discourage new users from adopting connect native until a longer term solution exists (i.e. proxyless GRPC for XDS [GH-10339](https://github.com/hashicorp/consul/issues/10339)) for native app integration into Consul Service Mesh. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
