### PR TITLE
feat: include nodes count in operator usage endpoint and cli command

### DIFF
--- a/.changelog/17939.txt
+++ b/.changelog/17939.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+http: GET API `operator/usage` endpoint now returns node count
+cli: `consul operator usage` command now returns node count
+```

--- a/agent/consul/state/usage.go
+++ b/agent/consul/state/usage.go
@@ -424,6 +424,11 @@ func (s *Store) ServiceUsage(ws memdb.WatchSet) (uint64, structs.ServiceUsage, e
 		return 0, structs.ServiceUsage{}, fmt.Errorf("failed services lookup: %s", err)
 	}
 
+	nodes, err := firstUsageEntry(ws, tx, tableNodes)
+	if err != nil {
+		return 0, structs.ServiceUsage{}, fmt.Errorf("failed nodes lookup: %s", err)
+	}
+
 	serviceKindInstances := make(map[string]int)
 	for _, kind := range allConnectKind {
 		usage, err := firstUsageEntry(ws, tx, connectUsageTableName(kind))
@@ -443,6 +448,7 @@ func (s *Store) ServiceUsage(ws memdb.WatchSet) (uint64, structs.ServiceUsage, e
 		Services:                 services.Count,
 		ConnectServiceInstances:  serviceKindInstances,
 		BillableServiceInstances: billableServiceInstances.Count,
+		Nodes:                    nodes.Count,
 	}
 	results, err := compileEnterpriseServiceUsage(ws, tx, usage)
 	if err != nil {

--- a/agent/operator_endpoint_oss_test.go
+++ b/agent/operator_endpoint_oss_test.go
@@ -65,6 +65,7 @@ func TestOperator_Usage(t *testing.T) {
 			},
 			// 4 = 6 total service instances - 1 connect proxy - 1 consul service
 			BillableServiceInstances: 4,
+			Nodes:                    2,
 		},
 	}
 	require.Equal(t, expected, raw.(structs.Usage).Usage)

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2324,6 +2324,7 @@ type ServiceUsage struct {
 	ServiceInstances         int
 	ConnectServiceInstances  map[string]int
 	BillableServiceInstances int
+	Nodes                    int
 	EnterpriseServiceUsage
 }
 

--- a/api/operator_usage.go
+++ b/api/operator_usage.go
@@ -10,6 +10,7 @@ type Usage struct {
 
 // ServiceUsage contains information about the number of services and service instances for a datacenter.
 type ServiceUsage struct {
+	Nodes                   int
 	Services                int
 	ServiceInstances        int
 	ConnectServiceInstances map[string]int

--- a/command/operator/usage/instances/usage_instances_oss_test.go
+++ b/command/operator/usage/instances/usage_instances_oss_test.go
@@ -117,3 +117,54 @@ Total                                    45`,
 		})
 	}
 }
+
+func TestUsageInstances_formatNodesCounts(t *testing.T) {
+	usageBasic := map[string]api.ServiceUsage{
+		"dc1": {
+			Nodes: 10,
+		},
+	}
+
+	usageMultiDC := map[string]api.ServiceUsage{
+		"dc1": {
+			Nodes: 10,
+		},
+		"dc2": {
+			Nodes: 11,
+		},
+	}
+
+	cases := []struct {
+		name          string
+		usageStats    map[string]api.ServiceUsage
+		expectedNodes string
+	}{
+		{
+			name:       "basic",
+			usageStats: usageBasic,
+			expectedNodes: `
+Datacenter      Count            
+dc1             10
+                
+Total           10`,
+		},
+		{
+			name:       "multi-datacenter",
+			usageStats: usageMultiDC,
+			expectedNodes: `
+Datacenter      Count            
+dc1             10
+dc2             11
+                
+Total           21`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nodesOutput, err := formatNodesCounts(tc.usageStats)
+			require.NoError(t, err)
+			require.Equal(t, strings.TrimSpace(tc.expectedNodes), nodesOutput)
+		})
+	}
+}

--- a/website/content/api-docs/operator/usage.mdx
+++ b/website/content/api-docs/operator/usage.mdx
@@ -64,7 +64,8 @@ $ curl \
         "mesh-gateway": 0,
         "terminating-gateway": 0
       },
-      "BillableServiceInstances": 0
+      "BillableServiceInstances": 0,
+      "Nodes": 1
     }
   },
   "Index": 13,

--- a/website/content/commands/operator/usage.mdx
+++ b/website/content/commands/operator/usage.mdx
@@ -50,6 +50,12 @@ Billable Services
 Services      Service instances
 2             3
 
+Nodes
+Datacenter      Count            
+dc1             1
+                
+Total           1
+
 Connect Services
 Type                     Service instances
 connect-native           0
@@ -73,6 +79,13 @@ dc1             2             3
 dc2             1             1
 
 Total           3             4
+
+Nodes
+Datacenter      Count            
+dc1             1
+dc2             2
+                
+Total           3
 
 Connect Services
 Datacenter      Type                     Service instances


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Enhances the `operator/usage` API endpoint and the corresponding CLI command to include node count in the output.

### Testing & Reproduction steps
Tested in dev mode
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
API

<img width="570" alt="Screenshot 2023-06-28 at 4 26 37 PM" src="https://github.com/hashicorp/consul/assets/20494842/f9c33452-a9e5-41a8-bcb3-f536e84045a2">

CLI
<img width="756" alt="Screenshot 2023-06-29 at 4 36 50 PM" src="https://github.com/hashicorp/consul/assets/20494842/7afa7c22-1901-46f2-821a-c88406213a3f">


### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->
API doc: https://developer.hashicorp.com/consul/api-docs/operator/usage

### PR Checklist

* [ ] ~updated test coverage~
* [x] external facing docs updated
* [x] appropriate backport labels added
* [ ] ~not a security concern~
