### PR TITLE
fixing typo in link to jwt-validations-with-intentions doc

### DIFF
--- a/website/content/docs/connect/intentions/jwt-authorization.mdx
+++ b/website/content/docs/connect/intentions/jwt-authorization.mdx
@@ -92,7 +92,7 @@ JWT = {
 }
 ```
 
-You can include additional configuration information to require the token to match specific claims. You can also configure the `JWT` field to apply only to requests that come from certain HTTP paths. Refer to [JWT validations with intentions](/consul/docs/conntect/config-entries/service-intentions#jwt-validations-with-intentions) for an example configuration.
+You can include additional configuration information to require the token to match specific claims. You can also configure the `JWT` field to apply only to requests that come from certain HTTP paths. Refer to [JWT validations with intentions](/consul/docs/connect/config-entries/service-intentions#jwt-validations-with-intentions) for an example configuration.
 
 After you update the service intention, write the configuration to Consul so that it takes effect:
 


### PR DESCRIPTION
### Description

Fix typo in JWT docs

### Testing & Reproduction steps


### Links


### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
