### PR TITLE
docs: samenessGroup YAML examples

### DIFF
--- a/website/content/docs/connect/config-entries/exported-services.mdx
+++ b/website/content/docs/connect/config-entries/exported-services.mdx
@@ -510,6 +510,57 @@ spec:
 </Tab>
 </Tabs>
 
+### Exporting a service to a sameness group
+
+The following example configures Consul to export a service named `api` to a defined group of partitions that belong to a separately defined [sameness group](/consul/docs/connect/config-entries/sameness-group) named `monitoring`.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind = "exported-services"
+Name = "default"
+
+Services = [
+  {
+    Name      = "api"
+    Consumers = [
+        {
+            SamenessGroup  = "monitoring"
+        }
+    ]
+  }
+]
+```
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+Kind: ExportedServices
+metadata:
+  name: default
+spec:
+  services:
+    - name: api
+      consumers:
+        - samenessGroup: monitoring
+```
+
+```json
+"Kind": "exported-services",
+  "Name": "default",
+  "Services": [
+    {
+      "Name": "api",
+      "Consumers": [
+        {
+          "SamenessGroup": "monitoring"
+        }
+      ]
+    }
+  ]
+```
+
+</CodeTabs>
+
 ### Exporting all services
 
 <Tabs>


### PR DESCRIPTION
### Description

This PR adds examples of of exported services YAML configurations that refer to the `samenessGroup` field.

Previously, this page only referred to the case used by HCL and JSON: `SamenessGroup`

Link to deployment preview of page: https://consul-5a02jffz5-hashicorp.vercel.app/consul/docs/connect/config-entries/exported-services

### Links

- [Slack thread](https://hashicorp.slack.com/archives/CPEPBFDEJ/p1688140230174659) that originated this change.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
