### PR TITLE
resource: make the populated registry available outside of server

### DIFF
--- a/agent/consul/type_registry.go
+++ b/agent/consul/type_registry.go
@@ -1,0 +1,25 @@
+package consul
+
+import (
+	"github.com/hashicorp/consul/internal/catalog"
+	"github.com/hashicorp/consul/internal/mesh"
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/demo"
+)
+
+// NewTypeRegistry returns a registry populated with all supported resource
+// types.
+//
+// Note: the registry includes resource types that may not be suitable for
+// production use (e.g. experimental or development resource types) because
+// it is used in the CLI, where feature flags and other runtime configuration
+// may not be available.
+func NewTypeRegistry() resource.Registry {
+	registry := resource.NewRegistry()
+
+	demo.RegisterTypes(registry)
+	mesh.RegisterTypes(registry)
+	catalog.RegisterTypes(registry)
+
+	return registry
+}

--- a/docs/resources/guide.md
+++ b/docs/resources/guide.md
@@ -61,8 +61,10 @@ func RegisterTypes(r resource.Registry) {
 }
 ```
 
-Update the `registerResources` method in [`server.go`] to call your package's
-type registration method:
+Update the `NewTypeRegistry` method in [`type_registry.go`] to call your
+package's type registration method:
+
+[`type_registry.go`]: ../../agent/consul/type_registry.go
 
 ```Go
 import (
@@ -71,14 +73,12 @@ import (
 	// …
 )
 
-func (s *Server) registerResources() {
+func NewTypeRegistry() resource.Registry {
 	// …
-	foo.RegisterTypes(s.typeRegistry)
+	foo.RegisterTypes(registry)
 	// …
 }
 ```
-
-[`server.go`]: ../../agent/consul/server.go
 
 That should be all you need to start using your new resource type. Test it out
 by starting an agent in dev mode:
@@ -277,7 +277,9 @@ func (barReconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 
 Next, register your controller with the controller manager. Another common
 pattern is to have your package expose a method for registering controllers,
-which is also called from `registerResources` in [`server.go`].
+which is called from `registerControllers` in [`server.go`].
+
+[`server.go`]: ../../agent/consul/server.go
 
 ```Go
 package foo
@@ -290,7 +292,7 @@ func RegisterControllers(mgr *controller.Manager) {
 ```Go
 package consul
 
-func (s *Server) registerResources() {
+func (s *Server) registerControllers() {
 	// …
 	foo.RegisterControllers(s.controllerManager)
 	// …


### PR DESCRIPTION
### Description
Moves type registration to an exported method, so that the registry can be used within the CLI for HCL validation, and inside the agent HTTP server for endpoint generation.

This does mean that we can no longer feature-flag the registration of experimental resource types, but I think that's fine, as long as the controller is still feature-flagged.
