### PR TITLE
Inverting jwt-auth and rbac filters

### DIFF
--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1381,12 +1381,11 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 		if err != nil {
 			return nil, err
 		}
-
-		filterOpts.httpAuthzFilters = []*envoy_http_v3.HttpFilter{rbacFilter}
-
+		filterOpts.httpAuthzFilters = []*envoy_http_v3.HttpFilter{}
 		if jwtFilter != nil {
 			filterOpts.httpAuthzFilters = append(filterOpts.httpAuthzFilters, jwtFilter)
 		}
+		filterOpts.httpAuthzFilters = append(filterOpts.httpAuthzFilters, rbacFilter)
 
 		meshConfig := cfgSnap.MeshConfig()
 		includeXFCC := meshConfig == nil || meshConfig.HTTP == nil || !meshConfig.HTTP.SanitizeXForwardedClientCert


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
- Inverting rbac filters and jwt-auth filters because the jwt-auth filters are supposed to forward data to the rbac filters. So when rbac get evaluated first, it will be doing so without the potential jwt-auth filter data