### PR TITLE
updated typo in tab heading

### DIFF
--- a/website/content/docs/connect/proxies/envoy-extensions/usage/ext-authz.mdx
+++ b/website/content/docs/connect/proxies/envoy-extensions/usage/ext-authz.mdx
@@ -53,7 +53,7 @@ EnvoyExtensions = [
 ```
 </CodeBlockConfig>
 </Tab>
-<Tab heading="JSON" group="hcl">
+<Tab heading="JSON" group="json">
 <CodeBlockConfig filename="api-auth-service-defaults.json">
 
 ```json

--- a/website/content/docs/connect/proxies/envoy-extensions/usage/ext-authz.mdx
+++ b/website/content/docs/connect/proxies/envoy-extensions/usage/ext-authz.mdx
@@ -53,7 +53,7 @@ EnvoyExtensions = [
 ```
 </CodeBlockConfig>
 </Tab>
-<Tab heading="HCL" group="hcl">
+<Tab heading="JSON" group="hcl">
 <CodeBlockConfig filename="api-auth-service-defaults.json">
 
 ```json


### PR DESCRIPTION
### Description
This PR fixes a typo in the ext-authz usage docs. 


### PR Checklist

* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
