### PR TITLE
docs - add service sync annotations and k8s service weight annotation

### DIFF
--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -81,7 +81,7 @@ The following Kubernetes resource annotations could be used on a pod to control 
   local port to listen for those connections. When transparent proxy is enabled,
   this annotation is optional. This annotation can be either _labeled_ or _unlabeled_. We recommend the labeled format because it has a more consistent syntax and can be used to reference cluster peers as upstreams.
 
- - **Labeled** (requires Consul on Kubernetes v0.45.0+):
+ - **Labeled**:
 
       The labeled annotation format allows you to reference any service as an upstream. You can specify a Consul Enterprise namespace. You can also specify an admin partition in the same datacenter, a cluster peer, or a WAN-federated datacenter.
 

--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -9,7 +9,7 @@ description: >-
 
 ## Overview
 
-Consul on Kubernetes provides a few options for customizing how connect-inject behavior should be configured.
+Consul on Kubernetes provides a few options for customizing how connect-inject or service sync behavior should be configured.
 This allows the user to configure natively configure Consul on select Kubernetes resources (i.e. pods, services).
 
 - [Consul Service Mesh](#consul-service-mesh)

--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -18,7 +18,9 @@ This allows the user to configure natively configure Consul on select Kubernetes
 The noun _connect_ is used throughout this documentation to refer to the connect
 subsystem that provides Consul's service mesh capabilities.
 
-## Consul Service Mesh Annotations
+## Consul Service Mesh
+
+### Annotations
 
 The following Kubernetes resource annotations could be used on a pod to control connect-inject behavior:
 
@@ -265,7 +267,20 @@ The following Kubernetes resource annotations could be used on a pod to control 
     "consul.hashicorp.com/consul-sidecar-user-volume-mount": "[{\"name\": \"secrets-store-mount\", \"mountPath\": \"/mnt/secrets-store\"}]"
   ```
 
-## Service Sync annotations
+### Labels
+
+Resource labels could be used on a Kubernetes service to control connect-inject behavior.
+
+- `consul.hashicorp.com/service-ignore` - This label can be set on a Kubernetes Service.
+  If set to "true", the service will not be used to register a Consul endpoint. This can be
+  useful in cases where 2 or more services point to the same deployment. Consul cannot register
+  multiple endpoints to the same deployment. This label can be used to tell the endpoint
+  registration to ignore all services except for the one which should be used for routing requests
+  using Consul.
+
+## Consul Service Sync 
+
+### Annotations
 
 The following Kubernetes resource annotations could be used on a pod to [Service Sync](https://developer.hashicorp.com/consul/docs/k8s/service-sync) behavior:
 
@@ -295,14 +310,4 @@ The following Kubernetes resource annotations could be used on a pod to [Service
     consul.hashicorp.com/service-weight: 10
   ```
 
-## Labels
-
-Resource labels could be used on a Kubernetes service to control connect-inject behavior.
-
-- `consul.hashicorp.com/service-ignore` - This label can be set on a Kubernetes Service.
-  If set to "true", the service will not be used to register a Consul endpoint. This can be
-  useful in cases where 2 or more services point to the same deployment. Consul cannot register
-  multiple endpoints to the same deployment. This label can be used to tell the endpoint
-  registration to ignore all services except for the one which should be used for routing requests
-  using Consul.
 

--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -12,8 +12,11 @@ description: >-
 Consul on Kubernetes provides a few options for customizing how connect-inject behavior should be configured.
 This allows the user to configure natively configure Consul on select Kubernetes resources (i.e. pods, services).
 
-- [Annotations](#annotations)
-- [Labels](#labels)
+- [Consul Service Mesh](#consul-service-mesh)
+  - [Annotations](#annotations)
+  - [Labels](#labels)
+- [Service Sync](#service-sync)
+  - [Annotations](#service-sync-annotations)
 
 The noun _connect_ is used throughout this documentation to refer to the connect
 subsystem that provides Consul's service mesh capabilities.
@@ -278,30 +281,30 @@ Resource labels could be used on a Kubernetes service to control connect-inject 
   registration to ignore all services except for the one which should be used for routing requests
   using Consul.
 
-## Consul Service Sync 
+## Service Sync 
 
 ### Annotations
 
 The following Kubernetes resource annotations could be used on a pod to [Service Sync](https://developer.hashicorp.com/consul/docs/k8s/service-sync) behavior:
 
-- 'consul.hashicorp.com/service-sync': If this is set to `true`, then the Kubernetes service is explicitly configured to be synced to Consul.  
-- 'consul.hashicorp.com/service-port': Configures the port to register to the Consul Catalog for the Kubernetes service. The annotation value may be a name of a port (recommended) or an exact port value. See [service ports](https://developer.hashicorp.com/consul/docs/k8s/service-sync#service-ports) for more information. 
+- `consul.hashicorp.com/service-sync`: If this is set to `true`, then the Kubernetes service is explicitly configured to be synced to Consul.  
 
+- `consul.hashicorp.com/service-port`: Configures the port to register to the Consul Catalog for the Kubernetes service. The annotation value may be a name of a port (recommended) or an exact port value. See [service ports](https://developer.hashicorp.com/consul/docs/k8s/service-sync#service-ports) for more information. 
   ```yaml
-    annotations:
-      'consul.hashicorp.com/service-port': 'http'
+  annotations:
+    'consul.hashicorp.com/service-port': 'http'
   ```
-- 'consul.hashicorp.com/service-tags': A comma separated list of strings (without whitespace) to use for registering tags to the service registered to Consul. These custom tags automatically include the `k8s` tag which can't be disabled.
+- `consul.hashicorp.com/service-tags`: A comma separated list of strings (without whitespace) to use for registering tags to the service registered to Consul. These custom tags automatically include the `k8s` tag which can't be disabled.
 
   ```yaml
-    annotations:
-      'consul.hashicorp.com/service-tags': 'primary,foo'
+  annotations:
+    'consul.hashicorp.com/service-tags': 'primary,foo'
   ```
-- 'consul.hashicorp.com/service-meta': A map for specifying service metadata for Consul services. The "KEY" below can be set to any key. This allows setting multiple meta values.
+- `consul.hashicorp.com/service-meta`: A map for specifying service metadata for Consul services. The "KEY" below can be set to any key. This allows setting multiple meta values.
 
   ```yaml
-    annotations:
-      'consul.hashicorp.com/service-meta-KEY': 'value'
+  annotations:
+    'consul.hashicorp.com/service-meta-KEY': 'value'
   ```
 - `consul.hashicorp.com/service-weight:` - Configure ability to support weighted loadbalancing by service annotation for Catalog Sync. The integer provided will be applied as a weight for the `passing` state for the health of the service. See [weights](/consul/docs/services/configuration/services-configuration-reference#weights) in service configuration for more information on how this is leveraged for services in the Consul catalog. 
 

--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -288,28 +288,34 @@ Resource labels could be used on a Kubernetes service to control connect-inject 
 The following Kubernetes resource annotations could be used on a pod to [Service Sync](https://developer.hashicorp.com/consul/docs/k8s/service-sync) behavior:
 
 - `consul.hashicorp.com/service-sync`: If this is set to `true`, then the Kubernetes service is explicitly configured to be synced to Consul.  
+
   ```yaml
   annotations:
     'consul.hashicorp.com/service-sync': 'true'
   ```
-- `consul.hashicorp.com/service-port`: Configures the port to register to the Consul Catalog for the Kubernetes service. The annotation value may be a name of a port (recommended) or an exact port value. See [service ports](https://developer.hashicorp.com/consul/docs/k8s/service-sync#service-ports) for more information. 
+
+- `consul.hashicorp.com/service-port`: Configures the port to register to the Consul Catalog for the Kubernetes service. The annotation value may be a name of a port (recommended) or an exact port value. Refer to [service ports](https://developer.hashicorp.com/consul/docs/k8s/service-sync#service-ports) for more information. 
+ 
   ```yaml
   annotations:
     'consul.hashicorp.com/service-port': 'http'
   ```
+
 - `consul.hashicorp.com/service-tags`: A comma separated list of strings (without whitespace) to use for registering tags to the service registered to Consul. These custom tags automatically include the `k8s` tag which can't be disabled.
 
   ```yaml
   annotations:
     'consul.hashicorp.com/service-tags': 'primary,foo'
   ```
-- `consul.hashicorp.com/service-meta-KEY`: A map for specifying service metadata for Consul services. The "KEY" below can be set to any key. This allows setting multiple meta values.
+
+- `consul.hashicorp.com/service-meta-KEY`: A map for specifying service metadata for Consul services. The "KEY" below can be set to any key. This allows you to set multiple meta values.
 
   ```yaml
   annotations:
     'consul.hashicorp.com/service-meta-KEY': 'value'
   ```
-- `consul.hashicorp.com/service-weight:` - Configure ability to support weighted loadbalancing by service annotation for Catalog Sync. The integer provided will be applied as a weight for the `passing` state for the health of the service. See [weights](/consul/docs/services/configuration/services-configuration-reference#weights) in service configuration for more information on how this is leveraged for services in the Consul catalog. 
+
+- `consul.hashicorp.com/service-weight:` - Configures ability to support weighted loadbalancing by service annotation for Catalog Sync. The integer provided will be applied as a weight for the `passing` state for the health of the service. Refer to [weights](/consul/docs/services/configuration/services-configuration-reference#weights) in service configuration for more information on how this is leveraged for services in the Consul catalog. 
 
   ```yaml
   annotations:

--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -265,11 +265,29 @@ The following Kubernetes resource annotations could be used on a pod to control 
     "consul.hashicorp.com/consul-sidecar-user-volume-mount": "[{\"name\": \"secrets-store-mount\", \"mountPath\": \"/mnt/secrets-store\"}]"
   ```
 
-## Consul Catalog Sync anntoations
+## Service Sync annotations
 
-The following Kubernetes resource annotations could be used on a pod to [Catalog Sync](https://developer.hashicorp.com/consul/docs/k8s/service-sync) behavior:
+The following Kubernetes resource annotations could be used on a pod to [Service Sync](https://developer.hashicorp.com/consul/docs/k8s/service-sync) behavior:
 
 - 'consul.hashicorp.com/service-sync': If this is set to `true`, then the Kubernetes service is explicitly configured to be synced to Consul.  
+- 'consul.hashicorp.com/service-port': Configures the port to register to the Consul Catalog for the Kubernetes service. The annotation value may be a name of a port (recommended) or an exact port value. See [service ports](https://developer.hashicorp.com/consul/docs/k8s/service-sync#service-ports) for more information. 
+
+  ```yaml
+    annotations:
+      'consul.hashicorp.com/service-port': 'http'
+  ```
+- 'consul.hashicorp.com/service-tags': A comma separated list of strings (without whitespace) to use for registering tags to the service registered to Consul. These custom tags automatically include the `k8s` tag which can't be disabled.
+
+  ```yaml
+    annotations:
+      'consul.hashicorp.com/service-tags': 'primary,foo'
+  ```
+- 'consul.hashicorp.com/service-meta': A map for specifying service metadata for Consul services. The "KEY" below can be set to any key. This allows setting multiple meta values.
+
+  ```yaml
+    annotations:
+      'consul.hashicorp.com/service-meta-KEY': 'value'
+  ```
 - `consul.hashicorp.com/service-weight:` - Configure ability to support weighted loadbalancing by service annotation for Catalog Sync. The integer provided will be applied as a weight for the `passing` state for the health of the service. See [weights](/consul/docs/services/configuration/services-configuration-reference#weights) in service configuration for more information on how this is leveraged for services in the Consul catalog. 
 
   ```yaml

--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -16,7 +16,7 @@ This allows the user to configure natively configure Consul on select Kubernetes
   - [Annotations](#annotations)
   - [Labels](#labels)
 - [Service Sync](#service-sync)
-  - [Annotations](#service-sync-annotations)
+  - [Annotations](#annotations-1)
 
 The noun _connect_ is used throughout this documentation to refer to the connect
 subsystem that provides Consul's service mesh capabilities.
@@ -288,7 +288,10 @@ Resource labels could be used on a Kubernetes service to control connect-inject 
 The following Kubernetes resource annotations could be used on a pod to [Service Sync](https://developer.hashicorp.com/consul/docs/k8s/service-sync) behavior:
 
 - `consul.hashicorp.com/service-sync`: If this is set to `true`, then the Kubernetes service is explicitly configured to be synced to Consul.  
-
+  ```yaml
+  annotations:
+    'consul.hashicorp.com/service-sync': 'true'
+  ```
 - `consul.hashicorp.com/service-port`: Configures the port to register to the Consul Catalog for the Kubernetes service. The annotation value may be a name of a port (recommended) or an exact port value. See [service ports](https://developer.hashicorp.com/consul/docs/k8s/service-sync#service-ports) for more information. 
   ```yaml
   annotations:
@@ -300,7 +303,7 @@ The following Kubernetes resource annotations could be used on a pod to [Service
   annotations:
     'consul.hashicorp.com/service-tags': 'primary,foo'
   ```
-- `consul.hashicorp.com/service-meta`: A map for specifying service metadata for Consul services. The "KEY" below can be set to any key. This allows setting multiple meta values.
+- `consul.hashicorp.com/service-meta-KEY`: A map for specifying service metadata for Consul services. The "KEY" below can be set to any key. This allows setting multiple meta values.
 
   ```yaml
   annotations:

--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -191,6 +191,13 @@ The following Kubernetes resource annotations could be used on a pod to control 
     consul.hashicorp.com/kubernetes-service: 'service-name-to-use'
   ```
 
+- `consul.hashicorp.com/service-weight:` - Configure ability to support weighted loadbalancing by service annotation for Catalog Sync. The integer provided will be applied as a weight for the `passing` state for the health of the service. See [weights](/consul/docs/services/configuration/services-configuration-reference#weights) in service configuration for more information on how this is leveraged for services in the Catalog. 
+
+  ```yaml
+  annotations:
+    consul.hashicorp.com/service-weight: 10
+  ```
+
 - `consul.hashicorp.com/service-tags` - A comma separated list of tags that will
   be applied to the Consul service and its sidecar.
 

--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -138,7 +138,7 @@ The following Kubernetes resource annotations could be used on a pod to control 
           "consul.hashicorp.com/connect-service-upstreams":"[service-name]:[port]:[optional datacenter]"
         ```
 
-      - Namespace (requires Consul Enterprise 1.7+): Upstream services may be running in a different namespace. Place
+      - Namespace: Upstream services may be running in a different namespace. Place
       the upstream namespace after the service name. For additional details about configuring the injector, refer to [Consul Enterprise namespaces](#consul-enterprise-namespaces) .
         
         ```yaml
@@ -149,7 +149,7 @@ The following Kubernetes resource annotations could be used on a pod to control 
         If the namespace is not specified, the annotation defaults to the namespace of the source service.
         Consul Enterprise v1.7 and older interprets the value placed in the namespace position as part of the service name.
 
-      - Admin partitions (requires Consul Enterprise 1.11+): Upstream services may be running in a different
+      - Admin partitions: Upstream services may be running in a different
         partition. When specifying a partition, you must also specify a namespace. Place the partition name after the namespace. If you specify the name of the datacenter, it must be the local datacenter. Communicating across partitions using this method is only supported within a
         datacenter. For cross partition communication across datacenters, [establish a cluster
         peering connection](/consul/docs/k8s/connect/cluster-peering/usage/establish-peering) and set the upstream with a labeled annotation format.

--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -18,7 +18,7 @@ This allows the user to configure natively configure Consul on select Kubernetes
 The noun _connect_ is used throughout this documentation to refer to the connect
 subsystem that provides Consul's service mesh capabilities.
 
-## Annotations
+## Consul Service Mesh Annotations
 
 The following Kubernetes resource annotations could be used on a pod to control connect-inject behavior:
 
@@ -191,13 +191,6 @@ The following Kubernetes resource annotations could be used on a pod to control 
     consul.hashicorp.com/kubernetes-service: 'service-name-to-use'
   ```
 
-- `consul.hashicorp.com/service-weight:` - Configure ability to support weighted loadbalancing by service annotation for Catalog Sync. The integer provided will be applied as a weight for the `passing` state for the health of the service. See [weights](/consul/docs/services/configuration/services-configuration-reference#weights) in service configuration for more information on how this is leveraged for services in the Catalog. 
-
-  ```yaml
-  annotations:
-    consul.hashicorp.com/service-weight: 10
-  ```
-
 - `consul.hashicorp.com/service-tags` - A comma separated list of tags that will
   be applied to the Consul service and its sidecar.
 
@@ -270,6 +263,18 @@ The following Kubernetes resource annotations could be used on a pod to control 
   ```yaml
   annotations:
     "consul.hashicorp.com/consul-sidecar-user-volume-mount": "[{\"name\": \"secrets-store-mount\", \"mountPath\": \"/mnt/secrets-store\"}]"
+  ```
+
+## Consul Catalog Sync anntoations
+
+The following Kubernetes resource annotations could be used on a pod to [Catalog Sync](https://developer.hashicorp.com/consul/docs/k8s/service-sync) behavior:
+
+- 'consul.hashicorp.com/service-sync': If this is set to `true`, then the Kubernetes service is explicitly configured to be synced to Consul.  
+- `consul.hashicorp.com/service-weight:` - Configure ability to support weighted loadbalancing by service annotation for Catalog Sync. The integer provided will be applied as a weight for the `passing` state for the health of the service. See [weights](/consul/docs/services/configuration/services-configuration-reference#weights) in service configuration for more information on how this is leveraged for services in the Consul catalog. 
+
+  ```yaml
+  annotations:
+    consul.hashicorp.com/service-weight: 10
   ```
 
 ## Labels

--- a/website/content/docs/k8s/service-sync.mdx
+++ b/website/content/docs/k8s/service-sync.mdx
@@ -31,7 +31,7 @@ service discovery, including hosted services like databases.
 
 ~> Enabling both Service Mesh and Service Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Ensure that Service Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](/consul/docs/k8s/service-sync#sync-enable-disable).
 
-The catalog sync feature deploys a long-running process which can
+The service sync feature deploys a long-running process which can
 can run either inside or outside of a Kubernetes cluster. However, running this process within
 the Kubernetes cluster is generally easier since it is automated using the
 [Helm chart](/consul/docs/k8s/helm).

--- a/website/content/docs/k8s/service-sync.mdx
+++ b/website/content/docs/k8s/service-sync.mdx
@@ -1,18 +1,18 @@
 ---
 layout: docs
-page_title: Service Sync for Consul on Kubernetes
+page_title: Catalog Sync for Consul on Kubernetes
 description: >-
-  Service sync is a Consul on Kubernetes feature that makes Kubernetes and Consul services available to each other. Learn how to configure Helm values so services can communicate and make Kubernetes services appear in the Consul UI.
+  Catalog sync is a Consul on Kubernetes feature that makes Kubernetes and Consul services available to each other. Learn how to configure Helm values so services can communicate and make Kubernetes services appear in the Consul UI.
 ---
 
-# Service Sync for Consul on Kubernetes
+# Catalog Sync for Consul on Kubernetes
 
 The services in Kubernetes and Consul can be automatically synced so that Kubernetes
 services are available to Consul agents and services in Consul can be available
 as first-class Kubernetes services. This functionality is provided by the
 [consul-k8s project](https://github.com/hashicorp/consul-k8s) and can be
 automatically installed and configured using the
-[Consul Helm chart](/consul/docs/k8s/installation/install).
+[Consul K8s Helm chart](/consul/docs/k8s/installation/install).
 
 ![screenshot of a Kubernetes service in the UI](/img/k8s-service.png)
 
@@ -29,10 +29,9 @@ service discovery, including hosted services like databases.
 
 ## Installation and configuration
 
-~> Enabling both Service Mesh and Service Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Ensure that Service Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](/consul/docs/k8s/service-sync#sync-enable-disable).
+~> Enabling both Service Mesh and Catalog Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Ensure that Catalog Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](/consul/docs/k8s/service-sync#sync-enable-disable).
 
-The service sync uses an external long-running process in the
-[consul-k8s project](https://github.com/hashicorp/consul-k8s). This process
+The catalog sync feature deploys a long-running process whic can
 can run either inside or outside of a Kubernetes cluster. However, running this process within
 the Kubernetes cluster is generally easier since it is automated using the
 [Helm chart](/consul/docs/k8s/helm).

--- a/website/content/docs/k8s/service-sync.mdx
+++ b/website/content/docs/k8s/service-sync.mdx
@@ -31,10 +31,7 @@ service discovery, including hosted services like databases.
 
 ~> Enabling both Service Mesh and Service Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Ensure that Service Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](/consul/docs/k8s/service-sync#sync-enable-disable).
 
-The service sync feature deploys a long-running process which can
-can run either inside or outside of a Kubernetes cluster. However, running this process within
-the Kubernetes cluster is generally easier since it is automated using the
-[Helm chart](/consul/docs/k8s/helm).
+The service sync feature deploys a long-running process which can run either inside or outside of a Kubernetes cluster. However, running this process within the Kubernetes cluster is generally easier since it is automated using the [Helm chart](/consul/docs/k8s/helm).
 
 The Consul server cluster can run either in or out of a Kubernetes cluster.
 The Consul server cluster does not need to be running on the same machine

--- a/website/content/docs/k8s/service-sync.mdx
+++ b/website/content/docs/k8s/service-sync.mdx
@@ -31,7 +31,7 @@ service discovery, including hosted services like databases.
 
 ~> Enabling both Service Mesh and Catalog Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Ensure that Catalog Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](/consul/docs/k8s/service-sync#sync-enable-disable).
 
-The catalog sync feature deploys a long-running process whic can
+The catalog sync feature deploys a long-running process which can
 can run either inside or outside of a Kubernetes cluster. However, running this process within
 the Kubernetes cluster is generally easier since it is automated using the
 [Helm chart](/consul/docs/k8s/helm).

--- a/website/content/docs/k8s/service-sync.mdx
+++ b/website/content/docs/k8s/service-sync.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: Catalog Sync for Consul on Kubernetes
+page_title: Service Sync for Consul on Kubernetes
 description: >-
-  Catalog sync is a Consul on Kubernetes feature that makes Kubernetes and Consul services available to each other. Learn how to configure Helm values so services can communicate and make Kubernetes services appear in the Consul UI.
+  Service sync is a Consul on Kubernetes feature that makes Kubernetes and Consul services available to each other. Learn how to configure Helm values so services can communicate and make Kubernetes services appear in the Consul UI.
 ---
 
-# Catalog Sync for Consul on Kubernetes
+# Service Sync for Consul on Kubernetes
 
 The services in Kubernetes and Consul can be automatically synced so that Kubernetes
 services are available to Consul agents and services in Consul can be available
@@ -29,7 +29,7 @@ service discovery, including hosted services like databases.
 
 ## Installation and configuration
 
-~> Enabling both Service Mesh and Catalog Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Ensure that Catalog Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](/consul/docs/k8s/service-sync#sync-enable-disable).
+~> Enabling both Service Mesh and Service Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Ensure that Catalog Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](/consul/docs/k8s/service-sync#sync-enable-disable).
 
 The catalog sync feature deploys a long-running process which can
 can run either inside or outside of a Kubernetes cluster. However, running this process within

--- a/website/content/docs/k8s/service-sync.mdx
+++ b/website/content/docs/k8s/service-sync.mdx
@@ -29,7 +29,7 @@ service discovery, including hosted services like databases.
 
 ## Installation and configuration
 
-~> Enabling both Service Mesh and Service Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Ensure that Catalog Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](/consul/docs/k8s/service-sync#sync-enable-disable).
+~> Enabling both Service Mesh and Service Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Ensure that Service Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](/consul/docs/k8s/service-sync#sync-enable-disable).
 
 The catalog sync feature deploys a long-running process which can
 can run either inside or outside of a Kubernetes cluster. However, running this process within


### PR DESCRIPTION
### Description

Docs for https://github.com/hashicorp/consul-k8s/pull/2293 and also adding new section for Service Sync in the annotations page. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
