### PR TITLE
removed sameness conf entry from failover nav

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -781,10 +781,6 @@
             "title": "Configuration",
             "routes": [
               {
-                "title": "Sameness groups",
-                "href": "/consul/docs/connect/config-entries/service-resolver"
-              },
-              {
                 "title": "Service resolver",
                 "href": "/consul/docs/connect/config-entries/service-resolver"
               },


### PR DESCRIPTION
### Description

This PR removes the alias for sameness groups configuration entry from the Failover > Configuration. We will reconsider this area of the docs for 1.17

### PR Checklist

* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
