### PR TITLE
docs - add jobs use case for service mesh k8s

### DIFF
--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -33,7 +33,7 @@ When transparent proxy mode is enabled, all service-to-service traffic is requir
 
 -> **Note:** A Kubernetes Service is **required** to register services on the Consul Service Mesh as Consul monitors the lifecyle of a Kubernetes service and its service instances using the service object. In addition the Kubernetes service is used to register and de-register the service from the Catalog. 
 
-Below are multiple scenarios for registering workloads on Kubernetes onto Consul Service Mesh. Each scenario provides an example Kubernetes manifest to help quickly understand how to use Consul Service Mesh once you have installed Consul on Kubernetes. 
+Below are multiple scenarios for registering workloads on Kubernetes onto Consul Service Mesh. Each scenario provides an example Kubernetes manifest to help quickly understand how to use Consul Service Mesh on a specific Kubernetes workload type.
 
 - [Kubernetes Pods running as a deployment](#kubernetes-pods-running-as-a-deployment)
 - [Connecting to mesh-enabled Services](#connecting-to-mesh-enabled-services)

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -468,7 +468,7 @@ spec:
         app: static-client
       annotations:
         'consul.hashicorp.com/connect-inject': 'true'
-		'consul.hashicorp.com/connect-service-upstreams': 'web:1234,web-admin:2234'
+        'consul.hashicorp.com/connect-service-upstreams': 'web:1234,web-admin:2234'
     spec:
       containers:
         - name: static-client

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -44,6 +44,8 @@ Below are multiple scenarios for registering workloads on Kubernetes onto Consul
 
 The following example shows a Kubernetes configuration that specifically enables service mesh connections for the `static-server` service. Consul starts and registers a sidecar proxy that listens on port 20000 by default and proxies valid inbound connections to port 8080. 
 
+<CodeBlockConfig filename="static-server.yaml">
+
 ```yaml
 apiVersion: v1
 kind: Service
@@ -93,6 +95,8 @@ spec:
       serviceAccountName: static-server
 ```
 
+<CodeBlockConfig/>
+
 To establish a connection to the Pod using service mesh, a client must use another mesh proxy. The client mesh proxy will use Consul service discovery to find all available upstream proxies and their public ports.
 
 #### Connecting to Mesh-Enabled Services
@@ -101,6 +105,8 @@ The example Deployment specification below configures a Deployment that is capab
 of establishing connections to our previous example "static-server" service. The
 connection to this static text service happens over an authorized and encrypted
 connection via service mesh.
+
+<CodeBlockConfig filename="static-client.yaml">
 
 ```yaml
 apiVersion: v1
@@ -146,6 +152,8 @@ spec:
       serviceAccountName: static-client
 ```
 
+<CodeBlockConfig/>
+
 By default when ACLs are enabled or when ACLs default policy is `allow`,
 Consul will automatically configure proxies with all upstreams from the same datacenter.
 When ACLs are enabled with default `deny` policy,
@@ -186,6 +194,7 @@ Kubernetes Jobs run pods that successfully terminate and only make outbound requ
 
 Below is an example Kubernetes manifest that deploys a job correctly. 
 
+<CodeBlockConfig filename="test-job.yaml">
 ```yaml
 ---
 apiVersion: v1
@@ -240,6 +249,8 @@ spec:
       restartPolicy: Never
 ```
 
+<CodeBlockConfig/>
+
 Upon completing the job you should be able to verify that all containers are shut down within the pod.
 
 ```bash
@@ -285,6 +296,9 @@ metadata:
   name: web-admin
 ```
 Create two Service objects for `web` and `web-admin`:
+
+<CodeBlockConfig filename="multiport-svc.yaml">
+
 ```yaml
 apiVersion: v1
 kind: Service
@@ -310,11 +324,16 @@ spec:
       port: 80
       targetPort: 9090
 ```
+
+<CodeBlockConfig/>
+
 `web` will target `containerPort` `8080` and select pods labeled `app: web`. `web-admin` will target `containerPort`
 `9090` and will also select the same pods.
 
 ~> Kubernetes 1.24+ only
 In Kubernetes 1.24+ you need to [create a Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets) for each multi-port service that references the ServiceAccount, and the Kubernetes secret must have the same name as the ServiceAccount:
+
+<CodeBlockConfig filename="multiport-sa.yaml">
 
 ```yaml
 apiVersion: v1
@@ -334,6 +353,8 @@ metadata:
   type: kubernetes.io/service-account-token
 ```
 
+<CodeBlockConfig/>
+
 Create a Deployment with any chosen name, and use the following annotations:
 ```yaml
 consul.hashicorp.com/connect-inject: true
@@ -350,6 +371,9 @@ serviceAccountName: web
 ```
 
 For reference, the full deployment example could look something like the following:
+
+<CodeBlockConfig filename="multiport-http-echo.yaml">
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -391,9 +415,12 @@ spec:
       serviceAccountName: web
 ```
 
+<CodeBlockConfig/>
+
 After deploying the `web` application, you can test service mesh connections by deploying the `static-client`
 application with the configuration in the [previous section](#connecting-to-mesh-enabled-services) and add the
 following annotation to the pod template on `static-client`:
+
 ```yaml
 consul.hashicorp.com/connect-service-upstreams: "web:1234,web-admin:2234"
 ```

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -195,6 +195,7 @@ Kubernetes Jobs run pods that successfully terminate and only make outbound requ
 Below is an example Kubernetes manifest that deploys a job correctly. 
 
 <CodeBlockConfig filename="test-job.yaml">
+
 ```yaml
 ---
 apiVersion: v1
@@ -253,20 +254,22 @@ spec:
 
 Upon completing the job you should be able to verify that all containers are shut down within the pod.
 
-```bash
-> kubectl get pods  
+```shell-session
+$ kubectl get pods  
 NAME             READY   STATUS      RESTARTS   AGE
 test-job-49st7   0/2     Completed   0          3m55s
+```
 
-> kubectl get job
+```shell-session 
+$ kubectl get job
 NAME       COMPLETIONS   DURATION   AGE
 test-job   1/1           30s        4m31s
 ```
 
 In addition, based on the logs emitted by the pod you can verify that the proxy was indeed shut down prior to job completing. 
 
-```
-> kubectl logs test-job-49st7 -c test-job
+```shell-session
+$ kubectl logs test-job-49st7 -c test-job
 Started test job
 Killing proxy
 Ended test job
@@ -357,10 +360,11 @@ metadata:
 
 Create a Deployment with any chosen name, and use the following annotations:
 ```yaml
-consul.hashicorp.com/connect-inject: true
-consul.hashicorp.com/transparent-proxy: false
-consul.hashicorp.com/connect-service: web,web-admin
-consul.hashicorp.com/connect-service-port: 8080,9090
+annotations:
+  consul.hashicorp.com/connect-inject: true
+  consul.hashicorp.com/transparent-proxy: false
+  consul.hashicorp.com/connect-service: web,web-admin
+  consul.hashicorp.com/connect-service-port: 8080,9090
 ```
 Note that the order the ports are listed in the same order as the service names, i.e. the first service name `web`
 corresponds to the first port, `8080`, and the second service name `web-admin` corresponds to the second port, `9090`.
@@ -422,7 +426,8 @@ application with the configuration in the [previous section](#connecting-to-mesh
 following annotation to the pod template on `static-client`:
 
 ```yaml
-consul.hashicorp.com/connect-service-upstreams: "web:1234,web-admin:2234"
+annotations:
+  consul.hashicorp.com/connect-service-upstreams: "web:1234,web-admin:2234"
 ```
 
 If you exec on to a static-client pod, using a command like:

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -226,8 +226,8 @@ spec:
   template:
     metadata:
       annotations:
-        "consul.hashicorp.com/connect-inject": "true"
-        "consul.hashicorp.com/sidecar-proxy-lifecycle-shutdown-grace-period-seconds": "5"
+        'consul.hashicorp.com/connect-inject': 'true'
+        'consul.hashicorp.com/sidecar-proxy-lifecycle-shutdown-grace-period-seconds': '5'
       labels:
         app: test-job
     spec:
@@ -276,6 +276,7 @@ Ended test job
 ```
 
 #### Kubernetes Pods with Multiple ports
+
 To configure a pod with multiple ports to be a part of the service mesh and receive and send service mesh traffic, you
 will need to add configuration so that a Consul service can be registered per port. This is because services in Consul
 currently support a single port per service instance.
@@ -287,6 +288,9 @@ First, decide on the names for the two Consul services that will correspond to t
 chooses the names `web` for `8080` and `web-admin` for `9090`.
 
 Create two service accounts for `web` and `web-admin`:
+
+<CodeBlockConfig filename="multiport-web-sa.yaml">
+
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -298,9 +302,13 @@ kind: ServiceAccount
 metadata:
   name: web-admin
 ```
+
+</CodeBlockConfig>
+
+
 Create two Service objects for `web` and `web-admin`:
 
-<CodeBlockConfig filename="multiport-svc.yaml">
+<CodeBlockConfig filename="multiport-web-svc.yaml">
 
 ```yaml
 apiVersion: v1
@@ -336,7 +344,7 @@ spec:
 ~> Kubernetes 1.24+ only
 In Kubernetes 1.24+ you need to [create a Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets) for each multi-port service that references the ServiceAccount, and the Kubernetes secret must have the same name as the ServiceAccount:
 
-<CodeBlockConfig filename="multiport-sa.yaml">
+<CodeBlockConfig filename="multiport-web-secret.yaml">
 
 ```yaml
 apiVersion: v1
@@ -361,10 +369,10 @@ metadata:
 Create a Deployment with any chosen name, and use the following annotations:
 ```yaml
 annotations:
-  consul.hashicorp.com/connect-inject: true
-  consul.hashicorp.com/transparent-proxy: false
-  consul.hashicorp.com/connect-service: web,web-admin
-  consul.hashicorp.com/connect-service-port: 8080,9090
+  'consul.hashicorp.com/connect-inject': 'true'
+  'consul.hashicorp.com/transparent-proxy': 'false'
+  'consul.hashicorp.com/connect-service': 'web,web-admin'
+  'consul.hashicorp.com/connect-service-port': '8080,9090'
 ```
 Note that the order the ports are listed in the same order as the service names, i.e. the first service name `web`
 corresponds to the first port, `8080`, and the second service name `web-admin` corresponds to the second port, `9090`.
@@ -376,7 +384,7 @@ serviceAccountName: web
 
 For reference, the full deployment example could look something like the following:
 
-<CodeBlockConfig filename="multiport-http-echo.yaml">
+<CodeBlockConfig filename="multiport-web.yaml">
 
 ```yaml
 apiVersion: apps/v1
@@ -425,10 +433,54 @@ After deploying the `web` application, you can test service mesh connections by 
 application with the configuration in the [previous section](#connecting-to-mesh-enabled-services) and add the
 following annotation to the pod template on `static-client`:
 
+<CodeBlockConfig filename="multiport-static-client.yaml" lineNumbers highlight="33">
+
 ```yaml
-annotations:
-  consul.hashicorp.com/connect-service-upstreams: "web:1234,web-admin:2234"
+apiVersion: v1
+kind: Service
+metadata:
+  # This name will be the service name in Consul.
+  name: static-client
+spec:
+  selector:
+    app: static-client
+  ports:
+    - port: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: static-client
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: static-client
+  template:
+    metadata:
+      name: static-client
+      labels:
+        app: static-client
+      annotations:
+        'consul.hashicorp.com/connect-inject': 'true'
+		'consul.hashicorp.com/connect-service-upstreams': 'web:1234,web-admin:2234'
+    spec:
+      containers:
+        - name: static-client
+          image: curlimages/curl:latest
+          # Just spin & wait forever, we'll use `kubectl exec` to demo
+          command: ['/bin/sh', '-c', '--']
+          args: ['while true; do sleep 30; done;']
+      # If ACLs are enabled, the serviceAccountName must match the Consul service name.
+      serviceAccountName: static-client
 ```
+
+</CodeBlockConfig>
 
 If you exec on to a static-client pod, using a command like:
 ```shell-session

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -31,16 +31,16 @@ When transparent proxy mode is enabled, all service-to-service traffic is requir
 
 ### Kubernetes service mesh workload scenarios 
 
-Below are multiple different scenarios for registering workloads on Kubernetes onto Consul Service Mesh
+-> **Note:** A Kubernetes Service is **required** to register services on the Consul Service Mesh as Consul monitors the lifecyle of a Kubernetes service and its service instances using the service object. In addition the Kubernetes service is used to register and de-register the service from the Catalog. 
 
-- [Kubernetes Pods running as a deployment](#example-kubernetes-deployment)
+Below are multiple scenarios for registering workloads on Kubernetes onto Consul Service Mesh. Each scenario provides an example Kubernetes manifest to help quickly understand how to use Consul Service Mesh once you have installed Consul on Kubernetes. 
+
+- [Kubernetes Pods running as a deployment](#kubernetes-pods-running-as-a-deployment)
 - [Connecting to mesh-enabled Services](#connecting-to-mesh-enabled-services)
 - [Kubernetes Jobs](#kubernetes-jobs)
 - [Kubernetes Pods with Multiple ports](#kubernetes-pods-with-multiple-ports)
 
 #### Kubernetes Pods running as a deployment
-
--> **Note:** A Kubernetes Service is **required** to register services on the Consul Service Mesh as Consul monitors the lifecyle of a Kubernetes service using a service object, and monitors the Kubernetes service to register and de-register it from the Catalog. 
 
 The following example shows a Kubernetes configuration that specifically enables service mesh connections for the `static-server` service. Consul starts and registers a sidecar proxy that listens on port 20000 by default and proxies valid inbound connections to port 8080. 
 

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -19,7 +19,28 @@ Consul service mesh is enabled by default when you install Consul on Kubernetes 
 
 If `connectInject.default` is set to `false` or you want to explicitly enable service mesh sidecar proxy injection for a specific deployment, add the `consul.hashicorp.com/connect-inject` annotation to the pod specification template and set it to `true` when connecting services to the mesh. 
 
-### Example 
+### Service names
+
+When the service is onboarded, the name registered in Consul is set to the name of the Kubernetes Service associated with the Pod. You can specify a custom name for the service in the [`consul.hashicorp.com/connect-service` annotation](/consul/docs/k8s/annotations-and-labels#consul-hashicorp-com-connect-service), but if ACLs are enabled, then the name of the service registered in Consul must match the Pod's `ServiceAccount` name.
+
+### Transparent proxy mode
+
+By default, the Consul service mesh runs in transparent proxy mode. This mode forces inbound and outbound traffic through the sidecar proxy even though the service binds to all interfaces. Transparent proxy infers the location of upstream services using Consul service intentions, and also allows you to use Kubernetes DNS as you normally would for your workloads. 
+
+When transparent proxy mode is enabled, all service-to-service traffic is required to use mTLS. While onboarding new services to service mesh, your network may have mixed mTLS and non-mTLS traffic, which can result in broken service-to-service communication. You can temporarily enable permissive mTLS mode during the onboarding process so that existing mesh services can accept traffic from services that are not yet fully onboarded. Permissive mTLS enables sidecar proxies to access both mTLS and non-mTLS traffic. Refer to [Onboard mesh services in transparent proxy mode](/consul/docs/k8s/connect/onboarding-tproxy-mode) for additional information.
+
+### Kubernetes service mesh workload scenarios 
+
+Below are multiple different scenarios for registering workloads on Kubernetes onto Consul Service Mesh
+
+- [Kubernetes Pods running as a deployment](#example-kubernetes-deployment)
+- [Connecting to mesh-enabled Services](#connecting-to-mesh-enabled-services)
+- [Kubernetes Jobs](#kubernetes-jobs)
+- [Kubernetes Pods with Multiple ports](#kubernetes-pods-with-multiple-ports)
+
+#### Kubernetes Pods running as a deployment
+
+-> **Note:** A Kubernetes Service is **required** to register services on the Consul Service Mesh as Consul monitors the lifecyle of a Kubernetes service using a service object, and monitors the Kubernetes service to register and de-register it from the Catalog. 
 
 The following example shows a Kubernetes configuration that specifically enables service mesh connections for the `static-server` service. Consul starts and registers a sidecar proxy that listens on port 20000 by default and proxies valid inbound connections to port 8080. 
 
@@ -74,25 +95,12 @@ spec:
 
 To establish a connection to the Pod using service mesh, a client must use another mesh proxy. The client mesh proxy will use Consul service discovery to find all available upstream proxies and their public ports.
 
-### Service names
-
-When the service is onboarded, the name registered in Consul is set to the name of the Kubernetes Service associated with the Pod. You can specify a custom name for the service in the [`consul.hashicorp.com/connect-service` annotation](/consul/docs/k8s/annotations-and-labels#consul-hashicorp-com-connect-service), but if ACLs are enabled, then the name of the service registered in Consul must match the Pod's `ServiceAccount` name.
-
-### Transparent proxy mode
-
-By default, the Consul service mesh runs in transparent proxy mode. This mode forces inbound and outbound traffic through the sidecar proxy even though the service binds to all interfaces. Transparent proxy infers the location of upstream services using Consul service intentions, and also allows you to use Kubernetes DNS as you normally would for your workloads. 
-
-When transparent proxy mode is enabled, all service-to-service traffic is required to use mTLS. While onboarding new services to service mesh, your network may have mixed mTLS and non-mTLS traffic, which can result in broken service-to-service communication. You can temporarily enable permissive mTLS mode during the onboarding process so that existing mesh services can accept traffic from services that are not yet fully onboarded. Permissive mTLS enables sidecar proxies to access both mTLS and non-mTLS traffic. Refer to [Onboard mesh services in transparent proxy mode](/consul/docs/k8s/connect/onboarding-tproxy-mode) for additional information.
-
-### Connecting to Mesh-Enabled Services
+#### Connecting to Mesh-Enabled Services
 
 The example Deployment specification below configures a Deployment that is capable
 of establishing connections to our previous example "static-server" service. The
 connection to this static text service happens over an authorized and encrypted
 connection via service mesh.
-
--> **Note:** As of consul-k8s `v0.26.0` and Consul Helm `v0.32.0`, having a Kubernetes
-Service is **required** to run services on the Consul Service Mesh.
 
 ```yaml
 apiVersion: v1
@@ -172,7 +180,88 @@ $ kubectl exec deploy/static-client -- curl --silent http://static-server/
 command terminated with exit code 52
 ```
 
-### Kubernetes Pods with Multiple ports
+#### Kubernetes Jobs
+
+Kubernetes Jobs run pods that successfully terminate and only make outbound requests to services on the mesh. In order to register a Kubernetes job on the mesh, you must provide an integer value for the `consul.hashicorp.com/sidecar-proxy-lifecycle-shutdown-grace-period-seconds` annotation, and issue a request the `http://127.0.0.1:20600/graceful_shutdown` API endpoint for `consul-dataplane` to gracefully shut down the `consul-dataplane` sidecar after the job is complete. ,
+
+Below is an example Kubernetes manifest that deploys a job correctly. 
+
+```yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-job
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-job
+  namespace: default
+spec:
+  selector:
+    app: test-job
+  ports:
+    - port: 80
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+   name: test-job
+   namespace: default
+   labels:
+     app: test-job
+spec:
+  template:
+    metadata:
+      annotations:
+        "consul.hashicorp.com/connect-inject": "true"
+        "consul.hashicorp.com/sidecar-proxy-lifecycle-shutdown-grace-period-seconds": "5"
+      labels:
+        app: test-job
+    spec:
+      containers:
+      - name: test-job
+        image: alpine/curl:3.14
+        ports:
+        - containerPort: 80
+        command:
+          - /bin/sh
+          - -c
+          - |
+            echo "Started test job"
+            sleep 10
+            echo "Killing proxy"
+            curl --max-time 2 -s -f -XPOST http://127.0.0.1:20600/graceful_shutdown
+            sleep 10
+            echo "Ended test job"
+      serviceAccountName: test-job
+      restartPolicy: Never
+```
+
+Upon completing the job you should be able to verify that all containers are shut down within the pod.
+
+```bash
+> kubectl get pods  
+NAME             READY   STATUS      RESTARTS   AGE
+test-job-49st7   0/2     Completed   0          3m55s
+
+> kubectl get job
+NAME       COMPLETIONS   DURATION   AGE
+test-job   1/1           30s        4m31s
+```
+
+In addition, based on the logs emitted by the pod you can verify that the proxy was indeed shut down prior to job completing. 
+
+```
+> kubectl logs test-job-49st7 -c test-job
+Started test job
+Killing proxy
+Ended test job
+```
+
+#### Kubernetes Pods with Multiple ports
 To configure a pod with multiple ports to be a part of the service mesh and receive and send service mesh traffic, you
 will need to add configuration so that a Consul service can be registered per port. This is because services in Consul
 currently support a single port per service instance.

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: static-server
 ```
 
-<CodeBlockConfig/>
+</CodeBlockConfig>
 
 To establish a connection to the Pod using service mesh, a client must use another mesh proxy. The client mesh proxy will use Consul service discovery to find all available upstream proxies and their public ports.
 
@@ -152,7 +152,7 @@ spec:
       serviceAccountName: static-client
 ```
 
-<CodeBlockConfig/>
+</CodeBlockConfig>
 
 By default when ACLs are enabled or when ACLs default policy is `allow`,
 Consul will automatically configure proxies with all upstreams from the same datacenter.
@@ -249,7 +249,7 @@ spec:
       restartPolicy: Never
 ```
 
-<CodeBlockConfig/>
+</CodeBlockConfig>
 
 Upon completing the job you should be able to verify that all containers are shut down within the pod.
 
@@ -325,7 +325,7 @@ spec:
       targetPort: 9090
 ```
 
-<CodeBlockConfig/>
+</CodeBlockConfig>
 
 `web` will target `containerPort` `8080` and select pods labeled `app: web`. `web-admin` will target `containerPort`
 `9090` and will also select the same pods.
@@ -353,7 +353,7 @@ metadata:
   type: kubernetes.io/service-account-token
 ```
 
-<CodeBlockConfig/>
+</CodeBlockConfig>
 
 Create a Deployment with any chosen name, and use the following annotations:
 ```yaml
@@ -415,7 +415,7 @@ spec:
       serviceAccountName: web
 ```
 
-<CodeBlockConfig/>
+</CodeBlockConfig>
 
 After deploying the `web` application, you can test service mesh connections by deploying the `static-client`
 application with the configuration in the [previous section](#connecting-to-mesh-enabled-services) and add the

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -382,7 +382,8 @@ The service account on the pod spec for the deployment should be set to the firs
 serviceAccountName: web
 ```
 
-For reference, the full deployment example could look something like the following:
+For reference, a full deployment example is provided below with the correct annotations provided. In addition, the previous yaml manifests can also be combined into
+a single manifest for easier deployment. 
 
 <CodeBlockConfig filename="multiport-web.yaml">
 
@@ -431,7 +432,7 @@ spec:
 
 After deploying the `web` application, you can test service mesh connections by deploying the `static-client`
 application with the configuration in the [previous section](#connecting-to-mesh-enabled-services) and add the
-following annotation to the pod template on `static-client`:
+`consul.hashicorp.com/connect-service-upstreams: 'web:1234,web-admin:2234'` annotation to the pod template on `static-client`:
 
 <CodeBlockConfig filename="multiport-static-client.yaml" lineNumbers highlight="33">
 


### PR DESCRIPTION
### Description

Add jobs use case for service mesh on k8s and provides better organization for workload types on the mesh. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
