### PR TITLE
NET-4657/add resource service client

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/types"
 
@@ -162,6 +163,9 @@ func (a *TestACLAgent) Stats() map[string]map[string]string {
 }
 func (a *TestACLAgent) ReloadConfig(_ consul.ReloadableConfig) error {
 	return fmt.Errorf("Unimplemented")
+}
+func (a *TestACLAgent) ResourceServiceClient() pbresource.ResourceServiceClient {
+	return nil
 }
 
 func TestACL_Version8EnabledByDefault(t *testing.T) {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -71,6 +71,7 @@ import (
 	"github.com/hashicorp/consul/lib/mutex"
 	"github.com/hashicorp/consul/lib/routine"
 	"github.com/hashicorp/consul/logging"
+	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/proto/private/pboperator"
 	"github.com/hashicorp/consul/proto/private/pbpeering"
 	"github.com/hashicorp/consul/tlsutil"
@@ -197,6 +198,9 @@ type delegate interface {
 	ResolveTokenAndDefaultMeta(token string, entMeta *acl.EnterpriseMeta, authzContext *acl.AuthorizerContext) (resolver.Result, error)
 
 	RPC(ctx context.Context, method string, args interface{}, reply interface{}) error
+
+	// ResourceServiceClient is a client for the gRPC Resource Service.
+	ResourceServiceClient() pbresource.ResourceServiceClient
 
 	SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io.Writer, replyFn structs.SnapshotReplyFn) error
 	Shutdown() error

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
+	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"
 )
@@ -93,6 +94,9 @@ type Client struct {
 	EnterpriseClient
 
 	tlsConfigurator *tlsutil.Configurator
+
+	// resourceServiceClient is a client for the gRPC Resource Service.
+	resourceServiceClient pbresource.ResourceServiceClient
 }
 
 // NewClient creates and returns a Client
@@ -150,6 +154,13 @@ func NewClient(config *Config, deps Deps) (*Client, error) {
 		return nil, fmt.Errorf("Failed to add LAN area to the RPC router: %w", err)
 	}
 	c.router = deps.Router
+
+	conn, err := deps.GRPCConnPool.ClientConn(deps.ConnPool.Datacenter)
+	if err != nil {
+		c.Shutdown()
+		return nil, fmt.Errorf("Failed to get gRPC client connection: %w", err)
+	}
+	c.resourceServiceClient = pbresource.NewResourceServiceClient(conn)
 
 	// Start LAN event handlers after the router is complete since the event
 	// handlers depend on the router and the router depends on Serf.
@@ -450,4 +461,8 @@ func (c *Client) AgentEnterpriseMeta() *acl.EnterpriseMeta {
 
 func (c *Client) agentSegmentName() string {
 	return c.config.Segment
+}
+
+func (c *Client) ResourceServiceClient() pbresource.ResourceServiceClient {
+	return c.resourceServiceClient
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Dan had already started on this [task](https://github.com/hashicorp/consul/pull/17849) which is needed to start building the HTTP APIs. This just needed some cleanup to get it ready for review.

Overview:

- Rename `internalResourceServiceClient` to `insecureResourceServiceClient` for name consistency
- Configure a `secureResourceServiceClient` with auth enabled

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [x] appropriate backport labels added
* [ ] ~not a security concern~
