### PR TITLE
NET-1718 - Fix failed anti entropy sync when snapshot is restored in brand new cluster

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -348,7 +348,7 @@ func ensureNoNodeWithSimilarNameTxn(tx ReadTxn, node *structs.Node, allowClashWi
 	}
 	for nodeIt := enodes.Next(); nodeIt != nil; nodeIt = enodes.Next() {
 		enode := nodeIt.(*structs.Node)
-		if strings.EqualFold(node.Node, enode.Node) && node.ID != enode.ID {
+		if strings.EqualFold(node.Node, enode.Node) && node.ID != enode.ID && node.Address != enode.Address {
 			// Look up the existing node's Serf health check to see if it's failed.
 			// If it is, the node can be renamed.
 			enodeCheck, err := tx.First(tableChecks, indexID, NodeCheckQuery{

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -204,6 +204,13 @@ func TestStateStore_ensureNoNodeWithSimilarNameTxn(t *testing.T) {
 		Status:  api.HealthCritical,
 	}))
 	require.NoError(t, ensureNoNodeWithSimilarNameTxn(tx, newNode, false))
+
+	node = &structs.Node{
+		ID:      makeRandomNodeID(t), // Different ID
+		Node:    "node1",             // Same name
+		Address: "1.2.3.4",           // Same address
+	}
+	require.NoError(t, ensureNoNodeWithSimilarNameTxn(tx, node, false), "Should not clash with itself")
 }
 
 func TestStateStore_EnsureRegistration(t *testing.T) {


### PR DESCRIPTION
### Description

A standard procedure of Consul snapshot recovery is to take a snapshot and recover it in a brand new cluster.

E.g.

From Consul official [doc](https://developer.hashicorp.com/consul/commands/snapshot/restore)
>This command is primarily intended to recover from a disaster. It restores your configuration into a fresh cluster of Consul servers as long as your new cluster runs the same Consul version as the cluster that originally took the snapshot.

From Vault Consul standard recovery [procedure](https://developer.hashicorp.com/vault/tutorials/standard-procedures/sop-restore#procedures)

A problem with this approach is that, if no `node_id` is configured, there's discrepancy between `node_id` used for Node registration in snapshot content versus latest `node_id` in Agent's config.

When this happens, anti-entropy sync will fail forever with these logs emitting in Consul Server

```
[WARN] agent.fsm: EnsureRegistration failed: error="failed inserting node: Error while renaming Node ID: "<NEW_UUID>": Node name <NAME> is reserved by node <OLD_UUID> with name <NAME> (<IP>)"
```

This PR fix this issue by updating `NoNodeWithSimilarName` check, to only run the check on node with different address. As such, this will allow anti-entropy to run and update the node registration successfully. 

### Testing & Reproduction steps

The bug can be replicated easily with:
- Start a new Consul server, e.g. `consul agent -server -bootstrap -bind 127.0.0.1 -client 127.0.0.1 -data-dir /tmp/consul`
- Take a new snapshot with `consul snapshot save snap.bak`
- Stop Consul server and delete the data directory `rm -r /tmp/consul`
- Start Consul server and restore the snapshot `consul snapshot restore snap.bak`
- Next anti-entropy sync will never succeed with above error

### Links

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
