### PR TITLE
docs updates - cluster peering and virtual services

### DIFF
--- a/website/content/docs/k8s/connect/cluster-peering/tech-specs.mdx
+++ b/website/content/docs/k8s/connect/cluster-peering/tech-specs.mdx
@@ -41,7 +41,7 @@ Refer to the following example Helm configuration:
 ```yaml
 global:
   name: consul
-  image: "hashicorp/consul:1.14.1"
+  image: "hashicorp/consul:1.16.0"
   peering:
     enabled: true
   tls:

--- a/website/content/docs/k8s/connect/cluster-peering/usage/establish-peering.mdx
+++ b/website/content/docs/k8s/connect/cluster-peering/usage/establish-peering.mdx
@@ -59,7 +59,7 @@ To use cluster peering with Consul on Kubernetes deployments, update the Helm ch
   ```
 
   ```shell-session
-  $ helm install ${HELM_RELEASE_NAME1} hashicorp/consul --create-namespace --namespace consul --version "1.0.1" --values values.yaml --set global.datacenter=dc1 --kube-context $CLUSTER1_CONTEXT
+  $ helm install ${HELM_RELEASE_NAME1} hashicorp/consul --create-namespace --namespace consul --version "1.2.0" --values values.yaml --set global.datacenter=dc1 --kube-context $CLUSTER1_CONTEXT
   ```
 
 1. In `cluster-02`, run the following commands:
@@ -69,8 +69,10 @@ To use cluster peering with Consul on Kubernetes deployments, update the Helm ch
   ```
 
   ```shell-session
-  $ helm install ${HELM_RELEASE_NAME2} hashicorp/consul --create-namespace --namespace consul --version "1.0.1" --values values.yaml --set global.datacenter=dc2 --kube-context $CLUSTER2_CONTEXT
+  $ helm install ${HELM_RELEASE_NAME2} hashicorp/consul --create-namespace --namespace consul --version "1.2.0" --values values.yaml --set global.datacenter=dc2 --kube-context $CLUSTER2_CONTEXT
   ```
+
+1. For both clusters apply `Mesh` Config entry values provided in [Mesh Gateway Specificaions](/consul/docs/k8s/connect/cluster-peering/tech-specs#mesh-gateway-specifications) to enable establsihing peering connections over Mesh Gateways. 
 
 ### Configure the mesh gateway mode for traffic between services
 

--- a/website/content/docs/k8s/connect/cluster-peering/usage/establish-peering.mdx
+++ b/website/content/docs/k8s/connect/cluster-peering/usage/establish-peering.mdx
@@ -72,7 +72,7 @@ To use cluster peering with Consul on Kubernetes deployments, update the Helm ch
   $ helm install ${HELM_RELEASE_NAME2} hashicorp/consul --create-namespace --namespace consul --version "1.2.0" --values values.yaml --set global.datacenter=dc2 --kube-context $CLUSTER2_CONTEXT
   ```
 
-1. For both clusters apply `Mesh` Config entry values provided in [Mesh Gateway Specificaions](/consul/docs/k8s/connect/cluster-peering/tech-specs#mesh-gateway-specifications) to enable establsihing peering connections over Mesh Gateways. 
+1. For both clusters apply `Mesh` Config entry values provided in [Mesh Gateway Specificaions](/consul/docs/k8s/connect/cluster-peering/tech-specs#mesh-gateway-specifications) to allow establishing peering connections over Mesh Gateways. 
 
 ### Configure the mesh gateway mode for traffic between services
 

--- a/website/content/docs/k8s/connect/cluster-peering/usage/establish-peering.mdx
+++ b/website/content/docs/k8s/connect/cluster-peering/usage/establish-peering.mdx
@@ -48,7 +48,7 @@ After you provision a Kubernetes cluster and set up your kubeconfig file to mana
   $ export CLUSTER2_CONTEXT=<CONTEXT for second Kubernetes cluster>
   ```
 
-### Update the Helm chart
+### Install Consul using Helm and configure peering over mesh gateways 
 
 To use cluster peering with Consul on Kubernetes deployments, update the Helm chart with [the required values](/consul/docs/k8s/connect/cluster-peering/tech-specs#helm-requirements). After updating the Helm chart, you can use the `consul-k8s` CLI to apply `values.yaml` to each cluster.
 

--- a/website/content/docs/k8s/connect/cluster-peering/usage/establish-peering.mdx
+++ b/website/content/docs/k8s/connect/cluster-peering/usage/establish-peering.mdx
@@ -72,7 +72,7 @@ To use cluster peering with Consul on Kubernetes deployments, update the Helm ch
   $ helm install ${HELM_RELEASE_NAME2} hashicorp/consul --create-namespace --namespace consul --version "1.2.0" --values values.yaml --set global.datacenter=dc2 --kube-context $CLUSTER2_CONTEXT
   ```
 
-1. For both clusters apply `Mesh` Config entry values provided in [Mesh Gateway Specificaions](/consul/docs/k8s/connect/cluster-peering/tech-specs#mesh-gateway-specifications) to allow establishing peering connections over Mesh Gateways. 
+1. For both clusters apply the `Mesh` configuration entry values provided in [Mesh Gateway Specifications](/consul/docs/k8s/connect/cluster-peering/tech-specs#mesh-gateway-specifications) to allow establishing peering connections over mesh gateways. 
 
 ### Configure the mesh gateway mode for traffic between services
 

--- a/website/content/docs/k8s/l7-traffic/failover-tproxy.mdx
+++ b/website/content/docs/k8s/l7-traffic/failover-tproxy.mdx
@@ -18,7 +18,7 @@ Complete the following steps to configure failover service instances in Consul o
 
 ## Requirements
  
-- `consul-k8s` v1.2.0-beta1 or newer.
+- `consul-k8s` v1.2.0 or newer.
 - Consul service mesh must be enabled. Refer to [How does Consul Service Mesh Work on Kubernetes](/consul/docs/k8s/connect).
 - Proxies must be configured to run in transparent proxy mode. 
 - To query virtual DNS names, you must use Consul DNS.

--- a/website/content/docs/k8s/l7-traffic/route-to-virtual-services.mdx
+++ b/website/content/docs/k8s/l7-traffic/route-to-virtual-services.mdx
@@ -20,7 +20,7 @@ Complete the following steps to configure failover service instances in Consul o
 
 ## Requirements
  
-- `consul-k8s` v1.2.0-beta1 or newer.
+- `consul-k8s` v1.2.0 or newer.
 - Consul service mesh must be enabled. Refer to [How does Consul service mesh work on Kubernetes](/consul/docs/k8s/connect).
 - Proxies must be configured to run in transparent proxy mode. 
 - To query virtual DNS names, you must use Consul DNS.


### PR DESCRIPTION
### Description

Mention peering over mesh gateways `Mesh` config that is required. Also update to consul k8s 1.2.0 on Virtual services

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
