### PR TITLE
test: fix FIPS inline cert test message

### DIFF
--- a/agent/structs/config_entry_inline_certificate_test.go
+++ b/agent/structs/config_entry_inline_certificate_test.go
@@ -162,7 +162,9 @@ func TestInlineCertificate(t *testing.T) {
 				PrivateKey:  tooShortPrivateKey,
 				Certificate: "foo",
 			},
-			validateErr: "key length must be at least 2048 bits",
+			// non-FIPS: "key length must be at least 2048 bits"
+			// FIPS: "key length invalid: only RSA lengths of 2048, 3072, and 4096 are allowed in FIPS mode"
+			validateErr: "key length",
 		},
 		"mismatched certificate": {
 			entry: &InlineCertificateConfigEntry{


### PR DESCRIPTION
### Description
This error message is different when running the test against FIPS build as noted in the comments.