### PR TITLE
ci: use gotestsum v1.10.1 [NET-4042]

### DIFF
--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -46,7 +46,7 @@ on:
         required: true
 env:
   TEST_RESULTS: /tmp/test-results
-  GOTESTSUM_VERSION: 1.8.2
+  GOTESTSUM_VERSION: "1.10.1"
   GOARCH: ${{inputs.go-arch}}
   TOTAL_RUNNERS: ${{inputs.runner-count}}
   CONSUL_LICENSE: ${{secrets.consul-license}}

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -42,7 +42,7 @@ on:
         required: true
 env:
   TEST_RESULTS: /tmp/test-results
-  GOTESTSUM_VERSION: 1.8.2
+  GOTESTSUM_VERSION: "1.10.1"
   GOARCH: ${{inputs.go-arch}}
   CONSUL_LICENSE: ${{secrets.consul-license}}
   GOTAGS: ${{ inputs.go-tags}}

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -19,7 +19,7 @@ env:
   TEST_RESULTS_ARTIFACT_NAME: test-results
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
   GOTAGS: ${{ endsWith(github.repository, '-enterprise') && 'consulent' || '' }}
-  GOTESTSUM_VERSION: "1.9.0"
+  GOTESTSUM_VERSION: "1.10.1"
   CONSUL_BINARY_UPLOAD_NAME: consul-bin
   # strip the hashicorp/ off the front of github.repository for consul
   CONSUL_LATEST_IMAGE_NAME: ${{ endsWith(github.repository, '-enterprise') && github.repository || 'consul' }}


### PR DESCRIPTION
Specifically to for this fix: https://github.com/gotestyourself/gotestsum/pull/338

### Description

@freddygv reported (internally) that a subtest `TestDecodeConfigEntry/service-defaults*` was passing on retry when it should have failed repeatably. 

### Testing & Reproduction steps

You can see in the raw logs for e.g. https://github.com/hashicorp/consul/actions/runs/4930752511/jobs/8813642599?pr=17208 that the test was retried, failed, but that the job succeeded.

```
2023-05-09T22:12:05.3648472Z exec: [go test -json -test.run=^TestDecodeConfigEntry$/^service-defaults_(camel_case)$ -tags= -p 2 -cover -coverprofile=coverage.txt github.com/hashicorp/consul/agent/structs]
2023-05-09T22:12:05.3649057Z go test pid: 35074
2023-05-09T22:12:06.3734309Z [32mPASS[0m agent/structs.TestDecodeConfigEntry (re-run 1) (0.00s)
2023-05-09T22:12:06.3754607Z 	github.com/hashicorp/consul/agent/structs	coverage: 0.2% of statements
2023-05-09T22:12:06.3857592Z [32mPASS[0m agent/structs
2023-05-09T22:12:06.4021309Z 
2023-05-09T22:12:06.4021727Z exec: go version
2023-05-09T22:12:06.4022166Z === [31mFailed[0m
2023-05-09T22:12:06.4023043Z === [31mFAIL[0m: agent/structs TestDecodeConfigEntry/service-defaults_(snake_case) (0.00s)
2023-05-09T22:12:06.4025861Z     config_entry_test.go:2137: 
2023-05-09T22:12:06.4026561Z         	Error Trace:	/home/runner/work/consul/consul/agent/structs/config_entry_test.go:2137
2023-05-09T22:12:06.4032800Z         	            				/home/runner/work/consul/consul/agent/structs/config_entry_test.go:2142
2023-05-09T22:12:06.4033232Z         	Error:      	Not equal: 
2023-05-09T22:12:06.4040091Z         	            	expected: &structs.ServiceConfigEntry{Kind:"service-defaults", Name:"main", Protocol:"http", Mode:"", TransparentProxy:structs.TransparentProxyConfig{OutboundListenerPort:0, DialedDirectly:false}, MeshGateway:structs.MeshGatewayConfig{Mode:"remote"}, Expose:structs.ExposeConfig{Checks:false, Paths:[]structs.ExposePath(nil)}, ExternalSNI:"abc-123", UpstreamConfig:(*structs.UpstreamConfiguration)(0xc0002d0660), Destination:(*structs.DestinationConfig)(nil), MaxInboundConnections:0, LocalConnectTimeoutMs:0, LocalRequestTimeoutMs:0, BalanceInboundConnections:"exact_balance", EnvoyExtensions:structs.EnvoyExtensions(nil), Meta:map[string]string{"foo":"bar", "gir":"zim"}, EnterpriseMeta:acl.EnterpriseMeta{}, RaftIndex:structs.RaftIndex{CreateIndex:0x0, ModifyIndex:0x0}}
2023-05-09T22:12:06.4049478Z         	            	actual  : &structs.ServiceConfigEntry{Kind:"service-defaults", Name:"main", Protocol:"http", Mode:"", TransparentProxy:structs.TransparentProxyConfig{OutboundListenerPort:0, DialedDirectly:false}, MeshGateway:structs.MeshGatewayConfig{Mode:"remote"}, Expose:structs.ExposeConfig{Checks:false, Paths:[]structs.ExposePath(nil)}, ExternalSNI:"abc-123", UpstreamConfig:(*structs.UpstreamConfiguration)(0xc0002d0e40), Destination:(*structs.DestinationConfig)(nil), MaxInboundConnections:0, LocalConnectTimeoutMs:0, LocalRequestTimeoutMs:0, BalanceInboundConnections:"exact_balance", EnvoyExtensions:structs.EnvoyExtensions(nil), Meta:map[string]string{"foo":"bar", "gir":"zim"}, EnterpriseMeta:acl.EnterpriseMeta{}, RaftIndex:structs.RaftIndex{CreateIndex:0x0, ModifyIndex:0x0}}
2023-05-09T22:12:06.4050913Z         	            	
2023-05-09T22:12:06.4051267Z         	            	Diff:
2023-05-09T22:12:06.4051765Z         	            	--- Expected
2023-05-09T22:12:06.4052169Z         	            	+++ Actual
2023-05-09T22:12:06.4052659Z         	            	@@ -32,5 +32,5 @@
2023-05-09T22:12:06.4053239Z         	            	      MaxFailures: (uint32) 3,
2023-05-09T22:12:06.4054024Z         	            	-     EnforcingConsecutive5xx: (*uint32)(<nil>),
2023-05-09T22:12:06.4054781Z         	            	-     MaxEjectionPercent: (*uint32)(<nil>),
2023-05-09T22:12:06.4055618Z         	            	-     BaseEjectionTime: (*time.Duration)(<nil>)
2023-05-09T22:12:06.4056324Z         	            	+     EnforcingConsecutive5xx: (*uint32)(4),
2023-05-09T22:12:06.4056973Z         	            	+     MaxEjectionPercent: (*uint32)(5),
2023-05-09T22:12:06.4057712Z         	            	+     BaseEjectionTime: (*time.Duration)(6000000000)
2023-05-09T22:12:06.4058148Z         	            	     }),
2023-05-09T22:12:06.4058742Z         	Test:       	TestDecodeConfigEntry/service-defaults_(snake_case)
2023-05-09T22:12:06.4058971Z 
2023-05-09T22:12:06.4059328Z === [31mFAIL[0m: agent/structs TestDecodeConfigEntry/service-defaults_(camel_case) (0.00s)
2023-05-09T22:12:06.4059768Z     config_entry_test.go:2137: 
2023-05-09T22:12:06.4060624Z         	Error Trace:	/home/runner/work/consul/consul/agent/structs/config_entry_test.go:2137
2023-05-09T22:12:06.4061749Z         	            				/home/runner/work/consul/consul/agent/structs/config_entry_test.go:2145
2023-05-09T22:12:06.4062151Z         	Error:      	Not equal: 
2023-05-09T22:12:06.4072573Z         	            	expected: &structs.ServiceConfigEntry{Kind:"service-defaults", Name:"main", Protocol:"http", Mode:"", TransparentProxy:structs.TransparentProxyConfig{OutboundListenerPort:0, DialedDirectly:false}, MeshGateway:structs.MeshGatewayConfig{Mode:"remote"}, Expose:structs.ExposeConfig{Checks:false, Paths:[]structs.ExposePath(nil)}, ExternalSNI:"abc-123", UpstreamConfig:(*structs.UpstreamConfiguration)(0xc0002d0660), Destination:(*structs.DestinationConfig)(nil), MaxInboundConnections:0, LocalConnectTimeoutMs:0, LocalRequestTimeoutMs:0, BalanceInboundConnections:"exact_balance", EnvoyExtensions:structs.EnvoyExtensions(nil), Meta:map[string]string{"foo":"bar", "gir":"zim"}, EnterpriseMeta:acl.EnterpriseMeta{}, RaftIndex:structs.RaftIndex{CreateIndex:0x0, ModifyIndex:0x0}}
2023-05-09T22:12:06.4082041Z         	            	actual  : &structs.ServiceConfigEntry{Kind:"service-defaults", Name:"main", Protocol:"http", Mode:"", TransparentProxy:structs.TransparentProxyConfig{OutboundListenerPort:0, DialedDirectly:false}, MeshGateway:structs.MeshGatewayConfig{Mode:"remote"}, Expose:structs.ExposeConfig{Checks:false, Paths:[]structs.ExposePath(nil)}, ExternalSNI:"abc-123", UpstreamConfig:(*structs.UpstreamConfiguration)(0xc0002d11a0), Destination:(*structs.DestinationConfig)(nil), MaxInboundConnections:0, LocalConnectTimeoutMs:0, LocalRequestTimeoutMs:0, BalanceInboundConnections:"exact_balance", EnvoyExtensions:structs.EnvoyExtensions(nil), Meta:map[string]string{"foo":"bar", "gir":"zim"}, EnterpriseMeta:acl.EnterpriseMeta{}, RaftIndex:structs.RaftIndex{CreateIndex:0x0, ModifyIndex:0x0}}
2023-05-09T22:12:06.4084355Z         	            	
2023-05-09T22:12:06.4084812Z         	            	Diff:
2023-05-09T22:12:06.4085507Z         	            	--- Expected
2023-05-09T22:12:06.4086061Z         	            	+++ Actual
2023-05-09T22:12:06.4086796Z         	            	@@ -32,5 +32,5 @@
2023-05-09T22:12:06.4087667Z         	            	      MaxFailures: (uint32) 3,
2023-05-09T22:12:06.4088848Z         	            	-     EnforcingConsecutive5xx: (*uint32)(<nil>),
2023-05-09T22:12:06.4089983Z         	            	-     MaxEjectionPercent: (*uint32)(<nil>),
2023-05-09T22:12:06.4091157Z         	            	-     BaseEjectionTime: (*time.Duration)(<nil>)
2023-05-09T22:12:06.4092236Z         	            	+     EnforcingConsecutive5xx: (*uint32)(4),
2023-05-09T22:12:06.4093242Z         	            	+     MaxEjectionPercent: (*uint32)(5),
2023-05-09T22:12:06.4094358Z         	            	+     BaseEjectionTime: (*time.Duration)(6000000000)
2023-05-09T22:12:06.4095015Z         	            	     }),
2023-05-09T22:12:06.4095929Z         	Test:       	TestDecodeConfigEntry/service-defaults_(camel_case)
2023-05-09T22:12:06.4096281Z 
2023-05-09T22:12:06.4096681Z === [31mFAIL[0m: agent/structs TestDecodeConfigEntry (0.01s)
2023-05-09T22:12:06.4096999Z 
2023-05-09T22:12:06.4097232Z DONE 2 runs, 2135 tests, 3 failures in 140.880s
```

Running locally, I could repro with `gotestsum` versions up to the fixed one, 1.10.1.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
