### PR TITLE
[NET-4876] docs - update upgrade index page to not recommend consul leave.

### DIFF
--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -36,7 +36,8 @@ Consul is A, and version B is released.
 
 2. On each Consul server agent, install version B of Consul.
 
-3. One Consul server agent at a time, shut down version A via `consul leave` and restart with version B. Wait until
+3. One Consul server agent at a time,  use a service management system
+   (e.g., systemd, upstart, etc.) to restart the Consul service with version B. Wait until
    the server agent is healthy and has rejoined the cluster before moving on to the
    next server agent.
 


### PR DESCRIPTION
### Description

consul leave is bad during upgrades because the leaving server will disconnect and think there is no leader and initiate a series of new elections, but cannot communicate with others.  When it comes up, its term is much higher than the leader and the leader will detect this and step down.  Having the leader change is bad when you are trying to guarantee that the leader is upgraded last.

We've already changed this on the general upgrade process page.  This is another instance we just found