### PR TITLE
Add ingress gateway deprecation notices to docs

### DIFF
--- a/website/content/docs/concepts/service-mesh.mdx
+++ b/website/content/docs/concepts/service-mesh.mdx
@@ -59,7 +59,7 @@ The mesh reduces the load balancer footprint as routing responsibilities are han
 
 API gateways can be used with a service mesh to bridge external networks (non-mesh) with a service mesh.
 
--> **API gateways and traffic direction:** API gateways are often used to accept north-south traffic. North-south traffic is networking traffic that either enters or exits a data center or a virtual private network (VPC). API Gateways can be connected to a service mesh and provide access to it from outside the mesh.
+-> **API gateways and traffic direction:** API gateways are often used to accept north-south traffic. North-south traffic is networking traffic that either enters or exits a datacenter or a virtual private network (VPC). You can connect API gateways to a service mesh and provide access to it from outside the mesh.
 A service mesh is primarily used for handling east-west traffic. East-west traffic traditionally remains inside a data center or a VPC.
 A service mesh can be connected to another service mesh in another data center or VPC to form a federated mesh.
 

--- a/website/content/docs/concepts/service-mesh.mdx
+++ b/website/content/docs/concepts/service-mesh.mdx
@@ -53,13 +53,13 @@ The API gateway will route the incoming requests to the respective service. The 
 
 A service mesh specializes in the network management of services and the communication between services.
 The mesh is responsible for keeping track of services and their health status, IP address, and traffic routing and ensuring all traffic between services is authenticated and encrypted.
-Unlike API gateways, a service mesh will track all registered services' lifecycle and ensure requests are routed to healthy instances of the service.
+Unlike some API gateways, a service mesh will track all registered services' lifecycle and ensure requests are routed to healthy instances of the service.
 API gateways are frequently deployed alongside a load balancer to ensure traffic is directed to healthy and available instances of the service.
 The mesh reduces the load balancer footprint as routing responsibilities are handled in a decentralized manner.
 
 API gateways can be used with a service mesh to bridge external networks (non-mesh) with a service mesh.
 
--> **API gateways and traffic direction:** API gateways are often used to accept north-south traffic. North-south traffic is networking traffic that either enters or exits a data center or a virtual private network (VPC).
+-> **API gateways and traffic direction:** API gateways are often used to accept north-south traffic. North-south traffic is networking traffic that either enters or exits a data center or a virtual private network (VPC). API Gateways can be connected to a service mesh and provide access to it from outside the mesh.
 A service mesh is primarily used for handling east-west traffic. East-west traffic traditionally remains inside a data center or a VPC.
 A service mesh can be connected to another service mesh in another data center or VPC to form a federated mesh.
 

--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -7,6 +7,14 @@ description: >-
 
 # Ingress gateway configuration entry reference
 
+<Note>
+
+Ingress gateway is deprecated and will not be enhanced beyond its current capabilities. Ingress gateway is fully supported in this version but will be removed in a future release of Consul.
+
+Consul's API gateway is the recommended alternative to ingress gateway.
+
+</Note>
+
 This topic provides configuration reference information for the ingress gateway configuration entry. An ingress gateway is a type of proxy you register as a service in Consul to enable network connectivity from external services to services inside of the service mesh. Refer to [Ingress gateways overview](/consul/docs/connect/gateways/ingress-gateway) for additional information. 
 
 ## Configuration model

--- a/website/content/docs/connect/gateways/index.mdx
+++ b/website/content/docs/connect/gateways/index.mdx
@@ -17,8 +17,6 @@ This topic provides an overview of the gateway features shipped with Consul. Gat
 
 ## Mesh Gateways
 
--> **1.6.0+:** This feature is available in Consul versions 1.6.0 and newer.
-
 Mesh gateways enable service mesh traffic to be routed between different Consul datacenters and admin partitions. The datacenters or partitions can reside
 in different clouds or runtime environments where general interconnectivity between all services in all datacenters
 isn't feasible.
@@ -36,8 +34,6 @@ Mesh gateways enable the following scenarios:
 -> **Mesh gateway tutorial**: Follow the [mesh gateway tutorial](/consul/tutorials/developer-mesh/service-mesh-gateways) to learn concepts associated with mesh gateways.
 
 ## API Gateways
-
--> **1.15.0+:** This feature is available in Consul versions 1.8.0 and newer.
 
 API gateways enable network access, from outside a service mesh, to services running in a Consul service mesh. The
 systems accessing the services in the mesh, may be within your organizational network or external to it. This type of
@@ -59,8 +55,6 @@ Refer to the following documentation for information on how to configure and dep
 
 
 ## Ingress Gateways
-
--> **1.8.0+:** This feature is available in Consul versions 1.8.0 and newer.
 
 <Note>
 
@@ -87,8 +81,6 @@ and the [ingress gateway tutorial](/consul/tutorials/developer-mesh/service-mesh
 ![Ingress Gateway Architecture](/img/ingress-gateways.png)
 
 ## Terminating Gateways
-
--> **1.8.0+:** This feature is available in Consul versions 1.8.0 and newer.
 
 Terminating gateways enable connectivity within your organizational network from services in the Consul service mesh
 to services outside the mesh.

--- a/website/content/docs/connect/gateways/index.mdx
+++ b/website/content/docs/connect/gateways/index.mdx
@@ -35,9 +35,41 @@ Mesh gateways enable the following scenarios:
 
 -> **Mesh gateway tutorial**: Follow the [mesh gateway tutorial](/consul/tutorials/developer-mesh/service-mesh-gateways) to learn concepts associated with mesh gateways.
 
+## API Gateways
+
+-> **1.15.0+:** This feature is available in Consul versions 1.8.0 and newer.
+
+API gateways enable network access, from outside a service mesh, to services running in a Consul service mesh. The
+systems accessing the services in the mesh, may be within your organizational network or external to it. This type of
+network traffic is commonly called _north-south_ network traffic because it refers to the flow of data into and out of
+a specific environment.
+
+API gateways solve the following primary use cases:
+
+- **Control access at the point of entry**: Set the protocols of external connection
+  requests and secure inbound connections with TLS certificates from trusted
+  providers, such as Verisign and Let's Encrypt.
+- **Simplify traffic management**: Load balance requests across services and route
+  traffic to the appropriate service by matching one or more criteria, such as
+  hostname, path, header presence or value, and HTTP method.
+
+Refer to the following documentation for information on how to configure and deploy API gateways:
+- [API Gateways on VMs](/consul/docs/connect/gateways/api-gateway/usage)
+- [API Gateways for Kubernetes](/consul/docs/api-gateway).
+
+
 ## Ingress Gateways
 
 -> **1.8.0+:** This feature is available in Consul versions 1.8.0 and newer.
+
+<Note>
+
+Ingress gateway is deprecated and will not be enhanced beyond its current capabilities. Ingress gateway is fully supported
+in this version but will be removed in a future release of Consul.
+
+Consul's API gateway is the recommended alternative to ingress gateway.
+
+</Note>
 
 Ingress gateways enable connectivity within your organizational network from services outside the Consul service mesh
 to services in the mesh. To accept ingress traffic from the public internet, use Consul's

--- a/website/content/docs/connect/gateways/ingress-gateway/index.mdx
+++ b/website/content/docs/connect/gateways/ingress-gateway/index.mdx
@@ -11,6 +11,15 @@ An ingress gateway is a type of proxy that enables network connectivity from ext
 
 ![Ingress Gateway Architecture](/img/ingress-gateways.png)
 
+<Note>
+
+Ingress gateway is deprecated and will not be enhanced beyond its current capabilities. Ingress gateway is fully supported
+in this version but will be removed in a future release of Consul.
+
+Consul's API gateway is the recommended alternative to ingress gateway.
+
+</Note>
+
 ## Workflow
 
 The following stages describe how to add an ingress gateway to your service mesh: 

--- a/website/content/docs/k8s/connect/ingress-gateways.mdx
+++ b/website/content/docs/k8s/connect/ingress-gateways.mdx
@@ -7,8 +7,6 @@ description: >-
 
 # Configure Ingress Gateways for Consul on Kubernetes
 
--> 1.9.0+: This feature is available in Consul versions 1.9.0 and higher
-
 <Note>
 
 Ingress gateway is deprecated and will not be enhanced beyond its current capabilities. Ingress gateway is fully supported

--- a/website/content/docs/k8s/connect/ingress-gateways.mdx
+++ b/website/content/docs/k8s/connect/ingress-gateways.mdx
@@ -9,6 +9,15 @@ description: >-
 
 -> 1.9.0+: This feature is available in Consul versions 1.9.0 and higher
 
+<Note>
+
+Ingress gateway is deprecated and will not be enhanced beyond its current capabilities. Ingress gateway is fully supported
+in this version but will be removed in a future release of Consul.
+
+Consul's API gateway is the recommended alternative to ingress gateway.
+
+</Note>
+
 ~> This topic requires familiarity with [Ingress Gateways](/consul/docs/connect/gateways/ingress-gateway).
 
 This page describes how to enable external access through Consul ingress gateways to mesh services running inside Kubernetes.


### PR DESCRIPTION
### Description

This adds notices, that ingress gateway is deprecated, to several places in the product docs where ingress gateway is the topic.

### Testing & Reproduction steps

Tested with a local copy of the website.

### Links

Deprecation of ingress gateway was announced in the Release Notes for Consul 1.16 and Consul-K8s 1.2. See:
[https://developer.hashicorp.com/consul/docs/release-notes/consul/v1_16_x#what-s-deprecated](https://developer.hashicorp.com/consul/docs/release-notes/consul/v1_16_x#what-s-deprecated
)
[https://developer.hashicorp.com/consul/docs/release-notes/consul-k8s/v1_2_x#what-s-deprecated](https://developer.hashicorp.com/consul/docs/release-notes/consul-k8s/v1_2_x#what-s-deprecated)

### PR Checklist

* [N/A] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
