### PR TITLE
Add updated helm docs for consul-k8s 0.49.8

### DIFF
--- a/website/content/docs/k8s/helm.mdx
+++ b/website/content/docs/k8s/helm.mdx
@@ -59,7 +59,7 @@ Use these links to navigate to a particular top-level stanza.
     the prefix will be `<helm release name>-consul`.
 
   - `domain` ((#v-global-domain)) (`string: consul`) - The domain Consul will answer DNS queries for
-    (see `-domain` (https://www.consul.io/docs/agent/config/cli-flags#_domain)) and the domain services synced from
+    (Refer to [`-domain`](https://developer.hashicorp.com/consul/docs/agent/config/cli-flags#_domain)) and the domain services synced from
     Consul into Kubernetes will have, e.g. `service-name.service.consul`.
 
   - `peering` ((#v-global-peering)) - [Experimental] Configures the Cluster Peering feature. Requires Consul v1.13+ and Consul-K8s v0.45+.
@@ -133,7 +133,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `imagePullSecrets` ((#v-global-imagepullsecrets)) (`array<map>`) - Array of objects containing image pull secret names that will be applied to each service account.
     This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
-    See https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry for reference.
+    Refer to https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry.
 
     Example:
 
@@ -153,12 +153,13 @@ Use these links to navigate to a particular top-level stanza.
     https://github.com/hashicorp/consul/issues/1858.
 
   - `enablePodSecurityPolicies` ((#v-global-enablepodsecuritypolicies)) (`boolean: false`) - Controls whether pod security policies are created for the Consul components
-    created by this chart. See https://kubernetes.io/docs/concepts/policy/pod-security-policy/.
+    created by this chart. Refer to https://kubernetes.io/docs/concepts/policy/pod-security-policy/.
 
   - `secretsBackend` ((#v-global-secretsbackend)) - secretsBackend is used to configure Vault as the secrets backend for the Consul on Kubernetes installation.
     The Vault cluster needs to have the Kubernetes Auth Method, KV2 and PKI secrets engines enabled
     and have necessary secrets, policies and roles created prior to installing Consul.
-    See https://www.consul.io/docs/k8s/installation/vault for full instructions.
+    Refer to [Vault as the Secrets Backend](https://developer.hashicorp.com/consul/docs/k8s/deployment-configurations/vault)
+    documentation for full instructions.
 
     The Vault cluster _must_ not have the Consul cluster installed by this Helm chart as its storage backend
     as that would cause a circular dependency.
@@ -263,21 +264,21 @@ Use these links to navigate to a particular top-level stanza.
         The provider will be configured to use the Vault Kubernetes auth method
         and therefore requires the role provided by `global.secretsBackend.vault.consulServerRole`
         to have permissions to the root and intermediate PKI paths.
-        Please see https://www.consul.io/docs/connect/ca/vault#vault-acl-policies
-        for information on how to configure the Vault policies.
+        Please refer to [Vault ACL policies](https://developer.hashicorp.com/consul/docs/connect/ca/vault#vault-acl-policies)
+        documentation for information on how to configure the Vault policies.
 
         - `address` ((#v-global-secretsbackend-vault-connectca-address)) (`string: ""`) - The address of the Vault server.
 
         - `authMethodPath` ((#v-global-secretsbackend-vault-connectca-authmethodpath)) (`string: kubernetes`) - The mount path of the Kubernetes auth method in Vault.
 
         - `rootPKIPath` ((#v-global-secretsbackend-vault-connectca-rootpkipath)) (`string: ""`) - The path to a PKI secrets engine for the root certificate.
-          For more details, please refer to [Vault Connect CA configuration](https://www.consul.io/docs/connect/ca/vault#rootpkipath).
+          For more details, please refer to [Vault Connect CA configuration](https://developer.hashicorp.com/consul/docs/connect/ca/vault#rootpkipath).
 
         - `intermediatePKIPath` ((#v-global-secretsbackend-vault-connectca-intermediatepkipath)) (`string: ""`) - The path to a PKI secrets engine for the generated intermediate certificate.
-          For more details, please refer to [Vault Connect CA configuration](https://www.consul.io/docs/connect/ca/vault#intermediatepkipath).
+          For more details, please refer to [Vault Connect CA configuration](https://developer.hashicorp.com/consul/docs/connect/ca/vault#intermediatepkipath).
 
         - `additionalConfig` ((#v-global-secretsbackend-vault-connectca-additionalconfig)) (`string: {}`) - Additional Connect CA configuration in JSON format.
-          Please refer to [Vault Connect CA configuration](https://www.consul.io/docs/connect/ca/vault#configuration)
+          Please refer to [Vault Connect CA configuration](https://developer.hashicorp.com/consul/docs/connect/ca/vault#configuration)
           for all configuration options available for that provider.
 
           Example:
@@ -327,7 +328,7 @@ Use these links to navigate to a particular top-level stanza.
             inject webhooks.
 
   - `gossipEncryption` ((#v-global-gossipencryption)) - Configures Consul's gossip encryption key.
-    (see `-encrypt` (https://www.consul.io/docs/agent/config/cli-flags#_encrypt)).
+    (Refer to [`-encrypt`](https://developer.hashicorp.com/consul/docs/agent/config/cli-flags#_encrypt)).
     By default, gossip encryption is not enabled. The gossip encryption key may be set automatically or manually.
     The recommended method is to automatically generate the key.
     To automatically generate and set a gossip encryption key, set autoGenerate to true.
@@ -335,7 +336,7 @@ Use these links to navigate to a particular top-level stanza.
     To manually generate a gossip encryption key, set secretName and secretKey and use Consul to generate
     a key, saving this as a Kubernetes secret or Vault secret path and key.
     If `global.secretsBackend.vault.enabled=true`, be sure to add the "data" component of the secretName path as required by
-    the Vault KV-2 secrets engine [see example].
+    the Vault KV-2 secrets engine [refer to example].
 
     ```shell-session
     $ kubectl create secret generic consul-gossip-encryption-key --from-literal=key=$(consul keygen)
@@ -358,10 +359,10 @@ Use these links to navigate to a particular top-level stanza.
 
   - `recursors` ((#v-global-recursors)) (`array<string>: []`) - A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
     These values are given as `-recursor` flags to Consul servers and clients.
-    See https://www.consul.io/docs/agent/config/cli-flags#_recursor for more details.
+    Refer to [`-recursor`](https://developer.hashicorp.com/consul/docs/agent/config/cli-flags#_recursor) for more details.
     If this is an empty array (the default), then Consul DNS will only resolve queries for the Consul top level domain (by default `.consul`).
 
-  - `tls` ((#v-global-tls)) - Enables TLS (https://learn.hashicorp.com/tutorials/consul/tls-encryption-secure)
+  - `tls` ((#v-global-tls)) - Enables [TLS](https://developer.hashicorp.com/consul/tutorials/security/tls-encryption-secure)
     across the cluster to verify authenticity of the Consul servers and clients.
     Requires Consul v1.4.1+.
 
@@ -384,7 +385,7 @@ Use these links to navigate to a particular top-level stanza.
     - `verify` ((#v-global-tls-verify)) (`boolean: true`) - If true, `verify_outgoing`, `verify_server_hostname`,
       and `verify_incoming` for internal RPC communication will be set to `true` for Consul servers and clients.
       Set this to false to incrementally roll out TLS on an existing Consul cluster.
-      Please see https://consul.io/docs/k8s/operations/tls-on-existing-cluster
+      Please refer to [TLS on existing clusters](https://developer.hashicorp.com/consul/docs/k8s/operations/tls-on-existing-cluster)
       for more details.
 
     - `httpsOnly` ((#v-global-tls-httpsonly)) (`boolean: true`) - If true, the Helm chart will configure Consul to disable the HTTP port on
@@ -420,8 +421,9 @@ Use these links to navigate to a particular top-level stanza.
 
       Note that we need the CA key so that we can generate server and client certificates.
       It is particularly important for the client certificates since they need to have host IPs
-      as Subject Alternative Names. In the future, we may support bringing your own server
-      certificates.
+      as Subject Alternative Names. If you are setting server certs yourself via `server.serverCert`
+      and you are not enabling clients (or clients are enabled with autoEncrypt) then you do not
+      need to provide the CA key.
 
       - `secretName` ((#v-global-tls-cakey-secretname)) (`string: null`) - The name of the Kubernetes or Vault secret that holds the CA key.
 
@@ -465,6 +467,23 @@ Use these links to navigate to a particular top-level stanza.
 
       - `secretKey` ((#v-global-acls-replicationtoken-secretkey)) (`string: null`) - The key within the Kubernetes or Vault secret that holds the replication token.
 
+    - `resources` ((#v-global-acls-resources)) (`map`) - The resource requests (CPU, memory, etc.) for the server-acl-init and server-acl-init-cleanup pods. 
+      This should be a YAML map corresponding to a Kubernetes
+      [`ResourceRequirements``](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core)
+      object.
+
+      Example:
+
+      ```yaml
+      resources:
+        requests:
+          memory: '200Mi'
+          cpu: '100m'
+        limits:
+          memory: '200Mi'
+          cpu: '100m'
+      ```
+
     - `partitionToken` ((#v-global-acls-partitiontoken)) - partitionToken references a Vault secret containing the ACL token to be used in non-default partitions.
       This value should only be provided in the default partition and only when setting
       the `global.secretsBackend.vault.enabled` value to true.
@@ -478,9 +497,9 @@ Use these links to navigate to a particular top-level stanza.
 
     - `tolerations` ((#v-global-acls-tolerations)) (`string: ""`) - tolerations configures the taints and tolerations for the server-acl-init
       and server-acl-init-cleanup jobs. This should be a multi-line string matching the
-      Tolerations (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
+      [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
 
-    - `nodeSelector` ((#v-global-acls-nodeselector)) (`string: null`) - This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+    - `nodeSelector` ((#v-global-acls-nodeselector)) (`string: null`) - This value defines [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
       labels for the server-acl-init and server-acl-init-cleanup jobs pod assignment, formatted as a multi-line string.
 
       Example:
@@ -530,7 +549,7 @@ Use these links to navigate to a particular top-level stanza.
       This address must be reachable from the Consul servers in the primary datacenter.
       This auth method will be used to provision ACL tokens for Consul components and is different
       from the one used by the Consul Service Mesh.
-      Please see the [Kubernetes Auth Method documentation](https://consul.io/docs/acl/auth-methods/kubernetes).
+      Please refer to the [Kubernetes Auth Method documentation](https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes).
 
       You can retrieve this value from your `kubeconfig` by running:
 
@@ -606,7 +625,7 @@ Use these links to navigate to a particular top-level stanza.
     Consul server agents.
 
   - `replicas` ((#v-server-replicas)) (`integer: 3`) - The number of server agents to run. This determines the fault tolerance of
-    the cluster. Please see the deployment table (https://consul.io/docs/internals/consensus#deployment-table)
+    the cluster. Please refer to the [deployment table](https://developer.hashicorp.com/consul/docs/architecture/consensus#deployment-table)
     for more information.
 
   - `bootstrapExpect` ((#v-server-bootstrapexpect)) (`int: null`) - The number of servers that are expected to be running.
@@ -644,9 +663,9 @@ Use these links to navigate to a particular top-level stanza.
 
     Vault Secrets backend:
     If you are using Vault as a secrets backend, a Vault Policy must be created which allows `["create", "update"]`
-    capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`. 
-    Please see the following guide for steps to generate a compatible certificate:
-    https://learn.hashicorp.com/tutorials/consul/vault-pki-consul-secure-tls
+    capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`.
+    Complete [this tutorial](https://developer.hashicorp.com/consul/tutorials/vault-secure/vault-pki-consul-secure-tls)
+    to learn how to generate a compatible certificate.
     Note: when using TLS, both the `server.serverCert` and `global.tls.caCert` which points to the CA endpoint of this PKI engine
     must be provided.
 
@@ -685,15 +704,15 @@ Use these links to navigate to a particular top-level stanza.
     storage classes, the PersistentVolumeClaims would need to be manually created.
     A `null` value will use the Kubernetes cluster's default StorageClass. If a default
     StorageClass does not exist, you will need to create one.
-    Refer to the [Read/Write Tuning](https://developer.hashicorp.com/consul/docs/install/performance#read-write-tuning) 
-    section of the Server Performance Requirements documentation for considerations 
+    Refer to the [Read/Write Tuning](https://developer.hashicorp.com/consul/docs/install/performance#read-write-tuning)
+    section of the Server Performance Requirements documentation for considerations
     around choosing a performant storage class.
 
-    ~> **Note:** The [Reference Architecture](https://learn.hashicorp.com/tutorials/consul/reference-architecture#hardware-sizing-for-consul-servers)
+    ~> **Note:** The [Reference Architecture](https://developer.hashicorp.com/consul/tutorials/production-deploy/reference-architecture#hardware-sizing-for-consul-servers)
     contains best practices and recommendations for selecting suitable
     hardware sizes for your Consul servers.
 
-  - `connect` ((#v-server-connect)) (`boolean: true`) - This will enable/disable Connect (https://consul.io/docs/connect). Setting this to true
+  - `connect` ((#v-server-connect)) (`boolean: true`) - This will enable/disable [Connect](https://developer.hashicorp.com/consul/docs/connect). Setting this to true
     _will not_ automatically secure pod communication, this
     setting will only enable usage of the feature. Consul will automatically initialize
     a new CA and set of certificates. Additional Connect settings can be configured
@@ -712,7 +731,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `resources` ((#v-server-resources)) (`map`) - The resource requests (CPU, memory, etc.)
     for each of the server agents. This should be a YAML map corresponding to a Kubernetes
-    ResourceRequirements (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core)
+    [`ResourceRequirements``](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core)
     object. NOTE: The use of a YAML string is deprecated.
 
     Example:
@@ -720,10 +739,10 @@ Use these links to navigate to a particular top-level stanza.
     ```yaml
     resources:
       requests:
-        memory: '100Mi'
+        memory: '200Mi'
         cpu: '100m'
       limits:
-        memory: '100Mi'
+        memory: '200Mi'
         cpu: '100m'
     ```
 
@@ -743,11 +762,12 @@ Use these links to navigate to a particular top-level stanza.
 
   - `updatePartition` ((#v-server-updatepartition)) (`integer: 0`) - This value is used to carefully
     control a rolling update of Consul server agents. This value specifies the
-    partition (https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions)
-    for performing a rolling update. Please read the linked Kubernetes documentation
-    and https://www.consul.io/docs/k8s/upgrade#upgrading-consul-servers for more information.
+    [partition](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions)
+    for performing a rolling update. Please read the linked Kubernetes
+    and [Upgrade Consul](https://developer.hashicorp.com/consul/docs/k8s/upgrade#upgrading-consul-servers)
+    documentation for more information.
 
-  - `disruptionBudget` ((#v-server-disruptionbudget)) - This configures the PodDisruptionBudget (https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+  - `disruptionBudget` ((#v-server-disruptionbudget)) - This configures the [`PodDisruptionBudget`](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
     for the server cluster.
 
     - `enabled` ((#v-server-disruptionbudget-enabled)) (`boolean: true`) - Enables registering a PodDisruptionBudget for the server
@@ -760,7 +780,7 @@ Use these links to navigate to a particular top-level stanza.
       --set 'server.disruptionBudget.maxUnavailable=0'` flag to the helm chart installation
       command because of a limitation in the Helm templating language.
 
-  - `extraConfig` ((#v-server-extraconfig)) (`string: {}`) - A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
+  - `extraConfig` ((#v-server-extraconfig)) (`string: {}`) - A raw string of extra [JSON configuration](https://developer.hashicorp.com/consul/docs/agent/config/config-files) for Consul
     servers. This will be saved as-is into a ConfigMap that is read by the Consul
     server agents. This can be used to add additional configuration that
     isn't directly exposed by the chart.
@@ -816,7 +836,7 @@ Use these links to navigate to a particular top-level stanza.
        - ...
     ```
 
-  - `affinity` ((#v-server-affinity)) (`string`) - This value defines the affinity (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+  - `affinity` ((#v-server-affinity)) (`string`) - This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     for server pods. It defaults to allowing only a single server pod on each node, which
     minimizes risk of the cluster becoming unusable if a node is lost. If you need
     to run more pods per node (for example, testing on Minikube), set this value
@@ -837,12 +857,14 @@ Use these links to navigate to a particular top-level stanza.
     ```
 
   - `tolerations` ((#v-server-tolerations)) (`string: ""`) - Toleration settings for server pods. This
-    should be a multi-line string matching the Tolerations
-    (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
+    should be a multi-line string matching the 
+    [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) 
+    array in a Pod spec.
 
   - `topologySpreadConstraints` ((#v-server-topologyspreadconstraints)) (`string: ""`) - Pod topology spread constraints for server pods.
-    This should be a multi-line YAML string matching the `topologySpreadConstraints` array
-    (https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) in a Pod Spec.
+    This should be a multi-line YAML string matching the 
+    [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) 
+    array in a Pod Spec.
 
     This requires K8S >= 1.18 (beta) or 1.19 (stable).
 
@@ -860,7 +882,7 @@ Use these links to navigate to a particular top-level stanza.
             component: server
     ```
 
-  - `nodeSelector` ((#v-server-nodeselector)) (`string: null`) - This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+  - `nodeSelector` ((#v-server-nodeselector)) (`string: null`) - This value defines [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
     labels for server pod assignment, formatted as a multi-line string.
 
     Example:
@@ -871,7 +893,7 @@ Use these links to navigate to a particular top-level stanza.
     ```
 
   - `priorityClassName` ((#v-server-priorityclassname)) (`string: ""`) - This value references an existing
-    Kubernetes `priorityClassName` (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)
+    Kubernetes [`priorityClassName`](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)
     that can be assigned to server pods.
 
   - `extraLabels` ((#v-server-extralabels)) (`map`) - Extra labels to attach to the server pods. This should be a YAML map.
@@ -934,6 +956,56 @@ Use these links to navigate to a particular top-level stanza.
     feature, in case kubernetes cluster is behind egress http proxies. Additionally,
     it could be used to configure custom consul parameters.
 
+  - `auditLogs` ((#v-server-auditlogs)) - <EnterpriseAlert inline /> Added in Consul 1.8, the audit object allow users to enable auditing 
+    and configure a sink and filters for their audit logs. Please refer to
+    [audit logs](https://developer.hashicorp.com/consul/docs/enterprise/audit-logging) documentation
+    for further information.
+
+    - `enabled` ((#v-server-auditlogs-enabled)) (`boolean: false`) - Controls whether Consul logs out each time a user performs an operation.
+      global.acls.manageSystemACLs must be enabled to use this feature.
+
+    - `sinks` ((#v-server-auditlogs-sinks)) (`array<map>`) - A single entry of the sink object provides configuration for the destination to which Consul 
+      will log auditing events.
+
+      Example:
+
+      ```yaml
+      sinks:
+        - name: My Sink
+          type: file
+          format: json
+          path: /tmp/audit.json
+          delivery_guarantee: best-effort
+          rotate_duration: 24h
+          rotate_max_files: 15
+          rotate_bytes: 25165824
+          
+      ```
+
+      The sink object supports the following keys:
+
+      - `name` - Name of the sink.
+
+      - `type` - Type specifies what kind of sink this is. Currently only file sinks are available
+
+      - `format` - Format specifies what format the events will be emitted with. Currently only `json`
+        events are emitted.
+
+      - `path` - The directory and filename to write audit events to.
+
+      - `delivery_guarantee` - Specifies the rules governing how audit events are written. Consul
+        only supports `best-effort` event delivery.
+
+      - `mode` - The permissions to set on the audit log files.
+
+      - `rotate_duration` - Specifies the interval by which the system rotates to a new log file.
+         At least one of `rotate_duration` or `rotate_bytes` must be configured to enable audit logging.
+
+      - `rotate_bytes` -  Specifies how large an individual log file can grow before Consul rotates to a new file.
+         At least one of rotate_bytes or rotate_duration must be configured to enable audit logging.
+
+      - `rotate_max_files` - Defines the limit that Consul should follow before it deletes old log files.
+
 ### externalServers ((#h-externalservers))
 
 - `externalServers` ((#v-externalservers)) - Configuration for Consul servers when the servers are running outside of Kubernetes.
@@ -970,7 +1042,7 @@ Use these links to navigate to a particular top-level stanza.
   - `k8sAuthMethodHost` ((#v-externalservers-k8sauthmethodhost)) (`string: null`) - If you are setting `global.acls.manageSystemACLs` and
     `connectInject.enabled` to true, set `k8sAuthMethodHost` to the address of the Kubernetes API server.
     This address must be reachable from the Consul servers.
-    Please see the Kubernetes Auth Method documentation (https://consul.io/docs/acl/auth-methods/kubernetes).
+    Please refer to the [Kubernetes Auth Method documentation](https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes).
 
     You could retrieve this value from your `kubeconfig` by running:
 
@@ -990,7 +1062,7 @@ Use these links to navigate to a particular top-level stanza.
   - `image` ((#v-client-image)) (`string: null`) - The name of the Docker image (including any tag) for the containers
     running Consul client agents.
 
-  - `join` ((#v-client-join)) (`array<string>: null`) - A list of valid `-retry-join` values (https://www.consul.io/docs/agent/config/cli-flags#_retry_join).
+  - `join` ((#v-client-join)) (`array<string>: null`) - A list of valid [`-retry-join` values](https://developer.hashicorp.com/consul/docs/agent/config/cli-flags#_retry_join).
     If this is `null` (default), then the clients will attempt to automatically
     join the server cluster running within Kubernetes.
     This means that with `server.enabled` set to true, clients will automatically
@@ -1011,7 +1083,7 @@ Use these links to navigate to a particular top-level stanza.
     required for Connect.
 
   - `nodeMeta` ((#v-client-nodemeta)) - nodeMeta specifies an arbitrary metadata key/value pair to associate with the node
-    (see https://www.consul.io/docs/agent/config/cli-flags#_node_meta)
+    (refer to [`-node-meta`](https://developer.hashicorp.com/consul/docs/agent/config/cli-flags#_node_meta))
 
     - `pod-name` ((#v-client-nodemeta-pod-name)) (`string: ${HOSTNAME}`)
 
@@ -1055,7 +1127,7 @@ Use these links to navigate to a particular top-level stanza.
 
     - `tlsInit` ((#v-client-containersecuritycontext-tlsinit)) (`map`) - The tls-init initContainer
 
-  - `extraConfig` ((#v-client-extraconfig)) (`string: {}`) - A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
+  - `extraConfig` ((#v-client-extraconfig)) (`string: {}`) - A raw string of extra [JSON configuration](https://developer.hashicorp.com/consul/docs/agent/config/config-files) for Consul
     clients. This will be saved as-is into a ConfigMap that is read by the Consul
     client agents. This can be used to add additional configuration that
     isn't directly exposed by the chart.
@@ -1148,7 +1220,7 @@ Use these links to navigate to a particular top-level stanza.
     ```
 
   - `priorityClassName` ((#v-client-priorityclassname)) (`string: ""`) - This value references an existing
-    Kubernetes `priorityClassName` (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)
+    Kubernetes [`priorityClassName`](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)
     that can be assigned to client pods.
 
   - `annotations` ((#v-client-annotations)) (`string: null`) - This value defines additional annotations for
@@ -1175,7 +1247,7 @@ Use these links to navigate to a particular top-level stanza.
     feature, in case kubernetes cluster is behind egress http proxies. Additionally,
     it could be used to configure custom consul parameters.
 
-  - `dnsPolicy` ((#v-client-dnspolicy)) (`string: null`) - This value defines the Pod DNS policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)
+  - `dnsPolicy` ((#v-client-dnspolicy)) (`string: null`) - This value defines the [Pod DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)
     for client pods to use.
 
   - `hostNetwork` ((#v-client-hostnetwork)) (`boolean: false`) - hostNetwork defines whether or not we use host networking instead of hostPort in the event
@@ -1185,7 +1257,8 @@ Use these links to navigate to a particular top-level stanza.
     combined with `dnsPolicy: ClusterFirstWithHostNet`
 
   - `updateStrategy` ((#v-client-updatestrategy)) (`string: null`) - updateStrategy for the DaemonSet.
-    See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy.
+    Refer to the Kubernetes [Daemonset upgrade strategy](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy)
+    documentation.
     This should be a multi-line string mapping directly to the updateStrategy
 
     Example:
@@ -1330,7 +1403,7 @@ Use these links to navigate to a particular top-level stanza.
 
     - `ingressClassName` ((#v-ui-ingress-ingressclassname)) (`string: ""`) - Optionally set the ingressClassName.
 
-    - `pathType` ((#v-ui-ingress-pathtype)) (`string: Prefix`) - pathType override - see: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+    - `pathType` ((#v-ui-ingress-pathtype)) (`string: Prefix`) - pathType override - refer to: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
 
     - `hosts` ((#v-ui-ingress-hosts)) (`array<map>`) - hosts is a list of host name to create Ingress rules.
 
@@ -1366,16 +1439,17 @@ Use these links to navigate to a particular top-level stanza.
     - `enabled` ((#v-ui-metrics-enabled)) (`boolean: global.metrics.enabled`) - Enable displaying metrics in the UI. The default value of "-"
       will inherit from `global.metrics.enabled` value.
 
-    - `provider` ((#v-ui-metrics-provider)) (`string: prometheus`) - Provider for metrics. See
-      https://www.consul.io/docs/agent/options#ui_config_metrics_provider
+    - `provider` ((#v-ui-metrics-provider)) (`string: prometheus`) - Provider for metrics. Refer to
+      [`metrics_provider`](https://developer.hashicorp.com/consul/docs/agent/config/config-files#ui_config_metrics_provider)
       This value is only used if `ui.enabled` is set to true.
 
     - `baseURL` ((#v-ui-metrics-baseurl)) (`string: http://prometheus-server`) - baseURL is the URL of the prometheus server, usually the service URL.
       This value is only used if `ui.enabled` is set to true.
 
-  - `dashboardURLTemplates` ((#v-ui-dashboardurltemplates)) - Corresponds to https://www.consul.io/docs/agent/options#ui_config_dashboard_url_templates configuration.
+  - `dashboardURLTemplates` ((#v-ui-dashboardurltemplates)) - Corresponds to [`dashboard_url_templates`](https://developer.hashicorp.com/consul/docs/agent/config/config-files#ui_config_dashboard_url_templates)
+    configuration.
 
-    - `service` ((#v-ui-dashboardurltemplates-service)) (`string: ""`) - Sets https://www.consul.io/docs/agent/options#ui_config_dashboard_url_templates_service.
+    - `service` ((#v-ui-dashboardurltemplates-service)) (`string: ""`) - Sets [`dashboardURLTemplates.service`](https://developer.hashicorp.com/consul/docs/agent/config/config-files#ui_config_dashboard_url_templates_service).
 
 ### syncCatalog ((#h-synccatalog))
 
@@ -1395,8 +1469,8 @@ Use these links to navigate to a particular top-level stanza.
     to run the sync program.
 
   - `default` ((#v-synccatalog-default)) (`boolean: true`) - If true, all valid services in K8S are
-    synced by default. If false, the service must be annotated
-    (https://consul.io/docs/k8s/service-sync#sync-enable-disable) properly to sync.
+    synced by default. If false, the service must be [annotated](https://developer.hashicorp.com/consul/docs/k8s/service-sync#enable-and-disable-sync)
+    properly to sync.
     In either case an annotation can override the default.
 
   - `priorityClassName` ((#v-synccatalog-priorityclassname)) (`string: ""`) - Optional priorityClassName.
@@ -1509,7 +1583,7 @@ Use these links to navigate to a particular top-level stanza.
 
     - `secretKey` ((#v-synccatalog-aclsynctoken-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the acl sync token.
 
-  - `nodeSelector` ((#v-synccatalog-nodeselector)) (`string: null`) - This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+  - `nodeSelector` ((#v-synccatalog-nodeselector)) (`string: null`) - This value defines [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
     labels for catalog sync pod assignment, formatted as a multi-line string.
 
     Example:
@@ -1575,7 +1649,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `default` ((#v-connectinject-default)) (`boolean: false`) - If true, the injector will inject the
     Connect sidecar into all pods by default. Otherwise, pods must specify the
-    injection annotation (https://consul.io/docs/k8s/connect#consul-hashicorp-com-connect-inject)
+    [injection annotation](https://developer.hashicorp.com/consul/docs/k8s/connect#consul-hashicorp-com-connect-inject)
     to opt-in to Connect injection. If this is true, pods can use the same annotation
     to explicitly opt-out of injection.
 
@@ -1593,7 +1667,7 @@ Use these links to navigate to a particular top-level stanza.
       This value is also overridable via the "consul.hashicorp.com/transparent-proxy-overwrite-probes" annotation.
       Note: This value has no effect if transparent proxy is disabled on the pod.
 
-  - `disruptionBudget` ((#v-connectinject-disruptionbudget)) - This configures the PodDisruptionBudget (https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+  - `disruptionBudget` ((#v-connectinject-disruptionbudget)) - This configures the [`PodDisruptionBudget`](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
     for the service mesh sidecar injector.
 
     - `enabled` ((#v-connectinject-disruptionbudget-enabled)) (`boolean: true`) - This will enable/disable registering a PodDisruptionBudget for the 
@@ -1646,7 +1720,8 @@ Use these links to navigate to a particular top-level stanza.
       by the OpenShift platform.
 
     - `updateStrategy` ((#v-connectinject-cni-updatestrategy)) (`string: null`) - updateStrategy for the CNI installer DaemonSet.
-      See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy.
+      Refer to the Kubernetes [Daemonset upgrade strategy](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy)
+      documentation.
       This should be a multi-line string mapping directly to the updateStrategy
 
       Example:
@@ -1726,7 +1801,19 @@ Use these links to navigate to a particular top-level stanza.
         "sample/annotation2": "bar"
       ```
 
-  - `resources` ((#v-connectinject-resources)) (`map`) - The resource settings for connect inject pods.
+  - `resources` ((#v-connectinject-resources)) (`map`) - The resource settings for connect inject pods. The defaults, are optimized for getting started worklows on developer deployments. The settings should be tweaked for production deployments.
+
+    - `requests` ((#v-connectinject-resources-requests))
+
+      - `memory` ((#v-connectinject-resources-requests-memory)) (`string: 200Mi`) - Recommended production default: 500Mi
+
+      - `cpu` ((#v-connectinject-resources-requests-cpu)) (`string: 50m`) - Recommended production default: 250m
+
+    - `limits` ((#v-connectinject-resources-limits))
+
+      - `memory` ((#v-connectinject-resources-limits-memory)) (`string: 200Mi`) - Recommended production default: 500Mi
+
+      - `cpu` ((#v-connectinject-resources-limits-cpu)) (`string: 50m`) - Recommended production default: 250m
 
   - `failurePolicy` ((#v-connectinject-failurepolicy)) (`string: Fail`) - Sets the failurePolicy for the mutating webhook. By default this will cause pods not part of the consul installation to fail scheduling while the webhook
     is offline. This prevents a pod from skipping mutation if the webhook were to be momentarily offline.
@@ -1737,12 +1824,12 @@ Use these links to navigate to a particular top-level stanza.
 
   - `namespaceSelector` ((#v-connectinject-namespaceselector)) (`string`) - Selector for restricting the webhook to only specific namespaces. 
     Use with `connectInject.default: true` to automatically inject all pods in namespaces that match the selector. This should be set to a multiline string.
-    See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
+    Refer to https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
     for more details.
 
-    By default, we exclude the kube-system namespace since usually users won't
-    want those pods injected and also the local-path-storage namespace so that
-    Kind (Kubernetes In Docker) can provision Pods used to create PVCs.
+    By default, we exclude kube-system since usually users won't
+    want those pods injected and local-path-storage and openebs so that
+    Kind (Kubernetes In Docker) and [OpenEBS](https://openebs.io/) respectively can provision Pods used to create PVCs.
     Note that this exclusion is only supported in Kubernetes v1.21.1+.
 
     Example:
@@ -1824,8 +1911,8 @@ Use these links to navigate to a particular top-level stanza.
     If set to an empty string all service accounts can log in.
     This only has effect if ACLs are enabled.
 
-    See https://www.consul.io/docs/acl/acl-auth-methods.html#binding-rules
-    and https://www.consul.io/docs/acl/auth-methods/kubernetes.html#trusted-identity-attributes
+    Refer to Auth methods [Binding rules](https://developer.hashicorp.com/consul/docs/security/acl/auth-methods#binding-rules)
+    and [Trusted identiy attributes](https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes#trusted-identity-attributes)
     for more details.
     Requires Consul >= v1.5.
 
@@ -1851,7 +1938,7 @@ Use these links to navigate to a particular top-level stanza.
       leads to unnecessary thread and memory usage and leaves unnecessary idle connections open. It is
       advised to keep this number low for sidecars and high for edge proxies.
       This will control the `--concurrency` flag to Envoy.
-      For additional information see also: https://blog.envoyproxy.io/envoy-threading-model-a8d44b922310
+      For additional information, refer to https://blog.envoyproxy.io/envoy-threading-model-a8d44b922310
 
       This setting can be overridden on a per-pod basis via this annotation:
       - `consul.hashicorp.com/consul-envoy-proxy-concurrency`
@@ -1867,17 +1954,39 @@ Use these links to navigate to a particular top-level stanza.
 
       - `requests` ((#v-connectinject-sidecarproxy-resources-requests))
 
-        - `memory` ((#v-connectinject-sidecarproxy-resources-requests-memory)) (`string: null`) - Recommended default: 100Mi
+        - `memory` ((#v-connectinject-sidecarproxy-resources-requests-memory)) (`string: null`) - Recommended production default: 100Mi
 
-        - `cpu` ((#v-connectinject-sidecarproxy-resources-requests-cpu)) (`string: null`) - Recommended default: 100m
+        - `cpu` ((#v-connectinject-sidecarproxy-resources-requests-cpu)) (`string: null`) - Recommended production default: 100m
 
       - `limits` ((#v-connectinject-sidecarproxy-resources-limits))
 
-        - `memory` ((#v-connectinject-sidecarproxy-resources-limits-memory)) (`string: null`) - Recommended default: 100Mi
+        - `memory` ((#v-connectinject-sidecarproxy-resources-limits-memory)) (`string: null`) - Recommended production default: 100Mi
 
-        - `cpu` ((#v-connectinject-sidecarproxy-resources-limits-cpu)) (`string: null`) - Recommended default: 100m
+        - `cpu` ((#v-connectinject-sidecarproxy-resources-limits-cpu)) (`string: null`) - Recommended production default: 100m
 
-  - `initContainer` ((#v-connectinject-initcontainer)) (`map`) - The resource settings for the Connect injected init container.
+  - `initContainer` ((#v-connectinject-initcontainer)) (`map`) - The resource settings for the Connect injected init container. If null, the resources
+    won't be set for the initContainer. The defaults are optimized for developer instances of 
+    Kubernetes, however they should be tweaked with the recommended defaults as shown below to speed up service registration times.
+
+    - `resources` ((#v-connectinject-initcontainer-resources))
+
+      - `requests` ((#v-connectinject-initcontainer-resources-requests))
+
+        - `memory` ((#v-connectinject-initcontainer-resources-requests-memory)) (`string: 25Mi`) - Recommended production default: 150Mi
+
+        - `cpu` ((#v-connectinject-initcontainer-resources-requests-cpu)) (`string: 50m`) - Recommended production default: 250m
+
+      - `limits` ((#v-connectinject-initcontainer-resources-limits))
+
+        - `memory` ((#v-connectinject-initcontainer-resources-limits-memory)) (`string: 150Mi`) - Recommended production default: 150Mi
+
+        - `cpu` ((#v-connectinject-initcontainer-resources-limits-cpu)) (`string: null`) - Recommended production default: 500m
+
+  - `prepareDataplanesUpgrade` ((#v-connectinject-preparedataplanesupgrade)) (`boolean: false`) - Set to true when upgrading to Consul dataplanes. This will ensure that the injector ACL tokens won't be deleted
+    during the upgrade to dataplanes. This is required because after an upgrade, non-dataplane enabled services won't
+    get re-registered by the new dataplane-capable injector, and so if the ACL token used to register them is deleted,
+    they won't be able to resolve new upstream services.
+    See https://developer.hashicorp.com/consul/docs/k8s/upgrade#upgrading-to-consul-dataplane for more information.
 
 ### controller ((#h-controller))
 
@@ -1973,7 +2082,7 @@ Use these links to navigate to a particular top-level stanza.
 
     - `port` ((#v-meshgateway-wanaddress-port)) (`integer: 443`) - Port that gets registered for WAN traffic.
       If source is set to "Service" then this setting will have no effect.
-      See the documentation for source as to which port will be used in that
+      Refer to the documentation for source as to which port will be used in that
       case.
 
     - `static` ((#v-meshgateway-wanaddress-static)) (`string: ""`) - If source is set to "Static" then this value will be used as the WAN
@@ -2042,15 +2151,31 @@ Use these links to navigate to a particular top-level stanza.
 
   - `initServiceInitContainer` ((#v-meshgateway-initserviceinitcontainer)) (`map`) - The resource settings for the `service-init` init container.
 
-  - `affinity` ((#v-meshgateway-affinity)) (`string`) - By default, we set an anti-affinity so that two gateway pods won't be
-    on the same node. NOTE: Gateways require that Consul client agents are
-    also running on the nodes alongside each gateway pod.
+  - `affinity` ((#v-meshgateway-affinity)) (`string`) - This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+    for mesh gateway pods. It defaults to `null` thereby allowing multiple gateway pods on each node. But if one would prefer
+    a mode which minimizes risk of the cluster becoming unusable if a node is lost, set this value
+    to the value in the example below.
+
+    Example:
+
+    ```yaml
+     affinity: |
+       podAntiAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+           - labelSelector:
+               matchLabels:
+                 app: {{ template "consul.name" . }}
+                 release: "{{ .Release.Name }}"
+                 component: mesh-gateway
+             topologyKey: kubernetes.io/hostname
+    ```
 
   - `tolerations` ((#v-meshgateway-tolerations)) (`string: null`) - Optional YAML string to specify tolerations.
 
   - `topologySpreadConstraints` ((#v-meshgateway-topologyspreadconstraints)) (`string: ""`) - Pod topology spread constraints for mesh gateway pods.
-    This should be a multi-line YAML string matching the `topologySpreadConstraints` array
-    (https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) in a Pod Spec.
+    This should be a multi-line YAML string matching the 
+    [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
+    array in a Pod Spec.
 
     This requires K8S >= 1.18 (beta) or 1.19 (stable).
 
@@ -2142,15 +2267,31 @@ Use these links to navigate to a particular top-level stanza.
 
     - `initCopyConsulContainer` ((#v-ingressgateways-defaults-initcopyconsulcontainer)) (`map`) - The resource settings for the `copy-consul-bin` init container.
 
-    - `affinity` ((#v-ingressgateways-defaults-affinity)) (`string`) - By default, we set an anti-affinity so that two of the same gateway pods
-      won't be on the same node. NOTE: Gateways require that Consul client agents are
-      also running on the nodes alongside each gateway pod.
+    - `affinity` ((#v-ingressgateways-defaults-affinity)) (`string`) - This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+      for ingress gateway pods. It defaults to `null` thereby allowing multiple gateway pods on each node. But if one would prefer
+      a mode which minimizes risk of the cluster becoming unusable if a node is lost, set this value
+      to the value in the example below.
+
+      Example:
+
+      ```yaml
+       affinity: |
+         podAntiAffinity:
+           requiredDuringSchedulingIgnoredDuringExecution:
+             - labelSelector:
+                 matchLabels:
+                   app: {{ template "consul.name" . }}
+                   release: "{{ .Release.Name }}"
+                   component: ingress-gateway
+               topologyKey: kubernetes.io/hostname
+      ```
 
     - `tolerations` ((#v-ingressgateways-defaults-tolerations)) (`string: null`) - Optional YAML string to specify tolerations.
 
     - `topologySpreadConstraints` ((#v-ingressgateways-defaults-topologyspreadconstraints)) (`string: ""`) - Pod topology spread constraints for ingress gateway pods.
-      This should be a multi-line YAML string matching the `topologySpreadConstraints` array
-      (https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) in a Pod Spec.
+      This should be a multi-line YAML string matching the 
+      [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
+      array in a Pod Spec.
 
       This requires K8S >= 1.18 (beta) or 1.19 (stable).
 
@@ -2235,15 +2376,31 @@ Use these links to navigate to a particular top-level stanza.
 
     - `initCopyConsulContainer` ((#v-terminatinggateways-defaults-initcopyconsulcontainer)) (`map`) - The resource settings for the `copy-consul-bin` init container.
 
-    - `affinity` ((#v-terminatinggateways-defaults-affinity)) (`string`) - By default, we set an anti-affinity so that two of the same gateway pods
-      won't be on the same node. NOTE: Gateways require that Consul client agents are
-      also running on the nodes alongside each gateway pod.
+    - `affinity` ((#v-terminatinggateways-defaults-affinity)) (`string`) - This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+      for terminating gateway pods. It defaults to `null` thereby allowing multiple gateway pods on each node. But if one would prefer
+      a mode which minimizes risk of the cluster becoming unusable if a node is lost, set this value
+      to the value in the example below.
+
+      Example:
+
+      ```yaml
+       affinity: |
+         podAntiAffinity:
+           requiredDuringSchedulingIgnoredDuringExecution:
+             - labelSelector:
+                 matchLabels:
+                   app: {{ template "consul.name" . }}
+                   release: "{{ .Release.Name }}"
+                   component: terminating-gateway
+               topologyKey: kubernetes.io/hostname
+      ```
 
     - `tolerations` ((#v-terminatinggateways-defaults-tolerations)) (`string: null`) - Optional YAML string to specify tolerations.
 
     - `topologySpreadConstraints` ((#v-terminatinggateways-defaults-topologyspreadconstraints)) (`string: ""`) - Pod topology spread constraints for terminating gateway pods.
-      This should be a multi-line YAML string matching the `topologySpreadConstraints` array
-      (https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) in a Pod Spec.
+      This should be a multi-line YAML string matching the
+      [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
+      array in a Pod Spec.
 
       This requires K8S >= 1.18 (beta) or 1.19 (stable).
 
@@ -2313,7 +2470,7 @@ Use these links to navigate to a particular top-level stanza.
 
     - `enabled` ((#v-apigateway-managedgatewayclass-enabled)) (`boolean: true`) - When true a GatewayClass is configured to automatically work with Consul as installed by helm.
 
-    - `nodeSelector` ((#v-apigateway-managedgatewayclass-nodeselector)) (`string: null`) - This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+    - `nodeSelector` ((#v-apigateway-managedgatewayclass-nodeselector)) (`string: null`) - This value defines [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
       labels for gateway pod assignment, formatted as a multi-line string.
 
       Example:
@@ -2340,7 +2497,7 @@ Use these links to navigate to a particular top-level stanza.
         ```yaml
         service:
           annotations: |
-          - external-dns.alpha.kubernetes.io/hostname
+            - external-dns.alpha.kubernetes.io/hostname
         ```
 
     - `deployment` ((#v-apigateway-managedgatewayclass-deployment)) (`map`) - This value defines the number of pods to deploy for each Gateway as well as a min and max number of pods for all Gateways
@@ -2377,10 +2534,10 @@ Use these links to navigate to a particular top-level stanza.
       ```
 
     - `priorityClassName` ((#v-apigateway-controller-priorityclassname)) (`string: ""`) - This value references an existing
-      Kubernetes `priorityClassName` (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)
+      Kubernetes [`priorityClassName`](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)
       that can be assigned to api-gateway-controller pods.
 
-    - `nodeSelector` ((#v-apigateway-controller-nodeselector)) (`string: null`) - This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+    - `nodeSelector` ((#v-apigateway-controller-nodeselector)) (`string: null`) - This value defines [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
       labels for api-gateway-controller pod assignment, formatted as a multi-line string.
 
       Example:
@@ -2391,7 +2548,7 @@ Use these links to navigate to a particular top-level stanza.
       ```
 
     - `tolerations` ((#v-apigateway-controller-tolerations)) (`string: null`) - This value defines the tolerations for api-gateway-controller pod, this should be a multi-line string matching the
-      Tolerations (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
+      [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
 
     - `service` ((#v-apigateway-controller-service)) - Configuration for the Service created for the api-gateway-controller
 
@@ -2415,7 +2572,7 @@ Use these links to navigate to a particular top-level stanza.
     This should be a multi-line string matching the Toleration array
     in a PodSpec.
 
-  - `nodeSelector` ((#v-webhookcertmanager-nodeselector)) (`string: null`) - This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+  - `nodeSelector` ((#v-webhookcertmanager-nodeselector)) (`string: null`) - This value defines [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
     labels for the webhook-cert-manager pod assignment, formatted as a multi-line string.
 
     Example:


### PR DESCRIPTION
### Description

- Updating helm docs as part of the consul-k8s 0.49.8 release process
- There are so many changes here because the helm docs were not updated when 0.49.7 was released.


### Testing & Reproduction steps

👀 

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
