### PR TITLE
re org registry

### DIFF
--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/hashicorp/consul/internal/resource"
 	"net"
 	"os"
 	"strings"
@@ -576,6 +577,7 @@ func newDefaultDeps(t *testing.T, c *Config) Deps {
 		GetNetRPCInterceptorFunc: middleware.GetNetRPCInterceptor,
 		EnterpriseDeps:           newDefaultDepsEnterprise(t, logger, c),
 		XDSStreamLimiter:         limiter.NewSessionLimiter(),
+		Registry:                 resource.NewRegistry(),
 	}
 }
 

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -7,13 +7,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/hashicorp/consul/internal/resource"
 	"net"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/internal/resource"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/serf"

--- a/agent/consul/options.go
+++ b/agent/consul/options.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/rpc/middleware"
 	"github.com/hashicorp/consul/agent/token"
+	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/tlsutil"
 )
 
@@ -29,6 +30,7 @@ type Deps struct {
 	GRPCConnPool     GRPCClientConner
 	LeaderForwarder  LeaderForwarder
 	XDSStreamLimiter *limiter.SessionLimiter
+	Registry         resource.Registry
 	// GetNetRPCInterceptorFunc, if not nil, sets the net/rpc rpc.ServerServiceCallInterceptor on
 	// the server side to record metrics around the RPC requests. If nil, no interceptor is added to
 	// the rpc server.

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/consul/internal/resource"
 	"io"
 	"net"
 	"os"
@@ -19,6 +18,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/hashicorp/consul/internal/resource"
 
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-connlimit"

--- a/agent/consul/type_registry.go
+++ b/agent/consul/type_registry.go
@@ -1,0 +1,25 @@
+package consul
+
+import (
+	"github.com/hashicorp/consul/internal/catalog"
+	"github.com/hashicorp/consul/internal/mesh"
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/demo"
+)
+
+// NewTypeRegistry returns a registry populated with all supported resource
+// types.
+//
+// Note: the registry includes resource types that may not be suitable for
+// production use (e.g. experimental or development resource types) because
+// it is used in the CLI, where feature flags and other runtime configuration
+// may not be available.
+func NewTypeRegistry() resource.Registry {
+	registry := resource.NewRegistry()
+
+	demo.RegisterTypes(registry)
+	mesh.RegisterTypes(registry)
+	catalog.RegisterTypes(registry)
+
+	return registry
+}

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -8,13 +8,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/consul/internal/resource"
 	"net"
 	"os"
 	"path"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/internal/resource"
 
 	"github.com/google/tcpproxy"
 	"github.com/hashicorp/go-hclog"

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/consul/internal/resource"
 	"net"
 	"os"
 	"path"
@@ -1950,6 +1951,7 @@ func newDefaultDeps(t *testing.T, c *consul.Config) consul.Deps {
 		NewRequestRecorderFunc:   middleware.NewRequestRecorder,
 		GetNetRPCInterceptorFunc: middleware.GetNetRPCInterceptor,
 		XDSStreamLimiter:         limiter.NewSessionLimiter(),
+		Registry:                 resource.NewRegistry(),
 	}
 }
 

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -260,6 +260,8 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer, providedLogger hcl
 
 	d.XDSStreamLimiter = limiter.NewSessionLimiter()
 
+	d.Registry = consul.NewTypeRegistry()
+
 	return d, nil
 }
 

--- a/docs/resources/guide.md
+++ b/docs/resources/guide.md
@@ -61,8 +61,10 @@ func RegisterTypes(r resource.Registry) {
 }
 ```
 
-Update the `registerResources` method in [`server.go`] to call your package's
-type registration method:
+Update the `NewTypeRegistry` method in [`type_registry.go`] to call your
+package's type registration method:
+
+[`type_registry.go`]: ../../agent/consul/type_registry.go
 
 ```Go
 import (
@@ -71,14 +73,12 @@ import (
 	// …
 )
 
-func (s *Server) registerResources() {
+func NewTypeRegistry() resource.Registry {
 	// …
-	foo.RegisterTypes(s.typeRegistry)
+    foo.RegisterTypes(registry)
 	// …
 }
 ```
-
-[`server.go`]: ../../agent/consul/server.go
 
 That should be all you need to start using your new resource type. Test it out
 by starting an agent in dev mode:
@@ -277,7 +277,9 @@ func (barReconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 
 Next, register your controller with the controller manager. Another common
 pattern is to have your package expose a method for registering controllers,
-which is also called from `registerResources` in [`server.go`].
+which is called from `registerControllers` in [`server.go`].
+
+[`server.go`]: ../../agent/consul/server.go
 
 ```Go
 package foo
@@ -290,7 +292,7 @@ func RegisterControllers(mgr *controller.Manager) {
 ```Go
 package consul
 
-func (s *Server) registerResources() {
+func (s *Server) registerControllers() {
 	// …
 	foo.RegisterControllers(s.controllerManager)
 	// …


### PR DESCRIPTION
### Description

In this PR, we lift the `registry` out of the server code so that client, server and cli can share the registry. It's stored in `BaseDeps.Deps` (not `setup.go` but `options.go`) because when we newServer, we are passing `baseDeps.Deps` instead of `baseDeps`.

This [PR](https://github.com/hashicorp/consul/pull/18052/files) shows how we use the registry when register the http endpoints.

Notice I changed the signature of functions: `setupExternalGRPC` and `setupInternalResourceService`. Please let me know if there are better options.

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [ ] ~appropriate backport labels added~
* [ ] ~not a security concern~
