### PR TITLE
add a conditional around setting LANFilter.AllSegments to make sure it is valid

### DIFF
--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -193,7 +193,7 @@ func AgentMembersMapAddrVer(s *HTTPHandlers, req *http.Request) (map[string]stri
 	if acl.IsDefaultPartition(filter.Partition) {
 		filter.AllSegments = true
 	}
-	
+
 	lanMembers, err := s.agent.delegate.LANMembers(filter)
 	if err != nil {
 		return nil, err

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -190,7 +190,10 @@ func AgentMembersMapAddrVer(s *HTTPHandlers, req *http.Request) (map[string]stri
 	filter := consul.LANMemberFilter{
 		Partition: entMeta.PartitionOrDefault(),
 	}
-	filter.AllSegments = true
+	if acl.IsDefaultPartition(filter.Partition) {
+		filter.AllSegments = true
+	}
+	
 	lanMembers, err := s.agent.delegate.LANMembers(filter)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description

This is to correct a code problem because this assumes all segments, but when you get to Enterprise, you can be in partition that is not the default partition, in which case specifying all segments does not validate and fails.  This is to correct the setting of this filter with `AllSegments` to `true` to only occur when in the the `default` partition.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
