### PR TITLE
[CC-5718] Remove HCP token requirement during bootstrap

### DIFF
--- a/agent/hcp/bootstrap/bootstrap_test.go
+++ b/agent/hcp/bootstrap/bootstrap_test.go
@@ -305,9 +305,10 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 		warning string
 	}
 	type testCase struct {
-		existingCluster bool
-		mutateFn        func(t *testing.T, dir string)
-		expect          expect
+		existingCluster        bool
+		disableManagementToken bool
+		mutateFn               func(t *testing.T, dir string)
+		expect                 expect
 	}
 
 	run := func(t *testing.T, tc testCase) {
@@ -319,7 +320,7 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 
 		// Do some common setup as if we received config from HCP and persisted it to disk.
 		require.NoError(t, lib.EnsurePath(dir, true))
-		require.NoError(t, persistSucessMarker(dir))
+		require.NoError(t, persistSuccessMarker(dir))
 
 		if !tc.existingCluster {
 			caCert, caKey, err := tlsutil.GenerateCA(tlsutil.CAOpts{})
@@ -333,9 +334,12 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 			require.NoError(t, persistBootstrapConfig(dir, cfgJSON))
 		}
 
-		token, err := uuid.GenerateUUID()
-		require.NoError(t, err)
-		require.NoError(t, persistManagementToken(dir, token))
+		var token string
+		if !tc.disableManagementToken {
+			token, err = uuid.GenerateUUID()
+			require.NoError(t, err)
+			require.NoError(t, persistManagementToken(dir, token))
+		}
 
 		// Optionally mutate the persisted data to trigger errors while loading.
 		if tc.mutateFn != nil {
@@ -348,7 +352,6 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 		if loaded {
 			require.Equal(t, token, cfg.ManagementToken)
 			require.Empty(t, ui.ErrorWriter.String())
-
 		} else {
 			require.Nil(t, cfg)
 			require.Contains(t, ui.ErrorWriter.String(), tc.expect.warning)
@@ -365,15 +368,11 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 				warning: "",
 			},
 		},
-		"existing cluster missing token": {
-			existingCluster: true,
-			mutateFn: func(t *testing.T, dir string) {
-				// Remove the token file while leaving the existing cluster marker.
-				require.NoError(t, os.Remove(filepath.Join(dir, tokenFileName)))
-			},
+		"existing cluster no token": {
+			existingCluster:        true,
+			disableManagementToken: true,
 			expect: expect{
-				loaded:  false,
-				warning: "configuration files on disk are incomplete",
+				loaded: true,
 			},
 		},
 		"existing cluster no files": {
@@ -394,6 +393,12 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 			expect: expect{
 				loaded:  true,
 				warning: "",
+			},
+		},
+		"new cluster with no token": {
+			disableManagementToken: true,
+			expect: expect{
+				loaded: true,
 			},
 		},
 		"new cluster some files": {


### PR DESCRIPTION
### Description

We are removing the requirement for HCP to provide Consul with a management token to support read-only tokens. This changes the validations to allow for a management token to be missing/ignored during bootstrapping with HCP.

### Links

[Ticket](https://go.hashi.co/cc5718)
[RFC](https://go.hashi.co/rfc-read-only)

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
