### PR TITLE
fix: update delegateMock used in ENT

### DIFF
--- a/agent/delegate_mock_test.go
+++ b/agent/delegate_mock_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
 type delegateMock struct {
@@ -75,4 +76,8 @@ func (m *delegateMock) Stats() map[string]map[string]string {
 
 func (m *delegateMock) ReloadConfig(config consul.ReloadableConfig) error {
 	return m.Called(config).Error(0)
+}
+
+func (m *delegateMock) ResourceServiceClient() pbresource.ResourceServiceClient {
+	return nil
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
The mock is used in `http_ent_test` file which caused lint failures. For OSS->ENT parity adding the same change here.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

Identified in OSS->ENT [merge PR](https://github.com/hashicorp/consul-enterprise/pull/6328)

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [x] appropriate backport labels added
* [ ] ~not a security concern~
