### PR TITLE
Change docs to say 168h instead of 7d for server_rejoin_age_max

### DIFF
--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -742,7 +742,7 @@ Refer to the [formatting specification](https://golang.org/pkg/time/#ParseDurati
 - `server_rejoin_age_max` - controls the allowed maximum age of a stale server attempting to rejoin a cluster.
   If a server is not running for this period, then it will refuse to start up again until an operator intervenes. This is to protect
   clusters from instability caused by decommissioned servers accidentally being started again.
-  Note: the default value is 7d and the minimum value is 6h.
+  Note: the default value is 168h (equal to 7d) and the minimum value is 6h.
 
 - `non_voting_server` - **This field is deprecated in Consul 1.9.1. See the [`read_replica`](#read_replica) field instead.**
 


### PR DESCRIPTION
### Description

Addresses https://github.com/hashicorp/consul/pull/17171#issuecomment-1636930705
 
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
