### PR TITLE
Re-order expected/actual for assertContainerState in consul container tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -54,7 +54,7 @@ QUIET=
 endif
 
 ifeq ("$(GOTAGS)","")
-CONSUL_COMPAT_TEST_IMAGE=consul
+CONSUL_COMPAT_TEST_IMAGE=hashicorp/consul
 else
 CONSUL_COMPAT_TEST_IMAGE=hashicorp/consul-enterprise
 endif

--- a/test/integration/consul-container/libs/assert/service.go
+++ b/test/integration/consul-container/libs/assert/service.go
@@ -252,5 +252,5 @@ func AssertFortioNameWithClient(t *testing.T, urlbase string, name string, reqHo
 func AssertContainerState(t *testing.T, service libservice.Service, state string) {
 	containerStatus, err := service.GetStatus()
 	require.NoError(t, err)
-	require.Equal(t, containerStatus, state, fmt.Sprintf("Expected: %s. Got %s", containerStatus, state))
+	require.Equal(t, containerStatus, state, fmt.Sprintf("Expected: %s. Got %s", state, containerStatus))
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
- with changes introduced in: https://github.com/hashicorp/consul/pull/18130/files, make dev-docker still builds `consul:local` image whilst the integration tests locally are looking for `hashicorp/consul:local`. This PR fixes that 
- Little bonus: whilst working on integration tests I realized `AssertContainerState` gives the container statuses in reverse orders 


### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
- CI tests
- or locally: `make dev-docker` and run any integration test of your choice
