### PR TITLE
Fix a bug that wrongly trims domains when there is an overlap with DC name 1.15.x

### DIFF
--- a/.changelog/17160.txt
+++ b/.changelog/17160.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix a bug that wrongly trims domains when there is an overlap with DC name.
+```

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -1043,7 +1043,7 @@ func (d *DNSServer) trimDomain(query string) string {
 		longer, shorter = shorter, longer
 	}
 
-	if strings.HasSuffix(query, longer) {
+	if strings.HasSuffix(query, "."+strings.TrimLeft(longer, ".")) {
 		return strings.TrimSuffix(query, longer)
 	}
 	return strings.TrimSuffix(query, shorter)


### PR DESCRIPTION
This is a backport of https://github.com/hashicorp/consul/pull/17160