### PR TITLE
Fix a bug that wrongly trims domains when there is an overlap with DC 1.16.x

### DIFF
--- a/.changelog/17160.txt
+++ b/.changelog/17160.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix a bug that wrongly trims domains when there is an overlap with DC name.
+```

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -1055,7 +1055,7 @@ func (d *DNSServer) trimDomain(query string) string {
 		longer, shorter = shorter, longer
 	}
 
-	if strings.HasSuffix(query, longer) {
+	if strings.HasSuffix(query, "."+strings.TrimLeft(longer, ".")) {
 		return strings.TrimSuffix(query, longer)
 	}
 	return strings.TrimSuffix(query, shorter)

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -7071,6 +7071,45 @@ func TestDNS_AltDomains_Overlap(t *testing.T) {
 	}
 }
 
+func TestDNS_AltDomain_DCName_Overlap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	// this tests the DC name overlap with the consul domain/alt-domain
+	// we should get response when DC suffix is a prefix of consul alt-domain
+	t.Parallel()
+	a := NewTestAgent(t, `
+		datacenter = "dc-test"
+		node_name = "test-node"
+		alt_domain = "test.consul."
+	`)
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc-test")
+
+	questions := []string{
+		"test-node.node.dc-test.consul.",
+		"test-node.node.dc-test.test.consul.",
+	}
+
+	for _, question := range questions {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeA)
+
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m, a.DNSAddr())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		require.Len(t, in.Answer, 1)
+
+		aRec, ok := in.Answer[0].(*dns.A)
+		require.True(t, ok)
+		require.Equal(t, aRec.A.To4().String(), "127.0.0.1")
+	}
+}
+
 func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")


### PR DESCRIPTION
This is a backport of https://github.com/hashicorp/consul/pull/17160