### PR TITLE
[NET-3700] add `omitempty` to api prepared query targets

### DIFF
--- a/api/prepared_query.go
+++ b/api/prepared_query.go
@@ -32,11 +32,11 @@ type QueryFailoverTarget struct {
 
 	// Partition specifies a partition to try during failover
 	// Note: Partition are available only in Consul Enterprise
-	Partition string
+	Partition string `json:",omitempty"`
 
 	// Namespace specifies a namespace to try during failover
 	// Note: Namespaces are available only in Consul Enterprise
-	Namespace string
+	Namespace string `json:",omitempty"`
 }
 
 // QueryDNSOptions controls settings when query results are served over DNS.


### PR DESCRIPTION
Manual backport of c2bbe67714ee7c603447e18c25ad391b8de6226e.

### Description

This change is needed to address client errors for consumers of the `api` submodule. Backporting to the only release line the bug exists in (1.16).

No changelog was added for the original fix in `main`, so will add one in a separate change in `main` and backport it.

### Testing & Reproduction steps

I expect automated tests to continue to pass.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
