### PR TITLE
[NET-4865] security: Update Go version to 1.20.6

### DIFF
--- a/.changelog/18190.txt
+++ b/.changelog/18190.txt
@@ -1,0 +1,5 @@
+```release-note:security
+Upgrade to use Go 1.20.6.
+This resolves [CVE-2023-29406](https://github.com/advisories/GHSA-f8f7-69v5-w4vx)(`net/http`) for uses of the standard library. 
+A separate change updates dependencies on `golang.org/x/net` to use `0.12.0`.
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,15 +84,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.20.4", goos: "linux", goarch: "386"}
-          - {go: "1.20.4", goos: "linux", goarch: "amd64"}
-          - {go: "1.20.4", goos: "linux", goarch: "arm"}
-          - {go: "1.20.4", goos: "linux", goarch: "arm64"}
-          - {go: "1.20.4", goos: "freebsd", goarch: "386"}
-          - {go: "1.20.4", goos: "freebsd", goarch: "amd64"}
-          - {go: "1.20.4", goos: "windows", goarch: "386"}
-          - {go: "1.20.4", goos: "windows", goarch: "amd64"}
-          - {go: "1.20.4", goos: "solaris", goarch: "amd64"}
+          - {go: "1.20.6", goos: "linux", goarch: "386"}
+          - {go: "1.20.6", goos: "linux", goarch: "amd64"}
+          - {go: "1.20.6", goos: "linux", goarch: "arm"}
+          - {go: "1.20.6", goos: "linux", goarch: "arm64"}
+          - {go: "1.20.6", goos: "freebsd", goarch: "386"}
+          - {go: "1.20.6", goos: "freebsd", goarch: "amd64"}
+          - {go: "1.20.6", goos: "windows", goarch: "386"}
+          - {go: "1.20.6", goos: "windows", goarch: "amd64"}
+          - {go: "1.20.6", goos: "solaris", goarch: "amd64"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -181,7 +181,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.20.4", goos: "linux", goarch: "s390x"}
+          - {go: "1.20.6", goos: "linux", goarch: "s390x"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -232,7 +232,7 @@ jobs:
       matrix:
         goos: [ darwin ]
         goarch: [ "amd64", "arm64" ]
-        go: [ "1.20.4" ]
+        go: [ "1.20.6" ]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-ARG GOLANG_VERSION=1.20.4
+ARG GOLANG_VERSION=1.20.6
 FROM golang:${GOLANG_VERSION}
 
 WORKDIR /consul


### PR DESCRIPTION
This resolves [CVE-2023-29406](https://nvd.nist.gov/vuln/detail/CVE-2023-29406) for uses of the `net/http` standard library.

Note that until the follow-up to #18124 is done, the version of Go used in those impacted tests will need to remain on 1.20.5.

See related PR for `golang.org/x/net` dependencies: https://github.com/hashicorp/consul/pull/18186

### Description

Resolves CVE and brings us up to the latest version of Go.

### Testing & Reproduction steps

Tests should continue to pass.

### Links

https://nvd.nist.gov/vuln/detail/CVE-2023-29406
https://go-review.googlesource.com/c/go/+/506996
https://go-review.googlesource.com/c/net/+/506995

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
