### PR TITLE
Fix deletion of non-existent config entry

### DIFF
--- a/.changelog/18199.txt
+++ b/.changelog/18199.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: return error when delete non-existent config entry with `consul config delete`command
+```

--- a/.changelog/18199.txt
+++ b/.changelog/18199.txt
@@ -1,3 +1,6 @@
 ```release-note:improvement
-cli: return error when delete non-existent config entry with `consul config delete`command
+cli: return error when delete non-existent config entry with `consul config delete` command
+```
+```release-note:breaking-change
+http: `DELETE /v1/config` endpoint now immediately return error when non-existent config entry is provided. Prior to this change, the endpoint return a success code with an empty result
 ```

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -144,7 +144,7 @@ func (c *ConfigEntry) shouldSkipOperation(args *structs.ConfigEntryRequest) (boo
 		return c.shouldSkipUpsertOperation(currentEntry, args.Entry)
 	case structs.ConfigEntryDelete, structs.ConfigEntryDeleteCAS:
 		if currentEntry == nil {
-			return false, fmt.Errorf("config entry Kind %q Name %q not found", args.Entry.GetKind(), args.Entry.GetName())
+			return true, fmt.Errorf("config entry Kind %q Name %q not found", args.Entry.GetKind(), args.Entry.GetName())
 		}
 		return false, nil
 	default:

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -143,7 +143,10 @@ func (c *ConfigEntry) shouldSkipOperation(args *structs.ConfigEntryRequest) (boo
 	case structs.ConfigEntryUpsert, structs.ConfigEntryUpsertCAS:
 		return c.shouldSkipUpsertOperation(currentEntry, args.Entry)
 	case structs.ConfigEntryDelete, structs.ConfigEntryDeleteCAS:
-		return (currentEntry == nil), nil
+		if currentEntry == nil {
+			return false, fmt.Errorf("config entry Kind %q Name %q not found", args.Entry.GetKind(), args.Entry.GetName())
+		}
+		return false, nil
 	default:
 		return false, fmt.Errorf("invalid config entry operation type: %v", args.Op)
 	}

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -994,7 +994,6 @@ func TestConfigEntry_Delete(t *testing.T) {
 		var out structs.ConfigEntryDeleteResponse
 		err := msgpackrpc.CallWithCodec(codec, "ConfigEntry.Delete", &args, &out)
 		require.Error(t, err)
-
 	})
 
 	testutil.RunStep(t, "delete non-existent config entry in dc1 - will error", func(t *testing.T) {
@@ -1006,8 +1005,10 @@ func TestConfigEntry_Delete(t *testing.T) {
 			},
 		}
 		var out structs.ConfigEntryDeleteResponse
+		errStr := fmt.Sprintf("config entry Kind %q Name %q not found", args.Entry.GetKind(), args.Entry.GetName())
 		err := msgpackrpc.CallWithCodec(codec, "ConfigEntry.Delete", &args, &out)
 		require.Error(t, err)
+		require.EqualError(t, err, errStr)
 	})
 }
 

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -983,7 +983,7 @@ func TestConfigEntry_Delete(t *testing.T) {
 		})
 	})
 
-	testutil.RunStep(t, "delete in dc1 again - should be fine", func(t *testing.T) {
+	testutil.RunStep(t, "delete in dc1 again - will error", func(t *testing.T) {
 		args := structs.ConfigEntryRequest{
 			Datacenter: "dc1",
 			Entry: &structs.ServiceConfigEntry{
@@ -992,8 +992,22 @@ func TestConfigEntry_Delete(t *testing.T) {
 			},
 		}
 		var out structs.ConfigEntryDeleteResponse
-		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Delete", &args, &out))
-		require.True(t, out.Deleted)
+		err := msgpackrpc.CallWithCodec(codec, "ConfigEntry.Delete", &args, &out)
+		require.Error(t, err)
+
+	})
+
+	testutil.RunStep(t, "delete non-existent config entry in dc1 - will error", func(t *testing.T) {
+		args := structs.ConfigEntryRequest{
+			Datacenter: "dc1",
+			Entry: &structs.ServiceConfigEntry{
+				Kind: structs.ServiceDefaults,
+				Name: "nonexistentconfig",
+			},
+		}
+		var out structs.ConfigEntryDeleteResponse
+		err := msgpackrpc.CallWithCodec(codec, "ConfigEntry.Delete", &args, &out)
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
### Description

This PR is for this issue https://github.com/hashicorp/consul/issues/18166

### Testing & Reproduction steps

- Manual test

```
 go test -timeout 30s -run ^TestConfigEntry_Delete$ github.com/hashicorp/consul/agent/consul
ok      github.com/hashicorp/consul/agent/consul        (cached)
```

### Links

### PR Checklist

* [X] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
