### PR TITLE
[NET-4122] Doc guidance for federation with externalServers

### DIFF
--- a/website/content/docs/k8s/deployment-configurations/servers-outside-kubernetes.mdx
+++ b/website/content/docs/k8s/deployment-configurations/servers-outside-kubernetes.mdx
@@ -114,6 +114,10 @@ to create policies, tokens, and an auth method. If you are [enabling Consul serv
 so that the Consul servers can validate a Kubernetes service account token when using the [Kubernetes auth method](/consul/docs/security/acl/auth-methods/kubernetes)
 with `consul login`.
 
+-> **Note:** If `externalServers.k8sAuthMethodHost` is set and you are also using WAN federation 
+(`global.federation.enabled` is set to `true`), ensure that `global.federation.k8sAuthMethodHost` is set to the same 
+value as `externalServers.k8sAuthMethodHost`.
+
 <CodeBlockConfig filename="values.yaml">
 
 ```yaml

--- a/website/content/docs/k8s/helm.mdx
+++ b/website/content/docs/k8s/helm.mdx
@@ -484,8 +484,9 @@ Use these links to navigate to a particular top-level stanza.
     - `enabled` ((#v-global-federation-enabled)) (`boolean: false`) - If enabled, this datacenter will be federation-capable. Only federation
       via mesh gateways is supported.
       Mesh gateways and servers will be configured to allow federation.
-      Requires `global.tls.enabled`, `meshGateway.enabled` and `connectInject.enabled`
-      to be true. Requires Consul 1.8+.
+      Requires `global.tls.enabled`, `connectInject.enabled`, and one of 
+      `meshGateway.enabled` or `externalServers.enabled` to be true.
+      Requires Consul 1.8+.
 
     - `createFederationSecret` ((#v-global-federation-createfederationsecret)) (`boolean: false`) - If true, the chart will create a Kubernetes secret that can be imported
       into secondary datacenters so they can federate with this datacenter. The
@@ -497,8 +498,8 @@ Use these links to navigate to a particular top-level stanza.
 
     - `primaryDatacenter` ((#v-global-federation-primarydatacenter)) (`string: null`) - The name of the primary datacenter.
 
-    - `primaryGateways` ((#v-global-federation-primarygateways)) (`array<string>: []`) - A list of addresses of the primary mesh gateways in the form `<ip>:<port>`.
-      (e.g. ["1.1.1.1:443", "2.3.4.5:443"]
+    - `primaryGateways` ((#v-global-federation-primarygateways)) (`array<string>: []`) - A list of addresses of the primary mesh gateways in the form `<ip>:<port>`
+      (e.g. `["1.1.1.1:443", "2.3.4.5:443"]`).
 
     - `k8sAuthMethodHost` ((#v-global-federation-k8sauthmethodhost)) (`string: null`) - If you are setting `global.federation.enabled` to true and are in a secondary datacenter,
       set `k8sAuthMethodHost` to the address of the Kubernetes API server of the secondary datacenter.
@@ -506,6 +507,9 @@ Use these links to navigate to a particular top-level stanza.
       This auth method will be used to provision ACL tokens for Consul components and is different
       from the one used by the Consul Service Mesh.
       Please refer to the [Kubernetes Auth Method documentation](/consul/docs/security/acl/auth-methods/kubernetes).
+
+      If `externalServers.enabled` is set to true, `global.federation.k8sAuthMethodHost` and 
+      `externalServers.k8sAuthMethodHost` should be set to the same value.
 
       You can retrieve this value from your `kubeconfig` by running:
 
@@ -1119,6 +1123,9 @@ Use these links to navigate to a particular top-level stanza.
     `connectInject.enabled` to true, set `k8sAuthMethodHost` to the address of the Kubernetes API server.
     This address must be reachable from the Consul servers.
     Please refer to the [Kubernetes Auth Method documentation](/consul/docs/security/acl/auth-methods/kubernetes).
+
+    If `global.federation.enabled` is set to true, `global.federation.k8sAuthMethodHost` and 
+    `externalServers.k8sAuthMethodHost` should be set to the same value.
 
     You could retrieve this value from your `kubeconfig` by running:
 


### PR DESCRIPTION
Add guidance for proper configuration when joining to a secondary cluster using WAN fed with external servers also enabled.

Also clarify federation requirements and fix formatting for an unrelated value.

Update both the Helm chart reference (synced from `consul-k8s`, see hashicorp/consul-k8s#2583) and the docs on using `externalServers`.

### Links

GH issue inspiring this clarification: https://github.com/hashicorp/consul-k8s/issues/2138

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
