### PR TITLE
ci: don't verify s390x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,7 +371,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["386", "amd64", "arm", "arm64", "s390x"]
+        arch: ["386", "amd64", "arm", "arm64"]
       fail-fast: true
     env:
       version: ${{ needs.set-product-version.outputs.product-version }}


### PR DESCRIPTION
### Description

Our verification process requires running the binary. We have no hardware to do this for `s390x`, so we can't verify.