### PR TITLE
Align build arch matrix with enterprise

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["386", "amd64", "arm", "arm64"]
+        include:
+          - { arch: "386" }
+          - { arch: "arm" }
+          - { arch: "amd64" }
+          - { arch: "arm64" }
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.set-product-version.outputs.product-version}}
@@ -371,7 +375,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["386", "amd64", "arm", "arm64"]
+        include:
+          - { arch: "386" }
+          - { arch: "arm" }
+          - { arch: "amd64" }
+          - { arch: "arm64" }
       fail-fast: true
     env:
       version: ${{ needs.set-product-version.outputs.product-version }}
@@ -432,7 +440,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["i386", "amd64", "armhf", "arm64"]
+        include:
+          - { arch: "i386" }
+          - { arch: "armhf" }
+          - { arch: "amd64" }
+          - { arch: "arm64" }
       # fail-fast: true
     env:
       version: ${{ needs.set-product-version.outputs.product-version }}
@@ -469,8 +481,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        include:
+          - { arch: "i386" }
+          - { arch: "x86_64" }
         # TODO(eculver): re-enable when there is a smaller verification container available
-        arch: ["i386", "x86_64"] #, "armv7hl", "aarch64"]
+          # - { arch: "armv7hl" }
+          # - { arch: "aarch64" }
     env:
       version: ${{ needs.set-product-version.outputs.product-version }}
 


### PR DESCRIPTION
Ensure that OSS remains in sync w/ Enterprise by aligning the format of arch matrix args for various build jobs.

This should help lower the chance of merge conflicts in the future.

Backporting to 1.16; prior to that branch, there was no divergence as it predates FIPS support in Enterprise.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
