### PR TITLE
NET-4996 - filter go-tests and test-integration workflows from running on docs only and ui only changes

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -2,14 +2,13 @@ name: go-tests
 
 on:
   pull_request:
-    branches-ignore:
-      - stable-website
+    paths-ignore: 
+      - '.changelog/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'contributing/**'
       - 'docs/**'
       - 'ui/**'
-      - 'mktg-**' # Digital Team Terraform-generated branches' prefix
-      - 'backport/docs/**'
-      - 'backport/ui/**'
-      - 'backport/mktg-**'
+      - 'website/**'
   push:
     branches:
       # Push events on the main branch

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -5,14 +5,13 @@ name: test-integrations
 
 on:
   pull_request:
-    branches-ignore:
-      - stable-website
+    paths-ignore:
+      - '.changelog/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'contributing/**'
       - 'docs/**'
       - 'ui/**'
-      - 'mktg-**' # Digital Team Terraform-generated branch prefix
-      - 'backport/docs/**'
-      - 'backport/ui/**'
-      - 'backport/mktg-**'
+      - 'website/**'
 
 env:
   TEST_RESULTS_DIR: /tmp/test-results


### PR DESCRIPTION


### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
