### PR TITLE
Revert "NET-4996 - filter go-tests and test-integration workflows from running on docs only and ui only changes"

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -2,13 +2,14 @@ name: go-tests
 
 on:
   pull_request:
-    paths-ignore: 
-      - '.changelog/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - 'contributing/**'
+    branches-ignore:
+      - stable-website
       - 'docs/**'
       - 'ui/**'
-      - 'website/**'
+      - 'mktg-**' # Digital Team Terraform-generated branches' prefix
+      - 'backport/docs/**'
+      - 'backport/ui/**'
+      - 'backport/mktg-**'
   push:
     branches:
       # Push events on the main branch

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -5,13 +5,14 @@ name: test-integrations
 
 on:
   pull_request:
-    paths-ignore:
-      - '.changelog/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - 'contributing/**'
+    branches-ignore:
+      - stable-website
       - 'docs/**'
       - 'ui/**'
-      - 'website/**'
+      - 'mktg-**' # Digital Team Terraform-generated branch prefix
+      - 'backport/docs/**'
+      - 'backport/ui/**'
+      - 'backport/mktg-**'
 
 env:
   TEST_RESULTS_DIR: /tmp/test-results


### PR DESCRIPTION
Reverts hashicorp/consul#18236

Our branch protection rules require that the last job in each of these two workflows pass.  So if they don't run, GH does not figure out why, it just blocks the PR based on the GitHub check is not complete.
<img width="913" alt="Screenshot 2023-07-24 at 9 04 56 AM" src="https://github.com/hashicorp/consul/assets/2481360/49150a41-45bc-450a-a673-633547c16473">

This is GitHub's [guidance](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks):

>Warning: If a workflow is skipped due to [path filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), [branch filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore) or a [commit message](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs), then checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging.

>For this reason you should not use path or branch filtering to skip workflow runs if the workflow is required. For more information, see "[Skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs)" and "[Required workflows](https://docs.github.com/en/actions/using-workflows/required-workflows)."

>If, however, a job within a workflow is skipped due to a conditional, it will report its status as "Success". For more information, see "[Using conditions to control job execution](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution)."
