### PR TITLE
add auto lic usage docs

### DIFF
--- a/website/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/website/content/docs/enterprise/license/utilization-reporting.mdx
@@ -1,0 +1,172 @@
+---
+page_title: Automated license utilization reporting
+description: >-
+  Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
+---
+
+# Automated license utilization reporting
+
+This topic describes how to enable automated license utilization reporting in Consul Enterprise. This feature automatically sends license utilization data to HashiCorp so that you do not have to manually collect and report them. It also enables you to review your license usage with the monitoring solution you already use, such as Splunk and Datadog, as you optimize and manage your deployments.
+
+## Introduction 
+
+You can use automated license utilization report to understand how much more networking infrastructure you can deploy under your current contract. This helps you protect against overutilization and budget for predicted consumption.  
+
+Automated reporting shares the minimum data required to validate license utilization as defined in our contracts. This data mostly consists of computed metrics, and it will never contain Personal Identifiable Information (PII) or other sensitive information. Automated reporting shares the data with HashiCorp using a secure unidirectional HTTPS API and makes an auditable record in the product logs each time it submits a report.
+
+## Requirements
+
+_Air-gapped_ installations, which are systems with no network interfaces, are not supported.
+
+The following versions of Consul Enterprise are support automated license utilization reporting:
+
+- Patch releases of Consul Enterprise 1.13.9 and newer.
+
+Download a supported release from the [Consul Versions page](https://releases.hashicorp.com/consul/).
+  
+## Enable automated reporting
+
+Outbound network traffic must be configured correctly. Otherwise, automated reporting will not work. 
+
+To enable automated reporting, complete the following steps:
+
+1. [Allow outbound HTTPS traffic on port 443](#allow-outbound-https-traffic)
+1. [Check product logs](#check-product-logs)
+
+### Allow outbound HTTPS traffic on port 443
+
+Make sure that your network allows HTTPS egress on port 443 from `https://reporting.hashicorp.services` by adding the following IP adddresses to your allow-list:
+
+- `100.20.70.12`
+- `35.166.5.222`
+- `23.95.85.111`
+- `44.215.244.1`
+
+### Check product logs
+
+Automatic license utilization reporting starts sending data within 24 hours. Check the product logs for records that the data sent successfully.
+
+<CodeBlockConfig hideClipboard>
+
+```
+[DEBUG] beginning snapshot export
+[DEBUG] creating payload
+[DEBUG] marshalling payload to json
+[DEBUG] generating authentication headers
+[DEBUG] creating request
+[DEBUG] sending request
+[DEBUG] performing request: method=POST url=https://census.license.hashicorp.services
+[DEBUG] recording audit record
+[INFO]  reporting: Report sent: auditRecord={"payload":{"payload_version":"1","license_id":"d2cdd857-4202-5a45-70a6-e4b531050c34","product":"consul","product_version":"1.16.0-dev+ent","export_timestamp":"2023-05-26T20:09:13.753921087Z","snapshots":[{"snapshot_version":1,"snapshot_id":"0001J724F90F4XWQDSAA76ZQWA","process_id":"01H1CTJPC1S8H7Q45MKTJ689ZW","timestamp":"2023-05-26T20:09:13.753513962Z","schema_version":"1.0.0","service":"consul","metrics":{"consul.billable.nodes":{"key":"consul.billable.nodes","kind":"counter","mode":"write","value":2},"consul.billable.service_instances":{"key":"consul.billable.service_instances","kind":"counter","mode":"write","value":2}}}],"metadata":{}}}
+[DEBUG] completed recording audit record
+[DEBUG] export finished successfully"
+```
+
+</CodeBlockConfig>
+
+If your installation is air-gapped or your network does not allow the correct egress, the logs show an error. 
+
+<CodeBlockConfig hideClipboard>
+
+```
+[DEBUG] reporting: beginning snapshot export
+[DEBUG] reporting: creating payload
+[DEBUG] reporting: marshalling payload to json
+[DEBUG] reporting: generating authentication headers
+[DEBUG] reporting: creating request
+[DEBUG] reporting: sending request
+[DEBUG] reporting: performing request: method=POST url=https://census.license.hashicorp.services
+[DEBUG] reporting: error status code received: statusCode=403
+```
+
+</CodeBlockConfig>
+
+In this case, reconfigure your network to allow egress and check back in 24 hours. 
+
+## Opt out
+
+If your installation is air-gapped or you want to manually collect and report on the same license utilization metrics, you can opt out of automated reporting. 
+
+Manually reporting these metrics can be time consuming. Opting out of automated reporting does not mean that you also opt out from sending license utilization metrics. Customers who opt out of automated reporting are still required to manually collect and send license utilization metrics to HashiCorp. 
+
+If you are considering opting out because you are worried about the data, we strongly recommend that you review the [example payloads](#example-payloads) before opting out. If you have concerns with any of the automatically reported data, raise these concerns with your account manager. 
+
+There are two methods for opting out of automated reporting: 
+
+- HCL configuration (recommended)
+- Environment variable (requires restart)
+
+We recommend opting out in your product's configuration file because it does not require a system restart. Add the following block to your `configuration.hcl` or `configuration.json` file.
+
+```hcl
+reporting {
+	license {
+		enabled = false
+  }
+}
+```
+
+When you opt out using an environment variable, once you restart your system it will provide a startup message confirming that you have disabled automated reporting. Set the following environment variable to disable automated reporting:
+
+<CodeBlockConfig>
+
+```shell-session
+$ export OPTOUT_LICENSE_REPORTING=true
+```
+
+</CodeBlockConfig>
+
+After you set the environment variable, restart your system to complete the process for opting out.
+
+```shell-session
+$ consul reload
+```
+
+
+Check your product logs 24 hours after opting out to make sure that the system is not trying to send reports. Keep in mind that if your configuration file and environment variable differ, the environment variable setting takes precedence.
+
+## Example payloads
+
+HashiCorp collects the following utilization data as JSON payloads: 
+`exporter_version` - The version of the licensing exporter
+
+<CodeBlockConfig hideClipboard>
+
+```json
+{
+  "payload": {
+    "payload_version": "1",
+    "license_id": "d2cdd857-4202-5a45-70a6-e4b531050c34",
+    "product": "consul",
+    "product_version": "1.16.0-dev+ent",
+    "export_timestamp": "2023-05-26T20:09:13.753921087Z",
+    "snapshots": [
+      {
+        "snapshot_version": 1,
+        "snapshot_id": "0001J724F90F4XWQDSAA76ZQWA",
+        "process_id": "01H1CTJPC1S8H7Q45MKTJ689ZW",
+        "timestamp": "2023-05-26T20:09:13.753513962Z",
+        "schema_version": "1.0.0",
+        "service": "consul",
+        "metrics": {
+          "consul.billable.nodes": {
+            "key": "consul.billable.nodes",
+            "kind": "counter",
+            "mode": "write",
+            "value": 2
+          },
+          "consul.billable.service_instances": {
+            "key": "consul.billable.service_instances",
+            "kind": "counter",
+            "mode": "write",
+            "value": 2
+          }
+        }
+      }
+    ],
+    "metadata": {}
+  }
+}
+```
+
+</CodeBlockConfig>

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1210,6 +1210,10 @@
             "path": "enterprise/license/overview"
           },
           {
+            "title": "Automated License Utilization Reporting",
+            "path": "enterprise/license/utilization-reporting"
+          },
+          {
             "title": "FAQ",
             "path": "enterprise/license/faq"
           }
@@ -1247,8 +1251,8 @@
             "path": "api-gateway/usage/usage"
           },
           {
-          "title": "Reroute HTTP Requests",
-          "path": "api-gateway/usage/reroute-http-requests"
+            "title": "Reroute HTTP Requests",
+            "path": "api-gateway/usage/reroute-http-requests"
           },
           {
             "title": "Route Traffic to Peered Services",
@@ -1257,8 +1261,7 @@
           {
             "title": "Error Messages",
             "path": "api-gateway/usage/errors"
-          }              
-              
+          }
         ]
       },
       {


### PR DESCRIPTION
### Description

Automated reporting for license consumptions was added to this release, but the docs were not back-ported. This PR adds the docs for this functionality. 
 

### PR Checklist

* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
