### PR TITLE
[NET-3700] Backfill changelog entry for c2bbe67 and 7402d06

### DIFF
--- a/.changelog/18184.txt
+++ b/.changelog/18184.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fix client deserialization errors by marking new Enterprise-only prepared query fields as omit empty
+```


### PR DESCRIPTION
Add a changelog entry for the follow-up PR since it was specific to the fix and references the original change.

(Note: this PR is marked `pr/no-changelog` because it's adding a changelog for a different PR.)

Follow-up to https://github.com/hashicorp/consul/pull/18184.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
