### PR TITLE
NET-4897 - update comment to include the current issue url from the go team.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1005,8 +1005,10 @@ func (r *request) toHTTP() (*http.Request, error) {
 	// this is required since go started validating req.host in 1.20.6 and 1.19.11.
 	// prior to that they would strip out the slashes for you.  They removed that
 	// behavior and added more strict validation as part of a CVE.
-	// https://github.com/golang/go/issues/60374
-	// the hope is that
+	// This issue is being tracked by the Go team:
+	// https://github.com/golang/go/issues/61431
+	// If there is a resolution in this issue, we will remove this code.
+	// In the time being, this is the accepted workaround.
 	if strings.HasPrefix(r.url.Host, "/") {
 		r.url.Host = "localhost"
 	}


### PR DESCRIPTION
### Description

A new [issue](https://github.com/golang/go/issues/61431) has been created on the Go project backlog that replaces the comment thread that was on the PR that introduced the breaking change.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
