### PR TITLE
Backport of member cli: add -filter expression to flags into release/1.15.x

### DIFF
--- a/.changelog/18223.txt
+++ b/.changelog/18223.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: `consul members` command uses `-filter` expression to filter members based on bexpr.
+```

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -614,6 +614,21 @@ func (s *HTTPHandlers) AgentMembers(resp http.ResponseWriter, req *http.Request)
 		}
 	}
 
+	// filter the members by parsed filter expression
+	var filterExpression string
+	s.parseFilter(req, &filterExpression)
+	if filterExpression != "" {
+		filter, err := bexpr.CreateFilter(filterExpression, nil, members)
+		if err != nil {
+			return nil, err
+		}
+		raw, err := filter.Execute(members)
+		if err != nil {
+			return nil, err
+		}
+		members = raw.([]serf.Member)
+	}
+
 	total := len(members)
 	if err := s.agent.filterMembers(token, &members); err != nil {
 		return nil, err

--- a/api/agent.go
+++ b/api/agent.go
@@ -270,6 +270,8 @@ type MembersOpts struct {
 	// Segment is the LAN segment to show members for. Setting this to the
 	// AllSegments value above will show members in all segments.
 	Segment string
+
+	Filter string
 }
 
 // AgentServiceRegistration is used to register a new service
@@ -765,6 +767,10 @@ func (a *Agent) MembersOpts(opts MembersOpts) ([]*AgentMember, error) {
 	r.params.Set("segment", opts.Segment)
 	if opts.WAN {
 		r.params.Set("wan", "1")
+	}
+
+	if opts.Filter != "" {
+		r.params.Set("filter", opts.Filter)
 	}
 
 	_, resp, err := a.c.doRequest(r)

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -152,6 +152,16 @@ func TestAPI_AgentMembersOpts(t *testing.T) {
 	if len(members) != 2 {
 		t.Fatalf("bad: %v", members)
 	}
+
+	members, err = agent.MembersOpts(MembersOpts{
+		WAN:    true,
+		Filter: `Tags["dc"] == dc2`,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	require.Equal(t, 1, len(members))
 }
 
 func TestAPI_AgentMembers(t *testing.T) {

--- a/command/members/members.go
+++ b/command/members/members.go
@@ -30,6 +30,7 @@ type cmd struct {
 	wan          bool
 	statusFilter string
 	segment      string
+	filter       string
 }
 
 func New(ui cli.Ui) *cmd {
@@ -51,6 +52,7 @@ func (c *cmd) init() {
 	c.flags.StringVar(&c.segment, "segment", consulapi.AllSegments,
 		"(Enterprise-only) If provided, output is filtered to only nodes in"+
 			"the given segment.")
+	c.flags.StringVar(&c.filter, "filter", "", "Filter to use with the request")
 
 	c.http = &flags.HTTPFlags{}
 	flags.Merge(c.flags, c.http.ClientFlags())
@@ -80,6 +82,7 @@ func (c *cmd) Run(args []string) int {
 	opts := consulapi.MembersOpts{
 		Segment: c.segment,
 		WAN:     c.wan,
+		Filter:  c.filter,
 	}
 	members, err := client.Agent().MembersOpts(opts)
 	if err != nil {

--- a/website/content/commands/members.mdx
+++ b/website/content/commands/members.mdx
@@ -48,6 +48,12 @@ Usage: `consul members [options]`
   in the WAN gossip pool. These are generally all the server nodes in
   each datacenter.
 
+- `-filter=<filter>` - Expression to use for filtering the results,
+  e.g., `-filter='Tags["dc"] == dc2'`.
+  See the [`/catalog/nodes` API documentation](/consul/api-docs/catalog#filtering) for a
+  description of what is filterable.
+
+
 #### Enterprise Options
 
 @include 'http_api_partition_options.mdx'


### PR DESCRIPTION
### Description

Manual backport of #18223 

The autogenerated one #18275  contains many irrelevant commits.

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
