### PR TITLE
docs: K8s secondary DC requirements

### DIFF
--- a/website/content/docs/k8s/deployment-configurations/multi-cluster/kubernetes.mdx
+++ b/website/content/docs/k8s/deployment-configurations/multi-cluster/kubernetes.mdx
@@ -81,7 +81,7 @@ Modifications:
 
 1. The Consul datacenter name is `dc1`. The datacenter name in each federated
    cluster **must be unique**.
-1. ACLs are enabled in the above config file. When ACLs are enabled, primary clusters must be able to make requests to the Kubernetes API URLs of secondary clusters. To disable ACLs for testing purposes, change the following settings:
+1. ACLs are enabled in the template configuration. When ACLs are enabled, primary clusters must be able to make requests to the Kubernetes API URLs of secondary clusters. To disable ACLs for testing purposes, change the following settings:
 
    ```yaml
    global:

--- a/website/content/docs/k8s/deployment-configurations/multi-cluster/kubernetes.mdx
+++ b/website/content/docs/k8s/deployment-configurations/multi-cluster/kubernetes.mdx
@@ -13,8 +13,8 @@ description: >-
 
 -> Looking for a step-by-step guide? Complete the [Secure and Route Service Mesh Communication Across Kubernetes](/consul/tutorials/kubernetes/kubernetes-mesh-gateways?utm_source=docs) tutorial to learn more.
 
-This page describes how to federate multiple Kubernetes clusters. See [Multi-Cluster Overview](/consul/docs/k8s/deployment-configurations/multi-cluster)
-for more information on use-cases and how it works.
+This page describes how to federate multiple Kubernetes clusters. Refer to [Multi-Cluster Overview](/consul/docs/k8s/deployment-configurations/multi-cluster)
+for more information, including [networking requirements](/consul/docs/k8s/deployment-configurations/multi-cluster#network-requirements).
 
 ## Primary Datacenter
 
@@ -81,8 +81,7 @@ Modifications:
 
 1. The Consul datacenter name is `dc1`. The datacenter name in each federated
    cluster **must be unique**.
-1. ACLs are enabled in the above config file. They can be disabled by setting:
-
+1. ACLs are enabled in the above config file. When ACLs are enabled, primary clusters must be able to make requests to the Kubernetes API URLs of secondary clusters. To disable ACLs for testing purposes, change the following settings:
 
    ```yaml
    global:
@@ -90,9 +89,9 @@ Modifications:
        manageSystemACLs: false
        createReplicationToken: false
    ```
+
    ACLs secure Consul by requiring every API call to present an ACL token that
-   is validated to ensure it has the proper permissions. If you are only testing Consul,
-   this is not required.
+   is validated to ensure it has the proper permissions.
 1. Gossip encryption is enabled in the above config file. To disable it, comment
    out or delete the `gossipEncryption` key:
 

--- a/website/content/docs/k8s/deployment-configurations/multi-cluster/vms-and-kubernetes.mdx
+++ b/website/content/docs/k8s/deployment-configurations/multi-cluster/vms-and-kubernetes.mdx
@@ -19,7 +19,7 @@ be federated with Kubernetes datacenters.
 
 ## Kubernetes as the Primary
 
-Just like with Kubernetes, one datacenter must be the [primary](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#primary-datacenter). If your primary datacenter is running on Kubernetes, use the Helm config from the [Primary Datacenter](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#primary-datacenter) section to install Consul.
+One Consul datacenter must be the [primary](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#primary-datacenter). If your primary datacenter is running on Kubernetes, use the Helm config from the [Primary Datacenter](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#primary-datacenter) section to install Consul.
 
 Once installed on Kubernetes, and with the `ProxyDefaults` [resource created](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#proxydefaults),
 you'll need to export the following information from the primary Kubernetes cluster:

--- a/website/content/docs/k8s/deployment-configurations/multi-cluster/vms-and-kubernetes.mdx
+++ b/website/content/docs/k8s/deployment-configurations/multi-cluster/vms-and-kubernetes.mdx
@@ -11,14 +11,15 @@ description: >-
 
 ~> This topic requires familiarity with [Mesh Gateways](/consul/docs/connect/gateways/mesh-gateway/service-to-service-traffic-wan-datacenters) and [WAN Federation Via Mesh Gateways](/consul/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways).
 
+This page describes how to federate Consul clusters separately deployed in VM and Kubernetes runtimes. Refer to [Multi-Cluster Overview](/consul/docs/k8s/deployment-configurations/multi-cluster)
+for more information, including [Kubernetes networking requirements](/consul/docs/k8s/deployment-configurations/multi-cluster#network-requirements).
+
 Consul datacenters running on non-kubernetes platforms like VMs or bare metal can
-be federated with Kubernetes datacenters. Just like with Kubernetes, one datacenter
-must be the [primary](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#primary-datacenter).
+be federated with Kubernetes datacenters. 
 
 ## Kubernetes as the Primary
 
-If your primary datacenter is running on Kubernetes, use the Helm config from the
-[Primary Datacenter](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#primary-datacenter) section to install Consul.
+Just like with Kubernetes, one datacenter must be the [primary](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#primary-datacenter). If your primary datacenter is running on Kubernetes, use the Helm config from the [Primary Datacenter](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#primary-datacenter) section to install Consul.
 
 Once installed on Kubernetes, and with the `ProxyDefaults` [resource created](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#proxydefaults),
 you'll need to export the following information from the primary Kubernetes cluster:
@@ -210,7 +211,7 @@ ports {
 
 If you're running your primary datacenter on VMs then you'll need to manually
 construct the [Federation Secret](/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#federation-secret) in order to federate
-Kubernetes clusters as secondaries.
+Kubernetes clusters as secondaries. In addition, primary clusters must be able to make requests to the Kubernetes API URLs of secondary clusters when ACLs are enabled.
 
 -> Your VM cluster must be running mesh gateways, and have mesh gateway WAN
 federation enabled. See [WAN Federation via Mesh Gateways](/consul/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways).


### PR DESCRIPTION
### Description

This PR responds to a request to highlight the Kubernetes WAN Federation requirement that when ACLs are enabled, the Kube API of the secondary datacenters must be routable from the primary datacenter.

### Links

- [JIRA Ticket](https://hashicorp.atlassian.net/browse/CE-433)
- [Slack convo](https://hashicorp.slack.com/archives/CMTKDL287/p1660697937824169)

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
