### PR TITLE
Fix typo in Envoy extensions doc

### DIFF
--- a/website/content/docs/connect/proxies/envoy-extensions/index.mdx
+++ b/website/content/docs/connect/proxies/envoy-extensions/index.mdx
@@ -40,7 +40,7 @@ The `lua` Envoy extension enables HTTP Lua filters in your Consul Envoy proxies.
 
 ### Property override
 
-The `property-override` extension lets you set and unset individual properties pm the Envoy resources that Consul generates. Use the extension instead of [escape-hatch overrides](/consul/docs/connect/proxies/envoy#escape-hatch-overrides) to enable advanced Envoy configuration. Refer to the [property override documentation](/consul/docs/connect/proxies/envoy-extensions/usage/property-override) for more information.
+The `property-override` extension lets you set and unset individual properties on the Envoy resources that Consul generates. Use the extension instead of [escape-hatch overrides](/consul/docs/connect/proxies/envoy#escape-hatch-overrides) to enable advanced Envoy configuration. Refer to the [property override documentation](/consul/docs/connect/proxies/envoy-extensions/usage/property-override) for more information.
 
 ### WebAssembly
 


### PR DESCRIPTION
### Description

Fix minor typo `pm` -> `on`.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
