### PR TITLE
Backport of [CC-5718] Remove HCP token requirement during bootstrap

### DIFF
--- a/.changelog/18140.txt
+++ b/.changelog/18140.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+hcp: Removes requirement for HCP to provide a management token
+```

--- a/agent/hcp/bootstrap/bootstrap.go
+++ b/agent/hcp/bootstrap/bootstrap.go
@@ -295,21 +295,25 @@ func persistAndProcessConfig(dataDir string, devMode bool, bsCfg *hcp.BootstrapC
 			return "", fmt.Errorf("failed to persist bootstrap config: %w", err)
 		}
 
-		if err := validateManagementToken(bsCfg.ManagementToken); err != nil {
-			return "", fmt.Errorf("invalid management token: %w", err)
-		}
-		if err := persistManagementToken(dir, bsCfg.ManagementToken); err != nil {
-			return "", fmt.Errorf("failed to persist HCP management token: %w", err)
+		// HCP only returns the management token if it requires Consul to
+		// initialize it
+		if bsCfg.ManagementToken != "" {
+			if err := validateManagementToken(bsCfg.ManagementToken); err != nil {
+				return "", fmt.Errorf("invalid management token: %w", err)
+			}
+			if err := persistManagementToken(dir, bsCfg.ManagementToken); err != nil {
+				return "", fmt.Errorf("failed to persist HCP management token: %w", err)
+			}
 		}
 
-		if err := persistSucessMarker(dir); err != nil {
+		if err := persistSuccessMarker(dir); err != nil {
 			return "", fmt.Errorf("failed to persist success marker: %w", err)
 		}
 	}
 	return cfgJSON, nil
 }
 
-func persistSucessMarker(dir string) error {
+func persistSuccessMarker(dir string) error {
 	name := filepath.Join(dir, successFileName)
 	return os.WriteFile(name, []byte(""), 0600)
 
@@ -349,12 +353,9 @@ func persistTLSCerts(dir string, serverCert, serverKey string, caCerts []string)
 	return nil
 }
 
-// Basic validation to ensure a UUID was loaded.
+// Basic validation to ensure a UUID was loaded and assumes the token is non-empty
 func validateManagementToken(token string) error {
-	if token == "" {
-		return errors.New("missing HCP management token")
-	}
-
+	// note: we assume that the token is not an empty string
 	if _, err := uuid.ParseUUID(token); err != nil {
 		return errors.New("management token is not a valid UUID")
 	}

--- a/agent/hcp/bootstrap/bootstrap_test.go
+++ b/agent/hcp/bootstrap/bootstrap_test.go
@@ -304,9 +304,10 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 		warning string
 	}
 	type testCase struct {
-		existingCluster bool
-		mutateFn        func(t *testing.T, dir string)
-		expect          expect
+		existingCluster        bool
+		disableManagementToken bool
+		mutateFn               func(t *testing.T, dir string)
+		expect                 expect
 	}
 
 	run := func(t *testing.T, tc testCase) {
@@ -318,7 +319,7 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 
 		// Do some common setup as if we received config from HCP and persisted it to disk.
 		require.NoError(t, lib.EnsurePath(dir, true))
-		require.NoError(t, persistSucessMarker(dir))
+		require.NoError(t, persistSuccessMarker(dir))
 
 		if !tc.existingCluster {
 			caCert, caKey, err := tlsutil.GenerateCA(tlsutil.CAOpts{})
@@ -332,9 +333,12 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 			require.NoError(t, persistBootstrapConfig(dir, cfgJSON))
 		}
 
-		token, err := uuid.GenerateUUID()
-		require.NoError(t, err)
-		require.NoError(t, persistManagementToken(dir, token))
+		var token string
+		if !tc.disableManagementToken {
+			token, err = uuid.GenerateUUID()
+			require.NoError(t, err)
+			require.NoError(t, persistManagementToken(dir, token))
+		}
 
 		// Optionally mutate the persisted data to trigger errors while loading.
 		if tc.mutateFn != nil {
@@ -347,7 +351,6 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 		if loaded {
 			require.Equal(t, token, cfg.ManagementToken)
 			require.Empty(t, ui.ErrorWriter.String())
-
 		} else {
 			require.Nil(t, cfg)
 			require.Contains(t, ui.ErrorWriter.String(), tc.expect.warning)
@@ -364,15 +367,11 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 				warning: "",
 			},
 		},
-		"existing cluster missing token": {
-			existingCluster: true,
-			mutateFn: func(t *testing.T, dir string) {
-				// Remove the token file while leaving the existing cluster marker.
-				require.NoError(t, os.Remove(filepath.Join(dir, tokenFileName)))
-			},
+		"existing cluster no token": {
+			existingCluster:        true,
+			disableManagementToken: true,
 			expect: expect{
-				loaded:  false,
-				warning: "configuration files on disk are incomplete",
+				loaded: false,
 			},
 		},
 		"existing cluster no files": {
@@ -393,6 +392,12 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 			expect: expect{
 				loaded:  true,
 				warning: "",
+			},
+		},
+		"new cluster with no token": {
+			disableManagementToken: true,
+			expect: expect{
+				loaded: false,
 			},
 		},
 		"new cluster some files": {


### PR DESCRIPTION
## Backport (manual!)

The below text is copied from the body of the original PR.

---

### Description

We are removing the requirement for HCP to provide Consul with a management token to support read-only tokens. This changes the validations to allow for a management token to be missing/ignored during bootstrapping with HCP.

### Links
[OSS PR](https://github.com/hashicorp/consul/pull/18140)
[Ticket](https://go.hashi.co/cc5718)
[RFC](https://go.hashi.co/rfc-read-only)

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
