### PR TITLE
Fix utilization reporting docs sync

### DIFF
--- a/website/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/website/content/docs/enterprise/license/utilization-reporting.mdx
@@ -6,27 +6,27 @@ description: >-
 
 # Automated license utilization reporting
 
-This topic describes how to enable automated license utilization reporting in Consul Enterprise. This feature automatically sends license utilization data to HashiCorp so that you do not have to manually collect and report them. It also enables you to review your license usage with the monitoring solution you already use, such as Splunk and Datadog, as you optimize and manage your deployments.
+This topic describes how to enable automated license utilization reporting in Consul Enterprise. This feature automatically sends license utilization data to HashiCorp so that you do not have to manually collect and report it. It also enables you to review your license usage with the monitoring solution you already use, such as Splunk and Datadog, as you optimize and manage your deployments.
 
-## Introduction 
+## Introduction
 
-You can use automated license utilization report to understand how much more networking infrastructure you can deploy under your current contract. This helps you protect against overutilization and budget for predicted consumption.  
+You can use automated license utilization report to understand how much additional networking infrastructure you can deploy under your current contract. This feature helps you protect against overutilization and budget for predicted consumption.
 
-Automated reporting shares the minimum data required to validate license utilization as defined in our contracts. This data mostly consists of computed metrics, and it will never contain Personal Identifiable Information (PII) or other sensitive information. Automated reporting shares the data with HashiCorp using a secure unidirectional HTTPS API and makes an auditable record in the product logs each time it submits a report.
+Automated reporting shares the minimum data required to validate license utilization as defined in our contracts. This data mostly consists of computed metrics, and it will never contain Personal Identifiable Information (PII) or other sensitive information. Automated reporting shares the data with HashiCorp using a secure unidirectional HTTPS API and makes an auditable record in the product logs each time it submits a report. This process is GDPR-compliant.
 
 ## Requirements
 
-_Air-gapped_ installations, which are systems with no network interfaces, are not supported.
+Automated license utilization reporting does not support _air-gapped installations_, which are systems with no network interfaces.
 
-The following versions of Consul Enterprise are support automated license utilization reporting:
+The following versions of Consul Enterprise support automated license utilization reporting:
 
-- Patch releases of Consul Enterprise 1.13.9 and newer.
+- Patch releases of Consul Enterprise v1.13.9 and newer.
 
-Download a supported release from the [Consul Versions page](https://releases.hashicorp.com/consul/).
-  
+Download a supported release from the [Consul Versions](https://releases.hashicorp.com/consul/) page.
+
 ## Enable automated reporting
 
-Outbound network traffic must be configured correctly. Otherwise, automated reporting will not work. 
+Before you enable automated reporting, make sure that outbound network traffic is configured correctly and upgrade your enterprise product to a version that supports it. If your installation is air-gapped or network settings are not in place, automated reporting will not work.
 
 To enable automated reporting, complete the following steps:
 
@@ -44,7 +44,7 @@ Make sure that your network allows HTTPS egress on port 443 from `https://report
 
 ### Check product logs
 
-Automatic license utilization reporting starts sending data within 24 hours. Check the product logs for records that the data sent successfully.
+Automatic license utilization reporting starts sending data within roughly 24 hours. Check the product logs for records that the data sent successfully.
 
 <CodeBlockConfig hideClipboard>
 
@@ -81,7 +81,7 @@ If your installation is air-gapped or your network does not allow the correct eg
 
 </CodeBlockConfig>
 
-In this case, reconfigure your network to allow egress and check back in 24 hours. 
+In this case, reconfigure your network to allow egress and check the logs again in roughly 24 hours to confirm that automated reporting works correctly.
 
 ## Opt out
 
@@ -106,7 +106,7 @@ reporting {
 }
 ```
 
-When you opt out using an environment variable, once you restart your system it will provide a startup message confirming that you have disabled automated reporting. Set the following environment variable to disable automated reporting:
+When opting out using an environment variable, the system provides a startup message confirming that you have disabled automated reporting. Set the following environment variable to disable automated reporting:
 
 <CodeBlockConfig>
 
@@ -123,7 +123,7 @@ $ consul reload
 ```
 
 
-Check your product logs 24 hours after opting out to make sure that the system is not trying to send reports. Keep in mind that if your configuration file and environment variable differ, the environment variable setting takes precedence.
+Check your product logs roughly 24 hours after opting out to make sure that the system is not trying to send reports. Keep in mind that if your configuration file and environment variable differ, the environment variable setting takes precedence.
 
 ## Example payloads
 


### PR DESCRIPTION
Ensure that all release branches are aligned on content.

@trujillo-adam I realized I missed this one when we paired - did we want backports of this doc to 1.13 since that line is no longer being released?

(The simplest thing at this point is to merge this either way; y'all can always remove if you want after)