### PR TITLE
Stop JWT provider from being written in non default namespace

### DIFF
--- a/.changelog/18325.txt
+++ b/.changelog/18325.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+mesh: **(Enterprise Only)** Require that `jwt-provider` config entries are created in the `default` namespace.
+```

--- a/agent/structs/config_entry_jwt_provider.go
+++ b/agent/structs/config_entry_jwt_provider.go
@@ -509,7 +509,7 @@ func (e *JWTProviderConfigEntry) Validate() error {
 		return err
 	}
 
-	if err := e.validatePartition(); err != nil {
+	if err := e.validatePartitionAndNamespace(); err != nil {
 		return err
 	}
 

--- a/agent/structs/config_entry_jwt_provider_oss.go
+++ b/agent/structs/config_entry_jwt_provider_oss.go
@@ -12,9 +12,14 @@ import (
 	"github.com/hashicorp/consul/acl"
 )
 
-func (e *JWTProviderConfigEntry) validatePartition() error {
+func (e *JWTProviderConfigEntry) validatePartitionAndNamespace() error {
 	if !acl.IsDefaultPartition(e.PartitionOrDefault()) {
 		return fmt.Errorf("Partitions are an enterprise only feature")
 	}
+
+	if acl.DefaultNamespaceName != e.NamespaceOrDefault() {
+		return fmt.Errorf("Namespaces are an enterprise only feature")
+	}
+
 	return nil
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
JWT provider config entries are supposed to be globally available via default namespace. Adding missing validation 
