### PR TITLE
KV Get incremental update

### DIFF
--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -968,7 +968,7 @@ func TestFSM_TombstoneReap(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	idx, _, err := fsm.state.KVSList(nil, "/remove", nil)
+	idx, _, err := fsm.state.KVSList(nil, "/remove", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/fsm/snapshot_test.go
+++ b/agent/consul/fsm/snapshot_test.go
@@ -172,7 +172,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 		Value: []byte("foo"),
 	})
 	fsm.state.KVSDelete(12, "/remove", nil)
-	idx, _, err := fsm.state.KVSList(nil, "/remove", nil)
+	idx, _, err := fsm.state.KVSList(nil, "/remove", nil, 0)
 	require.NoError(t, err)
 	require.EqualValues(t, 12, idx, "bad index")
 

--- a/agent/consul/kvs_endpoint.go
+++ b/agent/consul/kvs_endpoint.go
@@ -201,7 +201,7 @@ func (k *KVS) List(args *structs.KeyRequest, reply *structs.IndexedDirEntries) e
 		&args.QueryOptions,
 		&reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
-			index, ent, err := state.KVSList(ws, args.Key, &args.EnterpriseMeta)
+			index, ent, err := state.KVSList(ws, args.Key, &args.EnterpriseMeta, args.ModifyIndexAbove)
 			if err != nil {
 				return err
 			}
@@ -256,7 +256,7 @@ func (k *KVS) ListKeys(args *structs.KeyListRequest, reply *structs.IndexedKeyLi
 		&args.QueryOptions,
 		&reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
-			index, entries, err := state.KVSList(ws, args.Prefix, &args.EnterpriseMeta)
+			index, entries, err := state.KVSList(ws, args.Prefix, &args.EnterpriseMeta, args.ModifyIndexAbove)
 			if err != nil {
 				return err
 			}

--- a/agent/consul/state/graveyard_oss.go
+++ b/agent/consul/state/graveyard_oss.go
@@ -32,18 +32,28 @@ func (g *Graveyard) insertTombstoneWithTxn(tx WriteTxn, _ string, stone *Tombsto
 
 // GetMaxIndexTxn returns the highest index tombstone whose key matches the
 // given context, using a prefix match.
-func (g *Graveyard) GetMaxIndexTxn(tx ReadTxn, prefix string, _ *acl.EnterpriseMeta) (uint64, error) {
+func (g *Graveyard) GetMaxIndexTxn(tx ReadTxn, prefix string, _ *acl.EnterpriseMeta, modifyIndexAbove uint64) (uint64, structs.DirEntries, error) {
 	var lindex uint64
+	var ents structs.DirEntries
 	q := Query{Value: prefix, EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition()}
 	stones, err := tx.Get(tableTombstones, indexID+"_prefix", q)
 	if err != nil {
-		return 0, fmt.Errorf("failed querying tombstones: %s", err)
+		return 0, nil, fmt.Errorf("failed querying tombstones: %s", err)
 	}
 	for stone := stones.Next(); stone != nil; stone = stones.Next() {
 		s := stone.(*Tombstone)
 		if s.Index > lindex {
 			lindex = s.Index
 		}
+		// ents is populated only when 'modifyIndexAbove' parameter is provided in api call
+		if modifyIndexAbove > 0 && s.Index > modifyIndexAbove {
+			e := &structs.DirEntry{
+				Key:       s.Key,
+				RaftIndex: structs.RaftIndex{CreateIndex: s.Index, ModifyIndex: s.Index},
+				Value:     nil,
+			}
+			ents = append(ents, e)
+		}
 	}
-	return lindex, nil
+	return lindex, ents, nil
 }

--- a/agent/consul/state/graveyard_test.go
+++ b/agent/consul/state/graveyard_test.go
@@ -42,25 +42,25 @@ func TestGraveyard_Lifecycle(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		if idx, err := g.GetMaxIndexTxn(tx, "foo", nil); idx != 8 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "foo", nil, 0); idx != 8 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "foo/in/the/house", nil); idx != 2 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "foo/in/the/house", nil, 0); idx != 2 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "foo/bar/baz", nil); idx != 5 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "foo/bar/baz", nil, 0); idx != 5 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "foo/bar/zoo", nil); idx != 8 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "foo/bar/zoo", nil, 0); idx != 8 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "some/other/path", nil); idx != 9 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "some/other/path", nil, 0); idx != 9 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "", nil); idx != 9 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "", nil, 0); idx != 9 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "nope", nil); idx != 0 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "nope", nil, 0); idx != 0 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
 	}()
@@ -81,25 +81,25 @@ func TestGraveyard_Lifecycle(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		if idx, err := g.GetMaxIndexTxn(tx, "foo", nil); idx != 8 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "foo", nil, 0); idx != 8 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "foo/in/the/house", nil); idx != 0 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "foo/in/the/house", nil, 0); idx != 0 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "foo/bar/baz", nil); idx != 0 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "foo/bar/baz", nil, 0); idx != 0 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "foo/bar/zoo", nil); idx != 8 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "foo/bar/zoo", nil, 0); idx != 8 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "some/other/path", nil); idx != 9 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "some/other/path", nil, 0); idx != 9 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "", nil); idx != 9 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "", nil, 0); idx != 9 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
-		if idx, err := g.GetMaxIndexTxn(tx, "nope", nil); idx != 0 || err != nil {
+		if idx, _, err := g.GetMaxIndexTxn(tx, "nope", nil, 0); idx != 0 || err != nil {
 			t.Fatalf("bad: %d (%s)", idx, err)
 		}
 	}()

--- a/agent/consul/state/kvs_test.go
+++ b/agent/consul/state/kvs_test.go
@@ -36,7 +36,7 @@ func TestStateStore_ReapTombstones(t *testing.T) {
 
 	// Pull out the list and check the index, which should come from the
 	// tombstones.
-	idx, _, err := s.KVSList(nil, "foo/", nil)
+	idx, _, err := s.KVSList(nil, "foo/", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -50,7 +50,7 @@ func TestStateStore_ReapTombstones(t *testing.T) {
 	}
 
 	// Should still be good because 7 is in there.
-	idx, _, err = s.KVSList(nil, "foo/", nil)
+	idx, _, err = s.KVSList(nil, "foo/", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -64,7 +64,7 @@ func TestStateStore_ReapTombstones(t *testing.T) {
 	}
 
 	// At this point the sub index will slide backwards.
-	idx, _, err = s.KVSList(nil, "foo/", nil)
+	idx, _, err = s.KVSList(nil, "foo/", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -382,7 +382,7 @@ func TestStateStore_KVSList(t *testing.T) {
 
 	// Listing an empty KVS returns nothing
 	ws := memdb.NewWatchSet()
-	idx, entries, err := s.KVSList(ws, "", nil)
+	idx, entries, err := s.KVSList(ws, "", nil, 0)
 	if idx != 0 || entries != nil || err != nil {
 		t.Fatalf("expected (0, nil, nil), got: (%d, %#v, %#v)", idx, entries, err)
 	}
@@ -398,7 +398,7 @@ func TestStateStore_KVSList(t *testing.T) {
 	}
 
 	// List out all of the keys
-	idx, entries, err = s.KVSList(nil, "", nil)
+	idx, entries, err = s.KVSList(nil, "", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -412,7 +412,7 @@ func TestStateStore_KVSList(t *testing.T) {
 	}
 
 	// Try listing with a provided prefix
-	idx, entries, err = s.KVSList(nil, "foo/bar/zip", nil)
+	idx, entries, err = s.KVSList(nil, "foo/bar/zip", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -430,7 +430,7 @@ func TestStateStore_KVSList(t *testing.T) {
 
 	// Delete a key and make sure the index comes from the tombstone.
 	ws = memdb.NewWatchSet()
-	_, _, err = s.KVSList(ws, "foo/bar/baz", nil)
+	_, _, err = s.KVSList(ws, "foo/bar/baz", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -441,7 +441,7 @@ func TestStateStore_KVSList(t *testing.T) {
 		t.Fatalf("bad")
 	}
 	ws = memdb.NewWatchSet()
-	idx, _, err = s.KVSList(ws, "foo/bar/baz", nil)
+	idx, _, err = s.KVSList(ws, "foo/bar/baz", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -457,7 +457,7 @@ func TestStateStore_KVSList(t *testing.T) {
 	}
 
 	// Make sure we get the right index from the tombstone.
-	idx, _, err = s.KVSList(nil, "foo/bar/baz", nil)
+	idx, _, err = s.KVSList(nil, "foo/bar/baz", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -470,7 +470,7 @@ func TestStateStore_KVSList(t *testing.T) {
 	if err := s.ReapTombstones(8, 6); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	idx, _, err = s.KVSList(nil, "foo/bar/baz", nil)
+	idx, _, err = s.KVSList(nil, "foo/bar/baz", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -479,7 +479,7 @@ func TestStateStore_KVSList(t *testing.T) {
 	}
 
 	// List all the keys to make sure the index is also correct.
-	idx, _, err = s.KVSList(nil, "", nil)
+	idx, _, err = s.KVSList(nil, "", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -528,7 +528,7 @@ func TestStateStore_KVSDelete(t *testing.T) {
 
 	// Check that the tombstone was created and that prevents the index
 	// from sliding backwards.
-	idx, _, err := s.KVSList(nil, "foo", nil)
+	idx, _, err := s.KVSList(nil, "foo", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -541,7 +541,7 @@ func TestStateStore_KVSDelete(t *testing.T) {
 	if err := s.ReapTombstones(4, 3); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	idx, _, err = s.KVSList(nil, "foo", nil)
+	idx, _, err = s.KVSList(nil, "foo", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -610,7 +610,7 @@ func TestStateStore_KVSDeleteCAS(t *testing.T) {
 
 	// Check that the tombstone was created and that prevents the index
 	// from sliding backwards.
-	idx, _, err = s.KVSList(nil, "bar", nil)
+	idx, _, err = s.KVSList(nil, "bar", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -623,7 +623,7 @@ func TestStateStore_KVSDeleteCAS(t *testing.T) {
 	if err := s.ReapTombstones(6, 4); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	idx, _, err = s.KVSList(nil, "bar", nil)
+	idx, _, err = s.KVSList(nil, "bar", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -893,7 +893,7 @@ func TestStateStore_KVSDeleteTree(t *testing.T) {
 
 	// Check that the tombstones ware created and that prevents the index
 	// from sliding backwards.
-	idx, _, err := s.KVSList(nil, "foo", nil)
+	idx, _, err := s.KVSList(nil, "foo", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -906,7 +906,7 @@ func TestStateStore_KVSDeleteTree(t *testing.T) {
 	if err := s.ReapTombstones(6, 5); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	idx, _, err = s.KVSList(nil, "foo", nil)
+	idx, _, err = s.KVSList(nil, "foo", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -927,7 +927,7 @@ func TestStateStore_Watches_PrefixDelete(t *testing.T) {
 	testSetKey(t, s, 6, "foo/nope", "nope", nil)
 
 	ws := memdb.NewWatchSet()
-	got, _, err := s.KVSList(ws, "foo/bar", nil)
+	got, _, err := s.KVSList(ws, "foo/bar", nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected err: %s", err)
 	}
@@ -946,7 +946,7 @@ func TestStateStore_Watches_PrefixDelete(t *testing.T) {
 	}
 
 	//Verify index matches tombstone
-	got, _, err = s.KVSList(ws, "foo/bar", nil)
+	got, _, err = s.KVSList(ws, "foo/bar", nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected err: %s", err)
 	}
@@ -964,7 +964,7 @@ func TestStateStore_Watches_PrefixDelete(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	got, _, err = s.KVSList(nil, "foo/bar", nil)
+	got, _, err = s.KVSList(nil, "foo/bar", nil, 0)
 	wantIndex = 2
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -981,7 +981,7 @@ func TestStateStore_Watches_PrefixDelete(t *testing.T) {
 	// We expect to get the max index in the tree
 	wantIndex = 9
 	ws = memdb.NewWatchSet()
-	got, _, err = s.KVSList(ws, "foo/bar/baz", nil)
+	got, _, err = s.KVSList(ws, "foo/bar/baz", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -993,7 +993,7 @@ func TestStateStore_Watches_PrefixDelete(t *testing.T) {
 	}
 
 	// List all the keys to make sure the index returned is the max index
-	got, _, err = s.KVSList(nil, "", nil)
+	got, _, err = s.KVSList(nil, "", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1006,7 +1006,7 @@ func TestStateStore_Watches_PrefixDelete(t *testing.T) {
 		t.Fatalf("unexpected err: %s", err)
 	}
 	wantIndex = 10
-	got, _, err = s.KVSList(nil, "/foo/bar", nil)
+	got, _, err = s.KVSList(nil, "/foo/bar", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1350,7 +1350,7 @@ func TestStateStore_KVS_Snapshot_Restore(t *testing.T) {
 		restore.Commit()
 
 		// Read the restored keys back out and verify they match.
-		idx, res, err := s.KVSList(nil, "", nil)
+		idx, res, err := s.KVSList(nil, "", nil, 0)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1387,7 +1387,7 @@ func TestStateStore_Tombstone_Snapshot_Restore(t *testing.T) {
 	if err := s.ReapTombstones(5, 4); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	idx, _, err := s.KVSList(nil, "foo/bar", nil)
+	idx, _, err := s.KVSList(nil, "foo/bar", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1424,7 +1424,7 @@ func TestStateStore_Tombstone_Snapshot_Restore(t *testing.T) {
 		restore.Commit()
 
 		// See if the stone works properly in a list query.
-		idx, _, err := s.KVSList(nil, "foo/bar", nil)
+		idx, _, err := s.KVSList(nil, "foo/bar", nil, 0)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1438,7 +1438,7 @@ func TestStateStore_Tombstone_Snapshot_Restore(t *testing.T) {
 		if err := s.ReapTombstones(6, 4); err != nil {
 			t.Fatalf("err: %s", err)
 		}
-		idx, _, err = s.KVSList(nil, "foo/bar", nil)
+		idx, _, err = s.KVSList(nil, "foo/bar", nil, 0)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -415,7 +415,7 @@ func TestStateStore_Restore_Abort(t *testing.T) {
 	}
 	restore.Abort()
 
-	idx, entries, err := s.KVSList(nil, "", nil)
+	idx, entries, err := s.KVSList(nil, "", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/txn.go
+++ b/agent/consul/state/txn.go
@@ -72,7 +72,7 @@ func (s *Store) txnKVS(tx WriteTxn, idx uint64, op *structs.TxnKVOp) (structs.Tx
 
 	case api.KVGetTree:
 		var entries structs.DirEntries
-		_, entries, err = s.kvsListTxn(tx, nil, op.DirEnt.Key, op.DirEnt.EnterpriseMeta)
+		_, entries, err = s.kvsListTxn(tx, nil, op.DirEnt.Key, op.DirEnt.EnterpriseMeta, 0)
 		if err == nil {
 			results := make(structs.TxnResults, 0, len(entries))
 			for _, e := range entries {

--- a/agent/consul/state/txn_test.go
+++ b/agent/consul/state/txn_test.go
@@ -837,7 +837,7 @@ func TestStateStore_Txn_KVS(t *testing.T) {
 	}
 
 	// Pull the resulting state store contents.
-	idx, actual, err := s.KVSList(nil, "", nil)
+	idx, actual, err := s.KVSList(nil, "", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -918,7 +918,7 @@ func TestStateStore_Txn_KVS_Rollback(t *testing.T) {
 
 	// This function verifies that the state store wasn't changed.
 	verifyStateStore := func(desc string) {
-		idx, actual, err := s.KVSList(nil, "", nil)
+		idx, actual, err := s.KVSList(nil, "", nil, 0)
 		if err != nil {
 			t.Fatalf("err (%s): %s", desc, err)
 		}
@@ -1367,7 +1367,7 @@ func TestStateStore_Txn_KVS_ModifyIndexes(t *testing.T) {
 	}
 
 	// Pull the resulting state store contents.
-	idx, actual, err := s.KVSList(nil, "", nil)
+	idx, actual, err := s.KVSList(nil, "", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/kvs_endpoint.go
+++ b/agent/kvs_endpoint.go
@@ -59,6 +59,15 @@ func (s *HTTPHandlers) KVSGet(resp http.ResponseWriter, req *http.Request, args 
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: "Missing key name"}
 	}
 
+	// Check for ModifyIndexAbove in url query params
+	if index, ok := params["ModifyIndexAbove"]; ok {
+		uintVal, err := strconv.ParseUint(index[0], 10, 64)
+		if err != nil {
+			return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: "ModifyIndexAbove should be of type unsigned int"}
+		}
+		args.ModifyIndexAbove = uintVal
+	}
+
 	// Do not allow wildcard NS on GET reqs
 	if method == "KVS.Get" {
 		if err := s.parseEntMetaNoWildcard(req, &args.EnterpriseMeta); err != nil {

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2684,6 +2684,7 @@ type KeyRequest struct {
 	Key        string
 	acl.EnterpriseMeta
 	QueryOptions
+	ModifyIndexAbove uint64
 }
 
 func (r *KeyRequest) RequestDatacenter() string {
@@ -2697,6 +2698,7 @@ type KeyListRequest struct {
 	Seperator  string
 	QueryOptions
 	acl.EnterpriseMeta
+	ModifyIndexAbove uint64
 }
 
 func (r *KeyListRequest) RequestDatacenter() string {


### PR DESCRIPTION
Closes #16993 

@jkirschner-hashicorp @blake @phemmer

Please find here the analysis, proposed design and implementation for the KV enhancement #16993  

1. We cannot use existing filter parameter with ModifyIndex (inside RaftIndex) because it has  b-expr:’-‘ that denotes its ignored for filtering.
2. New query parameter is introduced 'ModifyIndexAbove'. 
- This query parameter is used while making api call -  v1/kv/_<prefix>_?recurse=true&ModifyIndexAbove=_<idx>_
- With this param 'ModifyIndexAbove' , the above api call returns all keys with ModifyIndex above _idx_
- It also looks into Graveyard and searches for tombstones matching the given _<prefix>_ and index above _<idx>_
   Thereby getting all deleted (if any) keys. Value is assigned as nil for these deleted KVs.
4. The Expiration age is already implemented and the default age is 15mins. https://github.com/hashicorp/consul/blob/main/agent/consul/config.go#527
Hence the api call (above in 2) with 'ModifyIndexAbove' param gets all KVs deleted past 15mins. 
The default can be tweaked if required.

Tested with few scenarios and working as expected for usecase mentioned in #16993  