### PR TITLE
docs: Simplify example jq commands by removing pipes

### DIFF
--- a/website/content/docs/connect/ca/consul.mdx
+++ b/website/content/docs/connect/ca/consul.mdx
@@ -100,13 +100,13 @@ In order to use the Update CA Configuration HTTP endpoint, the private key and c
 must be passed via JSON:
 
 ```shell-session
-$ jq --null-input --arg key "$(cat root.key)" --arg cert "$(cat root.crt)" '
+$ jq --null-input --rawfile key root.key --rawfile cert root.crt '
 {
     "Provider": "consul",
     "Config": {
         "LeafCertTTL": "72h",
-        "PrivateKey": $key,
-        "RootCert": $cert,
+        "PrivateKey": $key | sub("\\n$"; ""),
+        "RootCert": $cert | sub("\\n$"; ""),
         "IntermediateCertTTL": "8760h"
     }
 }' > ca_config.json

--- a/website/content/docs/ecs/manual/secure-configuration.mdx
+++ b/website/content/docs/ecs/manual/secure-configuration.mdx
@@ -346,9 +346,9 @@ script to the container.
 
 # Obtain details from the task metadata
 ECS_TASK_META=$(curl -s $ECS_CONTAINER_METADATA_URI_V4/task)
-TASK_REGION=$(echo "$ECS_TASK_META" | jq -r .TaskARN | cut -d ':' -f 4)
-TASK_ID=$(echo "$ECS_TASK_META" | jq -r .TaskARN | cut -d '/' -f 3)
-CLUSTER_ARN=$(echo "$ECS_TASK_META" | jq -r .TaskARN | sed -E 's|:task/([^/]+).*|:cluster/\1|')
+TASK_REGION=$(echo "$ECS_TASK_META" | jq --raw-output '.TaskARN / ":" | .[3]')
+TASK_ID=$(echo "$ECS_TASK_META" | jq --raw-output '.TaskARN / "/" | .[2]')
+CLUSTER_ARN=$(echo "$ECS_TASK_META" | jq --raw-output '.TaskARN | sub(":task/(?<cluster>[^/]+).*"; ":cluster/\(.cluster)")')
 
 # Write the CA certs to a files in the shared volume
 echo "$CONSUL_CACERT_PEM" > /consul/consul-ca-cert.pem

--- a/website/content/docs/security/acl/auth-methods/oidc.mdx
+++ b/website/content/docs/security/acl/auth-methods/oidc.mdx
@@ -202,7 +202,7 @@ be tricky to debug why things aren't working. Some tips for setting up OIDC:
   request to obtain a JWT that you can inspect. An example of how to decode the
   JWT (in this case located in the `access_token` field of a JSON response):
 
-      cat jwt.json | jq --raw-output .access_token | cut -d. -f2 | base64 --decode
+      jq --raw-output '.access_token / "." | .[1] | @base64d' jwt.json
 
 - The [`VerboseOIDCLogging`](#verboseoidclogging) option is available which
   will log the received OIDC token if debug level logging is enabled. This can

--- a/website/content/docs/troubleshoot/common-errors.mdx
+++ b/website/content/docs/troubleshoot/common-errors.mdx
@@ -44,7 +44,7 @@ There is a syntax error in your configuration file. If the error message doesn't
 ```shell-session
 $ consul agent -server -config-file server.json
 ==> Error parsing server.json: invalid character '`' looking for beginning of value
-$ cat server.json | jq .
+$ jq . server.json
 parse error: Invalid numeric literal at line 3, column 29
 ```
 


### PR DESCRIPTION
Simplify jq command examples by removing pipes to other commands.

### Description

Simply command examples with `jq` by no longer piping data to other commands. `jq` can internally handle all of the operations  that were being performed by the removed commands. This should also make the command examples more portable across non-Unix operating systems.

### Testing & Reproduction steps

I've manually tested each of the modified commands to ensure that they return the same output that was generated with the previous command.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
