### PR TITLE
fix typo in create a mesh token docs

### DIFF
--- a/website/content/docs/security/acl/tokens/create/create-a-mesh-gateway-token.mdx
+++ b/website/content/docs/security/acl/tokens/create/create-a-mesh-gateway-token.mdx
@@ -19,7 +19,7 @@ Gateways](/consul/docs/connect/gateways#mesh-gateways) for additional informatio
 Gateways must present a token linked to policies that grant the appropriate set of permissions in
 order to be discoverable and to route to other services in a mesh.
 
-## Requiremements
+## Requirements
 
 Core ACL functionality is available in all versions of Consul.
 


### PR DESCRIPTION
### Description

tiny docs typo fix
