### PR TITLE
Fix policy lookup to allow for slashes

### DIFF
--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/consul/acl"
@@ -145,6 +146,12 @@ func (s *HTTPHandlers) ACLPolicyCRUD(resp http.ResponseWriter, req *http.Request
 }
 
 func (s *HTTPHandlers) ACLPolicyRead(resp http.ResponseWriter, req *http.Request, policyID, policyName string) (interface{}, error) {
+	// policy name needs to be unescaped in case there were `/` characters
+	policyName, err := url.QueryUnescape(policyName)
+	if err != nil {
+		return nil, err
+	}
+
 	args := structs.ACLPolicyGetRequest{
 		Datacenter: s.agent.config.Datacenter,
 		PolicyID:   policyID,

--- a/command/acl/acl_helpers.go
+++ b/command/acl/acl_helpers.go
@@ -45,9 +45,13 @@ func GetTokenAccessorIDFromPartial(client *api.Client, partialAccessorID string)
 }
 
 func GetPolicyIDFromPartial(client *api.Client, partialID string) (string, error) {
-	if partialID == "global-management" {
-		return structs.ACLPolicyGlobalManagementID, nil
+	// try the builtin policies (by name) first
+	for _, policy := range structs.ACLBuiltinPolicies {
+		if partialID == policy.Name {
+			return policy.ID, nil
+		}
 	}
+
 	// The full UUID string was given
 	if len(partialID) == 36 {
 		return partialID, nil

--- a/command/acl/acl_test.go
+++ b/command/acl/acl_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package acl
+
+import (
+	"io"
+	"testing"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetPolicyIDByName_Builtins(t *testing.T) {
+	t.Parallel()
+
+	a := agent.StartTestAgent(t,
+		agent.TestAgent{
+			LogOutput: io.Discard,
+			HCL: `
+				primary_datacenter = "dc1"
+				acl {
+					enabled = true
+					tokens {
+						initial_management = "root"
+					}
+				}
+			`,
+		},
+	)
+
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1", testrpc.WithToken("root"))
+
+	client := a.Client()
+	client.AddHeader("X-Consul-Token", "root")
+
+	t.Run("global management policy", func(t *testing.T) {
+		id, err := GetPolicyIDByName(client, structs.ACLPolicyGlobalManagementName)
+		require.NoError(t, err)
+		require.Equal(t, structs.ACLPolicyGlobalManagementID, id)
+	})
+
+	t.Run("global read-only policy", func(t *testing.T) {
+		id, err := GetPolicyIDByName(client, structs.ACLPolicyGlobalReadOnlyName)
+		require.NoError(t, err)
+		require.Equal(t, structs.ACLPolicyGlobalReadOnlyID, id)
+	})
+}
+
+func Test_GetPolicyIDFromPartial_Builtins(t *testing.T) {
+	t.Parallel()
+
+	a := agent.StartTestAgent(t,
+		agent.TestAgent{
+			LogOutput: io.Discard,
+			HCL: `
+				primary_datacenter = "dc1"
+				acl {
+					enabled = true
+					tokens {
+						initial_management = "root"
+					}
+				}
+			`,
+		},
+	)
+
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1", testrpc.WithToken("root"))
+
+	client := a.Client()
+	client.AddHeader("X-Consul-Token", "root")
+
+	t.Run("global management policy", func(t *testing.T) {
+		id, err := GetPolicyIDFromPartial(client, structs.ACLPolicyGlobalManagementName)
+		require.NoError(t, err)
+		require.Equal(t, structs.ACLPolicyGlobalManagementID, id)
+	})
+
+	t.Run("global read-only policy", func(t *testing.T) {
+		id, err := GetPolicyIDFromPartial(client, structs.ACLPolicyGlobalReadOnlyName)
+		require.NoError(t, err)
+		require.Equal(t, structs.ACLPolicyGlobalReadOnlyID, id)
+	})
+}


### PR DESCRIPTION
### Description

This fixes the `PolicyRead` endpoint to allow for slashes in the name by unescaping argument received from the query string.

### Links

[Original PR](https://github.com/hashicorp/consul/pull/18319)
[Ticket](https://go.hashi.co/cc5719)
[RFC](https://go.hashi.co/rfc-read-only)

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
