### PR TITLE
Fix #17730 - Dev mode has new line

### DIFF
--- a/.changelog/18367.txt
+++ b/.changelog/18367.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+dev-mode: Fix dev mode has new line in responses. Now new line is added only when url has pretty query parameter.
+```

--- a/agent/http.go
+++ b/agent/http.go
@@ -604,7 +604,9 @@ func (s *HTTPHandlers) marshalJSON(req *http.Request, obj interface{}) ([]byte, 
 		if err != nil {
 			return nil, err
 		}
-		buf = append(buf, "\n"...)
+		if ok {
+			buf = append(buf, "\n"...)
+		}
 		return buf, nil
 	}
 


### PR DESCRIPTION
### Description

Removed new line in response when running consul in dev mode. This fixes https://github.com/hashicorp/consul/issues/17730.

Keeping new line only when pretty is passed in the url not in dev mode.

### Testing & Reproduction steps

Reproduction steps
```
1. make dev
2. ./bin/consul agent -data-dir=/tmp/consul  -node consul -bind 0.0.0.0 -server -bootstrap  -ui -dev
3. Open browser and network tab - save some k/v - observe new line in xhr response.
4. ./bin/consul agent -data-dir=/tmp/consul  -node consul -bind 0.0.0.0 -server -bootstrap  -ui
5. Open browser and network tab - save some k/v - observe no new line in xhr response
```
Tested the code with the above steps and issue is fixed. i.e. could not see any new line in dev mode now.
