### PR TITLE
[NET-5189] xds: Handle `[]any` in `property-override` extension

### DIFF
--- a/.changelog/18400.txt
+++ b/.changelog/18400.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: Fix handling of repeated field deserialization in `property-override` Envoy extension
+```

--- a/agent/envoyextensions/builtin/property-override/property_override_test.go
+++ b/agent/envoyextensions/builtin/property-override/property_override_test.go
@@ -335,6 +335,36 @@ func TestConstructor(t *testing.T) {
 			},
 			ok: true,
 		},
+		// We may receive repeated fields decoded generically. Assert that
+		// we can successfully coerce them to their appropriate type.
+		"repeated value decoded as interface{} construction succeeds": {
+			arguments: makeArguments(map[string]any{"Patches": []map[string]any{
+				makePatch(map[string]any{
+					"ResourceFilter": makeResourceFilter(map[string]any{
+						"ResourceType": ResourceTypeRoute,
+					}),
+					"Op":    OpAdd,
+					"Path":  "/internal_only_headers",
+					"Value": []any{"X-Custom-Header1", "X-Custom-Header2"},
+				}),
+			}}),
+			expected: propertyOverride{
+				Patches: []Patch{
+					{
+						ResourceFilter: ResourceFilter{
+							ResourceType:     ResourceTypeRoute,
+							TrafficDirection: extensioncommon.TrafficDirectionOutbound,
+						},
+						Op:    OpAdd,
+						Path:  "/internal_only_headers",
+						Value: []any{"X-Custom-Header1", "X-Custom-Header2"},
+					},
+				},
+				Debug:     true,
+				ProxyType: api.ServiceKindConnectProxy,
+			},
+			ok: true,
+		},
 		"invalid ProxyType": {
 			arguments: makeArguments(map[string]any{
 				"Patches": []map[string]any{

--- a/agent/envoyextensions/builtin/property-override/structpatcher_test.go
+++ b/agent/envoyextensions/builtin/property-override/structpatcher_test.go
@@ -429,6 +429,49 @@ func TestPatchStruct(t *testing.T) {
 			},
 			ok: true,
 		},
+		"add repeated field: int32 as any": {
+			args: args{
+				k: &envoy_route_v3.RetryPolicy{
+					RetriableStatusCodes: []uint32{429, 502},
+				},
+				patches: []Patch{makeAddPatch(
+					"/retriable_status_codes",
+					[]any{503, 504},
+				)},
+			},
+			expected: &envoy_route_v3.RetryPolicy{
+				RetriableStatusCodes: []uint32{503, 504},
+			},
+			ok: true,
+		},
+		"add repeated field: string as any": {
+			args: args{
+				k: &envoy_route_v3.RouteConfiguration{},
+				patches: []Patch{makeAddPatch(
+					"/internal_only_headers",
+					[]any{"X-Custom-Header1", "X-Custom-Header-2"},
+				)},
+			},
+			expected: &envoy_route_v3.RouteConfiguration{
+				InternalOnlyHeaders: []string{"X-Custom-Header1", "X-Custom-Header-2"},
+			},
+			ok: true,
+		},
+		"add repeated field: enum as any": {
+			args: args{
+				k: &corev3.HealthStatusSet{
+					Statuses: []corev3.HealthStatus{corev3.HealthStatus_DRAINING},
+				},
+				patches: []Patch{makeAddPatch(
+					"/statuses",
+					[]any{"HEALTHY", "UNHEALTHY"},
+				)},
+			},
+			expected: &corev3.HealthStatusSet{
+				Statuses: []corev3.HealthStatus{corev3.HealthStatus_HEALTHY, corev3.HealthStatus_UNHEALTHY},
+			},
+			ok: true,
+		},
 		"add message field: empty": {
 			args: args{
 				k: &envoy_listener_v3.Listener{},
@@ -856,7 +899,7 @@ func TestPatchStruct(t *testing.T) {
 				InternalOnlyHeaders: []string{"X-Custom-Header1", "X-Custom-Header-2"},
 			},
 			ok:     false,
-			errMsg: "patch value type []interface {} could not be applied to target field type 'repeated string'",
+			errMsg: "patch value type int could not be applied to target field type 'repeated string'",
 		},
 		"add unsupported target: message with non-scalar fields": {
 			args: args{


### PR DESCRIPTION
Due to the way Consul does dynamic struct deserialization, it's possible we will interpret slices of scalar values as `[]any`.

Ensure Property Override gracefully coerces these so that repeated non-message patch values are applied as expected regardless of its type specificity.

It's worth noting that I don't think this will impact all extensions necessarily - if I'm not mistaken, it'll only be those that 1) have dynamic (`any`) fields in their own config schema, and 2) those fields can be repeated. I don't know of any other extensions in that boat today (other dynamic fields are `string` or unused).

cc @blake 

### Description

When attempting to configure the extension as described via CRDs:
```json
"name": "builtin/property-override",
"arguments": {
  "proxyType": "connect-proxy",
  "patches": [
    {
      "resourceFilter": {
        "resourceType": "route",
        "trafficDirection": "outbound"
      },
      "op": "add",
      "path": "/internal_only_headers",
      "value": [
        "X-Custom-Header1",
        "X-Custom-Header2"
      ]
    }
  ]
}
```

... the following error is encountered:
```
│   | \t* invalid EnvoyExtensions[0][builtin/property-override]: 1 error occurred:                                                                                                │
│   | \t* patch value type []interface {} could not be applied to target field type 'repeated string'   
```

This is due to the `Value` field being interpreted as `[]any` rather than `[]string` when it's deserialized. We should handle this situation more gracefully.

### Testing & Reproduction steps

* Added unit tests for pre- and post- deserialization type assignment to exercise this case

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
