### PR TITLE
Integ test upgrade test

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -546,7 +546,9 @@ jobs:
             -p=4 \
             -tags "${{ env.GOTAGS }}" \
             -timeout=30m \
-            -json ./... \
+            -json \
+            ./... \
+            --follow-log=false \
             --target-image ${{ env.CONSUL_LATEST_IMAGE_NAME }} \
             --target-version local \
             --latest-image docker.mirror.hashicorp.services/${{ env.CONSUL_LATEST_IMAGE_NAME }} \

--- a/test/integration/consul-container/test/upgrade/basic/fullstopupgrade_test.go
+++ b/test/integration/consul-container/test/upgrade/basic/fullstopupgrade_test.go
@@ -32,99 +32,69 @@ var (
 
 // Test upgrade a cluster of latest version to the target version
 func TestStandardUpgradeToTarget_fromLatest(t *testing.T) {
-	tcs = append(tcs,
-		testcase{
-			// Use the case of "1.12.3" ==> "1.13.0" to verify the test can
-			// catch the upgrade bug found in snapshot of 1.13.0
-			oldVersion:    "1.12.3",
-			targetVersion: "1.13.0",
-			expectErr:     true,
-		},
-	)
+	const numServers = 1
+	buildOpts := &libcluster.BuildOptions{
+		ConsulImageName:      utils.GetLatestImageName(),
+		ConsulVersion:        utils.LatestVersion,
+		Datacenter:           "dc1",
+		InjectAutoEncryption: true,
+	}
 
-	tcs = append(tcs, testcase{
-		oldVersion:    utils.LatestVersion,
-		targetVersion: utils.TargetVersion,
-	},
-	)
+	cluster, _, _ := topology.NewCluster(t, &topology.ClusterConfig{
+		NumServers:                numServers,
+		BuildOpts:                 buildOpts,
+		ApplyDefaultProxySettings: true,
+	})
+	client := cluster.APIClient(0)
 
-	run := func(t *testing.T, tc testcase) {
-		const numServers = 1
-		buildOpts := &libcluster.BuildOptions{
-			ConsulImageName:      utils.GetLatestImageName(),
-			ConsulVersion:        utils.LatestVersion,
-			Datacenter:           "dc1",
-			InjectAutoEncryption: true,
-		}
+	libcluster.WaitForLeader(t, cluster, client)
+	libcluster.WaitForMembers(t, client, numServers)
 
-		cluster, _, _ := topology.NewCluster(t, &topology.ClusterConfig{
-			NumServers:                numServers,
-			BuildOpts:                 buildOpts,
-			ApplyDefaultProxySettings: true,
-		})
-		client := cluster.APIClient(0)
+	// Create a service to be stored in the snapshot
+	const serviceName = "api"
+	index := libservice.ServiceCreate(t, client, serviceName)
 
-		libcluster.WaitForLeader(t, cluster, client)
-		libcluster.WaitForMembers(t, client, numServers)
-
-		// Create a service to be stored in the snapshot
-		const serviceName = "api"
-		index := libservice.ServiceCreate(t, client, serviceName)
-
-		require.NoError(t, client.Agent().ServiceRegister(
-			&api.AgentServiceRegistration{Name: serviceName, Port: 9998},
-		))
-		err := goretry.Do(
-			func() error {
-				ch, errCh := libservice.ServiceHealthBlockingQuery(client, serviceName, index)
-				select {
-				case err := <-errCh:
-					require.NoError(t, err)
-				case service := <-ch:
-					index = service[0].Service.ModifyIndex
-					if len(service) != 1 {
-						return fmt.Errorf("service is %d, want 1", len(service))
-					}
-					if serviceName != service[0].Service.Service {
-						return fmt.Errorf("service name is %s, want %s", service[0].Service.Service, serviceName)
-					}
-					if service[0].Service.Port != 9998 {
-						return fmt.Errorf("service is %d, want 9998", service[0].Service.Port)
-					}
+	require.NoError(t, client.Agent().ServiceRegister(
+		&api.AgentServiceRegistration{Name: serviceName, Port: 9998},
+	))
+	err := goretry.Do(
+		func() error {
+			ch, errCh := libservice.ServiceHealthBlockingQuery(client, serviceName, index)
+			select {
+			case err := <-errCh:
+				require.NoError(t, err)
+			case service := <-ch:
+				index = service[0].Service.ModifyIndex
+				if len(service) != 1 {
+					return fmt.Errorf("service is %d, want 1", len(service))
 				}
-				return nil
-			},
-			goretry.Attempts(5),
-			goretry.Delay(time.Second),
-		)
-		require.NoError(t, err)
+				if serviceName != service[0].Service.Service {
+					return fmt.Errorf("service name is %s, want %s", service[0].Service.Service, serviceName)
+				}
+				if service[0].Service.Port != 9998 {
+					return fmt.Errorf("service is %d, want 9998", service[0].Service.Port)
+				}
+			}
+			return nil
+		},
+		goretry.Attempts(5),
+		goretry.Delay(time.Second),
+	)
+	require.NoError(t, err)
 
-		// upgrade the cluster to the Target version
-		t.Logf("initiating standard upgrade to version=%q", tc.targetVersion)
-		err = cluster.StandardUpgrade(t, context.Background(), utils.GetTargetImageName(), tc.targetVersion)
+	// upgrade the cluster to the Target version
+	t.Logf("initiating standard upgrade to version=%q", utils.TargetVersion)
+	err = cluster.StandardUpgrade(t, context.Background(), utils.GetTargetImageName(), utils.TargetVersion)
 
-		if !tc.expectErr {
-			require.NoError(t, err)
-			libcluster.WaitForLeader(t, cluster, client)
-			libcluster.WaitForMembers(t, client, numServers)
+	require.NoError(t, err)
+	libcluster.WaitForLeader(t, cluster, client)
+	libcluster.WaitForMembers(t, client, numServers)
 
-			// Verify service is restored from the snapshot
-			retry.RunWith(&retry.Timer{Timeout: 5 * time.Second, Wait: 500 * time.Microsecond}, t, func(r *retry.R) {
-				service, _, err := client.Catalog().Service(serviceName, "", &api.QueryOptions{})
-				require.NoError(r, err)
-				require.Len(r, service, 1)
-				require.Equal(r, serviceName, service[0].ServiceName)
-			})
-		} else {
-			require.ErrorContains(t, err, "context deadline exceeded")
-		}
-	}
-
-	for _, tc := range tcs {
-		t.Run(fmt.Sprintf("upgrade from %s to %s", tc.oldVersion, tc.targetVersion),
-			func(t *testing.T) {
-				run(t, tc)
-			})
-		time.Sleep(1 * time.Second)
-	}
+	// Verify service is restored from the snapshot
+	retry.RunWith(&retry.Timer{Timeout: 5 * time.Second, Wait: 500 * time.Microsecond}, t, func(r *retry.R) {
+		service, _, err := client.Catalog().Service(serviceName, "", &api.QueryOptions{})
+		require.NoError(r, err)
+		require.Len(r, service, 1)
+		require.Equal(r, serviceName, service[0].ServiceName)
+	})
 }


### PR DESCRIPTION
### Description

Two improvements to the upgrade test in CI

- This PR also removes an outdated upgrade test from 1.12 to 1.13, which was used in the POC during the project.
- Disable log in upgrade test since there are too many parallel jobs running

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
