### PR TITLE
Add ServiceEndpoints Mutation hook tests

### DIFF
--- a/internal/catalog/internal/types/service_endpoints.go
+++ b/internal/catalog/internal/types/service_endpoints.go
@@ -54,6 +54,7 @@ func MutateServiceEndpoints(res *pbresource.Resource) error {
 
 	if !resource.EqualTenancy(res.Owner.Tenancy, res.Id.Tenancy) {
 		err = multierror.Append(err, resource.ErrOwnerTenantInvalid{
+			ResourceType:    ServiceEndpointsV1Alpha1Type,
 			ResourceTenancy: res.Id.Tenancy,
 			OwnerTenancy:    res.Owner.Tenancy,
 		})

--- a/internal/catalog/internal/types/service_endpoints.go
+++ b/internal/catalog/internal/types/service_endpoints.go
@@ -44,6 +44,16 @@ func MutateServiceEndpoints(res *pbresource.Resource) error {
 		}
 	}
 
+	return nil
+}
+
+func ValidateServiceEndpoints(res *pbresource.Resource) error {
+	var svcEndpoints pbcatalog.ServiceEndpoints
+
+	if err := res.Data.UnmarshalTo(&svcEndpoints); err != nil {
+		return resource.NewErrDataParse(&svcEndpoints, err)
+	}
+
 	var err error
 	if !resource.EqualType(res.Owner.Type, ServiceV1Alpha1Type) {
 		err = multierror.Append(err, resource.ErrOwnerTypeInvalid{
@@ -70,17 +80,6 @@ func MutateServiceEndpoints(res *pbresource.Resource) error {
 		})
 	}
 
-	return err
-}
-
-func ValidateServiceEndpoints(res *pbresource.Resource) error {
-	var svcEndpoints pbcatalog.ServiceEndpoints
-
-	if err := res.Data.UnmarshalTo(&svcEndpoints); err != nil {
-		return resource.NewErrDataParse(&svcEndpoints, err)
-	}
-
-	var err error
 	for idx, endpoint := range svcEndpoints.Endpoints {
 		if endpointErr := validateEndpoint(endpoint, res); endpointErr != nil {
 			err = multierror.Append(err, resource.ErrInvalidListElement{

--- a/internal/catalog/internal/types/service_endpoints_test.go
+++ b/internal/catalog/internal/types/service_endpoints_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 var (
@@ -21,21 +20,6 @@ var (
 		PeerName:  "local",
 	}
 )
-
-func createServiceEndpointsResource(t *testing.T, data protoreflect.ProtoMessage) *pbresource.Resource {
-	res := &pbresource.Resource{
-		Id: &pbresource.ID{
-			Type:    ServiceEndpointsType,
-			Tenancy: defaultEndpointTenancy,
-			Name:    "test-service",
-		},
-	}
-
-	var err error
-	res.Data, err = anypb.New(data)
-	require.NoError(t, err)
-	return res
-}
 
 func TestValidateServiceEndpoints_Ok(t *testing.T) {
 	data := &pbcatalog.ServiceEndpoints{
@@ -62,7 +46,7 @@ func TestValidateServiceEndpoints_Ok(t *testing.T) {
 		},
 	}
 
-	res := createServiceEndpointsResource(t, data)
+	res := resourcetest.Resource(ServiceEndpointsType, "test-service").WithData(t, data).Build()
 
 	err := ValidateServiceEndpoints(res)
 	require.NoError(t, err)
@@ -73,7 +57,7 @@ func TestValidateServiceEndpoints_ParseError(t *testing.T) {
 	// to cause the error we are expecting
 	data := &pbcatalog.IP{Address: "198.18.0.1"}
 
-	res := createServiceEndpointsResource(t, data)
+	res := resourcetest.Resource(ServiceEndpointsType, "test-service").WithData(t, data).Build()
 
 	err := ValidateServiceEndpoints(res)
 	require.Error(t, err)
@@ -167,18 +151,56 @@ func TestValidateServiceEndpoints_EndpointInvalid(t *testing.T) {
 
 	for name, tcase := range cases {
 		t.Run(name, func(t *testing.T) {
-			data := genData()
-			tcase.modify(data)
+			endpoint := genData()
+			tcase.modify(endpoint)
 
-			res := createServiceEndpointsResource(t, &pbcatalog.ServiceEndpoints{
+			data := &pbcatalog.ServiceEndpoints{
 				Endpoints: []*pbcatalog.Endpoint{
-					data,
+					endpoint,
 				},
-			})
+			}
+			res := resourcetest.Resource(ServiceEndpointsType, "test-service").WithData(t, data).Build()
 
 			err := ValidateServiceEndpoints(res)
 			require.Error(t, err)
 			tcase.validateErr(t, err)
 		})
 	}
+}
+
+func TestMutateServiceEndpoints_PopulateOwner(t *testing.T) {
+	res := resourcetest.Resource(ServiceEndpointsType, "test-service").Build()
+
+	require.NoError(t, MutateServiceEndpoints(res))
+	require.NotNil(t, res.Owner)
+	require.True(t, resource.EqualType(res.Owner.Type, ServiceType))
+	require.True(t, resource.EqualTenancy(res.Owner.Tenancy, defaultEndpointTenancy))
+	require.Equal(t, res.Owner.Name, res.Id.Name)
+}
+
+func TestMutateServiceEndpoints_InvalidOwner(t *testing.T) {
+	badTenancy := &pbresource.Tenancy{Partition: "default", Namespace: "other", PeerName: "local"}
+	res := resourcetest.Resource(ServiceEndpointsType, "test-service").
+		WithTenancy(defaultEndpointTenancy).
+		WithOwner(&pbresource.ID{
+			Type:    DNSPolicyType,
+			Tenancy: badTenancy,
+			Name:    "wrong"}).
+		Build()
+
+	err := MutateServiceEndpoints(res)
+	require.Error(t, err)
+
+	resourcetest.RequireError(t, err, resource.ErrOwnerTypeInvalid{ResourceType: ServiceEndpointsType, OwnerType: DNSPolicyType})
+	resourcetest.RequireError(t, err, resource.ErrOwnerTenantInvalid{
+		ResourceType:    ServiceEndpointsType,
+		ResourceTenancy: defaultEndpointTenancy,
+		OwnerTenancy:    badTenancy,
+	})
+	resourcetest.RequireError(t, err, resource.ErrInvalidField{
+		Name: "name",
+		Wrapped: errInvalidEndpointsOwnerName{
+			Name:      "test-service",
+			OwnerName: "wrong"},
+	})
 }

--- a/internal/resource/errors.go
+++ b/internal/resource/errors.go
@@ -4,7 +4,6 @@
 package resource
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/consul/proto-public/pbresource"
@@ -12,10 +11,32 @@ import (
 )
 
 var (
-	ErrMissing                  = errors.New("missing required field")
-	ErrEmpty                    = errors.New("cannot be empty")
-	ErrReferenceTenancyNotEqual = errors.New("resource tenancy and reference tenancy differ")
+	ErrMissing                  = NewConstError("missing required field")
+	ErrEmpty                    = NewConstError("cannot be empty")
+	ErrReferenceTenancyNotEqual = NewConstError("resource tenancy and reference tenancy differ")
 )
+
+// ConstError is more or less equivalent to the stdlib errors.errorstring. However, having
+// our own exported type allows us to more accurately compare error values in tests.
+//
+//   - go-cmp will not compared unexported fields by default.
+//   - cmp.AllowUnexported(<type>) requires a concrete struct type and due to the stdlib not
+//     exporting the errorstring type there doesn't seem to be a way to get at the type.
+//   - cmpopts.EquateErrors has issues with protobuf types within other error structs.
+//
+// Due to these factors the easiest thing to do is to create a custom comparer for
+// the ConstError type and use it where necessary.
+type ConstError struct {
+	message string
+}
+
+func NewConstError(msg string) ConstError {
+	return ConstError{message: msg}
+}
+
+func (e ConstError) Error() string {
+	return e.message
+}
 
 type ErrDataParse struct {
 	TypeName string

--- a/internal/resource/resourcetest/builder.go
+++ b/internal/resource/resourcetest/builder.go
@@ -55,6 +55,11 @@ func ResourceID(id *pbresource.ID) *resourceBuilder {
 	}
 }
 
+func (b *resourceBuilder) WithTenancy(tenant *pbresource.Tenancy) *resourceBuilder {
+	b.resource.Id.Tenancy = tenant
+	return b
+}
+
 func (b *resourceBuilder) WithData(t T, data protoreflect.ProtoMessage) *resourceBuilder {
 	t.Helper()
 

--- a/internal/resource/resourcetest/require.go
+++ b/internal/resource/resourcetest/require.go
@@ -8,6 +8,15 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
+// RequireError is useful for asserting that some chained multierror contains a specific error.
+func RequireError[E error](t T, err error, expected E) {
+	t.Helper()
+
+	var actual E
+	require.ErrorAs(t, err, &actual)
+	prototest.AssertDeepEqual(t, expected, actual)
+}
+
 func RequireVersionUnchanged(t T, res *pbresource.Resource, version string) {
 	t.Helper()
 	require.Equal(t, version, res.Version)

--- a/internal/resource/resourcetest/require.go
+++ b/internal/resource/resourcetest/require.go
@@ -2,19 +2,36 @@ package resourcetest
 
 import (
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/proto/private/prototest"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
+// CompareErrorString is a helper to generate a custom go-cmp comparer method
+// that will perform an equality check on the error message. This is mainly
+// useful to get around not being able to see unexported data within errors.
+func CompareErrorString[T error]() cmp.Option {
+	return cmp.Comparer(func(e1, e2 T) bool {
+		return e1.Error() == e2.Error()
+	})
+}
+
+// default comparers for known types that don't play well with go-cmp
+var comparers = []cmp.Option{
+	CompareErrorString[resource.ConstError](),
+}
+
 // RequireError is useful for asserting that some chained multierror contains a specific error.
-func RequireError[E error](t T, err error, expected E) {
+func RequireError[E error](t T, err error, expected E, opts ...cmp.Option) {
 	t.Helper()
 
 	var actual E
 	require.ErrorAs(t, err, &actual)
-	prototest.AssertDeepEqual(t, expected, actual)
+
+	opts = append(opts, comparers...)
+	prototest.AssertDeepEqual(t, expected, actual, opts...)
 }
 
 func RequireVersionUnchanged(t T, res *pbresource.Resource, version string) {


### PR DESCRIPTION
### Description

Apparently when implementing the hooks previously I missed some tests for the Mutation hook specifically so this is adding them.

I also discovered that one error emitted by the Mutation hook wasn't filling in all the necessary fields and have fixed that.

### Testing & Reproduction steps

This PR is mainly just adding tests.

