### PR TITLE
docs: fix incorrect proxy-defaults config in Lua Envoy extension

### DIFF
--- a/website/content/docs/connect/proxies/envoy-extensions/usage/lua.mdx
+++ b/website/content/docs/connect/proxies/envoy-extensions/usage/lua.mdx
@@ -42,15 +42,17 @@ The following example configures the Lua Envoy extension on every service by usi
 <CodeBlockConfig filename="lua-envoy-extension-proxy-defaults.hcl">
 
 ```hcl
-Kind     = "proxy-defaults"
-Name     = "global"
-Protocol = "http"
+Kind = "proxy-defaults"
+Name = "global"
+Config {
+  protocol = "http"
+}
 EnvoyExtensions {
   Name = "builtin/lua"
   Arguments = {
     ProxyType = "connect-proxy"
     Listener  = "inbound"
-    Script    = <<-EOS
+    Script    = <<-EOF
 function envoy_on_request(request_handle)
   meta = request_handle:streamInfo():dynamicMetadata()
   m = meta:get("consul")
@@ -59,7 +61,7 @@ function envoy_on_request(request_handle)
   request_handle:headers():add("x-consul-datacenter", m["datacenter"])
   request_handle:headers():add("x-consul-trust-domain", m["trust-domain"])
 end
-EOS
+ EOF
   }
 }
 ```


### PR DESCRIPTION
### Description

The current example `proxy-defaults` config is incorrect and will cause these errors. 

```
Failed to decode config entry input: Failed to decode config entry input: At 22:1: heredoc not terminated

Failed to decode config entry input: 1 error occurred:
        * invalid config key "Protocol"
```

I updated the config with correct `protocol` setting, as well as changed heredoc delimiter to `EOF` to be consistent with other examples in `service-defaults`.

### Testing & Reproduction steps

- Built the doc locally with `make`
- Copy and apply the config successfully in Consul Dev

```
consul config write correct.hcl
Config entry written: proxy-defaults/global
```

### Links

https://developer.hashicorp.com/consul/docs/connect/proxies/envoy-extensions/usage/lua


### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
