### PR TITLE
fix the error in ent repo

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1629,7 +1629,9 @@ func TestHTTPHandlers_AgentMetricsStream_ACLDeny(t *testing.T) {
 	bd.MetricsConfig = &lib.MetricsConfig{
 		Handler: sink,
 	}
-	d := fakeResolveTokenDelegate{delegate: &delegateMock{}, authorizer: acl.DenyAll()}
+	mockDelegate := delegateMock{}
+	mockDelegate.On("LicenseCheck").Return()
+	d := fakeResolveTokenDelegate{delegate: &mockDelegate, authorizer: acl.DenyAll()}
 	agent := &Agent{
 		baseDeps: bd,
 		delegate: d,
@@ -1658,7 +1660,9 @@ func TestHTTPHandlers_AgentMetricsStream(t *testing.T) {
 	bd.MetricsConfig = &lib.MetricsConfig{
 		Handler: sink,
 	}
-	d := fakeResolveTokenDelegate{delegate: &delegateMock{}, authorizer: acl.ManageAll()}
+	mockDelegate := delegateMock{}
+	mockDelegate.On("LicenseCheck").Return()
+	d := fakeResolveTokenDelegate{delegate: &mockDelegate, authorizer: acl.ManageAll()}
 	agent := &Agent{
 		baseDeps: bd,
 		delegate: d,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -346,7 +346,9 @@ func TestAgent_HTTPMaxHeaderBytes(t *testing.T) {
 			require.NoError(t, err)
 
 			a, err := New(bd)
-			a.delegate = &delegateMock{}
+			mockDelegate := delegateMock{}
+			mockDelegate.On("LicenseCheck").Return()
+			a.delegate = &mockDelegate
 			require.NoError(t, err)
 
 			a.startLicenseManager(testutil.TestContext(t))
@@ -5503,7 +5505,9 @@ func TestAgent_ListenHTTP_MultipleAddresses(t *testing.T) {
 	require.NoError(t, err)
 
 	agent, err := New(bd)
-	agent.delegate = &delegateMock{}
+	mockDelegate := delegateMock{}
+	mockDelegate.On("LicenseCheck").Return()
+	agent.delegate = &mockDelegate
 	require.NoError(t, err)
 
 	agent.startLicenseManager(testutil.TestContext(t))
@@ -6097,7 +6101,9 @@ func TestAgent_startListeners(t *testing.T) {
 	require.NoError(t, err)
 
 	agent, err := New(bd)
-	agent.delegate = &delegateMock{}
+	mockDelegate := delegateMock{}
+	mockDelegate.On("LicenseCheck").Return()
+	agent.delegate = &mockDelegate
 	require.NoError(t, err)
 
 	// use up an address
@@ -6238,7 +6244,9 @@ func TestAgent_startListeners_scada(t *testing.T) {
 	require.NoError(t, err)
 
 	agent, err := New(bd)
-	agent.delegate = &delegateMock{}
+	mockDelegate := delegateMock{}
+	mockDelegate.On("LicenseCheck").Return()
+	agent.delegate = &mockDelegate
 	require.NoError(t, err)
 
 	_, err = agent.startListeners([]net.Addr{c})
@@ -6294,7 +6302,9 @@ func TestAgent_checkServerLastSeen(t *testing.T) {
 		Config:      leafcert.Config{},
 	})
 	agent, err := New(bd)
-	agent.delegate = &delegateMock{}
+	mockDelegate := delegateMock{}
+	mockDelegate.On("LicenseCheck").Return()
+	agent.delegate = &mockDelegate
 	require.NoError(t, err)
 
 	// Test that an ErrNotExist OS error is treated as ok.


### PR DESCRIPTION
### Description

The delegateMock missed some function mocking which breaks tests in ent repo. This is a fix for that.


### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
