### PR TITLE
NET-4952 Add docs for export command

### DIFF
--- a/website/content/commands/services/export.mdx
+++ b/website/content/commands/services/export.mdx
@@ -1,0 +1,8 @@
+---
+layout: commands
+page_title: 'Commands: Services Export'
+description: |
+  The `consul services export` command exports a service from one peer or admin partition to another.
+---
+
+# Consul Agent Service Export

--- a/website/content/commands/services/export.mdx
+++ b/website/content/commands/services/export.mdx
@@ -10,7 +10,9 @@ description: |
 Command: `consul services export`
 
 The services export subcommand is used to export a service from one admin partition
-or cluster peer to another.
+or cluster peer to another. This is accomplished by creating or updating the corresponding
+`exported-services` configuration entry. Running the command multiple times with the same
+arguments will result in a no-op.
 
 ```text
 Usage: consul services export [options] -name <service name> -consumer-peers <other cluster name>
@@ -45,3 +47,19 @@ Usage: consul services export [options] -name <service name> -consumer-peers <ot
 #### API Options
 
 @include 'http_api_options_client.mdx'
+
+## Examples
+
+The example below shows using the `export` command to export the `web` service to a cluster
+peer named `dc2`.
+
+```shell-session hideClipboard
+$ consul services export -name=web -consumer-peers=dc2
+```
+
+The example below shows using the `export` command to export the `web` service located in the
+namespace `ns1` and the admin partition `part1` to other admin partitions named `part2` and `part3`.
+
+```shell-session hideClipboard
+$ consul services export -name=web -namespace=ns1 -partition=part1 -consumer-partitions=part2,part3
+```

--- a/website/content/commands/services/export.mdx
+++ b/website/content/commands/services/export.mdx
@@ -28,14 +28,14 @@ Usage: consul services export [options] -name <service name> -consumer-peers <ot
 
 #### Command Options
 
-- `-name` - (Required) The name of the service to export.
+- `-name=<string>` - (Required) The name of the service to export.
 
-- `-consumer-peers` - (Required) A comma-separated list of cluster peers to export the service to.
+- `-consumer-peers=<string>` - (Required) A comma-separated list of cluster peers to export the service to.
   In Consul Enterprise, this flag is optional if -consumer-partitions is specified.
 
 #### Enterprise Options
 
-- `-consumer-partitions` - (Enterprise only) A comma-separated list of admin partitions within the
+- `-consumer-partitions=<string>` - A comma-separated list of admin partitions within the
   same datacenter to export the service to. This flag is optional if -consumer-peers is specified.
 
 @include 'http_api_partition_options.mdx'

--- a/website/content/commands/services/export.mdx
+++ b/website/content/commands/services/export.mdx
@@ -9,10 +9,10 @@ description: |
 
 Command: `consul services export`
 
-The services export subcommand is used to export a service from one admin partition
-or cluster peer to another. This is accomplished by creating or updating the corresponding
+The `services export` command exports a service from one admin partition
+or cluster peer to another. This command can be used in lieu of creating or updating the corresponding
 `exported-services` configuration entry. Running the command multiple times with the same
-arguments will result in a no-op.
+arguments results in a no-op.
 
 ```text
 Usage: consul services export [options] -name <service name> -consumer-peers <other cluster name>
@@ -28,38 +28,37 @@ Usage: consul services export [options] -name <service name> -consumer-peers <ot
   Additional flags and more advanced use cases are detailed below.
 ```
 
-#### Command Options
+#### Command options
 
 - `-name=<string>` - (Required) The name of the service to export.
 
 - `-consumer-peers=<string>` - (Required) A comma-separated list of cluster peers to export the service to.
-  In Consul Enterprise, this flag is optional if -consumer-partitions is specified.
+  In Consul Enterprise, this flag is optional when `-consumer-partitions` is specified.
 
-#### Enterprise Options
+#### Enterprise options
 
 - `-consumer-partitions=<string>` - A comma-separated list of admin partitions within the
-  same datacenter to export the service to. This flag is optional if -consumer-peers is specified.
+  same datacenter to export the service to. This flag is optional when `-consumer-peers` is specified.
 
 @include 'http_api_partition_options.mdx'
 
 @include 'http_api_namespace_options.mdx'
 
-#### API Options
+#### API options
 
 @include 'http_api_options_client.mdx'
 
 ## Examples
 
-The example below shows using the `export` command to export the `web` service to a cluster
-peer named `dc2`.
+In the following example, the `consul services export` command makes the `web` service available to services running in a cluster named `dc2` that has a previously-established cluster peering connection.
 
 ```shell-session hideClipboard
 $ consul services export -name=web -consumer-peers=dc2
 ```
 
-The example below shows using the `export` command to export the `web` service located in the
-namespace `ns1` and the admin partition `part1` to other admin partitions named `part2` and `part3`.
+In the following example, the `consul services export` command makes the `web` service located in the
+namespace `ns1` and the admin partition `alpha` to other admin partitions named `beta` and `delta`.
 
 ```shell-session hideClipboard
-$ consul services export -name=web -namespace=ns1 -partition=part1 -consumer-partitions=part2,part3
+$ consul services export -name=web -namespace=ns1 -partition=alpha -consumer-partitions=beta,delta
 ```

--- a/website/content/commands/services/export.mdx
+++ b/website/content/commands/services/export.mdx
@@ -5,4 +5,33 @@ description: |
   The `consul services export` command exports a service from one peer or admin partition to another.
 ---
 
-# Consul Agent Service Export
+# Consul Services Export
+
+Command: `consul services export`
+
+The services export subcommand is used to export a service from one admin partition
+or cluster peer to another.
+
+```text
+Usage: consul services export [options] -name <service name> -consumer-peers <other cluster name>
+
+  Export a service to a peered cluster.
+
+      $ consul services export -name=web -consumer-peers=other-cluster
+
+  Use the -consumer-partitions flag instead of -consumer-peers to export to a different partition in the same cluster.
+
+      $ consul services export -name=web -consumer-partitions=other-partition
+
+  Additional flags and more advanced use cases are detailed below.
+```
+
+#### Command Options
+
+- `-name` - (Required) The name of the service to export.
+
+- `-consumer-peers` - (Required) A comma-separated list of cluster peers to export the service to.
+  In Consul Enterprise, this flag is optional if -consumer-partitions is specified.
+
+- `-consumer-partitions` - (Enterprise only) A comma-separated list of admin partitions within the
+  same datacenter to export the service to. This flag is optional if -consumer-peers is specified.

--- a/website/content/commands/services/export.mdx
+++ b/website/content/commands/services/export.mdx
@@ -35,3 +35,9 @@ Usage: consul services export [options] -name <service name> -consumer-peers <ot
 
 - `-consumer-partitions` - (Enterprise only) A comma-separated list of admin partitions within the
   same datacenter to export the service to. This flag is optional if -consumer-peers is specified.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'

--- a/website/content/commands/services/export.mdx
+++ b/website/content/commands/services/export.mdx
@@ -33,11 +33,15 @@ Usage: consul services export [options] -name <service name> -consumer-peers <ot
 - `-consumer-peers` - (Required) A comma-separated list of cluster peers to export the service to.
   In Consul Enterprise, this flag is optional if -consumer-partitions is specified.
 
+#### Enterprise Options
+
 - `-consumer-partitions` - (Enterprise only) A comma-separated list of admin partitions within the
   same datacenter to export the service to. This flag is optional if -consumer-peers is specified.
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
 
 #### API Options
 
 @include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'

--- a/website/content/commands/services/index.mdx
+++ b/website/content/commands/services/index.mdx
@@ -31,6 +31,7 @@ Usage: consul services <subcommand> [options] [args]
 Subcommands:
     deregister    Deregister services with the local agent
     register      Register services with the local agent
+    export        Export services from one cluster peer or admin partition to another
 ```
 
 For more information, examples, and usage about a subcommand, click on the name

--- a/website/data/commands-nav-data.json
+++ b/website/data/commands-nav-data.json
@@ -487,6 +487,10 @@
       {
         "title": "deregister",
         "path": "services/deregister"
+      },
+      {
+        "title": "export",
+        "path": "services/export"
       }
     ]
   },


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Consul 1.16 introduced the `services export` command in the Consul CLI via #14547 / #15654 , and I intended to add docs at the time but forgot. These are the docs.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

Verify docs match usage introduced in #15654.

### Links
[Vercel deploy](https://consul-git-export-docs-hashicorp.vercel.app/consul/commands/services/export)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
