### PR TITLE
Disable deep-copy codegen verification for now.

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -76,28 +76,29 @@ jobs:
     - name: Notify Slack
       if: ${{ failure() }}
       run: .github/scripts/notify_slack.sh
-  check-generated-deep-copy:
-    needs:
-    - setup
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
-    steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-    - name: Setup Git
-      if: ${{ endsWith(github.repository, '-enterprise') }}
-      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-      with:
-        go-version-file: 'go.mod'
-    - run: make --always-make deep-copy
-    - run: |
-        if ! git diff --exit-code; then
-          echo "Generated code was not updated correctly"
-          exit 1
-        fi
-    - name: Notify Slack
-      if: ${{ failure() }}
-      run: .github/scripts/notify_slack.sh
+  # Temporarily changing until the situation with license headers in the generated code can be worked out
+  # check-generated-deep-copy:
+  #   needs:
+  #   - setup
+  #   runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
+  #   steps:
+  #   - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+  #   # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+  #   - name: Setup Git
+  #     if: ${{ endsWith(github.repository, '-enterprise') }}
+  #     run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+  #   - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+  #     with:
+  #       go-version-file: 'go.mod'
+  #   - run: make --always-make deep-copy
+  #   - run: |
+  #       if ! git diff --exit-code; then
+  #         echo "Generated code was not updated correctly"
+  #         exit 1
+  #       fi
+  #   - name: Notify Slack
+  #     if: ${{ failure() }}
+  #     run: .github/scripts/notify_slack.sh
 
   lint-enums:
     needs:
@@ -464,7 +465,8 @@ jobs:
   go-tests-success:
     needs:
     - setup
-    - check-generated-deep-copy
+    # Reenable later
+    #- check-generated-deep-copy
     - check-generated-protobuf
     - check-go-mod
     - lint-consul-retry


### PR DESCRIPTION

### Description

Once we figure out what to do with license headers for these files we should re-enable this check.

### Testing & Reproduction steps

### Links

