### PR TITLE
mesh: adding type aliases for mesh resource usage

### DIFF
--- a/internal/mesh/internal/types/decoded.go
+++ b/internal/mesh/internal/types/decoded.go
@@ -1,0 +1,20 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v1alpha1"
+)
+
+type (
+	DecodedHTTPRoute         = resource.DecodedResource[pbmesh.HTTPRoute, *pbmesh.HTTPRoute]
+	DecodedGRPCRoute         = resource.DecodedResource[pbmesh.GRPCRoute, *pbmesh.GRPCRoute]
+	DecodedTCPRoute          = resource.DecodedResource[pbmesh.TCPRoute, *pbmesh.TCPRoute]
+	DecodedDestinationPolicy = resource.DecodedResource[pbmesh.DestinationPolicy, *pbmesh.DestinationPolicy]
+	DecodedComputedRoutes    = resource.DecodedResource[pbmesh.ComputedRoutes, *pbmesh.ComputedRoutes]
+	DecodedFailoverPolicy    = resource.DecodedResource[pbcatalog.FailoverPolicy, *pbcatalog.FailoverPolicy]
+	DecodedService           = resource.DecodedResource[pbcatalog.Service, *pbcatalog.Service]
+)

--- a/internal/mesh/internal/types/decoded.go
+++ b/internal/mesh/internal/types/decoded.go
@@ -10,11 +10,11 @@ import (
 )
 
 type (
-	DecodedHTTPRoute         = resource.DecodedResource[pbmesh.HTTPRoute, *pbmesh.HTTPRoute]
-	DecodedGRPCRoute         = resource.DecodedResource[pbmesh.GRPCRoute, *pbmesh.GRPCRoute]
-	DecodedTCPRoute          = resource.DecodedResource[pbmesh.TCPRoute, *pbmesh.TCPRoute]
-	DecodedDestinationPolicy = resource.DecodedResource[pbmesh.DestinationPolicy, *pbmesh.DestinationPolicy]
-	DecodedComputedRoutes    = resource.DecodedResource[pbmesh.ComputedRoutes, *pbmesh.ComputedRoutes]
-	DecodedFailoverPolicy    = resource.DecodedResource[pbcatalog.FailoverPolicy, *pbcatalog.FailoverPolicy]
-	DecodedService           = resource.DecodedResource[pbcatalog.Service, *pbcatalog.Service]
+	DecodedHTTPRoute         = resource.DecodedResource[*pbmesh.HTTPRoute]
+	DecodedGRPCRoute         = resource.DecodedResource[*pbmesh.GRPCRoute]
+	DecodedTCPRoute          = resource.DecodedResource[*pbmesh.TCPRoute]
+	DecodedDestinationPolicy = resource.DecodedResource[*pbmesh.DestinationPolicy]
+	DecodedComputedRoutes    = resource.DecodedResource[*pbmesh.ComputedRoutes]
+	DecodedFailoverPolicy    = resource.DecodedResource[*pbcatalog.FailoverPolicy]
+	DecodedService           = resource.DecodedResource[*pbcatalog.Service]
 )

--- a/internal/resource/decode.go
+++ b/internal/resource/decode.go
@@ -20,7 +20,7 @@ type DecodedResource[T proto.Message] struct {
 	Data     T
 }
 
-func (d *DecodedResource[V, PV]) GetResource() *pbresource.Resource {
+func (d *DecodedResource[T]) GetResource() *pbresource.Resource {
 	if d == nil {
 		return nil
 	}
@@ -28,9 +28,10 @@ func (d *DecodedResource[V, PV]) GetResource() *pbresource.Resource {
 	return d.Resource
 }
 
-func (d *DecodedResource[V, PV]) GetData() PV {
+func (d *DecodedResource[T]) GetData() T {
 	if d == nil {
-		return nil
+		var zero T
+		return zero
 	}
 
 	return d.Data

--- a/internal/resource/decode.go
+++ b/internal/resource/decode.go
@@ -20,6 +20,22 @@ type DecodedResource[T proto.Message] struct {
 	Data     T
 }
 
+func (d *DecodedResource[V, PV]) GetResource() *pbresource.Resource {
+	if d == nil {
+		return nil
+	}
+
+	return d.Resource
+}
+
+func (d *DecodedResource[V, PV]) GetData() PV {
+	if d == nil {
+		return nil
+	}
+
+	return d.Data
+}
+
 // Decode will generically decode the provided resource into a 2-field
 // structure that holds onto the original Resource and the decoded contents.
 //


### PR DESCRIPTION
### Description

Introduces some simple type aliases for `DecodedResource[*X]` wrappers for each type which cut down on the verbosity in my own code so instead of having something like:

```
stuff map[resource.ReferenceKey]*resource.DecodedResource[*pbmesh.HTTPRoute]
```
you have

```
stuff map[resource.ReferenceKey]*types.DecodedHTTPRoute
```
