### PR TITLE
Update linux package license to BUSL-1.1

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 # This action creates downstream PRs for PRs with backport labels defined.
 # See docs here: https://github.com/hashicorp/backport-assistant

--- a/.github/workflows/backport-checker.yml
+++ b/.github/workflows/backport-checker.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 # This workflow checks that there is either a 'pr/no-backport' label applied to a PR
 # or there is a backport/* label indicating a backport has been set

--- a/.github/workflows/bot-auto-approve.yaml
+++ b/.github/workflows/bot-auto-approve.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: Bot Auto Approve
 

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: Broken Link Check
 

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 # This workflow builds a dev binary and distributes a Docker image on every push to the main branch.
 name: build-artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: build
 
@@ -146,7 +146,7 @@ jobs:
           version: ${{ needs.set-product-version.outputs.product-version }}
           maintainer: "HashiCorp"
           homepage: "https://github.com/hashicorp/consul"
-          license: "MPL-2.0"
+          license: "BUSL-1.1"
           binary: "dist/${{ env.PKG_NAME }}"
           deb_depends: "openssl"
           rpm_depends: "openssl"

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 # This workflow checks that there is either a 'pr/no-changelog' label applied to a PR
 # or there is a .changelog/<pr number>.txt file associated with a PR for a changelog entry

--- a/.github/workflows/embedded-asset-checker.yml
+++ b/.github/workflows/embedded-asset-checker.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 # This workflow detects if there is a diff in the `agent/uiserver/dist` directory
 # which is used by Consul to serve its embedded UI.

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: frontend
 

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: Issue Comment Created
 

--- a/.github/workflows/jira-issues.yaml
+++ b/.github/workflows/jira-issues.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 on:
   issues:

--- a/.github/workflows/jira-pr.yaml
+++ b/.github/workflows/jira-pr.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 on:
   pull_request_target:

--- a/.github/workflows/nightly-test-1.13.x.yaml
+++ b/.github/workflows/nightly-test-1.13.x.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: Nightly Test 1.13.x
 on:

--- a/.github/workflows/nightly-test-1.14.x.yaml
+++ b/.github/workflows/nightly-test-1.14.x.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: Nightly Test 1.14.x
 on:

--- a/.github/workflows/nightly-test-1.15.x.yaml
+++ b/.github/workflows/nightly-test-1.15.x.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: Nightly Test 1.15.x
 on:

--- a/.github/workflows/nightly-test-1.16.x.yaml
+++ b/.github/workflows/nightly-test-1.16.x.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: Nightly Test 1.16.x
 on:

--- a/.github/workflows/nightly-test-main.yaml
+++ b/.github/workflows/nightly-test-main.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: Nightly Test Main
 on:

--- a/.github/workflows/oss-merge-trigger.yml
+++ b/.github/workflows/oss-merge-trigger.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: Trigger OSS to Enterprise Merge
 on:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: "Pull Request Labeler"
 on:

--- a/.github/workflows/pr-metrics-test-checker.yml
+++ b/.github/workflows/pr-metrics-test-checker.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: "Check for metrics tests"
 on:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: stale
 on:

--- a/.github/workflows/test-integrations-windows.yml
+++ b/.github/workflows/test-integrations-windows.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: test-integrations-windows
 

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 name: test-integrations
 

--- a/.github/workflows/verify-ci.yml
+++ b/.github/workflows/verify-ci.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 # verify-ci is a no-op workflow that must run on every PR. It is used in a
 # branch protection rule to detect when CI workflows are not running.

--- a/.github/workflows/verify-envoy-version.yml
+++ b/.github/workflows/verify-envoy-version.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 # This action ensures that Envoy is up to date on main and release branches.
 # This workflow is only triggered on the main and release branches and will


### PR DESCRIPTION
This updates the linux package license to BUSL-1.1.
This PR should be merged to main so that the change is included in the next major release (#.X.#) that is cut from main.
License changes are not required on release branches (ongoing patch releases of current minor releases).

Also updates github workflow file headers to BUSL-1.1.
