### PR TITLE
NET-5187: Upgrade test timeout due to log producer errors

### DIFF
--- a/test/integration/consul-container/libs/service/connect.go
+++ b/test/integration/consul-container/libs/service/connect.go
@@ -68,14 +68,17 @@ func (g ConnectContainer) GetPort(port int) (int, error) {
 }
 
 func (g ConnectContainer) Restart() error {
-	_, err := g.GetStatus()
-	if err != nil {
-		return fmt.Errorf("error fetching sidecar container state %s", err)
+	var deferClean utils.ResettableDefer
+	defer deferClean.Execute()
+
+	if utils.FollowLog {
+		if err := g.container.StopLogProducer(); err != nil {
+			return fmt.Errorf("stopping log producer: %w", err)
+		}
 	}
 
 	fmt.Printf("Stopping container: %s\n", g.GetName())
-	err = g.container.Stop(g.ctx, nil)
-
+	err := g.container.Stop(g.ctx, nil)
 	if err != nil {
 		return fmt.Errorf("error stopping sidecar container %s", err)
 	}
@@ -85,6 +88,17 @@ func (g ConnectContainer) Restart() error {
 	if err != nil {
 		return fmt.Errorf("error starting sidecar container %s", err)
 	}
+
+	if utils.FollowLog {
+		if err := g.container.StartLogProducer(g.ctx); err != nil {
+			return fmt.Errorf("starting log producer: %w", err)
+		}
+		g.container.FollowOutput(&LogConsumer{})
+		deferClean.Add(func() {
+			_ = g.container.StopLogProducer()
+		})
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### Description

If `--follow-log=true` several upgrade tests timeout after passing. This was as a result of container failing to stop due to log producer not being stopped before container restart

**SOLUTION**
To restart a container - sidecar:
- Stop log producer
- Stop Container
- Start Container
- Start Log Producer
Then container can be stopped and terminated gracefully. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
