### PR TITLE
resource: Make resource list tenancy aware

### DIFF
--- a/agent/grpc-external/services/resource/list.go
+++ b/agent/grpc-external/services/resource/list.go
@@ -10,35 +10,36 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/storage"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
 func (s *Server) List(ctx context.Context, req *pbresource.ListRequest) (*pbresource.ListResponse, error) {
-	if err := validateListRequest(req); err != nil {
-		return nil, err
-	}
-
-	// check type
-	reg, err := s.resolveType(req.Type)
+	reg, err := s.validateListRequest(req)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO(spatel): Refactor _ and entMeta in NET-4915
-	authz, authzContext, err := s.getAuthorizer(tokenFromContext(ctx), acl.DefaultEnterpriseMeta())
+	// v1 ACL subsystem is "wildcard" aware so just pass on through.
+	entMeta := v2TenancyToV1EntMeta(req.Tenancy)
+	token := tokenFromContext(ctx)
+	authz, authzContext, err := s.getAuthorizer(token, entMeta)
 	if err != nil {
 		return nil, err
 	}
 
-	// check acls
-	err = reg.ACLs.List(authz, req.Tenancy)
+	// Check ACLs.
+	err = reg.ACLs.List(authz, authzContext)
 	switch {
 	case acl.IsErrPermissionDenied(err):
 		return nil, status.Error(codes.PermissionDenied, err.Error())
 	case err != nil:
 		return nil, status.Errorf(codes.Internal, "failed list acl: %v", err)
 	}
+
+	// Ensure we're defaulting correctly when request tenancy units are empty.
+	v1EntMetaToV2Tenancy(reg, entMeta, req.Tenancy)
 
 	resources, err := s.Backend.List(
 		ctx,
@@ -53,12 +54,21 @@ func (s *Server) List(ctx context.Context, req *pbresource.ListRequest) (*pbreso
 
 	result := make([]*pbresource.Resource, 0)
 	for _, resource := range resources {
-		// filter out non-matching GroupVersion
+		// Filter out non-matching GroupVersion.
 		if resource.Id.Type.GroupVersion != req.Type.GroupVersion {
 			continue
 		}
 
-		// filter out items that don't pass read ACLs
+		// Need to rebuild authorizer per resource since wildcard inputs may
+		// result in different tenancies. Consider caching per tenancy if this
+		// is deemed expensive.
+		entMeta = v2TenancyToV1EntMeta(resource.Id.Tenancy)
+		authz, authzContext, err = s.getAuthorizer(token, entMeta)
+		if err != nil {
+			return nil, err
+		}
+
+		// Filter out items that don't pass read ACLs.
 		err = reg.ACLs.Read(authz, authzContext, resource.Id)
 		switch {
 		case acl.IsErrPermissionDenied(err):
@@ -71,15 +81,37 @@ func (s *Server) List(ctx context.Context, req *pbresource.ListRequest) (*pbreso
 	return &pbresource.ListResponse{Resources: result}, nil
 }
 
-func validateListRequest(req *pbresource.ListRequest) error {
+func (s *Server) validateListRequest(req *pbresource.ListRequest) (*resource.Registration, error) {
 	var field string
 	switch {
 	case req.Type == nil:
 		field = "type"
 	case req.Tenancy == nil:
 		field = "tenancy"
-	default:
-		return nil
 	}
-	return status.Errorf(codes.InvalidArgument, "%s is required", field)
+
+	if field != "" {
+		return nil, status.Errorf(codes.InvalidArgument, "%s is required", field)
+	}
+
+	// Check type exists.
+	reg, err := s.resolveType(req.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lowercase
+	resource.Normalize(req.Tenancy)
+
+	// Error when partition scoped and namespace not empty.
+	if reg.Scope == resource.ScopePartition && req.Tenancy.Namespace != "" {
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"partition scoped type %s cannot have a namespace. got: %s",
+			resource.ToGVK(req.Type),
+			req.Tenancy.Namespace,
+		)
+	}
+
+	return reg, nil
 }

--- a/agent/grpc-external/services/resource/watch.go
+++ b/agent/grpc-external/services/resource/watch.go
@@ -32,7 +32,7 @@ func (s *Server) WatchList(req *pbresource.WatchListRequest, stream pbresource.R
 	}
 
 	// check acls
-	err = reg.ACLs.List(authz, req.Tenancy)
+	err = reg.ACLs.List(authz, authzContext)
 	switch {
 	case acl.IsErrPermissionDenied(err):
 		return status.Error(codes.PermissionDenied, err.Error())

--- a/internal/mesh/internal/types/proxy_state_template.go
+++ b/internal/mesh/internal/types/proxy_state_template.go
@@ -52,7 +52,7 @@ func RegisterProxyStateTemplate(r resource.Registry) {
 				// managed by a controller.
 				return authorizer.ToAllowAuthorizer().OperatorWriteAllowed(authzContext)
 			},
-			List: func(authorizer acl.Authorizer, tenancy *pbresource.Tenancy) error {
+			List: func(authorizer acl.Authorizer, authzContext *acl.AuthorizerContext) error {
 				// No-op List permission as we want to default to filtering resources
 				// from the list using the Read enforcement.
 				return nil

--- a/internal/resource/demo/demo.go
+++ b/internal/resource/demo/demo.go
@@ -87,13 +87,13 @@ func RegisterTypes(r resource.Registry) {
 
 	writeACL := func(authz acl.Authorizer, authzContext *acl.AuthorizerContext, res *pbresource.Resource) error {
 		key := fmt.Sprintf("resource/%s/%s", resource.ToGVK(res.Id.Type), res.Id.Name)
-		return authz.ToAllowAuthorizer().KeyWriteAllowed(key, &acl.AuthorizerContext{})
+		return authz.ToAllowAuthorizer().KeyWriteAllowed(key, authzContext)
 	}
 
-	makeListACL := func(typ *pbresource.Type) func(acl.Authorizer, *pbresource.Tenancy) error {
-		return func(authz acl.Authorizer, tenancy *pbresource.Tenancy) error {
+	makeListACL := func(typ *pbresource.Type) func(acl.Authorizer, *acl.AuthorizerContext) error {
+		return func(authz acl.Authorizer, authzContext *acl.AuthorizerContext) error {
 			key := fmt.Sprintf("resource/%s", resource.ToGVK(typ))
-			return authz.ToAllowAuthorizer().KeyListAllowed(key, &acl.AuthorizerContext{})
+			return authz.ToAllowAuthorizer().KeyListAllowed(key, authzContext)
 		}
 	}
 

--- a/internal/resource/registry.go
+++ b/internal/resource/registry.go
@@ -68,7 +68,7 @@ type ACLHooks struct {
 	// List is used to authorize List RPCs.
 	//
 	// If it is omitted, we only filter the results using Read.
-	List func(acl.Authorizer, *pbresource.Tenancy) error
+	List func(acl.Authorizer, *acl.AuthorizerContext) error
 }
 
 // Resource type registry
@@ -130,7 +130,7 @@ func (r *TypeRegistry) Register(registration Registration) {
 		}
 	}
 	if registration.ACLs.List == nil {
-		registration.ACLs.List = func(authz acl.Authorizer, tenancy *pbresource.Tenancy) error {
+		registration.ACLs.List = func(authz acl.Authorizer, authzContext *acl.AuthorizerContext) error {
 			return authz.ToAllowAuthorizer().OperatorReadAllowed(&acl.AuthorizerContext{})
 		}
 	}

--- a/internal/resource/registry_test.go
+++ b/internal/resource/registry_test.go
@@ -51,8 +51,8 @@ func TestRegister_Defaults(t *testing.T) {
 	require.True(t, acl.IsErrPermissionDenied(reg.ACLs.Write(testutils.ACLNoPermissions(t), nil, artist)))
 
 	// verify default list hook requires operator:read
-	require.NoError(t, reg.ACLs.List(testutils.ACLOperatorRead(t), artist.Id.Tenancy))
-	require.True(t, acl.IsErrPermissionDenied(reg.ACLs.List(testutils.ACLNoPermissions(t), artist.Id.Tenancy)))
+	require.NoError(t, reg.ACLs.List(testutils.ACLOperatorRead(t), nil))
+	require.True(t, acl.IsErrPermissionDenied(reg.ACLs.List(testutils.ACLNoPermissions(t), nil)))
 
 	// verify default validate is a no-op
 	require.NoError(t, reg.Validate(nil))


### PR DESCRIPTION
### Description

CE version of already approved ENT PR: https://github.com/hashicorp/consul-enterprise/pull/6600.

Clean merge, no changes.

See NET-4915 for details.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
