### PR TITLE
docs: Update OpenShift compatibility 

### DIFF
--- a/website/content/docs/k8s/compatibility.mdx
+++ b/website/content/docs/k8s/compatibility.mdx
@@ -42,7 +42,6 @@ Starting with Consul K8s 0.39.0 and Consul 1.11.x, Consul Kubernetes supports th
 ### Red Hat OpenShift
 
 You can enable support for Red Hat OpenShift by setting `enabled: true` in the `global.openshift` stanza. Refer to the [Deploy Consul on RedHat OpenShift tutorial](https://developer.hashicorp.com/consul/tutorials/kubernetes/kubernetes-openshift-red-hat) for instructions on deploying to OpenShift. 
-- Only the default CNI Plugin, [OpenShift SDN CNI Plugin](https://docs.openshift.com/container-platform/4.9/networking/openshift_sdn/about-openshift-sdn.html) is currently supported.
 
 ### VMware Tanzu Kubernetes Grid and Tanzu Kubernetes Grid Integrated Edition
 


### PR DESCRIPTION
### Description

Remove restriction of default CNI plugin only supported with OpenShifSDN as this is now working with OVN Kubernetes as of OpenShift 4.12. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
