### PR TITLE
[NET-5163] Support locality testing in consul-container

### DIFF
--- a/sdk/testutil/retry/timer.go
+++ b/sdk/testutil/retry/timer.go
@@ -2,6 +2,12 @@ package retry
 
 import "time"
 
+// ThirtySeconds repeats an operation for thirty seconds and waits 500ms in between.
+// Best for known slower operations like waiting on eventually consistent state.
+func ThirtySeconds() *Timer {
+	return &Timer{Timeout: 30 * time.Second, Wait: 500 * time.Millisecond}
+}
+
 // TwoSeconds repeats an operation for two seconds and waits 25ms in between.
 func TwoSeconds() *Timer {
 	return &Timer{Timeout: 2 * time.Second, Wait: 25 * time.Millisecond}

--- a/test/integration/consul-container/libs/service/connect.go
+++ b/test/integration/consul-container/libs/service/connect.go
@@ -163,8 +163,9 @@ func (g ConnectContainer) GetStatus() (string, error) {
 type SidecarConfig struct {
 	Name         string
 	ServiceID    string
-	Namespace    string
 	EnableTProxy bool
+	Namespace    string
+	Partition    string
 }
 
 // NewConnectService returns a container that runs envoy sidecar, launched by

--- a/test/integration/consul-container/libs/topology/peering_topology.go
+++ b/test/integration/consul-container/libs/topology/peering_topology.go
@@ -151,7 +151,7 @@ func BasicPeeringTwoClustersSetup(
 
 		// Create a service and proxy instance
 		var err error
-		clientSidecarService, err = libservice.CreateAndRegisterStaticClientSidecar(clientNode, DialingPeerName, true, false)
+		clientSidecarService, err = libservice.CreateAndRegisterStaticClientSidecar(clientNode, DialingPeerName, true, false, nil)
 		require.NoError(t, err)
 
 		libassert.CatalogServiceExists(t, dialingClient, "static-client-sidecar-proxy", nil)

--- a/test/integration/consul-container/libs/topology/service_topology.go
+++ b/test/integration/consul-container/libs/topology/service_topology.go
@@ -51,7 +51,7 @@ func CreateServices(t *testing.T, cluster *libcluster.Cluster, protocol string) 
 	libassert.CatalogServiceExists(t, client, libservice.StaticServerServiceName, nil)
 
 	// Create a client proxy instance with the server as an upstream
-	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false)
+	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false, nil)
 	require.NoError(t, err)
 
 	libassert.CatalogServiceExists(t, client, fmt.Sprintf("%s-sidecar-proxy", libservice.StaticClientServiceName), nil)

--- a/test/integration/consul-container/test/envoy_extensions/ext_authz_test.go
+++ b/test/integration/consul-container/test/envoy_extensions/ext_authz_test.go
@@ -110,7 +110,7 @@ func createServices(t *testing.T, cluster *libcluster.Cluster) libservice.Servic
 	libassert.CatalogServiceExists(t, client, libservice.StaticServerServiceName, nil)
 
 	// Create a client proxy instance with the server as an upstream
-	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false)
+	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false, nil)
 	require.NoError(t, err)
 
 	libassert.CatalogServiceExists(t, client, "static-client-sidecar-proxy", nil)

--- a/test/integration/consul-container/test/envoy_extensions/wasm_test.go
+++ b/test/integration/consul-container/test/envoy_extensions/wasm_test.go
@@ -311,7 +311,7 @@ func createTestServices(t *testing.T, cluster *libcluster.Cluster) (libservice.S
 
 	// Create a client proxy instance with the server as an upstream
 
-	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false)
+	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false, nil)
 	require.NoError(t, err)
 
 	libassert.CatalogServiceExists(t, client, "static-client-sidecar-proxy", nil)

--- a/test/integration/consul-container/test/jwtauth/jwt_auth_test.go
+++ b/test/integration/consul-container/test/jwtauth/jwt_auth_test.go
@@ -130,7 +130,7 @@ func createServices(t *testing.T, cluster *libcluster.Cluster) libservice.Servic
 	libassert.CatalogServiceExists(t, client, libservice.StaticServerServiceName, apiOpts)
 
 	// Create a client proxy instance with the server as an upstream
-	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false)
+	clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false, nil)
 	require.NoError(t, err)
 
 	libassert.CatalogServiceExists(t, client, "static-client-sidecar-proxy", apiOpts)

--- a/test/integration/consul-container/test/tproxy/tproxy_test.go
+++ b/test/integration/consul-container/test/tproxy/tproxy_test.go
@@ -215,7 +215,7 @@ func createServices(t *testing.T, cluster *libcluster.Cluster) libservice.Servic
 		client := node.GetClient()
 
 		// Create a client proxy instance with the server as an upstream
-		clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, true)
+		clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, true, nil)
 		require.NoError(t, err)
 
 		libassert.CatalogServiceExists(t, client, "static-client-sidecar-proxy", nil)

--- a/test/integration/consul-container/test/upgrade/ingress_gateway_grpc_test.go
+++ b/test/integration/consul-container/test/upgrade/ingress_gateway_grpc_test.go
@@ -92,7 +92,7 @@ func TestIngressGateway_GRPC_UpgradeToTarget_fromLatest(t *testing.T) {
 	serverNodes := cluster.Servers()
 	require.NoError(t, err)
 	require.True(t, len(serverNodes) > 0)
-	staticClientSvcSidecar, err := libservice.CreateAndRegisterStaticClientSidecar(serverNodes[0], "", true, false)
+	staticClientSvcSidecar, err := libservice.CreateAndRegisterStaticClientSidecar(serverNodes[0], "", true, false, nil)
 	require.NoError(t, err)
 
 	tests := func(t *testing.T) {

--- a/test/integration/consul-container/test/upgrade/l7_traffic_management/resolver_default_subset_test.go
+++ b/test/integration/consul-container/test/upgrade/l7_traffic_management/resolver_default_subset_test.go
@@ -349,7 +349,7 @@ func setup(t *testing.T) (*libcluster.Cluster, libservice.Service, libservice.Se
 	require.NoError(t, err)
 
 	// Create a client proxy instance with the server as an upstream
-	staticClientProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false)
+	staticClientProxy, err := libservice.CreateAndRegisterStaticClientSidecar(node, "", false, false, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, err)

--- a/test/integration/consul-container/test/upgrade/peering/peering_control_plane_mgw_test.go
+++ b/test/integration/consul-container/test/upgrade/peering/peering_control_plane_mgw_test.go
@@ -87,7 +87,7 @@ func TestPeering_ControlPlaneMGW(t *testing.T) {
 		"upstream_cx_total", 1)
 	require.NoError(t, accepting.Gateway.Start())
 
-	clientSidecarService, err := libservice.CreateAndRegisterStaticClientSidecar(dialingCluster.Servers()[0], libtopology.DialingPeerName, true, false)
+	clientSidecarService, err := libservice.CreateAndRegisterStaticClientSidecar(dialingCluster.Servers()[0], libtopology.DialingPeerName, true, false, nil)
 	require.NoError(t, err)
 	_, port := clientSidecarService.GetAddr()
 	_, adminPort := clientSidecarService.GetAdminAddr()

--- a/test/integration/consul-container/test/wanfed/wanfed_peering_test.go
+++ b/test/integration/consul-container/test/wanfed/wanfed_peering_test.go
@@ -57,7 +57,7 @@ func TestPeering_WanFedSecondaryDC(t *testing.T) {
 		require.NoError(t, service.Export("default", "alpha-to-secondary", c3Agent.GetClient()))
 
 		// Create a testing sidecar to proxy requests through
-		clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(c2Agent, "secondary-to-alpha", false, false)
+		clientConnectProxy, err := libservice.CreateAndRegisterStaticClientSidecar(c2Agent, "secondary-to-alpha", false, false, nil)
 		require.NoError(t, err)
 		libassert.CatalogServiceExists(t, c2Agent.GetClient(), "static-client-sidecar-proxy", nil)
 


### PR DESCRIPTION
* Support including locality in client sidecar config.
* Refactor fortio test helpers to separate HTTP retries from waiting on fortio result changes due to e.g. service startup and failovers.
* Align test config structs with Ent to avoid future conflicts.

I was planning to backport the non-locality changes further back, but there's other divergence that complicates doing that, so just doing 1.16 for now.

_Note: these changes are primarily to support Ent testing in a separate change_

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
