### PR TITLE
Add license-checker action that fails when any backported file contains BUSL header

### DIFF
--- a/.github/scripts/license_checker.sh
+++ b/.github/scripts/license_checker.sh
@@ -8,7 +8,7 @@ busl_files=$(grep -r 'SPDX-License-Identifier: BUSL' --exclude=./.github/scripts
 # If we do not find a file in .changelog/, we fail the check
 if [ -n "$busl_files" ]; then
     echo "Found BUSL occurrences in the PR branch!"
-    echo -e $busl_files
+    echo -n "$busl_files"
     exit 1
 else
     echo "Did not find any occurrences of BUSL in the PR branch"

--- a/.github/scripts/license_checker.sh
+++ b/.github/scripts/license_checker.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+
+busl_files=$(grep -r 'SPDX-License-Identifier: BUSL' --exclude=./.github/scripts/license_checker.sh .)
+
+# If we do not find a file in .changelog/, we fail the check
+if [ -n "$busl_files" ]; then
+    echo "Found BUSL occurrences in the PR branch!"
+    echo -e $busl_files
+    exit 1
+else
+    echo "Did not find any occurrences of BUSL in the PR branch"
+    exit 0
+fi

--- a/.github/scripts/license_checker.sh
+++ b/.github/scripts/license_checker.sh
@@ -7,7 +7,7 @@ busl_files=$(grep -r 'SPDX-License-Identifier: BUSL' --exclude=./.github/scripts
 
 # If we do not find a file in .changelog/, we fail the check
 if [ -n "$busl_files" ]; then
-    echo "Found BUSL occurrences in the PR branch!"
+    echo "Found BUSL occurrences in the PR branch! (See NET-5258 for details)"
     echo -n "$busl_files"
     exit 1
 else

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -1,0 +1,27 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# This workflow checks that the BUSL license is not mentioned anywhere in
+# a PR targeting a release that should maintain the MPL-2.0 license.
+name: License Checker
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - release/1.14.*
+      - release/1.15.*
+      - release/1.16.*
+
+jobs:
+  # checks that the diff does not contain any reference to
+  # the BUSL license and thus retains the MPL-2.0 license
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # by default the checkout action doesn't checkout all branches
+      - name: Check for BUSL text in diff
+        run: ./.github/scripts/license_checker.sh


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
We want to make sure that we aren't accidentally backporting the BUSL license header into versions of Consul that should remain under MPL through the end of the year.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
Run script locally on `main` where it should fail, identifying files which have the BUSL header, and on release branches such as `release/1.16.x` where it should succeed since no files have the BUSL header.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
