### PR TITLE
NET-5371 License checker pt2

### DIFF
--- a/.github/scripts/license_checker.sh
+++ b/.github/scripts/license_checker.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 
-busl_files=$(grep -r 'SPDX-License-Identifier: BUSL' --exclude=./.github/scripts/license_checker.sh .)
+busl_files=$(grep -r 'SPDX-License-Identifier: BUSL' . --exclude-dir .github)
 
 # If we do not find a file in .changelog/, we fail the check
 if [ -n "$busl_files" ]; then

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -7,7 +7,7 @@ name: License Checker
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
     branches:
       - release/1.14.*
       - release/1.15.*


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
I created a test PR (#18486) after merging this action originally in https://github.com/hashicorp/consul/pull/18485 and realized that `grep` behaves differently in `ubuntu:latest` than it does in MacOS.

This updates to use a format that works in Ubuntu and runs the action whenever new commits are pushed to a backport PR instead of just when it's initially opened.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
Ran script in an Ubuntu docker container
```bash
$ docker run -it ubuntu:latest /bin/sh
$ apt update && apt install git
$ git clone https://github.com/hashicorp/consul
$ cd consul
$ ./.github/scripts/license_checker.sh
# Observe failure because many files have the BUSL header
$ git checkout release/1.15.x
$ git checkout license-checker-pt2 -- .github/scripts/license_checker.sh
$ ./.github/scripts/license_checker.sh
# Observe success because no files have the BUSL header
```

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
