### PR TITLE
NET-5186 Add NET_BIND_SERVICE capability to consul-dataplane requirements

### DIFF
--- a/website/content/docs/connect/dataplane/index.mdx
+++ b/website/content/docs/connect/dataplane/index.mdx
@@ -11,9 +11,9 @@ This topic provides an overview of Consul Dataplane, a lightweight process for m
 
 ## Supported environments
 
-- Dataplanes can connect to Consul servers v1.14.0 and newer. 
-- Dataplanes on Kubernetes requires Consul K8s v1.0.0 and newer.  
-- Dataplanes on AWS Elastic Container Services (ECS) requires Consul ECS v0.7.0 and newer. 
+- Dataplanes can connect to Consul servers v1.14.0 and newer.
+- Dataplanes on Kubernetes requires Consul K8s v1.0.0 and newer.
+- Dataplanes on AWS Elastic Container Services (ECS) requires Consul ECS v0.7.0 and newer.
 
 
 ## What is Consul Dataplane?
@@ -87,7 +87,7 @@ $ export VERSION=1.0.0 && \
 Refer to the following documentation for Consul on ECS workloads:
 
 - [Deploy Consul with the Terraform module](/consul/docs/ecs/deploy/terraform)
-- [Deploy Consul manually](/consul/ecs/install-manul) 
+- [Deploy Consul manually](/consul/ecs/install-manul)
 
 </Tab>
 
@@ -135,4 +135,4 @@ Consul Dataplane on ECS support the following features:
 ### Technical Constraints
 
 - Consul Dataplane is not supported on Windows.
-
+- Consul Dataplane requires the `NET_BIND_SERVICE` capability.

--- a/website/content/docs/connect/dataplane/index.mdx
+++ b/website/content/docs/connect/dataplane/index.mdx
@@ -135,4 +135,4 @@ Consul Dataplane on ECS support the following features:
 ### Technical Constraints
 
 - Consul Dataplane is not supported on Windows.
-- Consul Dataplane requires the `NET_BIND_SERVICE` capability.
+- Consul Dataplane requires the `NET_BIND_SERVICE` capability. Refer to [Set capabilities for a Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container) in the Kubernetes Documentation for more information.


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
As a compliment to https://github.com/hashicorp/consul-dataplane/pull/238 and https://github.com/hashicorp/consul-k8s/pull/2787, this PR updates the docs to list the `NET_BIND_SERVICE` capability as a requirement for consul-dataplane.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
N/A

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->
Related to:
- https://github.com/hashicorp/consul-dataplane/pull/238
- https://github.com/hashicorp/consul-k8s/pull/2787

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
