### PR TITLE
NET-5382 & PLAT-1159: Do not trigger workflow if only doc files are in commit history

### DIFF
--- a/.github/scripts/filter_changed_files_go_test.sh
+++ b/.github/scripts/filter_changed_files_go_test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Get the list of changed files
+files_to_check=$(git diff --name-only origin/$GITHUB_BASE_REF)
+
+# Define the directories to check
+skipped_directories=("docs/" "ui/" "website/" "grafana/")
+
+# Initialize a variable to track directories outside the skipped ones
+other_directories=""
+trigger_ci=false
+
+# Loop through the changed files and find directories/files outside the skipped ones
+for file_to_check in $files_to_check; do
+	file_is_skipped=false
+	for dir in "${skipped_directories[@]}"; do
+		if [[ "$file_to_check" == "$dir"* ]] || [[ "$file_to_check" == *.md && "$dir" == *"/" ]]; then
+			file_is_skipped=true
+			break
+		fi
+	done
+	if [ "$file_is_skipped" = "false" ]; then
+		other_directories+="$(dirname "$file_to_check")\n"
+		trigger_ci=true
+		echo "Non doc file(s) changed - triggered ci: $trigger_ci"
+		echo -e $other_directories
+		echo "trigger-ci=$trigger_ci" >>"$GITHUB_OUTPUT"
+		exit 0 ## if file is outside of the skipped_directory exit script
+	fi
+done
+
+echo "Only doc file(s) changed - triggered ci: $trigger_ci"
+echo "trigger-ci=$trigger_ci" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -24,8 +24,23 @@ env:
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
+  conditional-skip:
+    runs-on: ubuntu-latest 
+    name: Get files changed and conditionally skip CI
+    outputs:
+      trigger-ci: ${{ steps.read-files.outputs.trigger-ci }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0  
+      - name: Get changed files
+        id: read-files
+        run: ./.github/scripts/filter_changed_files_go_test.sh
+
   setup:
+    needs: [conditional-skip]
     name: Setup
+    if: needs.conditional-skip.outputs.trigger-ci == 'true'
     runs-on: ubuntu-latest
     outputs:
       compute-small: ${{ steps.setup-outputs.outputs.compute-small }}
@@ -464,6 +479,7 @@ jobs:
 
   go-tests-success:
     needs:
+    - conditional-skip
     - setup
     # Reenable later
     #- check-generated-deep-copy
@@ -487,7 +503,7 @@ jobs:
     - go-test-32bit
     # - go-test-s390x
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-    if: ${{ always() }}
+    if: always() && needs.conditional-skip.outputs.trigger-ci == 'true'
     steps:
       - name: evaluate upstream job results
         run: |

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -26,9 +26,24 @@ env:
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
+  conditional-skip:
+    runs-on: ubuntu-latest 
+    name: Get files changed and conditionally skip CI
+    outputs:
+      trigger-ci: ${{ steps.read-files.outputs.trigger-ci }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0  
+      - name: Get changed files
+        id: read-files
+        run: ./.github/scripts/filter_changed_files_go_test.sh
+
   setup:
+    needs: [conditional-skip]
     runs-on: ubuntu-latest
     name: Setup
+    if: needs.conditional-skip.outputs.trigger-ci == 'true'
     outputs:
       compute-small: ${{ steps.runners.outputs.compute-small }}
       compute-medium: ${{ steps.runners.outputs.compute-medium }}
@@ -558,6 +573,7 @@ jobs:
 
   test-integrations-success:
     needs: 
+    - conditional-skip
     - setup
     - dev-build
     - nomad-integration-test
@@ -567,7 +583,7 @@ jobs:
     - compatibility-integration-test
     - peering_commontopo-integration-test
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-    if: ${{ always() }}
+    if: always() && needs.conditional-skip.outputs.trigger-ci == 'true'
     steps:
       - name: evaluate upstream job results
         run: |


### PR DESCRIPTION
### Description

Stop running go-test and test-integrations workflow if the changes in PR only occurs in docs, ui, website, grafana 
- Add a script to check changeset in branch history
- If change includes docs + `*.go` files, trigger test workflows
- If changes ONLY include docs/, do not trigger test workflows

### Testing & Reproduction steps
**Testcases**

1. Validate that the following jobs are skipped when changeset only occurs in `docs` file
See current CI result
* [x] go-test
* [x] test-integrations
<img width="1495" alt="Screenshot 2023-08-22 at 4 22 04 PM" src="https://github.com/hashicorp/consul/assets/18365710/0e862283-4d00-4a2b-a3a9-620ffeef17ab">

2. Validate that the following jobs are are NOT skipped when changeset occurs in `docs` and `*.go` files
* [x] go-test
* [x] test-integrations
<img width="1483" alt="Screenshot 2023-08-22 at 4 21 04 PM" src="https://github.com/hashicorp/consul/assets/18365710/bbbd64a8-50a3-4535-ba56-43b223a8dd5d">




### Links

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
