### PR TITLE
feat: add experiments flag to testserver sdk

### DIFF
--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -131,6 +131,7 @@ type TestServerConfig struct {
 	ReturnPorts         func()                 `json:"-"`
 	Audit               *TestAuditConfig       `json:"audit,omitempty"`
 	Version             string                 `json:"version,omitempty"`
+	Experiments         []string               `json:"experiments,omitempty"`
 }
 
 type TestACLs struct {


### PR DESCRIPTION
### Description
To test gRPC connections in `consul-k8s`, the experiments config option must be configured.
