### PR TITLE
catalog: add failover mode enum validation

### DIFF
--- a/internal/catalog/internal/types/failover_policy.go
+++ b/internal/catalog/internal/types/failover_policy.go
@@ -139,6 +139,18 @@ func validateFailoverConfig(config *pbcatalog.FailoverConfig, ported bool) []err
 		}
 	}
 
+	switch config.Mode {
+	case pbcatalog.FailoverMode_FAILOVER_MODE_UNSPECIFIED:
+		// means pbcatalog.FailoverMode_FAILOVER_MODE_SEQUENTIAL
+	case pbcatalog.FailoverMode_FAILOVER_MODE_SEQUENTIAL:
+	case pbcatalog.FailoverMode_FAILOVER_MODE_ORDER_BY_LOCALITY:
+	default:
+		errs = append(errs, resource.ErrInvalidField{
+			Name:    "mode",
+			Wrapped: fmt.Errorf("not a supported enum value: %v", config.Mode),
+		})
+	}
+
 	// TODO: validate sameness group requirements
 
 	return errs

--- a/internal/catalog/internal/types/failover_policy_test.go
+++ b/internal/catalog/internal/types/failover_policy_test.go
@@ -200,6 +200,15 @@ func TestValidateFailoverPolicy(t *testing.T) {
 				SamenessGroup: "blah",
 			},
 		},
+		"mode: invalid": {
+			config: &pbcatalog.FailoverConfig{
+				Mode: 99,
+				Destinations: []*pbcatalog.FailoverDestination{
+					{Ref: newRef(ServiceType, "api-backup")},
+				},
+			},
+			expectErr: `invalid "mode" field: not a supported enum value: 99`,
+		},
 		"dest: no ref": {
 			config: &pbcatalog.FailoverConfig{
 				Destinations: []*pbcatalog.FailoverDestination{


### PR DESCRIPTION
### Description

Check for unknown enum values of FailoverMode during validation and block them.

This sort of thing is required for `proto3` open enums: https://protobuf.dev/programming-guides/enum/
