### PR TITLE
bug: prevent go routine leakage due to existing DeferCheck

### DIFF
--- a/.changelog/18558.txt
+++ b/.changelog/18558.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+check: prevent go routine leakage when existing Defercheck of same check id is not nil
+```

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -838,6 +838,12 @@ func (l *State) setCheckStateLocked(c *CheckState) {
 	existing := l.checks[id]
 	if existing != nil {
 		c.InSync = c.Check.IsSame(existing.Check)
+		// If the existing check has a Defercheck, it needs to be
+		// assigned to the new check
+		if existing.DeferCheck != nil && c.DeferCheck == nil {
+			c.DeferCheck = existing.DeferCheck
+			c.InSync = false
+		}
 	}
 
 	l.checks[id] = c


### PR DESCRIPTION
### Description

Prevent go routine leakage due to existing DeferCheck

Please refer to https://github.com/hashicorp/consul/issues/18429 how to reproduce.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
