### PR TITLE
UI: Add enterprise suffix to UI version number

### DIFF
--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -199,7 +199,7 @@
 
   <:content-info>
     <p>
-      Consul v{{env 'CONSUL_VERSION'}}
+      Consul v{{this.consulVersion}}
     </p>
     {{{concat '<!-- ' (env 'CONSUL_GIT_SHA') '-->'}}}
   </:content-info>

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.js
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.js
@@ -8,4 +8,10 @@ import { inject as service } from '@ember/service';
 
 export default class HashiCorpConsul extends Component {
   @service('flashMessages') flashMessages;
+  @service('env') env;
+
+  get consulVersion() {
+    const suffix = this.env.var('CONSUL_BINARY_TYPE') !== 'oss' && this.env.var('CONSUL_BINARY_TYPE') !== '' ? '+ent' : '';
+    return `${this.env.var('CONSUL_VERSION')}${suffix}`;
+  }
 }


### PR DESCRIPTION
### Description

This fix checks the Consul Binary type, and for non-Community (i.e. Enterprise) binary versions, a "+ent" suffix is added to the version number of Consul that is displayed in the UI so that operators viewing the UI can see their enterprise license reflected in the sidebar.

### Testing & Reproduction steps

1. Checkout branch of any previous release (i.e. `1.15.0`)
2. Edit `ui/packages/consul-ui/config/environment.js` and change line `78` to read:
```
CONSUL_BINARY_TYPE: env('CONSUL_BINARY_TYPE', 'ent'),
```
3. run `make ui-docker` to build the ui image
4. run `make dev-docker`
5. clone https://github.com/WenInCode/consul-setup
6. in the consul-setup repo go to the `setups/peering` directory
7. run `docker-compose up`
8. run yarn setup:peerings
9. Go to https://localhost:8501/ui
10. Observe the index page and note the version number in the lower right corner of the UI does not have a "+ent" suffix

Now, check out this branch and repeat the above steps 1-9.

Observe the index page and note the version number in the lower right corner of the UI now shows the version number with the "+ent" suffix appended, i.e. `Consul v1.17.0+ent`

### Links

- [NET-438](https://hashicorp.atlassian.net/browse/NET-438)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern


[NET-438]: https://hashicorp.atlassian.net/browse/NET-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ