### PR TITLE
fix for , non presence of consul-version meta (#18464)

### DIFF
--- a/.changelog/18464.txt
+++ b/.changelog/18464.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+UI : Nodes list view was breaking for synthetic-nodes. Fix handles non existence of consul-version meta for node.
+```

--- a/ui/packages/consul-ui/app/serializers/application.js
+++ b/ui/packages/consul-ui/app/serializers/application.js
@@ -227,7 +227,7 @@ export default class ApplicationSerializer extends Serializer {
     // create a Set and add version with only major.minor : ex-1.24.6 as 1.24
     let versionSet = new Set();
     payload.forEach(function (item) {
-      if (item.Meta && item.Meta['consul-version'] !== '') {
+      if (item.Meta && item.Meta['consul-version']) {
         const split = item.Meta['consul-version'].split('.');
         versionSet.add(split[0] + '.' + split[1]);
       }

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/nodes
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/nodes
@@ -13,6 +13,7 @@
       function(item, i)
       {
         const peerNameString = i === 0 ? '"PeerName": "billing",' : '"PeerName": "",'
+        const isSyntheticNode = env('CONSUL_AGENTLESS_ENABLED') ? fake.helpers.randomize([true, false, false, false]) : false
         return `
           {
             "ID":"${fake.random.uuid()}",
@@ -25,8 +26,10 @@
             },
             "Meta": {
               "consul-network-segment":"",
+              ${isSyntheticNode ? `` : `
               "consul-version": "${env('CONSUL_VERSION') ? fake.helpers.randomize([env('CONSUL_VERSION'),"1.10.4","1.15.2", "1.17.8","1.7.2","1.12.4", "1.17.2","1.0.9","2.0.2"]) : fake.helpers.randomize(["1.10.4","1.15.2", "1.17.8","1.7.2","1.12.4", "1.17.2","1.0.9","2.0.2"])  }",
-              "synthetic-node": ${env('CONSUL_AGENTLESS_ENABLED') ? fake.helpers.randomize([true, false, false, false]) : false}
+              `}
+              "synthetic-node": ${isSyntheticNode}
             },
             "Services":[
                 ${

--- a/ui/packages/consul-ui/tests/unit/serializers/application-test.js
+++ b/ui/packages/consul-ui/tests/unit/serializers/application-test.js
@@ -6,6 +6,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import Node from 'consul-ui/models/node';
 
 module('Unit | Serializer | application', function (hooks) {
   setupTest(hooks);
@@ -121,5 +122,95 @@ module('Unit | Serializer | application', function (hooks) {
     const actual = serializer.respondForQuery(respond, { Name: 'name', dc: 'dc-1' });
     assert.deepEqual(actual, expected);
     // assert.ok(adapter.uidForURL.calledTwice);
+  });
+  test('normalizeResponse for Node returns the expected meta in response', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('application');
+    serializer.timestamp = () => 1234567890; //mocks actual timestamp
+    serializer.primaryKey = 'primary-key-name';
+    serializer.slugKey = 'Name';
+    serializer.fingerprint = function (primary, slug, foreignValue) {
+      return function (item) {
+        return {
+          ...item,
+          ...{
+            Datacenter: foreignValue,
+            [primary]: item[slug],
+          },
+        };
+      };
+    };
+
+    const payload = [
+      {
+        Node: 'node-0',
+        Meta: { 'consul-version': '1.7.2' },
+        uid: '1234',
+        SyncTime: 1234567890,
+      },
+      {
+        Node: 'node-1',
+        Meta: { 'consul-version': '1.18.0' },
+        uid: '1235',
+        SyncTime: 1234567891,
+      },
+      // synthetic-node without consul-version meta
+      {
+        Node: 'node-2',
+        Meta: { 'synthetic-node': true },
+        uid: '1236',
+        SyncTime: 1234567891,
+      },
+    ];
+
+    const expected = {
+      data: [
+        {
+          attributes: {
+            Node: 'node-0',
+            Meta: { 'consul-version': '1.7.2' },
+            SyncTime: 1234567890,
+            uid: '1234',
+          },
+          id: '1234',
+          relationships: {},
+          type: 'node',
+        },
+        {
+          attributes: {
+            Node: 'node-1',
+            Meta: { 'consul-version': '1.18.0' },
+            SyncTime: 1234567890,
+            uid: '1235',
+          },
+          id: '1235',
+          relationships: {},
+          type: 'node',
+        },
+        {
+          attributes: {
+            Node: 'node-2',
+            Meta: { 'synthetic-node': true },
+            SyncTime: 1234567890,
+            uid: '1236',
+          },
+          id: '1236',
+          relationships: {},
+          type: 'node',
+        },
+      ],
+      included: [],
+      meta: {
+        versions: ['1.18', '1.7'], //expect distinct major versions sorted
+        cacheControl: undefined,
+        cursor: undefined,
+        date: 1234567890,
+        dc: undefined,
+        nspace: undefined,
+        partition: undefined,
+      },
+    };
+    const actual = serializer.normalizeResponse(store, Node, payload, '2', 'query');
+    assert.deepEqual(actual, expected);
   });
 });


### PR DESCRIPTION
### Description

Manual backport of https://github.com/hashicorp/consul/pull/18464 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
