### PR TITLE
Set concurrency for workflows

### DIFF
--- a/.github/workflows/build-distros.yml
+++ b/.github/workflows/build-distros.yml
@@ -17,6 +17,10 @@ env:
   GOTAGS: ${{ endsWith(github.repository, '-enterprise') && 'consulent' || '' }}
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -23,6 +23,10 @@ env:
   TEST_RESULTS: /tmp/test-results
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -23,6 +23,7 @@ env:
   TEST_RESULTS: /tmp/test-results
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
+# concurrency
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -25,6 +25,10 @@ env:
   CONSUL_LATEST_IMAGE_NAME: ${{ endsWith(github.repository, '-enterprise') && github.repository || 'hashicorp/consul' }}
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

- This adds concurrency to the bigger workflows that we run.
- These should only work on 'push' style actions (ie pushing a commit or creating a PR).
- Merges to main as pushes are ok as they are done as part of the merge process and not developers pushing commits over and over.
- I've skipped all the smaller workflows because those will need to be cleaned up/merged together soon(tm)
- It will limit 1 workflow run per branch at a time and will cancel current runs of other workflows.


### Testing & Reproduction steps

- try doing 2 commits at the same time and the 1st set of workflows should be cancelled.

You can see in the `go-tests` below how they were cancelled because I pushed a 2nd commit.

https://github.com/hashicorp/consul/actions/runs/5954040559

### Links



### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
