### PR TITLE
xds: Use downstream protocol when connecting to local app

### DIFF
--- a/.changelog/18573.txt
+++ b/.changelog/18573.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+xds: Use downstream protocol when connecting to local app
+```

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -1096,7 +1096,7 @@ func (s *ResourceGenerator) makeAppCluster(cfgSnap *proxycfg.ConfigSnapshot, nam
 		protocol = cfg.Protocol
 	}
 	if protocol == "http2" || protocol == "grpc" {
-		if err := s.setHttp2ProtocolOptions(c); err != nil {
+		if err := s.setLocalAppHttpProtocolOptions(c); err != nil {
 			return c, err
 		}
 	}
@@ -2002,6 +2002,29 @@ func (s *ResourceGenerator) setHttp2ProtocolOptions(c *envoy_cluster_v3.Cluster)
 				ProtocolConfig: &envoy_upstreams_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
 					Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
 				},
+			},
+		},
+	}
+	any, err := anypb.New(cfg)
+	if err != nil {
+		return err
+	}
+	c.TypedExtensionProtocolOptions = map[string]*anypb.Any{
+		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": any,
+	}
+
+	return nil
+}
+
+// Allows forwarding either HTTP/1.1 or HTTP/2 traffic to the local application.
+// The protocol used depends on the protocol received from the downstream service
+// on the public listener.
+func (s *ResourceGenerator) setLocalAppHttpProtocolOptions(c *envoy_cluster_v3.Cluster) error {
+	cfg := &envoy_upstreams_v3.HttpProtocolOptions{
+		UpstreamProtocolOptions: &envoy_upstreams_v3.HttpProtocolOptions_UseDownstreamProtocolConfig{
+			UseDownstreamProtocolConfig: &envoy_upstreams_v3.HttpProtocolOptions_UseDownstreamHttpConfig{
+				HttpProtocolOptions:  &envoy_core_v3.Http1ProtocolOptions{},
+				Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
 			},
 		},
 	}

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -1096,8 +1096,14 @@ func (s *ResourceGenerator) makeAppCluster(cfgSnap *proxycfg.ConfigSnapshot, nam
 		protocol = cfg.Protocol
 	}
 	if protocol == "http2" || protocol == "grpc" {
-		if err := s.setLocalAppHttpProtocolOptions(c); err != nil {
-			return c, err
+		if name == xdscommon.LocalAppClusterName {
+			if err := s.setLocalAppHttpProtocolOptions(c); err != nil {
+				return c, err
+			}
+		} else {
+			if err := s.setHttp2ProtocolOptions(c); err != nil {
+				return c, err
+			}
 		}
 	}
 	if cfg.MaxInboundConnections > 0 {

--- a/agent/xds/testdata/clusters/expose-paths-grpc-new-cluster-http1.latest.golden
+++ b/agent/xds/testdata/clusters/expose-paths-grpc-new-cluster-http1.latest.golden
@@ -53,8 +53,9 @@
       "typedExtensionProtocolOptions": {
         "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-          "explicitHttpConfig": {
-            "http2ProtocolOptions": {}
+          "useDownstreamProtocolConfig": {
+            "http2ProtocolOptions": {},
+            "httpProtocolOptions": {}
           }
         }
       }

--- a/agent/xds/testdata/clusters/expose-paths-grpc-new-cluster-http1.latest.golden
+++ b/agent/xds/testdata/clusters/expose-paths-grpc-new-cluster-http1.latest.golden
@@ -53,8 +53,7 @@
       "typedExtensionProtocolOptions": {
         "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-          "useDownstreamProtocolConfig": {
-            "httpProtocolOptions": {},
+          "explicitHttpConfig": {
             "http2ProtocolOptions": {}
           }
         }

--- a/agent/xds/testdata/clusters/expose-paths-grpc-new-cluster-http1.latest.golden
+++ b/agent/xds/testdata/clusters/expose-paths-grpc-new-cluster-http1.latest.golden
@@ -53,7 +53,8 @@
       "typedExtensionProtocolOptions": {
         "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-          "explicitHttpConfig": {
+          "useDownstreamProtocolConfig": {
+            "httpProtocolOptions": {},
             "http2ProtocolOptions": {}
           }
         }

--- a/agent/xds/testdata/clusters/expose-paths-new-cluster-http2.latest.golden
+++ b/agent/xds/testdata/clusters/expose-paths-new-cluster-http2.latest.golden
@@ -28,7 +28,8 @@
       "typedExtensionProtocolOptions": {
         "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-          "explicitHttpConfig": {
+          "useDownstreamProtocolConfig": {
+            "httpProtocolOptions": {},
             "http2ProtocolOptions": {}
           }
         }

--- a/agent/xds/testdata/clusters/expose-paths-new-cluster-http2.latest.golden
+++ b/agent/xds/testdata/clusters/expose-paths-new-cluster-http2.latest.golden
@@ -28,8 +28,7 @@
       "typedExtensionProtocolOptions": {
         "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-          "useDownstreamProtocolConfig": {
-            "httpProtocolOptions": {},
+          "explicitHttpConfig": {
             "http2ProtocolOptions": {}
           }
         }

--- a/agent/xds/testdata/clusters/expose-paths-new-cluster-http2.latest.golden
+++ b/agent/xds/testdata/clusters/expose-paths-new-cluster-http2.latest.golden
@@ -28,8 +28,9 @@
       "typedExtensionProtocolOptions": {
         "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-          "explicitHttpConfig": {
-            "http2ProtocolOptions": {}
+          "useDownstreamProtocolConfig": {
+            "http2ProtocolOptions": {},
+            "httpProtocolOptions": {}
           }
         }
       }

--- a/agent/xds/testdata/clusters/expose-paths-new-cluster-http2.latest.golden
+++ b/agent/xds/testdata/clusters/expose-paths-new-cluster-http2.latest.golden
@@ -28,9 +28,8 @@
       "typedExtensionProtocolOptions": {
         "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-          "useDownstreamProtocolConfig": {
-            "http2ProtocolOptions": {},
-            "httpProtocolOptions": {}
+          "explicitHttpConfig": {
+            "http2ProtocolOptions": {}
           }
         }
       }

--- a/agent/xdsv2/cluster_resources.go
+++ b/agent/xdsv2/cluster_resources.go
@@ -163,7 +163,13 @@ func (pr *ProxyResources) makeEnvoyStaticCluster(name string, protocol string, s
 		ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_STATIC},
 		LoadAssignment:       makeEnvoyClusterLoadAssignment(name, endpointList.Endpoints),
 	}
-	err := addLocalAppHttpProtocolOptions(protocol, cluster)
+
+	var err error
+	if name == xdscommon.LocalAppClusterName {
+		err = addLocalAppHttpProtocolOptions(protocol, cluster)
+	} else {
+		err = addHttpProtocolOptions(protocol, cluster)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

Configure Envoy to use the same HTTP protocol version used by the downstream caller when forwarding requests to the local application.

This allows upstream applications that support both HTTP/1.1 and HTTP/2 to receive requests using either protocol.

For example, this is beneficial when the application primarily communicates using HTTP/2, but also needs to support HTTP/1.1 to correctly handle requests from Kubernetes readiness/liveness probes.
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [X] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [X] not a security concern
