### PR TITLE
Edited for clarity about Consul on Kubernetes

### DIFF
--- a/website/content/docs/k8s/architecture.mdx
+++ b/website/content/docs/k8s/architecture.mdx
@@ -45,4 +45,4 @@ By default, Consul on Kubernetes uses an alternate service mesh configuration th
 
 Refer to [Simplified Service Mesh with Consul Dataplanes](/consul/docs/connect/dataplane) for more information.
 
-Consul Dataplane is the default proxy manager in Consul on Kubernetes 1.14 and later. If you are on Consul 1.13 or older, refer to [upgrading to Consul Dataplane](/consul/docs/k8s/upgrade#upgrading-to-consul-dataplanes) for specific upgrade instructions.
+Consul Dataplane is the default proxy manager in Consul on Kubernetes 1.14 and later. If you are using Consul on Kubernetes 1.13 or older, refer to [upgrading to Consul Dataplane](/consul/docs/k8s/upgrade#upgrading-to-consul-dataplanes) for specific upgrade instructions.


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Changed "Consul 1.13" to "Consul on Kubernetes 1.13" for clarity

### Testing & Reproduction steps
Doc change only, no testing required

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

Non-applicable to this PR

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
