### PR TITLE
docs: admin partition and DNS clarification

### DIFF
--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -53,10 +53,10 @@ Only resources in the `default` admin partition will be replicated to secondary 
 
 ### DNS Queries
 
-The DNS interface returns results for a single admin partition.
+When queried, the DNS interface returns results for a single admin partition.
 The query may explicitly specify the admin partition to use in the lookup.
-If no admin partition is specified in the query,
-the lookup uses the admin partition of the Consul agent acting as the DNS server.
+If you do not specify an admin partition in the query,
+the lookup uses the admin partition of the Consul agent that received the query.
 Server agents always exist within the `default` admin partition.
 Client agents are configured to operate within a specific admin partition.
 

--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -53,7 +53,12 @@ Only resources in the `default` admin partition will be replicated to secondary 
 
 ### DNS Queries
 
-Client agents will be configured to operate within a specific admin partition. The DNS interface will only return results for the admin partition within the scope of the client.
+The DNS interface returns results for a single admin partition.
+The query may explicitly specify the admin partition to use in the lookup.
+If no admin partition is specified in the query,
+the lookup uses the admin partition of the Consul agent acting as the DNS server.
+Server agents always exist within the `default` admin partition.
+Client agents are configured to operate within a specific admin partition.
 
 ### Service Mesh Configurations
 


### PR DESCRIPTION
Current documentation is incorrect/misleading. Agents can return DNS responses with results from other partitions.