### PR TITLE
delete all v2 resources type when deleting a namespace (CE)

### DIFF
--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -7,6 +7,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/hashicorp/consul/internal/catalog"
+	"github.com/hashicorp/consul/internal/mesh"
+	"github.com/hashicorp/consul/internal/resource/demo"
 	"net"
 	"os"
 	"strings"
@@ -559,6 +562,10 @@ func newDefaultDeps(t *testing.T, c *Config) Deps {
 		RPCHoldTimeout:   c.RPCHoldTimeout,
 	}
 	connPool.SetRPCClientTimeout(c.RPCClientTimeout)
+	registry := resource.NewRegistry()
+	demo.RegisterTypes(registry)
+	mesh.RegisterTypes(registry)
+	catalog.RegisterTypes(registry)
 	return Deps{
 		EventPublisher:  stream.NewEventPublisher(10 * time.Second),
 		Logger:          logger,
@@ -578,7 +585,7 @@ func newDefaultDeps(t *testing.T, c *Config) Deps {
 		GetNetRPCInterceptorFunc: middleware.GetNetRPCInterceptor,
 		EnterpriseDeps:           newDefaultDepsEnterprise(t, logger, c),
 		XDSStreamLimiter:         limiter.NewSessionLimiter(),
-		Registry:                 resource.NewRegistry(),
+		Registry:                 registry,
 	}
 }
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -461,6 +461,8 @@ type Server struct {
 
 	// handles metrics reporting to HashiCorp
 	reportingManager *reporting.ReportingManager
+
+	registry resource.Registry
 }
 
 func (s *Server) DecrementBlockingQueries() uint64 {
@@ -547,6 +549,7 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 		publisher:               flat.EventPublisher,
 		incomingRPCLimiter:      incomingRPCLimiter,
 		routineManager:          routine.NewManager(logger.Named(logging.ConsulServer)),
+		registry:                flat.Registry,
 	}
 	incomingRPCLimiter.Register(s)
 

--- a/internal/catalog/internal/types/service.go
+++ b/internal/catalog/internal/types/service.go
@@ -32,6 +32,7 @@ func RegisterService(r resource.Registry) {
 		Type:     ServiceV1Alpha1Type,
 		Proto:    &pbcatalog.Service{},
 		Validate: ValidateService,
+		Scope:    resource.ScopeNamespace,
 	})
 }
 


### PR DESCRIPTION
### Description

As we will continue to use current tenancy implementation with the new resources API, we need to make current tenancy implementation aware of the resources under it and manage it.

In this PR we add the deletion of the resources within a namespace when the namespace is deleted. As there is no way to list all the resources under the same namespace (of any type) we iterate over all the registered types with a namespace scope and delete them except for Type: TypeV1Tombstone as those need to be present after the resource deletion and will be deleted later on.

The code in this PR is only needed as an intermediate step until we design v2 tenancy and come up with a way of deleting resources under v2 tenancy.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
