### PR TITLE
fix: make UNSPECIFIED protocol pass validation

### DIFF
--- a/internal/catalog/internal/types/validators.go
+++ b/internal/catalog/internal/types/validators.go
@@ -139,7 +139,9 @@ func validatePortName(name string) error {
 
 func validateProtocol(protocol pbcatalog.Protocol) error {
 	switch protocol {
-	case pbcatalog.Protocol_PROTOCOL_TCP,
+	case pbcatalog.Protocol_PROTOCOL_UNSPECIFIED,
+		// means pbcatalog.FailoverMode_FAILOVER_MODE_TCP
+		pbcatalog.Protocol_PROTOCOL_TCP,
 		pbcatalog.Protocol_PROTOCOL_HTTP,
 		pbcatalog.Protocol_PROTOCOL_HTTP2,
 		pbcatalog.Protocol_PROTOCOL_GRPC,

--- a/internal/catalog/internal/types/validators_test.go
+++ b/internal/catalog/internal/types/validators_test.go
@@ -334,6 +334,26 @@ func TestValidatePortName(t *testing.T) {
 	})
 }
 
+func TestValidateProtocol(t *testing.T) {
+	// this test simply verifies that we accept all enum values specified in our proto
+	// in order to avoid validator drift.
+	for name, value := range pbcatalog.Protocol_value {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, validateProtocol(pbcatalog.Protocol(value)))
+		})
+	}
+}
+
+func TestValidateHealth(t *testing.T) {
+	// this test simply verifies that we accept all enum values specified in our proto
+	// in order to avoid validator drift.
+	for name, value := range pbcatalog.Health_value {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, validateHealth(pbcatalog.Health(value)))
+		})
+	}
+}
+
 func TestValidateWorkloadAddress(t *testing.T) {
 	type testCase struct {
 		addr        *pbcatalog.WorkloadAddress


### PR DESCRIPTION
We explicitly enumerate the allowed protocols in validation, so this change is necessary to use the new enum value.

Also add tests for enum validators to ensure they stay aligned to protos unless we explicitly want them to diverge.

Follow-up to https://github.com/hashicorp/consul/pull/18612

### Description

When I went to test integration on the k8s side, I found out the server was rejecting any request with the newly added value.

There's a few other protos that are validated as part of larger structs; I opted not to rework tests for them in this change.

~I looked into the possibility of making this validation more generic, but I'm not sure it'll be trivial if we also want to keep the rich error feedback that includes the string name of the rejected enum value.~ _edit, see [this](https://github.com/hashicorp/consul/pull/18634#issuecomment-1701669718)._

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
