### PR TITLE
fix: remove Intention test with latency to make consul-enterprise rep…

### DIFF
--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/filtered-select.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/filtered-select.feature
@@ -31,42 +31,6 @@ Feature: dc / intentions / filtered-select: Intention Service Select Dropdowns
       | source      |
       | destination |
     ---------------
-  @onlyNamespaceable
-  Scenario: Opening and closing the nspace [Name] dropdown doesn't double up items
-    Given 1 datacenter model with the value "datacenter"
-    And 2 nspace models from yaml
-    ---
-    - Name: nspace-0
-    - Name: nspace-1
-    ---
-    When I visit the intention page for yaml
-    ---
-      dc: datacenter
-    ---
-    Then the url should be /datacenter/intentions/create
-    Given a network latency of 60000
-    And I click "[data-test-[Name]-nspace] .ember-power-select-trigger"
-    Then I see the text "* (All Namespaces)" in ".ember-power-select-option:nth-last-child(3)"
-    Then I see the text "nspace-0" in ".ember-power-select-option:nth-last-child(2)"
-    Then I see the text "nspace-1" in ".ember-power-select-option:last-child"
-    And I click ".ember-power-select-option:last-child"
-    And I click "[data-test-[Name]-nspace] .ember-power-select-trigger"
-    And I click ".ember-power-select-option:last-child"
-    And I click "[data-test-[Name]-nspace] .ember-power-select-trigger"
-    And I click ".ember-power-select-option:last-child"
-    And I click "[data-test-[Name]-nspace] .ember-power-select-trigger"
-    Then I don't see the text "nspace-1" in ".ember-power-select-option:nth-last-child(6)"
-    Then I don't see the text "nspace-1" in ".ember-power-select-option:nth-last-child(5)"
-    Then I don't see the text "nspace-1" in ".ember-power-select-option:nth-last-child(4)"
-    Then I see the text "* (All Namespaces)" in ".ember-power-select-option:nth-last-child(3)"
-    Then I see the text "nspace-0" in ".ember-power-select-option:nth-last-child(2)"
-    Then I see the text "nspace-1" in ".ember-power-select-option:last-child"
-    Where:
-      ---------------
-      | Name        |
-      | source      |
-      | destination |
-      ---------------
   Scenario: Opening the [Name] dropdown with 2 services with the same name from different nspaces
     Given 1 datacenter model with the value "datacenter"
     And 2 service models from yaml


### PR DESCRIPTION
…o tests work

### Description
Test is [failing](https://github.com/hashicorp/consul-enterprise/actions/runs/6040608473/job/16391784452) on a `consul-enterprise` repo with timeout error. 
Removing the test to unblock the process and UI team will address it in[ the ticket](https://hashicorp.atlassian.net/browse/CC-6261).


<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
