### PR TITLE
Backport 1.16 fix test snapshot save 

### DIFF
--- a/command/snapshot/save/snapshot_save_test.go
+++ b/command/snapshot/save/snapshot_save_test.go
@@ -101,7 +101,20 @@ func TestSnapshotSaveCommandWithAppendFileNameFlag(t *testing.T) {
 		status = "leader"
 	}
 
-	newFilePath := filepath.Join(dir, "backup"+"-"+a.Config.Version+"-"+a.Config.Datacenter+
+	// We need to use the self endpoint here for ENT, which returns the product suffix (+ent)
+	self, err := client.Agent().Self()
+	require.NoError(t, err)
+
+	cfg, ok := self["Config"]
+	require.True(t, ok)
+
+	versionAny, ok := cfg["Version"]
+	require.True(t, ok)
+
+	version, ok := versionAny.(string)
+	require.True(t, ok)
+
+	newFilePath := filepath.Join(dir, "backup"+"-"+version+"-"+a.Config.Datacenter+
 		"-"+a.Config.NodeName+"-"+status+".tgz")
 
 	code := c.Run(args)


### PR DESCRIPTION
### Description
Small fix for this test. This fails in ENT because the version has `1.17.0+ent`, but the test agent version does not have the `+ent` suffix.

The original PR is #18625
