### PR TITLE
Release 1.16.x reduce runner sizes and concurrency

### DIFF
--- a/.github/scripts/get_runner_classes.sh
+++ b/.github/scripts/get_runner_classes.sh
@@ -8,19 +8,19 @@
 set -euo pipefail
 
 case "$GITHUB_REPOSITORY" in
-    *-enterprise)
-        # shellcheck disable=SC2129
-        echo "compute-small=['self-hosted', 'linux', 'small']" >> "$GITHUB_OUTPUT"
-        echo "compute-medium=['self-hosted', 'linux', 'medium']" >> "$GITHUB_OUTPUT"
-        echo "compute-large=['self-hosted', 'linux', 'large']" >> "$GITHUB_OUTPUT"
-        # m5d.8xlarge is equivalent to our xl custom runner in CE
-        echo "compute-xl=['self-hosted', 'ondemand', 'linux', 'type=m5d.8xlarge']" >> "$GITHUB_OUTPUT"
-        ;;
-    *)
-        # shellcheck disable=SC2129
-        echo "compute-small=['custom-linux-s-consul-latest']" >> "$GITHUB_OUTPUT"
-        echo "compute-medium=['custom-linux-m-consul-latest']" >> "$GITHUB_OUTPUT"
-        echo "compute-large=['custom-linux-l-consul-latest']" >> "$GITHUB_OUTPUT"
-        echo "compute-xl=['custom-linux-xl-consul-latest']" >> "$GITHUB_OUTPUT"
-        ;;
+*-enterprise)
+	# shellcheck disable=SC2129
+	echo "compute-small=['self-hosted', 'linux', 'small']" >>"$GITHUB_OUTPUT"
+	echo "compute-medium=['self-hosted', 'linux', 'medium']" >>"$GITHUB_OUTPUT"
+	echo "compute-large=['self-hosted', 'linux', 'large']" >>"$GITHUB_OUTPUT"
+	# m5d.8xlarge is equivalent to our xl custom runner in CE
+	echo "compute-xl=['self-hosted', 'ondemand', 'linux', 'type=m6a.2xlarge']" >>"$GITHUB_OUTPUT"
+	;;
+*)
+	# shellcheck disable=SC2129
+	echo "compute-small=['custom-linux-s-consul-latest']" >>"$GITHUB_OUTPUT"
+	echo "compute-medium=['custom-linux-m-consul-latest']" >>"$GITHUB_OUTPUT"
+	echo "compute-large=['custom-linux-l-consul-latest']" >>"$GITHUB_OUTPUT"
+	echo "compute-xl=['custom-linux-xl-consul-latest']" >>"$GITHUB_OUTPUT"
+	;;
 esac

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -74,7 +74,7 @@ jobs:
 
   ember-build-test:
     needs: setup
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
     strategy:
       matrix:
         partition: [1, 2, 3, 4]

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -23,6 +23,11 @@ env:
   TEST_RESULTS: /tmp/test-results
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
+# concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   conditional-skip:
     runs-on: ubuntu-latest 
@@ -172,7 +177,7 @@ jobs:
     - setup
     uses: ./.github/workflows/reusable-lint.yml
     with:
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
     secrets:
       elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
@@ -183,7 +188,7 @@ jobs:
     uses: ./.github/workflows/reusable-lint.yml
     with:
       go-arch: "386"
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
     secrets:
       elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
@@ -194,7 +199,7 @@ jobs:
     - setup
     uses: ./.github/workflows/reusable-dev-build.yml
     with:
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
     secrets:
       elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
@@ -206,7 +211,7 @@ jobs:
   #   uses: ./.github/workflows/reusable-dev-build.yml
   #   with:
   #     uploaded-binary-name: 'consul-bin-s390x'
-  #     runs-on: ${{ needs.setup.outputs.compute-xl }}
+  #     runs-on: ${{ needs.setup.outputs.compute-large }}
   #     go-arch: "s390x"
   #     repository-name: ${{ github.repository }}
   #   secrets:
@@ -220,7 +225,7 @@ jobs:
   #   uses: ./.github/workflows/reusable-dev-build.yml
   #   with:
   #     uploaded-binary-name: 'consul-bin-arm64'
-  #     runs-on: ${{ needs.setup.outputs.compute-xl }}
+  #     runs-on: ${{ needs.setup.outputs.compute-large }}
   #     go-arch: "arm64"
   #     repository-name: ${{ github.repository }}
   #   secrets:
@@ -253,7 +258,7 @@ jobs:
     with:
       directory: .
       runner-count: 12
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: ""
     permissions:
@@ -273,7 +278,7 @@ jobs:
     with:
       directory: .
       runner-count: 12
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
     permissions:
@@ -293,7 +298,7 @@ jobs:
       directory: .
       go-test-flags: 'GO_TEST_FLAGS="-race -gcflags=all=-d=checkptr=0"'
       package-names-command: "go list ./... | grep -E -v '^github.com/hashicorp/consul/agent(/consul|/local|/routine-leak-checker)?$' | grep -E -v '^github.com/hashicorp/consul(/command|/connect|/snapshot)'"
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
     permissions:
@@ -313,7 +318,7 @@ jobs:
       directory: .
       go-arch: "386"
       go-test-flags: 'export GO_TEST_FLAGS="-short"'
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
     permissions:
@@ -334,7 +339,7 @@ jobs:
   #     uploaded-binary-name: 'consul-bin-s390x'
   #     directory: .
   #     go-test-flags: 'export GO_TEST_FLAGS="-short"'
-  #     runs-on: ${{ needs.setup.outputs.compute-xl }}
+  #     runs-on: ${{ needs.setup.outputs.compute-large }}
   #     repository-name: ${{ github.repository }}
   #     go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
   #   permissions:
@@ -352,7 +357,7 @@ jobs:
     uses: ./.github/workflows/reusable-unit.yml
     with:
       directory: envoyextensions
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
     permissions:
@@ -370,7 +375,7 @@ jobs:
     uses: ./.github/workflows/reusable-unit.yml
     with:
       directory: troubleshoot
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
     permissions:
@@ -388,7 +393,7 @@ jobs:
     uses: ./.github/workflows/reusable-unit.yml
     with:
       directory: api
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
       go-version: "1.19"
@@ -407,7 +412,7 @@ jobs:
     uses: ./.github/workflows/reusable-unit.yml
     with:
       directory: api
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
       go-version: "1.20"
@@ -426,7 +431,7 @@ jobs:
     uses: ./.github/workflows/reusable-unit.yml
     with:
       directory: sdk
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
       go-version: "1.19"
@@ -445,7 +450,7 @@ jobs:
     uses: ./.github/workflows/reusable-unit.yml
     with:
       directory: sdk
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
       go-version: "1.20"

--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -42,7 +42,7 @@ jobs:
     needs: [setup]
     uses: ./.github/workflows/reusable-dev-build.yml
     with:
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       uploaded-binary-name: 'consul-bin'
     secrets:
@@ -88,7 +88,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
   
   envoy-integration-test:
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
     needs:
       - setup
       - generate-envoy-job-matrices
@@ -183,7 +183,7 @@ jobs:
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" $TEST_RESULTS_DIR/results.xml
   
   upgrade-integration-test:
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
     needs:
       - setup
       - dev-build

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -25,6 +25,10 @@ env:
   CONSUL_LATEST_IMAGE_NAME: ${{ endsWith(github.repository, '-enterprise') && github.repository || 'hashicorp/consul' }}
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   conditional-skip:
     runs-on: ubuntu-latest 
@@ -59,7 +63,7 @@ jobs:
     needs: [setup]
     uses: ./.github/workflows/reusable-dev-build.yml
     with:
-      runs-on: ${{ needs.setup.outputs.compute-xl }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       uploaded-binary-name: 'consul-bin'
     secrets:
@@ -278,7 +282,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
   
   envoy-integration-test:
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
     needs:
       - setup
       - generate-envoy-job-matrices
@@ -370,7 +374,7 @@ jobs:
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" $TEST_RESULTS_DIR/results.xml
 
   compatibility-integration-test:
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
     needs:
       - setup
       - dev-build


### PR DESCRIPTION
### Description

I am seeing this very weird thing where backports are using the github workflows on the release branches themselves. I cannot explain it...

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
