### PR TITLE
update guide to reflect tenancy and scope

### DIFF
--- a/docs/resources/guide.md
+++ b/docs/resources/guide.md
@@ -50,7 +50,6 @@ import (
 var BarV1Alpha1Type = &pbresource.Type{
 	Group:        "foo",
 	GroupVersion: "v1alpha1",
-	Scope:    resource.ScopeNamespace,
 	Kind:         "bar",
 }
 

--- a/docs/resources/guide.md
+++ b/docs/resources/guide.md
@@ -50,16 +50,21 @@ import (
 var BarV1Alpha1Type = &pbresource.Type{
 	Group:        "foo",
 	GroupVersion: "v1alpha1",
+	Scope:    resource.ScopeNamespace,
 	Kind:         "bar",
 }
 
 func RegisterTypes(r resource.Registry) {
 	r.Register(resource.Registration{
-		Type:  BarV1Alpha1Type,
+		Type:  BarV1Alpha1Type, 
+		Scope:    resource.ScopePartition,
 		Proto: &pbv1alpha1.Bar{},
 	})
 }
 ```
+Note that Scope reference the scope of the new resource, `resource.ScopePartition` 
+mean that resource will be at the partition level and have no namespace, while `resource.ScopeNamespace` mean it will have both a namespace 
+and a partition.
 
 Update the `NewTypeRegistry` method in [`type_registry.go`] to call your
 package's type registration method:
@@ -140,7 +145,8 @@ using a validation hook provided in the type registration:
 func RegisterTypes(r resource.Registry) {
 	r.Register(resource.Registration{
 		Type:     BarV1Alpha1Type,
-		Proto:    &pbv1alpha1.Bar{},
+		Proto:    &pbv1alpha1.Bar{}, 
+		Scope:    resource.ScopeNamespace,
 		Validate: validateBar,
 	})
 }
@@ -172,7 +178,8 @@ a set of ACL hooks:
 func RegisterTypes(r resource.Registry) {
 	r.Register(resource.Registration{
 		Type:  BarV1Alpha1Type,
-		Proto: &pbv1alpha1.Bar{},
+		Proto: &pbv1alpha1.Bar{}, 
+		Scope:    resource.ScopeNamespace,
 		ACLs: &resource.ACLHooks{,
 			Read:  authzReadBar,
 			Write: authzWriteBar,
@@ -210,7 +217,8 @@ by providing a mutation hook:
 func RegisterTypes(r resource.Registry) {
 	r.Register(resource.Registration{
 		Type:   BarV1Alpha1Type,
-		Proto:  &pbv1alpha1.Bar{},
+		Proto:  &pbv1alpha1.Bar{}, 
+		Scope:    resource.ScopeNamespace,
 		Mutate: mutateBar,
 	})
 }

--- a/docs/resources/guide.md
+++ b/docs/resources/guide.md
@@ -188,19 +188,19 @@ func RegisterTypes(r resource.Registry) {
 	})
 }
 
-func authzReadBar(authz acl.Authorizer, id *pbresource.ID) error {
+func authzReadBar(authz acl.Authorizer, authzContext *acl.AuthorizerContext, id *pbresource.ID) error {
 	return authz.ToAllowAuthorizer().
-		BarReadAllowed(id.Name, resource.AuthorizerContext(id.Tenancy))
+		BarReadAllowed(id.Name, authzContext)
 }
 
-func authzWriteBar(authz acl.Authorizer, id *pbresource.ID) error {
+func authzWriteBar(authz acl.Authorizer, authzContext *acl.AuthorizerContext, res *pbresource.Resource) error {
 	return authz.ToAllowAuthorizer().
-		BarWriteAllowed(id.Name, resource.AuthorizerContext(id.Tenancy))
+		BarWriteAllowed(res.ID().Name, authzContext)
 }
 
-func authzListBar(authz acl.Authorizer, ten *pbresource.Tenancy) error {
+func authzListBar(authz acl.Authorizer, authzContext *acl.AuthorizerContext) error {
 	return authz.ToAllowAuthorizer().
-		BarListAllowed(resource.AuthorizerContext(ten))
+		BarListAllowed(authzContext)
 }
 ```
 

--- a/docs/resources/guide.md
+++ b/docs/resources/guide.md
@@ -57,7 +57,7 @@ var BarV1Alpha1Type = &pbresource.Type{
 func RegisterTypes(r resource.Registry) {
 	r.Register(resource.Registration{
 		Type:  BarV1Alpha1Type, 
-		Scope:    resource.ScopePartition,
+		Scope: resource.ScopePartition,
 		Proto: &pbv1alpha1.Bar{},
 	})
 }
@@ -179,7 +179,7 @@ func RegisterTypes(r resource.Registry) {
 	r.Register(resource.Registration{
 		Type:  BarV1Alpha1Type,
 		Proto: &pbv1alpha1.Bar{}, 
-		Scope:    resource.ScopeNamespace,
+		Scope: resource.ScopeNamespace,
 		ACLs: &resource.ACLHooks{,
 			Read:  authzReadBar,
 			Write: authzWriteBar,
@@ -218,7 +218,7 @@ func RegisterTypes(r resource.Registry) {
 	r.Register(resource.Registration{
 		Type:   BarV1Alpha1Type,
 		Proto:  &pbv1alpha1.Bar{}, 
-		Scope:    resource.ScopeNamespace,
+		Scope:  resource.ScopeNamespace,
 		Mutate: mutateBar,
 	})
 }


### PR DESCRIPTION
### Description

This PR update the resource dev guide to reflect the changes introduced by supporting tenancy v1 when using v2 resource API

### Testing & Reproduction steps

Doc change, not test needed
