### PR TITLE
Update debug.mdx

### DIFF
--- a/website/content/commands/debug.mdx
+++ b/website/content/commands/debug.mdx
@@ -90,7 +90,7 @@ the data is written to the specified path (defaulting to the current
 directory) on the host where the command runs.
 
 By default the command will capture all available data from the default
-agent address on loopback for 2 minutes at 30 second intervals.
+agent address on loopback for 5 minutes at 30 second intervals.
 
 ```shell-session
 $ consul debug


### PR DESCRIPTION
Update example to be consistent with default `-duration` setting of 5m vice 2m (changed in consul  version 1.16.x to 5m)

### Description

Document had conflicting information between example and default parameter value for duration.

### Testing & Reproduction steps

* Installed Consul versions 1.14.x, 1.15.x, and 1.16.x locally and ran in dev mode
* Per each installation run `consul debug` with no flags and note the `Duration:` output.

### Findings

Versions of consul <1.16.x default the debug capture to 2m while versions >=1.16.x default to 5m.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
