### PR TITLE
test: update sidecarproxy/builder golden tests to use determinstic golden data

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/builder/builder_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/builder_test.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"encoding/json"
 	"flag"
 	"os"
 	"testing"
@@ -22,5 +23,16 @@ func protoToJSON(t *testing.T, pb proto.Message) string {
 	}
 	gotJSON, err := m.Marshal(pb)
 	require.NoError(t, err)
+
+	// protojson format is non-determinstic, so scrub it through the determinstic json.Marshal so
+	// 'git diff' only shows real changes
+	//
+	// https://github.com/golang/protobuf/issues/1269
+	var tmp map[string]any
+	require.NoError(t, json.Unmarshal(gotJSON, &tmp))
+
+	gotJSON, err = json.MarshalIndent(&tmp, "", "  ")
+	require.NoError(t, err)
+
 	return string(gotJSON)
 }

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-multi-destination.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-multi-destination.golden
@@ -1,47 +1,5 @@
 {
   "proxyState": {
-    "identity": {
-      "tenancy": {
-        "partition": "default",
-        "namespace": "default",
-        "peerName": "local"
-      },
-      "name": "test-identity"
-    },
-    "listeners": [
-      {
-        "name": "api-1:tcp:1.1.1.1:1234",
-        "direction": "DIRECTION_OUTBOUND",
-        "hostPort": {
-          "host": "1.1.1.1",
-          "port": 1234
-        },
-        "routers": [
-          {
-            "l4": {
-              "name": "api-1.default.dc1.internal.foo.consul",
-              "statPrefix": "upstream.api-1.default.default.dc1"
-            }
-          }
-        ]
-      },
-      {
-        "name": "api-2:tcp:/path/to/socket",
-        "direction": "DIRECTION_OUTBOUND",
-        "unixSocket": {
-          "path": "/path/to/socket",
-          "mode": "0666"
-        },
-        "routers": [
-          {
-            "l4": {
-              "name": "api-2.default.dc1.internal.foo.consul",
-              "statPrefix": "upstream.api-2.default.default.dc1"
-            }
-          }
-        ]
-      }
-    ],
     "clusters": {
       "api-1.default.dc1.internal.foo.consul": {
         "endpointGroup": {
@@ -52,12 +10,12 @@
             "outboundTls": {
               "outboundMesh": {
                 "identityKey": "test-identity",
+                "sni": "api-1.default.dc1.internal.foo.consul",
                 "validationContext": {
                   "spiffeIds": [
                     "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
                   ]
-                },
-                "sni": "api-1.default.dc1.internal.foo.consul"
+                }
               }
             }
           }
@@ -72,32 +30,74 @@
             "outboundTls": {
               "outboundMesh": {
                 "identityKey": "test-identity",
+                "sni": "api-2.default.dc1.internal.foo.consul",
                 "validationContext": {
                   "spiffeIds": [
                     "spiffe://foo.consul/ap/default/ns/default/identity/api2-identity"
                   ]
-                },
-                "sni": "api-2.default.dc1.internal.foo.consul"
+                }
               }
             }
           }
         }
       }
-    }
+    },
+    "identity": {
+      "name": "test-identity",
+      "tenancy": {
+        "namespace": "default",
+        "partition": "default",
+        "peerName": "local"
+      }
+    },
+    "listeners": [
+      {
+        "direction": "DIRECTION_OUTBOUND",
+        "hostPort": {
+          "host": "1.1.1.1",
+          "port": 1234
+        },
+        "name": "api-1:tcp:1.1.1.1:1234",
+        "routers": [
+          {
+            "l4": {
+              "name": "api-1.default.dc1.internal.foo.consul",
+              "statPrefix": "upstream.api-1.default.default.dc1"
+            }
+          }
+        ]
+      },
+      {
+        "direction": "DIRECTION_OUTBOUND",
+        "name": "api-2:tcp:/path/to/socket",
+        "routers": [
+          {
+            "l4": {
+              "name": "api-2.default.dc1.internal.foo.consul",
+              "statPrefix": "upstream.api-2.default.default.dc1"
+            }
+          }
+        ],
+        "unixSocket": {
+          "mode": "0666",
+          "path": "/path/to/socket"
+        }
+      }
+    ]
   },
   "requiredEndpoints": {
     "api-1.default.dc1.internal.foo.consul": {
       "id": {
         "name": "api-1",
+        "tenancy": {
+          "namespace": "default",
+          "partition": "default",
+          "peerName": "local"
+        },
         "type": {
           "group": "catalog",
           "groupVersion": "v1alpha1",
           "kind": "ServiceEndpoints"
-        },
-        "tenancy": {
-          "partition": "default",
-          "namespace": "default",
-          "peerName": "local"
         }
       },
       "port": "mesh"
@@ -105,15 +105,15 @@
     "api-2.default.dc1.internal.foo.consul": {
       "id": {
         "name": "api-2",
+        "tenancy": {
+          "namespace": "default",
+          "partition": "default",
+          "peerName": "local"
+        },
         "type": {
           "group": "catalog",
           "groupVersion": "v1alpha1",
           "kind": "ServiceEndpoints"
-        },
-        "tenancy": {
-          "partition": "default",
-          "namespace": "default",
-          "peerName": "local"
         }
       },
       "port": "mesh"

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-multiple-workload-addresses-with-specific-ports.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-multiple-workload-addresses-with-specific-ports.golden
@@ -1,41 +1,5 @@
 {
   "proxyState": {
-    "identity": {
-      "tenancy": {
-        "partition": "default",
-        "namespace": "default",
-        "peerName": "local"
-      },
-      "name": "test-identity"
-    },
-    "listeners": [
-      {
-        "name": "public_listener",
-        "direction": "DIRECTION_INBOUND",
-        "hostPort": {
-          "host": "10.0.0.2",
-          "port": 20000
-        },
-        "routers": [
-          {
-            "l4": {
-              "name": "local_app:port1",
-              "statPrefix": "public_listener"
-            },
-            "inboundTls": {
-              "inboundMesh": {
-                "identityKey": "test-identity",
-                "validationContext": {
-                  "trustBundlePeerNameKeys": [
-                    "local"
-                  ]
-                }
-              }
-            }
-          }
-        ]
-      }
-    ],
     "clusters": {
       "local_app:port1": {
         "endpointGroup": {
@@ -54,7 +18,43 @@
           }
         ]
       }
-    }
+    },
+    "identity": {
+      "name": "test-identity",
+      "tenancy": {
+        "namespace": "default",
+        "partition": "default",
+        "peerName": "local"
+      }
+    },
+    "listeners": [
+      {
+        "direction": "DIRECTION_INBOUND",
+        "hostPort": {
+          "host": "10.0.0.2",
+          "port": 20000
+        },
+        "name": "public_listener",
+        "routers": [
+          {
+            "inboundTls": {
+              "inboundMesh": {
+                "identityKey": "test-identity",
+                "validationContext": {
+                  "trustBundlePeerNameKeys": [
+                    "local"
+                  ]
+                }
+              }
+            },
+            "l4": {
+              "name": "local_app:port1",
+              "statPrefix": "public_listener"
+            }
+          }
+        ]
+      }
+    ]
   },
   "requiredLeafCertificates": {
     "test-identity": {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-multiple-workload-addresses-without-ports.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-multiple-workload-addresses-without-ports.golden
@@ -1,41 +1,5 @@
 {
   "proxyState": {
-    "identity": {
-      "tenancy": {
-        "partition": "default",
-        "namespace": "default",
-        "peerName": "local"
-      },
-      "name": "test-identity"
-    },
-    "listeners": [
-      {
-        "name": "public_listener",
-        "direction": "DIRECTION_INBOUND",
-        "hostPort": {
-          "host": "10.0.0.1",
-          "port": 20000
-        },
-        "routers": [
-          {
-            "l4": {
-              "name": "local_app:port1",
-              "statPrefix": "public_listener"
-            },
-            "inboundTls": {
-              "inboundMesh": {
-                "identityKey": "test-identity",
-                "validationContext": {
-                  "trustBundlePeerNameKeys": [
-                    "local"
-                  ]
-                }
-              }
-            }
-          }
-        ]
-      }
-    ],
     "clusters": {
       "local_app:port1": {
         "endpointGroup": {
@@ -54,7 +18,43 @@
           }
         ]
       }
-    }
+    },
+    "identity": {
+      "name": "test-identity",
+      "tenancy": {
+        "namespace": "default",
+        "partition": "default",
+        "peerName": "local"
+      }
+    },
+    "listeners": [
+      {
+        "direction": "DIRECTION_INBOUND",
+        "hostPort": {
+          "host": "10.0.0.1",
+          "port": 20000
+        },
+        "name": "public_listener",
+        "routers": [
+          {
+            "inboundTls": {
+              "inboundMesh": {
+                "identityKey": "test-identity",
+                "validationContext": {
+                  "trustBundlePeerNameKeys": [
+                    "local"
+                  ]
+                }
+              }
+            },
+            "l4": {
+              "name": "local_app:port1",
+              "statPrefix": "public_listener"
+            }
+          }
+        ]
+      }
+    ]
   },
   "requiredLeafCertificates": {
     "test-identity": {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-single-destination-ip-port-bind-address.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-single-destination-ip-port-bind-address.golden
@@ -1,31 +1,5 @@
 {
   "proxyState": {
-    "identity": {
-      "tenancy": {
-        "partition": "default",
-        "namespace": "default",
-        "peerName": "local"
-      },
-      "name": "test-identity"
-    },
-    "listeners": [
-      {
-        "name": "api-1:tcp:1.1.1.1:1234",
-        "direction": "DIRECTION_OUTBOUND",
-        "hostPort": {
-          "host": "1.1.1.1",
-          "port": 1234
-        },
-        "routers": [
-          {
-            "l4": {
-              "name": "api-1.default.dc1.internal.foo.consul",
-              "statPrefix": "upstream.api-1.default.default.dc1"
-            }
-          }
-        ]
-      }
-    ],
     "clusters": {
       "api-1.default.dc1.internal.foo.consul": {
         "endpointGroup": {
@@ -36,32 +10,58 @@
             "outboundTls": {
               "outboundMesh": {
                 "identityKey": "test-identity",
+                "sni": "api-1.default.dc1.internal.foo.consul",
                 "validationContext": {
                   "spiffeIds": [
                     "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
                   ]
-                },
-                "sni": "api-1.default.dc1.internal.foo.consul"
+                }
               }
             }
           }
         }
       }
-    }
+    },
+    "identity": {
+      "name": "test-identity",
+      "tenancy": {
+        "namespace": "default",
+        "partition": "default",
+        "peerName": "local"
+      }
+    },
+    "listeners": [
+      {
+        "direction": "DIRECTION_OUTBOUND",
+        "hostPort": {
+          "host": "1.1.1.1",
+          "port": 1234
+        },
+        "name": "api-1:tcp:1.1.1.1:1234",
+        "routers": [
+          {
+            "l4": {
+              "name": "api-1.default.dc1.internal.foo.consul",
+              "statPrefix": "upstream.api-1.default.default.dc1"
+            }
+          }
+        ]
+      }
+    ]
   },
   "requiredEndpoints": {
     "api-1.default.dc1.internal.foo.consul": {
       "id": {
         "name": "api-1",
+        "tenancy": {
+          "namespace": "default",
+          "partition": "default",
+          "peerName": "local"
+        },
         "type": {
           "group": "catalog",
           "groupVersion": "v1alpha1",
           "kind": "ServiceEndpoints"
-        },
-        "tenancy": {
-          "partition": "default",
-          "namespace": "default",
-          "peerName": "local"
         }
       },
       "port": "mesh"

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-single-destination-unix-socket-bind-address.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-single-destination-unix-socket-bind-address.golden
@@ -1,31 +1,5 @@
 {
   "proxyState": {
-    "identity": {
-      "tenancy": {
-        "partition": "default",
-        "namespace": "default",
-        "peerName": "local"
-      },
-      "name": "test-identity"
-    },
-    "listeners": [
-      {
-        "name": "api-2:tcp:/path/to/socket",
-        "direction": "DIRECTION_OUTBOUND",
-        "unixSocket": {
-          "path": "/path/to/socket",
-          "mode": "0666"
-        },
-        "routers": [
-          {
-            "l4": {
-              "name": "api-2.default.dc1.internal.foo.consul",
-              "statPrefix": "upstream.api-2.default.default.dc1"
-            }
-          }
-        ]
-      }
-    ],
     "clusters": {
       "api-2.default.dc1.internal.foo.consul": {
         "endpointGroup": {
@@ -36,32 +10,58 @@
             "outboundTls": {
               "outboundMesh": {
                 "identityKey": "test-identity",
+                "sni": "api-2.default.dc1.internal.foo.consul",
                 "validationContext": {
                   "spiffeIds": [
                     "spiffe://foo.consul/ap/default/ns/default/identity/api2-identity"
                   ]
-                },
-                "sni": "api-2.default.dc1.internal.foo.consul"
+                }
               }
             }
           }
         }
       }
-    }
+    },
+    "identity": {
+      "name": "test-identity",
+      "tenancy": {
+        "namespace": "default",
+        "partition": "default",
+        "peerName": "local"
+      }
+    },
+    "listeners": [
+      {
+        "direction": "DIRECTION_OUTBOUND",
+        "name": "api-2:tcp:/path/to/socket",
+        "routers": [
+          {
+            "l4": {
+              "name": "api-2.default.dc1.internal.foo.consul",
+              "statPrefix": "upstream.api-2.default.default.dc1"
+            }
+          }
+        ],
+        "unixSocket": {
+          "mode": "0666",
+          "path": "/path/to/socket"
+        }
+      }
+    ]
   },
   "requiredEndpoints": {
     "api-2.default.dc1.internal.foo.consul": {
       "id": {
         "name": "api-2",
+        "tenancy": {
+          "namespace": "default",
+          "partition": "default",
+          "peerName": "local"
+        },
         "type": {
           "group": "catalog",
           "groupVersion": "v1alpha1",
           "kind": "ServiceEndpoints"
-        },
-        "tenancy": {
-          "partition": "default",
-          "namespace": "default",
-          "peerName": "local"
         }
       },
       "port": "mesh"

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-single-workload-address-without-ports.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/l4-single-workload-address-without-ports.golden
@@ -1,41 +1,5 @@
 {
   "proxyState": {
-    "identity": {
-      "tenancy": {
-        "partition": "default",
-        "namespace": "default",
-        "peerName": "local"
-      },
-      "name": "test-identity"
-    },
-    "listeners": [
-      {
-        "name": "public_listener",
-        "direction": "DIRECTION_INBOUND",
-        "hostPort": {
-          "host": "10.0.0.1",
-          "port": 20000
-        },
-        "routers": [
-          {
-            "l4": {
-              "name": "local_app:port1",
-              "statPrefix": "public_listener"
-            },
-            "inboundTls": {
-              "inboundMesh": {
-                "identityKey": "test-identity",
-                "validationContext": {
-                  "trustBundlePeerNameKeys": [
-                    "local"
-                  ]
-                }
-              }
-            }
-          }
-        ]
-      }
-    ],
     "clusters": {
       "local_app:port1": {
         "endpointGroup": {
@@ -54,7 +18,43 @@
           }
         ]
       }
-    }
+    },
+    "identity": {
+      "name": "test-identity",
+      "tenancy": {
+        "namespace": "default",
+        "partition": "default",
+        "peerName": "local"
+      }
+    },
+    "listeners": [
+      {
+        "direction": "DIRECTION_INBOUND",
+        "hostPort": {
+          "host": "10.0.0.1",
+          "port": 20000
+        },
+        "name": "public_listener",
+        "routers": [
+          {
+            "inboundTls": {
+              "inboundMesh": {
+                "identityKey": "test-identity",
+                "validationContext": {
+                  "trustBundlePeerNameKeys": [
+                    "local"
+                  ]
+                }
+              }
+            },
+            "l4": {
+              "name": "local_app:port1",
+              "statPrefix": "public_listener"
+            }
+          }
+        ]
+      }
+    ]
   },
   "requiredLeafCertificates": {
     "test-identity": {


### PR DESCRIPTION
### Description

In various places (like sidecarproxy/builder) we use `protojson` to marshal golden data for comparison. Unfortunately [by design](https://github.com/golang/protobuf/issues/1269) this introduces random whitespace in generated output so using `git diff` to peek at proposed output changes in your tests after running the test with `-update` will show more lines changed than expected which is confusing.

This patch updates only *one* of these call sites to use deterministic output by a trick:

1. protojson marshal (nondeterminstic)
2. json unmarshal
3. json marshal (determinstic)

The whitespace will be reasonable and the fields will be sorted alphabetically rather than by protobuf field id.

If this seems helpful we should likely update the `agent/xds` package tests too, but that will need to be a split PR.