### PR TITLE
Instantiate secure resource service client after the grpc server

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -817,17 +817,19 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 	s.reportingManager = reporting.NewReportingManager(s.logger, getEnterpriseReportingDeps(flat), s, s.fsm.State())
 	go s.reportingManager.Run(&lib.StopChannelContext{StopCh: s.shutdownCh})
 
-	// Setup resource service clients.
-	if err := s.setupSecureResourceServiceClient(); err != nil {
-		return nil, err
-	}
-
+	// Setup insecure resource service client.
 	if err := s.setupInsecureResourceServiceClient(flat.Registry, logger); err != nil {
 		return nil, err
 	}
 
 	// Initialize external gRPC server
 	s.setupExternalGRPC(config, flat, logger)
+
+	// Setup secure resource service client. We need to do it after we setup the
+	// gRPC server because it needs the server to be instantiated.
+	if err := s.setupSecureResourceServiceClient(); err != nil {
+		return nil, err
+	}
 
 	// Initialize internal gRPC server.
 	//
@@ -1400,6 +1402,10 @@ func (s *Server) setupExternalGRPC(config *Config, deps Deps, logger hclog.Logge
 }
 
 func (s *Server) setupInsecureResourceServiceClient(typeRegistry resource.Registry, logger hclog.Logger) error {
+	if s.raftStorageBackend == nil {
+		return fmt.Errorf("raft storage backend cannot be nil")
+	}
+
 	server := resourcegrpc.NewServer(resourcegrpc.Config{
 		Registry:        typeRegistry,
 		Backend:         s.raftStorageBackend,
@@ -1418,6 +1424,9 @@ func (s *Server) setupInsecureResourceServiceClient(typeRegistry resource.Regist
 }
 
 func (s *Server) setupSecureResourceServiceClient() error {
+	if s.resourceServiceServer == nil {
+		return fmt.Errorf("resource service server cannot be nil")
+	}
 	conn, err := s.runInProcessGRPCServer(s.resourceServiceServer.Register)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description

In a previous PR (https://github.com/hashicorp/consul/pull/18504), we moved resource client instantiation to be before setting up the external gRPC server. However, the secure client relies on the resource server not being nil which is done by the gRPC server setup. This PR moves the setup of the secure client to be after the gRPC server setup.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
