### PR TITLE
Extend stringified integer port expectation to BackendReference.port

### DIFF
--- a/proto-public/pbmesh/v1alpha1/common.pb.go
+++ b/proto-public/pbmesh/v1alpha1/common.pb.go
@@ -121,6 +121,7 @@ type BackendReference struct {
 	// (MCS+GAMMA) when translating
 	Ref *pbresource.Reference `protobuf:"bytes,1,opt,name=ref,proto3" json:"ref,omitempty"`
 	// For east/west this is the name of the consul port.
+	// For north/south this is the stringified integer port expected by GAMMA.
 	Port string `protobuf:"bytes,2,opt,name=port,proto3" json:"port,omitempty"`
 	// NOT IN GAMMA; multi-cluster + GWapi is still unknown
 	//

--- a/proto-public/pbmesh/v1alpha1/common.proto
+++ b/proto-public/pbmesh/v1alpha1/common.proto
@@ -52,6 +52,7 @@ message BackendReference {
   hashicorp.consul.resource.Reference ref = 1;
 
   // For east/west this is the name of the consul port.
+  // For north/south this is the stringified integer port expected by GAMMA.
   string port = 2;
 
   // NOT IN GAMMA; multi-cluster + GWapi is still unknown


### PR DESCRIPTION
### Description
This extends the behavior expectation that north/south uses stringified port numbers expected by GAMMA to the `BackendReference.port` field. Notably, this matches the documented expectation for `ParentReference.port`.

### Testing & Reproduction steps
N/A this is just a contract clarification.

### Links
N/A

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
