### PR TITLE
[NET-5574] Update Go version to 1.20.8

### DIFF
--- a/.changelog/18742.txt
+++ b/.changelog/18742.txt
@@ -1,0 +1,8 @@
+```release-note:security
+Upgrade to use Go 1.20.8. This resolves CVEs
+[CVE-2023-39320](https://github.com/advisories/GHSA-rxv8-v965-v333) (`cmd/go`),
+[CVE-2023-39318](https://github.com/advisories/GHSA-vq7j-gx56-rxjh) (`html/template`),
+[CVE-2023-39319](https://github.com/advisories/GHSA-vv9m-32rr-3g55) (`html/template`),
+[CVE-2023-39321](https://github.com/advisories/GHSA-9v7r-x7cv-v437) (`crypto/tls`), and
+[CVE-2023-39322](https://github.com/advisories/GHSA-892h-r6cr-53g4) (`crypto/tls`)
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,15 +85,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.20.7", goos: "linux", goarch: "386"}
-          - {go: "1.20.7", goos: "linux", goarch: "amd64"}
-          - {go: "1.20.7", goos: "linux", goarch: "arm"}
-          - {go: "1.20.7", goos: "linux", goarch: "arm64"}
-          - {go: "1.20.7", goos: "freebsd", goarch: "386"}
-          - {go: "1.20.7", goos: "freebsd", goarch: "amd64"}
-          - {go: "1.20.7", goos: "windows", goarch: "386"}
-          - {go: "1.20.7", goos: "windows", goarch: "amd64"}
-          - {go: "1.20.7", goos: "solaris", goarch: "amd64"}
+          - {go: "1.20.8", goos: "linux", goarch: "386"}
+          - {go: "1.20.8", goos: "linux", goarch: "amd64"}
+          - {go: "1.20.8", goos: "linux", goarch: "arm"}
+          - {go: "1.20.8", goos: "linux", goarch: "arm64"}
+          - {go: "1.20.8", goos: "freebsd", goarch: "386"}
+          - {go: "1.20.8", goos: "freebsd", goarch: "amd64"}
+          - {go: "1.20.8", goos: "windows", goarch: "386"}
+          - {go: "1.20.8", goos: "windows", goarch: "amd64"}
+          - {go: "1.20.8", goos: "solaris", goarch: "amd64"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -182,7 +182,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.20.7", goos: "linux", goarch: "s390x"}
+          - {go: "1.20.8", goos: "linux", goarch: "s390x"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -233,7 +233,7 @@ jobs:
       matrix:
         goos: [ darwin ]
         goarch: [ "amd64", "arm64" ]
-        go: [ "1.20.7" ]
+        go: [ "1.20.8" ]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-ARG GOLANG_VERSION=1.20.7
+ARG GOLANG_VERSION=1.20.8
 FROM golang:${GOLANG_VERSION}
 
 WORKDIR /consul


### PR DESCRIPTION
This resolves several CVEs:

* CVE-2023-39320: cmd/go: go.mod toolchain directive allows arbitrary execution
* CVE-2023-39318: html/template: improper handling of HTML-like comments within script contexts
* CVE-2023-39319: html/template: improper handling of special tags within script contexts
* CVE-2023-39321 and CVE-2023-39322: crypto/tls: panic when processing post-handshake message on QUIC connections

### Description

Resolves CVEs and brings us up to the latest version of Go.

### Testing & Reproduction steps

Tests should continue to pass.

### Links

* https://groups.google.com/g/golang-announce/c/Fm51GRLNRvM

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
