### PR TITLE
fix: write endpoint errors out gracefully

### DIFF
--- a/internal/resource/http/http.go
+++ b/internal/resource/http/http.go
@@ -82,14 +82,18 @@ func (h *resourceHandler) handleWrite(w http.ResponseWriter, r *http.Request, ct
 	var req writeRequest
 	// convert req body to writeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.logger.Error("Failed to decode request body", "error", err)
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Request body didn't follow schema."))
+		w.Write([]byte("Request body format is invalid"))
+		return
 	}
 	// convert data struct to proto message
 	data := h.reg.Proto.ProtoReflect().New().Interface()
 	if err := protojson.Unmarshal(req.Data, data); err != nil {
+		h.logger.Error("Failed to unmarshal to proto message", "error", err)
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Request body didn't follow schema."))
+		w.Write([]byte("Request body didn't follow the resource schema"))
+		return
 	}
 	// proto message to any
 	anyProtoMsg, err := anypb.New(data)


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
This PR fixes the following problem:
When the request body does not comply with the resource schema we still end up calling the gRPC endpoint and in some cases incorrectly creating a resource in the backend with partial data while returning the `400` status code.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

- Add unit tests that also asserts the error  message not just the status code

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

[Ticket](https://hashicorp.atlassian.net/browse/NET-5561)

### PR Checklist

* [x] updated test coverage
* [ ] ~external facing docs updated~
* [x] appropriate backport labels added
* [x] not a security concern
