### PR TITLE
Test: NET-5592 - update Nomad integration testing

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -79,7 +79,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        nomad-version: ['v1.3.3', 'v1.2.10', 'v1.1.16']
+        nomad-version: ['v1.6.1', 'v1.5.8', 'v1.4.12']
     steps:
       - name: Checkout Nomad
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
### Description

Test Nomad's latest supported releases : v1.6.1, v1.5.8, v1.4.12 

### Testing & Reproduction steps



### Links



### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
