### PR TITLE
fix: provide meaningful error messages and add test

### DIFF
--- a/command/resource/apply/apply.go
+++ b/command/resource/apply/apply.go
@@ -85,7 +85,7 @@ func (c *cmd) Run(args []string) int {
 		}
 		parsedResource = data
 	} else {
-		c.UI.Error("Flag -f is required")
+		c.UI.Error("Incorrect argument format: Flag -f with file path argument is required")
 		return 1
 	}
 

--- a/command/resource/apply/apply_test.go
+++ b/command/resource/apply/apply_test.go
@@ -78,7 +78,7 @@ func TestResourceApplyInvalidArgs(t *testing.T) {
 		"missing required flag": {
 			args:         []string{},
 			expectedCode: 1,
-			expectedErr:  errors.New("Flag -f is required"),
+			expectedErr:  errors.New("Incorrect argument format: Flag -f with file path argument is required"),
 		},
 		"file parsing failure": {
 			args:         []string{"-f=../testdata/invalid.hcl"},

--- a/command/resource/delete/delete.go
+++ b/command/resource/delete/delete.go
@@ -101,7 +101,8 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 		if c.filePath != "" {
-			c.UI.Warn("File argument is ignored when resource information is provided with the command")
+			c.UI.Error("Incorrect argument format: File argument is not needed when resource information is provided with the command")
+			return 1
 		}
 		opts = &api.QueryOptions{
 			Namespace: c.http.Namespace(),

--- a/command/resource/delete/delete.go
+++ b/command/resource/delete/delete.go
@@ -84,13 +84,13 @@ func (c *cmd) Run(args []string) int {
 		}
 	} else {
 		if len(args) < 2 {
-			c.UI.Error("Your argument format is incorrect: Must specify two arguments: resource type and resource name")
+			c.UI.Error("Incorrect argument format: Must specify two arguments: resource type and resource name")
 			return 1
 		}
 		var err error
 		gvk, resourceName, err = resource.GetTypeAndResourceName(args)
 		if err != nil {
-			c.UI.Error(fmt.Sprintf("Your argument format is incorrect: %s", err))
+			c.UI.Error(fmt.Sprintf("Incorrect argument format: %s", err))
 			return 1
 		}
 
@@ -101,7 +101,7 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 		if c.filePath != "" {
-			c.UI.Warn("We ignored the -f flag if you provide gvk and resource name")
+			c.UI.Warn("File argument is ignored when resource information is provided with the command")
 		}
 		opts = &api.QueryOptions{
 			Namespace: c.http.Namespace(),

--- a/command/resource/delete/delete_test.go
+++ b/command/resource/delete/delete_test.go
@@ -52,12 +52,12 @@ func TestResourceDeleteInvalidArgs(t *testing.T) {
 		"provide type and name with -f": {
 			args:         []string{"a.b.c", "name", "-f", "test.hcl"},
 			expectedCode: 1,
-			expectedErr:  errors.New("File argument is ignored when resource information is provided with the command"),
+			expectedErr:  errors.New("Incorrect argument format: File argument is not needed when resource information is provided with the command"),
 		},
 		"provide type and name with -f and other flags": {
 			args:         []string{"a.b.c", "name", "-f", "test.hcl", "-namespace", "default"},
 			expectedCode: 1,
-			expectedErr:  errors.New("File argument is ignored when resource information is provided with the command"),
+			expectedErr:  errors.New("Incorrect argument format: File argument is not needed when resource information is provided with the command"),
 		},
 		"does not provide resource name after type": {
 			args:         []string{"a.b.c", "-namespace", "default"},

--- a/command/resource/delete/delete_test.go
+++ b/command/resource/delete/delete_test.go
@@ -27,12 +27,12 @@ func TestResourceDeleteInvalidArgs(t *testing.T) {
 		"nil args": {
 			args:         nil,
 			expectedCode: 1,
-			expectedErr:  errors.New("Your argument format is incorrect: Must specify two arguments: resource type and resource name"),
+			expectedErr:  errors.New("Incorrect argument format: Must specify two arguments: resource type and resource name"),
 		},
 		"empty args": {
 			args:         []string{},
 			expectedCode: 1,
-			expectedErr:  errors.New("Your argument format is incorrect: Must specify two arguments: resource type and resource name"),
+			expectedErr:  errors.New("Incorrect argument format: Must specify two arguments: resource type and resource name"),
 		},
 		"missing file path": {
 			args:         []string{"-f"},
@@ -47,27 +47,27 @@ func TestResourceDeleteInvalidArgs(t *testing.T) {
 		"provide type and name": {
 			args:         []string{"a.b.c"},
 			expectedCode: 1,
-			expectedErr:  errors.New("Your argument format is incorrect: Must specify two arguments: resource type and resource name"),
+			expectedErr:  errors.New("Incorrect argument format: Must specify two arguments: resource type and resource name"),
 		},
 		"provide type and name with -f": {
 			args:         []string{"a.b.c", "name", "-f", "test.hcl"},
 			expectedCode: 1,
-			expectedErr:  errors.New("We ignored the -f flag if you provide gvk and resource name"),
+			expectedErr:  errors.New("File argument is ignored when resource information is provided with the command"),
 		},
 		"provide type and name with -f and other flags": {
 			args:         []string{"a.b.c", "name", "-f", "test.hcl", "-namespace", "default"},
 			expectedCode: 1,
-			expectedErr:  errors.New("We ignored the -f flag if you provide gvk and resource name"),
+			expectedErr:  errors.New("File argument is ignored when resource information is provided with the command"),
 		},
 		"does not provide resource name after type": {
 			args:         []string{"a.b.c", "-namespace", "default"},
 			expectedCode: 1,
-			expectedErr:  errors.New("Your argument format is incorrect: Must provide resource name right after type"),
+			expectedErr:  errors.New("Incorrect argument format: Must provide resource name right after type"),
 		},
 		"invalid resource type format": {
 			args:         []string{"a.", "name", "-namespace", "default"},
 			expectedCode: 1,
-			expectedErr:  errors.New("Your argument format is incorrect: Must include resource type argument in group.verion.kind format"),
+			expectedErr:  errors.New("Incorrect argument format: Must include resource type argument in group.verion.kind format"),
 		},
 	}
 

--- a/command/resource/list/list.go
+++ b/command/resource/list/list.go
@@ -47,11 +47,6 @@ func (c *cmd) Run(args []string) int {
 	var gvk *api.GVK
 	var opts *api.QueryOptions
 
-	if len(args) == 0 {
-		c.UI.Error("Please provide required arguments")
-		return 1
-	}
-
 	if err := c.flags.Parse(args); err != nil {
 		if !errors.Is(err, flag.ErrHelp) {
 			c.UI.Error(fmt.Sprintf("Failed to parse args: %v", err))
@@ -93,7 +88,7 @@ func (c *cmd) Run(args []string) int {
 		// extract resource type
 		gvk, err = getResourceType(c.flags.Args())
 		if err != nil {
-			c.UI.Error(fmt.Sprintf("Your argument format is incorrect: %v", err))
+			c.UI.Error(fmt.Sprintf("Incorrect argument format: %v", err))
 			return 1
 		}
 		// skip resource type to parse remaining args
@@ -104,7 +99,7 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 		if c.filePath != "" {
-			c.UI.Warn(fmt.Sprintf("File argument is ignored when resource definition is provided with the command"))
+			c.UI.Warn(fmt.Sprintf("File argument is ignored when resource information is provided with the command"))
 		}
 
 		opts = &api.QueryOptions{

--- a/command/resource/list/list.go
+++ b/command/resource/list/list.go
@@ -99,7 +99,8 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 		if c.filePath != "" {
-			c.UI.Warn(fmt.Sprintf("File argument is ignored when resource information is provided with the command"))
+			c.UI.Error("Incorrect argument format: File argument is not needed when resource information is provided with the command")
+			return 1
 		}
 
 		opts = &api.QueryOptions{
@@ -136,6 +137,10 @@ func (c *cmd) Run(args []string) int {
 func getResourceType(args []string) (gvk *api.GVK, e error) {
 	if len(args) < 1 {
 		return nil, fmt.Errorf("Must include resource type argument")
+	}
+	// it should not have resource name
+	if len(args) > 1 && !strings.HasPrefix(args[1], "-") {
+		return nil, fmt.Errorf("Must include flag arguments after resource type")
 	}
 
 	s := strings.Split(args[0], ".")

--- a/command/resource/list/list_test.go
+++ b/command/resource/list/list_test.go
@@ -99,12 +99,12 @@ func TestResourceListInvalidArgs(t *testing.T) {
 		"nil args": {
 			args:         nil,
 			expectedCode: 1,
-			expectedErr:  errors.New("Please provide required arguments"),
+			expectedErr:  errors.New("Incorrect argument format: Must include resource type argument"),
 		},
 		"minimum args required": {
 			args:         []string{},
 			expectedCode: 1,
-			expectedErr:  errors.New("Please provide required arguments"),
+			expectedErr:  errors.New("Incorrect argument format: Must include resource type argument"),
 		},
 		"no file path": {
 			args: []string{
@@ -138,7 +138,7 @@ func TestResourceListInvalidArgs(t *testing.T) {
 				"-f=demo.hcl",
 			},
 			expectedCode: 0,
-			expectedErr:  errors.New("File argument is ignored when resource definition is provided with the command"),
+			expectedErr:  errors.New("File argument is ignored when resource information is provided with the command"),
 		},
 		"resource type invalid": {
 			args: []string{

--- a/command/resource/list/list_test.go
+++ b/command/resource/list/list_test.go
@@ -127,7 +127,7 @@ func TestResourceListInvalidArgs(t *testing.T) {
 			expectedCode: 1,
 			expectedErr:  errors.New("Failed to decode resource from input file"),
 		},
-		"file argument is ignored": {
+		"file argument with resource type": {
 			args: []string{
 				"demo.v2.artist",
 				"-namespace=default",
@@ -137,8 +137,8 @@ func TestResourceListInvalidArgs(t *testing.T) {
 				"-token=root",
 				"-f=demo.hcl",
 			},
-			expectedCode: 0,
-			expectedErr:  errors.New("File argument is ignored when resource information is provided with the command"),
+			expectedCode: 1,
+			expectedErr:  errors.New("Incorrect argument format: File argument is not needed when resource information is provided with the command"),
 		},
 		"resource type invalid": {
 			args: []string{
@@ -149,6 +149,17 @@ func TestResourceListInvalidArgs(t *testing.T) {
 			},
 			expectedCode: 1,
 			expectedErr:  errors.New("Must include resource type argument in group.verion.kind format"),
+		},
+		"resource name is provided": {
+			args: []string{
+				"demo.v2.artist",
+				"test",
+				"-namespace=default",
+				"-peer=local",
+				"-partition=default",
+			},
+			expectedCode: 1,
+			expectedErr:  errors.New("Must include flag arguments after resource type"),
 		},
 	}
 

--- a/command/resource/read/read.go
+++ b/command/resource/read/read.go
@@ -103,7 +103,8 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 		if c.filePath != "" {
-			c.UI.Warn(fmt.Sprintf("File argument is ignored when resource information is provided with the command"))
+			c.UI.Error("Incorrect argument format: File argument is not needed when resource information is provided with the command")
+			return 1
 		}
 		opts = &api.QueryOptions{
 			Namespace:         c.http.Namespace(),

--- a/command/resource/read/read.go
+++ b/command/resource/read/read.go
@@ -86,13 +86,13 @@ func (c *cmd) Run(args []string) int {
 		}
 	} else {
 		if len(args) < 2 {
-			c.UI.Error("Your argument format is incorrect: Must specify two arguments: resource type and resource name")
+			c.UI.Error("Incorrect argument format: Must specify two arguments: resource type and resource name")
 			return 1
 		}
 		var err error
 		gvk, resourceName, err = resource.GetTypeAndResourceName(args)
 		if err != nil {
-			c.UI.Error(fmt.Sprintf("Your argument format is incorrect: %s", err))
+			c.UI.Error(fmt.Sprintf("Incorrect argument format: %s", err))
 			return 1
 		}
 
@@ -103,7 +103,7 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 		if c.filePath != "" {
-			c.UI.Warn("We ignored the -f flag if you provide gvk and resource name")
+			c.UI.Warn(fmt.Sprintf("File argument is ignored when resource information is provided with the command"))
 		}
 		opts = &api.QueryOptions{
 			Namespace:         c.http.Namespace(),

--- a/command/resource/read/read_test.go
+++ b/command/resource/read/read_test.go
@@ -27,12 +27,12 @@ func TestResourceReadInvalidArgs(t *testing.T) {
 		"nil args": {
 			args:         nil,
 			expectedCode: 1,
-			expectedErr:  errors.New("Your argument format is incorrect: Must specify two arguments: resource type and resource name"),
+			expectedErr:  errors.New("Incorrect argument format: Must specify two arguments: resource type and resource name"),
 		},
 		"empty args": {
 			args:         []string{},
 			expectedCode: 1,
-			expectedErr:  errors.New("Your argument format is incorrect: Must specify two arguments: resource type and resource name"),
+			expectedErr:  errors.New("Incorrect argument format: Must specify two arguments: resource type and resource name"),
 		},
 		"missing file path": {
 			args:         []string{"-f"},
@@ -47,27 +47,27 @@ func TestResourceReadInvalidArgs(t *testing.T) {
 		"provide type and name": {
 			args:         []string{"a.b.c"},
 			expectedCode: 1,
-			expectedErr:  errors.New("Your argument format is incorrect: Must specify two arguments: resource type and resource name"),
+			expectedErr:  errors.New("Incorrect argument format: Must specify two arguments: resource type and resource name"),
 		},
 		"provide type and name with -f": {
 			args:         []string{"a.b.c", "name", "-f", "test.hcl"},
 			expectedCode: 1,
-			expectedErr:  errors.New("We ignored the -f flag if you provide gvk and resource name"),
+			expectedErr:  errors.New("File argument is ignored when resource information is provided with the command"),
 		},
 		"provide type and name with -f and other flags": {
 			args:         []string{"a.b.c", "name", "-f", "test.hcl", "-namespace", "default"},
 			expectedCode: 1,
-			expectedErr:  errors.New("We ignored the -f flag if you provide gvk and resource name"),
+			expectedErr:  errors.New("File argument is ignored when resource information is provided with the command"),
 		},
 		"does not provide resource name after type": {
 			args:         []string{"a.b.c", "-namespace", "default"},
 			expectedCode: 1,
-			expectedErr:  errors.New("Your argument format is incorrect: Must provide resource name right after type"),
+			expectedErr:  errors.New("Incorrect argument format: Must provide resource name right after type"),
 		},
 		"invalid resource type format": {
 			args:         []string{"a.", "name", "-namespace", "default"},
 			expectedCode: 1,
-			expectedErr:  errors.New("Your argument format is incorrect: Must include resource type argument in group.verion.kind format"),
+			expectedErr:  errors.New("Incorrect argument format: Must include resource type argument in group.verion.kind format"),
 		},
 	}
 

--- a/command/resource/read/read_test.go
+++ b/command/resource/read/read_test.go
@@ -52,12 +52,12 @@ func TestResourceReadInvalidArgs(t *testing.T) {
 		"provide type and name with -f": {
 			args:         []string{"a.b.c", "name", "-f", "test.hcl"},
 			expectedCode: 1,
-			expectedErr:  errors.New("File argument is ignored when resource information is provided with the command"),
+			expectedErr:  errors.New("Incorrect argument format: File argument is not needed when resource information is provided with the command"),
 		},
 		"provide type and name with -f and other flags": {
 			args:         []string{"a.b.c", "name", "-f", "test.hcl", "-namespace", "default"},
 			expectedCode: 1,
-			expectedErr:  errors.New("File argument is ignored when resource information is provided with the command"),
+			expectedErr:  errors.New("Incorrect argument format: File argument is not needed when resource information is provided with the command"),
 		},
 		"does not provide resource name after type": {
 			args:         []string{"a.b.c", "-namespace", "default"},


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

- Add missing test cases and patch for variations of resource type format
- Consistent language/messaging across CLI commands
- Rely on the `flag.args` to confirm that required arguments are passed correctly

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->
Feedback that prompted this [PR](https://hashicorp.slack.com/archives/C0253EQ5B40/p1694462086447919) 

### PR Checklist

* [x] updated test coverage
* [ ] ~external facing docs updated~
* [x] appropriate backport labels added
* [ ] ~not a security concern~
