### PR TITLE
catalog: service endpoints inherits protocol from service when workload doesn't have one

### DIFF
--- a/internal/catalog/internal/controllers/endpoints/controller.go
+++ b/internal/catalog/internal/controllers/endpoints/controller.go
@@ -311,8 +311,13 @@ func workloadToEndpoint(svc *pbcatalog.Service, data *workloadData) *pbcatalog.E
 			continue
 		}
 
-		if workloadPort.Protocol != svcPort.Protocol {
-			// workload port mismatch - ignore it
+		// If workload protocol is not specified, we will default to service's protocol.
+		// This is because on some platforms (kubernetes), workload protocol is not always
+		// known, and so we need to inherit from the service instead.
+		if workloadPort.Protocol == pbcatalog.Protocol_PROTOCOL_UNSPECIFIED {
+			workloadPort.Protocol = svcPort.Protocol
+		} else if workloadPort.Protocol != svcPort.Protocol {
+			// Otherwise, there's workload port mismatch - ignore it.
 			continue
 		}
 

--- a/internal/catalog/internal/controllers/endpoints/controller_test.go
+++ b/internal/catalog/internal/controllers/endpoints/controller_test.go
@@ -191,7 +191,7 @@ func TestWorkloadToEndpoint_MissingWorkloadProtocol(t *testing.T) {
 
 	service := &pbcatalog.Service{
 		Ports: []*pbcatalog.ServicePort{
-			{TargetPort: "http", Protocol: pbcatalog.Protocol_PROTOCOL_HTTP},
+			{TargetPort: "test-port", Protocol: pbcatalog.Protocol_PROTOCOL_HTTP},
 		},
 	}
 
@@ -200,7 +200,7 @@ func TestWorkloadToEndpoint_MissingWorkloadProtocol(t *testing.T) {
 			{Host: "127.0.0.1"},
 		},
 		Ports: map[string]*pbcatalog.WorkloadPort{
-			"http": {Port: 8080},
+			"test-port": {Port: 8080},
 		},
 	}
 
@@ -214,10 +214,10 @@ func TestWorkloadToEndpoint_MissingWorkloadProtocol(t *testing.T) {
 	expected := &pbcatalog.Endpoint{
 		TargetRef: data.resource.Id,
 		Addresses: []*pbcatalog.WorkloadAddress{
-			{Host: "127.0.0.1", Ports: []string{"http"}},
+			{Host: "127.0.0.1", Ports: []string{"test-port"}},
 		},
 		Ports: map[string]*pbcatalog.WorkloadPort{
-			"http": {Port: 8080, Protocol: pbcatalog.Protocol_PROTOCOL_HTTP},
+			"test-port": {Port: 8080, Protocol: pbcatalog.Protocol_PROTOCOL_HTTP},
 		},
 		// The health is critical because we are not setting the workload's
 		// health status. The tests for determineWorkloadHealth will ensure


### PR DESCRIPTION
### Description

On Kubernetes, we don't know the workload port protocol (only service ports can have `appProtocol` provided), and for that case we need to inherit the protocol from the service if workload doesn't have one.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
