### PR TITLE
add fuzz tests to resourcehcl package and fix some panics 

### DIFF
--- a/internal/protohcl/primitives.go
+++ b/internal/protohcl/primitives.go
@@ -69,8 +69,11 @@ func protoEnumFromCty(desc protoreflect.FieldDescriptor, val cty.Value) (protore
 
 	valDesc := desc.Enum().Values().ByName(protoreflect.Name(val.AsString()))
 	if valDesc == nil {
-		defaultValDesc := desc.DefaultEnumValue()
-		return protoreflect.ValueOfEnum(defaultValDesc.Number()), nil
+		if desc.HasDefault() {
+			defaultValDesc := desc.DefaultEnumValue()
+			return protoreflect.ValueOfEnum(defaultValDesc.Number()), nil
+		}
+		return protoreflect.Value{}, fmt.Errorf("no default value for type")
 	}
 
 	return protoreflect.ValueOfEnum(valDesc.Number()), nil

--- a/internal/protohcl/primitives.go
+++ b/internal/protohcl/primitives.go
@@ -63,8 +63,11 @@ func protoEnumFromCty(desc protoreflect.FieldDescriptor, val cty.Value) (protore
 	}
 
 	if val.IsNull() {
-		defaultValDesc := desc.DefaultEnumValue()
-		return protoreflect.ValueOfEnum(defaultValDesc.Number()), nil
+		if desc.HasDefault() {
+			defaultValDesc := desc.DefaultEnumValue()
+			return protoreflect.ValueOfEnum(defaultValDesc.Number()), nil
+		}
+		return protoreflect.Value{}, fmt.Errorf("no default value for type and value is null")
 	}
 
 	valDesc := desc.Enum().Values().ByName(protoreflect.Name(val.AsString()))
@@ -73,7 +76,7 @@ func protoEnumFromCty(desc protoreflect.FieldDescriptor, val cty.Value) (protore
 			defaultValDesc := desc.DefaultEnumValue()
 			return protoreflect.ValueOfEnum(defaultValDesc.Number()), nil
 		}
-		return protoreflect.Value{}, fmt.Errorf("no default value for type")
+		return protoreflect.Value{}, fmt.Errorf("no default value for type and value is invalid")
 	}
 
 	return protoreflect.ValueOfEnum(valDesc.Number()), nil

--- a/internal/resourcehcl/any.go
+++ b/internal/resourcehcl/any.go
@@ -34,10 +34,13 @@ func (p anyProvider) AnyType(ctx *protohcl.UnmarshalContext, decoder protohcl.Me
 	if !isResource {
 		return p.base.AnyType(ctx, decoder)
 	}
-
-	resourceType := res.GetId().GetType()
 	if res == nil {
 		return "", nil, errors.New("ID.Type not found")
+	}
+
+	resourceType := res.GetId().GetType()
+	if resourceType == nil {
+		return "", nil, errors.New("ID.Type is nil")
 	}
 
 	reg, ok := p.reg.Resolve(resourceType)

--- a/internal/resourcehcl/naming.go
+++ b/internal/resourcehcl/naming.go
@@ -33,6 +33,9 @@ func (n fieldNamer) GetField(fds protoreflect.FieldDescriptors, name string) pro
 		}
 	}
 
+	if len(name) <= 1 {
+		return fds.ByJSONName(name)
+	}
 	camel := strings.ToLower(name[:1]) + name[1:]
 	return fds.ByJSONName(camel)
 }

--- a/internal/resourcehcl/testdata/fuzz/FuzzUnmarshall/0e4b8ec300611dbc
+++ b/internal/resourcehcl/testdata/fuzz/FuzzUnmarshall/0e4b8ec300611dbc
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("Data{}")

--- a/internal/resourcehcl/testdata/fuzz/FuzzUnmarshall/c800420b7494c6d1
+++ b/internal/resourcehcl/testdata/fuzz/FuzzUnmarshall/c800420b7494c6d1
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("ID={\"\"=\"\"}")

--- a/internal/resourcehcl/testdata/fuzz/FuzzUnmarshall/eaba8205942c3f31
+++ b/internal/resourcehcl/testdata/fuzz/FuzzUnmarshall/eaba8205942c3f31
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("ID {\nType = gvk(\"demo.v1.Artist\")\n} \nData {\nGenre = \"\"\n} ")

--- a/internal/resourcehcl/unmarshal_test.go
+++ b/internal/resourcehcl/unmarshal_test.go
@@ -23,6 +23,47 @@ import (
 
 var update = flag.Bool("update", false, "update golden files")
 
+func FuzzUnmarshall(f *testing.F) {
+	entries, err := os.ReadDir("./testdata")
+	require.NoError(f, err)
+
+	read := func(t *testing.F, path string) ([]byte, bool) {
+		t.Helper()
+
+		bytes, err := os.ReadFile(fmt.Sprintf("./testdata/%s", path))
+		switch {
+		case err == nil:
+			return bytes, true
+		case os.IsNotExist(err):
+			return nil, false
+		}
+
+		t.Fatalf("failed to read file %s %v", path, err)
+		return nil, false
+	}
+	for _, entry := range entries {
+		ext := path.Ext(entry.Name())
+
+		if ext != ".hcl" {
+			continue
+		}
+		input, _ := read(f, entry.Name())
+		f.Add(input)
+	}
+	registry := resource.NewRegistry()
+	demo.RegisterTypes(registry)
+	mesh.RegisterTypes(registry)
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		got, err := resourcehcl.Unmarshal(input, registry)
+		if err != nil {
+			return
+		}
+		require.NotNil(t, got)
+	})
+
+}
+
 func TestUnmarshal(t *testing.T) {
 	entries, err := os.ReadDir("./testdata")
 	require.NoError(t, err)


### PR DESCRIPTION
### Description

This PR add a simple fuzz test to `resourcehcl` package. Using that test 3 panic conditions were uncovered, the fix for those and the use cases of those are added to the corpus.

### Testing & Reproduction steps
Fuzz test added and fixes are covered by that test that should run in CI from now on.

### Links

### PR Checklist

* [x] updated test coverage
* [x] appropriate backport labels added
* [x] not a security concern