### PR TITLE
Clean up resources in test

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -354,10 +354,10 @@ func TestAgent_HTTPMaxHeaderBytes(t *testing.T) {
 			require.NoError(t, err)
 
 			a, err := New(bd)
+			require.NoError(t, err)
 			mockDelegate := delegateMock{}
 			mockDelegate.On("LicenseCheck").Return()
 			a.delegate = &mockDelegate
-			require.NoError(t, err)
 
 			a.startLicenseManager(testutil.TestContext(t))
 
@@ -392,6 +392,8 @@ func TestAgent_HTTPMaxHeaderBytes(t *testing.T) {
 				resp, err := client.Do(req.WithContext(ctx))
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedHTTPResponse, resp.StatusCode, "expected a '%d' http response, got '%d'", tt.expectedHTTPResponse, resp.StatusCode)
+				resp.Body.Close()
+				s.Shutdown(ctx)
 			}
 		})
 	}


### PR DESCRIPTION
### Description

TestAgent_HTTPMaxHeaderBytes always has ports hanging in CI. Trying to close resources on an at-best effort

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
