### PR TITLE
Removes errant word in docs that was breaking the build

### DIFF
--- a/website/content/docs/api-gateway/configuration/gatewayclassconfig.mdx
+++ b/website/content/docs/api-gateway/configuration/gatewayclassconfig.mdx
@@ -155,7 +155,6 @@ You can specify the following strings:
 * `trace`
 
 ### matchPrivilegedContainerPorts
-```suggestion
 Specifies a value that Consul adds to privileged ports defined in the gateway. Privileged ports are port numbers less than 1024 and some platforms, such as Red Hat OpenShift, explicitly configure Kubernetes to avoid running containers on privileged ports. The total value of the configured port number and the `matchPriviledgedContainerPorts` value must not exceed 65535, which is the highest possible TCP port number allowed.
 for gateway containers
 * Type: Integer


### PR DESCRIPTION
### Description
https://github.com/hashicorp/consul/pull/18776 Accidentally introduced an error into the docs site. This fixes it. This is already updated in the backport PR.

### PR Checklist
* [x] external facing docs updated