### PR TITLE
[NET-5329] use acl templated policy under the hood for node/service identities

### DIFF
--- a/.changelog/18813.txt
+++ b/.changelog/18813.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: Use templated policy to generate synthetic policies for tokens/roles with node and/or service identities
+```

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"hash/fnv"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib/stringslice"
 
 	"golang.org/x/crypto/blake2b"
@@ -182,22 +182,20 @@ func (s *ACLServiceIdentity) EstimateSize() int {
 }
 
 func (s *ACLServiceIdentity) SyntheticPolicy(entMeta *acl.EnterpriseMeta) *ACLPolicy {
+	// use templated policy to generate synthetic policy
+	templatedPolicy := ACLTemplatedPolicy{
+		TemplateID:   ACLTemplatedPolicyServiceID,
+		TemplateName: api.ACLTemplatedPolicyServiceName,
+		Datacenters:  s.Datacenters,
+		TemplateVariables: &ACLTemplatedPolicyVariables{
+			Name: s.ServiceName,
+		},
+	}
+
 	// Given that we validate this string name before persisting, we do not
-	// have to escape it before doing the following interpolation.
-	rules := aclServiceIdentityRules(s.ServiceName, entMeta)
+	// expect any errors from generating the synthetic policy
+	policy, _ := templatedPolicy.SyntheticPolicy(entMeta)
 
-	hasher := fnv.New128a()
-	hashID := fmt.Sprintf("%x", hasher.Sum([]byte(rules)))
-
-	policy := &ACLPolicy{}
-	policy.ID = hashID
-	policy.Name = fmt.Sprintf("synthetic-policy-%s", hashID)
-	sn := NewServiceName(s.ServiceName, entMeta)
-	policy.Description = fmt.Sprintf("synthetic policy for service identity %q", sn.String())
-	policy.Rules = rules
-	policy.Datacenters = s.Datacenters
-	policy.EnterpriseMeta.Merge(entMeta)
-	policy.SetHash(true)
 	return policy
 }
 
@@ -254,21 +252,20 @@ func (s *ACLNodeIdentity) EstimateSize() int {
 }
 
 func (s *ACLNodeIdentity) SyntheticPolicy(entMeta *acl.EnterpriseMeta) *ACLPolicy {
+	// use templated policy to generate synthetic policy
+	templatedPolicy := ACLTemplatedPolicy{
+		TemplateID:   ACLTemplatedPolicyNodeID,
+		TemplateName: api.ACLTemplatedPolicyNodeName,
+		Datacenters:  []string{s.Datacenter},
+		TemplateVariables: &ACLTemplatedPolicyVariables{
+			Name: s.NodeName,
+		},
+	}
+
 	// Given that we validate this string name before persisting, we do not
-	// have to escape it before doing the following interpolation.
-	rules := aclNodeIdentityRules(s.NodeName, entMeta)
+	// expect any errors from generating the synthetic policy
+	policy, _ := templatedPolicy.SyntheticPolicy(entMeta)
 
-	hasher := fnv.New128a()
-	hashID := fmt.Sprintf("%x", hasher.Sum([]byte(rules)))
-
-	policy := &ACLPolicy{}
-	policy.ID = hashID
-	policy.Name = fmt.Sprintf("synthetic-policy-%s", hashID)
-	policy.Description = fmt.Sprintf("synthetic policy for node identity %q", s.NodeName)
-	policy.Rules = rules
-	policy.Datacenters = []string{s.Datacenter}
-	policy.EnterpriseMeta.Merge(entMeta)
-	policy.SetHash(true)
 	return policy
 }
 

--- a/command/acl/token/testdata/FormatTokenExpanded/ce/complex.pretty-meta.golden
+++ b/command/acl/token/testdata/FormatTokenExpanded/ce/complex.pretty-meta.golden
@@ -26,7 +26,7 @@ Policies:
 
 Service Identities:
 	Name: gardener (Datacenters: middleearth-northwest)
-		Description: synthetic policy for service identity "gardener"
+		Description: synthetic policy generated from templated policy: builtin/service
 		Rules:
 			service "gardener" {
 				policy = "write"
@@ -43,7 +43,7 @@ Service Identities:
 
 Node Identities:
 	Name: bagend (Datacenter: middleearth-northwest)
-		Description: synthetic policy for node identity "bagend"
+		Description: synthetic policy generated from templated policy: builtin/node
 		Rules:
 			node "bagend" {
 				policy = "write"
@@ -96,7 +96,7 @@ Roles:
 
 		Service Identities:
 			Name: foo (Datacenters: middleearth-southwest)
-				Description: synthetic policy for service identity "foo"
+				Description: synthetic policy generated from templated policy: builtin/service
 				Rules:
 					service "foo" {
 						policy = "write"
@@ -125,7 +125,7 @@ Roles:
 
 		Node Identities:
 			Name: bar (Datacenter: middleearth-southwest)
-				Description: synthetic policy for node identity "bar"
+				Description: synthetic policy generated from templated policy: builtin/node
 				Rules:
 					node "bar" {
 						policy = "write"
@@ -158,7 +158,7 @@ Namespace Role Defaults:
 
 		Service Identities:
 			Name: web (Datacenters: middleearth-northeast)
-				Description: synthetic policy for service identity "web"
+				Description: synthetic policy generated from templated policy: builtin/service
 				Rules:
 					service "web" {
 						policy = "write"
@@ -175,7 +175,7 @@ Namespace Role Defaults:
 
 		Node Identities:
 			Name: db (Datacenter: middleearth-northwest)
-				Description: synthetic policy for node identity "db"
+				Description: synthetic policy generated from templated policy: builtin/node
 				Rules:
 					node "db" {
 						policy = "write"

--- a/command/acl/token/testdata/FormatTokenExpanded/ce/complex.pretty.golden
+++ b/command/acl/token/testdata/FormatTokenExpanded/ce/complex.pretty.golden
@@ -23,7 +23,7 @@ Policies:
 
 Service Identities:
 	Name: gardener (Datacenters: middleearth-northwest)
-		Description: synthetic policy for service identity "gardener"
+		Description: synthetic policy generated from templated policy: builtin/service
 		Rules:
 			service "gardener" {
 				policy = "write"
@@ -40,7 +40,7 @@ Service Identities:
 
 Node Identities:
 	Name: bagend (Datacenter: middleearth-northwest)
-		Description: synthetic policy for node identity "bagend"
+		Description: synthetic policy generated from templated policy: builtin/node
 		Rules:
 			node "bagend" {
 				policy = "write"
@@ -93,7 +93,7 @@ Roles:
 
 		Service Identities:
 			Name: foo (Datacenters: middleearth-southwest)
-				Description: synthetic policy for service identity "foo"
+				Description: synthetic policy generated from templated policy: builtin/service
 				Rules:
 					service "foo" {
 						policy = "write"
@@ -122,7 +122,7 @@ Roles:
 
 		Node Identities:
 			Name: bar (Datacenter: middleearth-southwest)
-				Description: synthetic policy for node identity "bar"
+				Description: synthetic policy generated from templated policy: builtin/node
 				Rules:
 					node "bar" {
 						policy = "write"
@@ -155,7 +155,7 @@ Namespace Role Defaults:
 
 		Service Identities:
 			Name: web (Datacenters: middleearth-northeast)
-				Description: synthetic policy for service identity "web"
+				Description: synthetic policy generated from templated policy: builtin/service
 				Rules:
 					service "web" {
 						policy = "write"
@@ -172,7 +172,7 @@ Namespace Role Defaults:
 
 		Node Identities:
 			Name: db (Datacenter: middleearth-northwest)
-				Description: synthetic policy for node identity "db"
+				Description: synthetic policy generated from templated policy: builtin/node
 				Rules:
 					node "db" {
 						policy = "write"


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
- ACL templated policies accomplish the same thing as node/service identities when it comes to generating a synthetic policy. The long term is for ACL templated policies to be the source of generating synthetic policies to simplify getting the right acl token
- We also rely on existing tests to catch any issues (as a lot of tests rely on synthetic policies generated by node/service identities), ideally there shouldn't a test update as all tests relying on service/node identities synthetic policies should just seamlessly pass

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
- step 1: create token with a service identity  
```
consul acl token create -service-identity "web"

AccessorID:       916a549b-148d-9026-7e08-5375405ba51f
SecretID:         5669dbcb-9f1e-c354-25d0-435915cb4858
Partition:        default
Namespace:        default
Description:
Local:            false
Create Time:      2023-09-13 09:44:38.846805 -0400 EDT
Service Identities:
   web (Datacenters: all)
```

- step 2: read the token with expanded flag to see what rules it generates 
```
AccessorID:       916a549b-148d-9026-7e08-5375405ba51f
SecretID:         5669dbcb-9f1e-c354-25d0-435915cb4858
Partition:        default
Namespace:        default
Description:
Local:            false
Create Time:      2023-09-13 09:44:38.846805 -0400 EDT
Service Identities:
	Name: web (Datacenters: all)
		Description: synthetic policy generated from templated policy: builtin/service
		Rules:
			partition "default" {
				namespace "default" {
					service "web" {
						policy = "write"
					}
					service "web-sidecar-proxy" {
						policy = "write"
					}
					service_prefix "" {
						policy = "read"
					}
					node_prefix "" {
						policy = "read"
					}
				}
			}

=== End of Authorizer Layer 0: Token ===
=== Start of Authorizer Layer 2: Agent Configuration Defaults (Inherited) ===
Description: Defined at request-time by the agent that resolves the ACL token; other agents may have different configuration defaults
Resolved By Agent: "cs01"

Default Policy: deny
	Description: Backstop rule used if no preceding layer has a matching rule (refer to default_policy option in agent configuration)

Down Policy: extend-cache
	Description: Defines what to do if this Token's information cannot be read from the primary_datacenter (refer to down_policy option in agent configuration)
```

- Step 3: redo step 1 and 2 on on main branch (compare generated rules) to ensure they are identical
- Step 4: use resulting token to register a service web 
```
consul services register -name=web -token "5669dbcb-9f1e-c354-25d0-435915cb4858"

Registered service: web
```
- step 5: attempt to register a random service
```
consul services register -name=random-service -token "5669dbcb-9f1e-c354-25d0-435915cb4858"

Error registering service "random-service": Unexpected response code: 403 (Permission denied: token with AccessorID '916a549b-148d-9026-7e08-5375405ba51f' lacks permission 'service:write' on "random-service" in partition "default" in namespace "default")
```
