### PR TITLE
fix templated policy cli output

### DIFF
--- a/command/acl/templatedpolicy/formatter.go
+++ b/command/acl/templatedpolicy/formatter.go
@@ -64,7 +64,7 @@ type prettyFormatter struct {
 func (f *prettyFormatter) FormatTemplatedPolicy(templatedPolicy api.ACLTemplatedPolicyResponse) (string, error) {
 	var buffer bytes.Buffer
 
-	buffer.WriteString(fmt.Sprintf("Name:									%s\n", templatedPolicy.TemplateName))
+	buffer.WriteString(fmt.Sprintf("Name:            %s\n", templatedPolicy.TemplateName))
 
 	buffer.WriteString("Input variables:")
 	switch templatedPolicy.TemplateName {
@@ -77,7 +77,7 @@ func (f *prettyFormatter) FormatTemplatedPolicy(templatedPolicy api.ACLTemplated
 		buffer.WriteString("Example usage:\n")
 		buffer.WriteString(fmt.Sprintf("%sconsul acl token create -templated-policy builtin/node -var name:node-1\n", WhitespaceIndent))
 	case api.ACLTemplatedPolicyDNSName:
-		buffer.WriteString("			None\n")
+		buffer.WriteString(" None\n")
 		buffer.WriteString("Example usage:\n")
 		buffer.WriteString(fmt.Sprintf("%sconsul acl token create -templated-policy builtin/dns\n", WhitespaceIndent))
 	default:

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/dns-templated-policy.pretty-meta.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/dns-templated-policy.pretty-meta.golden
@@ -1,5 +1,5 @@
-Name:									builtin/dns
-Input variables:			None
+Name:            builtin/dns
+Input variables: None
 Example usage:
 	consul acl token create -templated-policy builtin/dns
 Raw Template:

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/dns-templated-policy.pretty.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/dns-templated-policy.pretty.golden
@@ -1,4 +1,4 @@
-Name:									builtin/dns
-Input variables:			None
+Name:            builtin/dns
+Input variables: None
 Example usage:
 	consul acl token create -templated-policy builtin/dns

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/node-templated-policy.pretty-meta.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/node-templated-policy.pretty-meta.golden
@@ -1,4 +1,4 @@
-Name:									builtin/node
+Name:            builtin/node
 Input variables:
 	Name: String - Required - The node name.
 Example usage:

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/node-templated-policy.pretty.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/node-templated-policy.pretty.golden
@@ -1,4 +1,4 @@
-Name:									builtin/node
+Name:            builtin/node
 Input variables:
 	Name: String - Required - The node name.
 Example usage:

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/service-templated-policy.pretty-meta.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/service-templated-policy.pretty-meta.golden
@@ -1,4 +1,4 @@
-Name:									builtin/service
+Name:            builtin/service
 Input variables:
 	Name: String - Required - The name of the service.
 Example usage:

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/service-templated-policy.pretty.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/service-templated-policy.pretty.golden
@@ -1,4 +1,4 @@
-Name:									builtin/service
+Name:            builtin/service
 Input variables:
 	Name: String - Required - The name of the service.
 Example usage:


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

- The tab really ruins the output, fixed it by using spaces and it looks much better

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
```
consul acl templated-policy read -name "builtin/dns"
```