### PR TITLE
resource: default peername to "local" for now

### DIFF
--- a/agent/grpc-external/services/resource/server.go
+++ b/agent/grpc-external/services/resource/server.go
@@ -147,7 +147,7 @@ func validateId(id *pbresource.ID, errorPrefix string) error {
 		id.Tenancy = &pbresource.Tenancy{
 			Partition: "",
 			Namespace: "",
-			// TODO(spatel): Remove when peerTenancy introduced.
+			// TODO(spatel): NET-5475 - Remove as part of peer_name moving to PeerTenancy
 			PeerName: "local",
 		}
 	}

--- a/agent/grpc-external/services/resource/write_status.go
+++ b/agent/grpc-external/services/resource/write_status.go
@@ -173,7 +173,7 @@ func (s *Server) validateWriteStatusRequest(req *pbresource.WriteStatusRequest) 
 		req.Id.Tenancy = &pbresource.Tenancy{
 			Partition: "",
 			Namespace: "",
-			// TODO(spatel): Remove when peerTenancy introduced.
+			// TODO(spatel): NET-5475 - Remove as part of peer_name moving to PeerTenancy
 			PeerName: "local",
 		}
 	}

--- a/agent/grpc-external/services/resource/write_test.go
+++ b/agent/grpc-external/services/resource/write_test.go
@@ -256,6 +256,14 @@ func TestWrite_Create_Success(t *testing.T) {
 			},
 			expectedTenancy: resource.DefaultNamespacedTenancy(),
 		},
+		// TODO(spatel): NET-5475 - Remove as part of peer_name moving to PeerTenancy
+		"namespaced resource defaults peername to local when empty": {
+			modFn: func(artist, _ *pbresource.Resource) *pbresource.Resource {
+				artist.Id.Tenancy.PeerName = ""
+				return artist
+			},
+			expectedTenancy: resource.DefaultNamespacedTenancy(),
+		},
 		"partitioned resource provides nonempty partition": {
 			modFn: func(_, recordLabel *pbresource.Resource) *pbresource.Resource {
 				return recordLabel
@@ -279,6 +287,14 @@ func TestWrite_Create_Success(t *testing.T) {
 		"partitioned resource inherits tokens partition when tenancy nil": {
 			modFn: func(_, recordLabel *pbresource.Resource) *pbresource.Resource {
 				recordLabel.Id.Tenancy = nil
+				return recordLabel
+			},
+			expectedTenancy: resource.DefaultPartitionedTenancy(),
+		},
+		// TODO(spatel): NET-5475 - Remove as part of peer_name moving to PeerTenancy
+		"partitioned resource defaults peername to local when empty": {
+			modFn: func(_, recordLabel *pbresource.Resource) *pbresource.Resource {
+				recordLabel.Id.Tenancy.PeerName = ""
 				return recordLabel
 			},
 			expectedTenancy: resource.DefaultPartitionedTenancy(),

--- a/internal/resource/tenancy.go
+++ b/internal/resource/tenancy.go
@@ -52,12 +52,17 @@ func Normalize(tenancy *pbresource.Tenancy) {
 	}
 	tenancy.Partition = strings.ToLower(tenancy.Partition)
 	tenancy.Namespace = strings.ToLower(tenancy.Namespace)
+
+	// TODO(spatel): NET-5475 - Remove as part of peer_name moving to PeerTenancy
+	if tenancy.PeerName == "" {
+		tenancy.PeerName = "local"
+	}
 }
 
 // DefaultClusteredTenancy returns the default tenancy for a cluster scoped resource.
 func DefaultClusteredTenancy() *pbresource.Tenancy {
 	return &pbresource.Tenancy{
-		// TODO(spatel): Remove as part of "peer is not part of tenancy" ADR
+		// TODO(spatel): NET-5475 - Remove as part of peer_name moving to PeerTenancy
 		PeerName: "local",
 	}
 }
@@ -66,7 +71,7 @@ func DefaultClusteredTenancy() *pbresource.Tenancy {
 func DefaultPartitionedTenancy() *pbresource.Tenancy {
 	return &pbresource.Tenancy{
 		Partition: DefaultPartitionName,
-		// TODO(spatel): Remove as part of "peer is not part of tenancy" ADR
+		// TODO(spatel): NET-5475 - Remove as part of peer_name moving to PeerTenancy
 		PeerName: "local",
 	}
 }
@@ -76,7 +81,7 @@ func DefaultNamespacedTenancy() *pbresource.Tenancy {
 	return &pbresource.Tenancy{
 		Partition: DefaultPartitionName,
 		Namespace: DefaultNamespaceName,
-		// TODO(spatel): Remove as part of "peer is not part of tenancy" ADR
+		// TODO(spatel): NET-5475 - Remove as part of peer_name moving to PeerTenancy
 		PeerName: "local",
 	}
 }


### PR DESCRIPTION
### Description

CE version of merged ENT PR: https://github.com/hashicorp/consul-enterprise/pull/6981 

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
