### PR TITLE
Default to tcp protocol when workload protocol is unspecified

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/builder/local_app.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/local_app.go
@@ -82,7 +82,7 @@ func (l *ListenerBuilder) addInboundRouter(clusterName string, port *pbcatalog.W
 		return l
 	}
 
-	if port.Protocol == pbcatalog.Protocol_PROTOCOL_TCP {
+	if port.Protocol == pbcatalog.Protocol_PROTOCOL_TCP || port.Protocol == pbcatalog.Protocol_PROTOCOL_UNSPECIFIED {
 		r := &pbproxystate.Router{
 			Destination: &pbproxystate.Router_L4{
 				L4: &pbproxystate.L4Destination{

--- a/internal/mesh/internal/mappers/sidecarproxymapper/service_mapper.go
+++ b/internal/mesh/internal/mappers/sidecarproxymapper/service_mapper.go
@@ -24,7 +24,7 @@ func (m *Mapper) MapServiceToProxyStateTemplate(ctx context.Context, rt controll
 	return controller.MakeRequests(types.ProxyStateTemplateType, ids), nil
 }
 
-// mapServiceThroughDestinationsToProxyStateTemplates takes and explicit
+// mapServiceThroughDestinationsToProxyStateTemplates takes an explicit
 // Service and traverses back through Destinations to Workloads to
 // ProxyStateTemplates.
 //


### PR DESCRIPTION
### Description

Workload ports are allowed to have no protocol, and we need to default to tcp protocol in this case for now.

Note this PR has not test because we need to re-work how port protocols are handled properly for a case when they need to be inherited. This is just a quick fix for now as we don't fully support other protocols quite yet.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
