### PR TITLE
catalog: normalize/default/validate tenancy components of FailoverPolicy internal References

### DIFF
--- a/internal/catalog/exports.go
+++ b/internal/catalog/exports.go
@@ -126,3 +126,17 @@ type FailoverPolicyMapper interface {
 func NewFailoverPolicyMapper() FailoverPolicyMapper {
 	return failovermapper.New()
 }
+
+// ValidateLocalServiceRefNoSection ensures the following:
+//
+// - ref is non-nil
+// - type is ServiceType
+// - section is empty
+// - tenancy is set and partition/namespace are both non-empty
+// - peer_name must be "local"
+//
+// Each possible validation error is wrapped in the wrapErr function before
+// being collected in a multierror.Error.
+func ValidateLocalServiceRefNoSection(ref *pbresource.Reference, wrapErr func(error) error) error {
+	return types.ValidateLocalServiceRefNoSection(ref, wrapErr)
+}

--- a/internal/catalog/internal/types/validators.go
+++ b/internal/catalog/internal/types/validators.go
@@ -307,5 +307,12 @@ func ValidateLocalServiceRefNoSection(ref *pbresource.Reference, wrapErr func(er
 		}
 	}
 
+	if ref.Name == "" {
+		merr = multierror.Append(merr, wrapErr(resource.ErrInvalidField{
+			Name:    "name",
+			Wrapped: resource.ErrMissing,
+		}))
+	}
+
 	return merr
 }


### PR DESCRIPTION
### Description

`FailoverPolicy` resources contain inner `Reference` fields. We want to ensure that components of those reference `Tenancy` fields left unspecified are defaulted using the tenancy of the enclosing FailoverPolicy resource.

As the underlying helper being used to do the normalization calls the function modified in #18822, it also means that the `PeerName` field will be set to `"local"` for now automatically to avoid `"local" != ""` issues downstream.

NET-5641