### PR TITLE
mesh: normalize/default/validate tenancy components of mesh internal References

### DIFF
--- a/internal/mesh/internal/types/http_route_test.go
+++ b/internal/mesh/internal/types/http_route_test.go
@@ -1097,7 +1097,7 @@ func newRefWithTenancy(typ *pbresource.Type, tenancy *pbresource.Tenancy, name s
 		tenancy = resource.DefaultNamespacedTenancy()
 	}
 	return resourcetest.Resource(typ, name).
-		WithTenancy(resource.DefaultNamespacedTenancy()).
+		WithTenancy(tenancy).
 		Reference("")
 }
 

--- a/internal/mesh/internal/types/http_route_test.go
+++ b/internal/mesh/internal/types/http_route_test.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -23,13 +24,15 @@ import (
 
 func TestMutateHTTPRoute(t *testing.T) {
 	type testcase struct {
-		route     *pbmesh.HTTPRoute
-		expect    *pbmesh.HTTPRoute
-		expectErr string
+		routeTenancy *pbresource.Tenancy
+		route        *pbmesh.HTTPRoute
+		expect       *pbmesh.HTTPRoute
+		expectErr    string
 	}
 
 	run := func(t *testing.T, tc testcase) {
 		res := resourcetest.Resource(HTTPRouteType, "api").
+			WithTenancy(tc.routeTenancy).
 			WithData(t, tc.route).
 			Build()
 
@@ -139,6 +142,55 @@ func TestMutateHTTPRoute(t *testing.T) {
 		},
 	}
 
+	// Add common parent refs test cases.
+	for name, parentTC := range getXRouteParentRefMutateTestCases() {
+		cases["parent-ref: "+name] = testcase{
+			routeTenancy: parentTC.routeTenancy,
+			route: &pbmesh.HTTPRoute{
+				ParentRefs: parentTC.refs,
+			},
+			expect: &pbmesh.HTTPRoute{
+				ParentRefs: parentTC.expect,
+			},
+		}
+	}
+	// add common backend ref test cases.
+	for name, backendTC := range getXRouteBackendRefMutateTestCases() {
+		var (
+			refs   []*pbmesh.HTTPBackendRef
+			expect []*pbmesh.HTTPBackendRef
+		)
+		for _, br := range backendTC.refs {
+			refs = append(refs, &pbmesh.HTTPBackendRef{
+				BackendRef: br,
+			})
+		}
+		for _, br := range backendTC.expect {
+			expect = append(expect, &pbmesh.HTTPBackendRef{
+				BackendRef: br,
+			})
+		}
+		cases["backend-ref: "+name] = testcase{
+			routeTenancy: backendTC.routeTenancy,
+			route: &pbmesh.HTTPRoute{
+				ParentRefs: []*pbmesh.ParentReference{
+					newParentRef(catalog.ServiceType, "web", ""),
+				},
+				Rules: []*pbmesh.HTTPRouteRule{
+					{BackendRefs: refs},
+				},
+			},
+			expect: &pbmesh.HTTPRoute{
+				ParentRefs: []*pbmesh.ParentReference{
+					newParentRef(catalog.ServiceType, "web", ""),
+				},
+				Rules: []*pbmesh.HTTPRouteRule{
+					{BackendRefs: expect},
+				},
+			},
+		}
+	}
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			run(t, tc)
@@ -157,8 +209,13 @@ func TestValidateHTTPRoute(t *testing.T) {
 			WithData(t, tc.route).
 			Build()
 
+		// Ensure things are properly mutated and updated in the inputs.
 		err := MutateHTTPRoute(res)
 		require.NoError(t, err)
+		{
+			mutated := resourcetest.MustDecode[*pbmesh.HTTPRoute](t, res)
+			tc.route = mutated.Data
+		}
 
 		err = ValidateHTTPRoute(res)
 
@@ -761,6 +818,80 @@ func TestValidateHTTPRoute(t *testing.T) {
 	}
 }
 
+type xRouteParentRefMutateTestcase struct {
+	routeTenancy *pbresource.Tenancy
+	refs         []*pbmesh.ParentReference
+	expect       []*pbmesh.ParentReference
+}
+
+func getXRouteParentRefMutateTestCases() map[string]xRouteParentRefMutateTestcase {
+	newRef := func(typ *pbresource.Type, tenancyStr, name string) *pbresource.Reference {
+		return resourcetest.Resource(typ, name).
+			WithTenancy(newTestTenancy(tenancyStr)).
+			Reference("")
+	}
+
+	newParentRef := func(typ *pbresource.Type, tenancyStr, name, port string) *pbmesh.ParentReference {
+		return &pbmesh.ParentReference{
+			Ref:  newRef(typ, tenancyStr, name),
+			Port: port,
+		}
+	}
+
+	return map[string]xRouteParentRefMutateTestcase{
+		"parent ref tenancies defaulted": {
+			routeTenancy: newTestTenancy("foo.bar"),
+			refs: []*pbmesh.ParentReference{
+				newParentRef(catalog.ServiceType, "", "api", ""),
+				newParentRef(catalog.ServiceType, ".zim", "api", ""),
+				newParentRef(catalog.ServiceType, "gir.zim", "api", ""),
+			},
+			expect: []*pbmesh.ParentReference{
+				newParentRef(catalog.ServiceType, "foo.bar", "api", ""),
+				newParentRef(catalog.ServiceType, "foo.zim", "api", ""),
+				newParentRef(catalog.ServiceType, "gir.zim", "api", ""),
+			},
+		},
+	}
+}
+
+type xRouteBackendRefMutateTestcase struct {
+	routeTenancy *pbresource.Tenancy
+	refs         []*pbmesh.BackendReference
+	expect       []*pbmesh.BackendReference
+}
+
+func getXRouteBackendRefMutateTestCases() map[string]xRouteBackendRefMutateTestcase {
+	newRef := func(typ *pbresource.Type, tenancyStr, name string) *pbresource.Reference {
+		return resourcetest.Resource(typ, name).
+			WithTenancy(newTestTenancy(tenancyStr)).
+			Reference("")
+	}
+
+	newBackendRef := func(typ *pbresource.Type, tenancyStr, name, port string) *pbmesh.BackendReference {
+		return &pbmesh.BackendReference{
+			Ref:  newRef(typ, tenancyStr, name),
+			Port: port,
+		}
+	}
+
+	return map[string]xRouteBackendRefMutateTestcase{
+		"backend ref tenancies defaulted": {
+			routeTenancy: newTestTenancy("foo.bar"),
+			refs: []*pbmesh.BackendReference{
+				newBackendRef(catalog.ServiceType, "", "api", ""),
+				newBackendRef(catalog.ServiceType, ".zim", "api", ""),
+				newBackendRef(catalog.ServiceType, "gir.zim", "api", ""),
+			},
+			expect: []*pbmesh.BackendReference{
+				newBackendRef(catalog.ServiceType, "foo.bar", "api", ""),
+				newBackendRef(catalog.ServiceType, "foo.zim", "api", ""),
+				newBackendRef(catalog.ServiceType, "gir.zim", "api", ""),
+			},
+		},
+	}
+}
+
 type xRouteParentRefTestcase struct {
 	refs      []*pbmesh.ParentReference
 	expectErr string
@@ -786,7 +917,7 @@ func getXRouteParentRefTestCases() map[string]xRouteParentRefTestcase {
 				newParentRef(catalog.ServiceType, "api", ""),
 				newParentRef(catalog.WorkloadType, "api", ""),
 			},
-			expectErr: `invalid element at index 1 of list "parent_refs": invalid "ref" field: reference must have type catalog.v1alpha1.Service`,
+			expectErr: `invalid element at index 1 of list "parent_refs": invalid "ref" field: invalid "type" field: reference must have type catalog.v1alpha1.Service`,
 		},
 		"parent ref with section": {
 			refs: []*pbmesh.ParentReference{
@@ -796,35 +927,35 @@ func getXRouteParentRefTestCases() map[string]xRouteParentRefTestcase {
 					Port: "http",
 				},
 			},
-			expectErr: `invalid element at index 1 of list "parent_refs": invalid "ref" field: invalid "section" field: section not supported for service parent refs`,
+			expectErr: `invalid element at index 1 of list "parent_refs": invalid "ref" field: invalid "section" field: section cannot be set here`,
 		},
 		"duplicate exact parents": {
 			refs: []*pbmesh.ParentReference{
 				newParentRef(catalog.ServiceType, "api", "http"),
 				newParentRef(catalog.ServiceType, "api", "http"),
 			},
-			expectErr: `invalid element at index 1 of list "parent_refs": invalid "ref" field: parent ref "catalog.v1alpha1.Service/default.local.default/api" for port "http" exists twice`,
+			expectErr: `invalid element at index 1 of list "parent_refs": invalid "port" field: parent ref "catalog.v1alpha1.Service/default.local.default/api" for port "http" exists twice`,
 		},
 		"duplicate wild parents": {
 			refs: []*pbmesh.ParentReference{
 				newParentRef(catalog.ServiceType, "api", ""),
 				newParentRef(catalog.ServiceType, "api", ""),
 			},
-			expectErr: `invalid element at index 1 of list "parent_refs": invalid "ref" field: parent ref "catalog.v1alpha1.Service/default.local.default/api" for wildcard port exists twice`,
+			expectErr: `invalid element at index 1 of list "parent_refs": invalid "port" field: parent ref "catalog.v1alpha1.Service/default.local.default/api" for wildcard port exists twice`,
 		},
 		"duplicate parents via exact+wild overlap": {
 			refs: []*pbmesh.ParentReference{
 				newParentRef(catalog.ServiceType, "api", "http"),
 				newParentRef(catalog.ServiceType, "api", ""),
 			},
-			expectErr: `invalid element at index 1 of list "parent_refs": invalid "ref" field: parent ref "catalog.v1alpha1.Service/default.local.default/api" for ports [http] covered by wildcard port already`,
+			expectErr: `invalid element at index 1 of list "parent_refs": invalid "port" field: parent ref "catalog.v1alpha1.Service/default.local.default/api" for ports [http] covered by wildcard port already`,
 		},
 		"duplicate parents via exact+wild overlap (reversed)": {
 			refs: []*pbmesh.ParentReference{
 				newParentRef(catalog.ServiceType, "api", ""),
 				newParentRef(catalog.ServiceType, "api", "http"),
 			},
-			expectErr: `invalid element at index 1 of list "parent_refs": invalid "ref" field: parent ref "catalog.v1alpha1.Service/default.local.default/api" for port "http" covered by wildcard port already`,
+			expectErr: `invalid element at index 1 of list "parent_refs": invalid "port" field: parent ref "catalog.v1alpha1.Service/default.local.default/api" for port "http" covered by wildcard port already`,
 		},
 		"good single parent ref": {
 			refs: []*pbmesh.ParentReference{
@@ -865,7 +996,7 @@ func getXRouteBackendRefTestCases() map[string]xRouteBackendRefTestcase {
 				newBackendRef(catalog.ServiceType, "api", ""),
 				newBackendRef(catalog.WorkloadType, "api", ""),
 			},
-			expectErr: `invalid element at index 0 of list "rules": invalid element at index 1 of list "backend_refs": invalid "backend_ref" field: invalid "ref" field: reference must have type catalog.v1alpha1.Service`,
+			expectErr: `invalid element at index 0 of list "rules": invalid element at index 1 of list "backend_refs": invalid "backend_ref" field: invalid "ref" field: invalid "type" field: reference must have type catalog.v1alpha1.Service`,
 		},
 		"backend ref with section": {
 			refs: []*pbmesh.BackendReference{
@@ -875,7 +1006,7 @@ func getXRouteBackendRefTestCases() map[string]xRouteBackendRefTestcase {
 					Port: "http",
 				},
 			},
-			expectErr: `invalid element at index 0 of list "rules": invalid element at index 1 of list "backend_refs": invalid "backend_ref" field: invalid "ref" field: invalid "section" field: section not supported for service backend refs`,
+			expectErr: `invalid element at index 0 of list "rules": invalid element at index 1 of list "backend_refs": invalid "backend_ref" field: invalid "ref" field: invalid "section" field: section cannot be set here`,
 		},
 		"backend ref with datacenter": {
 			refs: []*pbmesh.BackendReference{
@@ -958,6 +1089,13 @@ func getXRouteRetriesTestCases() map[string]xRouteRetriesTestcase {
 }
 
 func newRef(typ *pbresource.Type, name string) *pbresource.Reference {
+	return newRefWithTenancy(typ, nil, name)
+}
+
+func newRefWithTenancy(typ *pbresource.Type, tenancy *pbresource.Tenancy, name string) *pbresource.Reference {
+	if tenancy == nil {
+		tenancy = resource.DefaultNamespacedTenancy()
+	}
 	return resourcetest.Resource(typ, name).
 		WithTenancy(resource.DefaultNamespacedTenancy()).
 		Reference("")
@@ -971,8 +1109,31 @@ func newBackendRef(typ *pbresource.Type, name, port string) *pbmesh.BackendRefer
 }
 
 func newParentRef(typ *pbresource.Type, name, port string) *pbmesh.ParentReference {
+	return newParentRefWithTenancy(typ, nil, name, port)
+}
+
+func newParentRefWithTenancy(typ *pbresource.Type, tenancy *pbresource.Tenancy, name, port string) *pbmesh.ParentReference {
 	return &pbmesh.ParentReference{
-		Ref:  newRef(typ, name),
+		Ref:  newRefWithTenancy(typ, tenancy, name),
 		Port: port,
+	}
+}
+
+func newTestTenancy(s string) *pbresource.Tenancy {
+	parts := strings.Split(s, ".")
+	switch len(parts) {
+	case 0:
+		return resource.DefaultClusteredTenancy()
+	case 1:
+		v := resource.DefaultPartitionedTenancy()
+		v.Partition = parts[0]
+		return v
+	case 2:
+		v := resource.DefaultNamespacedTenancy()
+		v.Partition = parts[0]
+		v.Namespace = parts[1]
+		return v
+	default:
+		return &pbresource.Tenancy{Partition: "BAD", Namespace: "BAD", PeerName: "BAD"}
 	}
 }

--- a/internal/mesh/internal/types/tcp_route.go
+++ b/internal/mesh/internal/types/tcp_route.go
@@ -29,12 +29,43 @@ var (
 
 func RegisterTCPRoute(r resource.Registry) {
 	r.Register(resource.Registration{
-		Type:  TCPRouteV1Alpha1Type,
-		Proto: &pbmesh.TCPRoute{},
-		Scope: resource.ScopeNamespace,
-		// TODO(rb): normalize parent/backend ref tenancies in a Mutate hook
+		Type:     TCPRouteV1Alpha1Type,
+		Proto:    &pbmesh.TCPRoute{},
+		Scope:    resource.ScopeNamespace,
+		Mutate:   MutateTCPRoute,
 		Validate: ValidateTCPRoute,
 	})
+}
+
+func MutateTCPRoute(res *pbresource.Resource) error {
+	var route pbmesh.TCPRoute
+
+	if err := res.Data.UnmarshalTo(&route); err != nil {
+		return resource.NewErrDataParse(&route, err)
+	}
+
+	changed := false
+
+	if mutateParentRefs(res.Id.Tenancy, route.ParentRefs) {
+		changed = true
+	}
+
+	for _, rule := range route.Rules {
+		for _, backend := range rule.BackendRefs {
+			if backend.BackendRef == nil || backend.BackendRef.Ref == nil {
+				continue
+			}
+			if mutateXRouteRef(res.Id.Tenancy, backend.BackendRef.Ref) {
+				changed = true
+			}
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	return res.Data.MarshalFrom(&route)
 }
 
 func ValidateTCPRoute(res *pbresource.Resource) error {
@@ -67,14 +98,6 @@ func ValidateTCPRoute(res *pbresource.Resource) error {
 		}
 
 		if len(rule.BackendRefs) == 0 {
-			/*
-				BackendRefs (optional)¶
-
-				BackendRefs defines API objects where matching requests should be
-				sent. If unspecified, the rule performs no forwarding. If
-				unspecified and no filters are specified that would result in a
-				response being sent, a 404 error code is returned.
-			*/
 			merr = multierror.Append(merr, wrapRuleErr(
 				resource.ErrInvalidField{
 					Name:    "backend_refs",
@@ -90,13 +113,15 @@ func ValidateTCPRoute(res *pbresource.Resource) error {
 					Wrapped: err,
 				})
 			}
-			for _, err := range validateBackendRef(hbref.BackendRef) {
-				merr = multierror.Append(merr, wrapBackendRefErr(
-					resource.ErrInvalidField{
-						Name:    "backend_ref",
-						Wrapped: err,
-					},
-				))
+
+			wrapBackendRefFieldErr := func(err error) error {
+				return wrapBackendRefErr(resource.ErrInvalidField{
+					Name:    "backend_ref",
+					Wrapped: err,
+				})
+			}
+			if err := validateBackendRef(hbref.BackendRef, wrapBackendRefFieldErr); err != nil {
+				merr = multierror.Append(merr, err)
 			}
 		}
 	}

--- a/internal/mesh/internal/types/upstreams.go
+++ b/internal/mesh/internal/types/upstreams.go
@@ -47,6 +47,9 @@ func MutateUpstreams(res *pbresource.Resource) error {
 	changed := false
 
 	for _, dest := range destinations.Upstreams {
+		if dest.DestinationRef == nil {
+			continue // skip; let the validation hook error out instead
+		}
 		if dest.DestinationRef.Tenancy != nil && !isLocalPeer(dest.DestinationRef.Tenancy.PeerName) {
 			// TODO(peering/v2): remove this bypass when we know what to do with
 			// non-local peer references.

--- a/internal/mesh/internal/types/upstreams.go
+++ b/internal/mesh/internal/types/upstreams.go
@@ -4,6 +4,10 @@
 package types
 
 import (
+	"github.com/hashicorp/go-multierror"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hashicorp/consul/internal/catalog"
 	"github.com/hashicorp/consul/internal/resource"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v1alpha1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
@@ -28,6 +32,82 @@ func RegisterUpstreams(r resource.Registry) {
 		Type:     UpstreamsV1Alpha1Type,
 		Proto:    &pbmesh.Upstreams{},
 		Scope:    resource.ScopeNamespace,
-		Validate: nil,
+		Mutate:   MutateUpstreams,
+		Validate: ValidateUpstreams,
 	})
+}
+
+func MutateUpstreams(res *pbresource.Resource) error {
+	var route pbmesh.Upstreams
+
+	if err := res.Data.UnmarshalTo(&route); err != nil {
+		return resource.NewErrDataParse(&route, err)
+	}
+
+	changed := false
+
+	for _, dest := range route.Upstreams {
+		if dest.DestinationRef.Tenancy != nil && !isLocalPeer(dest.DestinationRef.Tenancy.PeerName) {
+			// TODO(peering/v2): remove this bypass when we know what to do with
+			// non-local peer references.
+			continue
+		}
+		orig := proto.Clone(dest.DestinationRef).(*pbresource.Reference)
+		resource.DefaultReferenceTenancy(
+			dest.DestinationRef,
+			res.Id.GetTenancy(),
+			resource.DefaultNamespacedTenancy(), // Services are all namespace scoped.
+		)
+
+		if !proto.Equal(orig, dest.DestinationRef) {
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	return res.Data.MarshalFrom(&route)
+}
+
+func isLocalPeer(p string) bool {
+	return p == "local" || p == ""
+}
+
+func ValidateUpstreams(res *pbresource.Resource) error {
+	var route pbmesh.Upstreams
+
+	if err := res.Data.UnmarshalTo(&route); err != nil {
+		return resource.NewErrDataParse(&route, err)
+	}
+
+	var merr error
+
+	for i, dest := range route.Upstreams {
+		wrapDestErr := func(err error) error {
+			return resource.ErrInvalidListElement{
+				Name:    "upstreams",
+				Index:   i,
+				Wrapped: err,
+			}
+		}
+
+		wrapRefErr := func(err error) error {
+			return wrapDestErr(resource.ErrInvalidField{
+				Name:    "destination_ref",
+				Wrapped: err,
+			})
+		}
+
+		if refErr := catalog.ValidateLocalServiceRefNoSection(dest.DestinationRef, wrapRefErr); refErr != nil {
+			merr = multierror.Append(merr, refErr)
+		}
+
+		// TODO(v2): validate port name using catalog validator
+	}
+
+	// TODO(v2): validate workload selectors
+
+	return merr
 }

--- a/internal/mesh/internal/types/upstreams.go
+++ b/internal/mesh/internal/types/upstreams.go
@@ -38,15 +38,15 @@ func RegisterUpstreams(r resource.Registry) {
 }
 
 func MutateUpstreams(res *pbresource.Resource) error {
-	var route pbmesh.Upstreams
+	var destinations pbmesh.Upstreams
 
-	if err := res.Data.UnmarshalTo(&route); err != nil {
-		return resource.NewErrDataParse(&route, err)
+	if err := res.Data.UnmarshalTo(&destinations); err != nil {
+		return resource.NewErrDataParse(&destinations, err)
 	}
 
 	changed := false
 
-	for _, dest := range route.Upstreams {
+	for _, dest := range destinations.Upstreams {
 		if dest.DestinationRef.Tenancy != nil && !isLocalPeer(dest.DestinationRef.Tenancy.PeerName) {
 			// TODO(peering/v2): remove this bypass when we know what to do with
 			// non-local peer references.
@@ -68,7 +68,7 @@ func MutateUpstreams(res *pbresource.Resource) error {
 		return nil
 	}
 
-	return res.Data.MarshalFrom(&route)
+	return res.Data.MarshalFrom(&destinations)
 }
 
 func isLocalPeer(p string) bool {
@@ -76,15 +76,15 @@ func isLocalPeer(p string) bool {
 }
 
 func ValidateUpstreams(res *pbresource.Resource) error {
-	var route pbmesh.Upstreams
+	var destinations pbmesh.Upstreams
 
-	if err := res.Data.UnmarshalTo(&route); err != nil {
-		return resource.NewErrDataParse(&route, err)
+	if err := res.Data.UnmarshalTo(&destinations); err != nil {
+		return resource.NewErrDataParse(&destinations, err)
 	}
 
 	var merr error
 
-	for i, dest := range route.Upstreams {
+	for i, dest := range destinations.Upstreams {
 		wrapDestErr := func(err error) error {
 			return resource.ErrInvalidListElement{
 				Name:    "upstreams",
@@ -105,6 +105,7 @@ func ValidateUpstreams(res *pbresource.Resource) error {
 		}
 
 		// TODO(v2): validate port name using catalog validator
+		// TODO(v2): validate ListenAddr
 	}
 
 	// TODO(v2): validate workload selectors

--- a/internal/mesh/internal/types/upstreams_test.go
+++ b/internal/mesh/internal/types/upstreams_test.go
@@ -87,21 +87,18 @@ func TestValidateUpstreams(t *testing.T) {
 			WithData(t, tc.data).
 			Build()
 
-		var got *DecodedDestinations
 		if !tc.skipMutate {
 			require.NoError(t, MutateUpstreams(res))
 
 			// Verify that mutate didn't actually change the object.
-			got = resourcetest.MustDecode[*pbmesh.Upstreams](t, res)
+			got := resourcetest.MustDecode[*pbmesh.Upstreams](t, res)
 			prototest.AssertDeepEqual(t, tc.data, got.Data)
-		} else {
-			got = resourcetest.MustDecode[*pbmesh.Upstreams](t, res)
 		}
 
 		err := ValidateUpstreams(res)
 
 		// Verify that validate didn't actually change the object.
-		got = resourcetest.MustDecode[*pbmesh.Upstreams](t, res)
+		got := resourcetest.MustDecode[*pbmesh.Upstreams](t, res)
 		prototest.AssertDeepEqual(t, tc.data, got.Data)
 
 		if tc.expectErr == "" {

--- a/internal/mesh/internal/types/upstreams_test.go
+++ b/internal/mesh/internal/types/upstreams_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/internal/catalog"
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/resourcetest"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/hashicorp/consul/proto/private/prototest"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+func TestMutateUpstreams(t *testing.T) {
+	type testcase struct {
+		tenancy   *pbresource.Tenancy
+		data      *pbmesh.Upstreams
+		expect    *pbmesh.Upstreams
+		expectErr string
+	}
+
+	run := func(t *testing.T, tc testcase) {
+		res := resourcetest.Resource(UpstreamsType, "api").
+			WithTenancy(tc.tenancy).
+			WithData(t, tc.data).
+			Build()
+
+		err := MutateUpstreams(res)
+
+		got := resourcetest.MustDecode[*pbmesh.Upstreams](t, res)
+
+		if tc.expectErr == "" {
+			require.NoError(t, err)
+			prototest.AssertDeepEqual(t, tc.expect, got.Data)
+		} else {
+			testutil.RequireErrorContains(t, err, tc.expectErr)
+		}
+	}
+
+	cases := map[string]testcase{
+		"empty-1": {
+			data:   &pbmesh.Upstreams{},
+			expect: &pbmesh.Upstreams{},
+		},
+		"dest ref tenancy defaulting": {
+			tenancy: newTestTenancy("foo.bar"),
+			data: &pbmesh.Upstreams{
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy(""), "api")},
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy(".zim"), "api")},
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy("gir.zim"), "api")},
+				},
+			},
+			expect: &pbmesh.Upstreams{
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy("foo.bar"), "api")},
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy("foo.zim"), "api")},
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy("gir.zim"), "api")},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestValidateUpstreams(t *testing.T) {
+	type testcase struct {
+		data       *pbmesh.Upstreams
+		skipMutate bool
+		expectErr  string
+	}
+
+	run := func(t *testing.T, tc testcase) {
+		res := resourcetest.Resource(UpstreamsType, "api").
+			WithTenancy(resource.DefaultNamespacedTenancy()).
+			WithData(t, tc.data).
+			Build()
+
+		var got *DecodedDestinations
+		if !tc.skipMutate {
+			require.NoError(t, MutateUpstreams(res))
+
+			// Verify that mutate didn't actually change the object.
+			got = resourcetest.MustDecode[*pbmesh.Upstreams](t, res)
+			prototest.AssertDeepEqual(t, tc.data, got.Data)
+		} else {
+			got = resourcetest.MustDecode[*pbmesh.Upstreams](t, res)
+		}
+
+		err := ValidateUpstreams(res)
+
+		// Verify that validate didn't actually change the object.
+		got = resourcetest.MustDecode[*pbmesh.Upstreams](t, res)
+		prototest.AssertDeepEqual(t, tc.data, got.Data)
+
+		if tc.expectErr == "" {
+			require.NoError(t, err)
+		} else {
+			testutil.RequireErrorContains(t, err, tc.expectErr)
+		}
+	}
+
+	cases := map[string]testcase{
+		// emptiness
+		"empty": {
+			data: &pbmesh.Upstreams{},
+		},
+		"dest/nil ref": {
+			skipMutate: true,
+			data: &pbmesh.Upstreams{
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: nil},
+				},
+			},
+			expectErr: `invalid element at index 0 of list "upstreams": invalid "destination_ref" field: missing required field`,
+		},
+		"dest/bad type": {
+			skipMutate: true,
+			data: &pbmesh.Upstreams{
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: newRefWithTenancy(catalog.WorkloadType, nil, "api")},
+				},
+			},
+			expectErr: `invalid element at index 0 of list "upstreams": invalid "destination_ref" field: invalid "type" field: reference must have type catalog.v1alpha1.Service`,
+		},
+		"dest/nil tenancy": {
+			skipMutate: true,
+			data: &pbmesh.Upstreams{
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: &pbresource.Reference{Type: catalog.ServiceType, Name: "api"}},
+				},
+			},
+			expectErr: `invalid element at index 0 of list "upstreams": invalid "destination_ref" field: invalid "tenancy" field: missing required field`,
+		},
+		"dest/bad dest tenancy/partition": {
+			skipMutate: true,
+			data: &pbmesh.Upstreams{
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy(".bar"), "api")},
+				},
+			},
+			expectErr: `invalid element at index 0 of list "upstreams": invalid "destination_ref" field: invalid "tenancy" field: invalid "partition" field: cannot be empty`,
+		},
+		"dest/bad dest tenancy/namespace": {
+			skipMutate: true,
+			data: &pbmesh.Upstreams{
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy("foo"), "api")},
+				},
+			},
+			expectErr: `invalid element at index 0 of list "upstreams": invalid "destination_ref" field: invalid "tenancy" field: invalid "namespace" field: cannot be empty`,
+		},
+		"dest/bad dest tenancy/peer_name": {
+			skipMutate: true,
+			data: &pbmesh.Upstreams{
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, &pbresource.Tenancy{Partition: "foo", Namespace: "bar"}, "api")},
+				},
+			},
+			expectErr: `invalid element at index 0 of list "upstreams": invalid "destination_ref" field: invalid "tenancy" field: invalid "peer_name" field: must be set to "local"`,
+		},
+		"normal": {
+			data: &pbmesh.Upstreams{
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy("foo.bar"), "api")},
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy("foo.zim"), "api")},
+					{DestinationRef: newRefWithTenancy(catalog.ServiceType, newTestTenancy("gir.zim"), "api")},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}

--- a/internal/mesh/internal/types/upstreams_test.go
+++ b/internal/mesh/internal/types/upstreams_test.go
@@ -48,6 +48,18 @@ func TestMutateUpstreams(t *testing.T) {
 			data:   &pbmesh.Upstreams{},
 			expect: &pbmesh.Upstreams{},
 		},
+		"invalid/nil dest ref": {
+			data: &pbmesh.Upstreams{
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: nil},
+				},
+			},
+			expect: &pbmesh.Upstreams{ // untouched
+				Upstreams: []*pbmesh.Upstream{
+					{DestinationRef: nil},
+				},
+			},
+		},
 		"dest ref tenancy defaulting": {
 			tenancy: newTestTenancy("foo.bar"),
 			data: &pbmesh.Upstreams{


### PR DESCRIPTION
### Description

`HTTPRoute`, `GRPCRoute`, `TCPRoute`, and `Upstreams` resources contain inner `Reference` fields. We want to ensure that components of those reference `Tenancy` fields left unspecified are defaulted using the tenancy of the enclosing resource.

As the underlying helper being used to do the normalization calls the function modified in #18822, it also means that the `PeerName` field will be set to `"local"` for now automatically to avoid `"local" != ""` issues downstream.

NET-5641