### PR TITLE
Use embedded strings for templated policies

### DIFF
--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1378,7 +1378,7 @@ func TestACL_HTTP(t *testing.T) {
 
 			require.Equal(t, api.ACLTemplatedPolicyResponse{
 				TemplateName: api.ACLTemplatedPolicyServiceName,
-				Schema:       structs.ACLTemplatedPolicyIdentitiesSchema,
+				Schema:       structs.ACLTemplatedPolicyServiceSchema,
 				Template:     structs.ACLTemplatedPolicyService,
 			}, list[api.ACLTemplatedPolicyServiceName])
 		})

--- a/agent/structs/acl_templated_policy.go
+++ b/agent/structs/acl_templated_policy.go
@@ -5,6 +5,7 @@ package structs
 
 import (
 	"bytes"
+	_ "embed"
 	"fmt"
 	"hash"
 	"hash/fnv"
@@ -18,26 +19,17 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+//go:embed acltemplatedpolicy/schemas/node.json
+var ACLTemplatedPolicyNodeSchema string
+
+//go:embed acltemplatedpolicy/schemas/service.json
+var ACLTemplatedPolicyServiceSchema string
+
 type ACLTemplatedPolicies []*ACLTemplatedPolicy
 
 const (
-	ACLTemplatedPolicyNodeID           = "00000000-0000-0000-0000-000000000004"
-	ACLTemplatedPolicyServiceID        = "00000000-0000-0000-0000-000000000003"
-	ACLTemplatedPolicyIdentitiesSchema = `
-{
-	"type": "object",
-	"properties": {
-		"name": { "type": "string", "$ref": "#/definitions/min-length-one" }
-	},
-	"required": ["name"],
-	"definitions": {
-		"min-length-one": {
-				"type": "string",
-				"minLength": 1
-		}
-	}
-}`
-
+	ACLTemplatedPolicyServiceID = "00000000-0000-0000-0000-000000000003"
+	ACLTemplatedPolicyNodeID    = "00000000-0000-0000-0000-000000000004"
 	ACLTemplatedPolicyDNSID     = "00000000-0000-0000-0000-000000000005"
 	ACLTemplatedPolicyDNSSchema = "" // empty schema as it does not require variables
 )
@@ -59,13 +51,13 @@ var (
 		api.ACLTemplatedPolicyServiceName: {
 			TemplateID:   ACLTemplatedPolicyServiceID,
 			TemplateName: api.ACLTemplatedPolicyServiceName,
-			Schema:       ACLTemplatedPolicyIdentitiesSchema,
+			Schema:       ACLTemplatedPolicyServiceSchema,
 			Template:     ACLTemplatedPolicyService,
 		},
 		api.ACLTemplatedPolicyNodeName: {
 			TemplateID:   ACLTemplatedPolicyNodeID,
 			TemplateName: api.ACLTemplatedPolicyNodeName,
-			Schema:       ACLTemplatedPolicyIdentitiesSchema,
+			Schema:       ACLTemplatedPolicyNodeSchema,
 			Template:     ACLTemplatedPolicyNode,
 		},
 		api.ACLTemplatedPolicyDNSName: {
@@ -273,6 +265,7 @@ func GetACLTemplatedPolicyBase(templateName string) (*ACLTemplatedPolicyBase, bo
 	return nil, false
 }
 
+// GetACLTemplatedPolicyList returns a copy of the list of templated policies
 func GetACLTemplatedPolicyList() map[string]*ACLTemplatedPolicyBase {
 	m := make(map[string]*ACLTemplatedPolicyBase, len(aclTemplatedPoliciesList))
 	for k, v := range aclTemplatedPoliciesList {

--- a/agent/structs/acltemplatedpolicy/schemas/node.json
+++ b/agent/structs/acltemplatedpolicy/schemas/node.json
@@ -1,0 +1,13 @@
+{
+	"type": "object",
+	"properties": {
+		"name": { "type": "string", "$ref": "#/definitions/min-length-one" }
+	},
+	"required": ["name"],
+	"definitions": {
+		"min-length-one": {
+				"type": "string",
+				"minLength": 1
+		}
+	}
+}

--- a/agent/structs/acltemplatedpolicy/schemas/service.json
+++ b/agent/structs/acltemplatedpolicy/schemas/service.json
@@ -1,0 +1,13 @@
+{
+	"type": "object",
+	"properties": {
+		"name": { "type": "string", "$ref": "#/definitions/min-length-one" }
+	},
+	"required": ["name"],
+	"definitions": {
+		"min-length-one": {
+				"type": "string",
+				"minLength": 1
+		}
+	}
+}

--- a/command/acl/templatedpolicy/formatter_test.go
+++ b/command/acl/templatedpolicy/formatter_test.go
@@ -35,7 +35,7 @@ func testFormatTemplatedPolicy(t *testing.T, dirPath string) {
 		"node-templated-policy": {
 			templatedPolicy: api.ACLTemplatedPolicyResponse{
 				TemplateName: api.ACLTemplatedPolicyNodeName,
-				Schema:       structs.ACLTemplatedPolicyIdentitiesSchema,
+				Schema:       structs.ACLTemplatedPolicyNodeSchema,
 				Template:     structs.ACLTemplatedPolicyNode,
 			},
 		},
@@ -49,7 +49,7 @@ func testFormatTemplatedPolicy(t *testing.T, dirPath string) {
 		"service-templated-policy": {
 			templatedPolicy: api.ACLTemplatedPolicyResponse{
 				TemplateName: api.ACLTemplatedPolicyServiceName,
-				Schema:       structs.ACLTemplatedPolicyIdentitiesSchema,
+				Schema:       structs.ACLTemplatedPolicyServiceSchema,
 				Template:     structs.ACLTemplatedPolicyService,
 			},
 		},
@@ -89,7 +89,7 @@ func testFormatTemplatedPolicyList(t *testing.T, dirPath string) {
 	policies := map[string]api.ACLTemplatedPolicyResponse{
 		"builtin/node": {
 			TemplateName: api.ACLTemplatedPolicyNodeName,
-			Schema:       structs.ACLTemplatedPolicyIdentitiesSchema,
+			Schema:       structs.ACLTemplatedPolicyNodeSchema,
 			Template:     structs.ACLTemplatedPolicyNode,
 		},
 		"builtin/dns": {
@@ -99,7 +99,7 @@ func testFormatTemplatedPolicyList(t *testing.T, dirPath string) {
 		},
 		"builtin/service": {
 			TemplateName: api.ACLTemplatedPolicyServiceName,
-			Schema:       structs.ACLTemplatedPolicyIdentitiesSchema,
+			Schema:       structs.ACLTemplatedPolicyServiceSchema,
 			Template:     structs.ACLTemplatedPolicyService,
 		},
 	}

--- a/command/acl/templatedpolicy/read/templated_policy_read_test.go
+++ b/command/acl/templatedpolicy/read/templated_policy_read_test.go
@@ -128,7 +128,7 @@ func TestTemplatedPolicyReadCommand_JSON(t *testing.T) {
 		err := json.Unmarshal([]byte(output), &templatedPolicy)
 
 		assert.NoError(t, err)
-		assert.Equal(t, structs.ACLTemplatedPolicyIdentitiesSchema, templatedPolicy.Schema)
+		assert.Equal(t, structs.ACLTemplatedPolicyNodeSchema, templatedPolicy.Schema)
 		assert.Equal(t, api.ACLTemplatedPolicyNodeName, templatedPolicy.TemplateName)
 	})
 }

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/node-templated-policy.json.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/node-templated-policy.json.golden
@@ -1,5 +1,5 @@
 {
     "TemplateName": "builtin/node",
-    "Schema": "\n{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"name\": { \"type\": \"string\", \"$ref\": \"#/definitions/min-length-one\" }\n\t},\n\t\"required\": [\"name\"],\n\t\"definitions\": {\n\t\t\"min-length-one\": {\n\t\t\t\t\"type\": \"string\",\n\t\t\t\t\"minLength\": 1\n\t\t}\n\t}\n}",
+    "Schema": "{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"name\": { \"type\": \"string\", \"$ref\": \"#/definitions/min-length-one\" }\n\t},\n\t\"required\": [\"name\"],\n\t\"definitions\": {\n\t\t\"min-length-one\": {\n\t\t\t\t\"type\": \"string\",\n\t\t\t\t\"minLength\": 1\n\t\t}\n\t}\n}",
     "Template": "\nnode \"{{.Name}}\" {\n\tpolicy = \"write\"\n}\nservice_prefix \"\" {\n\tpolicy = \"read\"\n}"
 }

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/node-templated-policy.pretty-meta.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/node-templated-policy.pretty-meta.golden
@@ -4,7 +4,6 @@ Input variables:
 Example usage:
 	consul acl token create -templated-policy builtin/node -var name:node-1
 Schema:
-
 {
 	"type": "object",
 	"properties": {

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/service-templated-policy.json.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/service-templated-policy.json.golden
@@ -1,5 +1,5 @@
 {
     "TemplateName": "builtin/service",
-    "Schema": "\n{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"name\": { \"type\": \"string\", \"$ref\": \"#/definitions/min-length-one\" }\n\t},\n\t\"required\": [\"name\"],\n\t\"definitions\": {\n\t\t\"min-length-one\": {\n\t\t\t\t\"type\": \"string\",\n\t\t\t\t\"minLength\": 1\n\t\t}\n\t}\n}",
+    "Schema": "{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"name\": { \"type\": \"string\", \"$ref\": \"#/definitions/min-length-one\" }\n\t},\n\t\"required\": [\"name\"],\n\t\"definitions\": {\n\t\t\"min-length-one\": {\n\t\t\t\t\"type\": \"string\",\n\t\t\t\t\"minLength\": 1\n\t\t}\n\t}\n}",
     "Template": "\nservice \"{{.Name}}\" {\n\tpolicy = \"write\"\n}\nservice \"{{.Name}}-sidecar-proxy\" {\n\tpolicy = \"write\"\n}\nservice_prefix \"\" {\n\tpolicy = \"read\"\n}\nnode_prefix \"\" {\n\tpolicy = \"read\"\n}"
 }

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/service-templated-policy.pretty-meta.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/service-templated-policy.pretty-meta.golden
@@ -4,7 +4,6 @@ Input variables:
 Example usage:
 	consul acl token create -templated-policy builtin/service -var name:api
 Schema:
-
 {
 	"type": "object",
 	"properties": {

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicyList/ce/list.json.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicyList/ce/list.json.golden
@@ -6,12 +6,12 @@
     },
     "builtin/node": {
         "TemplateName": "builtin/node",
-        "Schema": "\n{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"name\": { \"type\": \"string\", \"$ref\": \"#/definitions/min-length-one\" }\n\t},\n\t\"required\": [\"name\"],\n\t\"definitions\": {\n\t\t\"min-length-one\": {\n\t\t\t\t\"type\": \"string\",\n\t\t\t\t\"minLength\": 1\n\t\t}\n\t}\n}",
+        "Schema": "{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"name\": { \"type\": \"string\", \"$ref\": \"#/definitions/min-length-one\" }\n\t},\n\t\"required\": [\"name\"],\n\t\"definitions\": {\n\t\t\"min-length-one\": {\n\t\t\t\t\"type\": \"string\",\n\t\t\t\t\"minLength\": 1\n\t\t}\n\t}\n}",
         "Template": "\nnode \"{{.Name}}\" {\n\tpolicy = \"write\"\n}\nservice_prefix \"\" {\n\tpolicy = \"read\"\n}"
     },
     "builtin/service": {
         "TemplateName": "builtin/service",
-        "Schema": "\n{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"name\": { \"type\": \"string\", \"$ref\": \"#/definitions/min-length-one\" }\n\t},\n\t\"required\": [\"name\"],\n\t\"definitions\": {\n\t\t\"min-length-one\": {\n\t\t\t\t\"type\": \"string\",\n\t\t\t\t\"minLength\": 1\n\t\t}\n\t}\n}",
+        "Schema": "{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"name\": { \"type\": \"string\", \"$ref\": \"#/definitions/min-length-one\" }\n\t},\n\t\"required\": [\"name\"],\n\t\"definitions\": {\n\t\t\"min-length-one\": {\n\t\t\t\t\"type\": \"string\",\n\t\t\t\t\"minLength\": 1\n\t\t}\n\t}\n}",
         "Template": "\nservice \"{{.Name}}\" {\n\tpolicy = \"write\"\n}\nservice \"{{.Name}}-sidecar-proxy\" {\n\tpolicy = \"write\"\n}\nservice_prefix \"\" {\n\tpolicy = \"read\"\n}\nnode_prefix \"\" {\n\tpolicy = \"read\"\n}"
     }
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

- We will have a total of 12 templated policies, to make it easier we thought each template schema could reside in its own json file and use go embedded strings 
- Splitting the node and service schema so it doesn't get confusing in the future 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

- The test cover all templated policy stuff to CI running fine should enough to know if we broke off anything. 
- Manually you can try reading an acl templated policy with meta: `consul acl templated-policy read -name "builtin/node" -meta`
