### PR TITLE
add v2 tenancy bridge Flag and v2 Tenancy Bridge initial implementation

### DIFF
--- a/agent/consul/tenancy_bridge.go
+++ b/agent/consul/tenancy_bridge.go
@@ -3,6 +3,8 @@
 
 package consul
 
+import "github.com/hashicorp/consul/agent/grpc-external/services/resource"
+
 // V1TenancyBridge is used by the resource service to access V1 implementations of
 // partitions and namespaces. This bridge will be removed when V2 implemenations
 // of partitions and namespaces are available.
@@ -10,6 +12,6 @@ type V1TenancyBridge struct {
 	server *Server
 }
 
-func NewV1TenancyBridge(server *Server) *V1TenancyBridge {
+func NewV1TenancyBridge(server *Server) resource.TenancyBridge {
 	return &V1TenancyBridge{server: server}
 }

--- a/agent/consul/tenancy_bridge_v2_ce.go
+++ b/agent/consul/tenancy_bridge_v2_ce.go
@@ -1,0 +1,29 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !consulent
+// +build !consulent
+
+package consul
+
+func (b *V2TenancyBridge) PartitionExists(partition string) (bool, error) {
+	if partition == "default" {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (b *V2TenancyBridge) IsPartitionMarkedForDeletion(partition string) (bool, error) {
+	return false, nil
+}
+
+func (b *V2TenancyBridge) NamespaceExists(partition, namespace string) (bool, error) {
+	if partition == "default" && namespace == "default" {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (b *V2TenancyBridge) IsNamespaceMarkedForDeletion(partition, namespace string) (bool, error) {
+	return false, nil
+}

--- a/agent/grpc-external/services/resource/delete.go
+++ b/agent/grpc-external/services/resource/delete.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
-// Deletes a resource.
+// Delete deletes a resource.
 // - To delete a resource regardless of the stored version, set Version = ""
 // - Supports deleting a resource by name, hence Id.Uid may be empty.
 // - Delete of a previously deleted or non-existent resource is a no-op to support idempotency.

--- a/agent/grpc-external/services/resource/list_by_owner.go
+++ b/agent/grpc-external/services/resource/list_by_owner.go
@@ -43,7 +43,7 @@ func (s *Server) ListByOwner(ctx context.Context, req *pbresource.ListByOwnerReq
 	}
 
 	// Check v1 tenancy exists for the v2 resource.
-	if err = v1TenancyExists(reg, s.V1TenancyBridge, req.Owner.Tenancy, codes.InvalidArgument); err != nil {
+	if err = v1TenancyExists(reg, s.TenancyBridge, req.Owner.Tenancy, codes.InvalidArgument); err != nil {
 		return nil, err
 	}
 

--- a/agent/grpc-external/services/resource/read.go
+++ b/agent/grpc-external/services/resource/read.go
@@ -54,7 +54,7 @@ func (s *Server) Read(ctx context.Context, req *pbresource.ReadRequest) (*pbreso
 	}
 
 	// Check V1 tenancy exists for the V2 resource.
-	if err = v1TenancyExists(reg, s.V1TenancyBridge, req.Id.Tenancy, codes.NotFound); err != nil {
+	if err = v1TenancyExists(reg, s.TenancyBridge, req.Id.Tenancy, codes.NotFound); err != nil {
 		return nil, err
 	}
 

--- a/agent/grpc-external/services/resource/server.go
+++ b/agent/grpc-external/services/resource/server.go
@@ -31,9 +31,9 @@ type Config struct {
 	// Backend is the storage backend that will be used for resource persistence.
 	Backend     Backend
 	ACLResolver ACLResolver
-	// V1TenancyBridge temporarily allows us to use V1 implementations of
+	// TenancyBridge temporarily allows us to use V1 implementations of
 	// partitions and namespaces until V2 implementations are available.
-	V1TenancyBridge TenancyBridge
+	TenancyBridge TenancyBridge
 }
 
 //go:generate mockery --name Registry --inpackage

--- a/agent/grpc-external/services/resource/server_test.go
+++ b/agent/grpc-external/services/resource/server_test.go
@@ -86,11 +86,11 @@ func testServer(t *testing.T) *Server {
 	mockTenancyBridge.On("IsNamespaceMarkedForDeletion", resource.DefaultPartitionName, resource.DefaultNamespaceName).Return(false, nil)
 
 	return NewServer(Config{
-		Logger:          testutil.Logger(t),
-		Registry:        resource.NewRegistry(),
-		Backend:         backend,
-		ACLResolver:     mockACLResolver,
-		V1TenancyBridge: mockTenancyBridge,
+		Logger:        testutil.Logger(t),
+		Registry:      resource.NewRegistry(),
+		Backend:       backend,
+		ACLResolver:   mockACLResolver,
+		TenancyBridge: mockTenancyBridge,
 	})
 }
 

--- a/agent/grpc-external/services/resource/testing/testing.go
+++ b/agent/grpc-external/services/resource/testing/testing.go
@@ -101,11 +101,11 @@ func RunResourceServiceWithACL(t *testing.T, aclResolver svc.ACLResolver, regist
 	mockTenancyBridge.On("IsNamespaceMarkedForDeletion", resource.DefaultPartitionName, resource.DefaultNamespaceName).Return(false, nil)
 
 	svc.NewServer(svc.Config{
-		Backend:         backend,
-		Registry:        registry,
-		Logger:          testutil.Logger(t),
-		ACLResolver:     aclResolver,
-		V1TenancyBridge: mockTenancyBridge,
+		Backend:       backend,
+		Registry:      registry,
+		Logger:        testutil.Logger(t),
+		ACLResolver:   aclResolver,
+		TenancyBridge: mockTenancyBridge,
 	}).Register(server)
 
 	pipe := internal.NewPipeListener()

--- a/agent/grpc-external/services/resource/write.go
+++ b/agent/grpc-external/services/resource/write.go
@@ -71,12 +71,12 @@ func (s *Server) Write(ctx context.Context, req *pbresource.WriteRequest) (*pbre
 	}
 
 	// Check V1 tenancy exists for the V2 resource
-	if err = v1TenancyExists(reg, s.V1TenancyBridge, req.Resource.Id.Tenancy, codes.InvalidArgument); err != nil {
+	if err = v1TenancyExists(reg, s.TenancyBridge, req.Resource.Id.Tenancy, codes.InvalidArgument); err != nil {
 		return nil, err
 	}
 
 	// Check V1 tenancy not marked for deletion.
-	if err = v1TenancyMarkedForDeletion(reg, s.V1TenancyBridge, req.Resource.Id.Tenancy); err != nil {
+	if err = v1TenancyMarkedForDeletion(reg, s.TenancyBridge, req.Resource.Id.Tenancy); err != nil {
 		return nil, err
 	}
 

--- a/agent/grpc-external/services/resource/write_status.go
+++ b/agent/grpc-external/services/resource/write_status.go
@@ -36,7 +36,7 @@ func (s *Server) WriteStatus(ctx context.Context, req *pbresource.WriteStatusReq
 
 	// Check V1 tenancy exists for the V2 resource. Ignore "marked for deletion" since status updates
 	// should still work regardless.
-	if err = v1TenancyExists(reg, s.V1TenancyBridge, req.Id.Tenancy, codes.InvalidArgument); err != nil {
+	if err = v1TenancyExists(reg, s.TenancyBridge, req.Id.Tenancy, codes.InvalidArgument); err != nil {
 		return nil, err
 	}
 

--- a/agent/grpc-external/services/resource/write_test.go
+++ b/agent/grpc-external/services/resource/write_test.go
@@ -416,7 +416,7 @@ func TestWrite_Tenancy_MarkedForDeletion(t *testing.T) {
 			mockTenancyBridge := &MockTenancyBridge{}
 			mockTenancyBridge.On("PartitionExists", "part1").Return(true, nil)
 			mockTenancyBridge.On("NamespaceExists", "part1", "ns1").Return(true, nil)
-			server.V1TenancyBridge = mockTenancyBridge
+			server.TenancyBridge = mockTenancyBridge
 
 			_, err = client.Write(testContext(t), &pbresource.WriteRequest{Resource: tc.modFn(artist, recordLabel, mockTenancyBridge)})
 			require.Error(t, err)

--- a/internal/resource/tenancy.go
+++ b/internal/resource/tenancy.go
@@ -12,10 +12,26 @@ import (
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
+type TenancyBridge interface {
+	PartitionExists(partition string) (bool, error)
+	IsPartitionMarkedForDeletion(partition string) (bool, error)
+	NamespaceExists(partition, namespace string) (bool, error)
+	IsNamespaceMarkedForDeletion(partition, namespace string) (bool, error)
+}
+
 const (
 	DefaultPartitionName = "default"
 	DefaultNamespaceName = "default"
 )
+
+// V2TenancyBridge is used by the resource service to access V2 implementations of
+// partitions and namespaces.
+type V2TenancyBridge struct {
+}
+
+func NewV2TenancyBridge() TenancyBridge {
+	return &V2TenancyBridge{}
+}
 
 // Scope describes the tenancy scope of a resource.
 type Scope int

--- a/internal/resource/tenancy_bridge_ce.go
+++ b/internal/resource/tenancy_bridge_ce.go
@@ -4,7 +4,7 @@
 //go:build !consulent
 // +build !consulent
 
-package consul
+package resource
 
 func (b *V2TenancyBridge) PartitionExists(partition string) (bool, error) {
 	if partition == "default" {


### PR DESCRIPTION
### Description
This PR is the initial introduction of a second implementation of the tenancy bridge that would allow us to use a v2 resources backed tenancy.

This also rename `V1TenancyBridge` to `TenancyBridge` as we would be using the bridge for both implementations.

### Testing & Reproduction steps
No tests are added as the introduced behaviour is just to return an `unimplemented` error for now.
All the tests using V1TenancyBridge should work as expected, notice that those tests are not yet part of the code and WIP.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
