### PR TITLE
Fix gateway services cleanup where proxy deregistration happens after service deregistration

### DIFF
--- a/.changelog/18831.txt
+++ b/.changelog/18831.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+gateways: Fix a bug where gateway to service mappings weren't being cleaned up properly when externally registered proxies were being deregistered.
+```

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2065,6 +2065,12 @@ func (s *Store) deleteServiceTxn(tx WriteTxn, idx uint64, nodeName, serviceID st
 			if err := cleanupKindServiceName(tx, idx, sn, structs.ServiceKindConnectEnabled); err != nil {
 				return fmt.Errorf("failed to cleanup connect-enabled service name: %v", err)
 			}
+			// we need to do this if the proxy is deleted after the service itself
+			// as the guard after this might not be 1-1 between proxy and service
+			// names.
+			if err := cleanupGatewayWildcards(tx, idx, sn, false); err != nil {
+				return fmt.Errorf("failed to clean up gateway-service associations for %q: %v", psn.String(), err)
+			}
 		}
 	}
 

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -8345,7 +8345,7 @@ func TestCatalog_cleanupGatewayWildcards_proxy(t *testing.T) {
 		},
 	}))
 
-	// Register two services that share a prefix, both will be covered by gateway wildcards above
+	// Register two services, a regular service, and a sidecar proxy for it
 	api := structs.NodeService{
 		ID:             "api",
 		Service:        "api",


### PR DESCRIPTION
### Description

<!-- NET-5557 -->

While trying to debug a customer issue, I noticed that when:

1. A user specifies an ingress gateway with a target of `"*"`
3. They boot up the ingress gateway and a service in the target namespace
4. They've registered the target and its sidecar proxy individually
5. They then deregister the target _followed_ by the corresponding sidecar
6. The gateway still attempts to route to the service

This happens because of a bug in the store that was causing wildcard-targeted gateway services to be pruned from `tableGatewayServices` only when they don't have existing sidecar proxies. In the above case, when the sidecar is deregistered second, the cleanup routine never triggers for the main service (instead a routine runs that attempts to prune the sidecar service name from `tableGatewayServices` rather than the service it's acting as a sidecar for).

### Testing & Reproduction steps

I added a unit test to exercise this case, but I also threw together a gist that manually recreates this. I did so using an enterprise Consul build, but the steps can be adjusted for non-enterprise as well.

1. Clone the repro [gist](https://gist.github.com/andrewstucki/c6228c9b286d90eb944e1595b3a2fd88)
2. build a local `consul-enterprise` build with `make dev-docker` and tag it with `docker tag consul:local consul-enterprise:local`
3. shove an enterprise license in the environment variable `CONSUL_LICENSE`
4. run `./reset.sh` in the gist
5. run `kubectl delete deployment static-server`
6. run `kubectl exec -it consul-server-0 -- consul catalog services` and see that `static-server` is not longer in the catalog
7. run `kubectl exec -it consul-server-0 -- curl https://localhost:8501/v1/catalog/gateway-services/consul-dc1-ingress-gateway -k | jq`

**Without the fix you'll see something like** (notice `static-server` still in the payload):

```json
[
  {
    "Gateway": {
      "Name": "consul-dc1-ingress-gateway",
      "Partition": "default",
      "Namespace": "default"
    },
    "Service": {
      "Name": "service-two",
      "Partition": "default",
      "Namespace": "default"
    },
    "GatewayKind": "ingress-gateway",
    "Port": 8080,
    "Protocol": "http",
    "FromWildcard": true,
    "ServiceKind": "service",
    "CreateIndex": 76,
    "ModifyIndex": 76
  },
  {
    "Gateway": {
      "Name": "consul-dc1-ingress-gateway",
      "Partition": "default",
      "Namespace": "default"
    },
    "Service": {
      "Name": "static-server",
      "Partition": "default",
      "Namespace": "default"
    },
    "GatewayKind": "ingress-gateway",
    "Port": 8080,
    "Protocol": "http",
    "FromWildcard": true,
    "ServiceKind": "service",
    "CreateIndex": 57,
    "ModifyIndex": 57
  }
]
```

**With the fix you should see something like**:

```json
[
  {
    "Gateway": {
      "Name": "consul-dc1-ingress-gateway",
      "Partition": "default",
      "Namespace": "default"
    },
    "Service": {
      "Name": "service-two",
      "Partition": "default",
      "Namespace": "default"
    },
    "GatewayKind": "ingress-gateway",
    "Port": 8080,
    "Protocol": "http",
    "FromWildcard": true,
    "CreateIndex": 607,
    "ModifyIndex": 607
  }
]
```

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [ ] not a security concern
