### PR TITLE
Adjust metrics test

### DIFF
--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -35,9 +35,8 @@ func recordPromMetrics(t *testing.T, a *TestAgent, respRec *httptest.ResponseRec
 	req, err := http.NewRequest("GET", "/v1/agent/metrics?format=prometheus", nil)
 	require.NoError(t, err, "Failed to generate new http request.")
 
-	_, err = a.srv.AgentMetrics(respRec, req)
-	require.NoError(t, err, "Failed to serve agent metrics")
-
+	a.srv.h.ServeHTTP(respRec, req)
+	require.Equalf(t, 200, respRec.Code, "expected 200, got %d, body: %s", respRec.Code, respRec.Body.String())
 }
 
 func assertMetricExists(t *testing.T, respRec *httptest.ResponseRecorder, metric string) {


### PR DESCRIPTION
This test suite flakes VERY often and we cannot debug why because the handlers may be returning without go errors (instead choosing to write to ResponseWriter instead).

Call the handler differently (through Consul's middleware) and assert for status code. This won't fix the flakes but it will help debug why the tests are failing.