### PR TITLE
docs: Add complete auth method payloads

### DIFF
--- a/website/content/api-docs/acl/binding-rules.mdx
+++ b/website/content/api-docs/acl/binding-rules.mdx
@@ -62,37 +62,62 @@ The corresponding CLI command is [`consul acl binding-rule create`](/consul/comm
   - `BindType=service` - The computed bind name value is used as an
     `ACLServiceIdentity.ServiceName` field in the token that is created.
 
+    <CodeBlockConfig heading="Equivalent payload for Consul token API endpoint">
+
     ```json
-    { ...other fields...
-        "ServiceIdentities": [
-            { "ServiceName": "<computed BindName>" }
-        ]
+    {
+      "AccessorID": "<token accessor ID>",
+      "SecretID": "<token secret ID>",
+      "ServiceIdentities": [
+        {
+          "ServiceName": "<computed BindName>"
+        }
+      ]
     }
     ```
+
+    </CodeBlockConfig>
 
   - `BindType=node` - The computed bind name value is used as an
     `ACLNodeIdentity.NodeName` field in the token that is created.
 
+    <CodeBlockConfig heading="Equivalent payload for Consul token API endpoint">
+
     ```json
-    { ...other fields...
-        "NodeIdentities": [
-            { "NodeName": "<computed BindName>", "Datacenter": "<local datacenter>" }
-        ]
+    {
+      "AccessorID": "<token accessor ID>",
+      "SecretID": "<token secret ID>",
+      "NodeIdentities": [
+        {
+          "NodeName": "<computed BindName>",
+          "Datacenter": "<local datacenter>"
+        }
+      ]
     }
     ```
+
+    </CodeBlockConfig>
 
   - `BindType=role` - The computed bind name value is used as a `RoleLink.Name`
     field in the token that is created. This binding rule will only apply if a
     role with the given name exists at login-time. If it does not then this
     rule is ignored.
 
+    <CodeBlockConfig heading="Equivalent payload for Consul token API endpoint">
+
     ```json
-    { ...other fields...
-        "Roles": [
-            { "Name": "<computed BindName>" }
-        ]
+    {
+      "AccessorID": "<token accessor ID>",
+      "SecretID": "<token secret ID>",
+      "Roles": [
+        {
+          "Name": "<computed BindName>"
+        }
+      ]
     }
     ```
+
+    </CodeBlockConfig>
 
 - `BindName` `(string: <required>)` - The name to bind to a token at
   login-time. What it binds to can be adjusted with different values of the
@@ -250,37 +275,62 @@ The corresponding CLI command is [`consul acl binding-rule update`](/consul/comm
   - `BindType=service` - The computed bind name value is used as an
     `ACLServiceIdentity.ServiceName` field in the token that is created.
 
+    <CodeBlockConfig heading="Equivalent payload for Consul token API endpoint">
+
     ```json
-    { ...other fields...
-        "ServiceIdentities": [
-            { "ServiceName": "<computed BindName>" }
-        ]
+    {
+      "AccessorID": "<token accessor ID>",
+      "SecretID": "<token secret ID>",
+      "ServiceIdentities": [
+        {
+          "ServiceName": "<computed BindName>"
+        }
+      ]
     }
     ```
+
+    </CodeBlockConfig>
 
   - `BindType=node` - The computed bind name value is used as an
     `ACLNodeIdentity.NodeName` field in the token that is created.
 
+    <CodeBlockConfig heading="Equivalent payload for Consul token API endpoint">
+
     ```json
-    { ...other fields...
-        "NodeIdentities": [
-            { "NodeName": "<computed BindName>", "Datacenter": "<local datacenter>" }
-        ]
+    {
+      "AccessorID": "<token accessor ID>",
+      "SecretID": "<token secret ID>",
+      "NodeIdentities": [
+        {
+          "NodeName": "<computed BindName>",
+          "Datacenter": "<local datacenter>"
+        }
+      ]
     }
     ```
+
+    </CodeBlockConfig>
 
   - `BindType=role` - The computed bind name value is used as a `RoleLink.Name`
     field in the token that is created. This binding rule will only apply if a
     role with the given name exists at login-time. If it does not then this
     rule is ignored.
 
+    <CodeBlockConfig heading="Equivalent payload for Consul token API endpoint">
+
     ```json
-    { ...other fields...
-        "Roles": [
-            { "Name": "<computed BindName>" }
-        ]
+    {
+      "AccessorID": "<token accessor ID>",
+      "SecretID": "<token secret ID>",
+      "Roles": [
+        {
+          "Name": "<computed BindName>"
+        }
+      ]
     }
     ```
+
+    </CodeBlockConfig>
 
 - `BindName` `(string: <required>)` - The name to bind to a token at
   login-time. What it binds to can be adjusted with different values of the

--- a/website/content/docs/security/acl/auth-methods/aws-iam.mdx
+++ b/website/content/docs/security/acl/auth-methods/aws-iam.mdx
@@ -86,7 +86,9 @@ parameters for an auth method of type `aws-iam`:
 
 ```json
 {
-    ...other fields...
+    "Name": "example-iam-auth",
+    "Type": "aws-iam",
+    "Description": "Example AWS IAM auth method",
     "Config": {
       "BoundIAMPrincipalARNs": ["arn:aws:iam::123456789012:role/MyRoleName"],
       "EnableIAMEntityDetails": true,

--- a/website/content/docs/security/acl/auth-methods/jwt.mdx
+++ b/website/content/docs/security/acl/auth-methods/jwt.mdx
@@ -92,7 +92,9 @@ parameters are required to properly configure an auth method of type
 
 ```json
 {
-    ...other fields...
+    "Name": "example-jwt-auth-static-keys",
+    "Type": "jwt",
+    "Description": "Example JWT auth method with static keys",
     "Config": {
         "BoundIssuer": "corp-issuer",
         "JWTValidationPubKeys": [
@@ -113,7 +115,9 @@ parameters are required to properly configure an auth method of type
 
 ```json
 {
-    ...other fields...
+    "Name": "example-jwt-auth-jwks",
+    "Type": "jwt",
+    "Description": "Example JWT auth method with JWKS",
     "Config": {
         "JWKSURL": "https://my-corp-jwks-url.example.com/",
         "ClaimMappings": {
@@ -131,7 +135,9 @@ parameters are required to properly configure an auth method of type
 
 ```json
 {
-    ...other fields...
+    "Name": "example-oidc-auth",
+    "Type": "oidc",
+    "Description": "Example OIDC auth method",
     "Config": {
         "BoundAudiences": [
             "V1RPi2MYptMV1RPi2MYptMV1RPi2MYpt"

--- a/website/content/docs/security/acl/auth-methods/kubernetes.mdx
+++ b/website/content/docs/security/acl/auth-methods/kubernetes.mdx
@@ -1,6 +1,6 @@
 ---
 layout: docs
-page_title: Kubernetes Auth Method 
+page_title: Kubernetes Auth Method
 description: >-
   Use the Kubernetes auth method type to authenticate to Consul with a Kubernetes service account token and receive an ACL token with privileges based on JWT identity attributes. Learn how to configure auth method parameters using this reference page and example configuration.
 ---
@@ -61,7 +61,9 @@ parameters are required to properly configure an auth method of type
 
 ```json
 {
-    ...other fields...
+    "Name": "example-k8s-auth",
+    "Type": "kubernetes",
+    "Description": "Example JWT auth method",
     "Config": {
         "Host": "https://192.0.2.42:8443",
         "CACert": "-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----\n",

--- a/website/content/docs/security/acl/auth-methods/oidc.mdx
+++ b/website/content/docs/security/acl/auth-methods/oidc.mdx
@@ -86,7 +86,9 @@ parameters are required to properly configure an auth method of type
 
 ```json
 {
-    ...other fields...
+    "Name": "example-oidc-auth",
+    "Type": "oidc",
+    "Description": "Example OIDC auth method",
     "Config": {
         "AllowedRedirectURIs": [
             "http://localhost:8550/oidc/callback",

--- a/website/content/partials/jwt_claim_mapping_details.mdx
+++ b/website/content/partials/jwt_claim_mapping_details.mdx
@@ -19,13 +19,18 @@ rule, and the lists of values mapped by `ListClaimMappings` cannot.
 Assume this is your config snippet:
 
 ```json
-{ ...other fields...
-  "ClaimMappings": {
-    "givenName": "first_name",
-    "surname": "last_name"
-  },
-  "ListClaimMappings": {
-    "groups": "groups"
+{
+  "Name": "example-auth-method",
+  "Type": "<jwt|oidc>",
+  "Description": "Example auth method",
+  "Config": {
+    "ClaimMappings": {
+      "givenName": "first_name",
+      "surname": "last_name"
+    },
+    "ListClaimMappings": {
+      "groups": "groups"
+    }
   }
 }
 ```


### PR DESCRIPTION
### Description

This commit modifies the example payloads for various auth methods to remove 'other fields' and instead use complete example payloads.

This helps readers clearly understand how the payloads should be constructed for the `/v1/acl/auth-method` API endpoint.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
