### PR TITLE
Update base ref property name

### DIFF
--- a/.github/scripts/filter_changed_files_go_test.sh
+++ b/.github/scripts/filter_changed_files_go_test.sh
@@ -2,36 +2,41 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+set -euo pipefail
 
 # Get the list of changed files
-files_to_check=$(git diff --name-only origin/$GITHUB_BASE_REF)
+# Using `git merge-base` ensures that we're always comparing against the correct branch point. 
+#For example, given the commits:
+#
+# A---B---C---D---W---X---Y---Z # origin/main
+#             \---E---F         # our feature branch
+#
+# ... `git merge-base origin/$SKIP_CHECK_BRANCH HEAD` would return commit `D`
+# `...HEAD` specifies from the common ancestor to the latest commit on the current branch (HEAD)..
+files_to_check=$(git diff --name-only "$(git merge-base origin/$SKIP_CHECK_BRANCH HEAD~)"...HEAD)
 
 # Define the directories to check
 skipped_directories=("docs/" "ui/" "website/" "grafana/")
 
-# Initialize a variable to track directories outside the skipped ones
-other_directories=""
-trigger_ci=true
+# Loop through the changed files and find directories/files outside the skipped ones
+for file_to_check in $files_to_check; do
+	file_is_skipped=false
+	for dir in "${skipped_directories[@]}"; do
+		if [[ "$file_to_check" == "$dir"* ]] || [[ "$file_to_check" == *.md && "$dir" == *"/" ]]; then
+			file_is_skipped=true
+			break
+		fi
+	done
+	if [ "$file_is_skipped" != "true" ]; then
+		echo -e $file_to_check
+        SKIP_CI=false # Set the SKIP_CI variable to false by default
+		echo "Changes detected in non-documentation files - skip-ci: $SKIP_CI"
+        export $SKIP_CI
+		exit 0 ## if file is outside of the skipped_directory exit script
+	fi
+done
 
-# # Loop through the changed files and find directories/files outside the skipped ones
-# for file_to_check in $files_to_check; do
-# 	file_is_skipped=false
-# 	for dir in "${skipped_directories[@]}"; do
-# 		if [[ "$file_to_check" == "$dir"* ]] || [[ "$file_to_check" == *.md && "$dir" == *"/" ]]; then
-# 			file_is_skipped=true
-# 			break
-# 		fi
-# 	done
-# 	if [ "$file_is_skipped" = "false" ]; then
-# 		other_directories+="$(dirname "$file_to_check")\n"
-# 		trigger_ci=true
-# 		echo "Non doc file(s) changed - triggered ci: $trigger_ci"
-# 		echo -e $other_directories
-# 		echo "trigger-ci=$trigger_ci" >>"$GITHUB_OUTPUT"
-# 		exit 0 ## if file is outside of the skipped_directory exit script
-# 	fi
-# done
-
-# echo "Only doc file(s) changed - triggered ci: $trigger_ci"
-echo "Doc file(s) change detection is currently disabled - triggering ci"
-echo "trigger-ci=$trigger_ci" >>"$GITHUB_OUTPUT"
+echo -e "$files_to_check"
+SKIP_CI=true
+echo "Changes detected in only documentation files - skip-ci: $SKIP_CI"
+export $SKIP_CI

--- a/.github/scripts/filter_changed_files_go_test.sh
+++ b/.github/scripts/filter_changed_files_go_test.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 #For example, given the commits:
 #
 # A---B---C---D---W---X---Y---Z # origin/main
-#             \---E---F         # our feature branch
+#             \---E---F         # feature/branch
 #
 # ... `git merge-base origin/$SKIP_CHECK_BRANCH HEAD` would return commit `D`
 # `...HEAD` specifies from the common ancestor to the latest commit on the current branch (HEAD)..
@@ -29,7 +29,7 @@ for file_to_check in $files_to_check; do
 	done
 	if [ "$file_is_skipped" != "true" ]; then
 		echo -e $file_to_check
-        SKIP_CI=false # Set the SKIP_CI variable to false by default
+        SKIP_CI=false
 		echo "Changes detected in non-documentation files - skip-ci: $SKIP_CI"
         export $SKIP_CI
 		exit 0 ## if file is outside of the skipped_directory exit script

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -22,6 +22,7 @@ permissions:
 env:
   TEST_RESULTS: /tmp/test-results
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
+  SKIP_CHECK_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 # concurrency
 concurrency:
@@ -33,19 +34,21 @@ jobs:
     runs-on: ubuntu-latest 
     name: Get files changed and conditionally skip CI
     outputs:
-      trigger-ci: ${{ steps.read-files.outputs.trigger-ci }}
+      skip-ci: ${{ steps.read-files.outputs.skip-ci }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files_go_test.sh
+        run: |
+          ./.github/scripts/filter_changed_files_go_test.sh
+          echo "skip-ci=${SKIP_CI}" >> "${GITHUB_ENV}"
 
   setup:
     needs: [conditional-skip]
     name: Setup
-    if: needs.conditional-skip.outputs.trigger-ci == 'true'
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
     runs-on: ubuntu-latest
     outputs:
       compute-small: ${{ steps.setup-outputs.outputs.compute-small }}
@@ -506,7 +509,7 @@ jobs:
     - go-test-32bit
     # - go-test-s390x
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-    if: always() && needs.conditional-skip.outputs.trigger-ci == 'true'
+    if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
       - name: evaluate upstream job results
         run: |

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  conditional-skip:
+  conditional-skip: #test-delete-me
     runs-on: ubuntu-latest 
     name: Get files changed and conditionally skip CI
     outputs:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  conditional-skip: #test-delete-me
+  conditional-skip:
     runs-on: ubuntu-latest 
     name: Get files changed and conditionally skip CI
     outputs:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -24,6 +24,7 @@ env:
   # strip the hashicorp/ off the front of github.repository for consul
   CONSUL_LATEST_IMAGE_NAME: ${{ endsWith(github.repository, '-enterprise') && github.repository || 'hashicorp/consul' }}
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
+  SKIP_CHECK_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -34,20 +35,22 @@ jobs:
     runs-on: ubuntu-latest 
     name: Get files changed and conditionally skip CI
     outputs:
-      trigger-ci: ${{ steps.read-files.outputs.trigger-ci }}
+      skip-ci: ${{ steps.read-files.outputs.skip-ci }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files_go_test.sh
+        run: |
+          ./.github/scripts/filter_changed_files_go_test.sh
+          echo "skip-ci=${SKIP_CI}" >> "${GITHUB_ENV}"
 
   setup:
     needs: [conditional-skip]
     runs-on: ubuntu-latest
     name: Setup
-    if: needs.conditional-skip.outputs.trigger-ci == 'true'
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
     outputs:
       compute-small: ${{ steps.runners.outputs.compute-small }}
       compute-medium: ${{ steps.runners.outputs.compute-medium }}
@@ -495,7 +498,7 @@ jobs:
     - envoy-integration-test
     - compatibility-integration-test
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-    if: always() && needs.conditional-skip.outputs.trigger-ci == 'true'
+    if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
       - name: evaluate upstream job results
         run: |


### PR DESCRIPTION
### Description

**PROBLEM**
We found a bug where on pull request merge, the following error was returned by the `filter_changed_files_go_test.sh ` 
```
fatal: ambiguous argument 'origin/': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
See example [here](https://github.com/hashicorp/consul/actions/runs/6172863474/job/16753960303#step:3:8) 

**SOLUTION**
Update the `conditional-skip` job with a step to conditional check the github event, 
- if event is `pull_request merged`, set GitHub branch value to `github.ref_name`
- for `pull_request` event, set GitHub branch value to `github.head_ref`
Update the `filter_changed_files_go_test.sh` script to fail on script error and set the default behaviour to trigger CI, the previous behaviour was to skip CI. 

### Testing & Reproduction steps
[CI ](https://github.com/hashicorp/consul/actions/runs/6241892960/job/16944877094) skipping tests  where all changes are from skipped directories
[CI](https://github.com/hashicorp/consul/actions/runs/6241914325/job/16944930107) running test workflows by default

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
