### PR TITLE
Move ACL templated policies to hcl files

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -27,6 +27,9 @@ project {
     "agent/grpc-middleware/rate_limit_mappings.gen.go",
     "agent/uiserver/dist/**",
 
+    # ignoring policy embedded files
+    "agent/structs/acltemplatedpolicy/policies/ce/**",
+
     # licensed under MPL - ignoring for now until the copywrite tool can support
     # multiple licenses per repo.
     "sdk/**",

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1401,7 +1401,7 @@ func TestACL_HTTP(t *testing.T) {
 
 				var templatedPolicy api.ACLTemplatedPolicyResponse
 				require.NoError(t, json.NewDecoder(resp.Body).Decode(&templatedPolicy))
-				require.Equal(t, structs.ACLTemplatedPolicyDNSSchema, templatedPolicy.Schema)
+				require.Equal(t, structs.ACLTemplatedPolicyNoRequiredVariablesSchema, templatedPolicy.Schema)
 				require.Equal(t, api.ACLTemplatedPolicyDNSName, templatedPolicy.TemplateName)
 				require.Equal(t, structs.ACLTemplatedPolicyDNS, templatedPolicy.Template)
 			})

--- a/agent/structs/acl_templated_policy.go
+++ b/agent/structs/acl_templated_policy.go
@@ -31,7 +31,8 @@ const (
 	ACLTemplatedPolicyServiceID = "00000000-0000-0000-0000-000000000003"
 	ACLTemplatedPolicyNodeID    = "00000000-0000-0000-0000-000000000004"
 	ACLTemplatedPolicyDNSID     = "00000000-0000-0000-0000-000000000005"
-	ACLTemplatedPolicyDNSSchema = "" // empty schema as it does not require variables
+
+	ACLTemplatedPolicyNoRequiredVariablesSchema = "" // catch-all schema for all templated policy that don't require a schema
 )
 
 // ACLTemplatedPolicyBase contains basic information about builtin templated policies
@@ -63,7 +64,7 @@ var (
 		api.ACLTemplatedPolicyDNSName: {
 			TemplateID:   ACLTemplatedPolicyDNSID,
 			TemplateName: api.ACLTemplatedPolicyDNSName,
-			Schema:       ACLTemplatedPolicyDNSSchema,
+			Schema:       ACLTemplatedPolicyNoRequiredVariablesSchema,
 			Template:     ACLTemplatedPolicyDNS,
 		},
 	}

--- a/agent/structs/acl_templated_policy_ce.go
+++ b/agent/structs/acl_templated_policy_ce.go
@@ -5,40 +5,16 @@
 
 package structs
 
-const (
-	ACLTemplatedPolicyService = `
-service "{{.Name}}" {
-	policy = "write"
-}
-service "{{.Name}}-sidecar-proxy" {
-	policy = "write"
-}
-service_prefix "" {
-	policy = "read"
-}
-node_prefix "" {
-	policy = "read"
-}`
+import _ "embed"
 
-	ACLTemplatedPolicyNode = `
-node "{{.Name}}" {
-	policy = "write"
-}
-service_prefix "" {
-	policy = "read"
-}`
+//go:embed acltemplatedpolicy/policies/ce/service.hcl
+var ACLTemplatedPolicyService string
 
-	ACLTemplatedPolicyDNS = `
-node_prefix "" {
-	policy = "read"
-}
-service_prefix "" {
-	policy = "read"
-}
-query_prefix "" {
-	policy = "read"
-}`
-)
+//go:embed acltemplatedpolicy/policies/ce/node.hcl
+var ACLTemplatedPolicyNode string
+
+//go:embed acltemplatedpolicy/policies/ce/dns.hcl
+var ACLTemplatedPolicyDNS string
 
 func (t *ACLToken) TemplatedPolicyList() []*ACLTemplatedPolicy {
 	if len(t.TemplatedPolicies) == 0 {

--- a/agent/structs/acltemplatedpolicy/policies/ce/dns.hcl
+++ b/agent/structs/acltemplatedpolicy/policies/ce/dns.hcl
@@ -1,0 +1,10 @@
+
+node_prefix "" {
+	policy = "read"
+}
+service_prefix "" {
+	policy = "read"
+}
+query_prefix "" {
+	policy = "read"
+}

--- a/agent/structs/acltemplatedpolicy/policies/ce/node.hcl
+++ b/agent/structs/acltemplatedpolicy/policies/ce/node.hcl
@@ -1,0 +1,7 @@
+
+node "{{.Name}}" {
+	policy = "write"
+}
+service_prefix "" {
+	policy = "read"
+}

--- a/agent/structs/acltemplatedpolicy/policies/ce/service.hcl
+++ b/agent/structs/acltemplatedpolicy/policies/ce/service.hcl
@@ -1,0 +1,13 @@
+
+service "{{.Name}}" {
+	policy = "write"
+}
+service "{{.Name}}-sidecar-proxy" {
+	policy = "write"
+}
+service_prefix "" {
+	policy = "read"
+}
+node_prefix "" {
+	policy = "read"
+}

--- a/command/acl/templatedpolicy/formatter_test.go
+++ b/command/acl/templatedpolicy/formatter_test.go
@@ -42,7 +42,7 @@ func testFormatTemplatedPolicy(t *testing.T, dirPath string) {
 		"dns-templated-policy": {
 			templatedPolicy: api.ACLTemplatedPolicyResponse{
 				TemplateName: api.ACLTemplatedPolicyDNSName,
-				Schema:       structs.ACLTemplatedPolicyDNSSchema,
+				Schema:       structs.ACLTemplatedPolicyNoRequiredVariablesSchema,
 				Template:     structs.ACLTemplatedPolicyDNS,
 			},
 		},
@@ -94,7 +94,7 @@ func testFormatTemplatedPolicyList(t *testing.T, dirPath string) {
 		},
 		"builtin/dns": {
 			TemplateName: api.ACLTemplatedPolicyDNSName,
-			Schema:       structs.ACLTemplatedPolicyDNSSchema,
+			Schema:       structs.ACLTemplatedPolicyNoRequiredVariablesSchema,
 			Template:     structs.ACLTemplatedPolicyDNS,
 		},
 		"builtin/service": {

--- a/command/acl/templatedpolicy/list/templated_policy_list_test.go
+++ b/command/acl/templatedpolicy/list/templated_policy_list_test.go
@@ -98,5 +98,5 @@ func TestTemplatedPolicyListCommand_JSON(t *testing.T) {
 	err := json.Unmarshal([]byte(output), &jsonOutput)
 	assert.NoError(t, err)
 	outputTemplate := jsonOutput[api.ACLTemplatedPolicyDNSName]
-	assert.Equal(t, structs.ACLTemplatedPolicyDNSSchema, outputTemplate.Schema)
+	assert.Equal(t, structs.ACLTemplatedPolicyNoRequiredVariablesSchema, outputTemplate.Schema)
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
- keeping the templated policies in the `.go` was fine initially but we will be adding another 9 templates so removing them to a separate file for each template sounds like a good idea 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

- The CI tests should catch any unintended changes.
- You can also manually test with:
```
consul acl templated-policy read -name "builtin/service" -meta
```
