### PR TITLE
agent/config: prevent startup if resource-apis experiment and cloud are enabled

### DIFF
--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -575,3 +575,72 @@ func TestBuidler_hostMetricsWithCloud(t *testing.T) {
 	require.NotNil(t, cfg)
 	require.True(t, cfg.Telemetry.EnableHostMetrics)
 }
+
+func TestBuilder_WarnCloudConfigWithResourceApis(t *testing.T) {
+	tests := []struct {
+		name      string
+		hcl       string
+		expectErr bool
+		override  bool
+	}{
+		{
+			name: "base_case",
+			hcl:  ``,
+		},
+		{
+			name: "resource-apis_no_cloud",
+			hcl:  `experiments = ["resource-apis"]`,
+		},
+		{
+			name: "cloud-config_no_experiments",
+			hcl:  `cloud{ resource_id = "abc" client_id = "abc" client_secret = "abc"}`,
+		},
+		{
+			name: "cloud-config_resource-apis_experiment",
+			hcl: `
+			experiments = ["resource-apis"]
+			cloud{ resource_id = "abc" client_id = "abc" client_secret = "abc"}`,
+			expectErr: true,
+		},
+		{
+			name: "cloud-config_other_experiment",
+			hcl: `
+			experiments = ["test"]
+			cloud{ resource_id = "abc" client_id = "abc" client_secret = "abc"}`,
+		},
+		{
+			name: "cloud-config_resource-apis_experiment_override",
+			hcl: `
+			experiments = ["resource-apis"]
+			cloud{ resource_id = "abc" client_id = "abc" client_secret = "abc"}`,
+			override: true,
+		},
+	}
+	for _, tc := range tests {
+		// using dev mode skips the need for a data dir
+		devMode := true
+		builderOpts := LoadOpts{
+			DevMode: &devMode,
+			Overrides: []Source{
+				FileSource{
+					Name:   "overrides",
+					Format: "hcl",
+					Data:   tc.hcl,
+				},
+			},
+		}
+		if tc.override {
+			os.Setenv("CONSUL_OVERRIDE_HCP_RESOURCE_APIS_CHECK", "1")
+		}
+		_, err := Load(builderOpts)
+		if tc.override {
+			os.Unsetenv("CONSUL_OVERRIDE_HCP_RESOURCE_APIS_CHECK")
+		}
+		if tc.expectErr {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "cannot include 'resource-apis' when HCP")
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Prevents configuration that enabled the resource-apis experiment and includes cloud credentials for linking with HCP Consul.