### PR TITLE
docs: Remove YAML service registration examples

### DIFF
--- a/website/content/docs/connect/gateways/mesh-gateway/index.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/index.mdx
@@ -103,6 +103,17 @@ spec:
   meshGateway:
     mode: local
 ```
+
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "MeshGateway": {
+    "Mode": "local"
+  }
+}
+```
+
 </CodeTabs>
 
 ### Enabling Gateways Per Service
@@ -127,6 +138,16 @@ metadata:
 spec:
   meshGateway:
     mode: local
+```
+
+```json
+{
+  "Kind": "service-defaults",
+  "Name": "web",
+  "MeshGateway": {
+    "Mode": "local"
+  }
+}
 ```
 
 </CodeTabs>
@@ -167,7 +188,7 @@ service {
     sidecar_service {
       proxy {
         mesh_gateway {
-         mode = "remote"
+          mode = "remote"
         }
         upstreams = [
           {
@@ -182,19 +203,27 @@ service {
 }
 ```
 
-```yaml
-service:
-- kind: connect-proxy
-  name: web-sidecar-proxy
-  port: 8181
-  proxy:
-  - destination_service_name: web
-    mesh_gateway:
-    - mode: remote
-    upstreams:
-    - datacenter: secondary
-      destination_name: api
-      local_bind_port: 100
+```json
+{
+  "service": {
+    "kind": "connect-proxy",
+    "name": "web-sidecar-proxy",
+    "port": 8181,
+    "proxy": {
+      "destination_service_name": "web",
+      "mesh_gateway": {
+        "mode": "remote"
+      },
+      "upstreams": [
+        {
+          "destination_name": "api",
+          "datacenter": "secondary",
+          "local_bind_port": 10000
+        }
+      ]
+    }
+  }
+}
 ```
 
 </CodeTabs>
@@ -241,25 +270,39 @@ service {
   }
 }
 ```
-```yaml
-service:
-- kind: connect-proxy
-  name: web-sidecar-proxy
-  port: 8181
-  proxy:
-  - destination_service_name: web
-    upstreams:
-    - destination_name: api
-      local_bind_port: 10000
-      mesh_gateway:
-      - mode: remote
-    - destination_name: db
-      local_bind_port: 10001
-      mesh_gateway:
-      - mode: local
-    - destination_name: logging
-      local_bind_port: 10002
-      mesh_gateway:
-      - mode: none
-  ```
+```json
+{
+  "service": {
+    "kind": "connect-proxy",
+    "name": "web-sidecar-proxy",
+    "port": 8181,
+    "proxy": {
+      "destination_service_name": "web",
+      "upstreams": [
+        {
+          "destination_name": "api",
+          "local_bind_port": 10000,
+          "mesh_gateway": {
+            "mode": "remote"
+          }
+        },
+        {
+          "destination_name": "db",
+          "local_bind_port": 10001,
+          "mesh_gateway": {
+            "mode": "local"
+          }
+        },
+        {
+          "destination_name": "logging",
+          "local_bind_port": 10002,
+          "mesh_gateway": {
+            "mode": "none"
+          }
+        }
+      ]
+    }
+  }
+}
+```
   </CodeTabs>

--- a/website/content/docs/connect/gateways/mesh-gateway/service-to-service-traffic-partitions.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/service-to-service-traffic-partitions.mdx
@@ -98,6 +98,16 @@ spec:
     mode: local
 ```
 
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "MeshGateway": {
+    "Mode": "local"
+  }
+}
+```
+
 </CodeTabs>
 
 ### Enabling Gateways Per Service
@@ -123,6 +133,17 @@ spec:
   meshGateway:
     mode: local
 ```
+
+```json
+{
+  "Kind": "service-defaults",
+  "Name": "web",
+  "MeshGateway": {
+    "Mode": "local"
+  }
+}
+```
+
 </CodeTabs>
 
 ### Enabling Gateways for a Service Instance
@@ -130,7 +151,7 @@ spec:
 The following [proxy service configuration](/consul/docs/connect/proxies/deploy-service-mesh-proxies)
 enables gateways for `web` service instances in the `finance` partition.
 
-<CodeTabs heading="Example: Enabling gateways for a service instance.">
+<CodeTabs heading="Example: Enabling gateways for a service instance">
 
 ```hcl
 service {
@@ -155,21 +176,29 @@ service {
 }
 ```
 
-```yaml
-service:
-- kind: connect-proxy
-  name: web-sidecar-proxy
-  port: 8181
-  proxy:
-  - destination_service_name: web
-    mesh_gateway:
-    - mode: local
-    upstreams:
-    - destination_name: billing
-      destination_namespace: default
-      destination_partition: finance
-      destination_type: service
-      local_bind_port: 9090
+```json
+{
+  "service": {
+    "kind": "connect-proxy",
+    "name": "web-sidecar-proxy",
+    "port": 8181,
+    "proxy": {
+      "destination_service_name": "web",
+      "mesh_gateway": {
+        "mode": "local"
+      },
+      "upstreams": [
+        {
+          "destination_name": "billing",
+          "destination_namespace": "default",
+          "destination_partition": "finance",
+          "destination_type": "service",
+          "local_bind_port": 9090
+        }
+      ]
+    }
+  }
+}
 ```
 </CodeTabs>
 
@@ -177,7 +206,7 @@ service:
 
 The following service definition will enable gateways in `local` mode for three different partitions. Note that each service exists in the same namespace, but are separated by admin partition.
 
-<CodeTabs heading="Example: Enabling gateways for a proxy upstream.">
+<CodeTabs heading="Example: Enabling gateways for a proxy upstream">
 
 ```hcl
 service {
@@ -219,31 +248,45 @@ service {
 }
 ```
 
-```yaml
-service:
-- kind: connect-proxy
-  name: web-sidecar-proxy
-  port: 8181
-  proxy:
-  - destination_service_name: web
-    upstreams:
-    - destination_name: api
-      destination_namespace: dev
-      destination_partition: api
-      local_bind_port: 10000
-      mesh_gateway:
-      - mode: local
-    - destination_name: db
-      destination_namespace: dev
-      destination_partition: db
-      local_bind_port: 10001
-      mesh_gateway:
-      - mode: local
-    - destination_name: logging
-      destination_namespace: dev
-      destination_partition: logging
-      local_bind_port: 10002
-      mesh_gateway:
-      - mode: local
+```json
+{
+  "service": {
+    "kind": "connect-proxy",
+    "name": "web-sidecar-proxy",
+    "port": 8181,
+    "proxy": {
+      "destination_service_name": "web",
+      "upstreams": [
+        {
+          "destination_name": "api",
+          "destination_namespace": "dev",
+          "destination_partition": "api",
+          "local_bind_port": 10000,
+          "mesh_gateway": {
+            "mode": "local"
+          }
+        },
+        {
+          "destination_name": "db",
+          "destination_namespace": "dev",
+          "destination_partition": "db",
+          "local_bind_port": 10001,
+          "mesh_gateway": {
+            "mode": "local"
+          }
+        },
+        {
+          "destination_name": "logging",
+          "destination_namespace": "dev",
+          "destination_partition": "logging",
+          "local_bind_port": 10002,
+          "mesh_gateway": {
+            "mode": "local"
+          }
+        }
+      ]
+    }
+  }
+}
 ```
 </CodeTabs>

--- a/website/content/docs/connect/gateways/mesh-gateway/service-to-service-traffic-wan-datacenters.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/service-to-service-traffic-wan-datacenters.mdx
@@ -113,6 +113,16 @@ spec:
   meshGateway:
     mode: local
 ```
+
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "MeshGateway": {
+    "Mode": "local"
+  }
+}
+```
 </CodeTabs>
 
 ### Enabling Gateways Per Service
@@ -138,6 +148,15 @@ spec:
   meshGateway:
     mode: local
 ```
+
+```json
+{
+  "Kind": "service-defaults",
+  "Name": "web",
+  "MeshGateway": {
+    "Mode": "local"
+  }
+}
 
 </CodeTabs>
 
@@ -192,19 +211,27 @@ service {
 }
 ```
 
-```yaml
-service:
-- kind: connect-proxy
-  name: web-sidecar-proxy
-  port: 8181
-  proxy:
-  - destination_service_name: web
-    mesh_gateway:
-    - mode: remote
-    upstreams:
-    - datacenter: secondary
-      destination_name: api
-      local_bind_port: 100
+```json
+{
+  "service": {
+    "kind": "connect-proxy",
+    "name": "web-sidecar-proxy",
+    "port": 8181,
+    "proxy": {
+      "destination_service_name": "web",
+      "mesh_gateway": {
+        "mode": "remote"
+      },
+      "upstreams": [
+        {
+          "destination_name": "api",
+          "datacenter": "secondary",
+          "local_bind_port": 10000
+        }
+      ]
+    }
+  }
+}
 ```
 
 </CodeTabs>
@@ -248,25 +275,39 @@ service {
    }
 }
 ```
-```yaml
-service:
-- kind: connect-proxy
-  name: web-sidecar-proxy
-  port: 8181
-  proxy:
-  - destination_service_name: web
-    upstreams:
-    - destination_name: api
-      local_bind_port: 10000
-      mesh_gateway:
-      - mode: remote
-    - destination_name: db
-      local_bind_port: 10001
-      mesh_gateway:
-      - mode: local
-    - destination_name: logging
-      local_bind_port: 10002
-      mesh_gateway:
-      - mode: none
-  ```
-  </CodeTabs>
+```json
+{
+  "service": {
+    "kind": "connect-proxy",
+    "name": "web-sidecar-proxy",
+    "port": 8181,
+    "proxy": {
+      "destination_service_name": "web",
+      "upstreams": [
+        {
+          "destination_name": "api",
+          "local_bind_port": 10000,
+          "mesh_gateway": {
+            "mode": "remote"
+          }
+        },
+        {
+          "destination_name": "db",
+          "local_bind_port": 10001,
+          "mesh_gateway": {
+            "mode": "local"
+          }
+        },
+        {
+          "destination_name": "logging",
+          "local_bind_port": 10002,
+          "mesh_gateway": {
+            "mode": "none"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+</CodeTabs>

--- a/website/content/docs/services/usage/define-services.mdx
+++ b/website/content/docs/services/usage/define-services.mdx
@@ -110,26 +110,6 @@ service {
 }
 ```
 </CodeBlockConfig>
-<CodeBlockConfig heading="service.yaml">
-
-```yaml
-service:
-- id: redis
-  meta:
-  - custom_meta_key: custom_meta_value
-  name: redis
-  port: 80
-  tagged_addresses:
-  - lan:
-    - address: 192.168.0.55
-      port: 8000
-    wan:
-    - address: 198.18.0.23
-      port: 80
-  tags:
-  - primary
-```
-</CodeBlockConfig>
 </CodeTabs>
 
 ### Health checks
@@ -427,10 +407,12 @@ service {
 ```
 
 ```json
-"service": {
-  ## ...
-  "enable_tag_override": true,
-  ## ...
+{
+  "service": {
+    ## ...
+    "enable_tag_override": true,
+    ## ...
+  }
 }
 ```
 


### PR DESCRIPTION
### Description

Remove YAML service registration examples and replace them with JSON. This is because YAML is not a supported configuration format for the Consul's agent configuration, nor is it supported by the HTTP API.

This commit replaces the YAML examples with JSON and adds additional JSON examples where they were missing.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
