### PR TITLE
docs: Fix HCL, JSON, and YAML syntax errors

### DIFF
--- a/website/content/docs/connect/config-entries/control-plane-request-limit.mdx
+++ b/website/content/docs/connect/config-entries/control-plane-request-limit.mdx
@@ -41,30 +41,34 @@ When every field is defined, a control plane request limit configuration entry h
 
 ```hcl
 kind = "control-plane-request-limit"
-mode = "permissive"
 name = "<name-for-the-entry>"
+
+mode = "permissive"
+
 read_rate =  100
 write_rate = 100
+
 kv = {
   read_rate =  100
   write_rate = 100
-  }
+}
+
 acl = {
   read_rate =  100
   write_rate = 100
-mode = "permissive"
-  }
+}
+
 catalog = {
   read_rate =  100
   write_rate = 100
-  }
+}
 ```
 
 ```json
 {
   "kind": "control-plane-request-limit",
-  "mode": "permissive",
   "name": "<name-for-the-entry>",
+  "mode": "permissive",
   "read_rate":  100,
   "write_rate": 100,
   "kv": {
@@ -75,7 +79,7 @@ catalog = {
     "read_rate": 100,
     "write_rate": 100
     },
-  "catalog: {
+  "catalog": {
     "read_rate": 100,
     "write_rate": 100
   }

--- a/website/content/docs/connect/config-entries/jwt-provider.mdx
+++ b/website/content/docs/connect/config-entries/jwt-provider.mdx
@@ -132,74 +132,74 @@ Kind = "jwt-provider"                                # required
 Name = "<name-of-provider-configuration-entry>"      # required
 Issuer = "<jwt-issuer>"                              # required
 JSONWebKeySet = {                                    # required
-    Local = {                                        # cannot specify with JWKS{}.Remote
-        JWKS = "<JWKS-as-base64-string>"             # cannot specify with JWKS{}.Local{}.Filename
-        Filename = "<path/to/JWKS/file>"             # cannot specify with JWKS{}.Local{}.String
-    }
+  Local = {                                        # cannot specify with JWKS{}.Remote
+    JWKS = "<JWKS-as-base64-string>"             # cannot specify with JWKS{}.Local{}.Filename
+    Filename = "<path/to/JWKS/file>"             # cannot specify with JWKS{}.Local{}.String
+  }
 }
 JSONWebKeySet = {
-        Remote = {                                   # cannot specify with JWKS{}.Local
-          URI = "<uniform-resource-identifier>"
-          RequestTimeoutMs = 1500
-          CacheDuration = "5m"
-          FetchAsynchronously = false
-          RetryPolicy = {
-            NumRetries = 0
-            RetryPolicyBackoff = {
-              BaseInterval = "1s"
-              MaxInterval = "10s"
-            }
-          }
-          JWKSCluster = {
-            DiscoveryType = "STATIC"
-            ConnectTimeout = "10s"
-            # specify only one child: TrustedCA or CaCertificateProviderInstance
-            TLSCertificates = {
-              # specify only one child: Filename, EnvironmentVariable, InlineString or InlineBytes
-              TrustedCA = {
-                Filename = "<path/to/cert/file>"
-                EnvironmentVariable = "<env-variable>"
-                InlineString = "<inline-string>"
-                InlineBytes = "\302\000\302\302\302\302"
-              }
-            }
-            TLSCertificates = {
-              CaCertificateProviderInstance = {
-                InstanceName = "<instance-name>"
-                CertificateName = "<certificate-name>"
-              }
-            }
-          }
+  Remote = {                                   # cannot specify with JWKS{}.Local
+    URI = "<uniform-resource-identifier>"
+    RequestTimeoutMs = 1500
+    CacheDuration = "5m"
+    FetchAsynchronously = false
+    RetryPolicy = {
+      NumRetries = 0
+      RetryPolicyBackoff = {
+        BaseInterval = "1s"
+        MaxInterval = "10s"
+      }
+    }
+    JWKSCluster = {
+      DiscoveryType = "STATIC"
+      ConnectTimeout = "10s"
+      # specify only one child: TrustedCA or CaCertificateProviderInstance
+      TLSCertificates = {
+        # specify only one child: Filename, EnvironmentVariable, InlineString or InlineBytes
+        TrustedCA = {
+          Filename = "<path/to/cert/file>"
+          EnvironmentVariable = "<env-variable>"
+          InlineString = "<inline-string>"
+          InlineBytes = "\302\000\302\302\302\302"
         }
       }
+      TLSCertificates = {
+        CaCertificateProviderInstance = {
+          InstanceName = "<instance-name>"
+          CertificateName = "<certificate-name>"
+        }
+      }
+    }
+  }
+}
 
 Audiences = ["<aud-claims>"]
 Locations = [
-    {
-        Header = {
-            Name = "<name-of-header-with-token>"
-            ValuePrefix = "<prefix-in-header-before-token>"
-            Forward = false
-        }
-    },
-    {
-        QueryParam = {
-            Name = "<name-of-query-parameter-with-token>"
-        }
-    },
-    {
-        Cookie = {
-            Name = "<name-of-cookie-with-token>"
-        }
+  {
+    Header = {
+      Name = "<name-of-header-with-token>"
+      ValuePrefix = "<prefix-in-header-before-token>"
+      Forward = false
     }
+  },
+  {
+    QueryParam = {
+      Name = "<name-of-query-parameter-with-token>"
+    }
+  },
+  {
+    Cookie = {
+      Name = "<name-of-cookie-with-token>"
+    }
+  }
 ]
 Forwarding = {
-    HeaderName = "<name-appended-to-forwarding-header>"
-    PadForwardPayloadHeader = false
+  HeaderName = "<name-appended-to-forwarding-header>"
+  PadForwardPayloadHeader = false
 }
 ClockSkewSeconds = 30
 CacheConfig = {
-    Size = 0
+  Size = 0
 }
 ```
 

--- a/website/content/docs/connect/config-entries/jwt-provider.mdx
+++ b/website/content/docs/connect/config-entries/jwt-provider.mdx
@@ -209,77 +209,78 @@ CacheConfig = {
 
 ```json
 {
-"Kind": "jwt-provider",                               // required
-"Name": "<name-of-provider-configuration-entry>",     // required
-"Issuer": "<jwt-issuer>",                             // required
-"JSONWebKeySet": {                                    // required
+  "Kind": "jwt-provider",                               // required
+  "Name": "<name-of-provider-configuration-entry>",     // required
+  "Issuer": "<jwt-issuer>",                             // required
+  "JSONWebKeySet": {                                    // required
     "Local": {                                        // cannot specify with JWKS.Remote
-        "JWKS": "<JWKS-as-base64-string>",            // cannot specify with JWKS.Local.Filename
-        "Filename": "<path/to/JWKS/file>"             // cannot specify with JWKS.Local.String
+      "JWKS": "<JWKS-as-base64-string>",            // cannot specify with JWKS.Local.Filename
+      "Filename": "<path/to/JWKS/file>"             // cannot specify with JWKS.Local.String
     }
-},
-"JSONWebKeySet": {
-        "Remote": {                                   // cannot specify with JWKS.Local
-          "URI": "<uniform-resource-identifier>",
-          "RequestTimeoutMs": "1500",
-          "CacheDuration": "5m",
-          "FetchAsynchronously": "false",
-          "RetryPolicy": {
-            "NumRetries": "0",
-            "RetryPolicyBackOff": {
-              "BaseInterval": "1s",
-              "MaxInterval": "10s"
-            }
+  },
+  "JSONWebKeySet": {
+    "Remote": {                                   // cannot specify with JWKS.Local
+      "URI": "<uniform-resource-identifier>",
+      "RequestTimeoutMs": "1500",
+      "CacheDuration": "5m",
+      "FetchAsynchronously": "false",
+      "RetryPolicy": {
+        "NumRetries": "0",
+        "RetryPolicyBackOff": {
+          "BaseInterval": "1s",
+          "MaxInterval": "10s"
+        }
+      },
+      "JWKSCluster": {
+        "DiscoveryType": "STATIC",
+        "ConnectTimeout": "10s",
+        // specify only one child: TrustedCA or CaCertificateProviderInstance
+        "TLSCertificates": {
+          // specify only one child: Filename, EnvironmentVariable, InlineString or InlineBytes
+          "TrustedCA": {
+            "Filename": "<path/to/cert/file>",
+            "EnvironmentVariable": "<env-variable>",
+            "InlineString": "<inline-string>",
+            "InlineBytes": "\302\000\302\302\302\302"
           },
-          "JWKSCluster": {
-            "DiscoveryType": "STATIC",
-            "ConnectTimeout": "10s",
-            // specify only one child: TrustedCA or CaCertificateProviderInstance
-            "TLSCertificates": {
-              // specify only one child: Filename, EnvironmentVariable, InlineString or InlineBytes
-              "TrustedCA": {
-                "Filename": "<path/to/cert/file>",
-                "EnvironmentVariable": "<env-variable>",
-                "InlineString": "<inline-string>",
-                "InlineBytes": "\302\000\302\302\302\302"
-            },
-            "TLSCertificates": {
-              "CaCertificateProviderInstance": {
-                "InstanceName": "<instance-name>",
-                "CertificateName": "<certificate-name>"
-              }
-            }
+        },
+        "TLSCertificates": {
+          "CaCertificateProviderInstance": {
+            "InstanceName": "<instance-name>",
+            "CertificateName": "<certificate-name>"
           }
         }
-},
-"Audiences": ["<aud-claims>"],
-"Locations": [
-    {
-        "Header": {
-            "Name": "<name-of-header-with-token>",
-            "ValuePrefix": "<prefix-in-header-before-token>",
-            "Forward": "false"
-        }
-    },
-    {
-        "QueryParam": {
-            "Name":"<name-of-query-parameter-with-token>",
-        }
-    },
-    {
-        "Cookie": {
-            "Name": "<name-of-cookie-with-token>"
-        }
+      }
     }
-],
-"Forwarding": {
+  },
+  "Audiences": ["<aud-claims>"],
+  "Locations": [
+    {
+      "Header": {
+        "Name": "<name-of-header-with-token>",
+        "ValuePrefix": "<prefix-in-header-before-token>",
+        "Forward": "false"
+      }
+    },
+    {
+      "QueryParam": {
+        "Name":"<name-of-query-parameter-with-token>",
+      }
+    },
+    {
+      "Cookie": {
+        "Name": "<name-of-cookie-with-token>"
+      }
+    }
+  ],
+  "Forwarding": {
     "HeaderName": "<name-appended-to-forwarding-header>",
     "PadForwardPayloadHeader": "false"
-},
-"ClockSkewSeconds": "30",
-"CacheConfig": {
+  },
+  "ClockSkewSeconds": "30",
+  "CacheConfig": {
     "Size": "0"
-}
+  }
 }
 ```
 

--- a/website/content/docs/connect/proxies/envoy-extensions/configuration/property-override.mdx
+++ b/website/content/docs/connect/proxies/envoy-extensions/configuration/property-override.mdx
@@ -177,16 +177,16 @@ EnvoyExtensions = [
       ProxyType = "connect-proxy",
       Patches = [
         {
-          "ResourceFilter" = {
-            "ResourceType" = "cluster",
-            "TrafficDirection" = "outbound",
-            "Service" = {
-              "Name" = "other-svc"
-            },
-          },
-          "Op" = "add",
-          "Path" =  "/respect_dns_ttl",
-          "Value" = true,
+          ResourceFilter = {
+            ResourceType = "cluster"
+            TrafficDirection = "outbound"
+            Service = {
+              Name = "other-svc"
+            }
+          }
+          Op = "add"
+          Path =  "/respect_dns_ttl"
+          Value = true
         }
       ]
     }

--- a/website/content/docs/k8s/connect/transparent-proxy/enable-transparent-proxy.mdx
+++ b/website/content/docs/k8s/connect/transparent-proxy/enable-transparent-proxy.mdx
@@ -43,8 +43,8 @@ connectInject:
 
 Apply the `consul.hashicorp.com/transparent-proxy=true` label to enable transparent proxy for a Kubernetes namespace. The label overrides the `connectInject.transparentProxy.defaultEnabled` Helm value and defines the default behavior of Pods in the namespace. The following example enables transparent proxy for Pods in the `my-app` namespace:
 
-```bash
-kubectl label namespaces my-app "consul.hashicorp.com/transparent-proxy=true"
+```shell-session
+$ kubectl label namespaces my-app "consul.hashicorp.com/transparent-proxy=true"
 ```
 ### Individual service
 

--- a/website/content/docs/k8s/connect/transparent-proxy/enable-transparent-proxy.mdx
+++ b/website/content/docs/k8s/connect/transparent-proxy/enable-transparent-proxy.mdx
@@ -121,12 +121,11 @@ The [`consul.hashicorp.com/transparent-proxy-exclude-inbound-ports`](/consul/doc
 <CodeBlockConfig heading="Exclude inbound port numbers from redirection">
 
 ```yaml
-"metadata": {
-  "annotations": {
-    "consul.hashicorp.com/transparent-proxy-exclude-inbound-ports" : "8200, 8201”
-  }
-}
+metadata:
+  annotations:
+    consul.hashicorp.com/transparent-proxy-exclude-inbound-ports: "8200, 8201"
 ```
+
 </CodeBlockConfig>
 
 ### Exclude outbound ports
@@ -136,11 +135,9 @@ The [`consul.hashicorp.com/transparent-proxy-exclude-outbound-ports`](/consul/do
 <CodeBlockConfig heading="Exclude outbound port numbers from redirection">
 
 ```yaml
-"metadata": {
-  "annotations": {
-    "consul.hashicorp.com/transparent-proxy-exclude-outbound-ports" : "8200, 8201”
-  }
-}
+metadata:
+  annotations":
+    consul.hashicorp.com/transparent-proxy-exclude-outbound-ports: "8200, 8201"
 ```
 
 </CodeBlockConfig>
@@ -154,11 +151,9 @@ In the following example, services in the `3.3.3.3/24` IP range are not redirect
 <CodeBlockConfig heading="Exclude outbound CIDR blocks from redirection">
 
 ```yaml
-"metadata": {
-  "annotations": {
-    "consul.hashicorp.com/transparent-proxy-exclude-outbound-cidrs" : "3.3.3.3,3.3.3.3/24"
-  }
-}
+metadata:
+  annotations:
+    consul.hashicorp.com/transparent-proxy-exclude-outbound-cidrs: "3.3.3.3,3.3.3.3/24"
 ```
 </CodeBlockConfig>
 
@@ -171,9 +166,9 @@ In the following example, services with the IDs `4444 ` and `44444 ` are not red
 <CodeBlockConfig heading="Exclude user IDs from redirection">
 
 ```yaml
-"metadata": {
-  "annotations": {
-    "consul.hashicorp.com/transparent-proxy-exclude-uids" : "4444,44444”
+metadata:
+  annotations:
+    consul.hashicorp.com/transparent-proxy-exclude-uids: "4444,44444"
   }
 }
 ```
@@ -201,7 +196,7 @@ then you must configure services in one Kubernetes cluster to explicitly dial a 
 The following example configures the service to dial an upstream service called `my-service` in datacenter `dc2` on port `1234`:
 
 ```yaml
-  "consul.hashicorp.com/connect-service-upstreams": "my-service:1234:dc2"
+consul.hashicorp.com/connect-service-upstreams: "my-service:1234:dc2"
 ```
 
 If your Consul cluster is deployed to a [single datacenter spanning multiple Kubernetes clusters](/consul/docs/k8s/deployment-configurations/single-dc-multi-k8s),
@@ -210,7 +205,7 @@ then you must configure services in one Kubernetes cluster to explicitly dial a 
 The following example configures the service to dial an upstream service called `my-service` in another Kubernetes cluster on port `1234`:
 
 ```yaml
-"consul.hashicorp.com/connect-service-upstreams": "my-service:1234"
+consul.hashicorp.com/connect-service-upstreams: "my-service:1234"
 ```
 
 You do not need to configure services to explicitly dial upstream services if your Consul clusters are connected with a [peering connection](/consul/docs/connect/cluster-peering).

--- a/website/content/docs/nia/cli/task.mdx
+++ b/website/content/docs/nia/cli/task.mdx
@@ -34,7 +34,7 @@ task_example.hcl:
 task {
   name           = "task_a"
   description    = ""
-  enabled        = true,
+  enabled        = true
   providers      = []
   module         = "org/example/module"
   version        = "1.0.0"

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -277,7 +277,7 @@ A `task` block configures which task to execute in automation. Use  the `conditi
 task {
   name           = "taskA"
   description    = ""
-  enabled        = true,
+  enabled        = true
   providers      = []
   module         = "org/example/module"
   version        = "1.0.0"


### PR DESCRIPTION
### Description

This commit fixes syntax errors in HCL, JSON, and YAML example configurations. In some cases, it replaces the code example with the proper format for the code block.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
