### PR TITLE
Fix code block examples on dns-static-lookups.mdx

### DIFF
--- a/website/content/docs/services/discovery/dns-static-lookups.mdx
+++ b/website/content/docs/services/discovery/dns-static-lookups.mdx
@@ -239,6 +239,8 @@ If a service registered with Consul is configured with an explicit IP address or
 
 In the following example, the `rabbitmq` service is registered with an explicit IPv4 address of `192.0.2.10`.
 
+<CodeTabs>
+
 ```hcl
 node_name = "node1"
 
@@ -247,6 +249,9 @@ services {
   address = "192.0.2.10"
   port = 5672
 }
+```
+
+```json
 {
   "node_name": "node1",
   "services": [
@@ -258,6 +263,8 @@ services {
   ]
 }
 ```
+
+</CodeTabs>
 
 The following example SRV query response contains a single record with a hostname written as a hexadecimal value:
 
@@ -275,6 +282,8 @@ $ echo -n "c000020a" | perl -ne 'printf("%vd\n", pack("H*", $_))'
 
 In the following example, the `rabbitmq` service is registered with an explicit IPv6 address of `2001:db8:1:2:cafe::1337`.
 
+<CodeTabs>
+
 ```hcl
 node_name = "node1"
 
@@ -283,6 +292,9 @@ services {
   address = "2001:db8:1:2:cafe::1337"
   port = 5672
 }
+```
+
+```json
 {
   "node_name": "node1",
   "services": [
@@ -294,6 +306,8 @@ services {
   ]
 }
 ```
+
+</CodeTabs>
 
 The following example SRV query response contains a single record with a hostname written as a hexadecimal value:
 

--- a/website/content/docs/services/discovery/dns-static-lookups.mdx
+++ b/website/content/docs/services/discovery/dns-static-lookups.mdx
@@ -234,7 +234,7 @@ _redis._tcp.service.phx1.peer.consul. 0 IN SRV 1 1 29142 0a010d56.addr.consul.
 If a service registered with Consul is configured with an explicit IP address or addresses in the  [`address`](/consul/docs/services/configuration/services-configuration-reference#address) or [`tagged_address`](/consul/docs/services/configuration/services-configuration-reference#tagged_address) parameter, then Consul returns the hostname in the target field of the answer section for the DNS SRV query according to the following format:
 
 ```text
-<hexadecimal-encoded IP>.addr.<datacenter>.consul`.
+<hexadecimal-encoded IP>.addr.<datacenter>.consul.
 ```
 
 In the following example, the `rabbitmq` service is registered with an explicit IPv4 address of `192.0.2.10`.


### PR DESCRIPTION
### Description

HCL and JSON configuration examples were being displayed in the same code block. This commit separates the configurations to properly display them as independent configuration examples.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
