### PR TITLE
Honor Default Traffic Permissions in V2

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -657,13 +657,8 @@ func (a *Agent) Start(ctx context.Context) error {
 	// Create proxy config manager now because it is a dependency of creating the proxyWatcher
 	// which will be passed to consul.NewServer so that it is then passed to the
 	// controller registration for the XDS controller in v2 mode, and the xds server in v1 and v2 mode.
-	var intentionDefaultAllow bool
-	switch a.config.ACLResolverSettings.ACLDefaultPolicy {
-	case "allow":
-		intentionDefaultAllow = true
-	case "deny":
-		intentionDefaultAllow = false
-	default:
+	intentionDefaultAllow, err := a.config.ACLResolverSettings.IsDefaultAllow()
+	if err != nil {
 		return fmt.Errorf("unexpected ACL default policy value of %q", a.config.ACLResolverSettings.ACLDefaultPolicy)
 	}
 

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -221,6 +221,17 @@ type ACLResolverSettings struct {
 	ACLDefaultPolicy string
 }
 
+func (s ACLResolverSettings) IsDefaultAllow() (bool, error) {
+	switch s.ACLDefaultPolicy {
+	case "allow":
+		return true, nil
+	case "deny":
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected ACL default policy value of %q", s.ACLDefaultPolicy)
+	}
+}
+
 // ACLResolver is the type to handle all your token and policy resolution needs.
 //
 // Supports:

--- a/internal/auth/internal/types/computed_traffic_permissions.go
+++ b/internal/auth/internal/types/computed_traffic_permissions.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	ComputedTrafficPermissionsKind = "ComputedTrafficPermission"
+	ComputedTrafficPermissionsKind = "ComputedTrafficPermissions"
 )
 
 var (

--- a/internal/mesh/internal/controllers/register.go
+++ b/internal/mesh/internal/controllers/register.go
@@ -21,6 +21,7 @@ import (
 type Dependencies struct {
 	TrustDomainFetcher sidecarproxy.TrustDomainFetcher
 	LocalDatacenter    string
+	DefaultAllow       bool
 	TrustBundleFetcher xds.TrustBundleFetcher
 	ProxyUpdater       xds.ProxyUpdater
 	LeafCertManager    *leafcert.Manager
@@ -44,7 +45,7 @@ func Register(mgr *controller.Manager, deps Dependencies) {
 		m                   = sidecarproxymapper.New(destinationsCache, proxyCfgCache, computedRoutesCache, identitiesCache)
 	)
 	mgr.Register(
-		sidecarproxy.Controller(destinationsCache, proxyCfgCache, computedRoutesCache, identitiesCache, m, deps.TrustDomainFetcher, deps.LocalDatacenter),
+		sidecarproxy.Controller(destinationsCache, proxyCfgCache, computedRoutesCache, identitiesCache, m, deps.TrustDomainFetcher, deps.LocalDatacenter, deps.DefaultAllow),
 	)
 
 	mgr.Register(routes.Controller())

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/builder.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/builder.go
@@ -16,6 +16,7 @@ type Builder struct {
 	proxyCfg           *pbmesh.ProxyConfiguration
 	trustDomain        string
 	localDatacenter    string
+	defaultAllow       bool
 }
 
 func New(
@@ -23,12 +24,14 @@ func New(
 	identity *pbresource.Reference,
 	trustDomain string,
 	dc string,
+	defaultAllow bool,
 	proxyCfg *pbmesh.ProxyConfiguration,
 ) *Builder {
 	return &Builder{
 		id:              id,
 		trustDomain:     trustDomain,
 		localDatacenter: dc,
+		defaultAllow:    defaultAllow,
 		proxyCfg:        proxyCfg,
 		proxyStateTemplate: &pbmesh.ProxyStateTemplate{
 			ProxyState: &pbmesh.ProxyState{
@@ -55,6 +58,7 @@ func (b *Builder) Build() *pbmesh.ProxyStateTemplate {
 	b.proxyStateTemplate.RequiredTrustBundles[b.id.Tenancy.PeerName] = &pbproxystate.TrustBundleRef{
 		Peer: b.id.Tenancy.PeerName,
 	}
+	b.proxyStateTemplate.ProxyState.TrafficPermissionDefaultAllow = b.defaultAllow
 
 	return b.proxyStateTemplate
 }

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destination_builder_multiport_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destination_builder_multiport_test.go
@@ -210,7 +210,7 @@ func TestBuildMultiportImplicitDestinations(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), trustDomain, datacenter, proxyCfg).
+			proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), trustDomain, datacenter, false, proxyCfg).
 				BuildDestinations(c.getDestinations()).
 				Build()
 

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destination_builder_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destination_builder_test.go
@@ -243,7 +243,7 @@ func TestBuildExplicitDestinations(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), "foo.consul", "dc1", nil).
+			proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), "foo.consul", "dc1", false, nil).
 				BuildDestinations(c.destinations).
 				Build()
 
@@ -360,7 +360,7 @@ func TestBuildImplicitDestinations(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), "foo.consul", "dc1", proxyCfg).
+			proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), "foo.consul", "dc1", false, proxyCfg).
 				BuildDestinations(c.destinations).
 				Build()
 

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/local_app_multiport_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/local_app_multiport_test.go
@@ -88,7 +88,7 @@ func TestBuildLocalApp_Multiport(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), "foo.consul", "dc1", nil).
+			proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), "foo.consul", "dc1", false, nil).
 				BuildLocalApp(c.workload, nil).
 				Build()
 

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/local_app_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/local_app_test.go
@@ -21,8 +21,9 @@ import (
 
 func TestBuildLocalApp(t *testing.T) {
 	cases := map[string]struct {
-		workload *pbcatalog.Workload
-		ctp      *pbauth.ComputedTrafficPermissions
+		workload     *pbcatalog.Workload
+		ctp          *pbauth.ComputedTrafficPermissions
+		defaultAllow bool
 	}{
 		"source/l4-single-workload-address-without-ports": {
 			workload: &pbcatalog.Workload{
@@ -83,12 +84,13 @@ func TestBuildLocalApp(t *testing.T) {
 					},
 				},
 			},
+			defaultAllow: true,
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), "foo.consul", "dc1", nil).
+			proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), "foo.consul", "dc1", c.defaultAllow, nil).
 				BuildLocalApp(c.workload, c.ctp).
 				Build()
 			actual := protoToJSON(t, proxyTmpl)

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/l4-multiple-workload-addresses-with-specific-ports.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/l4-multiple-workload-addresses-with-specific-ports.golden
@@ -74,7 +74,8 @@
           }
         ]
       }
-    ]
+    ],
+    "trafficPermissionDefaultAllow": true
   },
   "requiredLeafCertificates": {
     "test-identity": {

--- a/internal/mesh/internal/controllers/sidecarproxy/controller.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/controller.go
@@ -35,6 +35,7 @@ func Controller(
 	mapper *sidecarproxymapper.Mapper,
 	trustDomainFetcher TrustDomainFetcher,
 	dc string,
+	defaultAllow bool,
 ) controller.Controller {
 	if destinationsCache == nil || proxyCfgCache == nil || computedRoutesCache == nil || identitiesCache == nil || mapper == nil || trustDomainFetcher == nil {
 		panic("destinations cache, proxy configuration cache, computed routes cache, identities cache, mapper, and trust domain fetcher are required")
@@ -99,6 +100,7 @@ func Controller(
 			identitiesCache:     identitiesCache,
 			getTrustDomain:      trustDomainFetcher,
 			dc:                  dc,
+			defaultAllow:        defaultAllow,
 		})
 }
 
@@ -108,6 +110,7 @@ type reconciler struct {
 	computedRoutesCache *sidecarproxycache.ComputedRoutesCache
 	identitiesCache     *sidecarproxycache.IdentitiesCache
 	getTrustDomain      TrustDomainFetcher
+	defaultAllow        bool
 	dc                  string
 }
 
@@ -194,7 +197,7 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 		ctp = trafficPermissions.Data
 	}
 
-	b := builder.New(req.ID, identityRefFromWorkload(workload), trustDomain, r.dc, proxyCfg).
+	b := builder.New(req.ID, identityRefFromWorkload(workload), trustDomain, r.dc, r.defaultAllow, proxyCfg).
 		BuildLocalApp(workload.Data, ctp)
 
 	// Get all destinationsData.

--- a/internal/resource/resourcetest/decode.go
+++ b/internal/resource/resourcetest/decode.go
@@ -4,8 +4,6 @@
 package resourcetest
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -13,8 +11,8 @@ import (
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
-func MustDecode[T proto.Message](t *testing.T, res *pbresource.Resource) *resource.DecodedResource[T] {
-	dec, err := resource.Decode[T](res)
+func MustDecode[Tp proto.Message](t T, res *pbresource.Resource) *resource.DecodedResource[Tp] {
+	dec, err := resource.Decode[Tp](res)
 	require.NoError(t, err)
 	return dec
 }


### PR DESCRIPTION
### Description

This PR wires up default traffic permissions in v2.

### Testing & Reproduction steps
* Unit tests
* Manual testing

### PR Checklist

* [X] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
