### PR TITLE
Add operator audit endpoint changes

### DIFF
--- a/api/operator_audit.go
+++ b/api/operator_audit.go
@@ -1,0 +1,40 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// The /v1/operator/audit-hash endpoint is available only in Consul Enterprise and
+// interact with its audit logging subsystem.
+
+package api
+
+type AuditHashRequest struct {
+	Input string
+}
+
+type AuditHashResponse struct {
+	Hash string
+}
+
+func (op *Operator) AuditHash(a *AuditHashRequest, q *QueryOptions) (*AuditHashResponse, error) {
+	r := op.c.newRequest("POST", "/v1/operator/audit-hash")
+	r.setQueryOptions(q)
+	r.obj = a
+
+	rtt, resp, err := op.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+	if err := requireOK(resp); err != nil {
+		return nil, err
+	}
+
+	wm := &WriteMeta{}
+	wm.RequestTime = rtt
+
+	var out AuditHashResponse
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
- Api feature parity for 1.16.x following [example of operator-area ](https://github.com/hashicorp/consul/blob/main/api/operator_area.go) 
