### PR TITLE
resource: ensure resource.AuthorizerContext properly strips the local…

### DIFF
--- a/internal/resource/authz.go
+++ b/internal/resource/authz.go
@@ -1,0 +1,20 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resource
+
+func peerNameV2ToV1(peer string) string {
+	// The name of the local/default peer is different between v1 and v2.
+	if peer == "local" {
+		return ""
+	}
+	return peer
+}
+
+func peerNameV1ToV2(peer string) string {
+	// The name of the local/default peer is different between v1 and v2.
+	if peer == "" {
+		return "local"
+	}
+	return peer
+}

--- a/internal/resource/authz_ce.go
+++ b/internal/resource/authz_ce.go
@@ -13,5 +13,7 @@ import (
 
 // AuthorizerContext builds an ACL AuthorizerContext for the given tenancy.
 func AuthorizerContext(t *pbresource.Tenancy) *acl.AuthorizerContext {
-	return &acl.AuthorizerContext{Peer: t.PeerName}
+	return &acl.AuthorizerContext{
+		Peer: peerNameV2ToV1(t.PeerName),
+	}
 }

--- a/internal/resource/authz_ce_test.go
+++ b/internal/resource/authz_ce_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !consulent
+// +build !consulent
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+func TestAuthorizerContext_CE(t *testing.T) {
+	t.Run("no peer", func(t *testing.T) {
+		require.Equal(t,
+			&acl.AuthorizerContext{},
+			AuthorizerContext(&pbresource.Tenancy{
+				Partition: "foo",
+				Namespace: "bar",
+			}),
+		)
+	})
+
+	t.Run("with local peer", func(t *testing.T) {
+		require.Equal(t,
+			&acl.AuthorizerContext{},
+			AuthorizerContext(&pbresource.Tenancy{
+				Partition: "foo",
+				Namespace: "bar",
+				PeerName:  "local",
+			}),
+		)
+	})
+
+	t.Run("with non-local peer", func(t *testing.T) {
+		require.Equal(t,
+			&acl.AuthorizerContext{
+				Peer: "remote",
+			},
+			AuthorizerContext(&pbresource.Tenancy{
+				Partition: "foo",
+				Namespace: "bar",
+				PeerName:  "remote",
+			}),
+		)
+	})
+}


### PR DESCRIPTION
### Description

When turning a `pbresource.Tenancy` in the v2 system into a `acl.AuthorizerContext` in the v1 system we have to ensure that we convert the v2 notion of local peer (`"local"`) into a v1 notion of local peer (`""`) to avoid having the ACL system thing we are making an inquiry about a remote peer named `"local"` which causes a completely different authz evaluation to occur.
