### PR TITLE
catalog: add ACL checks for FailoverPolicy resources

### DIFF
--- a/internal/catalog/internal/types/failover_policy_test.go
+++ b/internal/catalog/internal/types/failover_policy_test.go
@@ -4,7 +4,6 @@
 package types
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -728,8 +727,6 @@ func TestFailoverPolicyACLs(t *testing.T) {
 			checkF(t, tc.readOK, err)
 		})
 		t.Run("write", func(t *testing.T) {
-			fmt.Printf("write start\n")
-			defer fmt.Printf("write end\n")
 			err := aclWriteHookFailoverPolicy(authz, &acl.AuthorizerContext{}, res)
 			checkF(t, tc.writeOK, err)
 		})

--- a/internal/catalog/internal/types/failover_policy_test.go
+++ b/internal/catalog/internal/types/failover_policy_test.go
@@ -4,12 +4,15 @@
 package types
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
@@ -653,6 +656,113 @@ func TestSimplifyFailoverPolicy(t *testing.T) {
 					},
 				}).
 				Build(),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestFailoverPolicyACLs(t *testing.T) {
+	type testcase struct {
+		rules   string
+		check   func(t *testing.T, authz acl.Authorizer, res *pbresource.Resource)
+		readOK  string
+		writeOK string
+		listOK  string
+	}
+
+	const (
+		DENY    = "deny"
+		ALLOW   = "allow"
+		DEFAULT = "default"
+	)
+
+	checkF := func(t *testing.T, expect string, got error) {
+		switch expect {
+		case ALLOW:
+			if acl.IsErrPermissionDenied(got) {
+				t.Fatal("should be allowed")
+			}
+		case DENY:
+			if !acl.IsErrPermissionDenied(got) {
+				t.Fatal("should be denied")
+			}
+		case DEFAULT:
+			require.Nil(t, got, "expected fallthrough decision")
+		default:
+			t.Fatalf("unexpected expectation: %q", expect)
+		}
+	}
+
+	run := func(t *testing.T, tc testcase) {
+		failoverData := &pbcatalog.FailoverPolicy{
+			Config: &pbcatalog.FailoverConfig{
+				Destinations: []*pbcatalog.FailoverDestination{
+					{Ref: newRef(ServiceType, "api-backup")},
+				},
+			},
+		}
+		res := resourcetest.Resource(FailoverPolicyType, "api").
+			WithTenancy(resource.DefaultNamespacedTenancy()).
+			WithData(t, failoverData).
+			Build()
+
+		err := MutateFailoverPolicy(res)
+		require.NoError(t, err)
+		err = ValidateFailoverPolicy(res)
+		require.NoError(t, err)
+
+		config := acl.Config{
+			WildcardName: structs.WildcardSpecifier,
+		}
+		authz, err := acl.NewAuthorizerFromRules(tc.rules, &config, nil)
+		require.NoError(t, err)
+		authz = acl.NewChainedAuthorizer([]acl.Authorizer{authz, acl.DenyAll()})
+
+		t.Run("read", func(t *testing.T) {
+			err := aclReadHookFailoverPolicy(authz, &acl.AuthorizerContext{}, res.Id)
+			checkF(t, tc.readOK, err)
+		})
+		t.Run("write", func(t *testing.T) {
+			fmt.Printf("write start\n")
+			defer fmt.Printf("write end\n")
+			err := aclWriteHookFailoverPolicy(authz, &acl.AuthorizerContext{}, res)
+			checkF(t, tc.writeOK, err)
+		})
+		t.Run("list", func(t *testing.T) {
+			err := aclListHookFailoverPolicy(authz, &acl.AuthorizerContext{})
+			checkF(t, tc.listOK, err)
+		})
+	}
+
+	cases := map[string]testcase{
+		"no rules": {
+			rules:   ``,
+			readOK:  DENY,
+			writeOK: DENY,
+			listOK:  DEFAULT,
+		},
+		"service api read": {
+			rules:   `service "api" { policy = "read" }`,
+			readOK:  ALLOW,
+			writeOK: DENY,
+			listOK:  DEFAULT,
+		},
+		"service api write": {
+			rules:   `service "api" { policy = "write" }`,
+			readOK:  ALLOW,
+			writeOK: DENY,
+			listOK:  DEFAULT,
+		},
+		"service api write and api-backup read": {
+			rules:   `service "api" { policy = "write" } service "api-backup" { policy = "read" }`,
+			readOK:  ALLOW,
+			writeOK: ALLOW,
+			listOK:  DEFAULT,
 		},
 	}
 


### PR DESCRIPTION
### Description

FailoverPolicy resources are name-aligned with the Service they control. They also contain a list of possible failover destinations that are References to other Services.

The ACLs should be:
- list: (default)
- read: `service:<resource_name>:read`
- write: `service:<resource_name>:write` + `service:<destination_name>:read` (for any destination)

NET-5058
