### PR TITLE
Fix create dns token docs

### DIFF
--- a/website/content/docs/security/acl/tokens/create/create-a-dns-token.mdx
+++ b/website/content/docs/security/acl/tokens/create/create-a-dns-token.mdx
@@ -170,6 +170,13 @@ The following example policy is defined in a file. The policy grants the appropr
 <CodeTabs>
 
 ```hcl
+partition "default" {
+	namespace "default" {
+		query_prefix "" {
+			policy = "read"
+		}
+	}
+}
 partition_prefix "" {
   namespace_prefix "" {
     node_prefix "" {
@@ -178,25 +185,30 @@ partition_prefix "" {
     service_prefix "" {
       policy = "read"
     }
-    query_prefix "" {
-      policy = "read"
-    }
   }
 }
 ```
 
 ```json
 {
+  "partition": {
+    "default": [{
+      "namespace": {
+        "default": [{
+          "query_prefix": {
+            "": [{
+              "policy": "read"
+            }]
+          }
+        }]
+      }
+    }]
+  },
   "partition_prefix": {
     "": [{
       "namespace_prefix": {
         "": [{
           "node_prefix": {
-            "": [{
-              "policy": "read"
-            }]
-          },
-          "query_prefix": {
             "": [{
               "policy": "read"
             }]


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

- Fixing the policy used in enterprise for creating a dns token
