### PR TITLE
Fix for loop in filter_changed_files_go_test script

### DIFF
--- a/.github/scripts/filter_changed_files_go_test.sh
+++ b/.github/scripts/filter_changed_files_go_test.sh
@@ -21,7 +21,6 @@ skipped_directories=("docs/" "ui/" "website/" "grafana/")
 # Loop through the changed files and find directories/files outside the skipped ones
 for file_to_check in "${files_to_check[@]}"; do
 	file_is_skipped=false
-	echo $file_to_check
 	for dir in "${skipped_directories[@]}"; do
 		if [[ "$file_to_check" == "$dir"* ]] || [[ "$file_to_check" == *.md && "$dir" == *"/" ]]; then
 			file_is_skipped=true

--- a/.github/scripts/filter_changed_files_go_test.sh
+++ b/.github/scripts/filter_changed_files_go_test.sh
@@ -19,8 +19,9 @@ files_to_check=$(git diff --name-only "$(git merge-base origin/$SKIP_CHECK_BRANC
 skipped_directories=("docs/" "ui/" "website/" "grafana/")
 
 # Loop through the changed files and find directories/files outside the skipped ones
-for file_to_check in $files_to_check; do
+for file_to_check in "${files_to_check[@]}"; do
 	file_is_skipped=false
+	echo $file_to_check
 	for dir in "${skipped_directories[@]}"; do
 		if [[ "$file_to_check" == "$dir"* ]] || [[ "$file_to_check" == *.md && "$dir" == *"/" ]]; then
 			file_is_skipped=true


### PR DESCRIPTION
### Description

Fix bug in `.github/scripts/filter_changed_files_go_test.sh` script. Update the script with the correct code for for loop. It currently only checks first file, iterate step to check all changed files. See original [PR](https://github.com/hashicorp/consul/pull/18851)

### Testing & Reproduction steps

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
