### PR TITLE
Added an initial openapi protobuf generator for our resource APIs.

### DIFF
--- a/build-support/scripts/devtools.sh
+++ b/build-support/scripts/devtools.sh
@@ -132,6 +132,7 @@ function proto_tools_install {
     install_local_protoc_generator "${SOURCE_DIR}/internal/tools/protoc-gen-consul-rate-limit"
     
     install_local_protoc_generator "${SOURCE_DIR}/internal/resource/protoc-gen-resource-types"
+    install_local_protoc_generator "${SOURCE_DIR}/internal/resource/protoc-gen-resource-openapi"
 
     install_local_protoc_generator "${SOURCE_DIR}/internal/resource/protoc-gen-json-shim"
 

--- a/internal/resource/protoc-gen-resource-openapi/internal/generate/generate.go
+++ b/internal/resource/protoc-gen-resource-openapi/internal/generate/generate.go
@@ -1,0 +1,455 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"gopkg.in/yaml.v3"
+
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/protoc-gen-resource-openapi/internal/types"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	baseResourceType = "hashicorp.consul.resource.Resource"
+)
+
+func Generate(files []*protogen.File) (map[string][]byte, error) {
+	g := newGenerator()
+	for _, f := range files {
+		if err := g.addMessagesFromFile(f); err != nil {
+			return nil, err
+		}
+	}
+	return g.generate()
+}
+
+type generator struct {
+	apis         apiGroups
+	schemas      map[string]*types.Schema
+	dependencies map[string][]string
+
+	resourceProperties map[string]*types.Schema
+}
+
+func newGenerator() *generator {
+	return &generator{
+		apis:         newAPIGroups(),
+		schemas:      make(map[string]*types.Schema),
+		dependencies: make(map[string][]string),
+	}
+}
+
+func (g *generator) addMessagesFromFile(f *protogen.File) error {
+	if !f.Generate {
+		return nil
+	}
+
+	for _, m := range f.Messages {
+		if m.Desc.FullName() == baseResourceType {
+			props, err := g.getPropertiesFromMessageFields(m)
+			if err != nil {
+				return err
+			}
+			g.resourceProperties = props
+			continue
+		}
+
+		ext := proto.GetExtension(m.Desc.Options(), pbresource.E_Spec).(*pbresource.ResourceTypeSpec)
+		if ext == nil || ext.DontMapHttp {
+			continue
+		}
+
+		gvkString := strings.TrimPrefix(string(m.Desc.FullName()), "hashicorp.consul.")
+		rtype, err := resource.ParseGVK(gvkString)
+		if err != nil {
+			return err
+		}
+
+		g.apis.addResource(&resourceKind{
+			group:       rtype.Group,
+			version:     rtype.GroupVersion,
+			kind:        rtype.Kind,
+			scope:       ext.Scope,
+			dataTypeRef: schemaRef(m.Desc.FullName()),
+			name:        string(m.Desc.FullName()),
+		})
+
+		if err := g.addMessage(m); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (g *generator) addMessage(m *protogen.Message) error {
+	name := string(m.Desc.FullName())
+	if _, found := g.schemas[name]; found {
+		return nil
+	}
+
+	s := &types.Schema{
+		Type:        "object",
+		Description: string(m.Comments.Leading),
+	}
+
+	// need to add this into the map to prevent infinite recursion
+	g.schemas[name] = s
+	g.dependencies[name] = make([]string, 0)
+
+	props, err := g.getPropertiesFromMessageFields(m)
+	if err != nil {
+		return err
+	}
+	s.Properties = props
+
+	for _, nestedMsg := range m.Messages {
+		// maps will be handled in a way that the wire formats KV pair map
+		// entry type doesn't need to be present in the openapi spec. See
+		// the createMapFieldSchema method.
+		if nestedMsg.Desc.IsMapEntry() {
+			continue
+		}
+
+		if err := g.addMessage(nestedMsg); err != nil {
+			return err
+		}
+
+		g.dependencies[name] = append(g.dependencies[name], string(nestedMsg.Desc.FullName()))
+	}
+
+	for _, nestedEnum := range m.Enums {
+		if err := g.addEnum(nestedEnum); err != nil {
+			return err
+		}
+		g.dependencies[name] = append(g.dependencies[name], string(nestedEnum.Desc.FullName()))
+	}
+
+	// TODO handle mutual exclusivity of oneof fields. The solution is probably to add to the description
+	// field which other fields it is exclusive with.
+
+	return nil
+}
+
+func (g *generator) getPropertiesFromMessageFields(m *protogen.Message) (map[string]*types.Schema, error) {
+	props := make(map[string]*types.Schema)
+	name := string(m.Desc.FullName())
+	for _, f := range m.Fields {
+		fs, deps, err := g.createFieldSchema(f)
+		if err != nil {
+			return nil, err
+		}
+		props[string(f.Desc.Name())] = fs
+
+		g.dependencies[name] = append(g.dependencies[name], deps...)
+	}
+
+	return props, nil
+}
+
+func schemaRef(name protoreflect.FullName) string {
+	return fmt.Sprintf("#/components/schemas/%s", string(name))
+}
+
+func paramRef(name string) string {
+	return fmt.Sprintf("#/components/parameters/%s", name)
+}
+
+func (g *generator) createFieldSchema(f *protogen.Field) (*types.Schema, []string, error) {
+	if f.Desc.IsList() {
+		return g.createListFieldSchema(f)
+	} else if f.Desc.IsMap() {
+		return g.createMapFieldSchema(f)
+	}
+	return g.createRawFieldSchema(f, false)
+}
+
+func (g *generator) createListFieldSchema(f *protogen.Field) (*types.Schema, []string, error) {
+	items, deps, err := g.createRawFieldSchema(f, true)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &types.Schema{
+		Type:        "array",
+		Items:       items,
+		Description: f.Comments.Leading.String(),
+	}, deps, nil
+}
+
+func getMapValueField(m *protogen.Field) *protogen.Field {
+	const mapEntryFieldLength = 2
+	const mapEntryValueFieldName = "value"
+	const mapEntryValueFieldNumber = 2
+
+	if m.Message == nil {
+		panic("getMapValueField called on non-map value")
+	}
+
+	// The Golang protobuf implementation will auto-generate a MapEntry type to hold the Key/Value pair
+	// that represents one entry in the map. Within that auto-generated message type their will be two
+	// fields called "key" (index 1) and "value" (index 2).
+	//
+	// see https://pkg.go.dev/google.golang.org/protobuf@v1.31.0/reflect/protoreflect#MessageDescriptor
+	if !m.Message.Desc.IsMapEntry() {
+		panic("getMapValueField called on a message which is not a MapEntry type")
+	}
+
+	// Ensure that the message contains the documented number of fields exactly.
+	if len(m.Message.Fields) != mapEntryFieldLength {
+		panic("MapEntry type doesn't have the required 2 fields")
+	}
+
+	// if we didn't want the protogen.Field but were fine with the protoreflect.FieldDescriptor
+	// we could just call m.Message.Desc.Fields().Get(mapEntryValueFieldNumber).
+	// As we do want the protogen.Field the only way to get it is to loop through all the fields
+	// and try to match on the elements we are looking for.
+	for _, field := range m.Message.Fields {
+		if field.Desc.Name() == mapEntryValueFieldName && field.Desc.Number() == mapEntryValueFieldNumber {
+			return field
+		}
+	}
+
+	panic("the MapEntry \"value\" field was not found")
+}
+
+func (g *generator) createMapFieldSchema(f *protogen.Field) (*types.Schema, []string, error) {
+	// f should point to a Field that was defined as map<K, V> within the proto files. protoc/buf
+	// will translate `map<K, V> field_name` into a `repeated FieldNameMapEntry` with the FieldNameMapEntry
+	// message type being synthesized. The structure of that message is documented and well known:
+	//
+	// https://pkg.go.dev/google.golang.org/protobuf@v1.31.0/reflect/protoreflect#MessageDescriptor
+	//
+	// For the purposes of generating an openapi schema, we want to expose the field as an object with
+	// whose properties have the type defined as the type of the "value" field within the synthesized
+	// MapEntry. Therefore we have to first peer through the MapEntry type to pull out the protogen.Field
+	// for the "value" field.
+	valueSchema, deps, err := g.createRawFieldSchema(getMapValueField(f), true)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &types.Schema{
+		Type:                 "object",
+		AdditionalProperties: valueSchema,
+		Description:          f.Comments.Leading.String(),
+	}, deps, nil
+}
+
+func (g *generator) createRawFieldSchema(f *protogen.Field, omitDescription bool) (*types.Schema, []string, error) {
+	var deps []string
+
+	description := func() string {
+		if !omitDescription {
+			return f.Comments.Leading.String()
+		}
+
+		return ""
+	}
+
+	addDescription := func(s *types.Schema) *types.Schema {
+		s.Description = description()
+		return s
+	}
+
+	factory, found := types.PrimitiveSchemas[f.Desc.Kind()]
+	if found {
+		return addDescription(factory()), nil, nil
+	}
+
+	switch f.Desc.Kind() {
+	case protoreflect.EnumKind:
+		name := f.Enum.Desc.FullName()
+		deps = append(deps, string(name))
+		if err := g.addEnum(f.Enum); err != nil {
+			return nil, nil, err
+		}
+
+		return &types.Schema{
+			Ref:         schemaRef(name),
+			Description: f.Comments.Leading.String(),
+		}, deps, nil
+	case protoreflect.MessageKind:
+		name := f.Message.Desc.FullName()
+		if factory, found := types.WrapperSchemas[string(name)]; found {
+			return addDescription(factory()), nil, nil
+		}
+
+		if factory, found := types.WKTSchemas[string(name)]; found {
+			return addDescription(factory()), nil, nil
+		}
+
+		deps = append(deps, string(name))
+		if err := g.addMessage(f.Message); err != nil {
+			return nil, nil, err
+		}
+
+		return &types.Schema{
+			Ref:         schemaRef(name),
+			Description: description(),
+		}, deps, nil
+	default:
+		panic(fmt.Sprintf("unknown/unsupported protobuf kind: %v", f.Desc.Kind()))
+	}
+}
+
+func (g *generator) addEnum(e *protogen.Enum) error {
+	name := string(e.Desc.FullName())
+	if _, found := g.schemas[name]; found {
+		return nil
+	}
+
+	g.schemas[name] = g.createEnumSchema(e)
+
+	return nil
+}
+
+func (g *generator) createEnumSchema(e *protogen.Enum) *types.Schema {
+	// For now we are going to emit enums with a string type with possible
+	// values being the string form of the enum values. We could allow
+	// Enum's to use the integer encoding instead.
+
+	s := types.Schema{
+		Type:        "string",
+		Description: string(e.Comments.Leading),
+	}
+
+	for _, v := range e.Values {
+		s.Enum = append(s.Enum, string(v.Desc.Name()))
+	}
+
+	return &s
+}
+
+func (g *generator) generate() (map[string][]byte, error) {
+	files := make(map[string][]byte)
+	// loop over each api group
+	for group, versions := range g.apis {
+		// loop over each api group version
+		for version, kinds := range versions {
+			doc := types.Document{
+				Version: "3.0.0",
+				Info: types.Info{
+					Title:       fmt.Sprintf("Consul %s", group),
+					Description: fmt.Sprintf("Consul APIs for interacting with the %s resource kinds at version %s", group, version),
+					Version:     version,
+				},
+				Security: security,
+				Components: types.Components{
+					Schemas:         make(map[string]*types.Schema),
+					Parameters:      allParameters,
+					SecuritySchemes: securitySchemes,
+				},
+				Paths: make(map[string]types.Path),
+			}
+
+			// Add all the base resource dependent schemas
+			for name, s := range g.getTypesSchemaDependencies(baseResourceType) {
+				doc.Components.Schemas[name] = s
+			}
+
+			// add all paths for the different resource kinds in the group version
+			for _, rsc := range kinds {
+				// Get all component schemas and merge them with the final set
+				for name, s := range g.getComponentSchemasForType(rsc.name) {
+					doc.Components.Schemas[name] = s
+				}
+
+				for path, pathConfig := range g.generatePathsForResource(rsc) {
+					doc.Paths[path] = pathConfig
+				}
+			}
+
+			content, err := yaml.Marshal(doc)
+			if err != nil {
+				return nil, err
+			}
+			fname := fmt.Sprintf("%s-%s.openapi.yml", group, version)
+			files[fname] = content
+		}
+	}
+
+	return files, nil
+}
+
+func (g *generator) getComponentSchemasForType(name string) map[string]*types.Schema {
+	schemas := g.getTypesSchemaDependencies(name)
+	schemas[name] = g.schemas[name]
+
+	return schemas
+}
+
+func (g *generator) getTypesSchemaDependencies(name string) map[string]*types.Schema {
+	schemas := make(map[string]*types.Schema)
+
+	deps := g.dependencies[name]
+	for len(deps) > 0 {
+		dep := deps[0]
+		if _, found := schemas[dep]; !found {
+			schemas[dep] = g.schemas[dep]
+			deps = append(deps[1:], g.dependencies[dep]...)
+		} else {
+			deps = deps[1:]
+		}
+	}
+
+	return schemas
+}
+
+type apiGroups map[string]groupVersions
+
+func newAPIGroups() apiGroups {
+	return make(apiGroups)
+}
+
+func (g apiGroups) addResource(rsc *resourceKind) {
+	grp, ok := g[rsc.group]
+	if !ok {
+		grp = newGroupVersions()
+		g[rsc.group] = grp
+	}
+	grp.addResource(rsc)
+}
+
+type groupVersions map[string]groupKinds
+
+func newGroupVersions() groupVersions {
+	return make(groupVersions)
+}
+
+func (v groupVersions) addResource(rsc *resourceKind) {
+	k, ok := v[rsc.version]
+	if !ok {
+		k = newGroupKinds()
+		v[rsc.version] = k
+	}
+	k.addResource(rsc)
+}
+
+type groupKinds map[string]*resourceKind
+
+func newGroupKinds() groupKinds {
+	return make(groupKinds)
+}
+
+func (k groupKinds) addResource(rsc *resourceKind) {
+	k[rsc.kind] = rsc
+}
+
+type resourceKind struct {
+	name    string
+	group   string
+	version string
+	kind    string
+
+	scope       pbresource.Scope
+	dataTypeRef string
+}

--- a/internal/resource/protoc-gen-resource-openapi/internal/generate/http.go
+++ b/internal/resource/protoc-gen-resource-openapi/internal/generate/http.go
@@ -1,0 +1,335 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul/internal/resource/protoc-gen-resource-openapi/internal/types"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+var (
+	consistentParameter = &types.Parameter{
+		Name:        "consistent",
+		In:          "query",
+		Schema:      types.BoolSchema(),
+		Description: "When true, the operation will be performed with strong consistency",
+	}
+
+	namePrefixParameter = &types.Parameter{
+		Name:        "name_prefix",
+		In:          "query",
+		Description: "The resource name prefix used to filter the result list.",
+		Schema:      types.StringSchema(),
+	}
+
+	namespaceParameter = &types.Parameter{
+		Name:        "namespace",
+		In:          "query",
+		Schema:      types.StringSchema(),
+		Description: "Specifies the Consul namespace of resources to operate on. This parameter takes precedence over the `ns` alias.",
+	}
+
+	nsParameter = &types.Parameter{
+		Name:        "ns",
+		In:          "query",
+		Schema:      types.StringSchema(),
+		Description: "`ns` is an alias for the `namespace` query param. The `namespace` parameter takes precedence.",
+	}
+
+	peerParameter = &types.Parameter{
+		Name:        "peer",
+		In:          "query",
+		Schema:      types.StringSchema(),
+		Description: "Specifies the Consul peer of imported resources to operate on.",
+	}
+
+	partitionParameter = &types.Parameter{
+		Name:        "partition",
+		In:          "query",
+		Schema:      types.StringSchema(),
+		Description: "Specifies the Consul partition of resources to operate on.",
+	}
+
+	nameParameter = &types.Parameter{
+		Name:        "name",
+		In:          "path",
+		Schema:      types.StringSchema(),
+		Description: "The name of the resource to operate on.",
+		Required:    true,
+	}
+
+	allParameters = map[string]*types.Parameter{
+		"namespace":   namespaceParameter,
+		"ns":          nsParameter,
+		"peer":        peerParameter,
+		"partition":   partitionParameter,
+		"name":        nameParameter,
+		"name_prefix": namePrefixParameter,
+		"consistent":  consistentParameter,
+	}
+
+	listParamsFromScope = map[pbresource.Scope]map[string]*types.Parameter{
+		pbresource.Scope_SCOPE_UNDEFINED: {
+			"peer":        peerParameter,
+			"consistent":  consistentParameter,
+			"name_prefix": namePrefixParameter,
+			"namespace":   namespaceParameter,
+			"ns":          nsParameter,
+			"partition":   partitionParameter,
+		},
+		pbresource.Scope_SCOPE_CLUSTER: {
+			"peer":        peerParameter,
+			"consistent":  consistentParameter,
+			"name_prefix": namePrefixParameter,
+		},
+		pbresource.Scope_SCOPE_PARTITION: {
+			"peer":        peerParameter,
+			"consistent":  consistentParameter,
+			"name_prefix": namePrefixParameter,
+			"partition":   partitionParameter,
+		},
+		pbresource.Scope_SCOPE_NAMESPACE: {
+			"peer":        peerParameter,
+			"consistent":  consistentParameter,
+			"name_prefix": namePrefixParameter,
+			"namespace":   namespaceParameter,
+			"ns":          nsParameter,
+			"partition":   partitionParameter,
+		},
+	}
+
+	instanceOpParamsFromScope = map[pbresource.Scope]map[string]*types.Parameter{
+		pbresource.Scope_SCOPE_UNDEFINED: {
+			"peer":      peerParameter,
+			"name":      namePrefixParameter,
+			"namespace": namespaceParameter,
+			"ns":        nsParameter,
+			"partition": partitionParameter,
+		},
+		pbresource.Scope_SCOPE_CLUSTER: {
+			"peer": peerParameter,
+			"name": namePrefixParameter,
+		},
+		pbresource.Scope_SCOPE_PARTITION: {
+			"peer":      peerParameter,
+			"name":      namePrefixParameter,
+			"partition": partitionParameter,
+		},
+		pbresource.Scope_SCOPE_NAMESPACE: {
+			"peer":      peerParameter,
+			"name":      namePrefixParameter,
+			"namespace": namespaceParameter,
+			"ns":        nsParameter,
+			"partition": partitionParameter,
+		},
+	}
+
+	readConsistencyParams = map[string]*types.Parameter{
+		"consistent": consistentParameter,
+	}
+
+	listParamRefsFromScope       map[pbresource.Scope][]*types.Parameter
+	instanceOpParamRefsFromScope map[pbresource.Scope][]*types.Parameter
+	readConsistencyParamRefs     []*types.Parameter
+
+	securitySchemes = map[string]*types.SecurityScheme{
+		"ConsulTokenHeader": {
+			Type: "apiKey",
+			In:   "header",
+			Name: "X-Consul-Token",
+		},
+		"BearerAuth": {
+			Type:   "http",
+			Scheme: "bearer",
+		},
+	}
+
+	security []map[string][]string
+)
+
+func createParamRefs(params map[string]*types.Parameter) []*types.Parameter {
+	var result []*types.Parameter
+	for paramName, param := range params {
+		if param.Name == "" {
+			param.Name = paramName
+		}
+
+		result = append(result, &types.Parameter{Ref: paramRef(paramName)})
+	}
+	return result
+}
+
+func createParamRefsForScopes(scopes map[pbresource.Scope]map[string]*types.Parameter) map[pbresource.Scope][]*types.Parameter {
+	result := make(map[pbresource.Scope][]*types.Parameter)
+	for scope, params := range scopes {
+		result[scope] = createParamRefs(params)
+	}
+	return result
+}
+
+func init() {
+	// validation that the protoc generator code can handle all the relevant resource scopes.
+	for _, scope := range pbresource.Scope_value {
+		_, ok := listParamsFromScope[pbresource.Scope(scope)]
+		if !ok {
+			panic(fmt.Sprintf("openapi generator needs modification to support a new resource scope: %s (list)", pbresource.Scope_name[scope]))
+		}
+
+		_, ok = instanceOpParamsFromScope[pbresource.Scope(scope)]
+		if !ok {
+			panic(fmt.Sprintf("openapi generator needs modification to support a new resource scope: %s (instance op)", pbresource.Scope_name[scope]))
+		}
+	}
+
+	listParamRefsFromScope = createParamRefsForScopes(listParamsFromScope)
+	instanceOpParamRefsFromScope = createParamRefsForScopes(instanceOpParamsFromScope)
+	readConsistencyParamRefs = createParamRefs(readConsistencyParams)
+
+	for securityReq := range securitySchemes {
+		security = append(security, map[string][]string{securityReq: {}})
+	}
+}
+
+func (g *generator) generateTypedResourceSchema(rsc *resourceKind) *types.Schema {
+	s := &types.Schema{
+		Type:       "object",
+		Properties: make(map[string]*types.Schema),
+	}
+
+	for name, prop := range g.resourceProperties {
+		s.Properties[name] = prop
+	}
+
+	// overwrite the "data" field with the schema of the actual type
+	s.Properties["data"] = &types.Schema{
+		Ref: rsc.dataTypeRef,
+	}
+
+	return s
+}
+
+func (g *generator) generatePathsForResource(rsc *resourceKind) map[string]types.Path {
+	kindSchema := g.generateTypedResourceSchema(rsc)
+
+	paths := make(map[string]types.Path)
+
+	paths[multiPath(rsc)] = types.Path{
+		Get: &types.Operation{
+			Summary:     listSummary(rsc),
+			OperationID: listId(rsc),
+			Parameters:  listParamRefsFromScope[rsc.scope],
+			Responses: map[string]types.Response{
+				"200": {
+					Description: "The listing was successful and the body contains the array of results.",
+					Content: map[string]types.Content{
+						"application/json": {
+							Schema: &types.Schema{
+								Type:  "array",
+								Items: kindSchema,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	paths[singlePath(rsc)] = types.Path{
+		Parameters: instanceOpParamRefsFromScope[rsc.scope],
+		Get: &types.Operation{
+			Summary:     readSummary(rsc),
+			OperationID: readId(rsc),
+			Parameters:  readConsistencyParamRefs,
+			Responses: map[string]types.Response{
+				"200": {
+					Description: "The read was successful and the body contains the result.",
+					Content: map[string]types.Content{
+						"application/json": {
+							Schema: kindSchema,
+						},
+					},
+				},
+			},
+		},
+		Put: &types.Operation{
+			Summary:     writeSummary(rsc),
+			OperationID: writeId(rsc),
+			RequestBody: &types.RequestBody{
+				Description: writeBodyDescription(rsc),
+				Content: map[string]types.Content{
+					"application/json": {
+						Schema: kindSchema,
+					},
+				},
+			},
+			Responses: map[string]types.Response{
+				"200": {
+					Description: "The write was successful and the body contains the result.",
+					Content: map[string]types.Content{
+						"application/json": {
+							Schema: kindSchema,
+						},
+					},
+				},
+			},
+		},
+		Delete: &types.Operation{
+			Summary:     deleteSummary(rsc),
+			OperationID: deleteId(rsc),
+			Responses: map[string]types.Response{
+				"200": {
+					Description: "The delete was successful and the body contains the result.",
+				},
+			},
+		},
+	}
+
+	return paths
+}
+
+func multiPath(rsc *resourceKind) string {
+	return fmt.Sprintf("/%s/%s/%s", rsc.group, rsc.version, rsc.kind)
+}
+
+func listSummary(rsc *resourceKind) string {
+	return fmt.Sprintf("List %s.%s.%s resources", rsc.group, rsc.version, rsc.kind)
+}
+
+func listId(rsc *resourceKind) string {
+	return fmt.Sprintf("list-%s", rsc.kind)
+}
+
+func singlePath(rsc *resourceKind) string {
+	return fmt.Sprintf("/%s/%s/%s/{name}", rsc.group, rsc.version, rsc.kind)
+}
+
+func readSummary(rsc *resourceKind) string {
+	return fmt.Sprintf("Read %s.%s.%s resources", rsc.group, rsc.version, rsc.kind)
+}
+
+func readId(rsc *resourceKind) string {
+	return fmt.Sprintf("read-%s.", rsc.kind)
+}
+
+func writeSummary(rsc *resourceKind) string {
+	return fmt.Sprintf("Write %s.%s.%s resources", rsc.group, rsc.version, rsc.kind)
+}
+
+func writeId(rsc *resourceKind) string {
+	return fmt.Sprintf("write-%s", rsc.kind)
+}
+
+func writeBodyDescription(rsc *resourceKind) string {
+	return fmt.Sprintf("The %s.%s.%s resource to be updated.", rsc.group, rsc.version, rsc.kind)
+}
+
+func deleteSummary(rsc *resourceKind) string {
+	return fmt.Sprintf("Delete %s.%s.%s resources", rsc.group, rsc.version, rsc.kind)
+}
+
+func deleteId(rsc *resourceKind) string {
+	return fmt.Sprintf("delete-%s", rsc.kind)
+}

--- a/internal/resource/protoc-gen-resource-openapi/internal/types/types.go
+++ b/internal/resource/protoc-gen-resource-openapi/internal/types/types.go
@@ -1,0 +1,245 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// The types package contains structs which comprimse elements of an OpenAPI 3.0 configuration.
+// This is basically just used as a means to marshal the generated configuration.
+
+package types
+
+import "google.golang.org/protobuf/reflect/protoreflect"
+
+type Document struct {
+	Version    string                `yaml:"openapi"`
+	Info       Info                  `yaml:"info"`
+	Paths      map[string]Path       `yaml:"paths,omitempty"`
+	Components Components            `yaml:"components,omitempty"`
+	Security   []map[string][]string `yaml:"security,omitempty"`
+}
+
+type Info struct {
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
+	Version     string `yaml:"version"`
+}
+
+type Path struct {
+	Summary     string `yaml:"summary,omitempty"`
+	Description string `yaml:"description,omitempty"`
+
+	Get    *Operation `yaml:"get,omitempty"`
+	Put    *Operation `yaml:"put,omitempty"`
+	Delete *Operation `yaml:"delete,omitempty"`
+
+	Parameters []*Parameter `yaml:"parameters,omitempty"`
+}
+
+type Operation struct {
+	Summary     string              `yaml:"summary,omitempty"`
+	Description string              `yaml:"description,omitempty"`
+	OperationID string              `yaml:"operationId"`
+	Parameters  []*Parameter        `yaml:"parameters,omitempty"`
+	RequestBody *RequestBody        `yaml:"requestBody,omitempty"`
+	Responses   map[string]Response `yaml:"responses"`
+}
+
+type Parameter struct {
+	Name        string  `yaml:"name,omitempty"`
+	In          string  `yaml:"in,omitempty"`
+	Description string  `yaml:"description,omitempty"`
+	Required    bool    `yaml:"required,omitempty"`
+	Schema      *Schema `yaml:"schema,omitempty"`
+	Ref         string  `yaml:"$ref,omitempty"`
+}
+
+type RequestBody struct {
+	Description string             `yaml:"description,omitempty"`
+	Content     map[string]Content `yaml:"content,omitempty"`
+	Required    bool               `yaml:"required,omitempty"`
+}
+
+type Content struct {
+	Schema *Schema `yaml:"schema"`
+}
+
+type Response struct {
+	Description string                  `yaml:"description,omitempty"`
+	Headers     map[string]HeaderObject `yaml:"headers,omitempty"`
+	Content     map[string]Content      `yaml:"content,omitempty"`
+}
+
+type HeaderObject struct {
+	Description string `yaml:"description,omitempty"`
+	Required    bool   `yaml:"required,omitempty"`
+	Schema      Schema `yaml:"schema,omitempty"`
+}
+
+type Components struct {
+	Schemas         map[string]*Schema         `yaml:"schemas"`
+	Parameters      map[string]*Parameter      `yaml:"parameters"`
+	SecuritySchemes map[string]*SecurityScheme `yaml:"securitySchemes"`
+}
+
+type Schema struct {
+	Type                 string             `yaml:"type,omitempty"`
+	OneOf                []*Schema          `yaml:"oneof,omitempty"`
+	Enum                 []string           `yaml:"enum,omitempty"`
+	Properties           map[string]*Schema `yaml:"properties,omitempty"`
+	Ref                  string             `yaml:"$ref,omitempty"`
+	Items                *Schema            `yaml:"items,omitempty"`
+	AdditionalProperties *Schema            `yaml:"additionalProperties,omitempty"`
+	Format               string             `yaml:"format,omitempty"`
+	Description          string             `yaml:"description,omitempty"`
+	Minimum              int                `yaml:"minimum,omitempty"`
+	Pattern              string             `yaml:"pattern,omitempty"`
+}
+
+type SecurityScheme struct {
+	Type        string `yaml:"type"`
+	Description string `yaml:"description,omitempty"`
+	Scheme      string `yaml:"scheme,omitempty"`
+	In          string `yaml:"in,omitempty"`
+	Name        string `yaml:"name,omitempty"`
+}
+
+func BoolSchema() *Schema {
+	return &Schema{
+		Type: "boolean",
+	}
+}
+
+func FloatSchema() *Schema {
+	return &Schema{
+		Type:   "number",
+		Format: "float",
+	}
+}
+
+func DoubleSchema() *Schema {
+	return &Schema{
+		Type:   "number",
+		Format: "double",
+	}
+}
+
+func Uint32Schema() *Schema {
+	return &Schema{
+		Type:    "integer",
+		Format:  "int32",
+		Minimum: 0,
+	}
+}
+
+func Int32Schema() *Schema {
+	return &Schema{
+		Type:   "integer",
+		Format: "int32",
+	}
+}
+
+func Uint64Schema() *Schema {
+	return &Schema{
+		Type:    "integer",
+		Format:  "int64",
+		Minimum: 0,
+	}
+}
+
+func Int64Schema() *Schema {
+	return &Schema{
+		Type:   "integer",
+		Format: "int64",
+	}
+}
+
+func StringSchema() *Schema {
+	return &Schema{
+		Type: "string",
+	}
+}
+
+func BytesSchema() *Schema {
+	return &Schema{
+		Type:   "string",
+		Format: "byte",
+	}
+}
+
+func DurationSchema() *Schema {
+	return &Schema{
+		Type:        "string",
+		Pattern:     `^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$`,
+		Description: "Represents a a duration between -315,576,000,000s and 315,576,000,000s (around 10000 years). Precision is in nanoseconds. 1 nanosecond is represented as 0.000000001s",
+	}
+}
+
+func TimestampSchema() *Schema {
+	return &Schema{
+		Type:   "string",
+		Format: "date-time",
+	}
+}
+
+func StructSchema() *Schema {
+	return &Schema{
+		Type: "object",
+	}
+}
+
+func AnySchema() *Schema {
+	return &Schema{
+		Type: "object",
+		Properties: map[string]*Schema{
+			"@type": {
+				Type:        "string",
+				Description: "The type of the serialize message",
+			},
+		},
+	}
+}
+
+// SchemaCreators are used instead of variables/constants for known
+// schemas to allow for consumers to add additional fields like descriptions
+// without having to worry about deep copying data.
+type SchemaCreator func() *Schema
+
+var (
+	HTTPAuthzBearerScheme = &SecurityScheme{
+		Type:   "http",
+		Scheme: "bearer",
+	}
+
+	WrapperSchemas = map[string]SchemaCreator{
+		"google.protobuf.BoolValue":   BoolSchema,
+		"google.protobuf.BytesValue":  BytesSchema,
+		"google.protobuf.StringValue": StringSchema,
+		"google.protobuf.Uint32Value": Uint32Schema,
+		"google.protobuf.Uint64Value": Uint64Schema,
+		"google.protobuf.Int32Value":  Int32Schema,
+		"google.protobuf.Int64Value":  Int64Schema,
+		"google.protobuf.FloatValue":  FloatSchema,
+		"google.protobuf.DoubleValue": DoubleSchema,
+	}
+
+	WKTSchemas = map[string]SchemaCreator{
+		"google.protobuf.Duration":  DurationSchema,
+		"google.protobuf.Timestamp": TimestampSchema,
+		"google.protobuf.Struct":    StructSchema,
+		"google.protobuf.Any":       AnySchema,
+	}
+
+	PrimitiveSchemas = map[protoreflect.Kind]SchemaCreator{
+		protoreflect.BoolKind:     BoolSchema,
+		protoreflect.Int32Kind:    Int32Schema,
+		protoreflect.Int64Kind:    Int64Schema,
+		protoreflect.Uint32Kind:   Uint32Schema,
+		protoreflect.Uint64Kind:   Uint64Schema,
+		protoreflect.BytesKind:    BytesSchema,
+		protoreflect.DoubleKind:   DoubleSchema,
+		protoreflect.FloatKind:    FloatSchema,
+		protoreflect.StringKind:   StringSchema,
+		protoreflect.Fixed32Kind:  Uint32Schema,
+		protoreflect.Fixed64Kind:  Uint64Schema,
+		protoreflect.Sfixed32Kind: Int32Schema,
+		protoreflect.Sfixed64Kind: Int64Schema,
+	}
+)

--- a/internal/resource/protoc-gen-resource-openapi/main.go
+++ b/internal/resource/protoc-gen-resource-openapi/main.go
@@ -1,0 +1,37 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"flag"
+
+	"github.com/hashicorp/consul/internal/resource/protoc-gen-resource-openapi/internal/generate"
+	"google.golang.org/protobuf/compiler/protogen"
+	plugin "google.golang.org/protobuf/types/pluginpb"
+)
+
+var (
+	file = flag.String("file", "-", "where to load data from")
+)
+
+func main() {
+	flag.Parse()
+
+	protogen.Options{
+		ParamFunc: flag.CommandLine.Set,
+	}.Run(func(gp *protogen.Plugin) error {
+
+		gp.SupportedFeatures = uint64(plugin.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
+		files, err := generate.Generate(gp.Files)
+		if err != nil {
+			return err
+		}
+
+		for name, content := range files {
+			out := gp.NewGeneratedFile(name, "")
+			out.Write(content)
+		}
+		return nil
+	})
+}

--- a/proto-public/buf.gen.yaml
+++ b/proto-public/buf.gen.yaml
@@ -27,6 +27,11 @@ plugins:
     opt:
       - paths=source_relative
     strategy: all
+  - name: resource-openapi
+    out: ./openapi
+    opt:
+      - paths=source_relative
+    strategy: all
   - name: consul-rate-limit
     out: .
     opt:

--- a/proto-public/openapi/auth-v2beta1.openapi.yml
+++ b/proto-public/openapi/auth-v2beta1.openapi.yml
@@ -1,0 +1,1736 @@
+openapi: 3.0.0
+info:
+    title: Consul auth
+    description: Consul APIs for interacting with the auth resource kinds at version v2beta1
+    version: v2beta1
+paths:
+    /auth/v2beta1/ComputedTrafficPermissions:
+        get:
+            summary: List auth.v2beta1.ComputedTrafficPermissions resources
+            operationId: list-ComputedTrafficPermissions
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.ComputedTrafficPermissions'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /auth/v2beta1/ComputedTrafficPermissions/{name}:
+        get:
+            summary: Read auth.v2beta1.ComputedTrafficPermissions resources
+            operationId: read-ComputedTrafficPermissions.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.ComputedTrafficPermissions'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write auth.v2beta1.ComputedTrafficPermissions resources
+            operationId: write-ComputedTrafficPermissions
+            requestBody:
+                description: The auth.v2beta1.ComputedTrafficPermissions resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.ComputedTrafficPermissions'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.ComputedTrafficPermissions'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete auth.v2beta1.ComputedTrafficPermissions resources
+            operationId: delete-ComputedTrafficPermissions
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /auth/v2beta1/NamespaceTrafficPermissions:
+        get:
+            summary: List auth.v2beta1.NamespaceTrafficPermissions resources
+            operationId: list-NamespaceTrafficPermissions
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.NamespaceTrafficPermissions'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /auth/v2beta1/NamespaceTrafficPermissions/{name}:
+        get:
+            summary: Read auth.v2beta1.NamespaceTrafficPermissions resources
+            operationId: read-NamespaceTrafficPermissions.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.NamespaceTrafficPermissions'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write auth.v2beta1.NamespaceTrafficPermissions resources
+            operationId: write-NamespaceTrafficPermissions
+            requestBody:
+                description: The auth.v2beta1.NamespaceTrafficPermissions resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.NamespaceTrafficPermissions'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.NamespaceTrafficPermissions'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete auth.v2beta1.NamespaceTrafficPermissions resources
+            operationId: delete-NamespaceTrafficPermissions
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /auth/v2beta1/PartitionTrafficPermissions:
+        get:
+            summary: List auth.v2beta1.PartitionTrafficPermissions resources
+            operationId: list-PartitionTrafficPermissions
+            parameters:
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/partition'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.PartitionTrafficPermissions'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /auth/v2beta1/PartitionTrafficPermissions/{name}:
+        get:
+            summary: Read auth.v2beta1.PartitionTrafficPermissions resources
+            operationId: read-PartitionTrafficPermissions.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.PartitionTrafficPermissions'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write auth.v2beta1.PartitionTrafficPermissions resources
+            operationId: write-PartitionTrafficPermissions
+            requestBody:
+                description: The auth.v2beta1.PartitionTrafficPermissions resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.PartitionTrafficPermissions'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.PartitionTrafficPermissions'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete auth.v2beta1.PartitionTrafficPermissions resources
+            operationId: delete-PartitionTrafficPermissions
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/partition'
+    /auth/v2beta1/TrafficPermissions:
+        get:
+            summary: List auth.v2beta1.TrafficPermissions resources
+            operationId: list-TrafficPermissions
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.TrafficPermissions'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /auth/v2beta1/TrafficPermissions/{name}:
+        get:
+            summary: Read auth.v2beta1.TrafficPermissions resources
+            operationId: read-TrafficPermissions.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.TrafficPermissions'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write auth.v2beta1.TrafficPermissions resources
+            operationId: write-TrafficPermissions
+            requestBody:
+                description: The auth.v2beta1.TrafficPermissions resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.TrafficPermissions'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.TrafficPermissions'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete auth.v2beta1.TrafficPermissions resources
+            operationId: delete-TrafficPermissions
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /auth/v2beta1/WorkloadIdentity:
+        get:
+            summary: List auth.v2beta1.WorkloadIdentity resources
+            operationId: list-WorkloadIdentity
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.WorkloadIdentity'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /auth/v2beta1/WorkloadIdentity/{name}:
+        get:
+            summary: Read auth.v2beta1.WorkloadIdentity resources
+            operationId: read-WorkloadIdentity.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.WorkloadIdentity'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write auth.v2beta1.WorkloadIdentity resources
+            operationId: write-WorkloadIdentity
+            requestBody:
+                description: The auth.v2beta1.WorkloadIdentity resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.WorkloadIdentity'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.WorkloadIdentity'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete auth.v2beta1.WorkloadIdentity resources
+            operationId: delete-WorkloadIdentity
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+components:
+    schemas:
+        hashicorp.consul.auth.v2beta1.Action:
+            type: string
+            enum:
+                - ACTION_UNSPECIFIED
+                - ACTION_DENY
+                - ACTION_ALLOW
+            description: |4
+                 +kubebuilder:validation:Enum=ACTION_ALLOW;ACTION_DENY;ACTION_UNKNOWN
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.auth.v2beta1.ComputedTrafficPermissions:
+            type: object
+            properties:
+                allow_permissions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.Permission'
+                deny_permissions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.Permission'
+                is_default:
+                    type: boolean
+        hashicorp.consul.auth.v2beta1.Destination:
+            type: object
+            properties:
+                identity_name:
+                    type: string
+            description: |4
+                 Destination contains the name or name-prefix of the WorkloadIdentity.
+                 The WorkloadIdentity resource must be in the same tenancy as the TrafficPermissions resource.
+        hashicorp.consul.auth.v2beta1.DestinationRule:
+            type: object
+            properties:
+                exclude:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.ExcludePermissionRule'
+                    description: |
+                        // Exclude contains a list of rules to exclude when evaluating rules for the incoming connection.
+                header:
+                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.DestinationRuleHeader'
+                methods:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // Methods is the list of HTTP methods. If no methods are specified,
+                        // this rule will apply to all methods.
+                path_exact:
+                    type: string
+                path_prefix:
+                    type: string
+                path_regex:
+                    type: string
+                port_names:
+                    type: array
+                    items:
+                        type: string
+            description: |4
+                 DestinationRule contains rules rules to apply to the incoming connection.
+        hashicorp.consul.auth.v2beta1.DestinationRuleHeader:
+            type: object
+            properties:
+                exact:
+                    type: string
+                invert:
+                    type: boolean
+                name:
+                    type: string
+                prefix:
+                    type: string
+                present:
+                    type: boolean
+                regex:
+                    type: string
+                suffix:
+                    type: string
+        hashicorp.consul.auth.v2beta1.ExcludePermissionRule:
+            type: object
+            properties:
+                header:
+                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.DestinationRuleHeader'
+                methods:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // Methods is the list of HTTP methods.
+                path_exact:
+                    type: string
+                path_prefix:
+                    type: string
+                path_regex:
+                    type: string
+                port_names:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // PortNames is a list of workload ports to apply this rule to. The ports specified here
+                        // must be the ports used in the connection.
+        hashicorp.consul.auth.v2beta1.ExcludeSource:
+            type: object
+            properties:
+                identity_name:
+                    type: string
+                namespace:
+                    type: string
+                partition:
+                    type: string
+                peer:
+                    type: string
+                sameness_group:
+                    type: string
+            description: |4
+                 ExcludeSource is almost the same as source but it prevents the addition of
+                 matching sources.
+        hashicorp.consul.auth.v2beta1.NamespaceTrafficPermissions:
+            type: object
+            properties:
+                action:
+                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.Action'
+                permissions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.Permission'
+        hashicorp.consul.auth.v2beta1.PartitionTrafficPermissions:
+            type: object
+            properties:
+                action:
+                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.Action'
+                permissions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.Permission'
+        hashicorp.consul.auth.v2beta1.Permission:
+            type: object
+            properties:
+                destination_rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.DestinationRule'
+                    description: |
+                        // DestinationRules is a list of rules to apply for matching sources in this Permission.
+                        // These rules are specific to the request or connection that is going to the destination(s)
+                        // selected by the TrafficPermissions resource.
+                sources:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.Source'
+                    description: |
+                        // Sources is a list of sources in this traffic permission.
+            description: |4
+                 Permissions is a list of permissions to match on.
+        hashicorp.consul.auth.v2beta1.Source:
+            type: object
+            properties:
+                exclude:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.ExcludeSource'
+                    description: |
+                        // Exclude is a list of sources to exclude from this source.
+                identity_name:
+                    type: string
+                namespace:
+                    type: string
+                partition:
+                    type: string
+                peer:
+                    type: string
+                sameness_group:
+                    type: string
+            description: |4
+                 Source represents the source identity.
+                 To specify any of the wildcard sources, the specific fields need to be omitted.
+                 For example, for a wildcard namespace, identity_name should be omitted.
+        hashicorp.consul.auth.v2beta1.TrafficPermissions:
+            type: object
+            properties:
+                action:
+                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.Action'
+                    description: |
+                        // Action can be either allow or deny for the entire object. It will default to allow.
+                        //
+                        // If action is allow, we will allow the connection if one of the rules in Rules matches, in other words, we will deny
+                        // all requests except for the ones that match Rules. If Consul is in default allow mode, then allow
+                        // actions have no effect without a deny permission as everything is allowed by default.
+                        //
+                        // If action is deny, we will deny the connection if one of the rules in Rules match, in other words,
+                        // we will allow all requests except for the ones that match Rules. If Consul is default deny mode,
+                        // then deny permissions have no effect without an allow permission as everything is denied by default.
+                        //
+                        // Action unspecified is reserved for compatibility with the addition of future actions.
+                destination:
+                    $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.Destination'
+                    description: |
+                        // Destination is a configuration of the destination proxies
+                        // where these traffic permissions should apply.
+                permissions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.auth.v2beta1.Permission'
+                    description: |
+                        // Permissions is a list of permissions to match on. They are applied using OR semantics.
+        hashicorp.consul.auth.v2beta1.WorkloadIdentity:
+            type: object
+        hashicorp.consul.resource.Condition:
+            type: object
+            properties:
+                message:
+                    type: string
+                    description: |
+                        // Message contains a human-friendly description of the status.
+                reason:
+                    type: string
+                    description: |
+                        // Reason provides more machine-readable details about the condition (e.g.
+                        // "InvalidProtocol").
+                resource:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // Resource identifies which resource this condition relates to, when it is
+                        // not the core resource itself.
+                state:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Condition.State'
+                    description: |
+                        // State represents the state of the condition (i.e. true/false/unknown).
+                type:
+                    type: string
+                    description: |
+                        // Type identifies the type of condition (e.g. "Invalid", "ResolvedRefs").
+            description: |4
+                 Condition represents a discreet observation about a resource in relation to
+                 the current state of the system.
+
+                 It is heavily inspired by Kubernetes' [conditions](https://bit.ly/3H9Y6IK)
+                 and the Gateway API [types and reasons](https://bit.ly/3n2PPiP).
+        hashicorp.consul.resource.Condition.State:
+            type: string
+            enum:
+                - STATE_UNKNOWN
+                - STATE_TRUE
+                - STATE_FALSE
+            description: |4
+                 State represents the state of the condition (i.e. true/false/unknown).
+        hashicorp.consul.resource.ID:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the user-given name of the resource (e.g. the "billing" service).
+                tenancy:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Tenancy'
+                    description: |
+                        // Tenancy identifies the tenancy units (i.e. partition, namespace) in which
+                        // the resource resides.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Type'
+                    description: |
+                        // Type identifies the resource's type.
+                uid:
+                    type: string
+                    description: |
+                        // Uid is the unique internal identifier we gave to the resource.
+                        //
+                        // It is primarily used to tell the difference between the current resource
+                        // and previous deleted resources with the same user-given name.
+                        //
+                        // Concretely, Uid is a [ULID](https://github.com/ulid/spec) and you can treat
+                        // its timestamp component as the resource's creation time.
+            description: |4
+                 ID uniquely identifies a resource.
+        hashicorp.consul.resource.Reference:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the user-given name of the resource (e.g. the "billing" service).
+                section:
+                    type: string
+                    description: |
+                        // Section identifies which part of the resource the condition relates to.
+                tenancy:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Tenancy'
+                    description: |
+                        // Tenancy identifies the tenancy units (i.e. partition, namespace) in which
+                        // the resource resides.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Type'
+                    description: |
+                        // Type identifies the resource's type.
+            description: |4
+                 Reference identifies which resource a condition relates to, when it is not
+                 the core resource itself.
+        hashicorp.consul.resource.Status:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.resource.Condition'
+                    description: |
+                        // Conditions contains a set of discreet observations about the resource in
+                        // relation to the current state of the system (e.g. it is semantically valid).
+                observed_generation:
+                    type: string
+                    description: |
+                        // ObservedGeneration identifies which generation of a resource this status
+                        // related to. It can be used to determine whether the current generation of
+                        // a resource has been reconciled.
+                updated_at:
+                    type: string
+                    format: date-time
+                    description: |
+                        // UpdatedAt is the time at which the status was last written.
+            description: |4
+                 Status is used by controllers to communicate the result of attempting to
+                 reconcile and apply a resource (e.g. surface semantic validation errors)
+                 with users and other controllers.
+        hashicorp.consul.resource.Tenancy:
+            type: object
+            properties:
+                namespace:
+                    type: string
+                    description: |
+                        // Namespace further isolates resources within a partition.
+                        // https://developer.hashicorp.com/consul/docs/enterprise/namespaces
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all namespaces.
+                partition:
+                    type: string
+                    description: |
+                        // Partition is the topmost administrative boundary within a cluster.
+                        // https://developer.hashicorp.com/consul/docs/enterprise/admin-partitions
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all partitions.
+                peer_name:
+                    type: string
+                    description: |
+                        // PeerName identifies which peer the resource is imported from.
+                        // https://developer.hashicorp.com/consul/docs/connect/cluster-peering
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all peers.
+            description: |4
+                 Tenancy describes the tenancy units in which the resource resides.
+        hashicorp.consul.resource.Type:
+            type: object
+            properties:
+                group:
+                    type: string
+                    description: |
+                        // Group describes the area of functionality to which this resource type
+                        // relates (e.g. "catalog", "authorization").
+                group_version:
+                    type: string
+                    description: |
+                        // GroupVersion is incremented when sweeping or backward-incompatible changes
+                        // are made to the group's resource types.
+                kind:
+                    type: string
+                    description: |
+                        // Kind identifies the specific resource type within the group.
+            description: |4
+                 Type describes a resource's type. It follows the GVK (Group Version Kind)
+                 [pattern](https://book.kubebuilder.io/cronjob-tutorial/gvks.html) established
+                 by Kubernetes.
+    parameters:
+        consistent:
+            name: consistent
+            in: query
+            description: When true, the operation will be performed with strong consistency
+            schema:
+                type: boolean
+        name:
+            name: name
+            in: path
+            description: The name of the resource to operate on.
+            required: true
+            schema:
+                type: string
+        name_prefix:
+            name: name_prefix
+            in: query
+            description: The resource name prefix used to filter the result list.
+            schema:
+                type: string
+        namespace:
+            name: namespace
+            in: query
+            description: Specifies the Consul namespace of resources to operate on. This parameter takes precedence over the `ns` alias.
+            schema:
+                type: string
+        ns:
+            name: ns
+            in: query
+            description: '`ns` is an alias for the `namespace` query param. The `namespace` parameter takes precedence.'
+            schema:
+                type: string
+        partition:
+            name: partition
+            in: query
+            description: Specifies the Consul partition of resources to operate on.
+            schema:
+                type: string
+        peer:
+            name: peer
+            in: query
+            description: Specifies the Consul peer of imported resources to operate on.
+            schema:
+                type: string
+    securitySchemes:
+        BearerAuth:
+            type: http
+            scheme: bearer
+        ConsulTokenHeader:
+            type: apiKey
+            in: header
+            name: X-Consul-Token
+security:
+    - BearerAuth: []
+    - ConsulTokenHeader: []

--- a/proto-public/openapi/catalog-v2beta1.openapi.yml
+++ b/proto-public/openapi/catalog-v2beta1.openapi.yml
@@ -1,0 +1,3005 @@
+openapi: 3.0.0
+info:
+    title: Consul catalog
+    description: Consul APIs for interacting with the catalog resource kinds at version v2beta1
+    version: v2beta1
+paths:
+    /catalog/v2beta1/DNSPolicy:
+        get:
+            summary: List catalog.v2beta1.DNSPolicy resources
+            operationId: list-DNSPolicy
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.DNSPolicy'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /catalog/v2beta1/DNSPolicy/{name}:
+        get:
+            summary: Read catalog.v2beta1.DNSPolicy resources
+            operationId: read-DNSPolicy.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.DNSPolicy'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write catalog.v2beta1.DNSPolicy resources
+            operationId: write-DNSPolicy
+            requestBody:
+                description: The catalog.v2beta1.DNSPolicy resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.DNSPolicy'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.DNSPolicy'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete catalog.v2beta1.DNSPolicy resources
+            operationId: delete-DNSPolicy
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /catalog/v2beta1/FailoverPolicy:
+        get:
+            summary: List catalog.v2beta1.FailoverPolicy resources
+            operationId: list-FailoverPolicy
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.FailoverPolicy'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /catalog/v2beta1/FailoverPolicy/{name}:
+        get:
+            summary: Read catalog.v2beta1.FailoverPolicy resources
+            operationId: read-FailoverPolicy.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.FailoverPolicy'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write catalog.v2beta1.FailoverPolicy resources
+            operationId: write-FailoverPolicy
+            requestBody:
+                description: The catalog.v2beta1.FailoverPolicy resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.FailoverPolicy'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.FailoverPolicy'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete catalog.v2beta1.FailoverPolicy resources
+            operationId: delete-FailoverPolicy
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /catalog/v2beta1/HealthChecks:
+        get:
+            summary: List catalog.v2beta1.HealthChecks resources
+            operationId: list-HealthChecks
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.HealthChecks'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /catalog/v2beta1/HealthChecks/{name}:
+        get:
+            summary: Read catalog.v2beta1.HealthChecks resources
+            operationId: read-HealthChecks.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.HealthChecks'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write catalog.v2beta1.HealthChecks resources
+            operationId: write-HealthChecks
+            requestBody:
+                description: The catalog.v2beta1.HealthChecks resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.HealthChecks'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.HealthChecks'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete catalog.v2beta1.HealthChecks resources
+            operationId: delete-HealthChecks
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /catalog/v2beta1/HealthStatus:
+        get:
+            summary: List catalog.v2beta1.HealthStatus resources
+            operationId: list-HealthStatus
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.HealthStatus'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /catalog/v2beta1/HealthStatus/{name}:
+        get:
+            summary: Read catalog.v2beta1.HealthStatus resources
+            operationId: read-HealthStatus.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.HealthStatus'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write catalog.v2beta1.HealthStatus resources
+            operationId: write-HealthStatus
+            requestBody:
+                description: The catalog.v2beta1.HealthStatus resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.HealthStatus'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.HealthStatus'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete catalog.v2beta1.HealthStatus resources
+            operationId: delete-HealthStatus
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /catalog/v2beta1/Node:
+        get:
+            summary: List catalog.v2beta1.Node resources
+            operationId: list-Node
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Node'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /catalog/v2beta1/Node/{name}:
+        get:
+            summary: Read catalog.v2beta1.Node resources
+            operationId: read-Node.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Node'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write catalog.v2beta1.Node resources
+            operationId: write-Node
+            requestBody:
+                description: The catalog.v2beta1.Node resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Node'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Node'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete catalog.v2beta1.Node resources
+            operationId: delete-Node
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /catalog/v2beta1/Service:
+        get:
+            summary: List catalog.v2beta1.Service resources
+            operationId: list-Service
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Service'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /catalog/v2beta1/Service/{name}:
+        get:
+            summary: Read catalog.v2beta1.Service resources
+            operationId: read-Service.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Service'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write catalog.v2beta1.Service resources
+            operationId: write-Service
+            requestBody:
+                description: The catalog.v2beta1.Service resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Service'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Service'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete catalog.v2beta1.Service resources
+            operationId: delete-Service
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /catalog/v2beta1/ServiceEndpoints:
+        get:
+            summary: List catalog.v2beta1.ServiceEndpoints resources
+            operationId: list-ServiceEndpoints
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.ServiceEndpoints'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /catalog/v2beta1/ServiceEndpoints/{name}:
+        get:
+            summary: Read catalog.v2beta1.ServiceEndpoints resources
+            operationId: read-ServiceEndpoints.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.ServiceEndpoints'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write catalog.v2beta1.ServiceEndpoints resources
+            operationId: write-ServiceEndpoints
+            requestBody:
+                description: The catalog.v2beta1.ServiceEndpoints resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.ServiceEndpoints'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.ServiceEndpoints'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete catalog.v2beta1.ServiceEndpoints resources
+            operationId: delete-ServiceEndpoints
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /catalog/v2beta1/VirtualIPs:
+        get:
+            summary: List catalog.v2beta1.VirtualIPs resources
+            operationId: list-VirtualIPs
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.VirtualIPs'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /catalog/v2beta1/VirtualIPs/{name}:
+        get:
+            summary: Read catalog.v2beta1.VirtualIPs resources
+            operationId: read-VirtualIPs.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.VirtualIPs'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write catalog.v2beta1.VirtualIPs resources
+            operationId: write-VirtualIPs
+            requestBody:
+                description: The catalog.v2beta1.VirtualIPs resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.VirtualIPs'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.VirtualIPs'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete catalog.v2beta1.VirtualIPs resources
+            operationId: delete-VirtualIPs
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /catalog/v2beta1/Workload:
+        get:
+            summary: List catalog.v2beta1.Workload resources
+            operationId: list-Workload
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Workload'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /catalog/v2beta1/Workload/{name}:
+        get:
+            summary: Read catalog.v2beta1.Workload resources
+            operationId: read-Workload.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Workload'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write catalog.v2beta1.Workload resources
+            operationId: write-Workload
+            requestBody:
+                description: The catalog.v2beta1.Workload resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Workload'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Workload'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete catalog.v2beta1.Workload resources
+            operationId: delete-Workload
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+components:
+    schemas:
+        hashicorp.consul.catalog.v2beta1.CheckTLSConfig:
+            type: object
+            properties:
+                tls_server_name:
+                    type: string
+                tls_skip_verify:
+                    type: boolean
+                use_tls:
+                    type: boolean
+        hashicorp.consul.catalog.v2beta1.DNSPolicy:
+            type: object
+            properties:
+                weights:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Weights'
+                workloads:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadSelector'
+        hashicorp.consul.catalog.v2beta1.Endpoint:
+            type: object
+            properties:
+                addresses:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadAddress'
+                    description: |
+                        // addresses is the list of addresses for this endpoint.
+                        // This has the same structure as the workload addresses.
+                health_status:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Health'
+                    description: |
+                        // health_status is the aggregated health status of this endpoint.
+                identity:
+                    type: string
+                    description: |
+                        // identity is the name of the workload identity for this endpoint.
+                ports:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadPort'
+                    description: |
+                        // ports is the map of ports for this endpoint.
+                        // This has the same structure as the workload ports but
+                        // will be filtered to just the ports selected by the service.
+                target_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                    description: |
+                        // target_ref is the reference to the resource
+                        // for this endpoint endpoint. This currently must be a workload.
+        hashicorp.consul.catalog.v2beta1.FailoverConfig:
+            type: object
+            properties:
+                destinations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.FailoverDestination'
+                    description: |
+                        // Destinations specifies a fixed list of failover destinations to try. We
+                        // never try a destination multiple times, so those are subtracted from this
+                        // list before proceeding.
+                mode:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.FailoverMode'
+                    description: |
+                        // Mode specifies the type of failover that will be performed. Valid values are
+                        // "sequential", "" (equivalent to "sequential") and "order-by-locality".
+                regions:
+                    type: array
+                    items:
+                        type: string
+                sameness_group:
+                    type: string
+                    description: |
+                        // SamenessGroup specifies the sameness group to failover to.
+        hashicorp.consul.catalog.v2beta1.FailoverDestination:
+            type: object
+            properties:
+                datacenter:
+                    type: string
+                port:
+                    type: string
+                    description: |
+                        // TODO: what should an empty port mean?
+                ref:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // This must be a Service.
+        hashicorp.consul.catalog.v2beta1.FailoverMode:
+            type: string
+            enum:
+                - FAILOVER_MODE_UNSPECIFIED
+                - FAILOVER_MODE_SEQUENTIAL
+                - FAILOVER_MODE_ORDER_BY_LOCALITY
+            description: |4
+                 +kubebuilder:validation:Enum=FAILOVER_MODE_UNSPECIFIED;FAILOVER_MODE_SEQUENTIAL;FAILOVER_MODE_ORDER_BY_LOCALITY
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.catalog.v2beta1.FailoverPolicy:
+            type: object
+            properties:
+                config:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.FailoverConfig'
+                    description: |
+                        // Config defines failover for any named port not present in PortConfigs.
+                port_configs:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.FailoverConfig'
+                    description: |
+                        // PortConfigs defines failover for a specific port on this service and takes
+                        // precedence over Config.
+            description: |4
+                 This is a Resource type.
+        hashicorp.consul.catalog.v2beta1.GRPCCheck:
+            type: object
+            properties:
+                address:
+                    type: string
+                tls:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.CheckTLSConfig'
+        hashicorp.consul.catalog.v2beta1.HTTPCheck:
+            type: object
+            properties:
+                body:
+                    type: string
+                disable_redirects:
+                    type: boolean
+                header:
+                    type: object
+                    additionalProperties:
+                        type: string
+                method:
+                    type: string
+                tls:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.CheckTLSConfig'
+                url:
+                    type: string
+        hashicorp.consul.catalog.v2beta1.Health:
+            type: string
+            enum:
+                - HEALTH_ANY
+                - HEALTH_PASSING
+                - HEALTH_WARNING
+                - HEALTH_CRITICAL
+                - HEALTH_MAINTENANCE
+            description: |4
+                 +kubebuilder:validation:Enum=HEALTH_ANY;HEALTH_PASSING;HEALTH_WARNING;HEALTH_CRITICAL;HEALTH_MAINTENANCE
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.catalog.v2beta1.HealthCheck:
+            type: object
+            properties:
+                deregister_critical_after:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                grpc:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.GRPCCheck'
+                http:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.HTTPCheck'
+                interval:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                name:
+                    type: string
+                os_service:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.OSServiceCheck'
+                tcp:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.TCPCheck'
+                timeout:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                udp:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.UDPCheck'
+        hashicorp.consul.catalog.v2beta1.HealthChecks:
+            type: object
+            properties:
+                health_checks:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.HealthCheck'
+                workloads:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadSelector'
+        hashicorp.consul.catalog.v2beta1.HealthStatus:
+            type: object
+            properties:
+                description:
+                    type: string
+                    description: |
+                        // Description is the description for this status.
+                output:
+                    type: string
+                    description: |
+                        // Output is the output from running the check that resulted in this status
+                status:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Health'
+                    description: |
+                        // Health is the status. This maps to existing health check statuses.
+                type:
+                    type: string
+                    description: |
+                        // Type is the type of this health check, such as http, tcp, or kubernetes-readiness
+            description: |4
+                 This resource will belong to a workload or a node and will have an ownership relationship.
+        hashicorp.consul.catalog.v2beta1.IP:
+            type: object
+            properties:
+                address:
+                    type: string
+                    description: |
+                        // address is the string IPv4 address.
+                        // This could also store IPv6 in the future.
+                generated:
+                    type: boolean
+                    description: |
+                        // generated indicates whether Consul generated or it is user-provided
+                        // (e.g. a ClusterIP of the Kubernetes service).
+        hashicorp.consul.catalog.v2beta1.Locality:
+            type: object
+            properties:
+                region:
+                    type: string
+                    description: |
+                        // Region is region the zone belongs to.
+                zone:
+                    type: string
+                    description: |
+                        // Zone is the zone the entity is running in.
+        hashicorp.consul.catalog.v2beta1.Node:
+            type: object
+            properties:
+                addresses:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.NodeAddress'
+        hashicorp.consul.catalog.v2beta1.NodeAddress:
+            type: object
+            properties:
+                external:
+                    type: boolean
+                    description: |
+                        // external indicates whether this address should be used for external communication
+                        // (aka a WAN address).
+                host:
+                    type: string
+                    description: |
+                        // host can be an IP or DNS name.Í
+        hashicorp.consul.catalog.v2beta1.OSServiceCheck:
+            type: object
+            properties:
+                address:
+                    type: string
+        hashicorp.consul.catalog.v2beta1.Protocol:
+            type: string
+            enum:
+                - PROTOCOL_UNSPECIFIED
+                - PROTOCOL_TCP
+                - PROTOCOL_HTTP
+                - PROTOCOL_HTTP2
+                - PROTOCOL_GRPC
+                - PROTOCOL_MESH
+            description: |4
+                 +kubebuilder:validation:Enum=PROTOCOL_UNSPECIFIED;PROTOCOL_TCP;PROTOCOL_HTTP;PROTOCOL_HTTP2;PROTOCOL_GRPC
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.catalog.v2beta1.Service:
+            type: object
+            properties:
+                ports:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.ServicePort'
+                    description: |
+                        // ports is the list of mappings of workload ports that this service
+                        // represents.
+                virtual_ips:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // virtual_ips is a list of virtual IPs for this service. This is useful when you need to set
+                        // an IP from an external system (like Kubernetes). This can be an IPv4 or IPv6 string.
+                workloads:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadSelector'
+                    description: |
+                        // workloads is a selector for the workloads this service should represent.
+        hashicorp.consul.catalog.v2beta1.ServiceEndpoints:
+            type: object
+            properties:
+                endpoints:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Endpoint'
+        hashicorp.consul.catalog.v2beta1.ServicePort:
+            type: object
+            properties:
+                protocol:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Protocol'
+                    description: |
+                        // protocol is the port's protocol. This should be set to "mesh"
+                        // if the target port is the proxy's inbound port.
+                target_port:
+                    type: string
+                    description: |
+                        // target_port is the name of the workload port.
+                virtual_port:
+                    type: integer
+                    format: int32
+                    description: |
+                        // virtual_port is the port that could only be used when transparent
+                        // proxy is used alongside a virtual IP or a virtual DNS address.
+                        // This value is ignored in other cases. Whether or not using transparent
+                        // proxy, this value is optional.
+        hashicorp.consul.catalog.v2beta1.TCPCheck:
+            type: object
+            properties:
+                address:
+                    type: string
+        hashicorp.consul.catalog.v2beta1.UDPCheck:
+            type: object
+            properties:
+                address:
+                    type: string
+        hashicorp.consul.catalog.v2beta1.VirtualIPs:
+            type: object
+            properties:
+                ips:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.IP'
+        hashicorp.consul.catalog.v2beta1.Weights:
+            type: object
+            properties:
+                passing:
+                    type: integer
+                    format: int32
+                warning:
+                    type: integer
+                    format: int32
+        hashicorp.consul.catalog.v2beta1.Workload:
+            type: object
+            properties:
+                addresses:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadAddress'
+                    description: |
+                        // addresses has a list of all workload addresses. This should include
+                        // LAN and WAN addresses as well as any addresses a proxy would need
+                        // to bind to (if different from the default address).
+                connect_native:
+                    type: boolean
+                    description: |
+                        // deprecated: connect_native indicates whether this workload is connect native which will allow it to be
+                        // part of MeshEndpoints without having the corresponding Proxy resource.
+                enable_tag_override:
+                    type: boolean
+                    description: |
+                        // deprecated: enable_tag_override indicates whether agents should be overriding tags during anti-entropy syncs.
+                identity:
+                    type: string
+                    description: |
+                        // identity is the name of the workload identity this workload is associated with.
+                locality:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Locality'
+                    description: |
+                        // Locality specifies workload locality.
+                node_name:
+                    type: string
+                    description: |
+                        // node_name is the name of the node this workload belongs to.
+                ports:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadPort'
+                    description: |
+                        // ports is a map from port name to workload port’s number and protocol.
+                tags:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // deprecated: tags correspond to service tags that you can add to a service for DNS resolution.
+            description: |4
+                 Workload is the representation of a unit of addressable work. This could
+                 represent a process on a VM, a Kubernetes pod or something else entirely.
+        hashicorp.consul.catalog.v2beta1.WorkloadAddress:
+            type: object
+            properties:
+                external:
+                    type: boolean
+                    description: |
+                        // external indicates whether this address should be used for external communication
+                        // (aka a WAN address).
+                host:
+                    type: string
+                    description: |
+                        // host can be an IP, DNS name or a unix socket.
+                        // If it's a unix socket, only one port can be provided.
+                ports:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // ports is a list of names of ports that this host binds to.
+                        // If no ports are provided, we will assume all ports from the ports map.
+        hashicorp.consul.catalog.v2beta1.WorkloadPort:
+            type: object
+            properties:
+                port:
+                    type: integer
+                    format: int32
+                protocol:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Protocol'
+        hashicorp.consul.catalog.v2beta1.WorkloadSelector:
+            type: object
+            properties:
+                filter:
+                    type: string
+                names:
+                    type: array
+                    items:
+                        type: string
+                prefixes:
+                    type: array
+                    items:
+                        type: string
+            description: |4
+                 WorkloadSelector represents criteria for selecting a subset of workloads.
+        hashicorp.consul.resource.Condition:
+            type: object
+            properties:
+                message:
+                    type: string
+                    description: |
+                        // Message contains a human-friendly description of the status.
+                reason:
+                    type: string
+                    description: |
+                        // Reason provides more machine-readable details about the condition (e.g.
+                        // "InvalidProtocol").
+                resource:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // Resource identifies which resource this condition relates to, when it is
+                        // not the core resource itself.
+                state:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Condition.State'
+                    description: |
+                        // State represents the state of the condition (i.e. true/false/unknown).
+                type:
+                    type: string
+                    description: |
+                        // Type identifies the type of condition (e.g. "Invalid", "ResolvedRefs").
+            description: |4
+                 Condition represents a discreet observation about a resource in relation to
+                 the current state of the system.
+
+                 It is heavily inspired by Kubernetes' [conditions](https://bit.ly/3H9Y6IK)
+                 and the Gateway API [types and reasons](https://bit.ly/3n2PPiP).
+        hashicorp.consul.resource.Condition.State:
+            type: string
+            enum:
+                - STATE_UNKNOWN
+                - STATE_TRUE
+                - STATE_FALSE
+            description: |4
+                 State represents the state of the condition (i.e. true/false/unknown).
+        hashicorp.consul.resource.ID:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the user-given name of the resource (e.g. the "billing" service).
+                tenancy:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Tenancy'
+                    description: |
+                        // Tenancy identifies the tenancy units (i.e. partition, namespace) in which
+                        // the resource resides.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Type'
+                    description: |
+                        // Type identifies the resource's type.
+                uid:
+                    type: string
+                    description: |
+                        // Uid is the unique internal identifier we gave to the resource.
+                        //
+                        // It is primarily used to tell the difference between the current resource
+                        // and previous deleted resources with the same user-given name.
+                        //
+                        // Concretely, Uid is a [ULID](https://github.com/ulid/spec) and you can treat
+                        // its timestamp component as the resource's creation time.
+            description: |4
+                 ID uniquely identifies a resource.
+        hashicorp.consul.resource.Reference:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the user-given name of the resource (e.g. the "billing" service).
+                section:
+                    type: string
+                    description: |
+                        // Section identifies which part of the resource the condition relates to.
+                tenancy:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Tenancy'
+                    description: |
+                        // Tenancy identifies the tenancy units (i.e. partition, namespace) in which
+                        // the resource resides.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Type'
+                    description: |
+                        // Type identifies the resource's type.
+            description: |4
+                 Reference identifies which resource a condition relates to, when it is not
+                 the core resource itself.
+        hashicorp.consul.resource.Status:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.resource.Condition'
+                    description: |
+                        // Conditions contains a set of discreet observations about the resource in
+                        // relation to the current state of the system (e.g. it is semantically valid).
+                observed_generation:
+                    type: string
+                    description: |
+                        // ObservedGeneration identifies which generation of a resource this status
+                        // related to. It can be used to determine whether the current generation of
+                        // a resource has been reconciled.
+                updated_at:
+                    type: string
+                    format: date-time
+                    description: |
+                        // UpdatedAt is the time at which the status was last written.
+            description: |4
+                 Status is used by controllers to communicate the result of attempting to
+                 reconcile and apply a resource (e.g. surface semantic validation errors)
+                 with users and other controllers.
+        hashicorp.consul.resource.Tenancy:
+            type: object
+            properties:
+                namespace:
+                    type: string
+                    description: |
+                        // Namespace further isolates resources within a partition.
+                        // https://developer.hashicorp.com/consul/docs/enterprise/namespaces
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all namespaces.
+                partition:
+                    type: string
+                    description: |
+                        // Partition is the topmost administrative boundary within a cluster.
+                        // https://developer.hashicorp.com/consul/docs/enterprise/admin-partitions
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all partitions.
+                peer_name:
+                    type: string
+                    description: |
+                        // PeerName identifies which peer the resource is imported from.
+                        // https://developer.hashicorp.com/consul/docs/connect/cluster-peering
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all peers.
+            description: |4
+                 Tenancy describes the tenancy units in which the resource resides.
+        hashicorp.consul.resource.Type:
+            type: object
+            properties:
+                group:
+                    type: string
+                    description: |
+                        // Group describes the area of functionality to which this resource type
+                        // relates (e.g. "catalog", "authorization").
+                group_version:
+                    type: string
+                    description: |
+                        // GroupVersion is incremented when sweeping or backward-incompatible changes
+                        // are made to the group's resource types.
+                kind:
+                    type: string
+                    description: |
+                        // Kind identifies the specific resource type within the group.
+            description: |4
+                 Type describes a resource's type. It follows the GVK (Group Version Kind)
+                 [pattern](https://book.kubebuilder.io/cronjob-tutorial/gvks.html) established
+                 by Kubernetes.
+    parameters:
+        consistent:
+            name: consistent
+            in: query
+            description: When true, the operation will be performed with strong consistency
+            schema:
+                type: boolean
+        name:
+            name: name
+            in: path
+            description: The name of the resource to operate on.
+            required: true
+            schema:
+                type: string
+        name_prefix:
+            name: name_prefix
+            in: query
+            description: The resource name prefix used to filter the result list.
+            schema:
+                type: string
+        namespace:
+            name: namespace
+            in: query
+            description: Specifies the Consul namespace of resources to operate on. This parameter takes precedence over the `ns` alias.
+            schema:
+                type: string
+        ns:
+            name: ns
+            in: query
+            description: '`ns` is an alias for the `namespace` query param. The `namespace` parameter takes precedence.'
+            schema:
+                type: string
+        partition:
+            name: partition
+            in: query
+            description: Specifies the Consul partition of resources to operate on.
+            schema:
+                type: string
+        peer:
+            name: peer
+            in: query
+            description: Specifies the Consul peer of imported resources to operate on.
+            schema:
+                type: string
+    securitySchemes:
+        BearerAuth:
+            type: http
+            scheme: bearer
+        ConsulTokenHeader:
+            type: apiKey
+            in: header
+            name: X-Consul-Token
+security:
+    - BearerAuth: []
+    - ConsulTokenHeader: []

--- a/proto-public/openapi/mesh-v2beta1.openapi.yml
+++ b/proto-public/openapi/mesh-v2beta1.openapi.yml
@@ -1,0 +1,7325 @@
+openapi: 3.0.0
+info:
+    title: Consul mesh
+    description: Consul APIs for interacting with the mesh resource kinds at version v2beta1
+    version: v2beta1
+paths:
+    /mesh/v2beta1/ComputedExplicitDestinations:
+        get:
+            summary: List mesh.v2beta1.ComputedExplicitDestinations resources
+            operationId: list-ComputedExplicitDestinations
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedExplicitDestinations'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/ComputedExplicitDestinations/{name}:
+        get:
+            summary: Read mesh.v2beta1.ComputedExplicitDestinations resources
+            operationId: read-ComputedExplicitDestinations.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedExplicitDestinations'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.ComputedExplicitDestinations resources
+            operationId: write-ComputedExplicitDestinations
+            requestBody:
+                description: The mesh.v2beta1.ComputedExplicitDestinations resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedExplicitDestinations'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedExplicitDestinations'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.ComputedExplicitDestinations resources
+            operationId: delete-ComputedExplicitDestinations
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/ComputedProxyConfiguration:
+        get:
+            summary: List mesh.v2beta1.ComputedProxyConfiguration resources
+            operationId: list-ComputedProxyConfiguration
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedProxyConfiguration'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/ComputedProxyConfiguration/{name}:
+        get:
+            summary: Read mesh.v2beta1.ComputedProxyConfiguration resources
+            operationId: read-ComputedProxyConfiguration.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedProxyConfiguration'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.ComputedProxyConfiguration resources
+            operationId: write-ComputedProxyConfiguration
+            requestBody:
+                description: The mesh.v2beta1.ComputedProxyConfiguration resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedProxyConfiguration'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedProxyConfiguration'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.ComputedProxyConfiguration resources
+            operationId: delete-ComputedProxyConfiguration
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/ComputedRoutes:
+        get:
+            summary: List mesh.v2beta1.ComputedRoutes resources
+            operationId: list-ComputedRoutes
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedRoutes'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/ComputedRoutes/{name}:
+        get:
+            summary: Read mesh.v2beta1.ComputedRoutes resources
+            operationId: read-ComputedRoutes.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedRoutes'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.ComputedRoutes resources
+            operationId: write-ComputedRoutes
+            requestBody:
+                description: The mesh.v2beta1.ComputedRoutes resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedRoutes'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedRoutes'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.ComputedRoutes resources
+            operationId: delete-ComputedRoutes
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/DestinationPolicy:
+        get:
+            summary: List mesh.v2beta1.DestinationPolicy resources
+            operationId: list-DestinationPolicy
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationPolicy'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/DestinationPolicy/{name}:
+        get:
+            summary: Read mesh.v2beta1.DestinationPolicy resources
+            operationId: read-DestinationPolicy.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationPolicy'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.DestinationPolicy resources
+            operationId: write-DestinationPolicy
+            requestBody:
+                description: The mesh.v2beta1.DestinationPolicy resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationPolicy'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationPolicy'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.DestinationPolicy resources
+            operationId: delete-DestinationPolicy
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/Destinations:
+        get:
+            summary: List mesh.v2beta1.Destinations resources
+            operationId: list-Destinations
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.Destinations'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/Destinations/{name}:
+        get:
+            summary: Read mesh.v2beta1.Destinations resources
+            operationId: read-Destinations.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.Destinations'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.Destinations resources
+            operationId: write-Destinations
+            requestBody:
+                description: The mesh.v2beta1.Destinations resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.Destinations'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.Destinations'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.Destinations resources
+            operationId: delete-Destinations
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/DestinationsConfiguration:
+        get:
+            summary: List mesh.v2beta1.DestinationsConfiguration resources
+            operationId: list-DestinationsConfiguration
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationsConfiguration'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/DestinationsConfiguration/{name}:
+        get:
+            summary: Read mesh.v2beta1.DestinationsConfiguration resources
+            operationId: read-DestinationsConfiguration.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationsConfiguration'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.DestinationsConfiguration resources
+            operationId: write-DestinationsConfiguration
+            requestBody:
+                description: The mesh.v2beta1.DestinationsConfiguration resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationsConfiguration'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationsConfiguration'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.DestinationsConfiguration resources
+            operationId: delete-DestinationsConfiguration
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/GRPCRoute:
+        get:
+            summary: List mesh.v2beta1.GRPCRoute resources
+            operationId: list-GRPCRoute
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRoute'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/GRPCRoute/{name}:
+        get:
+            summary: Read mesh.v2beta1.GRPCRoute resources
+            operationId: read-GRPCRoute.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRoute'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.GRPCRoute resources
+            operationId: write-GRPCRoute
+            requestBody:
+                description: The mesh.v2beta1.GRPCRoute resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRoute'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRoute'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.GRPCRoute resources
+            operationId: delete-GRPCRoute
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/GatewayClass:
+        get:
+            summary: List mesh.v2beta1.GatewayClass resources
+            operationId: list-GatewayClass
+            parameters:
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+                - $ref: '#/components/parameters/name_prefix'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GatewayClass'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/GatewayClass/{name}:
+        get:
+            summary: Read mesh.v2beta1.GatewayClass resources
+            operationId: read-GatewayClass.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GatewayClass'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.GatewayClass resources
+            operationId: write-GatewayClass
+            requestBody:
+                description: The mesh.v2beta1.GatewayClass resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GatewayClass'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GatewayClass'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.GatewayClass resources
+            operationId: delete-GatewayClass
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+    /mesh/v2beta1/GatewayClassConfig:
+        get:
+            summary: List mesh.v2beta1.GatewayClassConfig resources
+            operationId: list-GatewayClassConfig
+            parameters:
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+                - $ref: '#/components/parameters/name_prefix'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GatewayClassConfig'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/GatewayClassConfig/{name}:
+        get:
+            summary: Read mesh.v2beta1.GatewayClassConfig resources
+            operationId: read-GatewayClassConfig.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GatewayClassConfig'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.GatewayClassConfig resources
+            operationId: write-GatewayClassConfig
+            requestBody:
+                description: The mesh.v2beta1.GatewayClassConfig resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GatewayClassConfig'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GatewayClassConfig'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.GatewayClassConfig resources
+            operationId: delete-GatewayClassConfig
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+    /mesh/v2beta1/HTTPRoute:
+        get:
+            summary: List mesh.v2beta1.HTTPRoute resources
+            operationId: list-HTTPRoute
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRoute'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/HTTPRoute/{name}:
+        get:
+            summary: Read mesh.v2beta1.HTTPRoute resources
+            operationId: read-HTTPRoute.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRoute'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.HTTPRoute resources
+            operationId: write-HTTPRoute
+            requestBody:
+                description: The mesh.v2beta1.HTTPRoute resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRoute'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRoute'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.HTTPRoute resources
+            operationId: delete-HTTPRoute
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/MeshConfiguration:
+        get:
+            summary: List mesh.v2beta1.MeshConfiguration resources
+            operationId: list-MeshConfiguration
+            parameters:
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+                - $ref: '#/components/parameters/name_prefix'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MeshConfiguration'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/MeshConfiguration/{name}:
+        get:
+            summary: Read mesh.v2beta1.MeshConfiguration resources
+            operationId: read-MeshConfiguration.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MeshConfiguration'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.MeshConfiguration resources
+            operationId: write-MeshConfiguration
+            requestBody:
+                description: The mesh.v2beta1.MeshConfiguration resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MeshConfiguration'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MeshConfiguration'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.MeshConfiguration resources
+            operationId: delete-MeshConfiguration
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+    /mesh/v2beta1/MeshGateway:
+        get:
+            summary: List mesh.v2beta1.MeshGateway resources
+            operationId: list-MeshGateway
+            parameters:
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/partition'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MeshGateway'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/MeshGateway/{name}:
+        get:
+            summary: Read mesh.v2beta1.MeshGateway resources
+            operationId: read-MeshGateway.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MeshGateway'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.MeshGateway resources
+            operationId: write-MeshGateway
+            requestBody:
+                description: The mesh.v2beta1.MeshGateway resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MeshGateway'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MeshGateway'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.MeshGateway resources
+            operationId: delete-MeshGateway
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/ProxyConfiguration:
+        get:
+            summary: List mesh.v2beta1.ProxyConfiguration resources
+            operationId: list-ProxyConfiguration
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ProxyConfiguration'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/ProxyConfiguration/{name}:
+        get:
+            summary: Read mesh.v2beta1.ProxyConfiguration resources
+            operationId: read-ProxyConfiguration.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ProxyConfiguration'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.ProxyConfiguration resources
+            operationId: write-ProxyConfiguration
+            requestBody:
+                description: The mesh.v2beta1.ProxyConfiguration resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ProxyConfiguration'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ProxyConfiguration'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.ProxyConfiguration resources
+            operationId: delete-ProxyConfiguration
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/ProxyStateTemplate:
+        get:
+            summary: List mesh.v2beta1.ProxyStateTemplate resources
+            operationId: list-ProxyStateTemplate
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ProxyStateTemplate'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/ProxyStateTemplate/{name}:
+        get:
+            summary: Read mesh.v2beta1.ProxyStateTemplate resources
+            operationId: read-ProxyStateTemplate.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ProxyStateTemplate'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.ProxyStateTemplate resources
+            operationId: write-ProxyStateTemplate
+            requestBody:
+                description: The mesh.v2beta1.ProxyStateTemplate resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ProxyStateTemplate'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ProxyStateTemplate'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.ProxyStateTemplate resources
+            operationId: delete-ProxyStateTemplate
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /mesh/v2beta1/TCPRoute:
+        get:
+            summary: List mesh.v2beta1.TCPRoute resources
+            operationId: list-TCPRoute
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.TCPRoute'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /mesh/v2beta1/TCPRoute/{name}:
+        get:
+            summary: Read mesh.v2beta1.TCPRoute resources
+            operationId: read-TCPRoute.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.TCPRoute'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write mesh.v2beta1.TCPRoute resources
+            operationId: write-TCPRoute
+            requestBody:
+                description: The mesh.v2beta1.TCPRoute resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.TCPRoute'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.TCPRoute'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete mesh.v2beta1.TCPRoute resources
+            operationId: delete-TCPRoute
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+components:
+    schemas:
+        google.protobuf.UInt32Value:
+            type: object
+            properties:
+                value:
+                    type: integer
+                    format: int32
+                    description: |
+                        // The uint32 value.
+            description: |4
+                 Wrapper message for `uint32`.
+
+                 The JSON representation for `UInt32Value` is JSON number.
+        google.protobuf.UInt64Value:
+            type: object
+            properties:
+                value:
+                    type: integer
+                    format: int64
+                    description: |
+                        // The uint64 value.
+            description: |4
+                 Wrapper message for `uint64`.
+
+                 The JSON representation for `UInt64Value` is JSON string.
+        hashicorp.consul.catalog.v2beta1.Endpoint:
+            type: object
+            properties:
+                addresses:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadAddress'
+                    description: |
+                        // addresses is the list of addresses for this endpoint.
+                        // This has the same structure as the workload addresses.
+                health_status:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Health'
+                    description: |
+                        // health_status is the aggregated health status of this endpoint.
+                identity:
+                    type: string
+                    description: |
+                        // identity is the name of the workload identity for this endpoint.
+                ports:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadPort'
+                    description: |
+                        // ports is the map of ports for this endpoint.
+                        // This has the same structure as the workload ports but
+                        // will be filtered to just the ports selected by the service.
+                target_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                    description: |
+                        // target_ref is the reference to the resource
+                        // for this endpoint endpoint. This currently must be a workload.
+        hashicorp.consul.catalog.v2beta1.FailoverMode:
+            type: string
+            enum:
+                - FAILOVER_MODE_UNSPECIFIED
+                - FAILOVER_MODE_SEQUENTIAL
+                - FAILOVER_MODE_ORDER_BY_LOCALITY
+            description: |4
+                 +kubebuilder:validation:Enum=FAILOVER_MODE_UNSPECIFIED;FAILOVER_MODE_SEQUENTIAL;FAILOVER_MODE_ORDER_BY_LOCALITY
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.catalog.v2beta1.Health:
+            type: string
+            enum:
+                - HEALTH_ANY
+                - HEALTH_PASSING
+                - HEALTH_WARNING
+                - HEALTH_CRITICAL
+                - HEALTH_MAINTENANCE
+            description: |4
+                 +kubebuilder:validation:Enum=HEALTH_ANY;HEALTH_PASSING;HEALTH_WARNING;HEALTH_CRITICAL;HEALTH_MAINTENANCE
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.catalog.v2beta1.Protocol:
+            type: string
+            enum:
+                - PROTOCOL_UNSPECIFIED
+                - PROTOCOL_TCP
+                - PROTOCOL_HTTP
+                - PROTOCOL_HTTP2
+                - PROTOCOL_GRPC
+                - PROTOCOL_MESH
+            description: |4
+                 +kubebuilder:validation:Enum=PROTOCOL_UNSPECIFIED;PROTOCOL_TCP;PROTOCOL_HTTP;PROTOCOL_HTTP2;PROTOCOL_GRPC
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.catalog.v2beta1.ServiceEndpoints:
+            type: object
+            properties:
+                endpoints:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Endpoint'
+        hashicorp.consul.catalog.v2beta1.WorkloadAddress:
+            type: object
+            properties:
+                external:
+                    type: boolean
+                    description: |
+                        // external indicates whether this address should be used for external communication
+                        // (aka a WAN address).
+                host:
+                    type: string
+                    description: |
+                        // host can be an IP, DNS name or a unix socket.
+                        // If it's a unix socket, only one port can be provided.
+                ports:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // ports is a list of names of ports that this host binds to.
+                        // If no ports are provided, we will assume all ports from the ports map.
+        hashicorp.consul.catalog.v2beta1.WorkloadPort:
+            type: object
+            properties:
+                port:
+                    type: integer
+                    format: int32
+                protocol:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Protocol'
+        hashicorp.consul.catalog.v2beta1.WorkloadSelector:
+            type: object
+            properties:
+                filter:
+                    type: string
+                names:
+                    type: array
+                    items:
+                        type: string
+                prefixes:
+                    type: array
+                    items:
+                        type: string
+            description: |4
+                 WorkloadSelector represents criteria for selecting a subset of workloads.
+        hashicorp.consul.mesh.v2beta1.AccessLogsConfig:
+            type: object
+            properties:
+                disable_listener_logs:
+                    type: boolean
+                    description: |
+                        // DisableListenerLogs turns off just listener logs for connections rejected by Envoy because they don't
+                        // have a matching listener filter.
+                enabled:
+                    type: boolean
+                    description: |
+                        // Enabled turns off all access logging
+                json_format:
+                    type: string
+                    description: |
+                        // The presence of one format string or the other implies the access log string encoding.
+                        // Defining both is invalid.
+                path:
+                    type: string
+                    description: |
+                        // Path is the output file to write logs
+                text_format:
+                    type: string
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.LogSinkType'
+                    description: |
+                        // Type selects the output for logs: "file", "stderr". "stdout"
+            description: |4
+                 AccessLogsConfig contains the associated default settings for all Envoy
+                 instances within the datacenter or partition
+        hashicorp.consul.mesh.v2beta1.BackendReference:
+            type: object
+            properties:
+                datacenter:
+                    type: string
+                port:
+                    type: string
+                    description: |
+                        // For east/west this is the name of the Consul Service port to direct traffic to
+                        // or empty to imply using the same value as the parent ref.
+                        //
+                        // For north/south this is TBD.
+                ref:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // For east/west configuration, this should point to a Service.
+        hashicorp.consul.mesh.v2beta1.BackendTargetDetails:
+            type: object
+            properties:
+                backend_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.BackendReference'
+                destination_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationConfig'
+                failover_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedFailoverConfig'
+                identity_refs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // IdentityRefs are not populated naturally and the field exists only for
+                        // downstream consumers.
+                mesh_port:
+                    type: string
+                service_endpoints:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.ServiceEndpoints'
+                    description: |
+                        // ServiceEndpoints is not populated naturally and the field exists only for
+                        // downstream consumers.
+                service_endpoints_id:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                    description: |
+                        // ServiceEndpointsID is not populated naturally and the field exists only for
+                        // downstream consumers.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.BackendTargetDetailsType'
+        hashicorp.consul.mesh.v2beta1.BackendTargetDetailsType:
+            type: string
+            enum:
+                - BACKEND_TARGET_DETAILS_TYPE_UNSPECIFIED
+                - BACKEND_TARGET_DETAILS_TYPE_DIRECT
+                - BACKEND_TARGET_DETAILS_TYPE_INDIRECT
+            description: |4
+                 +kubebuilder:validation:Enum=BACKEND_TARGET_DETAILS_TYPE_UNSPECIFIED;BACKEND_TARGET_DETAILS_TYPE_DIRECT;BACKEND_TARGET_DETAILS_TYPE_INDIRECT
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.BalanceConnections:
+            type: string
+            enum:
+                - BALANCE_CONNECTIONS_DEFAULT
+                - BALANCE_CONNECTIONS_EXACT
+            description: |4
+                 +kubebuilder:validation:Enum=BALANCE_CONNECTIONS_DEFAULT;BALANCE_CONNECTIONS_EXACT
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.BootstrapConfig:
+            type: object
+            properties:
+                dogstatsd_url:
+                    type: string
+                override_json_tpl:
+                    type: string
+                prometheus_bind_addr:
+                    type: string
+                ready_bind_addr:
+                    type: string
+                static_clusters_json:
+                    type: string
+                static_listeners_json:
+                    type: string
+                stats_bind_addr:
+                    type: string
+                stats_config_json:
+                    type: string
+                stats_flush_interval:
+                    type: string
+                stats_sinks_json:
+                    type: string
+                stats_tags:
+                    type: array
+                    items:
+                        type: string
+                statsd_url:
+                    type: string
+                telemetry_collector_bind_socket_dir:
+                    type: string
+                tracing_config_json:
+                    type: string
+            description: |4
+                 BootstrapConfig is equivalent to configuration defined
+                 in our docs.
+        hashicorp.consul.mesh.v2beta1.ComputedExplicitDestinations:
+            type: object
+            properties:
+                destinations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.Destination'
+                    description: |
+                        // destinations is the list of explicit destinations to define for the selected workloads.
+        hashicorp.consul.mesh.v2beta1.ComputedFailoverConfig:
+            type: object
+            properties:
+                destinations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedFailoverDestination'
+                mode:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.FailoverMode'
+                regions:
+                    type: array
+                    items:
+                        type: string
+                sameness_group:
+                    type: string
+                    description: |
+                        // SamenessGroup specifies the sameness group to failover to.
+        hashicorp.consul.mesh.v2beta1.ComputedFailoverDestination:
+            type: object
+            properties:
+                backend_target:
+                    type: string
+                    description: |
+                        // BackendTarget must be a Service.
+        hashicorp.consul.mesh.v2beta1.ComputedGRPCBackendRef:
+            type: object
+            properties:
+                backend_target:
+                    type: string
+                    description: |
+                        // BackendTarget indicates which key in the targets map provides
+                        // the rest of the configuration.
+                        //
+                        // If this field is set to the empty string, or is the sentinel value
+                        // "NULL-ROUTE" is an indication that all of the traffic destined for this
+                        // backend reference should be null routed in a format appropriate for the
+                        // protocol (i.e. for HTTP use 5xx).
+                filters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRouteFilter'
+                weight:
+                    type: integer
+                    format: int32
+        hashicorp.consul.mesh.v2beta1.ComputedGRPCRoute:
+            type: object
+            properties:
+                rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedGRPCRouteRule'
+        hashicorp.consul.mesh.v2beta1.ComputedGRPCRouteRule:
+            type: object
+            properties:
+                backend_refs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedGRPCBackendRef'
+                filters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRouteFilter'
+                matches:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRouteMatch'
+                retries:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteRetries'
+                timeouts:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteTimeouts'
+        hashicorp.consul.mesh.v2beta1.ComputedHTTPBackendRef:
+            type: object
+            properties:
+                backend_target:
+                    type: string
+                    description: |
+                        // BackendTarget indicates which key in the targets map provides
+                        // the rest of the configuration.
+                        //
+                        // If this field is set to the empty string, or is the sentinel value
+                        // "NULL-ROUTE" is an indication that all of the traffic destined for this
+                        // backend reference should be null routed in a format appropriate for the
+                        // protocol (i.e. for HTTP use 5xx).
+                filters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteFilter'
+                weight:
+                    type: integer
+                    format: int32
+        hashicorp.consul.mesh.v2beta1.ComputedHTTPRoute:
+            type: object
+            properties:
+                rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedHTTPRouteRule'
+        hashicorp.consul.mesh.v2beta1.ComputedHTTPRouteRule:
+            type: object
+            properties:
+                backend_refs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedHTTPBackendRef'
+                filters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteFilter'
+                matches:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteMatch'
+                retries:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteRetries'
+                timeouts:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteTimeouts'
+        hashicorp.consul.mesh.v2beta1.ComputedPortRoutes:
+            type: object
+            properties:
+                grpc:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedGRPCRoute'
+                http:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedHTTPRoute'
+                parent_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ParentReference'
+                protocol:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Protocol'
+                    description: |
+                        // Protocol is the ParentRef.Port's protocol. It is based on the value in the
+                        // Service object, but may differ depending upon which xRoutes are actually
+                        // in use.
+                targets:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.BackendTargetDetails'
+                    description: |
+                        // map key is an opaque string; like disco chain target name
+                tcp:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedTCPRoute'
+                using_default_config:
+                    type: boolean
+        hashicorp.consul.mesh.v2beta1.ComputedProxyConfiguration:
+            type: object
+            properties:
+                bootstrap_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.BootstrapConfig'
+                    description: |
+                        // bootstrap_config is the configuration that requires proxies
+                        // to be restarted to be applied.
+                dynamic_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DynamicConfig'
+                    description: |
+                        // dynamic_config is the configuration that could be changed
+                        // dynamically (i.e. without needing restart).
+        hashicorp.consul.mesh.v2beta1.ComputedRoutes:
+            type: object
+            properties:
+                bound_references:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // BoundReferences is a slice of mixed type references of resources that were
+                        // involved in the formulation of this resource.
+                ported_configs:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedPortRoutes'
+            description: |4
+                 This is a Resource type.
+        hashicorp.consul.mesh.v2beta1.ComputedTCPBackendRef:
+            type: object
+            properties:
+                backend_target:
+                    type: string
+                    description: |
+                        // BackendTarget indicates which key in the targets map provides
+                        // the rest of the configuration.
+                        //
+                        // If this field is set to the empty string, or is the sentinel value
+                        // "NULL-ROUTE" is an indication that all of the traffic destined for this
+                        // backend reference should be null routed in a format appropriate for the
+                        // protocol (i.e. for HTTP use 5xx).
+                weight:
+                    type: integer
+                    format: int32
+            description: |4
+                 TODO: look into smuggling the target through a different typeURL, or just skip in favor of letting the caller do their own lookups?
+        hashicorp.consul.mesh.v2beta1.ComputedTCPRoute:
+            type: object
+            properties:
+                rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedTCPRouteRule'
+        hashicorp.consul.mesh.v2beta1.ComputedTCPRouteRule:
+            type: object
+            properties:
+                backend_refs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ComputedTCPBackendRef'
+        hashicorp.consul.mesh.v2beta1.ConnectionConfig:
+            type: object
+            properties:
+                connect_timeout:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                request_timeout:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+            description: |4
+                 Referenced by ProxyConfiguration
+        hashicorp.consul.mesh.v2beta1.CookieConfig:
+            type: object
+            properties:
+                path:
+                    type: string
+                    description: |
+                        // The path to set for the cookie
+                session:
+                    type: boolean
+                    description: |
+                        // Generates a session cookie with no expiration.
+                ttl:
+                    type: string
+                    description: |
+                        // TTL for generated cookies. Cannot be specified for session cookies.
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+            description: |4
+                 CookieConfig contains configuration for the "cookie" hash policy type.
+                 This is specified to have Envoy generate a cookie for a client on its first request.
+        hashicorp.consul.mesh.v2beta1.CopyAnnotations:
+            type: object
+            properties:
+                service:
+                    type: array
+                    items:
+                        type: string
+        hashicorp.consul.mesh.v2beta1.Deployment:
+            type: object
+            properties:
+                default_instances:
+                    type: integer
+                    format: int32
+                    description: |
+                        // +kubebuilder:default:=1
+                        // +kubebuilder:validation:Maximum=8
+                        // +kubebuilder:validation:Minimum=1
+                        // Number of gateway instances that should be deployed by default
+                max_instances:
+                    type: integer
+                    format: int32
+                    description: |
+                        // +kubebuilder:default:=8
+                        // +kubebuilder:validation:Maximum=8
+                        // +kubebuilder:validation:Minimum=1
+                        // Max allowed number of gateway instances
+                min_instances:
+                    type: integer
+                    format: int32
+                    description: |
+                        // +kubebuilder:default:=1
+                        // +kubebuilder:validation:Maximum=8
+                        // +kubebuilder:validation:Minimum=1
+                        // Minimum allowed number of gateway instances
+                resources:
+                    $ref: '#/components/schemas/k8s.io.api.core.v1.ResourceRequirements'
+                    description: |
+                        // Resources defines the resource requirements for the gateway.
+        hashicorp.consul.mesh.v2beta1.Destination:
+            type: object
+            properties:
+                datacenter:
+                    type: string
+                    description: |
+                        // Datacenter is the datacenter for where this destination service lives.
+                destination_port:
+                    type: string
+                    description: |
+                        // DestinationPort is the port name of the destination service. This should be the name
+                        // of the service's target port.
+                destination_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // DestinationRef is the reference to an destination service. This has to be pbcatalog.Service type.
+                ip_port:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.IPPortAddress'
+                unix:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.UnixSocketAddress'
+        hashicorp.consul.mesh.v2beta1.DestinationConfig:
+            type: object
+            properties:
+                connect_timeout:
+                    type: string
+                    description: |
+                        // ConnectTimeout is the timeout for establishing new network connections
+                        // to this service.
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                load_balancer:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.LoadBalancer'
+                    description: |
+                        // LoadBalancer determines the load balancing policy and configuration for
+                        // services issuing requests to this upstream service.
+                locality_prioritization:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.LocalityPrioritization'
+                    description: |
+                        // LocalityPrioritization controls whether the locality of services within the
+                        // local partition will be used to prioritize connectivity.
+                request_timeout:
+                    type: string
+                    description: |
+                        // RequestTimeout is the timeout for an HTTP request to complete before the
+                        // connection is automatically terminated. If unspecified, defaults to 15
+                        // seconds.
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+        hashicorp.consul.mesh.v2beta1.DestinationConfigOverrides:
+            type: object
+            properties:
+                config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationConfiguration'
+                    description: |
+                        // Config is the configuration that should apply to this destination.
+                datacenter:
+                    type: string
+                    description: |
+                        // Datacenter is the datacenter for where this destination service lives.
+                destination_port:
+                    type: string
+                    description: |
+                        // DestinationPort is the port name of the destination service. This should be the name
+                        // of the service's target port. If not provided, this configuration will apply to all ports of an destination.
+                destination_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // DestinationRef is the reference to an destination service that this configuration applies to.
+                        // This has to be pbcatalog.Service type.
+            description: |4
+                 UpstreamConfigOverrides allow to override destination configuration per destination_ref/port/datacenter.
+                 In that sense, those three fields (destination_ref, destination_port and datacenter) are treated
+                 sort of like map keys and config is a like a map value for that key.
+        hashicorp.consul.mesh.v2beta1.DestinationConfiguration:
+            type: object
+            properties:
+                balance_outbound_connections:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.BalanceConnections'
+                    description: |
+                        // BalanceOutboundConnections indicates how the proxy should attempt to distribute
+                        // connections across worker threads.
+                connect_timeout:
+                    type: string
+                    description: |
+                        // ConnectTimeout is the timeout used when making a new
+                        // connection to this destination. Defaults to 5 seconds if not set.
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                limits:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationLimits'
+                    description: |
+                        // Limits are the set of limits that are applied to the proxy for a specific destination.
+                mesh_gateway_mode:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MeshGatewayMode'
+                    description: |
+                        // MeshGatewayMode is the Mesh Gateway routing mode.
+                passive_health_check:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.PassiveHealthCheck'
+                    description: |
+                        // PassiveHealthCheck configuration determines how destination proxy instances will
+                        // be monitored for removal from the load balancing pool.
+                protocol:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.Protocol'
+                    description: |
+                        // Protocol overrides destination's port protocol. If no port for an destination is specified
+                        // or if used in the default configuration, this protocol will be used for all ports
+                        // or for all ports of all destinations respectively.
+        hashicorp.consul.mesh.v2beta1.DestinationLimits:
+            type: object
+            properties:
+                max_concurrent_requests:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                    description: |
+                        // MaxConcurrentRequests is the maximum number of in-flight requests that will be allowed
+                        // to the destination cluster at a point in time. This is mostly applicable to HTTP/2
+                        // clusters since all HTTP/1.1 requests are limited by MaxConnections.
+                max_connections:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                    description: |
+                        // MaxConnections is the maximum number of connections the local proxy can
+                        // make to the destination service.
+                max_pending_requests:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                    description: |
+                        // MaxPendingRequests is the maximum number of requests that will be queued
+                        // waiting for an available connection. This is mostly applicable to HTTP/1.1
+                        // clusters since all HTTP/2 requests are streamed over a single
+                        // connection.
+            description: |4
+                 UpstreamLimits describes the limits that are associated with a specific
+                 destination of a service instance.
+        hashicorp.consul.mesh.v2beta1.DestinationPolicy:
+            type: object
+            properties:
+                port_configs:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationConfig'
+            description: |4
+                 DestinationPolicy is the destination-controlled set of defaults that
+                 are used when similar controls defined in an UpstreamConfig are left
+                 unspecified.
+
+                 Users may wish to share commonly configured settings for communicating with
+                 a service in one place, but yet retain the ability to tweak those on a
+                 client-by-client basis, which is why there are separate resources to control
+                 the definition of these values from either end of the connection.
+
+                 This is a Resource type.
+        hashicorp.consul.mesh.v2beta1.Destinations:
+            type: object
+            properties:
+                destinations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.Destination'
+                    description: |
+                        // Destinations is the list of explicit destinations to define for the selected workloads.
+                pq_destinations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.PreparedQueryDestination'
+                    description: |
+                        // PQDestinations is the list of prepared query destinations. This field is not supported directly in v2
+                        // and should only be used for migration reasons.
+                workloads:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadSelector'
+                    description: |
+                        // Selection of workloads these destinations should apply to.
+                        // These can be prefixes or specific workload names.
+        hashicorp.consul.mesh.v2beta1.DestinationsConfiguration:
+            type: object
+            properties:
+                config_overrides:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationConfigOverrides'
+                    description: |
+                        // ConfigOverrides provides per-destination or per-destination-port config overrides.
+                default_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationConfiguration'
+                    description: |
+                        // DefaultConfig applies to all destinations for the workloads selected by this resource.
+                workloads:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadSelector'
+                    description: |
+                        // Selection of workloads these destinations should apply to.
+                        // These can be prefixes or specific workload names.
+        hashicorp.consul.mesh.v2beta1.DynamicConfig:
+            type: object
+            properties:
+                access_logs:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.AccessLogsConfig'
+                    description: |
+                        // AccessLogs configures the output and format of Envoy access logs
+                expose_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ExposeConfig'
+                inbound_connections:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.InboundConnectionsConfig'
+                    description: |
+                        // inbound_connections configures inbound connections to the proxy.
+                listener_tracing_json:
+                    type: string
+                local_cluster_json:
+                    type: string
+                local_connection:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ConnectionConfig'
+                    description: |
+                        // local_connection is the configuration that should be used
+                        // to connect to the local application provided per-port.
+                        // The map keys should correspond to port names on the workload.
+                local_workload_address:
+                    type: string
+                    description: |
+                        // deprecated:
+                        // local_workload_address, local_workload_port, and local_workload_socket_path
+                        // are deprecated and are only needed for migration of existing resources.
+                local_workload_port:
+                    type: integer
+                    format: int32
+                local_workload_socket_path:
+                    type: string
+                mesh_gateway_mode:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MeshGatewayMode'
+                mode:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ProxyMode'
+                    description: |
+                        // mode indicates the proxy's mode. This will default to 'transparent'.
+                mutual_tls_mode:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.MutualTLSMode'
+                public_listener_json:
+                    type: string
+                transparent_proxy:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.TransparentProxy'
+        hashicorp.consul.mesh.v2beta1.ExposeConfig:
+            type: object
+            properties:
+                expose_paths:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ExposePath'
+        hashicorp.consul.mesh.v2beta1.ExposePath:
+            type: object
+            properties:
+                listener_port:
+                    type: integer
+                    format: int32
+                local_path_port:
+                    type: integer
+                    format: int32
+                path:
+                    type: string
+                protocol:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ExposePathProtocol'
+        hashicorp.consul.mesh.v2beta1.ExposePathProtocol:
+            type: string
+            enum:
+                - EXPOSE_PATH_PROTOCOL_HTTP
+                - EXPOSE_PATH_PROTOCOL_HTTP2
+            description: |4
+                 +kubebuilder:validation:Enum=EXPOSE_PATH_PROTOCOL_HTTP;EXPOSE_PATH_PROTOCOL_HTTP2
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.GRPCBackendRef:
+            type: object
+            properties:
+                backend_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.BackendReference'
+                filters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRouteFilter'
+                    description: |
+                        // Filters defined at this level should be executed if and only if the
+                        // request is being forwarded to the backend defined here.
+                weight:
+                    type: integer
+                    format: int32
+                    description: |
+                        // Weight specifies the proportion of requests forwarded to the referenced
+                        // backend. This is computed as weight/(sum of all weights in this
+                        // BackendRefs list). For non-zero values, there may be some epsilon from the
+                        // exact proportion defined here depending on the precision an implementation
+                        // supports. Weight is not a percentage and the sum of weights does not need
+                        // to equal 100.
+                        //
+                        //If only one backend is specified and it has a weight greater than 0, 100%
+                        //of the traffic is forwarded to that backend. If weight is set to 0, no
+                        //traffic should be forwarded for this entry. If unspecified, weight defaults
+                        //to 1.
+        hashicorp.consul.mesh.v2beta1.GRPCHeaderMatch:
+            type: object
+            properties:
+                name:
+                    type: string
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HeaderMatchType'
+                value:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.GRPCMethodMatch:
+            type: object
+            properties:
+                method:
+                    type: string
+                    description: |
+                        // Value of the method to match against. If left empty or omitted, will match
+                        // all services.
+                        //
+                        // At least one of Service and Method MUST be a non-empty string.}
+                service:
+                    type: string
+                    description: |
+                        // Value of the service to match against. If left empty or omitted, will
+                        // match any service.
+                        //
+                        // At least one of Service and Method MUST be a non-empty string.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCMethodMatchType'
+                    description: |
+                        // Type specifies how to match against the service and/or method. Support:
+                        // Core (Exact with service and method specified)
+        hashicorp.consul.mesh.v2beta1.GRPCMethodMatchType:
+            type: string
+            enum:
+                - GRPC_METHOD_MATCH_TYPE_UNSPECIFIED
+                - GRPC_METHOD_MATCH_TYPE_EXACT
+                - GRPC_METHOD_MATCH_TYPE_REGEX
+            description: |4
+                 +kubebuilder:validation:Enum=GRPC_METHOD_MATCH_TYPE_UNSPECIFIED;GRPC_METHOD_MATCH_TYPE_EXACT;GRPC_METHOD_MATCH_TYPE_REGEX
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.GRPCRoute:
+            type: object
+            properties:
+                hostnames:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // Hostnames are the hostnames for which this GRPCRoute should respond to requests.
+                        //
+                        // This is only valid for north/south.
+                parent_refs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ParentReference'
+                    description: |
+                        // ParentRefs references the resources (usually Services) that a Route wants
+                        // to be attached to.
+                        //
+                        // It is invalid to reference an identical parent more than once. It is valid
+                        // to reference multiple distinct sections within the same parent resource.
+                rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRouteRule'
+                    description: |
+                        // Rules are a list of GRPC matchers, filters and actions.
+            description: |4
+                 NOTE: this should align to the GAMMA/gateway-api version, or at least be
+                 easily translatable.
+
+                 https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRoute
+
+                 This is a Resource type.
+        hashicorp.consul.mesh.v2beta1.GRPCRouteFilter:
+            type: object
+            properties:
+                request_header_modifier:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPHeaderFilter'
+                    description: |
+                        // RequestHeaderModifier defines a schema for a filter that modifies request
+                        // headers.
+                response_header_modifier:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPHeaderFilter'
+                    description: |
+                        // ResponseHeaderModifier defines a schema for a filter that modifies
+                        // response headers.
+                url_rewrite:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPURLRewriteFilter'
+                    description: |
+                        // URLRewrite defines a schema for a filter that modifies a request during
+                        // forwarding.
+        hashicorp.consul.mesh.v2beta1.GRPCRouteMatch:
+            type: object
+            properties:
+                headers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCHeaderMatch'
+                    description: |
+                        // Headers specifies gRPC request header matchers. Multiple match values are
+                        // ANDed together, meaning, a request MUST match all the specified headers to
+                        // select the route.
+                method:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCMethodMatch'
+                    description: |
+                        // Method specifies a gRPC request service/method matcher. If this field is
+                        // not specified, all services and methods will match.
+        hashicorp.consul.mesh.v2beta1.GRPCRouteRule:
+            type: object
+            properties:
+                backend_refs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCBackendRef'
+                    description: |
+                        // BackendRefs defines the backend(s) where matching requests should be sent.
+                        // Failure behavior here depends on how many BackendRefs are specified and
+                        // how many are invalid.
+                        //
+                        // If all entries in BackendRefs are invalid, and there are also no filters
+                        // specified in this route rule, all traffic which matches this rule MUST
+                        // receive a 500 status code.
+                        //
+                        // See the GRPCBackendRef definition for the rules about what makes a single
+                        // GRPCBackendRef invalid.
+                        //
+                        // When a GRPCBackendRef is invalid, 500 status codes MUST be returned for
+                        // requests that would have otherwise been routed to an invalid backend. If
+                        // multiple backends are specified, and some are invalid, the proportion of
+                        // requests that would otherwise have been routed to an invalid backend MUST
+                        // receive a 500 status code.
+                        //
+                        // For example, if two backends are specified with equal weights, and one is
+                        // invalid, 50 percent of traffic must receive a 500. Implementations may
+                        // choose how that 50 percent is determined.
+                filters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRouteFilter'
+                matches:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.GRPCRouteMatch'
+                retries:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteRetries'
+                timeouts:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteTimeouts'
+        hashicorp.consul.mesh.v2beta1.GatewayClass:
+            type: object
+            properties:
+                controller_name:
+                    type: string
+                    description: |
+                        // ControllerName is the name of the Kubernetes controller that manages Gateways of this class
+                description:
+                    type: string
+                    description: |
+                        // Description of GatewayClass
+                parameters_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ParametersReference'
+                    description: |
+                        // ParametersRef refers to a resource responsible for configuring
+                        // the behavior of the GatewayClass.
+            description: |4
+                 NOTE: this should align to the GAMMA/gateway-api version, or at least be
+                 easily translatable.
+
+                 https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayClass
+
+                 This is a Resource type.
+        hashicorp.consul.mesh.v2beta1.GatewayClassConfig:
+            type: object
+            properties:
+                copy_annotations:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.CopyAnnotations'
+                deployment:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.Deployment'
+                node_selector:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: |
+                        // NodeSelector is a selector which must be true for the pod to fit on a node.
+                        // Selector which must match a node's labels for the pod to be scheduled on that node.
+                        // More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                openshift_scc_name:
+                    type: string
+                pod_security_policy:
+                    type: string
+                service_type:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
+                tolerations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/k8s.io.api.core.v1.Toleration'
+                    description: |
+                        // Tolerations allow the scheduler to schedule nodes with matching taints.
+                        // More Info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                use_host_ports:
+                    type: boolean
+            description: |4
+                 This is a Resource type.
+        hashicorp.consul.mesh.v2beta1.HTTPBackendRef:
+            type: object
+            properties:
+                backend_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.BackendReference'
+                filters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteFilter'
+                    description: |
+                        // Filters defined at this level should be executed if and only if the
+                        // request is being forwarded to the backend defined here.
+                weight:
+                    type: integer
+                    format: int32
+                    description: |
+                        // Weight specifies the proportion of requests forwarded to the referenced
+                        // backend. This is computed as weight/(sum of all weights in this
+                        // BackendRefs list). For non-zero values, there may be some epsilon from the
+                        // exact proportion defined here depending on the precision an implementation
+                        // supports. Weight is not a percentage and the sum of weights does not need
+                        // to equal 100.
+                        //
+                        // If only one backend is specified and it has a weight greater than 0, 100%
+                        // of the traffic is forwarded to that backend. If weight is set to 0, no
+                        // traffic should be forwarded for this entry. If unspecified, weight defaults
+                        // to 1.
+        hashicorp.consul.mesh.v2beta1.HTTPHeader:
+            type: object
+            properties:
+                name:
+                    type: string
+                value:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.HTTPHeaderFilter:
+            type: object
+            properties:
+                add:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPHeader'
+                    description: |
+                        // Add adds the given header(s) (name, value) to the request before the
+                        // action. It appends to any existing values associated with the header name.
+                remove:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // Remove the given header(s) from the HTTP request before the action. The
+                        // value of Remove is a list of HTTP header names. Note that the header names
+                        // are case-insensitive (see
+                        // https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                set:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPHeader'
+                    description: |
+                        // Set overwrites the request with the given header (name, value) before the
+                        // action.
+        hashicorp.consul.mesh.v2beta1.HTTPHeaderMatch:
+            type: object
+            properties:
+                invert:
+                    type: boolean
+                    description: |
+                        // NOTE: not in gamma; service-router compat
+                name:
+                    type: string
+                    description: |
+                        // Name is the name of the HTTP Header to be matched. Name matching MUST be
+                        // case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                        //
+                        // If multiple entries specify equivalent header names, only the first entry
+                        // with an equivalent name MUST be considered for a match. Subsequent entries
+                        // with an equivalent header name MUST be ignored. Due to the
+                        // case-insensitivity of header names, “foo” and “Foo” are considered
+                        // equivalent.
+                        //
+                        // When a header is repeated in an HTTP request, it is
+                        // implementation-specific behavior as to how this is represented. Generally,
+                        // proxies should follow the guidance from the RFC:
+                        // https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                        // processing a repeated header, with special handling for “Set-Cookie”.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HeaderMatchType'
+                    description: |
+                        // Type specifies how to match against the value of the header.
+                value:
+                    type: string
+                    description: |
+                        // Value is the value of HTTP Header to be matched.
+        hashicorp.consul.mesh.v2beta1.HTTPPathMatch:
+            type: object
+            properties:
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.PathMatchType'
+                    description: |
+                        // Type specifies how to match against the path Value.
+                value:
+                    type: string
+                    description: |
+                        // Value of the HTTP path to match against.
+        hashicorp.consul.mesh.v2beta1.HTTPQueryParamMatch:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the name of the HTTP query param to be matched. This must be an
+                        // exact string match. (See
+                        // https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                        //
+                        // If multiple entries specify equivalent query param names, only the first
+                        // entry with an equivalent name MUST be considered for a match. Subsequent
+                        // entries with an equivalent query param name MUST be ignored.
+                        //
+                        // If a query param is repeated in an HTTP request, the behavior is purposely
+                        // left undefined, since different data planes have different capabilities.
+                        // However, it is recommended that implementations should match against the
+                        // first value of the param if the data plane supports it, as this behavior
+                        // is expected in other load balancing contexts outside of the Gateway API.
+                        //
+                        // Users SHOULD NOT route traffic based on repeated query params to guard
+                        // themselves against potential differences in the implementations.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.QueryParamMatchType'
+                    description: |
+                        // Type specifies how to match against the value of the query parameter.
+                value:
+                    type: string
+                    description: |
+                        // Value is the value of HTTP query param to be matched.
+        hashicorp.consul.mesh.v2beta1.HTTPRoute:
+            type: object
+            properties:
+                hostnames:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // Hostnames are the hostnames for which this HTTPRoute should respond to requests.
+                        //
+                        // This is only valid for north/south.
+                parent_refs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ParentReference'
+                    description: |
+                        // ParentRefs references the resources (usually Services) that a Route wants
+                        // to be attached to.
+                        //
+                        // It is invalid to reference an identical parent more than once. It is valid
+                        // to reference multiple distinct sections within the same parent resource.
+                rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteRule'
+                    description: |
+                        // Rules are a list of HTTP-based routing rules that this route should
+                        // use for constructing a routing table.
+            description: |4
+                 NOTE: this should align to the GAMMA/gateway-api version, or at least be
+                 easily translatable.
+
+                 https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute
+
+                 This is a Resource type.
+        hashicorp.consul.mesh.v2beta1.HTTPRouteFilter:
+            type: object
+            properties:
+                request_header_modifier:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPHeaderFilter'
+                    description: |
+                        // RequestHeaderModifier defines a schema for a filter that modifies request
+                        // headers.
+                response_header_modifier:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPHeaderFilter'
+                    description: |
+                        // ResponseHeaderModifier defines a schema for a filter that modifies
+                        // response headers.
+                url_rewrite:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPURLRewriteFilter'
+                    description: |
+                        // URLRewrite defines a schema for a filter that modifies a request during
+                        // forwarding.
+        hashicorp.consul.mesh.v2beta1.HTTPRouteMatch:
+            type: object
+            properties:
+                headers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPHeaderMatch'
+                    description: |
+                        // Headers specifies HTTP request header matchers. Multiple match values are
+                        // ANDed together, meaning, a request must match all the specified headers to
+                        // select the route.
+                method:
+                    type: string
+                    description: |
+                        // Method specifies HTTP method matcher. When specified, this route will be
+                        // matched only if the request has the specified method.
+                path:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPPathMatch'
+                    description: |
+                        // Path specifies a HTTP request path matcher. If this field is not
+                        // specified, a default prefix match on the “/” path is provided.
+                query_params:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPQueryParamMatch'
+                    description: |
+                        // QueryParams specifies HTTP query parameter matchers. Multiple match values
+                        // are ANDed together, meaning, a request must match all the specified query
+                        // parameters to select the route.
+        hashicorp.consul.mesh.v2beta1.HTTPRouteRetries:
+            type: object
+            properties:
+                number:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                    description: |
+                        // Number is the number of times to retry the request when a retryable
+                        // result occurs.
+                on_conditions:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // RetryOn allows setting envoy specific conditions when a request should
+                        // be automatically retried.
+                on_connect_failure:
+                    type: boolean
+                    description: |
+                        // RetryOnConnectFailure allows for connection failure errors to trigger a
+                        // retry.
+                on_status_codes:
+                    type: array
+                    items:
+                        type: integer
+                        format: int32
+                    description: |
+                        // RetryOnStatusCodes is a flat list of http response status codes that are
+                        // eligible for retry. This again should be feasible in any reasonable proxy.
+        hashicorp.consul.mesh.v2beta1.HTTPRouteRule:
+            type: object
+            properties:
+                backend_refs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPBackendRef'
+                    description: |
+                        // BackendRefs defines the backend(s) where matching requests should be sent.
+                        //
+                        // Failure behavior here depends on how many BackendRefs are specified and
+                        // how many are invalid.
+                        //
+                        // If all entries in BackendRefs are invalid, and there are also no filters
+                        // specified in this route rule, all traffic which matches this rule MUST
+                        // receive a 500 status code.
+                        //
+                        // See the HTTPBackendRef definition for the rules about what makes a single
+                        // HTTPBackendRef invalid.
+                        //
+                        // When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
+                        // requests that would have otherwise been routed to an invalid backend. If
+                        // multiple backends are specified, and some are invalid, the proportion of
+                        // requests that would otherwise have been routed to an invalid backend MUST
+                        // receive a 500 status code.
+                        //
+                        // For example, if two backends are specified with equal weights, and one is
+                        // invalid, 50 percent of traffic must receive a 500. Implementations may
+                        // choose how that 50 percent is determined.
+                filters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteFilter'
+                matches:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteMatch'
+                retries:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteRetries'
+                timeouts:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HTTPRouteTimeouts'
+            description: |4
+                 HTTPRouteRule specifies the routing rules used to determine what upstream
+                 service an HTTP request is routed to.
+        hashicorp.consul.mesh.v2beta1.HTTPRouteTimeouts:
+            type: object
+            properties:
+                idle:
+                    type: string
+                    description: |
+                        // Idle specifies the total amount of time permitted for the request stream to be idle.
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                request:
+                    type: string
+                    description: |
+                        // RequestTimeout is the total amount of time permitted for the entire
+                        // downstream request (and retries) to be processed.
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+            description: |4
+                 HTTPRouteTimeouts defines timeouts that can be configured for an HTTPRoute
+                 or GRPCRoute.
+        hashicorp.consul.mesh.v2beta1.HTTPURLRewriteFilter:
+            type: object
+            properties:
+                path_prefix:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.HashPolicy:
+            type: object
+            properties:
+                cookie_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.CookieConfig'
+                    description: |
+                        // CookieConfig contains configuration for the "cookie" hash policy type.
+                field:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HashPolicyField'
+                    description: |
+                        // Field is the attribute type to hash on.
+                        // Must be one of "header","cookie", or "query_parameter".
+                        // Cannot be specified along with SourceIP.
+                field_value:
+                    type: string
+                    description: |
+                        // FieldValue is the value to hash.
+                        // ie. header name, cookie name, URL query parameter name
+                        // Cannot be specified along with SourceIP.
+                source_ip:
+                    type: boolean
+                    description: |
+                        // SourceIP determines whether the hash should be of the source IP rather than of a field and field value.
+                        // Cannot be specified along with Field or FieldValue.
+                terminal:
+                    type: boolean
+                    description: |
+                        // Terminal will short circuit the computation of the hash when multiple hash policies are present.
+                        // If a hash is computed when a Terminal policy is evaluated,
+                        // then that hash will be used and subsequent hash policies will be ignored.
+            description: |4
+                 HashPolicy defines which attributes will be hashed by hash-based LB algorithms
+        hashicorp.consul.mesh.v2beta1.HashPolicyField:
+            type: string
+            enum:
+                - HASH_POLICY_FIELD_UNSPECIFIED
+                - HASH_POLICY_FIELD_HEADER
+                - HASH_POLICY_FIELD_COOKIE
+                - HASH_POLICY_FIELD_QUERY_PARAMETER
+            description: |4
+                 +kubebuilder:validation:Enum=HASH_POLICY_FIELD_UNSPECIFIED;HASH_POLICY_FIELD_HEADER;HASH_POLICY_FIELD_COOKIE;HASH_POLICY_FIELD_QUERY_PARAMETER
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.HeaderMatchType:
+            type: string
+            enum:
+                - HEADER_MATCH_TYPE_UNSPECIFIED
+                - HEADER_MATCH_TYPE_EXACT
+                - HEADER_MATCH_TYPE_REGEX
+                - HEADER_MATCH_TYPE_PRESENT
+                - HEADER_MATCH_TYPE_PREFIX
+                - HEADER_MATCH_TYPE_SUFFIX
+            description: |4
+                 HeaderMatchType specifies the semantics of how HTTP header values should be
+                 compared. Valid HeaderMatchType values, along with their conformance levels,
+                 are:
+
+                 Note that values may be added to this enum, implementations must ensure that
+                 unknown values will not cause a crash.
+
+                 Unknown values here must result in the implementation setting the Accepted
+                 Condition for the Route to status: False, with a Reason of UnsupportedValue.
+
+                 +kubebuilder:validation:Enum=HEADER_MATCH_TYPE_UNSPECIFIED;HEADER_MATCH_TYPE_EXACT;HEADER_MATCH_TYPE_REGEX;HEADER_MATCH_TYPE_PRESENT;HEADER_MATCH_TYPE_PREFIX;HEADER_MATCH_TYPE_SUFFIX
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.IPPortAddress:
+            type: object
+            properties:
+                ip:
+                    type: string
+                    description: |
+                        // ip is an IPv4 or an IPv6 address.
+                port:
+                    type: integer
+                    format: int32
+                    description: |
+                        // port is the port number.
+        hashicorp.consul.mesh.v2beta1.InboundConnectionsConfig:
+            type: object
+            properties:
+                balance_inbound_connections:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.BalanceConnections'
+                max_inbound_connections:
+                    type: integer
+                    format: int32
+            description: |4
+                 Referenced by ProxyConfiguration
+        hashicorp.consul.mesh.v2beta1.LeastRequestConfig:
+            type: object
+            properties:
+                choice_count:
+                    type: integer
+                    format: int32
+                    description: |
+                        // ChoiceCount determines the number of random healthy hosts from which to select the one with the least requests.
+            description: |4
+                 LeastRequestConfig contains configuration for the "least_request" policy type
+        hashicorp.consul.mesh.v2beta1.LoadBalancer:
+            type: object
+            properties:
+                hash_policies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.HashPolicy'
+                    description: |
+                        // HashPolicies is a list of hash policies to use for hashing load balancing
+                        // algorithms. Hash policies are evaluated individually and combined such
+                        // that identical lists result in the same hash.
+                        //
+                        // If no hash policies are present, or none are successfully evaluated,
+                        // then a random backend host will be selected.
+                least_request_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.LeastRequestConfig'
+                    description: |
+                        // LeastRequestConfig contains configuration for the "least_request" policy type
+                policy:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.LoadBalancerPolicy'
+                    description: |
+                        // Policy is the load balancing policy used to select a host
+                ring_hash_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.RingHashConfig'
+                    description: |
+                        // RingHashConfig contains configuration for the "ring_hash" policy type
+            description: |4+
+                 LoadBalancer determines the load balancing policy and configuration
+                 for services issuing requests to this upstream service.
+
+        hashicorp.consul.mesh.v2beta1.LoadBalancerPolicy:
+            type: string
+            enum:
+                - LOAD_BALANCER_POLICY_UNSPECIFIED
+                - LOAD_BALANCER_POLICY_RANDOM
+                - LOAD_BALANCER_POLICY_ROUND_ROBIN
+                - LOAD_BALANCER_POLICY_LEAST_REQUEST
+                - LOAD_BALANCER_POLICY_MAGLEV
+                - LOAD_BALANCER_POLICY_RING_HASH
+            description: |4
+                 +kubebuilder:validation:Enum=LOAD_BALANCER_POLICY_UNSPECIFIED;LOAD_BALANCER_POLICY_RANDOM;LOAD_BALANCER_POLICY_ROUND_ROBIN;LOAD_BALANCER_POLICY_LEAST_REQUEST;LOAD_BALANCER_POLICY_MAGLEV;LOAD_BALANCER_POLICY_RING_HASH
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.LocalityPrioritization:
+            type: object
+            properties:
+                mode:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.LocalityPrioritizationMode'
+                    description: |
+                        // Mode specifies the type of prioritization that will be performed
+                        // when selecting nodes in the local partition.
+                        // Valid values are: "" (default "none"), "none", and "failover".
+        hashicorp.consul.mesh.v2beta1.LocalityPrioritizationMode:
+            type: string
+            enum:
+                - LOCALITY_PRIORITIZATION_MODE_UNSPECIFIED
+                - LOCALITY_PRIORITIZATION_MODE_NONE
+                - LOCALITY_PRIORITIZATION_MODE_FAILOVER
+            description: |4
+                 +kubebuilder:validation:Enum=LOCALITY_PRIORITIZATION_MODE_UNSPECIFIED;LOCALITY_PRIORITIZATION_MODE_NONE;LOCALITY_PRIORITIZATION_MODE_FAILOVER
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.LogSinkType:
+            type: string
+            enum:
+                - LOG_SINK_TYPE_DEFAULT
+                - LOG_SINK_TYPE_FILE
+                - LOG_SINK_TYPE_STDERR
+                - LOG_SINK_TYPE_STDOUT
+            description: |4
+                 +kubebuilder:validation:Enum=LOG_SINK_TYPE_DEFAULT;LOG_SINK_TYPE_FILE;LOG_SINK_TYPE_STDERR;LOG_SINK_TYPE_STDOUT
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.MeshConfiguration:
+            type: object
+            description: |4
+                 MeshConfiguration is responsible for configuring the default behavior of Mesh Gateways.
+                 This is a Resource type.
+        hashicorp.consul.mesh.v2beta1.MeshGateway:
+            type: object
+            properties:
+                gateway_class_name:
+                    type: string
+                    description: |
+                        // GatewayClassName is the name of the GatewayClass used by the MeshGateway
+        hashicorp.consul.mesh.v2beta1.MeshGatewayMode:
+            type: string
+            enum:
+                - MESH_GATEWAY_MODE_UNSPECIFIED
+                - MESH_GATEWAY_MODE_NONE
+                - MESH_GATEWAY_MODE_LOCAL
+                - MESH_GATEWAY_MODE_REMOTE
+            description: |4
+                 +kubebuilder:validation:Enum=MESH_GATEWAY_MODE_UNSPECIFIED;MESH_GATEWAY_MODE_NONE;MESH_GATEWAY_MODE_LOCAL;MESH_GATEWAY_MODE_REMOTE
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.MutualTLSMode:
+            type: string
+            enum:
+                - MUTUAL_TLS_MODE_DEFAULT
+                - MUTUAL_TLS_MODE_STRICT
+                - MUTUAL_TLS_MODE_PERMISSIVE
+            description: |4
+                 +kubebuilder:validation:Enum=MUTUAL_TLS_MODE_DEFAULT;MUTUAL_TLS_MODE_STRICT;MUTUAL_TLS_MODE_PERMISSIVE
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.ParametersReference:
+            type: object
+            properties:
+                group:
+                    type: string
+                    description: |
+                        // The Kubernetes Group that the referred object belongs to
+                kind:
+                    type: string
+                    description: |
+                        // The Kubernetes Kind that the referred object is
+                name:
+                    type: string
+                    description: |
+                        // The name of the referred object
+                namespace:
+                    type: string
+                    description: |
+                        // The kubernetes namespace that the referred object is in
+            description: |4+
+                 NOTE: this should align to the GAMMA/gateway-api version, or at least be
+                 easily translatable.
+
+                 ParametersReference specifies a resource that contains Kubernetes controller-specific configuration
+                 for a resource
+                 https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParametersReference
+
+        hashicorp.consul.mesh.v2beta1.ParentReference:
+            type: object
+            properties:
+                port:
+                    type: string
+                    description: |
+                        // For east/west this is the name of the Consul Service port to direct traffic to
+                        // or empty to imply all.
+                        // For north/south this is TBD.
+                ref:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // For east/west configuration, this should point to a Service.
+                        // For north/south it should point to a Gateway.
+            description: |4
+                 NOTE: roughly equivalent to structs.ResourceReference
+        hashicorp.consul.mesh.v2beta1.PassiveHealthCheck:
+            type: object
+            properties:
+                enforcing_consecutive_5xx:
+                    type: integer
+                    format: int32
+                    description: |
+                        // EnforcingConsecutive5XX is the % chance that a host will be actually ejected
+                        // when an outlier status is detected through consecutive 5xx.
+                        // This setting can be used to disable ejection or to ramp it up slowly. Defaults to 100.
+                interval:
+                    type: string
+                    description: |
+                        // Interval between health check analysis sweeps. Each sweep may remove
+                        // hosts or return hosts to the pool.
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                max_failures:
+                    type: integer
+                    format: int32
+                    description: |
+                        // MaxFailures is the count of consecutive failures that results in a host
+                        // being removed from the pool.
+        hashicorp.consul.mesh.v2beta1.PathMatchType:
+            type: string
+            enum:
+                - PATH_MATCH_TYPE_UNSPECIFIED
+                - PATH_MATCH_TYPE_EXACT
+                - PATH_MATCH_TYPE_PREFIX
+                - PATH_MATCH_TYPE_REGEX
+            description: |4
+                 PathMatchType specifies the semantics of how HTTP paths should be compared.
+                 Valid PathMatchType values, along with their support levels, are:
+
+                 PathPrefix and Exact paths must be syntactically valid:
+
+                 - Must begin with the / character
+                 - Must not contain consecutive / characters (e.g. /foo///, //).
+                 - Note that values may be added to this enum, implementations must ensure that unknown values will not cause a crash.
+
+                 Unknown values here must result in the implementation setting the Accepted
+                 Condition for the Route to status: False, with a Reason of UnsupportedValue.
+
+                 +kubebuilder:validation:Enum=PATH_MATCH_TYPE_UNSPECIFIED;PATH_MATCH_TYPE_EXACT;PATH_MATCH_TYPE_PREFIX;PATH_MATCH_TYPE_REGEX
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.PreparedQueryDestination:
+            type: object
+            properties:
+                datacenter:
+                    type: string
+                    description: |
+                        // Datacenter is the datacenter for where this destination service lives.
+                destination_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DestinationConfiguration'
+                name:
+                    type: string
+                    description: |
+                        // Name is the name of the prepared query to use as an destination.
+                tcp:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.IPPortAddress'
+                unix:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.UnixSocketAddress'
+        hashicorp.consul.mesh.v2beta1.ProxyConfiguration:
+            type: object
+            properties:
+                bootstrap_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.BootstrapConfig'
+                    description: |
+                        // bootstrap_config is the configuration that requires proxies
+                        // to be restarted to be applied.
+                dynamic_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.DynamicConfig'
+                    description: |
+                        // dynamic_config is the configuration that could be changed
+                        // dynamically (i.e. without needing restart).
+                opaque_config:
+                    type: object
+                    description: |
+                        // deprecated: prevent usage when using v2 APIs directly.
+                        // needed for backwards compatibility
+                        //
+                        // +kubebuilder:validation:Type=object
+                        // +kubebuilder:validation:Schemaless
+                        // +kubebuilder:pruning:PreserveUnknownFields
+                workloads:
+                    $ref: '#/components/schemas/hashicorp.consul.catalog.v2beta1.WorkloadSelector'
+                    description: |
+                        // Selection of workloads this proxy configuration should apply to.
+                        // These can be prefixes or specific workload names.
+            description: |4
+                 This is a Resource type.
+        hashicorp.consul.mesh.v2beta1.ProxyMode:
+            type: string
+            enum:
+                - PROXY_MODE_DEFAULT
+                - PROXY_MODE_TRANSPARENT
+                - PROXY_MODE_DIRECT
+            description: |4
+                 +kubebuilder:validation:Enum=PROXY_MODE_DEFAULT;PROXY_MODE_TRANSPARENT;PROXY_MODE_DIRECT
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.ProxyState:
+            type: object
+            properties:
+                access_logs:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.AccessLogs'
+                    description: |
+                        // AccessLogs configures access logging for this proxy.
+                clusters:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Cluster'
+                    description: |
+                        // Clusters is a map from cluster name to clusters. The keys are referenced from listeners or routes.
+                endpoints:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Endpoints'
+                    description: |
+                        // Endpoints is a map from cluster name to endpoints.
+                escape:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.EscapeHatches'
+                    description: |
+                        // Escape defines top level escape hatches. These are user configured json strings that configure an entire piece of listener or cluster Envoy configuration.
+                identity:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // Identity is a reference to the identity of the workload this proxy is for.
+                leaf_certificates:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.LeafCertificate'
+                    description: |
+                        // LeafCertificates is a map from UUID to leaf certificates.
+                listeners:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Listener'
+                    description: |
+                        // Listeners is a list of listeners for this proxy.
+                routes:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Route'
+                    description: |
+                        // Routes is a map from route name to routes. The keys are referenced from listeners.
+                tls:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TLS'
+                    description: |
+                        // TLS has TLS configuration for this proxy.
+                trust_bundles:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TrustBundle'
+                    description: |
+                        // TrustBundles is a map from peer name to trust bundles.
+        hashicorp.consul.mesh.v2beta1.ProxyStateTemplate:
+            type: object
+            properties:
+                proxy_state:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ProxyState'
+                    description: |
+                        // ProxyState is the partially filled out ProxyState resource. The Endpoints, LeafCertificates and TrustBundles fields will need filling in after the resource is stored.
+                required_endpoints:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.EndpointRef'
+                    description: |
+                        // RequiredEndpoints is a map of arbitrary string names to endpoint refs that need fetching by the proxy state controller.
+                required_leaf_certificates:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.LeafCertificateRef'
+                    description: |
+                        // RequiredLeafCertificates is a map of arbitrary string names to leaf certificates that need fetching/generation by the proxy state controller.
+                required_trust_bundles:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TrustBundleRef'
+                    description: |
+                        // RequiredTrustBundles is a map of arbitrary string names to trust bundle refs that need fetching by the proxy state controller.
+        hashicorp.consul.mesh.v2beta1.QueryParamMatchType:
+            type: string
+            enum:
+                - QUERY_PARAM_MATCH_TYPE_UNSPECIFIED
+                - QUERY_PARAM_MATCH_TYPE_EXACT
+                - QUERY_PARAM_MATCH_TYPE_REGEX
+                - QUERY_PARAM_MATCH_TYPE_PRESENT
+            description: |4
+                 +kubebuilder:validation:Enum=QUERY_PARAM_MATCH_TYPE_UNSPECIFIED;QUERY_PARAM_MATCH_TYPE_EXACT;QUERY_PARAM_MATCH_TYPE_REGEX;QUERY_PARAM_MATCH_TYPE_PRESENT
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.RingHashConfig:
+            type: object
+            properties:
+                maximum_ring_size:
+                    type: integer
+                    format: int64
+                    description: |
+                        // MaximumRingSize determines the maximum number of entries in the hash ring
+                minimum_ring_size:
+                    type: integer
+                    format: int64
+                    description: |
+                        // MinimumRingSize determines the minimum number of entries in the hash ring
+            description: |4
+                 RingHashConfig contains configuration for the "ring_hash" policy type
+        hashicorp.consul.mesh.v2beta1.TCPBackendRef:
+            type: object
+            properties:
+                backend_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.BackendReference'
+                weight:
+                    type: integer
+                    format: int32
+                    description: |
+                        // Weight specifies the proportion of requests forwarded to the referenced
+                        // backend. This is computed as weight/(sum of all weights in this
+                        // BackendRefs list). For non-zero values, there may be some epsilon from the
+                        // exact proportion defined here depending on the precision an implementation
+                        // supports. Weight is not a percentage and the sum of weights does not need
+                        // to equal 100.
+                        //
+                        // If only one backend is specified and it has a weight greater than 0, 100%
+                        // of the traffic is forwarded to that backend. If weight is set to 0, no
+                        // traffic should be forwarded for this entry. If unspecified, weight defaults
+                        // to 1.
+        hashicorp.consul.mesh.v2beta1.TCPRoute:
+            type: object
+            properties:
+                parent_refs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.ParentReference'
+                    description: |
+                        // ParentRefs references the resources (usually Services) that a Route wants
+                        // to be attached to.
+                        //
+                        // It is invalid to reference an identical parent more than once. It is valid
+                        // to reference multiple distinct sections within the same parent resource.
+                rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.TCPRouteRule'
+                    description: |
+                        // Rules are a list of TCP matchers and actions.
+            description: |4
+                 NOTE: this should align to the GAMMA/gateway-api version, or at least be
+                 easily translatable.
+
+                 https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
+
+                 This is a Resource type.
+        hashicorp.consul.mesh.v2beta1.TCPRouteRule:
+            type: object
+            properties:
+                backend_refs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.TCPBackendRef'
+                    description: |
+                        // BackendRefs defines the backend(s) where matching requests should be sent.
+                        // If unspecified or invalid (refers to a non-existent resource or a Service
+                        // with no endpoints), the underlying implementation MUST actively reject
+                        // connection attempts to this backend. Connection rejections must respect
+                        // weight; if an invalid backend is requested to have 80% of connections,
+                        // then 80% of connections must be rejected instead.
+        hashicorp.consul.mesh.v2beta1.TransparentProxy:
+            type: object
+            properties:
+                dialed_directly:
+                    type: boolean
+                    description: |
+                        // dialed_directly indicates whether this proxy should be dialed using original destination IP
+                        // in the connection rather than load balance between all endpoints.
+                outbound_listener_port:
+                    type: integer
+                    format: int32
+                    description: |
+                        // outbound_listener_port is the port for the proxy's outbound listener.
+                        // This defaults to 15001.
+        hashicorp.consul.mesh.v2beta1.UnixSocketAddress:
+            type: object
+            properties:
+                mode:
+                    type: string
+                    description: |
+                        // Mode is the Unix file mode for the socket file. It should be provided
+                        // in the numeric notation, for example, "0600".
+                path:
+                    type: string
+                    description: |
+                        // Path is the file system path at which to bind a Unix domain socket listener.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.AccessLogs:
+            type: object
+            properties:
+                disable_listener_logs:
+                    type: boolean
+                    description: |
+                        // disable_listener_logs turns off just listener logs for connections rejected by Envoy because they don't
+                        // have a matching listener filter.
+                enabled:
+                    type: boolean
+                    description: |
+                        // enabled enables access logging.
+                json:
+                    type: string
+                path:
+                    type: string
+                    description: |
+                        // path is the output file to write logs
+                text:
+                    type: string
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.LogSinkType'
+                    description: |
+                        // type selects the output for logs: "file", "stderr". "stdout"
+        hashicorp.consul.mesh.v2beta1.pbproxystate.AppendAction:
+            type: string
+            enum:
+                - APPEND_ACTION_APPEND_IF_EXISTS_OR_ADD
+                - APPEND_ACTION_OVERWRITE_IF_EXISTS_OR_ADD
+            description: |4
+                 +kubebuilder:validation:Enum=APPEND_ACTION_APPEND_IF_EXISTS_OR_ADD;APPEND_ACTION_OVERWRITE_IF_EXISTS_OR_ADD
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.BalanceConnections:
+            type: string
+            enum:
+                - BALANCE_CONNECTIONS_DEFAULT
+                - BALANCE_CONNECTIONS_EXACT
+            description: |4
+                 +kubebuilder:validation:Enum=BALANCE_CONNECTIONS_DEFAULT;BALANCE_CONNECTIONS_EXACT
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Capability:
+            type: string
+            enum:
+                - CAPABILITY_TRANSPARENT
+                - CAPABILITY_L7_PROTOCOL_INSPECTION
+                - CAPABILITY_L4_TLS_INSPECTION
+            description: |4
+                 Capabilities map to proxy functionality to enable. These enable tproxy, l7 protocol/alpn inspection, or l4 sni/alpn inspection.
+
+                 +kubebuilder:validation:Enum=CAPABILITY_TRANSPARENT;CAPABILITY_L7_PROTOCOL_INSPECTION;CAPABILITY_L4_TLS_INSPECTION
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.CidrRange:
+            type: object
+            properties:
+                address_prefix:
+                    type: string
+                prefix_len:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.CircuitBreakers:
+            type: object
+            properties:
+                upstream_limits:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.UpstreamLimits'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Cluster:
+            type: object
+            properties:
+                alt_stat_name:
+                    type: string
+                    description: |
+                        // alt_stat_name is the name used for observability in place of cluster name if provided.
+                endpoint_group:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.EndpointGroup'
+                escape_hatch_cluster_json:
+                    type: string
+                    description: |
+                        // escape_hatch_cluster_json configures a user configured escape hatch cluster.
+                failover_group:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.FailoverGroup'
+                name:
+                    type: string
+                    description: |
+                        // name is the name of the cluster.
+                protocol:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Protocol'
+                    description: |
+                        // protocol is the local path protocol or the service protocol.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.ConnectionPropertiesPolicy:
+            type: object
+            properties:
+                source_ip:
+                    type: boolean
+                terminal:
+                    type: boolean
+        hashicorp.consul.mesh.v2beta1.pbproxystate.CookiePolicy:
+            type: object
+            properties:
+                name:
+                    type: string
+                path:
+                    type: string
+                terminal:
+                    type: boolean
+                ttl:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+        hashicorp.consul.mesh.v2beta1.pbproxystate.DNSEndpointGroup:
+            type: object
+            properties:
+                config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.DNSEndpointGroupConfig'
+                    description: |
+                        // config configures how to connect to the endpoints.
+                outbound_tls:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TransportSocket'
+                    description: |
+                        // outbound_tls will configure what TLS information to use when connecting to an upstream.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.DNSEndpointGroupConfig:
+            type: object
+            properties:
+                circuit_breakers:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.CircuitBreakers'
+                connect_timeout:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                disable_panic_threshold:
+                    type: boolean
+                discovery_type:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.DiscoveryType'
+                outlier_detection:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.OutlierDetection'
+                upstream_connection_options:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.UpstreamConnectionOptions'
+                use_alt_stat_name:
+                    type: boolean
+        hashicorp.consul.mesh.v2beta1.pbproxystate.DestinationCluster:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // name is the name of the cluster. This will be used to look up a cluster in the clusters map.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.DestinationConfiguration:
+            type: object
+            properties:
+                auto_host_rewrite:
+                    type: boolean
+                hash_policies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.LoadBalancerHashPolicy'
+                prefix_rewrite:
+                    type: string
+                retry_policy:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.RetryPolicy'
+                timeout_config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TimeoutConfig'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Direction:
+            type: string
+            enum:
+                - DIRECTION_UNSPECIFIED
+                - DIRECTION_INBOUND
+                - DIRECTION_OUTBOUND
+            description: |4
+                 +kubebuilder:validation:Enum=DIRECTION_UNSPECIFIED;DIRECTION_INBOUND;DIRECTION_OUTBOUND
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.DiscoveryType:
+            type: string
+            enum:
+                - DISCOVERY_TYPE_LOGICAL
+                - DISCOVERY_TYPE_STRICT
+            description: |4
+                 +kubebuilder:validation:Enum=DISCOVERY_TYPE_LOGICAL;DISCOVERY_TYPE_STRICT
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.DynamicEndpointGroup:
+            type: object
+            properties:
+                config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.DynamicEndpointGroupConfig'
+                    description: |
+                        // config configures how to connect to the endpoints.
+                outbound_tls:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TransportSocket'
+                    description: |
+                        // outbound_tls will configure what TLS information to use when connecting to an upstream.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.DynamicEndpointGroupConfig:
+            type: object
+            properties:
+                circuit_breakers:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.CircuitBreakers'
+                connect_timeout:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                disable_panic_threshold:
+                    type: boolean
+                least_request:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.LBPolicyLeastRequest'
+                maglev:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.LBPolicyMaglev'
+                outlier_detection:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.OutlierDetection'
+                random:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.LBPolicyRandom'
+                ring_hash:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.LBPolicyRingHash'
+                round_robin:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.LBPolicyRoundRobin'
+                upstream_connection_options:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.UpstreamConnectionOptions'
+                use_alt_stat_name:
+                    type: boolean
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Endpoint:
+            type: object
+            properties:
+                health_status:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.HealthStatus'
+                host_port:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.HostPortAddress'
+                load_balancing_weight:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                unix_socket:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.UnixSocketAddress'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.EndpointGroup:
+            type: object
+            properties:
+                dns:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.DNSEndpointGroup'
+                    description: |
+                        // dns is used to reach mesh and non-mesh destinations using a hostname.
+                dynamic:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.DynamicEndpointGroup'
+                    description: |
+                        // dynamic endpoint group is used to reach mesh destinations that are dynamically configured from Consul's catalog.
+                name:
+                    type: string
+                    description: |
+                        // name is used to name the cluster created. This is only required when used inside of a FailoverGroup.
+                passthrough:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.PassthroughEndpointGroup'
+                    description: |
+                        // passthrough is used to reach destinations that don't have endpoints saved in Consul.
+                static:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.StaticEndpointGroup'
+                    description: |
+                        // static endpoint group is used to reach local app ports.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.EndpointRef:
+            type: object
+            properties:
+                id:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                    description: |
+                        // id is the ServiceEndpoints resource id.
+                port:
+                    type: string
+                    description: |
+                        // port is the name of the port in the ServiceEndpoints to generate the Endpoints from.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Endpoints:
+            type: object
+            properties:
+                endpoints:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Endpoint'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.EscapeHatches:
+            type: object
+            properties:
+                listener_tracing_json:
+                    type: string
+                    description: |
+                        // listener_tracing_json contains user provided tracing configuration.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.FailoverGroup:
+            type: object
+            properties:
+                config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.FailoverGroupConfig'
+                endpoint_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.EndpointGroup'
+                    description: |
+                        // endpoint_groups is an ordered list of which groups to failover to.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.FailoverGroupConfig:
+            type: object
+            properties:
+                connect_timeout:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Type=string
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                use_alt_stat_name:
+                    type: boolean
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Header:
+            type: object
+            properties:
+                key:
+                    type: string
+                value:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.HeaderMatch:
+            type: object
+            properties:
+                exact:
+                    type: string
+                invert_match:
+                    type: boolean
+                name:
+                    type: string
+                prefix:
+                    type: string
+                present:
+                    type: boolean
+                regex:
+                    type: string
+                suffix:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.HeaderMutation:
+            type: object
+            properties:
+                request_header_add:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.RequestHeaderAdd'
+                request_header_remove:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.RequestHeaderRemove'
+                response_header_add:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.ResponseHeaderAdd'
+                response_header_remove:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.ResponseHeaderRemove'
+            description: |4
+                 Note: it's nice to have this list of header mutations as opposed to configuration similar to Envoy because it
+                 translates more nicely from GAMMA HTTPRoute, and our existing service router config. Then xds code can handle turning
+                 it into envoy xds.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.HeaderPolicy:
+            type: object
+            properties:
+                name:
+                    type: string
+                terminal:
+                    type: boolean
+        hashicorp.consul.mesh.v2beta1.pbproxystate.HealthStatus:
+            type: string
+            enum:
+                - HEALTH_STATUS_UNKNOWN
+                - HEALTH_STATUS_HEALTHY
+                - HEALTH_STATUS_UNHEALTHY
+            description: |4
+                 +kubebuilder:validation:Enum=HEALTH_STATUS_UNKNOWN;HEALTH_STATUS_HEALTHY;HEALTH_STATUS_UNHEALTHY
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.HostPortAddress:
+            type: object
+            properties:
+                host:
+                    type: string
+                port:
+                    type: integer
+                    format: int32
+        hashicorp.consul.mesh.v2beta1.pbproxystate.InboundMeshMTLS:
+            type: object
+            properties:
+                identity_key:
+                    type: string
+                    description: |
+                        // identity_key is UUID key to use to look up the leaf certificate in ProxyState to present for incoming connections.
+                validation_context:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.MeshInboundValidationContext'
+                    description: |
+                        // validation_context has what is needed to validate incoming connections.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.InboundNonMeshTLS:
+            type: object
+            properties:
+                leaf_key:
+                    type: string
+                    description: |
+                        // leaf_key is the UUID key to use to look up the leaf certificate in the ProxyState leaf certificate map.
+                sds:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.SDSCertificate'
+                    description: |
+                        // sds refers to certificates retrieved via Envoy SDS.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.L4Destination:
+            type: object
+            properties:
+                cluster:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.DestinationCluster'
+                max_inbound_connections:
+                    type: integer
+                    format: int64
+                    description: |
+                        // max_inbound_connections specifies how many connections this destination can accept.
+                stat_prefix:
+                    type: string
+                    description: |
+                        // stat_prefix is for compatibility with v1 xds configuration, so it is generated in exactly the same way.
+                traffic_permissions:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TrafficPermissions'
+                    description: |
+                        // traffic_permissions is a list of traffic permissions for this destination.
+                weighted_clusters:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.L4WeightedClusterGroup'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.L4WeightedClusterGroup:
+            type: object
+            properties:
+                clusters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.L4WeightedDestinationCluster'
+                    description: |
+                        // clusters to route to by weight.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.L4WeightedDestinationCluster:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // name is the name of the cluster. This will be used to look up a cluster in the clusters map.
+                weight:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.L7Destination:
+            type: object
+            properties:
+                include_xfcc_policy:
+                    type: boolean
+                    description: |
+                        // include_xfcc specifies whether to add an xfcc policy for handling xfcc headers.
+                max_inbound_connections:
+                    type: integer
+                    format: int64
+                    description: |
+                        // max_inbound_connections specifies how many connections this destination can accept.
+                parse_xfcc_headers:
+                    type: boolean
+                    description: |
+                        // parse_xfcc_headers determines whether to add filters to parse xfcc headers on incoming connections.
+                protocol:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.L7Protocol'
+                    description: |
+                        // protocol for the destination.
+                route:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.L7DestinationRoute'
+                    description: |
+                        // route specifies which route to go to in this L7 destination.
+                stat_prefix:
+                    type: string
+                    description: |
+                        // stat_prefix is for compatibility with v1 xds configuration, so it is generated in exactly the same way.
+                static_route:
+                    type: boolean
+                    description: |
+                        // static_route specifies whether this is a static route that is inlined in the listener filter. This is required to
+                        // match existing xds config.
+                traffic_permissions:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TrafficPermissions'
+                    description: |
+                        // traffic_permissions is a list of intentions for this destination.
+                xfcc_policy:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.XFCCPolicy'
+                    description: |
+                        // xfcc_policy determines how to handle xfcc headers.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.L7DestinationRoute:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // name is a key in the top level routes map. This specifies which route to go to in this L7 destination.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.L7Protocol:
+            type: string
+            enum:
+                - L7_PROTOCOL_HTTP
+                - L7_PROTOCOL_HTTP2
+                - L7_PROTOCOL_GRPC
+            description: |4
+                 +kubebuilder:validation:Enum=L7_PROTOCOL_HTTP;L7_PROTOCOL_HTTP2;L7_PROTOCOL_GRPC
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.L7WeightedClusterGroup:
+            type: object
+            properties:
+                clusters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.L7WeightedDestinationCluster'
+                    description: |
+                        // clusters to route to by weight.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.L7WeightedDestinationCluster:
+            type: object
+            properties:
+                header_mutations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.HeaderMutation'
+                name:
+                    type: string
+                    description: |
+                        // name is the name of the cluster. This will be used to look up a cluster in the clusters map.
+                weight:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.LBPolicyLeastRequest:
+            type: object
+            properties:
+                choice_count:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.LBPolicyMaglev:
+            type: object
+        hashicorp.consul.mesh.v2beta1.pbproxystate.LBPolicyRandom:
+            type: object
+        hashicorp.consul.mesh.v2beta1.pbproxystate.LBPolicyRingHash:
+            type: object
+            properties:
+                maximum_ring_size:
+                    $ref: '#/components/schemas/google.protobuf.UInt64Value'
+                minimum_ring_size:
+                    $ref: '#/components/schemas/google.protobuf.UInt64Value'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.LBPolicyRoundRobin:
+            type: object
+        hashicorp.consul.mesh.v2beta1.pbproxystate.LeafCertificate:
+            type: object
+            properties:
+                cert:
+                    type: string
+                key:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.LeafCertificateRef:
+            type: object
+            properties:
+                datacenter:
+                    type: string
+                dns_san:
+                    type: array
+                    items:
+                        type: string
+                host:
+                    type: string
+                name:
+                    type: string
+                namespace:
+                    type: string
+                partition:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Listener:
+            type: object
+            properties:
+                balance_connections:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.BalanceConnections'
+                    description: |
+                        // balance_connections configures how the listener should balance connections.
+                capabilities:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Capability'
+                        description: |
+                            // capabilities describe Envoy proxy functionality to enable. These map closely to Envoy listener filters.
+                    description: |
+                        // capabilities describe Envoy proxy functionality to enable. These map closely to Envoy listener filters.
+                default_router:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Router'
+                    description: |
+                        // default_router describes where to route if none of the other router matches match the connection.
+                direction:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Direction'
+                    description: |
+                        // direction tells the listener the direction of traffic.
+                escape_hatch_listener:
+                    type: string
+                    description: |
+                        // escape_hatch_listener_json configures a user configured escape hatch listener.
+                host_port:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.HostPortAddress'
+                name:
+                    type: string
+                    description: |
+                        // name is the name of the listener.
+                routers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Router'
+                    description: |
+                        // routers describes how to route traffic from this listener.
+                unix_socket:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.UnixSocketAddress'
+                use_escape_hatch_tracing:
+                    type: boolean
+                    description: |
+                        // use_escape_hatch_tracing configures whether to use the top level user configured tracing escape hatch for this listener.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.LoadBalancerHashPolicy:
+            type: object
+            properties:
+                connection_properties:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.ConnectionPropertiesPolicy'
+                cookie:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.CookiePolicy'
+                header:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.HeaderPolicy'
+                query_parameter:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.QueryParameterPolicy'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.LogSinkType:
+            type: string
+            enum:
+                - LOG_SINK_TYPE_DEFAULT
+                - LOG_SINK_TYPE_FILE
+                - LOG_SINK_TYPE_STDERR
+                - LOG_SINK_TYPE_STDOUT
+            description: |4
+                 +kubebuilder:validation:Enum=LOG_SINK_TYPE_DEFAULT;LOG_SINK_TYPE_FILE;LOG_SINK_TYPE_STDERR;LOG_SINK_TYPE_STDOUT
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Match:
+            type: object
+            properties:
+                alpn_protocols:
+                    type: array
+                    items:
+                        type: string
+                destination_port:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                prefix_ranges:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.CidrRange'
+                server_names:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // server_names matches based on SNI of the incoming request.
+                source_prefix_ranges:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.CidrRange'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.MeshInboundValidationContext:
+            type: object
+            properties:
+                trust_bundle_peer_name_keys:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // trust_bundle_peer_name_keys is which trust bundles to use for validating incoming connections. If this workload is exported
+                        // to peers, the incoming connection could be from a different peer, requiring that trust bundle to validate the
+                        // connection. These could be local or peered trust bundles. This will be a key in the trust bundle map.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.MeshOutboundValidationContext:
+            type: object
+            properties:
+                spiffe_ids:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // spiffe_ids is one or more spiffe IDs to validate.
+                trust_bundle_peer_name_key:
+                    type: string
+                    description: |
+                        // trust_bundle_peer_name_key is which trust bundle to use for the destination. It could be the local or a peer's trust bundle.
+                        // This will be a key in the trust bundle map.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.NonMeshOutboundValidationContext:
+            type: object
+            properties:
+                ca_file:
+                    type: string
+                    description: |
+                        // ca_file is a filename for a ca for outbound connections to validate the destination.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.OutboundMeshMTLS:
+            type: object
+            properties:
+                identity_key:
+                    type: string
+                    description: |
+                        // identity_key is UUID key to use to look up the leaf certificate in ProxyState when connecting to destinations.
+                sni:
+                    type: string
+                    description: |
+                        // sni to use when connecting to the destination.
+                validation_context:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.MeshOutboundValidationContext'
+                    description: |
+                        // validation_context has what is needed to validate the destination.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.OutboundNonMeshTLS:
+            type: object
+            properties:
+                cert_file:
+                    type: string
+                    description: |
+                        // cert_file is a filename for a certificate to present for outbound connections.
+                key_file:
+                    type: string
+                    description: |
+                        // key_file is a filename for a key for outbound connections.
+                validation_context:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.NonMeshOutboundValidationContext'
+                    description: |
+                        // validation_context has what is needed to validate the destination.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.OutlierDetection:
+            type: object
+            properties:
+                base_ejection_time:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                consecutive_5xx:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                enforcing_consecutive_5xx:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                interval:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                max_ejection_percent:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.PassthroughEndpointGroup:
+            type: object
+            properties:
+                config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.PassthroughEndpointGroupConfig'
+                    description: |
+                        // config configures how to connect to the endpoints.
+                outbound_tls:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TransportSocket'
+                    description: |
+                        // outbound_tls will configure what TLS information to use when connecting to an upstream.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.PassthroughEndpointGroupConfig:
+            type: object
+            properties:
+                connect_timeout:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+        hashicorp.consul.mesh.v2beta1.pbproxystate.PathMatch:
+            type: object
+            properties:
+                exact:
+                    type: string
+                prefix:
+                    type: string
+                regex:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Permission:
+            type: object
+            properties:
+                principals:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Principal'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Principal:
+            type: object
+            properties:
+                exclude_spiffes:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Spiffe'
+                spiffe:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Spiffe'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Protocol:
+            type: string
+            enum:
+                - PROTOCOL_UNSPECIFIED
+                - PROTOCOL_TCP
+                - PROTOCOL_HTTP
+                - PROTOCOL_HTTP2
+                - PROTOCOL_GRPC
+                - PROTOCOL_MESH
+            description: |4
+                 +kubebuilder:validation:Enum=PROTOCOL_UNSPECIFIED;PROTOCOL_TCP;PROTOCOL_HTTP;PROTOCOL_HTTP2;PROTOCOL_GRPC
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.QueryParameterMatch:
+            type: object
+            properties:
+                exact:
+                    type: string
+                name:
+                    type: string
+                present:
+                    type: boolean
+                regex:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.QueryParameterPolicy:
+            type: object
+            properties:
+                name:
+                    type: string
+                terminal:
+                    type: boolean
+        hashicorp.consul.mesh.v2beta1.pbproxystate.RequestHeaderAdd:
+            type: object
+            properties:
+                append_action:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.AppendAction'
+                header:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Header'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.RequestHeaderRemove:
+            type: object
+            properties:
+                header_keys:
+                    type: array
+                    items:
+                        type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.ResponseHeaderAdd:
+            type: object
+            properties:
+                append_action:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.AppendAction'
+                header:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Header'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.ResponseHeaderRemove:
+            type: object
+            properties:
+                header_keys:
+                    type: array
+                    items:
+                        type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.RetryPolicy:
+            type: object
+            properties:
+                num_retries:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                retriable_status_codes:
+                    type: array
+                    items:
+                        type: integer
+                        format: int32
+                retry_on:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Route:
+            type: object
+            properties:
+                virtual_hosts:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.VirtualHost'
+                    description: |
+                        // virtual_hosts is a list of virtual hosts. A virtual host is selected based on an incoming request's host header.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.RouteDestination:
+            type: object
+            properties:
+                cluster:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.DestinationCluster'
+                destination_configuration:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.DestinationConfiguration'
+                weighted_clusters:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.L7WeightedClusterGroup'
+            description: |4
+                 RouteDestination has configuration for where to send a request.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.RouteMatch:
+            type: object
+            properties:
+                header_matches:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.HeaderMatch'
+                method_matches:
+                    type: array
+                    items:
+                        type: string
+                path_match:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.PathMatch'
+                query_parameter_matches:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.QueryParameterMatch'
+            description: |4
+                 RouteMatch has configuration to match a request.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.RouteRule:
+            type: object
+            properties:
+                destination:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.RouteDestination'
+                    description: |
+                        // destination is where to send the request to.
+                header_mutations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.HeaderMutation'
+                    description: |
+                        // header_mutations to apply to the request. These are applied before the VirtualHost header mutations.
+                match:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.RouteMatch'
+                    description: |
+                        // match determines how to match the request. The first match determines which destination the request will go to.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Router:
+            type: object
+            properties:
+                inbound_tls:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TransportSocket'
+                    description: |
+                        // inbound_tls is used by inbound listeners that terminate TLS.
+                l4:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.L4Destination'
+                    description: |
+                        // l4 is an l4 destination to route to, which will have a reference to a cluster.
+                l7:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.L7Destination'
+                    description: |
+                        // l7 is an l7 destination to route to, which will have a reference to a route.
+                match:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Match'
+                    description: |
+                        // match specifies how to match traffic coming into this listener. If the traffic matches, it will be routed to the
+                        // destination.
+                sni:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.SNIDestination'
+                    description: |
+                        // sni is an SNI destination, which means there will be no references, but the SNI name will be tied to the cluster
+                        // name, so we should generate all clusters.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.SDSCertificate:
+            type: object
+            properties:
+                cert_resource:
+                    type: string
+                cluster_name:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.SNIDestination:
+            type: object
+            properties:
+                stat_prefix:
+                    type: string
+                    description: |
+                        // stat_prefix is for compatibility with v1 xds configuration, so it is generated in exactly the same way.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.Spiffe:
+            type: object
+            properties:
+                regex:
+                    type: string
+                    description: |
+                        // regex is the regular expression for matching spiffe ids.
+                xfcc_regex:
+                    type: string
+                    description: |
+                        // xfcc_regex specifies that Envoy needs to find the spiffe id in an xfcc header.
+                        // It is currently unused, but considering this is important for to avoid breaking changes.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.StaticEndpointGroup:
+            type: object
+            properties:
+                config:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.StaticEndpointGroupConfig'
+                    description: |
+                        // config configures how to connect to the endpoints.
+            description: |4
+                 StaticEndpointGroup is used to reach local app ports.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.StaticEndpointGroupConfig:
+            type: object
+            properties:
+                circuit_breakers:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.CircuitBreakers'
+                connect_timeout:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+        hashicorp.consul.mesh.v2beta1.pbproxystate.TLS:
+            type: object
+            properties:
+                inbound_tls_parameters:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TLSParameters'
+                    description: |
+                        // inbound_tls_parameters has default TLS parameter configuration for inbound connections. These can be overridden per
+                        // transport socket.
+                outbound_tls_parameters:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TLSParameters'
+                    description: |
+                        // outbound_tls_parameters has default TLS parameter configuration for inbound connections. These can be overridden per transport socket.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.TLSCipherSuite:
+            type: string
+            enum:
+                - TLS_CIPHER_SUITE_ECDHE_ECDSA_AES128_GCM_SHA256
+                - TLS_CIPHER_SUITE_ECDHE_ECDSA_CHACHA20_POLY1305
+                - TLS_CIPHER_SUITE_ECDHE_RSA_AES128_GCM_SHA256
+                - TLS_CIPHER_SUITE_ECDHE_RSA_CHACHA20_POLY1305
+                - TLS_CIPHER_SUITE_ECDHE_ECDSA_AES128_SHA
+                - TLS_CIPHER_SUITE_ECDHE_RSA_AES128_SHA
+                - TLS_CIPHER_SUITE_AES128_GCM_SHA256
+                - TLS_CIPHER_SUITE_AES128_SHA
+                - TLS_CIPHER_SUITE_ECDHE_ECDSA_AES256_GCM_SHA384
+                - TLS_CIPHER_SUITE_ECDHE_RSA_AES256_GCM_SHA384
+                - TLS_CIPHER_SUITE_ECDHE_ECDSA_AES256_SHA
+                - TLS_CIPHER_SUITE_ECDHE_RSA_AES256_SHA
+                - TLS_CIPHER_SUITE_AES256_GCM_SHA384
+                - TLS_CIPHER_SUITE_AES256_SHA
+            description: |4
+                 +kubebuilder:validation:Enum=TLS_CIPHER_SUITE_ECDHE_ECDSA_AES128_GCM_SHA256;TLS_CIPHER_SUITE_AES256_SHA;TLS_CIPHER_SUITE_ECDHE_ECDSA_CHACHA20_POLY1305;TLS_CIPHER_SUITE_ECDHE_RSA_AES128_GCM_SHA256;TLS_CIPHER_SUITE_ECDHE_RSA_CHACHA20_POLY1305;TLS_CIPHER_SUITE_ECDHE_ECDSA_AES128_SHA;TLS_CIPHER_SUITE_ECDHE_RSA_AES128_SHA;TLS_CIPHER_SUITE_AES128_GCM_SHA256;TLS_CIPHER_SUITE_AES128_SHA;TLS_CIPHER_SUITE_ECDHE_ECDSA_AES256_GCM_SHA384;TLS_CIPHER_SUITE_ECDHE_RSA_AES256_GCM_SHA384;TLS_CIPHER_SUITE_ECDHE_ECDSA_AES256_SHA;TLS_CIPHER_SUITE_ECDHE_RSA_AES256_SHA;TLS_CIPHER_SUITE_AES256_GCM_SHA384
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.TLSParameters:
+            type: object
+            properties:
+                cipher_suites:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TLSCipherSuite'
+                max_version:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TLSVersion'
+                min_version:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TLSVersion'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.TLSVersion:
+            type: string
+            enum:
+                - TLS_VERSION_AUTO
+                - TLS_VERSION_1_0
+                - TLS_VERSION_1_1
+                - TLS_VERSION_1_2
+                - TLS_VERSION_1_3
+                - TLS_VERSION_INVALID
+                - TLS_VERSION_UNSPECIFIED
+            description: |4
+                 +kubebuilder:validation:Enum=TLS_VERSION_AUTO;TLS_VERSION_1_0;TLS_VERSION_1_1;TLS_VERSION_1_2;TLS_VERSION_1_3;TLS_VERSION_INVALID;TLS_VERSION_UNSPECIFIED
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.TimeoutConfig:
+            type: object
+            properties:
+                idle_timeout:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                timeout:
+                    type: string
+                    description: |
+                        // +kubebuilder:validation:Format=duration
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+        hashicorp.consul.mesh.v2beta1.pbproxystate.TrafficPermissions:
+            type: object
+            properties:
+                allow_permissions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Permission'
+                default_allow:
+                    type: boolean
+                    description: |
+                        // default_allow determines if the workload is in default allow mode. This is determined
+                        // by combining the cluster's default allow setting with the is_default property on
+                        // computed traffic permissions.
+                deny_permissions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.Permission'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.TransportSocket:
+            type: object
+            properties:
+                alpn_protocols:
+                    type: array
+                    items:
+                        type: string
+                inbound_mesh:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.InboundMeshMTLS'
+                    description: |
+                        // inbound_mesh is for incoming connections FROM the mesh.
+                inbound_non_mesh:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.InboundNonMeshTLS'
+                    description: |
+                        // inbound_non_mesh is for incoming connections FROM non mesh.
+                name:
+                    type: string
+                    description: |
+                        // name of the transport socket
+                outbound_mesh:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.OutboundMeshMTLS'
+                    description: |
+                        // outbound_mesh is for outbound connections TO mesh destinations.
+                outbound_non_mesh:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.OutboundNonMeshTLS'
+                    description: |
+                        // outbound_non_mesh is for outbound connections TO non mesh destinations.
+                tls_parameters:
+                    $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.TLSParameters'
+                    description: |
+                        // tls_parameters can override any top level tls parameters that are configured.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.TrustBundle:
+            type: object
+            properties:
+                roots:
+                    type: array
+                    items:
+                        type: string
+                trust_domain:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.TrustBundleRef:
+            type: object
+            properties:
+                peer:
+                    type: string
+                trust_domain:
+                    type: string
+        hashicorp.consul.mesh.v2beta1.pbproxystate.UnixSocketAddress:
+            type: object
+            properties:
+                mode:
+                    type: string
+                    description: |
+                        // mode is the Unix file mode for the socket file. It should be provided
+                        // in the numeric notation, for example, "0600".
+                path:
+                    type: string
+                    description: |
+                        // path is the file system path at which to bind a Unix domain socket listener.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.UpstreamConnectionOptions:
+            type: object
+            properties:
+                tcp_keepalive_interval:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                tcp_keepalive_probes:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                tcp_keepalive_time:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.UpstreamLimits:
+            type: object
+            properties:
+                max_concurrent_requests:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                max_connections:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+                max_pending_requests:
+                    $ref: '#/components/schemas/google.protobuf.UInt32Value'
+        hashicorp.consul.mesh.v2beta1.pbproxystate.VirtualHost:
+            type: object
+            properties:
+                domains:
+                    type: array
+                    items:
+                        type: string
+                    description: |
+                        // domains are used to match an incoming request's host header and determine which virtual host to use.
+                header_mutations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.HeaderMutation'
+                    description: |
+                        // header_mutations to apply to the request when it matches this virtual host. These are applied after any headers in
+                        // the RouteRule.
+                name:
+                    type: string
+                route_rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.mesh.v2beta1.pbproxystate.RouteRule'
+                    description: |
+                        // route_rules are a list of rules to use for what to do next with this request. The first rule with a match will be
+                        // used.
+        hashicorp.consul.mesh.v2beta1.pbproxystate.XFCCPolicy:
+            type: string
+            enum:
+                - XFCC_POLICY_SANITIZE
+                - XFCC_POLICY_FORWARD_ONLY
+                - XFCC_POLICY_APPEND_FORWARD
+                - XFCC_POLICY_SANITIZE_SET
+                - XFCC_POLICY_ALWAYS_FORWARD_ONLY
+            description: |4
+                 +kubebuilder:validation:Enum=XFCC_POLICY_SANITIZE;XFCC_POLICY_FORWARD_ONLY;XFCC_POLICY_APPEND_FORWARD;XFCC_POLICY_SANITIZE_SET;XFCC_POLICY_ALWAYS_FORWARD_ONLY
+                 +kubebuilder:validation:Type=string
+        hashicorp.consul.resource.Condition:
+            type: object
+            properties:
+                message:
+                    type: string
+                    description: |
+                        // Message contains a human-friendly description of the status.
+                reason:
+                    type: string
+                    description: |
+                        // Reason provides more machine-readable details about the condition (e.g.
+                        // "InvalidProtocol").
+                resource:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // Resource identifies which resource this condition relates to, when it is
+                        // not the core resource itself.
+                state:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Condition.State'
+                    description: |
+                        // State represents the state of the condition (i.e. true/false/unknown).
+                type:
+                    type: string
+                    description: |
+                        // Type identifies the type of condition (e.g. "Invalid", "ResolvedRefs").
+            description: |4
+                 Condition represents a discreet observation about a resource in relation to
+                 the current state of the system.
+
+                 It is heavily inspired by Kubernetes' [conditions](https://bit.ly/3H9Y6IK)
+                 and the Gateway API [types and reasons](https://bit.ly/3n2PPiP).
+        hashicorp.consul.resource.Condition.State:
+            type: string
+            enum:
+                - STATE_UNKNOWN
+                - STATE_TRUE
+                - STATE_FALSE
+            description: |4
+                 State represents the state of the condition (i.e. true/false/unknown).
+        hashicorp.consul.resource.ID:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the user-given name of the resource (e.g. the "billing" service).
+                tenancy:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Tenancy'
+                    description: |
+                        // Tenancy identifies the tenancy units (i.e. partition, namespace) in which
+                        // the resource resides.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Type'
+                    description: |
+                        // Type identifies the resource's type.
+                uid:
+                    type: string
+                    description: |
+                        // Uid is the unique internal identifier we gave to the resource.
+                        //
+                        // It is primarily used to tell the difference between the current resource
+                        // and previous deleted resources with the same user-given name.
+                        //
+                        // Concretely, Uid is a [ULID](https://github.com/ulid/spec) and you can treat
+                        // its timestamp component as the resource's creation time.
+            description: |4
+                 ID uniquely identifies a resource.
+        hashicorp.consul.resource.Reference:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the user-given name of the resource (e.g. the "billing" service).
+                section:
+                    type: string
+                    description: |
+                        // Section identifies which part of the resource the condition relates to.
+                tenancy:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Tenancy'
+                    description: |
+                        // Tenancy identifies the tenancy units (i.e. partition, namespace) in which
+                        // the resource resides.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Type'
+                    description: |
+                        // Type identifies the resource's type.
+            description: |4
+                 Reference identifies which resource a condition relates to, when it is not
+                 the core resource itself.
+        hashicorp.consul.resource.Status:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.resource.Condition'
+                    description: |
+                        // Conditions contains a set of discreet observations about the resource in
+                        // relation to the current state of the system (e.g. it is semantically valid).
+                observed_generation:
+                    type: string
+                    description: |
+                        // ObservedGeneration identifies which generation of a resource this status
+                        // related to. It can be used to determine whether the current generation of
+                        // a resource has been reconciled.
+                updated_at:
+                    type: string
+                    format: date-time
+                    description: |
+                        // UpdatedAt is the time at which the status was last written.
+            description: |4
+                 Status is used by controllers to communicate the result of attempting to
+                 reconcile and apply a resource (e.g. surface semantic validation errors)
+                 with users and other controllers.
+        hashicorp.consul.resource.Tenancy:
+            type: object
+            properties:
+                namespace:
+                    type: string
+                    description: |
+                        // Namespace further isolates resources within a partition.
+                        // https://developer.hashicorp.com/consul/docs/enterprise/namespaces
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all namespaces.
+                partition:
+                    type: string
+                    description: |
+                        // Partition is the topmost administrative boundary within a cluster.
+                        // https://developer.hashicorp.com/consul/docs/enterprise/admin-partitions
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all partitions.
+                peer_name:
+                    type: string
+                    description: |
+                        // PeerName identifies which peer the resource is imported from.
+                        // https://developer.hashicorp.com/consul/docs/connect/cluster-peering
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all peers.
+            description: |4
+                 Tenancy describes the tenancy units in which the resource resides.
+        hashicorp.consul.resource.Type:
+            type: object
+            properties:
+                group:
+                    type: string
+                    description: |
+                        // Group describes the area of functionality to which this resource type
+                        // relates (e.g. "catalog", "authorization").
+                group_version:
+                    type: string
+                    description: |
+                        // GroupVersion is incremented when sweeping or backward-incompatible changes
+                        // are made to the group's resource types.
+                kind:
+                    type: string
+                    description: |
+                        // Kind identifies the specific resource type within the group.
+            description: |4
+                 Type describes a resource's type. It follows the GVK (Group Version Kind)
+                 [pattern](https://book.kubebuilder.io/cronjob-tutorial/gvks.html) established
+                 by Kubernetes.
+        k8s.io.api.core.v1.ResourceClaim:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name must match the name of one entry in pod.spec.resourceClaims of
+                        // the Pod where this field is used. It makes that resource available
+                        // inside a container.
+            description: |4
+                 ResourceClaim references one entry in PodSpec.ResourceClaims.
+        k8s.io.api.core.v1.ResourceRequirements:
+            type: object
+            properties:
+                claims:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/k8s.io.api.core.v1.ResourceClaim'
+                    description: |
+                        // Claims lists the names of resources, defined in spec.resourceClaims,
+                        // that are used by this container.
+                        //
+                        // This is an alpha field and requires enabling the
+                        // DynamicResourceAllocation feature gate.
+                        //
+                        // This field is immutable. It can only be set for containers.
+                        //
+                        // +listType=map
+                        // +listMapKey=name
+                        // +featureGate=DynamicResourceAllocation
+                        // +optional
+                limits:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/k8s.io.apimachinery.pkg.api.resource.Quantity'
+                    description: |
+                        // Limits describes the maximum amount of compute resources allowed.
+                        // More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        // +optional
+                requests:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/k8s.io.apimachinery.pkg.api.resource.Quantity'
+                    description: |
+                        // Requests describes the minimum amount of compute resources required.
+                        // If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        // otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        // More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        // +optional
+            description: |4
+                 ResourceRequirements describes the compute resource requirements.
+        k8s.io.api.core.v1.Toleration:
+            type: object
+            properties:
+                effect:
+                    type: string
+                    description: |
+                        // Effect indicates the taint effect to match. Empty means match all taint effects.
+                        // When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                        // +optional
+                key:
+                    type: string
+                    description: |
+                        // Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        // If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                        // +optional
+                operator:
+                    type: string
+                    description: |
+                        // Operator represents a key's relationship to the value.
+                        // Valid operators are Exists and Equal. Defaults to Equal.
+                        // Exists is equivalent to wildcard for value, so that a pod can
+                        // tolerate all taints of a particular category.
+                        // +optional
+                tolerationSeconds:
+                    type: integer
+                    format: int64
+                    description: |
+                        // TolerationSeconds represents the period of time the toleration (which must be
+                        // of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        // it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        // negative values will be treated as 0 (evict immediately) by the system.
+                        // +optional
+                value:
+                    type: string
+                    description: |
+                        // Value is the taint value the toleration matches to.
+                        // If the operator is Exists, the value should be empty, otherwise just a regular string.
+                        // +optional
+            description: |4
+                 The pod this Toleration is attached to tolerates any taint that matches
+                 the triple <key,value,effect> using the matching operator <operator>.
+        k8s.io.apimachinery.pkg.api.resource.Quantity:
+            type: object
+            properties:
+                string:
+                    type: string
+            description: |4
+                 Quantity is a fixed-point representation of a number.
+                 It provides convenient marshaling/unmarshaling in JSON and YAML,
+                 in addition to String() and AsInt64() accessors.
+
+                 The serialization format is:
+
+                 ```
+                 <quantity>        ::= <signedNumber><suffix>
+
+                 	(Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+
+                 <digit>           ::= 0 | 1 | ... | 9
+                 <digits>          ::= <digit> | <digit><digits>
+                 <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits>
+                 <sign>            ::= "+" | "-"
+                 <signedNumber>    ::= <number> | <sign><number>
+                 <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI>
+                 <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+
+                 	(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+
+                 <decimalSI>       ::= m | "" | k | M | G | T | P | E
+
+                 	(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+
+                 <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+                 ```
+
+                 No matter which of the three exponent forms is used, no quantity may represent
+                 a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal
+                 places. Numbers larger or more precise will be capped or rounded up.
+                 (E.g.: 0.1m will rounded up to 1m.)
+                 This may be extended in the future if we require larger or smaller quantities.
+
+                 When a Quantity is parsed from a string, it will remember the type of suffix
+                 it had, and will use the same type again when it is serialized.
+
+                 Before serializing, Quantity will be put in "canonical form".
+                 This means that Exponent/suffix will be adjusted up or down (with a
+                 corresponding increase or decrease in Mantissa) such that:
+
+                 - No precision is lost
+                 - No fractional digits will be emitted
+                 - The exponent (or suffix) is as large as possible.
+
+                 The sign will be omitted unless the number is negative.
+
+                 Examples:
+
+                 - 1.5 will be serialized as "1500m"
+                 - 1.5Gi will be serialized as "1536Mi"
+
+                 Note that the quantity will NEVER be internally represented by a
+                 floating point number. That is the whole point of this exercise.
+
+                 Non-canonical values will still parse as long as they are well formed,
+                 but will be re-emitted in their canonical form. (So always use canonical
+                 form, or don't diff.)
+
+                 This format is intended to make it difficult to use these numbers without
+                 writing some sort of special handling code in the hopes that that will
+                 cause implementors to also use a fixed point implementation.
+
+                 +protobuf=true
+                 +protobuf.embed=string
+                 +protobuf.options.marshal=false
+                 +protobuf.options.(gogoproto.goproto_stringer)=false
+                 +k8s:deepcopy-gen=true
+                 +k8s:openapi-gen=true
+    parameters:
+        consistent:
+            name: consistent
+            in: query
+            description: When true, the operation will be performed with strong consistency
+            schema:
+                type: boolean
+        name:
+            name: name
+            in: path
+            description: The name of the resource to operate on.
+            required: true
+            schema:
+                type: string
+        name_prefix:
+            name: name_prefix
+            in: query
+            description: The resource name prefix used to filter the result list.
+            schema:
+                type: string
+        namespace:
+            name: namespace
+            in: query
+            description: Specifies the Consul namespace of resources to operate on. This parameter takes precedence over the `ns` alias.
+            schema:
+                type: string
+        ns:
+            name: ns
+            in: query
+            description: '`ns` is an alias for the `namespace` query param. The `namespace` parameter takes precedence.'
+            schema:
+                type: string
+        partition:
+            name: partition
+            in: query
+            description: Specifies the Consul partition of resources to operate on.
+            schema:
+                type: string
+        peer:
+            name: peer
+            in: query
+            description: Specifies the Consul peer of imported resources to operate on.
+            schema:
+                type: string
+    securitySchemes:
+        BearerAuth:
+            type: http
+            scheme: bearer
+        ConsulTokenHeader:
+            type: apiKey
+            in: header
+            name: X-Consul-Token
+security:
+    - BearerAuth: []
+    - ConsulTokenHeader: []

--- a/proto-public/openapi/multicluster-v2beta1.openapi.yml
+++ b/proto-public/openapi/multicluster-v2beta1.openapi.yml
@@ -1,0 +1,1321 @@
+openapi: 3.0.0
+info:
+    title: Consul multicluster
+    description: Consul APIs for interacting with the multicluster resource kinds at version v2beta1
+    version: v2beta1
+paths:
+    /multicluster/v2beta1/ComputedExportedServices:
+        get:
+            summary: List multicluster.v2beta1.ComputedExportedServices resources
+            operationId: list-ComputedExportedServices
+            parameters:
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/partition'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ComputedExportedServices'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /multicluster/v2beta1/ComputedExportedServices/{name}:
+        get:
+            summary: Read multicluster.v2beta1.ComputedExportedServices resources
+            operationId: read-ComputedExportedServices.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ComputedExportedServices'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write multicluster.v2beta1.ComputedExportedServices resources
+            operationId: write-ComputedExportedServices
+            requestBody:
+                description: The multicluster.v2beta1.ComputedExportedServices resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ComputedExportedServices'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ComputedExportedServices'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete multicluster.v2beta1.ComputedExportedServices resources
+            operationId: delete-ComputedExportedServices
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/partition'
+    /multicluster/v2beta1/ExportedServices:
+        get:
+            summary: List multicluster.v2beta1.ExportedServices resources
+            operationId: list-ExportedServices
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ExportedServices'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /multicluster/v2beta1/ExportedServices/{name}:
+        get:
+            summary: Read multicluster.v2beta1.ExportedServices resources
+            operationId: read-ExportedServices.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ExportedServices'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write multicluster.v2beta1.ExportedServices resources
+            operationId: write-ExportedServices
+            requestBody:
+                description: The multicluster.v2beta1.ExportedServices resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ExportedServices'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ExportedServices'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete multicluster.v2beta1.ExportedServices resources
+            operationId: delete-ExportedServices
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /multicluster/v2beta1/NamespaceExportedServices:
+        get:
+            summary: List multicluster.v2beta1.NamespaceExportedServices resources
+            operationId: list-NamespaceExportedServices
+            parameters:
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/namespace'
+                - $ref: '#/components/parameters/ns'
+                - $ref: '#/components/parameters/partition'
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.NamespaceExportedServices'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /multicluster/v2beta1/NamespaceExportedServices/{name}:
+        get:
+            summary: Read multicluster.v2beta1.NamespaceExportedServices resources
+            operationId: read-NamespaceExportedServices.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.NamespaceExportedServices'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write multicluster.v2beta1.NamespaceExportedServices resources
+            operationId: write-NamespaceExportedServices
+            requestBody:
+                description: The multicluster.v2beta1.NamespaceExportedServices resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.NamespaceExportedServices'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.NamespaceExportedServices'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete multicluster.v2beta1.NamespaceExportedServices resources
+            operationId: delete-NamespaceExportedServices
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/namespace'
+            - $ref: '#/components/parameters/ns'
+            - $ref: '#/components/parameters/partition'
+    /multicluster/v2beta1/PartitionExportedServices:
+        get:
+            summary: List multicluster.v2beta1.PartitionExportedServices resources
+            operationId: list-PartitionExportedServices
+            parameters:
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/partition'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.PartitionExportedServices'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /multicluster/v2beta1/PartitionExportedServices/{name}:
+        get:
+            summary: Read multicluster.v2beta1.PartitionExportedServices resources
+            operationId: read-PartitionExportedServices.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.PartitionExportedServices'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write multicluster.v2beta1.PartitionExportedServices resources
+            operationId: write-PartitionExportedServices
+            requestBody:
+                description: The multicluster.v2beta1.PartitionExportedServices resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.PartitionExportedServices'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.PartitionExportedServices'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete multicluster.v2beta1.PartitionExportedServices resources
+            operationId: delete-PartitionExportedServices
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/partition'
+components:
+    schemas:
+        hashicorp.consul.multicluster.v2beta1.ComputedExportedService:
+            type: object
+            properties:
+                consumers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ComputedExportedServicesConsumer'
+                target_ref:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+        hashicorp.consul.multicluster.v2beta1.ComputedExportedServices:
+            type: object
+            properties:
+                consumers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ComputedExportedService'
+        hashicorp.consul.multicluster.v2beta1.ComputedExportedServicesConsumer:
+            type: object
+            properties:
+                partition:
+                    type: string
+                peer:
+                    type: string
+        hashicorp.consul.multicluster.v2beta1.ExportedServices:
+            type: object
+            properties:
+                consumers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ExportedServicesConsumer'
+                services:
+                    type: array
+                    items:
+                        type: string
+        hashicorp.consul.multicluster.v2beta1.ExportedServicesConsumer:
+            type: object
+            properties:
+                partition:
+                    type: string
+                peer:
+                    type: string
+                sameness_group:
+                    type: string
+        hashicorp.consul.multicluster.v2beta1.NamespaceExportedServices:
+            type: object
+            properties:
+                consumers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ExportedServicesConsumer'
+        hashicorp.consul.multicluster.v2beta1.PartitionExportedServices:
+            type: object
+            properties:
+                consumers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.multicluster.v2beta1.ExportedServicesConsumer'
+        hashicorp.consul.resource.Condition:
+            type: object
+            properties:
+                message:
+                    type: string
+                    description: |
+                        // Message contains a human-friendly description of the status.
+                reason:
+                    type: string
+                    description: |
+                        // Reason provides more machine-readable details about the condition (e.g.
+                        // "InvalidProtocol").
+                resource:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // Resource identifies which resource this condition relates to, when it is
+                        // not the core resource itself.
+                state:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Condition.State'
+                    description: |
+                        // State represents the state of the condition (i.e. true/false/unknown).
+                type:
+                    type: string
+                    description: |
+                        // Type identifies the type of condition (e.g. "Invalid", "ResolvedRefs").
+            description: |4
+                 Condition represents a discreet observation about a resource in relation to
+                 the current state of the system.
+
+                 It is heavily inspired by Kubernetes' [conditions](https://bit.ly/3H9Y6IK)
+                 and the Gateway API [types and reasons](https://bit.ly/3n2PPiP).
+        hashicorp.consul.resource.Condition.State:
+            type: string
+            enum:
+                - STATE_UNKNOWN
+                - STATE_TRUE
+                - STATE_FALSE
+            description: |4
+                 State represents the state of the condition (i.e. true/false/unknown).
+        hashicorp.consul.resource.ID:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the user-given name of the resource (e.g. the "billing" service).
+                tenancy:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Tenancy'
+                    description: |
+                        // Tenancy identifies the tenancy units (i.e. partition, namespace) in which
+                        // the resource resides.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Type'
+                    description: |
+                        // Type identifies the resource's type.
+                uid:
+                    type: string
+                    description: |
+                        // Uid is the unique internal identifier we gave to the resource.
+                        //
+                        // It is primarily used to tell the difference between the current resource
+                        // and previous deleted resources with the same user-given name.
+                        //
+                        // Concretely, Uid is a [ULID](https://github.com/ulid/spec) and you can treat
+                        // its timestamp component as the resource's creation time.
+            description: |4
+                 ID uniquely identifies a resource.
+        hashicorp.consul.resource.Reference:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the user-given name of the resource (e.g. the "billing" service).
+                section:
+                    type: string
+                    description: |
+                        // Section identifies which part of the resource the condition relates to.
+                tenancy:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Tenancy'
+                    description: |
+                        // Tenancy identifies the tenancy units (i.e. partition, namespace) in which
+                        // the resource resides.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Type'
+                    description: |
+                        // Type identifies the resource's type.
+            description: |4
+                 Reference identifies which resource a condition relates to, when it is not
+                 the core resource itself.
+        hashicorp.consul.resource.Status:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.resource.Condition'
+                    description: |
+                        // Conditions contains a set of discreet observations about the resource in
+                        // relation to the current state of the system (e.g. it is semantically valid).
+                observed_generation:
+                    type: string
+                    description: |
+                        // ObservedGeneration identifies which generation of a resource this status
+                        // related to. It can be used to determine whether the current generation of
+                        // a resource has been reconciled.
+                updated_at:
+                    type: string
+                    format: date-time
+                    description: |
+                        // UpdatedAt is the time at which the status was last written.
+            description: |4
+                 Status is used by controllers to communicate the result of attempting to
+                 reconcile and apply a resource (e.g. surface semantic validation errors)
+                 with users and other controllers.
+        hashicorp.consul.resource.Tenancy:
+            type: object
+            properties:
+                namespace:
+                    type: string
+                    description: |
+                        // Namespace further isolates resources within a partition.
+                        // https://developer.hashicorp.com/consul/docs/enterprise/namespaces
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all namespaces.
+                partition:
+                    type: string
+                    description: |
+                        // Partition is the topmost administrative boundary within a cluster.
+                        // https://developer.hashicorp.com/consul/docs/enterprise/admin-partitions
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all partitions.
+                peer_name:
+                    type: string
+                    description: |
+                        // PeerName identifies which peer the resource is imported from.
+                        // https://developer.hashicorp.com/consul/docs/connect/cluster-peering
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all peers.
+            description: |4
+                 Tenancy describes the tenancy units in which the resource resides.
+        hashicorp.consul.resource.Type:
+            type: object
+            properties:
+                group:
+                    type: string
+                    description: |
+                        // Group describes the area of functionality to which this resource type
+                        // relates (e.g. "catalog", "authorization").
+                group_version:
+                    type: string
+                    description: |
+                        // GroupVersion is incremented when sweeping or backward-incompatible changes
+                        // are made to the group's resource types.
+                kind:
+                    type: string
+                    description: |
+                        // Kind identifies the specific resource type within the group.
+            description: |4
+                 Type describes a resource's type. It follows the GVK (Group Version Kind)
+                 [pattern](https://book.kubebuilder.io/cronjob-tutorial/gvks.html) established
+                 by Kubernetes.
+    parameters:
+        consistent:
+            name: consistent
+            in: query
+            description: When true, the operation will be performed with strong consistency
+            schema:
+                type: boolean
+        name:
+            name: name
+            in: path
+            description: The name of the resource to operate on.
+            required: true
+            schema:
+                type: string
+        name_prefix:
+            name: name_prefix
+            in: query
+            description: The resource name prefix used to filter the result list.
+            schema:
+                type: string
+        namespace:
+            name: namespace
+            in: query
+            description: Specifies the Consul namespace of resources to operate on. This parameter takes precedence over the `ns` alias.
+            schema:
+                type: string
+        ns:
+            name: ns
+            in: query
+            description: '`ns` is an alias for the `namespace` query param. The `namespace` parameter takes precedence.'
+            schema:
+                type: string
+        partition:
+            name: partition
+            in: query
+            description: Specifies the Consul partition of resources to operate on.
+            schema:
+                type: string
+        peer:
+            name: peer
+            in: query
+            description: Specifies the Consul peer of imported resources to operate on.
+            schema:
+                type: string
+    securitySchemes:
+        BearerAuth:
+            type: http
+            scheme: bearer
+        ConsulTokenHeader:
+            type: apiKey
+            in: header
+            name: X-Consul-Token
+security:
+    - BearerAuth: []
+    - ConsulTokenHeader: []

--- a/proto-public/openapi/tenancy-v2beta1.openapi.yml
+++ b/proto-public/openapi/tenancy-v2beta1.openapi.yml
@@ -1,0 +1,497 @@
+openapi: 3.0.0
+info:
+    title: Consul tenancy
+    description: Consul APIs for interacting with the tenancy resource kinds at version v2beta1
+    version: v2beta1
+paths:
+    /tenancy/v2beta1/Namespace:
+        get:
+            summary: List tenancy.v2beta1.Namespace resources
+            operationId: list-Namespace
+            parameters:
+                - $ref: '#/components/parameters/peer'
+                - $ref: '#/components/parameters/consistent'
+                - $ref: '#/components/parameters/name_prefix'
+                - $ref: '#/components/parameters/partition'
+            responses:
+                "200":
+                    description: The listing was successful and the body contains the array of results.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        data:
+                                            $ref: '#/components/schemas/hashicorp.consul.tenancy.v2beta1.Namespace'
+                                        generation:
+                                            type: string
+                                            description: |
+                                                // Generation is incremented whenever the resource's content (i.e. not its
+                                                // status) is modified. You can think of it as being the "user version".
+                                                //
+                                                // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                                // can treat its timestamp component as the resource's modification time.
+                                        id:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // ID uniquely identifies the resource.
+                                        metadata:
+                                            type: object
+                                            additionalProperties:
+                                                type: string
+                                            description: |
+                                                // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                                // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                        owner:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                            description: |
+                                                // Owner (optionally) describes which resource "owns" this resource, it is
+                                                // immutable and can only be set on resource creation. Owned resources will
+                                                // be automatically deleted when their owner is deleted.
+                                        status:
+                                            type: object
+                                            additionalProperties:
+                                                $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                            description: |
+                                                // Status is used by controllers to communicate the result of attempting to
+                                                // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                                // with users and other controllers. Each status is identified by a unique key
+                                                // and should only ever be updated by one controller.
+                                                //
+                                                // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                                // so via the Write endpoint will result in an InvalidArgument error code.
+                                        version:
+                                            type: string
+                                            description: |
+                                                // Version is the low-level version identifier used by the storage backend
+                                                // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                                // modified in any way, including status updates.
+                                                //
+                                                // When calling the Write endpoint, providing a non-blank version will perform
+                                                // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                                // if the given version doesn't match what is stored.
+    /tenancy/v2beta1/Namespace/{name}:
+        get:
+            summary: Read tenancy.v2beta1.Namespace resources
+            operationId: read-Namespace.
+            parameters:
+                - $ref: '#/components/parameters/consistent'
+            responses:
+                "200":
+                    description: The read was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.tenancy.v2beta1.Namespace'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        put:
+            summary: Write tenancy.v2beta1.Namespace resources
+            operationId: write-Namespace
+            requestBody:
+                description: The tenancy.v2beta1.Namespace resource to be updated.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                data:
+                                    $ref: '#/components/schemas/hashicorp.consul.tenancy.v2beta1.Namespace'
+                                generation:
+                                    type: string
+                                    description: |
+                                        // Generation is incremented whenever the resource's content (i.e. not its
+                                        // status) is modified. You can think of it as being the "user version".
+                                        //
+                                        // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                        // can treat its timestamp component as the resource's modification time.
+                                id:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // ID uniquely identifies the resource.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: |
+                                        // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                        // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                owner:
+                                    $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                    description: |
+                                        // Owner (optionally) describes which resource "owns" this resource, it is
+                                        // immutable and can only be set on resource creation. Owned resources will
+                                        // be automatically deleted when their owner is deleted.
+                                status:
+                                    type: object
+                                    additionalProperties:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                    description: |
+                                        // Status is used by controllers to communicate the result of attempting to
+                                        // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                        // with users and other controllers. Each status is identified by a unique key
+                                        // and should only ever be updated by one controller.
+                                        //
+                                        // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                        // so via the Write endpoint will result in an InvalidArgument error code.
+                                version:
+                                    type: string
+                                    description: |
+                                        // Version is the low-level version identifier used by the storage backend
+                                        // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                        // modified in any way, including status updates.
+                                        //
+                                        // When calling the Write endpoint, providing a non-blank version will perform
+                                        // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                        // if the given version doesn't match what is stored.
+            responses:
+                "200":
+                    description: The write was successful and the body contains the result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/hashicorp.consul.tenancy.v2beta1.Namespace'
+                                    generation:
+                                        type: string
+                                        description: |
+                                            // Generation is incremented whenever the resource's content (i.e. not its
+                                            // status) is modified. You can think of it as being the "user version".
+                                            //
+                                            // Concretely, Generation is a [ULID](https://github.com/ulid/spec) and you
+                                            // can treat its timestamp component as the resource's modification time.
+                                    id:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // ID uniquely identifies the resource.
+                                    metadata:
+                                        type: object
+                                        additionalProperties:
+                                            type: string
+                                        description: |
+                                            // Metadata contains key/value pairs of arbitrary metadata about the resource.
+                                            // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
+                                    owner:
+                                        $ref: '#/components/schemas/hashicorp.consul.resource.ID'
+                                        description: |
+                                            // Owner (optionally) describes which resource "owns" this resource, it is
+                                            // immutable and can only be set on resource creation. Owned resources will
+                                            // be automatically deleted when their owner is deleted.
+                                    status:
+                                        type: object
+                                        additionalProperties:
+                                            $ref: '#/components/schemas/hashicorp.consul.resource.Status'
+                                        description: |
+                                            // Status is used by controllers to communicate the result of attempting to
+                                            // reconcile and apply the resource (e.g. surface semantic validation errors)
+                                            // with users and other controllers. Each status is identified by a unique key
+                                            // and should only ever be updated by one controller.
+                                            //
+                                            // Status can only be updated via the WriteStatus endpoint. Attempting to do
+                                            // so via the Write endpoint will result in an InvalidArgument error code.
+                                    version:
+                                        type: string
+                                        description: |
+                                            // Version is the low-level version identifier used by the storage backend
+                                            // in CAS (Compare-And-Swap) operations. It will change when the resource is
+                                            // modified in any way, including status updates.
+                                            //
+                                            // When calling the Write endpoint, providing a non-blank version will perform
+                                            // a CAS (Compare-And-Swap) write, which will result in an Aborted error code
+                                            // if the given version doesn't match what is stored.
+        delete:
+            summary: Delete tenancy.v2beta1.Namespace resources
+            operationId: delete-Namespace
+            responses:
+                "200":
+                    description: The delete was successful and the body contains the result.
+        parameters:
+            - $ref: '#/components/parameters/peer'
+            - $ref: '#/components/parameters/name'
+            - $ref: '#/components/parameters/partition'
+components:
+    schemas:
+        hashicorp.consul.resource.Condition:
+            type: object
+            properties:
+                message:
+                    type: string
+                    description: |
+                        // Message contains a human-friendly description of the status.
+                reason:
+                    type: string
+                    description: |
+                        // Reason provides more machine-readable details about the condition (e.g.
+                        // "InvalidProtocol").
+                resource:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Reference'
+                    description: |
+                        // Resource identifies which resource this condition relates to, when it is
+                        // not the core resource itself.
+                state:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Condition.State'
+                    description: |
+                        // State represents the state of the condition (i.e. true/false/unknown).
+                type:
+                    type: string
+                    description: |
+                        // Type identifies the type of condition (e.g. "Invalid", "ResolvedRefs").
+            description: |4
+                 Condition represents a discreet observation about a resource in relation to
+                 the current state of the system.
+
+                 It is heavily inspired by Kubernetes' [conditions](https://bit.ly/3H9Y6IK)
+                 and the Gateway API [types and reasons](https://bit.ly/3n2PPiP).
+        hashicorp.consul.resource.Condition.State:
+            type: string
+            enum:
+                - STATE_UNKNOWN
+                - STATE_TRUE
+                - STATE_FALSE
+            description: |4
+                 State represents the state of the condition (i.e. true/false/unknown).
+        hashicorp.consul.resource.ID:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the user-given name of the resource (e.g. the "billing" service).
+                tenancy:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Tenancy'
+                    description: |
+                        // Tenancy identifies the tenancy units (i.e. partition, namespace) in which
+                        // the resource resides.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Type'
+                    description: |
+                        // Type identifies the resource's type.
+                uid:
+                    type: string
+                    description: |
+                        // Uid is the unique internal identifier we gave to the resource.
+                        //
+                        // It is primarily used to tell the difference between the current resource
+                        // and previous deleted resources with the same user-given name.
+                        //
+                        // Concretely, Uid is a [ULID](https://github.com/ulid/spec) and you can treat
+                        // its timestamp component as the resource's creation time.
+            description: |4
+                 ID uniquely identifies a resource.
+        hashicorp.consul.resource.Reference:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |
+                        // Name is the user-given name of the resource (e.g. the "billing" service).
+                section:
+                    type: string
+                    description: |
+                        // Section identifies which part of the resource the condition relates to.
+                tenancy:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Tenancy'
+                    description: |
+                        // Tenancy identifies the tenancy units (i.e. partition, namespace) in which
+                        // the resource resides.
+                type:
+                    $ref: '#/components/schemas/hashicorp.consul.resource.Type'
+                    description: |
+                        // Type identifies the resource's type.
+            description: |4
+                 Reference identifies which resource a condition relates to, when it is not
+                 the core resource itself.
+        hashicorp.consul.resource.Status:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/hashicorp.consul.resource.Condition'
+                    description: |
+                        // Conditions contains a set of discreet observations about the resource in
+                        // relation to the current state of the system (e.g. it is semantically valid).
+                observed_generation:
+                    type: string
+                    description: |
+                        // ObservedGeneration identifies which generation of a resource this status
+                        // related to. It can be used to determine whether the current generation of
+                        // a resource has been reconciled.
+                updated_at:
+                    type: string
+                    format: date-time
+                    description: |
+                        // UpdatedAt is the time at which the status was last written.
+            description: |4
+                 Status is used by controllers to communicate the result of attempting to
+                 reconcile and apply a resource (e.g. surface semantic validation errors)
+                 with users and other controllers.
+        hashicorp.consul.resource.Tenancy:
+            type: object
+            properties:
+                namespace:
+                    type: string
+                    description: |
+                        // Namespace further isolates resources within a partition.
+                        // https://developer.hashicorp.com/consul/docs/enterprise/namespaces
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all namespaces.
+                partition:
+                    type: string
+                    description: |
+                        // Partition is the topmost administrative boundary within a cluster.
+                        // https://developer.hashicorp.com/consul/docs/enterprise/admin-partitions
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all partitions.
+                peer_name:
+                    type: string
+                    description: |
+                        // PeerName identifies which peer the resource is imported from.
+                        // https://developer.hashicorp.com/consul/docs/connect/cluster-peering
+                        //
+                        // When using the List and WatchList endpoints, provide the wildcard value "*"
+                        // to list resources across all peers.
+            description: |4
+                 Tenancy describes the tenancy units in which the resource resides.
+        hashicorp.consul.resource.Type:
+            type: object
+            properties:
+                group:
+                    type: string
+                    description: |
+                        // Group describes the area of functionality to which this resource type
+                        // relates (e.g. "catalog", "authorization").
+                group_version:
+                    type: string
+                    description: |
+                        // GroupVersion is incremented when sweeping or backward-incompatible changes
+                        // are made to the group's resource types.
+                kind:
+                    type: string
+                    description: |
+                        // Kind identifies the specific resource type within the group.
+            description: |4
+                 Type describes a resource's type. It follows the GVK (Group Version Kind)
+                 [pattern](https://book.kubebuilder.io/cronjob-tutorial/gvks.html) established
+                 by Kubernetes.
+        hashicorp.consul.tenancy.v2beta1.Namespace:
+            type: object
+            properties:
+                description:
+                    type: string
+                    description: |
+                        // Description is where the user puts any information they want
+                        // about the namespace. It is not used internally.
+            description: |4
+                 The name of the Namespace is in the outer Resource.ID.Name.
+                 It must be unique within a partition and must be a
+                 DNS hostname. There are also other reserved names that may not be used.
+    parameters:
+        consistent:
+            name: consistent
+            in: query
+            description: When true, the operation will be performed with strong consistency
+            schema:
+                type: boolean
+        name:
+            name: name
+            in: path
+            description: The name of the resource to operate on.
+            required: true
+            schema:
+                type: string
+        name_prefix:
+            name: name_prefix
+            in: query
+            description: The resource name prefix used to filter the result list.
+            schema:
+                type: string
+        namespace:
+            name: namespace
+            in: query
+            description: Specifies the Consul namespace of resources to operate on. This parameter takes precedence over the `ns` alias.
+            schema:
+                type: string
+        ns:
+            name: ns
+            in: query
+            description: '`ns` is an alias for the `namespace` query param. The `namespace` parameter takes precedence.'
+            schema:
+                type: string
+        partition:
+            name: partition
+            in: query
+            description: Specifies the Consul partition of resources to operate on.
+            schema:
+                type: string
+        peer:
+            name: peer
+            in: query
+            description: Specifies the Consul peer of imported resources to operate on.
+            schema:
+                type: string
+    securitySchemes:
+        BearerAuth:
+            type: http
+            scheme: bearer
+        ConsulTokenHeader:
+            type: apiKey
+            in: header
+            name: X-Consul-Token
+security:
+    - BearerAuth: []
+    - ConsulTokenHeader: []


### PR DESCRIPTION
### Description

I wrote a protobuf generator to output openapi specs for all our resource API groups. 

Areas for improvement:
* Handling of doc comments need some improvement.
   * stripping `//` from the beginning of lines
   * better HTTP path/operation docs
   * high level resource docs attached to the component schemas
   * external docs links eventually
* Annotations for field validations
* Support for knowing whether a resource can be imported/peered.


### Testing & Reproduction steps

* Ran openapi linters to ensure things are okay.
* Opened openapi previews using a vscode extension to ensure the auto-generated docs look right.
