### PR TITLE
api: add `CheckRegisterOpts` method to Agent API

### DIFF
--- a/.changelog/18943.txt
+++ b/.changelog/18943.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: added `CheckRegisterOpts` to Agent API
+```

--- a/api/agent.go
+++ b/api/agent.go
@@ -991,7 +991,14 @@ func (a *Agent) UpdateTTLOpts(checkID, output, status string, q *QueryOptions) e
 // CheckRegister is used to register a new check with
 // the local agent
 func (a *Agent) CheckRegister(check *AgentCheckRegistration) error {
+	return a.CheckRegisterOpts(check, nil)
+}
+
+// CheckRegisterOpts is used to register a new check with
+// the local agent using query options
+func (a *Agent) CheckRegisterOpts(check *AgentCheckRegistration, q *QueryOptions) error {
 	r := a.c.newRequest("PUT", "/v1/agent/check/register")
+	r.setQueryOptions(q)
 	r.obj = check
 	_, resp, err := a.c.doRequest(r)
 	if err != nil {

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -1058,7 +1058,7 @@ func TestAPI_AgentChecks(t *testing.T) {
 		Name: "foo",
 	}
 	reg.TTL = "15s"
-	if err := agent.CheckRegister(reg); err != nil {
+	if err := agent.CheckRegisterOpts(reg, nil); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1080,6 +1080,19 @@ func TestAPI_AgentChecks(t *testing.T) {
 	if err := agent.CheckDeregister("foo"); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+}
+
+func TestAgent_AgentChecksRegisterOpts_WithContextTimeout(t *testing.T) {
+	c, err := NewClient(DefaultConfig())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	t.Cleanup(cancel)
+
+	opts := &QueryOptions{}
+	opts = opts.WithContext(ctx)
+	err = c.Agent().CheckRegisterOpts(&AgentCheckRegistration{}, opts)
+	require.True(t, errors.Is(err, context.DeadlineExceeded), "expected timeout")
 }
 
 func TestAPI_AgentChecksWithFilterOpts(t *testing.T) {


### PR DESCRIPTION
Ongoing work to support Nomad Workload Identity for authenticating with Consul will mean that Nomad's service registration sync with Consul will want to use Consul tokens scoped to individual workloads for registering services and checks. The `CheckRegister` method in the API doesn't have an option to pass the token in, which prevent us from sharing the same Consul connection for all workloads. Add a `CheckRegisterOpts` to match the behavior of `CheckDeregisterOpts`.

### Links

Related: https://github.com/hashicorp/nomad/issues/15618
Related: https://github.com/hashicorp/consul/pull/18983

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated (automated)
* [ ] appropriate backport labels added
* [ ] not a security concern
