### PR TITLE
when skip-ci is true do not trigger integration and go tests

### DIFF
--- a/.github/scripts/filter_changed_files_go_test.sh
+++ b/.github/scripts/filter_changed_files_go_test.sh
@@ -31,7 +31,7 @@ for file_to_check in "${files_to_check[@]}"; do
 		echo -e $file_to_check
         SKIP_CI=false
 		echo "Changes detected in non-documentation files - skip-ci: $SKIP_CI"
-        export $SKIP_CI
+        echo "skip-ci=$SKIP_CI" >> "$GITHUB_OUTPUT"
 		exit 0 ## if file is outside of the skipped_directory exit script
 	fi
 done
@@ -39,4 +39,4 @@ done
 echo -e "$files_to_check"
 SKIP_CI=true
 echo "Changes detected in only documentation files - skip-ci: $SKIP_CI"
-export $SKIP_CI
+echo "skip-ci=$SKIP_CI" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -41,9 +41,7 @@ jobs:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: |
-          ./.github/scripts/filter_changed_files_go_test.sh
-          echo "skip-ci=${SKIP_CI}" >> "${GITHUB_ENV}"
+        run: ./.github/scripts/filter_changed_files_go_test.sh
 
   setup:
     needs: [conditional-skip]

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -42,9 +42,7 @@ jobs:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: |
-          ./.github/scripts/filter_changed_files_go_test.sh
-          echo "skip-ci=${SKIP_CI}" >> "${GITHUB_ENV}"
+        run: ./.github/scripts/filter_changed_files_go_test.sh
 
   setup:
     needs: [conditional-skip]


### PR DESCRIPTION
### Description

**PROBLEM**
Actions was not correctly reading the result of script to not run CI, it continuously ran CI when changes were only to docs file. See example [here](https://github.com/hashicorp/consul/actions/runs/6265236668/job/17013624352)

**SOLUTION**
Push the result of script to GITHUB_OUTPUT which can be read easily by Github Actions to execute workflows conditionally. 

### Testing & Reproduction steps
[CI](https://github.com/hashicorp/consul/actions/runs/6265534204/job/17014579594) runs all workflows where non doc files are included in changeset
[CI](https://github.com/hashicorp/consul/actions/runs/6265490477/job/17014449286) skips test workflows when only doc files are  in changeset
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
