### PR TITLE
docs: Change heading to filename in CodeBlockConfig

### DIFF
--- a/website/content/docs/connect/gateways/ingress-gateway/tls-external-service.mdx
+++ b/website/content/docs/connect/gateways/ingress-gateway/tls-external-service.mdx
@@ -49,7 +49,7 @@ You must manually register the ingress gateway with Consul proxy to define extra
 In the following example, the `public-ingress` gateway includes a static cluster named `sds-cluster` that specifies paths to the SDS certificate and SDS certification validation files:
 
 
-<CodeBlockConfig heading="public-ingress-service.hcl">
+<CodeBlockConfig filename="public-ingress-service.hcl">
 
 ```hcl
 Services {
@@ -133,7 +133,7 @@ Store TLS client authentication files, certificate files, and keys on disk where
 The following example specifies certificate chain:
 
 
-<CodeBlockConfig heading="certs/sds-auth-cert.json">
+<CodeBlockConfig filename="certs/sds-auth-cert.json">
 
 ```json
 {
@@ -158,7 +158,7 @@ The following example specifies certificate chain:
 
 The following example specifies the validation context:
 
-<CodeBlockConfig heading="/certs/sds-validation.json">
+<CodeBlockConfig filename="/certs/sds-validation.json">
 
 ```json
 {
@@ -209,7 +209,7 @@ Refer to [Ingress gateway configuration entry reference](/consul/docs/connect/co
 
 The following example directs Consul to retrieve `example.com-public-cert` certificates from an SDS cluster named `sds-cluster` and serve them to all listeners:
 
-<CodeBlockConfig heading="public-ingress-cfg.hcl">
+<CodeBlockConfig filename="public-ingress-cfg.hcl">
 
 ```hcl
 Kind = "ingress-gateway"

--- a/website/content/docs/connect/gateways/mesh-gateway/index.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/index.mdx
@@ -305,4 +305,5 @@ service {
   }
 }
 ```
-  </CodeTabs>
+
+</CodeTabs>

--- a/website/content/docs/connect/intentions/create-manage-intentions.mdx
+++ b/website/content/docs/connect/intentions/create-manage-intentions.mdx
@@ -52,7 +52,7 @@ Refer to the `/connect/intentions/exact` [HTTP API endpoint documentation](/cons
 
 For L7 intentions, specify the `Permissions` in the request payload to configure attributes for dynamically enforcing intentions. In the following example payload, Consul allows HTTP GET requests if the request body is empty:
 
-<CodeBlockConfig heading="payload.json">
+<CodeBlockConfig filename="payload.json">
 
 ```json
 {

--- a/website/content/docs/k8s/l7-traffic/failover-tproxy.mdx
+++ b/website/content/docs/k8s/l7-traffic/failover-tproxy.mdx
@@ -32,7 +32,7 @@ The default ACLs that the Consul Helm chart configures are suitable for most cas
 
 Specify the target failover in the [`spec.failover.targets`](/consul/docs/connect/config-entries/service-resolver#failover-targets-service) field in the service resolver configuration entry. In the following example, the `api-beta` service is configured to failover to the `api` service in any service subset:
 
-<CodeBlockConfig heading="api-beta-failover.yaml">
+<CodeBlockConfig filename="api-beta-failover.yaml">
 
 ```yaml
 apiversion: consul.hashicorp.com/v1alpha1
@@ -61,7 +61,7 @@ $ kubectl apply -f api-beta-failover.yaml
 If intentions are not already defined, create and apply intentions that allow the appropriate downstream to access the target service and the failover service. In the following examples, the `frontend` service is allowed to send messages to the `api` service, which is allowed to send messages to the `api-beta` failover service.
 
 
-<CodeBlockConfig heading="frontend-api-api-beta-allow.yaml">
+<CodeBlockConfig filename="frontend-api-api-beta-allow.yaml">
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1

--- a/website/content/docs/k8s/l7-traffic/route-to-virtual-services.mdx
+++ b/website/content/docs/k8s/l7-traffic/route-to-virtual-services.mdx
@@ -34,7 +34,7 @@ The default ACLs that the Consul Helm chart configures are suitable for most cas
 
 Specify the target failover in the [`spec.redirect.service`](/consul/docs/connect/config-entries/service-resolver#spec-redirect-service) field in the service resolver configuration entry. In the following example, the `virtual-api` service is configured to redirect to the `real-api`:
 
-<CodeBlockConfig heading="virtual-api-redirect.yaml">
+<CodeBlockConfig filename="virtual-api-redirect.yaml">
 
 ```yaml
 apiversion: consul.hashicorp.com/v1alpha1
@@ -61,7 +61,7 @@ $ kubectl apply -f virtual-api-redirect.yaml
 If intentions are not already defined, create and apply intentions that allow the appropriate downstream to access the real service and the target redirect service. In the following examples, the `frontend` service is allowed to send messages to the `virtual-api` and `real-api` services:
 
 
-<CodeBlockConfig heading="frontend-api-api-beta-allow.yaml">
+<CodeBlockConfig filename="frontend-api-api-beta-allow.yaml">
 
 ```yaml
 apiversion: consul.hashicorp.com/v1alpha1

--- a/website/content/docs/services/discovery/dns-dynamic-lookups.mdx
+++ b/website/content/docs/services/discovery/dns-dynamic-lookups.mdx
@@ -31,6 +31,8 @@ Refer to the [prepared query reference](/consul/api-docs/query#create-prepared-q
 
 1. Specify the prepared query options in JSON format. The following prepared query targets all instances of the `redis` service in `dc1` and `dc2`:
 
+    <CodeBlockConfig filename="payload.json">
+
     ```json
     {
       "Name": "my-query",
@@ -57,6 +59,8 @@ Refer to the [prepared query reference](/consul/api-docs/query#create-prepared-q
         }
     }
     ```
+
+    </CodeBlockConfig>
 
  Refer to the [prepared query configuration reference](/consul/api-docs/query#create-prepared-query) for information about all available options.
 

--- a/website/content/docs/services/usage/define-services.mdx
+++ b/website/content/docs/services/usage/define-services.mdx
@@ -44,7 +44,7 @@ For Kubernetes environments, you can enable the  [`connectInject`](/consul/docs/
 The following example defines a service named `redis` that is available on port `80`. By default, the service has the IP address of the agent node.
 
 <CodeTabs>
-<CodeBlockConfig heading="service.hcl">
+<CodeBlockConfig filename="service.hcl">
 
 ```hcl
 service {
@@ -72,7 +72,7 @@ service {
 ```
 
 </CodeBlockConfig>
-<CodeBlockConfig heading="service.json">
+<CodeBlockConfig filename="service.json">
 
 ```json
 {


### PR DESCRIPTION
### Description

Change various CodeBlockConfig objects to use the `filename` attribute instead of `heading` when the code block references a named file.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
