### PR TITLE
fix disabling panic threshold logic

### DIFF
--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -5,12 +5,13 @@ package xds
 
 import (
 	"bytes"
-	"github.com/hashicorp/consul/types"
 	"path/filepath"
 	"sort"
 	"testing"
 	"text/template"
 	"time"
+
+	"github.com/hashicorp/consul/types"
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"

--- a/agent/xds/proxystateconverter/clusters.go
+++ b/agent/xds/proxystateconverter/clusters.go
@@ -6,10 +6,11 @@ package proxystateconverter
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-uuid"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
 
 	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -312,7 +313,8 @@ func (s *Converter) makePassthroughClusters(cfgSnap *proxycfg.ConfigSnapshot) (m
 									ConnectTimeout: durationpb.New(5 * time.Second),
 									// Endpoints are managed separately by EDS
 									// Having an empty config enables outlier detection with default config.
-									OutlierDetection: &pbproxystate.OutlierDetection{},
+									OutlierDetection:      &pbproxystate.OutlierDetection{},
+									DisablePanicThreshold: true,
 								},
 							},
 						},
@@ -653,8 +655,7 @@ func (s *Converter) makeUpstreamClusterForPreparedQuery(upstream structs.Upstrea
 								ConnectTimeout: durationpb.New(time.Duration(cfg.ConnectTimeoutMs) * time.Millisecond),
 								// Endpoints are managed separately by EDS
 								// Having an empty config enables outlier detection with default config.
-								OutlierDetection:      makeOutlierDetection(cfg.PassiveHealthCheck, nil, true),
-								DisablePanicThreshold: true,
+								OutlierDetection: makeOutlierDetection(cfg.PassiveHealthCheck, nil, true),
 								CircuitBreakers: &pbproxystate.CircuitBreakers{
 									UpstreamLimits: makeUpstreamLimitsIfNeeded(cfg.Limits),
 								},
@@ -880,7 +881,8 @@ func (s *Converter) makeUpstreamClustersForDiscoveryChain(
 					CircuitBreakers: &pbproxystate.CircuitBreakers{
 						UpstreamLimits: makeUpstreamLimitsIfNeeded(upstreamConfig.Limits),
 					},
-					OutlierDetection: makeOutlierDetection(upstreamConfig.PassiveHealthCheck, nil, true),
+					DisablePanicThreshold: true,
+					OutlierDetection:      makeOutlierDetection(upstreamConfig.PassiveHealthCheck, nil, true),
 				},
 			}
 			ti := groupedTarget.Targets[0]

--- a/agent/xdsv2/cluster_resources.go
+++ b/agent/xdsv2/cluster_resources.go
@@ -125,7 +125,7 @@ func (pr *ProxyResources) makeEnvoyDynamicCluster(name string, protocol string, 
 			cluster.AltStatName = name
 		}
 		cluster.ConnectTimeout = dynamic.Config.ConnectTimeout
-		if !dynamic.Config.DisablePanicThreshold {
+		if dynamic.Config.DisablePanicThreshold {
 			cluster.CommonLbConfig = &envoy_cluster_v3.Cluster_CommonLbConfig{
 				HealthyPanicThreshold: &envoy_type_v3.Percent{
 					Value: 0, // disable panic threshold

--- a/agent/xdsv2/testdata/output/clusters/l4-single-implicit-destination-tproxy.golden
+++ b/agent/xdsv2/testdata/output/clusters/l4-single-implicit-destination-tproxy.golden
@@ -11,6 +11,9 @@
           "resourceApiVersion":  "V3"
         }
       },
+      "commonLbConfig": {
+        "healthyPanicThreshold": {}
+      },
       "name": "tcp.api-1.default.dc1.internal.foo.consul",
       "transportSocket": {
         "name": "tls",


### PR DESCRIPTION
### Description
The panic threshold logic was just slightly off, where we do want to disable panic threshold on discovery chain clusters, peered clusters, and passthrough clusters. I just made sure we do that in those cases. This fixed acceptance tests for k8s here: https://github.com/hashicorp/consul-k8s/pull/2994 

### Testing & Reproduction steps
Ran acceptance tests on k8s with health status syncing and ensured endpoints are not routed to: https://github.com/hashicorp/consul-k8s/pull/2994

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
