### PR TITLE
Allow connections through Terminating Gateways from peered clusters NET-3463

### DIFF
--- a/.changelog/18959.txt
+++ b/.changelog/18959.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+gateways: Fix a bug where a service in a peered datacenter could not access an external service through a terminating gateway
+```

--- a/.changelog/18959.txt
+++ b/.changelog/18959.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-gateways: Fix a bug where a service in a peered datacenter could not access an external service through a terminating gateway
+gateways: Fix a bug where a service in a peered datacenter could not access an external node service
 ```

--- a/.changelog/18959.txt
+++ b/.changelog/18959.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-gateways: Fix a bug where a service in a peered datacenter could not access an external node service
+gateways: Fix a bug where a service in a peered datacenter could not access an external node service through a terminating gateway
 ```

--- a/agent/proxycfg/proxycfg.deepcopy.go
+++ b/agent/proxycfg/proxycfg.deepcopy.go
@@ -826,5 +826,27 @@ func (o *configSnapshotTerminatingGateway) DeepCopy() *configSnapshotTerminating
 			cp.HostnameServices[k2] = cp_HostnameServices_v2
 		}
 	}
+	if o.WatchedInboundPeerTrustBundles != nil {
+		cp.WatchedInboundPeerTrustBundles = make(map[structs.ServiceName]context.CancelFunc, len(o.WatchedInboundPeerTrustBundles))
+		for k2, v2 := range o.WatchedInboundPeerTrustBundles {
+			cp.WatchedInboundPeerTrustBundles[k2] = v2
+		}
+	}
+	if o.InboundPeerTrustBundles != nil {
+		cp.InboundPeerTrustBundles = make(map[structs.ServiceName][]*pbpeering.PeeringTrustBundle, len(o.InboundPeerTrustBundles))
+		for k2, v2 := range o.InboundPeerTrustBundles {
+			var cp_InboundPeerTrustBundles_v2 []*pbpeering.PeeringTrustBundle
+			if v2 != nil {
+				cp_InboundPeerTrustBundles_v2 = make([]*pbpeering.PeeringTrustBundle, len(v2))
+				copy(cp_InboundPeerTrustBundles_v2, v2)
+				for i3 := range v2 {
+					if v2[i3] != nil {
+						cp_InboundPeerTrustBundles_v2[i3] = v2[i3].DeepCopy()
+					}
+				}
+			}
+			cp.InboundPeerTrustBundles[k2] = cp_InboundPeerTrustBundles_v2
+		}
+	}
 	return &cp
 }

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -282,6 +282,15 @@ type configSnapshotTerminatingGateway struct {
 	// HostnameServices is a map of service name to service instances with a hostname as the address.
 	// If hostnames are configured they must be provided to Envoy via CDS not EDS.
 	HostnameServices map[structs.ServiceName]structs.CheckServiceNodes
+
+	// WatchedInboundPeerTrustBundles is a map of service name to a cancel function. This cancel
+	// function is tied to the watch of the inbound peer trust bundles for the gateway.
+	WatchedInboundPeerTrustBundles map[structs.ServiceName]context.CancelFunc
+
+	// InboundPeerTrustBundles is a map of service name to a list of peering trust bundles.
+	// These bundles are used to configure RBAC policies for inbound filter chains on the gateway
+	// from services that are in a cluster-peered datacenter.
+	InboundPeerTrustBundles map[structs.ServiceName][]*pbpeering.PeeringTrustBundle
 }
 
 // ValidServices returns the list of service keys that have enough data to be emitted.

--- a/agent/proxycfg/terminating_gateway.go
+++ b/agent/proxycfg/terminating_gateway.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"strings"
 
+	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/leafcert"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/proto/private/pbpeering"
 )
 
 type handlerTerminatingGateway struct {
@@ -68,6 +70,8 @@ func (s *handlerTerminatingGateway) initialize(ctx context.Context) (ConfigSnaps
 	snap.TerminatingGateway.GatewayServices = make(map[structs.ServiceName]structs.GatewayService)
 	snap.TerminatingGateway.DestinationServices = make(map[structs.ServiceName]structs.GatewayService)
 	snap.TerminatingGateway.HostnameServices = make(map[structs.ServiceName]structs.CheckServiceNodes)
+	snap.TerminatingGateway.WatchedInboundPeerTrustBundles = make(map[structs.ServiceName]context.CancelFunc)
+	snap.TerminatingGateway.InboundPeerTrustBundles = make(map[structs.ServiceName][]*pbpeering.PeeringTrustBundle)
 	return snap, nil
 }
 
@@ -166,6 +170,29 @@ func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u UpdateEv
 					return err
 				}
 				snap.TerminatingGateway.WatchedIntentions[svc.Service] = cancel
+			}
+
+			if _, ok := snap.TerminatingGateway.WatchedInboundPeerTrustBundles[svc.Service]; !ok {
+				ctx, cancel := context.WithCancel(ctx)
+
+				err := s.dataSources.TrustBundleList.Notify(ctx, &cachetype.TrustBundleListRequest{
+					Request: &pbpeering.TrustBundleListByServiceRequest{
+						ServiceName: svc.Service.Name,
+						Namespace:   svc.Service.EnterpriseMeta.NamespaceOrDefault(),
+						Partition:   svc.Service.EnterpriseMeta.PartitionOrDefault(),
+					},
+					QueryOptions: structs.QueryOptions{Token: s.token},
+				}, peerTrustBundleIDPrefix+svc.Service.String(), s.ch)
+
+				if err != nil {
+					logger.Error("failed to register watch for peer trust bundles",
+						"service", svc.Service.String(),
+						"error", err,
+					)
+					cancel()
+					return err
+				}
+				snap.TerminatingGateway.WatchedInboundPeerTrustBundles[svc.Service] = cancel
 			}
 
 			// Watch leaf certificate for the service
@@ -299,6 +326,16 @@ func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u UpdateEv
 			}
 		}
 
+		// Cancel watches for peered trust bundle that were not in the update
+		for sn, cancelFn := range snap.TerminatingGateway.WatchedInboundPeerTrustBundles {
+			if _, ok := svcMap[sn]; !ok {
+				logger.Debug("canceling watch for peered trust bundle", "service", sn.String())
+				delete(snap.TerminatingGateway.WatchedInboundPeerTrustBundles, sn)
+				delete(snap.TerminatingGateway.InboundPeerTrustBundles, sn)
+				cancelFn()
+			}
+		}
+
 		// Cancel intention watches for services that were not in the update
 		for sn, cancelFn := range snap.TerminatingGateway.WatchedIntentions {
 			if _, ok := svcMap[sn]; !ok {
@@ -373,6 +410,16 @@ func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u UpdateEv
 
 		sn := structs.ServiceNameFromString(strings.TrimPrefix(u.CorrelationID, serviceIntentionsIDPrefix))
 		snap.TerminatingGateway.Intentions[sn] = resp
+
+	case strings.HasPrefix(u.CorrelationID, peerTrustBundleIDPrefix):
+		resp, ok := u.Result.(*pbpeering.TrustBundleListByServiceResponse)
+		if !ok {
+			return fmt.Errorf("invalid type for response: %T", u.Result)
+		}
+		if len(resp.Bundles) > 0 {
+			sn := structs.ServiceNameFromString(strings.TrimPrefix(u.CorrelationID, peerTrustBundleIDPrefix))
+			snap.TerminatingGateway.InboundPeerTrustBundles[sn] = resp.Bundles
+		}
 
 	default:
 		// do nothing

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1640,6 +1640,7 @@ func (s *ResourceGenerator) makeTerminatingGatewayListener(
 
 		intentions := cfgSnap.TerminatingGateway.Intentions[svc]
 		svcConfig := cfgSnap.TerminatingGateway.ServiceConfigs[svc]
+		peerTrustBundles := cfgSnap.TerminatingGateway.InboundPeerTrustBundles[svc]
 
 		cfg, err := config.ParseProxyConfig(svcConfig.ProxyConfig)
 		if err != nil {
@@ -1653,10 +1654,11 @@ func (s *ResourceGenerator) makeTerminatingGatewayListener(
 		}
 
 		opts := terminatingGatewayFilterChainOpts{
-			cluster:    clusterName,
-			service:    svc,
-			intentions: intentions,
-			protocol:   cfg.Protocol,
+			cluster:          clusterName,
+			service:          svc,
+			intentions:       intentions,
+			protocol:         cfg.Protocol,
+			peerTrustBundles: peerTrustBundles,
 		}
 
 		clusterChain, err := s.makeFilterChainTerminatingGateway(cfgSnap, opts)
@@ -1760,12 +1762,13 @@ func (s *ResourceGenerator) makeTerminatingGatewayListener(
 }
 
 type terminatingGatewayFilterChainOpts struct {
-	cluster    string
-	service    structs.ServiceName
-	intentions structs.SimplifiedIntentions
-	protocol   string
-	address    string // only valid for destination listeners
-	port       int    // only valid for destination listeners
+	cluster          string
+	service          structs.ServiceName
+	intentions       structs.SimplifiedIntentions
+	protocol         string
+	address          string // only valid for destination listeners
+	port             int    // only valid for destination listeners
+	peerTrustBundles []*pbpeering.PeeringTrustBundle
 }
 
 func (s *ResourceGenerator) makeFilterChainTerminatingGateway(cfgSnap *proxycfg.ConfigSnapshot, tgtwyOpts terminatingGatewayFilterChainOpts) (*envoy_listener_v3.FilterChain, error) {
@@ -1801,7 +1804,7 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(cfgSnap *proxycfg.
 				datacenter:  cfgSnap.Datacenter,
 				partition:   cfgSnap.ProxyID.PartitionOrDefault(),
 			},
-			nil, // TODO(peering): verify intentions w peers don't apply to terminatingGateway
+			tgtwyOpts.peerTrustBundles,
 		)
 		if err != nil {
 			return nil, err
@@ -1847,7 +1850,7 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(cfgSnap *proxycfg.
 				datacenter:  cfgSnap.Datacenter,
 				partition:   cfgSnap.ProxyID.PartitionOrDefault(),
 			},
-			nil, // TODO(peering): verify intentions w peers don't apply to terminatingGateway
+			tgtwyOpts.peerTrustBundles,
 			cfgSnap.JWTProviders,
 		)
 		if err != nil {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -1076,7 +1076,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 				roots, _ := proxycfg.TestCerts(t)
 				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []proxycfg.UpdateEvent{
 					{
-						CorrelationID: "peer-trust-bundle:",
+						CorrelationID: "peer-trust-bundle:web",
 						Result: &pbpeering.TrustBundleListByServiceResponse{
 							Bundles: []*pbpeering.PeeringTrustBundle{
 								{
@@ -1090,6 +1090,15 @@ func TestListenersFromSnapshot(t *testing.T) {
 									CreateIndex:       0,
 									ModifyIndex:       0,
 								},
+							},
+						},
+					},
+					{
+						CorrelationID: "service-intentions:web",
+						Result: structs.SimplifiedIntentions{
+							{
+								SourceName:      "*",
+								DestinationName: "web",
 							},
 						},
 					},

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/consul/agent/xds/testcommon"
 	"github.com/hashicorp/consul/agent/xdsv2"
 	"github.com/hashicorp/consul/envoyextensions/xdscommon"
+	"github.com/hashicorp/consul/proto/private/pbpeering"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/types"
 )
@@ -1065,6 +1066,32 @@ func TestListenersFromSnapshot(t *testing.T) {
 					{
 						CorrelationID: "service-leaf:" + api.String(), // serviceLeafIDPrefix
 						Result:        nil,                            // tombstone this
+					},
+				})
+			},
+		},
+		{
+			name: "terminating-gateway-with-peer-trust-bundle",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				roots, _ := proxycfg.TestCerts(t)
+				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []proxycfg.UpdateEvent{
+					{
+						CorrelationID: "peer-trust-bundle:",
+						Result: &pbpeering.TrustBundleListByServiceResponse{
+							Bundles: []*pbpeering.PeeringTrustBundle{
+								{
+									TrustDomain: "foo.bar.gov",
+									PeerName:    "dc1",
+									Partition:   "default",
+									RootPEMs: []string{
+										roots.Roots[0].RootCert,
+									},
+									ExportedPartition: "dc1",
+									CreateIndex:       0,
+									ModifyIndex:       0,
+								},
+							},
+						},
 					},
 				})
 			},

--- a/agent/xds/testdata/builtin_extension/clusters/otel-access-logging-http.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/otel-access-logging-http.latest.golden
@@ -1,39 +1,27 @@
 {
-  "versionInfo": "00000001",
+  "nonce": "00000001",
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
-      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "altStatName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-      "type": "EDS",
+      "circuitBreakers": {},
+      "commonLbConfig": {
+        "healthyPanicThreshold": {}
+      },
+      "connectTimeout": "5s",
       "edsClusterConfig": {
         "edsConfig": {
-          "ads": {
-
-          },
+          "ads": {},
           "resourceApiVersion": "V3"
         }
       },
-      "connectTimeout": "5s",
-      "circuitBreakers": {
-
-      },
-      "outlierDetection": {
-
-      },
-      "commonLbConfig": {
-        "healthyPanicThreshold": {
-
-        }
-      },
+      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "outlierDetection": {},
       "transportSocket": {
         "name": "tls",
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsParams": {
-
-            },
             "tlsCertificates": [
               {
                 "certificateChain": {
@@ -44,48 +32,40 @@
                 }
               }
             ],
+            "tlsParams": {},
             "validationContext": {
-              "trustedCa": {
-                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
-              },
               "matchSubjectAltNames": [
                 {
                   "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
                 }
-              ]
+              ],
+              "trustedCa": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+              }
             }
           },
           "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
         }
-      }
+      },
+      "type": "EDS"
     },
     {
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
-      "name": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-      "type": "EDS",
+      "circuitBreakers": {},
+      "connectTimeout": "5s",
       "edsClusterConfig": {
         "edsConfig": {
-          "ads": {
-
-          },
+          "ads": {},
           "resourceApiVersion": "V3"
         }
       },
-      "connectTimeout": "5s",
-      "circuitBreakers": {
-
-      },
-      "outlierDetection": {
-
-      },
+      "name": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "outlierDetection": {},
       "transportSocket": {
         "name": "tls",
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsParams": {
-
-            },
             "tlsCertificates": [
               {
                 "certificateChain": {
@@ -96,10 +76,8 @@
                 }
               }
             ],
+            "tlsParams": {},
             "validationContext": {
-              "trustedCa": {
-                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
-              },
               "matchSubjectAltNames": [
                 {
                   "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
@@ -107,17 +85,19 @@
                 {
                   "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
-              ]
+              ],
+              "trustedCa": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+              }
             }
           },
           "sni": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
         }
-      }
+      },
+      "type": "EDS"
     },
     {
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
-      "name": "local_app",
-      "type": "STATIC",
       "connectTimeout": "5s",
       "loadAssignment": {
         "clusterName": "local_app",
@@ -137,9 +117,11 @@
             ]
           }
         ]
-      }
+      },
+      "name": "local_app",
+      "type": "STATIC"
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
-  "nonce": "00000001"
+  "versionInfo": "00000001"
 }

--- a/agent/xds/testdata/builtin_extension/endpoints/otel-access-logging-http.latest.golden
+++ b/agent/xds/testdata/builtin_extension/endpoints/otel-access-logging-http.latest.golden
@@ -1,5 +1,5 @@
 {
-  "versionInfo": "00000001",
+  "nonce": "00000001",
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
@@ -71,5 +71,5 @@
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
-  "nonce": "00000001"
+  "versionInfo": "00000001"
 }

--- a/agent/xds/testdata/builtin_extension/listeners/otel-access-logging-http.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/otel-access-logging-http.latest.golden
@@ -1,233 +1,114 @@
 {
-  "versionInfo":  "00000001",
-  "resources":  [
+  "nonce": "00000001",
+  "resources": [
     {
-      "@type":  "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name":  "db:127.0.0.1:9191",
-      "address":  {
-        "socketAddress":  {
-          "address":  "127.0.0.1",
-          "portValue":  9191
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
         }
       },
-      "filterChains":  [
+      "filterChains": [
         {
-          "filters":  [
+          "filters": [
             {
-              "name":  "envoy.filters.network.tcp_proxy",
-              "typedConfig":  {
-                "@type":  "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix":  "upstream.db.default.default.dc1",
-                "cluster":  "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "statPrefix": "upstream.db.default.default.dc1"
               }
             }
           ]
         }
       ],
-      "trafficDirection":  "OUTBOUND"
+      "name": "db:127.0.0.1:9191",
+      "trafficDirection": "OUTBOUND"
     },
     {
-      "@type":  "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name":  "prepared_query:geo-cache:127.10.10.10:8181",
-      "address":  {
-        "socketAddress":  {
-          "address":  "127.10.10.10",
-          "portValue":  8181
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
         }
       },
-      "filterChains":  [
+      "filterChains": [
         {
-          "filters":  [
+          "filters": [
             {
-              "name":  "envoy.filters.network.tcp_proxy",
-              "typedConfig":  {
-                "@type":  "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix":  "upstream.prepared_query_geo-cache",
-                "cluster":  "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+                "statPrefix": "upstream.prepared_query_geo-cache"
               }
             }
           ]
         }
       ],
-      "trafficDirection":  "OUTBOUND"
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "trafficDirection": "OUTBOUND"
     },
     {
-      "@type":  "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name":  "public_listener:0.0.0.0:9999",
-      "address":  {
-        "socketAddress":  {
-          "address":  "0.0.0.0",
-          "portValue":  9999
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
         }
       },
-      "filterChains":  [
+      "filterChains": [
         {
-          "filters":  [
+          "filters": [
             {
-              "name":  "envoy.filters.network.http_connection_manager",
-              "typedConfig":  {
-                "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix":  "public_listener",
-                "routeConfig":  {
-                  "name":  "public_listener",
-                  "virtualHosts":  [
-                    {
-                      "name":  "public_listener",
-                      "domains":  [
-                        "*"
-                      ],
-                      "routes":  [
-                        {
-                          "match":  {
-                            "prefix":  "/"
-                          },
-                          "route":  {
-                            "cluster":  "local_app"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "httpFilters":  [
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "accessLog": [
                   {
-                    "name":  "envoy.filters.http.rbac",
-                    "typedConfig":  {
-                      "@type":  "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                      "rules":  {}
-                    }
-                  },
-                  {
-                    "name":  "envoy.filters.http.header_to_metadata",
-                    "typedConfig":  {
-                      "@type":  "type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config",
-                      "requestRules":  [
-                        {
-                          "header":  "x-forwarded-client-cert",
-                          "onHeaderPresent":  {
-                            "metadataNamespace":  "consul",
-                            "key":  "trust-domain",
-                            "regexValueRewrite":  {
-                              "pattern":  {
-                                "googleRe2":  {},
-                                "regex":  ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution":  "\\1"
-                            }
-                          }
-                        },
-                        {
-                          "header":  "x-forwarded-client-cert",
-                          "onHeaderPresent":  {
-                            "metadataNamespace":  "consul",
-                            "key":  "partition",
-                            "regexValueRewrite":  {
-                              "pattern":  {
-                                "googleRe2":  {},
-                                "regex":  ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution":  "\\2"
-                            }
-                          }
-                        },
-                        {
-                          "header":  "x-forwarded-client-cert",
-                          "onHeaderPresent":  {
-                            "metadataNamespace":  "consul",
-                            "key":  "namespace",
-                            "regexValueRewrite":  {
-                              "pattern":  {
-                                "googleRe2":  {},
-                                "regex":  ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution":  "\\3"
-                            }
-                          }
-                        },
-                        {
-                          "header":  "x-forwarded-client-cert",
-                          "onHeaderPresent":  {
-                            "metadataNamespace":  "consul",
-                            "key":  "datacenter",
-                            "regexValueRewrite":  {
-                              "pattern":  {
-                                "googleRe2":  {},
-                                "regex":  ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution":  "\\4"
-                            }
-                          }
-                        },
-                        {
-                          "header":  "x-forwarded-client-cert",
-                          "onHeaderPresent":  {
-                            "metadataNamespace":  "consul",
-                            "key":  "service",
-                            "regexValueRewrite":  {
-                              "pattern":  {
-                                "googleRe2":  {},
-                                "regex":  ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution":  "\\5"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "name":  "envoy.filters.http.router",
-                    "typedConfig":  {
-                      "@type":  "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-                    }
-                  }
-                ],
-                "tracing":  {
-                  "randomSampling":  {}
-                },
-                "accessLog":  [
-                  {
-                    "name":  "envoy.access_loggers.open_telemetry",
-                    "typedConfig":  {
-                      "@type":  "type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig",
-                      "commonConfig":  {
-                        "logName":  "otel-logger",
-                        "grpcService":  {
-                          "envoyGrpc":  {
-                            "clusterName":  "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
-                          }
-                        },
-                        "transportApiVersion":  "V3",
-                        "bufferFlushInterval":  "0.001s",
-                        "bufferSizeBytes":  4096,
-                        "filterStateObjectsToLog":  [
-                          "obj-1",
-                          "obj-2"
-                        ],
-                        "grpcStreamRetryPolicy":  {
-                          "retryBackOff":  {
-                            "baseInterval":  "1s",
-                            "maxInterval":  "10s"
-                          },
-                          "numRetries":  5
-                        }
-                      },
-                      "resourceAttributes":  {
-                        "values":  [
+                    "name": "envoy.access_loggers.open_telemetry",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig",
+                      "attributes": {
+                        "values": [
                           {
-                            "key":  "type",
-                            "value":  {
-                              "stringValue":  "compute"
+                            "key": "name",
+                            "value": {
+                              "stringValue": "Bugs Bunny"
                             }
                           }
                         ]
                       },
-                      "attributes":  {
-                        "values":  [
+                      "commonConfig": {
+                        "bufferFlushInterval": "0.001s",
+                        "bufferSizeBytes": 4096,
+                        "filterStateObjectsToLog": [
+                          "obj-1",
+                          "obj-2"
+                        ],
+                        "grpcService": {
+                          "envoyGrpc": {
+                            "clusterName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                          }
+                        },
+                        "grpcStreamRetryPolicy": {
+                          "numRetries": 5,
+                          "retryBackOff": {
+                            "baseInterval": "1s",
+                            "maxInterval": "10s"
+                          }
+                        },
+                        "logName": "otel-logger",
+                        "transportApiVersion": "V3"
+                      },
+                      "resourceAttributes": {
+                        "values": [
                           {
-                            "key":  "name",
-                            "value":  {
-                              "stringValue":  "Bugs Bunny"
+                            "key": "type",
+                            "value": {
+                              "stringValue": "compute"
                             }
                           }
                         ]
@@ -235,55 +116,174 @@
                     }
                   }
                 ],
-                "forwardClientCertDetails":  "APPEND_FORWARD",
-                "setCurrentClientCertDetails":  {
-                  "subject":  true,
-                  "cert":  true,
-                  "chain":  true,
-                  "dns":  true,
-                  "uri":  true
-                },
-                "upgradeConfigs":  [
+                "forwardClientCertDetails": "APPEND_FORWARD",
+                "httpFilters": [
                   {
-                    "upgradeType":  "websocket"
+                    "name": "envoy.filters.http.rbac",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                      "rules": {}
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.header_to_metadata",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config",
+                      "requestRules": [
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "trust-domain",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\1"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "partition",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\2"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "namespace",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\3"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "datacenter",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\4"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "service",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\5"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "routeConfig": {
+                  "name": "public_listener",
+                  "virtualHosts": [
+                    {
+                      "domains": [
+                        "*"
+                      ],
+                      "name": "public_listener",
+                      "routes": [
+                        {
+                          "match": {
+                            "prefix": "/"
+                          },
+                          "route": {
+                            "cluster": "local_app"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
+                },
+                "statPrefix": "public_listener",
+                "tracing": {
+                  "randomSampling": {}
+                },
+                "upgradeConfigs": [
+                  {
+                    "upgradeType": "websocket"
                   }
                 ]
               }
             }
           ],
-          "transportSocket":  {
-            "name":  "tls",
-            "typedConfig":  {
-              "@type":  "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
-              "commonTlsContext":  {
-                "tlsParams":  {},
-                "tlsCertificates":  [
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "alpnProtocols": [
+                  "http/1.1"
+                ],
+                "tlsCertificates": [
                   {
-                    "certificateChain":  {
-                      "inlineString":  "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
                     },
-                    "privateKey":  {
-                      "inlineString":  "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
                     }
                   }
                 ],
-                "validationContext":  {
-                  "trustedCa":  {
-                    "inlineString":  "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                "tlsParams": {},
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
                   }
-                },
-                "alpnProtocols":  [
-                  "http/1.1"
-                ]
+                }
               },
-              "requireClientCertificate":  true
+              "requireClientCertificate": true
             }
           }
         }
       ],
-      "trafficDirection":  "INBOUND"
+      "name": "public_listener:0.0.0.0:9999",
+      "trafficDirection": "INBOUND"
     }
   ],
-  "typeUrl":  "type.googleapis.com/envoy.config.listener.v3.Listener",
-  "nonce":  "00000001"
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "versionInfo": "00000001"
 }

--- a/agent/xds/testdata/builtin_extension/routes/otel-access-logging-http.latest.golden
+++ b/agent/xds/testdata/builtin_extension/routes/otel-access-logging-http.latest.golden
@@ -1,5 +1,5 @@
 {
-  "versionInfo": "00000001",
+  "nonce": "00000001",
   "typeUrl": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
-  "nonce": "00000001"
+  "versionInfo": "00000001"
 }

--- a/agent/xds/testdata/listeners/terminating-gateway-with-peer-trust-bundle.latest.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-with-peer-trust-bundle.latest.golden
@@ -1,0 +1,246 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8443
+        }
+      },
+      "filterChains": [
+        {
+          "filterChainMatch": {
+            "serverNames": [
+              "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {},
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "statPrefix": "upstream.api.default.default.dc1"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICnTCCAkKgAwIBAgIRAJrvEdaRAkSltrotd/l/j2cwCgYIKoZIzj0EAwIwgbgx\nCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNj\nbzEaMBgGA1UECRMRMTAxIFNlY29uZCBTdHJlZXQxDjAMBgNVBBETBTk0MTA1MRcw\nFQYDVQQKEw5IYXNoaUNvcnAgSW5jLjE/MD0GA1UEAxM2Q29uc3VsIEFnZW50IENB\nIDk2NjM4NzM1MDkzNTU5NTIwNDk3MTQwOTU3MDY1MTc0OTg3NDMxMB4XDTIwMDQx\nNDIyMzE1MloXDTIxMDQxNDIyMzE1MlowHDEaMBgGA1UEAxMRc2VydmVyLmRjMS5j\nb25zdWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQ4v0FoIYI0OWmxE2MR6w5l\n0pWGhc02RpsOPj/6RS1fmXMMu7JzPzwCmkGcR16RlwwhNFKCZsWpvAjVRHf/pTp+\no4HHMIHEMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYB\nBQUHAwIwDAYDVR0TAQH/BAIwADApBgNVHQ4EIgQgk7kABFitAy3PluyNtmzYiC7H\njSN8W/K/OXNJQAQAscMwKwYDVR0jBCQwIoAgNKbPPepvRHXSAPTc+a/BXBzFX1qJ\ny+Zi7qtjlFX7qtUwLQYDVR0RBCYwJIIRc2VydmVyLmRjMS5jb25zdWyCCWxvY2Fs\naG9zdIcEfwAAATAKBggqhkjOPQQDAgNJADBGAiEAhP4HmN5BWysWTbQWClXaWUah\nLpBGFrvc/2cCQuyEZKsCIQD6JyYCYMArtWwZ4G499zktxrFlqfX14bqyONrxtA5I\nDw==\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIE3KbKXHdsa0vvC1fysQaGdoJRgjRALIolI4XJanie+coAoGCCqGSM49\nAwEHoUQDQgAEOL9BaCGCNDlpsRNjEesOZdKVhoXNNkabDj4/+kUtX5lzDLuycz88\nAppBnEdekZcMITRSgmbFqbwI1UR3/6U6fg==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "tlsParams": {},
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        },
+        {
+          "filterChainMatch": {
+            "serverNames": [
+              "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {},
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "statPrefix": "upstream.cache.default.default.dc1"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICmjCCAkGgAwIBAgIQe1ZmC0rzRwer6jaH1YIUIjAKBggqhkjOPQQDAjCBuDEL\nMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2Nv\nMRowGAYDVQQJExExMDEgU2Vjb25kIFN0cmVldDEOMAwGA1UEERMFOTQxMDUxFzAV\nBgNVBAoTDkhhc2hpQ29ycCBJbmMuMT8wPQYDVQQDEzZDb25zdWwgQWdlbnQgQ0Eg\nODE5ODAwNjg0MDM0MTM3ODkyNDYxNTA1MDk0NDU3OTU1MTQxNjEwHhcNMjAwNjE5\nMTU1MjAzWhcNMjEwNjE5MTU1MjAzWjAcMRowGAYDVQQDExFzZXJ2ZXIuZGMxLmNv\nbnN1bDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABH2aWaaa3fpQLBayheHiKlrH\n+z53m0frfGknKjOhOPVYDVHV8x0OE01negswVQbKHAtxPf1M8Zy+WbI9rK7Ua1mj\ngccwgcQwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEF\nBQcDAjAMBgNVHRMBAf8EAjAAMCkGA1UdDgQiBCDf9CPBSUwwZvpeW73oJLTmgQE2\ntW1NKpL5t1uq9WFcqDArBgNVHSMEJDAigCCPPd/NxgZB0tq2M8pdVpPj3Cr79iTv\ni4/T1ysodfMb7zAtBgNVHREEJjAkghFzZXJ2ZXIuZGMxLmNvbnN1bIIJbG9jYWxo\nb3N0hwR/AAABMAoGCCqGSM49BAMCA0cAMEQCIFCjFZAoXq0s2ied2eIBv0i1KoW5\nIhCylnKFt6iHkyDeAiBBCByTcjHRgEQmqyPojQKoO584EFiczTub9aWdnf9tEw==\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEINsen3S8xzxMrKcRZIvxXzhKDn43Tw9ttqWEFU9TqS5hoAoGCCqGSM49\nAwEHoUQDQgAEfZpZpprd+lAsFrKF4eIqWsf7PnebR+t8aScqM6E49VgNUdXzHQ4T\nTWd6CzBVBsocC3E9/UzxnL5Zsj2srtRrWQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "tlsParams": {},
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        },
+        {
+          "filterChainMatch": {
+            "serverNames": [
+              "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {},
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "statPrefix": "upstream.db.default.default.dc1"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICnTCCAkOgAwIBAgIRAKF+qDJbaOULNL1TIatrsBowCgYIKoZIzj0EAwIwgbkx\nCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNj\nbzEaMBgGA1UECRMRMTAxIFNlY29uZCBTdHJlZXQxDjAMBgNVBBETBTk0MTA1MRcw\nFQYDVQQKEw5IYXNoaUNvcnAgSW5jLjFAMD4GA1UEAxM3Q29uc3VsIEFnZW50IENB\nIDE4Nzg3MDAwNjUzMDcxOTYzNTk1ODkwNTE1ODY1NjEzMDA2MTU0NDAeFw0yMDA2\nMTkxNTMxMzRaFw0yMTA2MTkxNTMxMzRaMBwxGjAYBgNVBAMTEXNlcnZlci5kYzEu\nY29uc3VsMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdQ8Igci5f7ZvvCVsxXt9\ntLfvczD+60XHg0OC0+Aka7ZjQfbEjQwZbz/82EwPoS7Dqo3LTK4IuelOimoNNxuk\nkaOBxzCBxDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsG\nAQUFBwMCMAwGA1UdEwEB/wQCMAAwKQYDVR0OBCIEILzTLkfJcdWQnTMKUcai/YJq\n0RqH1pjCqtY7SOU4gGOTMCsGA1UdIwQkMCKAIMa2vNcTEC5AGfHIYARJ/4sodX0o\nLzCj3lpw7BcEzPTcMC0GA1UdEQQmMCSCEXNlcnZlci5kYzEuY29uc3Vsgglsb2Nh\nbGhvc3SHBH8AAAEwCgYIKoZIzj0EAwIDSAAwRQIgBZ/Z4GSLEc98WvT/qjTVCNTG\n1WNaAaesVbkRx+J0yl8CIQDAVoqY9ByA5vKHjnQrxWlc/JUtJz8wudg7e/OCRriP\nSg==\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIN1v14FaNxgY4MgjDOOWthen8dgwB0lNMs9/j2TfrnxzoAoGCCqGSM49\nAwEHoUQDQgAEdQ8Igci5f7ZvvCVsxXt9tLfvczD+60XHg0OC0+Aka7ZjQfbEjQwZ\nbz/82EwPoS7Dqo3LTK4IuelOimoNNxukkQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "tlsParams": {},
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        },
+        {
+          "filterChainMatch": {
+            "serverNames": [
+              "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {},
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "statPrefix": "upstream.web.default.default.dc1"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "tlsParams": {},
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        },
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.sni_cluster",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.sni_cluster.v3.SniCluster"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "",
+                "statPrefix": "terminating_gateway.default"
+              }
+            }
+          ]
+        }
+      ],
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.tls_inspector",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+          }
+        }
+      ],
+      "name": "default:1.2.3.4:8443",
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/rbac/v2-default-deny.golden
+++ b/agent/xds/testdata/rbac/v2-default-deny.golden
@@ -1,8 +1,8 @@
 {
-  "name":  "envoy.filters.network.rbac",
-  "typedConfig":  {
-    "@type":  "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-    "rules":  {},
-    "statPrefix":  "connect_authz"
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+    "rules": {},
+    "statPrefix": "connect_authz"
   }
 }

--- a/agent/xds/testdata/rbac/v2-kitchen-sink.golden
+++ b/agent/xds/testdata/rbac/v2-kitchen-sink.golden
@@ -1,35 +1,35 @@
 {
-  "filters":  [
+  "filters": [
     {
-      "name":  "envoy.filters.network.rbac",
-      "typedConfig":  {
-        "@type":  "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-        "rules":  {
-          "action":  "DENY",
-          "policies":  {
-            "consul-intentions-layer4":  {
-              "permissions":  [
+      "name": "envoy.filters.network.rbac",
+      "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+        "rules": {
+          "action": "DENY",
+          "policies": {
+            "consul-intentions-layer4": {
+              "permissions": [
                 {
-                  "any":  true
+                  "any": true
                 }
               ],
-              "principals":  [
+              "principals": [
                 {
-                  "authenticated":  {
-                    "principalName":  {
-                      "safeRegex":  {
-                        "googleRe2":  {},
-                        "regex":  "^spiffe://test.consul/ns/default/dc/[^/]+/svc/db$"
+                  "authenticated": {
+                    "principalName": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/db$"
                       }
                     }
                   }
                 },
                 {
-                  "authenticated":  {
-                    "principalName":  {
-                      "safeRegex":  {
-                        "googleRe2":  {},
-                        "regex":  "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
+                  "authenticated": {
+                    "principalName": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
                       }
                     }
                   }
@@ -38,52 +38,52 @@
             }
           }
         },
-        "statPrefix":  "connect_authz"
+        "statPrefix": "connect_authz"
       }
     },
     {
-      "name":  "envoy.filters.network.rbac",
-      "typedConfig":  {
-        "@type":  "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-        "rules":  {
-          "policies":  {
-            "consul-intentions-layer4-0":  {
-              "permissions":  [
+      "name": "envoy.filters.network.rbac",
+      "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+        "rules": {
+          "policies": {
+            "consul-intentions-layer4-0": {
+              "permissions": [
                 {
-                  "any":  true
+                  "any": true
                 }
               ],
-              "principals":  [
+              "principals": [
                 {
-                  "authenticated":  {
-                    "principalName":  {
-                      "safeRegex":  {
-                        "googleRe2":  {},
-                        "regex":  "^spiffe://test.consul/ns/default/dc/[^/]+/svc/api$"
+                  "authenticated": {
+                    "principalName": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/api$"
                       }
                     }
                   }
                 },
                 {
-                  "andIds":  {
-                    "ids":  [
+                  "andIds": {
+                    "ids": [
                       {
-                        "authenticated":  {
-                          "principalName":  {
-                            "safeRegex":  {
-                              "googleRe2":  {},
-                              "regex":  "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                        "authenticated": {
+                          "principalName": {
+                            "safeRegex": {
+                              "googleRe2": {},
+                              "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                             }
                           }
                         }
                       },
                       {
-                        "notId":  {
-                          "authenticated":  {
-                            "principalName":  {
-                              "safeRegex":  {
-                                "googleRe2":  {},
-                                "regex":  "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
+                        "notId": {
+                          "authenticated": {
+                            "principalName": {
+                              "safeRegex": {
+                                "googleRe2": {},
+                                "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
                               }
                             }
                           }
@@ -94,19 +94,19 @@
                 }
               ]
             },
-            "consul-intentions-layer4-1":  {
-              "permissions":  [
+            "consul-intentions-layer4-1": {
+              "permissions": [
                 {
-                  "any":  true
+                  "any": true
                 }
               ],
-              "principals":  [
+              "principals": [
                 {
-                  "authenticated":  {
-                    "principalName":  {
-                      "safeRegex":  {
-                        "googleRe2":  {},
-                        "regex":  "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                  "authenticated": {
+                    "principalName": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                       }
                     }
                   }
@@ -115,7 +115,7 @@
             }
           }
         },
-        "statPrefix":  "connect_authz"
+        "statPrefix": "connect_authz"
       }
     }
   ]


### PR DESCRIPTION


### Description

This PR enables services in one datacenter to access resources through a terminating gateway in another datacenter over cluster peering.

In the diagram below, previously only `backend` could reach `Google`. Now `frontend` can also reach `Google`.

```text
__ dc1 ________________          __ dc2 ________________
|  ____________       |          |  ___________        |
|  |          |       |          |  |         |        |
|  | frontend |       |          |  | backend |        |
|  |__________|       |          |  |_________|        |
|        |            |          |         |           |
|        |    ___________     ___________  |  _______________    __________
|        |    |         |     |         |  -->|             |    |        |
|        ---->|  Mesh   |---->|  Mesh   |---->| Terminating |--->| Google |
|             | Gateway |     | Gateway |     |   Gateway   |    |________|
|             |_________|     |_________|     |_____________|
|                     |          |                     |
|_____________________|          |_____________________|
```


- Add InboundPeerTrustBundle maps to Terminating Gateway
- Add notify and cancelation of watch for inbound peer trust bundles
- Pass peer trust bundles to the RBAC creation function
- Regenerate Golden Files

### Testing & Reproduction steps

I tested this using Kubernetes with [this set of configuration files](https://github.com/t-eckert/consul-lab/tree/main/cluster-peering-termgw).

### Links


### PR Checklist

* [ ] updated test coverage
* [x] appropriate backport labels added
* [x] not a security concern
