### PR TITLE
tenancy: split up tenancy `types.go` into CE version

### DIFF
--- a/internal/tenancy/internal/types/types.go
+++ b/internal/tenancy/internal/types/types.go
@@ -3,16 +3,8 @@
 
 package types
 
-import (
-	"github.com/hashicorp/consul/internal/resource"
-)
-
 const (
 	GroupName       = "tenancy"
 	VersionV1Alpha1 = "v1alpha1"
 	CurrentVersion  = VersionV1Alpha1
 )
-
-func Register(r resource.Registry) {
-	RegisterNamespace(r)
-}

--- a/internal/tenancy/internal/types/types_ce.go
+++ b/internal/tenancy/internal/types/types_ce.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !consulent
+// +build !consulent
+
+package types
+
+import "github.com/hashicorp/consul/internal/resource"
+
+func Register(r resource.Registry) {
+	RegisterNamespace(r)
+}


### PR DESCRIPTION
### Description

See NET-5516 for acceptance criteria.
This is the CE version of merged ENT PR: https://github.com/hashicorp/consul-enterprise/pull/7090
Just splits up `types.go` into a CE version so the ENT version can register both partition and namespace.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
