### PR TITLE
catalog: fix for new method argument

### DIFF
--- a/internal/catalog/internal/types/failover_policy.go
+++ b/internal/catalog/internal/types/failover_policy.go
@@ -323,7 +323,7 @@ func SimplifyFailoverPolicy(svc *pbcatalog.Service, failover *pbcatalog.Failover
 	return failover
 }
 
-func aclReadHookFailoverPolicy(authorizer acl.Authorizer, authzContext *acl.AuthorizerContext, id *pbresource.ID) error {
+func aclReadHookFailoverPolicy(authorizer acl.Authorizer, authzContext *acl.AuthorizerContext, id *pbresource.ID, _ *pbresource.Resource) error {
 	// FailoverPolicy is name-aligned with Service
 	serviceName := id.Name
 

--- a/internal/catalog/internal/types/failover_policy_test.go
+++ b/internal/catalog/internal/types/failover_policy_test.go
@@ -726,7 +726,7 @@ func TestFailoverPolicyACLs(t *testing.T) {
 		authz = acl.NewChainedAuthorizer([]acl.Authorizer{authz, acl.DenyAll()})
 
 		t.Run("read", func(t *testing.T) {
-			err := reg.ACLs.Read(authz, &acl.AuthorizerContext{}, res.Id)
+			err := reg.ACLs.Read(authz, &acl.AuthorizerContext{}, res.Id, nil)
 			checkF(t, tc.readOK, err)
 		})
 		t.Run("write", func(t *testing.T) {


### PR DESCRIPTION
### Description

The intersection of 2 PRs merged cleanly and ultimately did not work together. The github actions did not detect this sadly.
