### PR TITLE
api: add Token field to ServiceRegisterOpts

### DIFF
--- a/.changelog/18983.txt
+++ b/.changelog/18983.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: added `Token` field to `ServiceRegisterOpts` type in Agent API
+```

--- a/api/agent.go
+++ b/api/agent.go
@@ -307,6 +307,10 @@ type ServiceRegisterOpts struct {
 	// having to manually deregister checks.
 	ReplaceExistingChecks bool
 
+	// Token is used to provide a per-request ACL token
+	// which overrides the agent's default token.
+	Token string
+
 	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use WithContext() to set the context.
 	ctx context.Context
@@ -834,6 +838,9 @@ func (a *Agent) serviceRegister(service *AgentServiceRegistration, opts ServiceR
 	r.ctx = opts.ctx
 	if opts.ReplaceExistingChecks {
 		r.params.Set("replace-existing-checks", "true")
+	}
+	if opts.Token != "" {
+		r.header.Set("X-Consul-Token", opts.Token)
 	}
 	_, resp, err := a.c.doRequest(r)
 	if err != nil {

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -297,6 +297,21 @@ func TestAgent_ServiceRegisterOpts_WithContextTimeout(t *testing.T) {
 	require.True(t, errors.Is(err, context.DeadlineExceeded), "expected timeout")
 }
 
+func TestAgent_ServiceRegisterOpts_Token(t *testing.T) {
+	c, s := makeACLClient(t)
+	defer s.Stop()
+
+	reg := &AgentServiceRegistration{Name: "example"}
+	opts := &ServiceRegisterOpts{}
+	opts.Token = "invalid"
+	err := c.Agent().ServiceRegisterOpts(reg, *opts)
+	require.EqualError(t, err, "Unexpected response code: 403 (ACL not found)")
+
+	opts.Token = "root"
+	err = c.Agent().ServiceRegisterOpts(reg, *opts)
+	require.NoError(t, err)
+}
+
 func TestAPI_NewClient_TokenFileCLIFirstPriority(t *testing.T) {
 	os.Setenv("CONSUL_HTTP_TOKEN_FILE", "httpTokenFile.txt")
 	os.Setenv("CONSUL_HTTP_TOKEN", "httpToken")


### PR DESCRIPTION
Ongoing work to support Nomad Workload Identity for authenticating with Consul will mean that Nomad's service registration sync with Consul will want to use Consul tokens scoped to individual workloads for registering services and checks. The `ServiceRegisterOpts` type in the API doesn't have an option to pass the token in, which prevent us from sharing the same Consul connection for all workloads. Add a `Token` field to match the behavior of `ServiceDeregisterOpts`.

### Links

Related: https://github.com/hashicorp/nomad/issues/15618
Related: https://github.com/hashicorp/consul/pull/18943

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated (automatd)
* [ ] appropriate backport labels added
* [ ] not a security concern
