### PR TITLE
Fix type of datacenter in Service Resolvers Config Entry

### DIFF
--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -36,7 +36,7 @@ The following list outlines field hierarchy, language-specific data types, and r
   - [`Namespace`](#redirect-namespace): string <EnterpriseAlert inline />
   - [`Partition`](#redirect-partition): string | `default` <EnterpriseAlert inline />
   - [`SamenessGroup`](#redirect-samenessgroup): string <EnterpriseAlert inline />
-  - [`Datacenter`](#redirect-datacenter): list
+  - [`Datacenter`](#redirect-datacenter): string
   - [`Peer`](#redirect-peer): string
 - [`Failover`](#failover): map
   - [`Service`](#failover-service): string


### PR DESCRIPTION
### Description

Datacenter inside Redirect map is of type string. As mentioned [here also](https://developer.hashicorp.com/consul/docs/connect/config-entries/service-resolver#redirect-datacenter)

Fixes the doc.

### Links
https://developer.hashicorp.com/consul/docs/connect/config-entries/service-resolver#redirect-datacenter
