### PR TITLE
Skip the catalog v2 upgrade test

### DIFF
--- a/test/integration/consul-container/test/upgrade/catalog/catalog_test.go
+++ b/test/integration/consul-container/test/upgrade/catalog/catalog_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 )
 
-var minCatalogResourceVersion = version.Must(version.NewVersion("v1.16.0"))
+var minCatalogResourceVersion = version.Must(version.NewVersion("v1.17.0"))
 
 const (
 	versionUndetermined = `


### PR DESCRIPTION
### Description

We intentionally broke api compatibility here as we are not yet maintaining backwards compat for the v2 apis

### Testing & Reproduction steps

