### PR TITLE
acl: default tenancy with the no-auth ACL resolver

### DIFF
--- a/acl/resolver/danger.go
+++ b/acl/resolver/danger.go
@@ -3,13 +3,17 @@
 
 package resolver
 
-import "github.com/hashicorp/consul/acl"
+import (
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/structs"
+)
 
 // DANGER_NO_AUTH implements an ACL resolver short-circuit authorization in
 // cases where it is handled somewhere else or expressly not required.
 type DANGER_NO_AUTH struct{}
 
 // ResolveTokenAndDefaultMeta returns an authorizer with unfettered permissions.
-func (DANGER_NO_AUTH) ResolveTokenAndDefaultMeta(string, *acl.EnterpriseMeta, *acl.AuthorizerContext) (Result, error) {
+func (DANGER_NO_AUTH) ResolveTokenAndDefaultMeta(_ string, entMeta *acl.EnterpriseMeta, _ *acl.AuthorizerContext) (Result, error) {
+	entMeta.Merge(structs.DefaultEnterpriseMetaInDefaultPartition())
 	return Result{Authorizer: acl.ManageAll()}, nil
 }


### PR DESCRIPTION
### Description

When using the no-auth acl resolver (the case for most controllers and the get-envoy-boostrap-params endpoint), ResolveTokenAndDefaultMeta method only returns an acl resolver. However, the resource service relies on the ent meta to be filled in to do the tenancy defaulting and inheriting it from the token when one is present.

So this change makes sure that the ent meta defaulting always happens in the ACL resolver.

This is needed when using consul-ent binary with various resource service endpoints that use the no-auth resolver. Without this change, we're seeing errors like:

```
code = NotFound desc = partition resource not found: 
```

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
