### PR TITLE
rc: Workaround for docker dev tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,8 +354,7 @@ jobs:
       - name: Set docker dev tag
         # One-off RC hack to munge docker dev tag: https://hashicorp.slack.com/archives/CR024M999/p1695845055293629
         run: |
-          version="${{ env.version }}"
-          echo "dev_tag=${version%.-}-dev" >> $GITHUB_ENV
+          echo "dev_tag=${{ env.version }}" >> $GITHUB_ENV
 
       - uses: hashicorp/actions-docker-build@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -352,9 +352,10 @@ jobs:
       # Strip everything but MAJOR.MINOR from the version string and add a `-dev` suffix
       # This naming convention will be used ONLY for per-commit dev images
       - name: Set docker dev tag
+        # One-off RC hack to munge docker dev tag: https://hashicorp.slack.com/archives/CR024M999/p1695845055293629
         run: |
           version="${{ env.version }}"
-          echo "dev_tag=${version%.*}-dev" >> $GITHUB_ENV
+          echo "dev_tag=${version%.-}-dev" >> $GITHUB_ENV
 
       - uses: hashicorp/actions-docker-build@v1
         with:


### PR DESCRIPTION
### Description

See link in inline comment.

### Testing & Reproduction steps
```
$ cat blah.sh                                                                                                                                                                                                                                    #!/bin/bash
version="1.17.0-rc1"
echo "dev_tag=${version%.-}-dev"

$ ./blah.sh
dev_tag=1.17.0-rc1-dev
```