### PR TITLE
Include RequestTimeout in marshal/unmarshal of ServiceResolverConfigE…

### DIFF
--- a/.changelog/19031.txt
+++ b/.changelog/19031.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: add custom marshal/unmarshal for ServiceResolverConfigEntry.RequestTimeout so config entries that set this field can be read using the API.
+```

--- a/agent/structs/config_entry_discoverychain_test.go
+++ b/agent/structs/config_entry_discoverychain_test.go
@@ -1571,6 +1571,15 @@ func TestServiceResolverConfigEntry(t *testing.T) {
 			},
 			validateErr: "Bad ConnectTimeout",
 		},
+		{
+			name: "bad request timeout",
+			entry: &ServiceResolverConfigEntry{
+				Kind:           ServiceResolver,
+				Name:           "test",
+				RequestTimeout: -1 * time.Second,
+			},
+			validateErr: "Bad RequestTimeout",
+		},
 	}
 
 	// Bulk add a bunch of similar validation cases.

--- a/api/config_entry_discoverychain_test.go
+++ b/api/config_entry_discoverychain_test.go
@@ -173,6 +173,7 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 					},
 				},
 				ConnectTimeout: 5 * time.Second,
+				RequestTimeout: 10 * time.Second,
 				Meta: map[string]string{
 					"foo": "bar",
 					"gir": "zim",


### PR DESCRIPTION
### Description

This PR fixes a bug where we’re missing the custom JSON marshal and unmarshal for the `ServiceResolverConfigEntry.RequestTimeout` field. This has the effect that the config entry can be written successfully to Consul but it cannot be read back through the API.

### Testing & Reproduction steps

Before the changes proposed in this PR:

```sh
$ consul agent -dev &> /dev/null &
$ consul config write -
Kind      = "service-resolver"
Name      = "frontend-se"
ConnectTimeout = "10s"
RequestTimeout = "15s"
Subsets = {
 v1 = {
   OnlyPassing = true
 }
 v2  = {
   OnlyPassing = true
 }
}^D
Config entry written: service-resolver/frontend-se
$ consul config read -kind service-resolver -name frontend-se
Error reading config entry service-resolver/frontend-se: json: cannot unmarshal string into Go struct field .RequestTimeout of type time.Duration
```

After these changes:

```sh
# setup as above
consul config read -kind service-resolver -name frontend-se
{
    "ConnectTimeout": "10s",
    "RequestTimeout": "15s",
    "Kind": "service-resolver",
    "Name": "frontend-se",
    "Partition": "default",
    "Namespace": "default",
    "Subsets": {
        "v1": {
            "OnlyPassing": true
        },
        "v2": {
            "OnlyPassing": true
        }
    },
    "CreateIndex": 22,
    "ModifyIndex": 22
}
```

### Links

[Slack thread](https://hashicorp.slack.com/archives/C0253EQ5B40/p1695812641978069)

### PR Checklist

* [x] updated test coverage
* [x] ~external facing docs updated~
* [x] appropriate backport labels added
* [x] not a security concern
