### PR TITLE
docs: fix the description of meshgateway.mode=local in peering doc

### DIFF
--- a/website/content/docs/k8s/connect/cluster-peering/usage/establish-peering.mdx
+++ b/website/content/docs/k8s/connect/cluster-peering/usage/establish-peering.mdx
@@ -76,7 +76,7 @@ To use cluster peering with Consul on Kubernetes deployments, update the Helm ch
 
 ### Configure the mesh gateway mode for traffic between services
 
-In Kubernetes deployments, you can configure mesh gateways to use `local` mode so that a service dialing a service in a remote peer dials the remote mesh gateway instead of the local mesh gateway. To configure the mesh gateway mode so that this traffic always leaves through the local mesh gateway, you can use the `ProxyDefaults` CRD.
+In Kubernetes deployments, you can configure mesh gateways to use `local` mode so that a service dialing a service in a remote peer dials the local mesh gateway instead of the remote mesh gateway. To configure the mesh gateway mode so that this traffic always leaves through the local mesh gateway, you can use the `ProxyDefaults` CRD.
 
 1. In `cluster-01` apply the following `ProxyDefaults` CRD to configure the mesh gateway mode.
 


### PR DESCRIPTION
### Description

When `meshgateway.mode=local`, service dials local mesh gateway. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
