### PR TITLE
Reduce number of ports that consul test agents take

### DIFF
--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -17,9 +17,9 @@ import (
 	"text/template"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-uuid"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/config"
@@ -414,12 +414,12 @@ func (a *TestAgent) consulConfig() *consul.Config {
 // Instead of relying on one set of ports to be sufficient we retry
 // starting the agent with different ports on port conflict.
 func randomPortsSource(t *testing.T, useHTTPS bool) string {
-	ports := freeport.GetN(t, 8)
+	ports := freeport.GetN(t, 7)
 
 	var http, https int
 	if useHTTPS {
 		http = -1
-		https = ports[2]
+		https = ports[1]
 	} else {
 		http = ports[1]
 		https = -1
@@ -430,11 +430,11 @@ func randomPortsSource(t *testing.T, useHTTPS bool) string {
 			dns = ` + strconv.Itoa(ports[0]) + `
 			http = ` + strconv.Itoa(http) + `
 			https = ` + strconv.Itoa(https) + `
-			serf_lan = ` + strconv.Itoa(ports[3]) + `
-			serf_wan = ` + strconv.Itoa(ports[4]) + `
-			server = ` + strconv.Itoa(ports[5]) + `
-			grpc = ` + strconv.Itoa(ports[6]) + `
-			grpc_tls = ` + strconv.Itoa(ports[7]) + `
+			serf_lan = ` + strconv.Itoa(ports[2]) + `
+			serf_wan = ` + strconv.Itoa(ports[3]) + `
+			server = ` + strconv.Itoa(ports[4]) + `
+			grpc = ` + strconv.Itoa(ports[5]) + `
+			grpc_tls = ` + strconv.Itoa(ports[6]) + `
 		}
 	`
 }


### PR DESCRIPTION
### Description

After I increased test parallelism in https://github.com/hashicorp/consul/pull/18999, I noticed random tests would panic due to not enough ports being free:
```
2023-10-03T16:41:26.3801137Z === [31mFAIL[0m: command/monitor TestMonitorCommand_exitsOnSignalBeforeLinesArrive (0.00s)
2023-10-03T16:41:26.3801752Z     testagent.go:417: failed to take 8 ports: %!w(*errors.errorString=&{freeport: block size too small})
2023-10-03T16:41:26.3802154Z panic: freeport: cannot allocate port block [recovered]
2023-10-03T16:41:26.3802542Z 	panic: freeport: cannot allocate port block [recovered]
2023-10-03T16:41:26.3802949Z 	panic: freeport: cannot allocate port block
```

This PR attempts to reduce reserved ports by 1, hoping to reduce the frequency of these panics.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
