### PR TITLE
NET-5590 - authorization: check for identity:write in CA certs, xds server, and getting envoy bootstrap params

### DIFF
--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -1456,7 +1456,10 @@ func (c *CAManager) AuthorizeAndSignCertificate(csr *x509.CertificateRequest, au
 				"we are %s", v.Datacenter, dc)
 		}
 	case *connect.SpiffeIDWorkloadIdentity:
-		// TODO: Check for identity:write on the token when identity permissions are supported.
+		v.GetEnterpriseMeta().FillAuthzContext(&authzContext)
+		if err := allow.IdentityWriteAllowed(v.WorkloadIdentity, &authzContext); err != nil {
+			return nil, err
+		}
 	case *connect.SpiffeIDAgent:
 		v.GetEnterpriseMeta().FillAuthzContext(&authzContext)
 		if err := allow.NodeWriteAllowed(v.Agent, &authzContext); err != nil {

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -1317,6 +1317,12 @@ func TestCAManager_AuthorizeAndSignCertificate(t *testing.T) {
 		Host:       "test-host",
 		Partition:  "test-partition",
 	}.URI()
+	identityURL := connect.SpiffeIDWorkloadIdentity{
+		TrustDomain:      "test-trust-domain",
+		Partition:        "test-partition",
+		Namespace:        "test-namespace",
+		WorkloadIdentity: "test-workload-identity",
+	}.URI()
 
 	tests := []struct {
 		name      string
@@ -1409,6 +1415,15 @@ func TestCAManager_AuthorizeAndSignCertificate(t *testing.T) {
 				}.URI()
 				return &x509.CertificateRequest{
 					URIs: []*url.URL{u},
+				}
+			},
+		},
+		{
+			name:      "err_identity_write_not_allowed",
+			expectErr: "Permission denied",
+			getCSR: func() *x509.CertificateRequest {
+				return &x509.CertificateRequest{
+					URIs: []*url.URL{identityURL},
 				}
 			},
 		},

--- a/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
+++ b/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
@@ -80,7 +80,10 @@ func (s *Server) GetEnvoyBootstrapParams(ctx context.Context, req *pbdataplane.G
 			return nil, status.Errorf(codes.InvalidArgument, "workload %q doesn't have identity associated with it", req.ProxyId)
 		}
 
-		// todo (ishustava): ACL enforcement ensuring there's identity:write permissions.
+		// verify identity:write is allowed.  if not, give permission denied error.
+		if err := authz.ToAllowAuthorizer().IdentityWriteAllowed(workload.Identity, &authzContext); err != nil {
+			return nil, err
+		}
 
 		// Get all proxy configurations for this workload. Currently we're only looking
 		// for proxy configurations in the same tenancy as the workload.

--- a/agent/grpc-external/testutils/acl.go
+++ b/agent/grpc-external/testutils/acl.go
@@ -84,6 +84,18 @@ func ACLServiceRead(t *testing.T, serviceName string) resolver.Result {
 	}
 }
 
+func ACLUseProvidedPolicy(t *testing.T, aclPolicy *acl.Policy) resolver.Result {
+	t.Helper()
+
+	authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{aclPolicy}, nil)
+	require.NoError(t, err)
+
+	return resolver.Result{
+		Authorizer:  authz,
+		ACLIdentity: randomACLIdentity(t),
+	}
+}
+
 func ACLOperatorRead(t *testing.T) resolver.Result {
 	t.Helper()
 

--- a/internal/mesh/proxy-tracker/proxy_state_exports.go
+++ b/internal/mesh/proxy-tracker/proxy_state_exports.go
@@ -5,6 +5,7 @@ package proxytracker
 
 import (
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/internal/resource"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 )
 
@@ -34,9 +35,13 @@ func (p *ProxyState) AllowEmptyClusters() bool {
 }
 
 func (p *ProxyState) Authorize(authz acl.Authorizer) error {
-	// TODO(proxystate): we'll need to implement this once identity policy is implemented
-
-	// Authed OK!
+	// authorize for mesh proxies.
+	// TODO(proxystate): implement differently for gateways
+	allow := authz.ToAllowAuthorizer()
+	if err := allow.IdentityWriteAllowed(p.Identity.Name, resource.AuthorizerContext(p.Identity.Tenancy)); err != nil {
+		return err
+	}
+	
 	return nil
 }
 

--- a/internal/mesh/proxy-tracker/proxy_state_exports.go
+++ b/internal/mesh/proxy-tracker/proxy_state_exports.go
@@ -41,7 +41,7 @@ func (p *ProxyState) Authorize(authz acl.Authorizer) error {
 	if err := allow.IdentityWriteAllowed(p.Identity.Name, resource.AuthorizerContext(p.Identity.Tenancy)); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 

--- a/internal/mesh/proxy-tracker/proxy_state_exports_test.go
+++ b/internal/mesh/proxy-tracker/proxy_state_exports_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package proxytracker
+
+import (
+	"github.com/hashicorp/consul/acl"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestProxyState_Authorize(t *testing.T) {
+	testIdentity := &pbresource.Reference{
+		Type: &pbresource.Type{
+			Group:        "mesh",
+			GroupVersion: "v1alpha1",
+			Kind:         "Identity",
+		},
+		Tenancy: &pbresource.Tenancy{
+			Partition: "default",
+			Namespace: "default",
+			PeerName:  "local",
+		},
+		Name: "test-identity",
+	}
+
+	type testCase struct {
+		description          string
+		proxyState           *ProxyState
+		configureAuthorizer  func(authorizer *acl.MockAuthorizer)
+		expectedErrorMessage string
+	}
+	testsCases := []testCase{
+		{
+			description: "ProxyState - if identity write is allowed for the workload then allow.",
+			proxyState: &ProxyState{
+				ProxyState: &pbmesh.ProxyState{
+					Identity: testIdentity,
+				},
+			},
+			expectedErrorMessage: "",
+			configureAuthorizer: func(authz *acl.MockAuthorizer) {
+				authz.On("IdentityWrite", testIdentity.Name, mock.Anything).Return(acl.Allow)
+			},
+		},
+		{
+			description: "ProxyState - if identity write is not allowed for the workload then deny.",
+			proxyState: &ProxyState{
+				ProxyState: &pbmesh.ProxyState{
+					Identity: testIdentity,
+				},
+			},
+			expectedErrorMessage: "Permission denied: token with AccessorID '' lacks permission 'identity:write' on \"test-identity\"",
+			configureAuthorizer: func(authz *acl.MockAuthorizer) {
+				authz.On("IdentityWrite", testIdentity.Name, mock.Anything).Return(acl.Deny)
+			},
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.description, func(t *testing.T) {
+			authz := &acl.MockAuthorizer{}
+			authz.On("ToAllow").Return(acl.AllowAuthorizer{Authorizer: authz})
+			tc.configureAuthorizer(authz)
+			err := tc.proxyState.Authorize(authz)
+			errMsg := ""
+			if err != nil {
+				errMsg = err.Error()
+			}
+			// using contains because Enterprise tests append the parition and namespace
+			// information to the message.
+			require.True(t, strings.Contains(errMsg, tc.expectedErrorMessage))
+		})
+	}
+}


### PR DESCRIPTION
### Description
PR Discussion: https://github.com/hashicorp/consul-enterprise/pull/6760#discussion_r1319233169

TODO in code: https://github.com/hashicorp/consul/blob/main/agent/consul/leader_connect_ca.go#L1459

AuthorizeAndSignCertificate is called from two places and both resolve the authorizer from the token.  So, we can utilize IdentityWriteAllowed which will pass in the authorizer based on the token to achieve Check for identity:write on the token when identity permissions are supported. 

- https://github.com/hashicorp/consul/blob/21ea527089ef81e6b2ec48042915e60c3d385b5a/agent/grpc-external/services/connectca/sign.go#L71-L76

- https://github.com/hashicorp/consul/blob/21ea527089ef81e6b2ec48042915e60c3d385b5a/agent/consul/connect_ca_endpoint.go#L155-L161

Acceptance Criteria:

- check that we have identity:write on the token when the system signs a leaf certificate for the service or agent identified by the SPIFFE ID in the given CSR's SAN. It performs authorization.
- enforce identity:write in xds server
- enforce identity:write in getEnvoyBootstrapParams
- when identity:write permission is not available on the token, return an Permission denied error.


### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
