### PR TITLE
Net-5771/apply command stdin input

### DIFF
--- a/command/resource/apply/apply.go
+++ b/command/resource/apply/apply.go
@@ -79,7 +79,7 @@ func (c *cmd) Run(args []string) int {
 
 	input := c.filePath
 
-	if input == "" && len(c.flags.Args()) > 0 && c.flags.Arg(0) == "-" {
+	if input == "" && len(c.flags.Args()) > 0 {
 		input = c.flags.Arg(0)
 	}
 
@@ -93,7 +93,7 @@ func (c *cmd) Run(args []string) int {
 		}
 		parsedResource = data
 	} else {
-		c.UI.Error("Incorrect argument format: Must provide one argument to write the resource. Flag -f can be used to pass the file path or - to for stdin")
+		c.UI.Error("Incorrect argument format: Must provide exactly one positional argument to specify the resource to write")
 		return 1
 	}
 
@@ -160,31 +160,42 @@ func (c *cmd) Help() string {
 const synopsis = "Writes/updates resource information"
 
 const help = `
-Usage: consul resource apply -f=<file-path>
+Usage: consul resource apply [options] <resource>
 
-Write and/or update a resource by providing the definition in an hcl file as an argument
+	Write and/or update a resource by providing the definition. The configuration
+	argument is either a file path or '-' to indicate that the resource
+    should be read from stdin. The data should be either in HCL or
+	JSON form.
 
-Example:
+	Example (with flag):
 
-$ consul resource apply -f=demo.hcl
+	$ consul resource apply -f=demo.hcl
 
-Sample demo.hcl:
+	Example (from file):
 
-ID {
-	Type = gvk("group.version.kind")
-	Name = "resource-name"
-	Tenancy {
-	  Namespace = "default"
-	  Partition = "default"
-	  PeerName = "local"
+	$ consul resource apply demo.hcl
+
+	Example (from stdin):
+
+	$ consul resource apply -
+
+	Sample demo.hcl:
+
+	ID {
+		Type = gvk("group.version.kind")
+		Name = "resource-name"
+		Tenancy {
+		Namespace = "default"
+		Partition = "default"
+		PeerName = "local"
+		}
 	}
-  }
 
-  Data {
-	Name = "demo"
-  }
+	Data {
+		Name = "demo"
+	}
 
-  Metadata = {
-	"foo" = "bar"
-  }
+	Metadata = {
+		"foo" = "bar"
+	}
 `

--- a/command/resource/apply/apply_test.go
+++ b/command/resource/apply/apply_test.go
@@ -5,12 +5,14 @@ package apply
 
 import (
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/command/resource/read"
 	"github.com/hashicorp/consul/testrpc"
 )
 
@@ -61,6 +63,129 @@ func TestResourceApplyCommand(t *testing.T) {
 	}
 }
 
+func readResource(t *testing.T, a *agent.TestAgent, extraArgs []string) string {
+	readUi := cli.NewMockUi()
+	readCmd := read.New(readUi)
+
+	args := []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-token=root",
+	}
+
+	args = append(extraArgs, args...)
+
+	code := readCmd.Run(args)
+	require.Equal(t, 0, code)
+	require.Empty(t, readUi.ErrorWriter.String())
+	return readUi.OutputWriter.String()
+}
+
+func TestResourceApplyCommand_StdIn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	t.Run("hcl", func(t *testing.T) {
+		stdinR, stdinW := io.Pipe()
+
+		ui := cli.NewMockUi()
+		c := New(ui)
+		c.testStdin = stdinR
+
+		stdInput := `ID {
+			Type = gvk("demo.v2.Artist")
+			Name = "korn"
+			Tenancy {
+			  Namespace = "default"
+			  Partition = "default"
+			  PeerName = "local"
+			}
+		  }
+		  
+		  Data {
+			Name = "Korn"
+			Genre = "GENRE_METAL"
+		  }
+		  
+		  Metadata = {
+			"foo" = "bar"
+		  }`
+
+		go func() {
+			stdinW.Write([]byte(stdInput))
+			stdinW.Close()
+		}()
+
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-token=root",
+			"-",
+		}
+
+		code := c.Run(args)
+		require.Equal(t, 0, code)
+		require.Empty(t, ui.ErrorWriter.String())
+		expected := readResource(t, a, []string{"demo.v2.Artist", "korn"})
+		require.Contains(t, ui.OutputWriter.String(), "demo.v2.Artist 'korn' created.")
+		require.Contains(t, ui.OutputWriter.String(), expected)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		stdinR, stdinW := io.Pipe()
+
+		ui := cli.NewMockUi()
+		c := New(ui)
+		c.testStdin = stdinR
+
+		stdInput := `{
+			"data": {
+				"genre": "GENRE_METAL",
+				"name": "Korn"
+			},
+			"id": {
+				"name": "korn",
+				"tenancy": {
+					"namespace": "default",
+					"partition": "default",
+					"peerName": "local"
+				},
+				"type": {
+					"group": "demo",
+					"groupVersion": "v2",
+					"kind": "Artist"
+				}
+			},
+			"metadata": {
+				"foo": "bar"
+			}
+		}`
+
+		go func() {
+			stdinW.Write([]byte(stdInput))
+			stdinW.Close()
+		}()
+
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-token=root",
+			"-",
+		}
+
+		code := c.Run(args)
+		require.Equal(t, 0, code)
+		require.Empty(t, ui.ErrorWriter.String())
+		expected := readResource(t, a, []string{"demo.v2.Artist", "korn"})
+		require.Contains(t, ui.OutputWriter.String(), "demo.v2.Artist 'korn' created.")
+		require.Contains(t, ui.OutputWriter.String(), expected)
+	})
+}
+
 func TestResourceApplyInvalidArgs(t *testing.T) {
 	t.Parallel()
 
@@ -79,7 +204,7 @@ func TestResourceApplyInvalidArgs(t *testing.T) {
 		"missing required flag": {
 			args:         []string{},
 			expectedCode: 1,
-			expectedErr:  errors.New("Incorrect argument format: Flag -f with file path argument is required"),
+			expectedErr:  errors.New("Incorrect argument format: Must provide one argument to write the resource. Flag -f can be used to pass the file path or - to for stdin"),
 		},
 		"file parsing failure": {
 			args:         []string{"-f=../testdata/invalid.hcl"},

--- a/command/resource/apply/apply_test.go
+++ b/command/resource/apply/apply_test.go
@@ -41,6 +41,11 @@ func TestResourceApplyCommand(t *testing.T) {
 			args:   []string{"-f=../testdata/nested_data.hcl"},
 			output: "mesh.v2beta1.Destinations 'api' created.",
 		},
+		{
+			name:   "file path with no flag",
+			args:   []string{"../testdata/nested_data.hcl"},
+			output: "mesh.v2beta1.Destinations 'api' created.",
+		},
 	}
 
 	for _, tc := range cases {
@@ -204,7 +209,7 @@ func TestResourceApplyInvalidArgs(t *testing.T) {
 		"missing required flag": {
 			args:         []string{},
 			expectedCode: 1,
-			expectedErr:  errors.New("Incorrect argument format: Must provide one argument to write the resource. Flag -f can be used to pass the file path or - to for stdin"),
+			expectedErr:  errors.New("Incorrect argument format: Must provide exactly one positional argument to specify the resource to write"),
 		},
 		"file parsing failure": {
 			args:         []string{"-f=../testdata/invalid.hcl"},

--- a/command/resource/helper.go
+++ b/command/resource/helper.go
@@ -17,9 +17,6 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/types/known/anypb"
-
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/command/helpers"
 	"github.com/hashicorp/consul/command/resource/client"

--- a/command/resource/helper.go
+++ b/command/resource/helper.go
@@ -143,12 +143,13 @@ func ParseResourceInput(filePath string, stdin io.Reader) (*pbresource.Resource,
 		return nil, fmt.Errorf("Failed to load data: %v", err)
 	}
 	var parsedResource *pbresource.Resource
-	parsedResource, err = resourcehcl.Unmarshal([]byte(data), consul.NewTypeRegistry())
-	if err != nil {
+	if isHCL([]byte(data)) {
+		parsedResource, err = resourcehcl.Unmarshal([]byte(data), consul.NewTypeRegistry())
+	} else {
 		parsedResource, err = parseJson(data)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to decode resource from input file: %v", err)
-		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("Failed to decode resource from input: %v", err)
 	}
 
 	return parsedResource, nil


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Similar to the config entry write command the resource apply command can take input from stdin directly without having to store the HCL file on the file system.

 `echo {{resource-definition}} | consul resource apply -`

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

Added automated tests and manual testing locally


### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [x] appropriate backport labels added
* [ ] ~not a security concern~
