### PR TITLE
mesh: ensure we add the virtual port number for L7 implicit upstreams

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destination_builder.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destination_builder.go
@@ -241,7 +241,7 @@ func (b *Builder) buildDestination(
 
 		rb := lb.addL7Router("", effectiveProtocol)
 		if destination.Explicit == nil {
-			rb.addIPMatch(destination.VirtualIPs)
+			rb.addIPAndPortMatch(destination.VirtualIPs, virtualPortNumber)
 		}
 		rb.buildRouter()
 	} else {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-multiple-implicit-destinations-tproxy.golden
@@ -223,6 +223,40 @@
             }
           },
           {
+            "l7": {
+              "name": "outbound_listener",
+              "statPrefix": "upstream."
+            },
+            "match": {
+              "destinationPort": 8080,
+              "prefixRanges": [
+                {
+                  "addressPrefix": "1.1.1.1",
+                  "prefixLen": 32
+                }
+              ]
+            }
+          },
+          {
+            "l7": {
+              "name": "outbound_listener",
+              "statPrefix": "upstream."
+            },
+            "match": {
+              "destinationPort": 8080,
+              "prefixRanges": [
+                {
+                  "addressPrefix": "2.2.2.2",
+                  "prefixLen": 32
+                },
+                {
+                  "addressPrefix": "3.3.3.3",
+                  "prefixLen": 32
+                }
+              ]
+            }
+          },
+          {
             "l4": {
               "cluster": {
                 "name": "tcp2.api-app.default.dc1.internal.foo.consul"
@@ -248,38 +282,6 @@
             },
             "match": {
               "destinationPort": 8081,
-              "prefixRanges": [
-                {
-                  "addressPrefix": "2.2.2.2",
-                  "prefixLen": 32
-                },
-                {
-                  "addressPrefix": "3.3.3.3",
-                  "prefixLen": 32
-                }
-              ]
-            }
-          },
-          {
-            "l7": {
-              "name": "outbound_listener",
-              "statPrefix": "upstream."
-            },
-            "match": {
-              "prefixRanges": [
-                {
-                  "addressPrefix": "1.1.1.1",
-                  "prefixLen": 32
-                }
-              ]
-            }
-          },
-          {
-            "l7": {
-              "name": "outbound_listener",
-              "statPrefix": "upstream."
-            },
-            "match": {
               "prefixRanges": [
                 {
                   "addressPrefix": "2.2.2.2",

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-tproxy.golden
@@ -121,14 +121,12 @@
             }
           },
           {
-            "l4": {
-              "cluster": {
-                "name": "tcp2.api-app.default.dc1.internal.foo.consul"
-              },
-              "statPrefix": "upstream.tcp2.api-app.default.default.dc1"
+            "l7": {
+              "name": "outbound_listener",
+              "statPrefix": "upstream."
             },
             "match": {
-              "destinationPort": 8081,
+              "destinationPort": 8080,
               "prefixRanges": [
                 {
                   "addressPrefix": "1.1.1.1",
@@ -138,11 +136,14 @@
             }
           },
           {
-            "l7": {
-              "name": "outbound_listener",
-              "statPrefix": "upstream."
+            "l4": {
+              "cluster": {
+                "name": "tcp2.api-app.default.dc1.internal.foo.consul"
+              },
+              "statPrefix": "upstream.tcp2.api-app.default.default.dc1"
             },
             "match": {
+              "destinationPort": 8081,
               "prefixRanges": [
                 {
                   "addressPrefix": "1.1.1.1",

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-with-multiple-workloads-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-with-multiple-workloads-tproxy.golden
@@ -121,14 +121,12 @@
             }
           },
           {
-            "l4": {
-              "cluster": {
-                "name": "tcp2.api-app.default.dc1.internal.foo.consul"
-              },
-              "statPrefix": "upstream.tcp2.api-app.default.default.dc1"
+            "l7": {
+              "name": "outbound_listener",
+              "statPrefix": "upstream."
             },
             "match": {
-              "destinationPort": 8081,
+              "destinationPort": 8080,
               "prefixRanges": [
                 {
                   "addressPrefix": "1.1.1.1",
@@ -138,11 +136,14 @@
             }
           },
           {
-            "l7": {
-              "name": "outbound_listener",
-              "statPrefix": "upstream."
+            "l4": {
+              "cluster": {
+                "name": "tcp2.api-app.default.dc1.internal.foo.consul"
+              },
+              "statPrefix": "upstream.tcp2.api-app.default.default.dc1"
             },
             "match": {
+              "destinationPort": 8081,
               "prefixRanges": [
                 {
                   "addressPrefix": "1.1.1.1",


### PR DESCRIPTION
### Description

The virtual port number should be present for implicit upstreams in both L4 and L7 so that the tproxy matching rules can correctly "catch" the traffic.
