### PR TITLE
Docs/ce 475 retries timeouts for apigw

### DIFF
--- a/website/content/docs/connect/config-entries/http-route.mdx
+++ b/website/content/docs/connect/config-entries/http-route.mdx
@@ -34,6 +34,14 @@ to view additional details, including default values.
       - [`Set`](#rules-filters-headers-set): map | no default
     - [`URLRewrite`](#rules-filters-urlrewrite): map | no default
       - [`Path`](#rules-filters-urlrewrite-path): string | no default
+    - [`RetryFilter`](#rules-filters-retryfilter): map 
+      - [`NumRetries`](#rules-filters-retryfilter-numretries): number | `1`
+      - [`RetryOnConnectionFailure`](#rules-filters-retryfilter-retryonconnectionfailure): boolean | `false`
+      - [`RetryOn`](#rules-filters-retryfilter-retryon): list of strings
+      - [`RetryOnStatusCodes`](#rules-filters-retryfilter-retryon): list of numbers
+    - [`TimeoutFilter`](#rules-filters-timeoutfilter): map
+      - [`IdleTimeout`](#rules-filters-timeoutfilter): number | `0`
+      - [`RequestTimeout`](#rules-filters-timeoutfilter): number | `0`
     - [`JWT`](#rules-filters-jwt): map
          - [`Providers`](#rules-filters-jwt-providers): list
             - [`Name`](#rules-filters-jwt-providers): string
@@ -65,6 +73,15 @@ to view additional details, including default values.
         - [`Set`](#rules-services-filters-headers-set): map | no default
       - [`URLRewrite`](#rules-services-filters-urlrewrite): map | no default
         - [`Path`](#rules-services-filters-urlrewrite-path): string | no default
+      - [`RetryFilter`](#rules-filters-retryfilter): map 
+        - [`NumRetries`](#rules-filters-retryfilter-numretries): number | `1`
+        - [`RetryOnConnectionFailure`](#rules-filters-retryfilter-retryonconnectionfailure): boolean | `false`
+        - [`RetryOn`](#rules-filters-retryfilter-retryon): list of strings
+        - [`RetryOnStatusCodes`](#rules-filters-retryfilter-retryon): list of numbers
+      - [`TimeoutFilter`](#rules-filters-timeoutfilter): map
+        -[`IdleTimeout`](#rules-filters-timeoutfilter): number | `0`
+        -[`RequestTimeout`](#rules-filters-timeoutfilter): number | `0`
+
 
 ## Complete configuration
 
@@ -432,6 +449,8 @@ Specifies the list of HTTP-based filters used to modify a request prior to routi
 - Data type: Map that contains the following fields:
   - `Headers`
   - `UrlRewrite`
+  - `RetryFilter`
+  - `TimeoutFilter`
 
 ### `Rules[].Filters.Headers[]`
 
@@ -468,6 +487,99 @@ The following table describes the parameters for `path`:
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
 | `replacePrefixMatch` | Specifies a value that replaces the path prefix for incoming HTTP requests. The operation only affects the path prefix. The rest of the path is unchanged.                                       | String |
 | `type`               | Specifies the type of replacement to use for the URL path. You can specify the following values: <ul><li>`ReplacePrefixMatch`: Replaces the matched prefix of the URL path (default). </li></ul> | String |
+
+### `Rules[].Filters{}.RetryFilter`
+
+Specifies a block of settings Consul uses to retry a request if it fails.  
+
+### Values
+
+- Default: None
+- Data type: Map containing the following parameters:
+  - `NumRetries`
+  - `RetryOnConnectFailure`
+  - `RetryOn`
+  - `RetryOnStatusCodes`
+
+### `Rules[].Filters{}.RetryFilter{}.NumRetries`
+
+Specifies the number of times to retry the request when a retry condition occurs. 
+
+#### Values
+
+- Default: `1`
+- Data type: Integer
+
+### `Rules[].Filters{}.RetryFilter{}.RetryOnConnectFailure`
+
+Enables Consul to retry the request if the connection fails. Define the one or more retry configurations to define the retry logic for the route. 
+
+#### Values
+
+- Default: `false`
+- Data type: Boolean
+
+### `Rules[].Filters{}.RetryFilter{}.RetryOn`
+
+Specifies a list of conditions for Consul to retry requests based on the response from an upstream service. The following retry conditions are supported:
+
+| Conditions           | Description                                                                                              |
+| :------------------- | :------------------------------------------------------------------------------------------------------- |
+| `5xx`                | Consul retries the request when an upstream responds with any 5xx error code or does not respond at all. |
+| `gateway-error`      | Consul retries the request when the upstream responds with a 502, 503, or 504 error.                     |
+| `reset`              | Consul retries the request when the upstream does not respond at all.                                    |
+| `connect-failure`    | Consul retries the request when the connection to the upstream fails.                                    |
+| `envoy-ratelimited`  | Consul retries the request when the header `x-envoy-ratelimited` is present.                             |
+| `retriable-4xx`      | Consul retries the request when the upstream responds with a retriable 4xx code.                         |
+| `refused-stream`     | Consul retries the request when the upstream resets the stream with a `REFUSED_STREAM` error code.       |
+| `cancelled`          | Consul retries the request when the gRPC status code in the response headers is `cancelled`.             |
+| `deadline-exceeded`  | Consul retries the request when the gRPC status code in the response headers is `deadline-exceeded`.     |
+| `internal`           | Consul retries the request when the gRPC status code in the response headers is `internal`.              |
+| <nobr>`resource-exhausted`</nobr> | Consul retries the request when the gRPC status code in the response headers is `resource-exhausted`.    |
+| `unavailable`        | Consul retries the request when the gRPC status code in the response headers is `unavailable`.           |
+
+#### Values
+
+- Default: None
+- Data type: List of strings. Strings must match one of the following values:
+
+  - `5xx`
+  - `gateway-error`
+  - `reset`
+  - `connect-failure`
+  - `envoy-ratelimited`
+  - `retriable-4xx`
+  - `refused-stream`
+  - `cancelled`
+  - `deadline-exceeded`
+  - `internal`
+  - `resource-exhausted`
+  - `unavailable`
+
+### `Rules[].Filters{}.RetryFilter{}.RetryOnStatusCodes`
+
+Specifies a list of integers for [HTTP response status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) that trigger a retry request.
+
+#### Values
+
+- Default: None
+- Data type: List of integers
+
+### `Rules[].Filters{}.TimeoutFilter`
+
+Specifies timeout settings for routes from an API gateway listener to the destination service in Consul service mesh. 
+
+#### Values
+
+- Default: None
+- Data type: Map
+
+The following table describes the settings you can configure in the `TimeoutFilter` map:
+
+| Parameter | Description | Data type | Default |
+| ---       | ---         | ---       | ---     |
+| `IdleTimeout` | Specifies the total amount of time permitted for the request stream to be idle. | Integer | `0` |
+| `RequestTimeout` | Specifies the total amount of time in nanoseconds, including retry attempts, Consul permits for the entire downstream request to be processed. | Integer | `0` |
 
 ### `Rules[].Filters{}.JWT`
 
@@ -732,6 +844,100 @@ Specifies rule for rewriting the URL of incoming requests.
 
 - Default: none
 - This field is a map that contains a `Path` field.
+
+### `Rules[].Services[].Filters{}.RetryFilters`
+
+Specifies a block of settings Consul uses to retry a request if it fails.  
+
+### Values
+
+- Default: None
+- Data type: Map containing the following parameters:
+  - `NumRetries`
+  - `RetryOnConnectFailure`
+  - `RetryOn`
+  - `RetryOnStatusCodes`
+
+### `Rules[].Services[].Filters{}.RetryFilters{}.NumRetries`
+
+Specifies the number of times to retry the request when a retry condition occurs. 
+
+#### Values
+
+- Default: `1`
+- Data type: Integer
+
+### `Rules[].Services[].Filters{}.RetryFilters{}.RetryOnConnectFailure`
+
+Enables Consul to retry the request if the connection fails. Define the one or more retry configurations to define the retry logic for the route. 
+
+#### Values
+
+- Default: `false`
+- Data type: Boolean
+
+### `Rules[].Services[].Filters{}.RetryFilters{}.RetryOn`
+
+Specifies a list of conditions for Consul to retry requests based on the response from an upstream service. The following retry conditions are supported:
+
+| Conditions           | Description                                                                                              |
+| :------------------- | :------------------------------------------------------------------------------------------------------- |
+| `5xx`                | Consul retries the request when an upstream responds with any 5xx error code or does not respond at all. |
+| `gateway-error`      | Consul retries the request when the upstream responds with a 502, 503, or 504 error.                     |
+| `reset`              | Consul retries the request when the upstream does not respond at all.                                    |
+| `connect-failure`    | Consul retries the request when the connection to the upstream fails.                                    |
+| `envoy-ratelimited`  | Consul retries the request when the header `x-envoy-ratelimited` is present.                             |
+| `retriable-4xx`      | Consul retries the request when the upstream responds with a retriable 4xx code.                         |
+| `refused-stream`     | Consul retries the request when the upstream resets the stream with a `REFUSED_STREAM` error code.       |
+| `cancelled`          | Consul retries the request when the gRPC status code in the response headers is `cancelled`.             |
+| `deadline-exceeded`  | Consul retries the request when the gRPC status code in the response headers is `deadline-exceeded`.     |
+| `internal`           | Consul retries the request when the gRPC status code in the response headers is `internal`.              |
+| <nobr>`resource-exhausted`</nobr> | Consul retries the request when the gRPC status code in the response headers is `resource-exhausted`.    |
+| `unavailable`        | Consul retries the request when the gRPC status code in the response headers is `unavailable`.           |
+
+#### Values
+
+- Default: None
+- Data type: List of strings. Strings must match one of the following values:
+
+  - `5xx`
+  - `gateway-error`
+  - `reset`
+  - `connect-failure`
+  - `envoy-ratelimited`
+  - `retriable-4xx`
+  - `refused-stream`
+  - `cancelled`
+  - `deadline-exceeded`
+  - `internal`
+  - `resource-exhausted`
+  - `unavailable`
+
+### ``Rules[].Services[].Filters{}.RetryFilters{}.RetryOnStatusCodes`
+
+Specifies a list of integers for [HTTP response status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) that trigger a retry request.
+
+#### Values
+
+- Default: None
+- Data type: List of integers
+
+### `Rules[].Service[].Filters{}.TimeoutFilter`
+
+Specifies timeout settings for routes from an API gateway listener to the destination service in Consul service mesh. 
+
+#### Values
+
+- Default: None
+- Data type: Map
+
+The following table describes the settings you can configure in the `TimeoutFilter` map:
+
+| Parameter | Description | Data type | Default |
+| ---       | ---         | ---       | ---     |
+| `IdleTimeout` | Specifies the total amount of time permitted for the request stream to be idle. | Integer | `0` |
+| `RequestTimeout` | Specifies the total amount of time in nanoseconds, including retry attempts, Consul permits for the entire downstream request to be processed. | Integer | `0` |
+
 
 ## Examples
 

--- a/website/content/docs/connect/config-entries/http-route.mdx
+++ b/website/content/docs/connect/config-entries/http-route.mdx
@@ -941,38 +941,7 @@ The following table describes the settings you can configure in the `TimeoutFilt
 
 ## Examples
 
-The following examples demonstrates how to set an idle timeout and a request timeout. 
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: RouteTimeoutFilter
-metadata:
-  name: timeouts
-spec:
-  requestTimeout: 15s
-  idleTimeout: 15s
-  
- ---
- 
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: HTTPRoute
-metadata:
-  name: example-route
-  namespace: default
-spec:
-  parentRefs:
-    - name: gateway
-  rules:
-     - backendRefs:
-          - name: example-service
-            kind: Service
-            port: 80
-       filters:
-        - type: ExtensionRef
-          extensionRef:
-            group: consul.hashicorp.com
-            kind: RouteTimeoutFilter
-            name: timeouts
+The following examples demonstrate common HTTP route configuration patterns for specific use cases.
 
 ### Configure JWT verification settings
 

--- a/website/content/docs/connect/config-entries/http-route.mdx
+++ b/website/content/docs/connect/config-entries/http-route.mdx
@@ -941,7 +941,38 @@ The following table describes the settings you can configure in the `TimeoutFilt
 
 ## Examples
 
-The following examples demonstrate common HTTP route configuration patterns for specific use cases.
+The following examples demonstrates how to set an idle timeout and a request timeout. 
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: RouteTimeoutFilter
+metadata:
+  name: timeouts
+spec:
+  requestTimeout: 15s
+  idleTimeout: 15s
+  
+ ---
+ 
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: gateway
+  rules:
+     - backendRefs:
+          - name: example-service
+            kind: Service
+            port: 80
+       filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: consul.hashicorp.com
+            kind: RouteTimeoutFilter
+            name: timeouts
 
 ### Configure JWT verification settings
 

--- a/website/content/docs/connect/gateways/api-gateway/configuration/routeretryfilter.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/routeretryfilter.mdx
@@ -1,0 +1,184 @@
+---
+layout: docs
+page_title: RouteRetryFilter configuration reference
+description: >-
+  Learn how to configure the `RouteRetryFilter` resource, which defines retry settings for specific routes from an API gateway listener to the destination service in Consul service mesh.
+---
+
+# RouteRetryFilter configuration reference
+
+This topic provides configuration reference information for  details about the `RouteRetryFilter` resource, which defines retry settings for specific routes from an API gateway listener to the destination service in Consul service mesh. 
+
+## Introduction
+
+Define the one or more configurations in the `spec` to define the retry logic for the route. Refer to the [retry logic example configuration](#example) for additional information. 
+
+To apply retry settings to a `HTTPRoute`, set the `rules.filters.type` parameter in an route to `extensionRef` and specify the name of the filter in `rules.filters.extensionRef.name` field. Refer to [Route resource configuration reference](/consul/docs/connect/gateways/api-gateway/configuration/routes) for additional information. 
+
+## Configuration Model
+
+The following list outlines field hierarchy, data types, and requirements in a `RouteRetryFilter` resource. Click on a property name to view additional details, including default values.
+
+- [`apiVersion`](#apiversion): string | required | must be set to `consul.hashicorp.com/v1alpha1`
+- [`kind`](#kind): string | required | must be set to `RouteRetryFilter`
+- [`metadata`](#metadata): map | required
+   - [`name`](#metadata-name): string | required 
+   - [`namespace`](#metadata-namespace): string  | `default`
+- [`spec`](#spec): map | required
+  - [`numRetries`](#spec-numretries): number | `1`
+  - [`retryOnConnectFailure`](#spec-retryonconnectfailure): boolean | `false`
+  - [`retryOn`](#spec-retryon): list
+  - [`retryOnStatusCodes`](#spec-retryonstatuscodes): list
+
+## Complete configuration
+
+When every field is defined, this resource has the following form: 
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: RouteRetryFilter
+metadata:
+  name: <name for the retry filter>
+spec:
+  requestTimeout: <amount of time to wait before retrying>
+  numRetries: <number of times to retry>
+  retryOnConnectFailure: false
+  retryOn: ['<condition types that trigger retries>']
+```
+
+## Specification
+
+This section provides details about the fields you can configure in the resource.
+
+### `apiVersion`
+
+Specifies the version of the Consul API for integrating with Kubernetes. The value must be `consul.hashicorp.com/v1alpha1`.
+
+#### Values
+
+- Default: None
+- This field is required.
+- String value that must be set to `consul.hashicorp.com/v1alpha1`.
+
+### `kind`
+
+Specifies the type of configuration entry to implement. Must be set to `RouteRetryFilter`.
+
+#### Values
+
+- Default: None
+- This field is required.
+- Data type: String value that must be set to `RouteRetryFilter`.
+
+### `metadata`
+
+Map that contains an arbitrary name for the resource and the namespace it applies to.
+
+#### Values
+
+- Default: None
+- Data type: Map
+
+### `metadata.name`
+
+Specifies a name for the resource. The name is metadata that you can use to reference the resource when performing Consul operations, such as applying the resource to a specific cluster. 
+
+#### Values
+
+- Default: None
+- This field is required.
+- Data type: String
+
+### `metadata.namespace` 
+
+Specifies the namespace that the configuration applies to. Refer to [namespaces](/consul/docs/enterprise/namespaces) for more information.
+
+#### Values
+
+- Default: None
+- Data type: String
+
+### `spec`
+
+Map that contains the details about the gateway policy. The `apiVersion`, `kind`, and `metadata` fields are siblings of the `spec` field. All other configurations are children.
+
+### `spec.numRetries`
+
+Specifies the number of times to retry the request when a retry condition occurs. 
+
+#### Values
+
+- Default: `1`
+- Data type: Integer
+
+### `spec.retryOnConnectFailure`
+
+Enables Consul to retry the request if the connection fails. Define the one or more retry configurations to define the retry logic for the route. 
+
+#### Values
+
+- Default: `false`
+- Data type: Boolean
+
+### `spec.retryOn`
+
+Specifies a list of conditions for Consul to retry requests based on the response from an upstream service. The following retry conditions are supported:
+
+| Conditions           | Description                                                                                              |
+| :------------------- | :------------------------------------------------------------------------------------------------------- |
+| `5xx`                | Consul retries the request when an upstream responds with any 5xx error code or does not respond at all. |
+| `gateway-error`      | Consul retries the request when the upstream responds with a 502, 503, or 504 error.                     |
+| `reset`              | Consul retries the request when the upstream does not respond at all.                                    |
+| `connect-failure`    | Consul retries the request when the connection to the upstream fails.                                    |
+| `envoy-ratelimited`  | Consul retries the request when the header `x-envoy-ratelimited` is present.                             |
+| `retriable-4xx`      | Consul retries the request when the upstream responds with a retriable 4xx code.                         |
+| `refused-stream`     | Consul retries the request when the upstream resets the stream with a `REFUSED_STREAM` error code.       |
+| `cancelled`          | Consul retries the request when the gRPC status code in the response headers is `cancelled`.             |
+| `deadline-exceeded`  | Consul retries the request when the gRPC status code in the response headers is `deadline-exceeded`.     |
+| `internal`           | Consul retries the request when the gRPC status code in the response headers is `internal`.              |
+| <nobr>`resource-exhausted`</nobr> | Consul retries the request when the gRPC status code in the response headers is `resource-exhausted`.    |
+| `unavailable`        | Consul retries the request when the gRPC status code in the response headers is `unavailable`.           |
+
+#### Values
+
+- Default: None
+- Data type: List of strings. Strings must match one of the following values:
+
+  - `5xx`
+  - `gateway-error`
+  - `reset`
+  - `connect-failure`
+  - `envoy-ratelimited`
+  - `retriable-4xx`
+  - `refused-stream`
+  - `cancelled`
+  - `deadline-exceeded`
+  - `internal`
+  - `resource-exhausted`
+  - `unavailable`
+
+### `spec.retryOnStatusCodes`
+
+Specifies a list of integers for [HTTP response status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) that trigger a retry request.
+
+#### Values
+
+- Default: None
+- Data type: List of integers
+
+
+## Example
+
+The following example configures Consul to retry the route five times after 15 when the connection fails:
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: RouteRetryFilter
+metadata:
+  name: orders
+spec:
+  requestTimeout: 15s
+  numRetries: 5
+  retryOnConnectFailure: true
+  retryOn: ['reset']
+```

--- a/website/content/docs/connect/gateways/api-gateway/configuration/routeretryfilter.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/routeretryfilter.mdx
@@ -177,7 +177,6 @@ kind: RouteRetryFilter
 metadata:
   name: orders
 spec:
-  requestTimeout: 15s
   numRetries: 5
   retryOnConnectFailure: true
   retryOn: ['reset']

--- a/website/content/docs/connect/gateways/api-gateway/configuration/routeretryfilter.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/routeretryfilter.mdx
@@ -181,4 +181,27 @@ spec:
   numRetries: 5
   retryOnConnectFailure: true
   retryOn: ['reset']
+  
+  ---
+  
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: gateway
+  rules:
+     - backendRefs:
+          - name: example-service
+            kind: Service
+            port: 80
+       filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: consul.hashicorp.com
+            kind: RouteRetryFilter
+            name: orders
+
 ```

--- a/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
@@ -1,0 +1,114 @@
+---
+layout: docs
+page_title: RouteTimeoutFilter configuration reference
+description: >-
+  Learn how to configure the `RouteTimeoutFilter` resource, which defines timeout settings for specific routes from an API gateway listener to the destination service in Consul service mesh.
+---
+
+# RouteTimeoutFilter configuration reference
+
+This topic provides configuration reference information for  details about the `RouteTimeoutFilter` resource, which defines timeout settings for specific routes from an API gateway listener to the destination service in Consul service mesh. 
+
+To apply retry settings to a `HTTPRoute`, set the `rules.filters.type` parameter in an route to `extensionRef` and specify the name of the filter in `rules.filters.extensionRef.name` field. Refer to [Route resource configuration reference](/consul/docs/connect/gateways/api-gateway/configuration/routes) for additional information. 
+
+## Configuration Model
+
+The following list outlines field hierarchy, data types, and requirements in a `RouteTimeoutFilter` resource. Click on a property name to view additional details, including default values.
+
+- [`apiVersion`](#apiversion): string | required | must be set to `consul.hashicorp.com/v1alpha1`
+- [`kind`](#kind): string | required | must be set to `RouteTimeoutFilter`
+- [`metadata`](#metadata): map | required
+   - [`name`](#metadata-name): string | required 
+   - [`namespace`](#metadata-namespace): string  | `default`
+- [`spec`](#spec): map | required
+  - [`idleTimeout`](#spec-idletimeout): number | `0`
+  - [`requestTimeout`](#spec-retryonconnectfailure): number | `0`
+
+## Complete configuration
+
+When every field is defined, this resource has the following form: 
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: RouteTimeoutFilter
+metadata:
+  name: <name for the retry filter>
+spec:
+  idleTimeout: <amount of time the request stream can remain idle>
+  requestTimeout: <total amount of time Consul allows for processing the request stream>
+```
+
+## Specification
+
+This section provides details about the fields you can configure in the resource.
+
+### `apiVersion`
+
+Specifies the version of the Consul API for integrating with Kubernetes. The value must be `consul.hashicorp.com/v1alpha1`.
+
+#### Values
+
+- Default: None
+- This field is required.
+- String value that must be set to `consul.hashicorp.com/v1alpha1`.
+
+### `kind`
+
+Specifies the type of configuration entry to implement. Must be set to `RouteTimeoutFilter`.
+
+#### Values
+
+- Default: None
+- This field is required.
+- Data type: String value that must be set to `RouteTimeoutFilter`.
+
+### `metadata`
+
+Map that contains an arbitrary name for the resource and the namespace it applies to.
+
+#### Values
+
+- Default: None
+- Data type: Map
+
+### `metadata.name`
+
+Specifies a name for the resource. The name is metadata that you can use to reference the resource when performing Consul operations, such as applying the resource to a specific cluster. 
+
+#### Values
+
+- Default: None
+- This field is required.
+- Data type: String
+
+### `metadata.namespace` 
+
+Specifies the namespace that the configuration applies to. Refer to [namespaces](/consul/docs/enterprise/namespaces) for more information.
+
+#### Values
+
+- Default: None
+- Data type: String
+
+### `spec`
+
+Map that contains the details about the gateway policy. The `apiVersion`, `kind`, and `metadata` fields are siblings of the `spec` field. All other configurations are children.
+
+
+### `spec.idleTimeout
+
+Specifies the total amount of time permitted for the request stream to be idle.
+
+#### Values
+
+- Default: 0
+- Data type: Integer
+
+### `spec.requestTimeout`
+
+Specifies the total amount of time in nanoseconds, including retry attempts, Consul permits for the entire downstream request to be processed.
+
+#### Values
+
+- Default: 0
+- Data type: Integer

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -750,6 +750,14 @@
                     "path": "connect/gateways/api-gateway/configuration/routes"
                   },
                   {
+                    "title": "RouteRetryFilter",
+                    "path": "connect/gateways/api-gateway/configuration/routeretryfilter"
+                  },
+                  {
+                    "title": "RouteTimeoutFilter",
+                    "path": "connect/gateways/api-gateway/configuration/routetimeoutfilter"
+                  },
+                  {
                     "title": "MeshService",
                     "path": "connect/gateways/api-gateway/configuration/meshservice"
                   }


### PR DESCRIPTION
### Description

This PR adds timeout and retry configurations to API gateway configuration references. Usage pages are out of scope.


### Links

[Draft doc](https://docs.google.com/document/d/13InnTu6k-7mM7VUFO2OqYuMSBOjimHbpLp1trd3dpo4/edit?usp=sharing)
[Jira ticket](https://hashicorp.atlassian.net/browse/CE-475)

### PR Checklist

* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
