### PR TITLE
NET-5822 - Add default outbound router in TProxy

### DIFF
--- a/agent/xdsv2/testdata/input/l4-single-implicit-destination-tproxy.golden
+++ b/agent/xdsv2/testdata/input/l4-single-implicit-destination-tproxy.golden
@@ -37,7 +37,15 @@
         ],
         "capabilities": [
           "CAPABILITY_TRANSPARENT"
-        ]
+        ],
+        "defaultRouter": {
+          "l4": {
+            "cluster": {
+              "name": "original-destination"
+            },
+            "statPrefix": "upstream.original-destination"
+          }
+        }
       }
     ],
     "clusters": {
@@ -66,18 +74,20 @@
         }
       }
     },
-  "leafCertificates": {
-    "test-identity": {
+    "leafCertificates": {
+      "test-identity": {
         "cert": "cert1",
         "key": "key1"
-    }
-  },
-  "trustBundles": {
-    "local": {
+      }
+    },
+    "trustBundles": {
+      "local": {
         "trustDomain": "foo.consul",
-        "roots": ["root1"]
+        "roots": [
+          "root1"
+        ]
+      }
     }
-  }
   },
   "requiredEndpoints": {
     "api-1.default.dc1.internal.foo.consul": {

--- a/agent/xdsv2/testdata/output/listeners/l4-single-implicit-destination-tproxy.golden
+++ b/agent/xdsv2/testdata/output/listeners/l4-single-implicit-destination-tproxy.golden
@@ -10,6 +10,18 @@
           "portValue":  15001
         }
       },
+      "defaultFilterChain": {
+        "filters": [
+          {
+            "name": "envoy.filters.network.tcp_proxy",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+              "cluster": "original-destination",
+              "statPrefix": "upstream.original-destination"
+            }
+          }
+        ]
+      },
       "filterChains":  [
         {
           "filterChainMatch":  {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destination_builder.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destination_builder.go
@@ -5,6 +5,7 @@ package builder
 
 import (
 	"fmt"
+	"github.com/hashicorp/consul/agent/xds/naming"
 	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -27,6 +28,8 @@ func (b *Builder) BuildDestinations(destinations []*intermediate.Destination) *B
 	var lb *ListenerBuilder
 	if b.proxyCfg.IsTransparentProxy() {
 		lb = b.addTransparentProxyOutboundListener(b.proxyCfg.DynamicConfig.TransparentProxy.OutboundListenerPort)
+		lb.listener.DefaultRouter = lb.addL4RouterForDirect(naming.OriginalDestinationClusterName, fmt.Sprintf("upstream.%s", naming.OriginalDestinationClusterName)).router
+		b.addL4ClusterForDirect(naming.OriginalDestinationClusterName)
 	}
 
 	for _, destination := range destinations {
@@ -370,6 +373,26 @@ func (b *ListenerBuilder) addL4RouterForDirect(clusterName, statPrefix string) *
 	}
 
 	return b.NewRouterBuilder(router)
+}
+
+func (b *Builder) addL4ClusterForDirect(clusterName string) *Builder {
+	cluster := &pbproxystate.Cluster{
+		Name: clusterName,
+		Group: &pbproxystate.Cluster_EndpointGroup{
+			EndpointGroup: &pbproxystate.EndpointGroup{
+				Group: &pbproxystate.EndpointGroup_Passthrough{
+					Passthrough: &pbproxystate.PassthroughEndpointGroup{
+						Config: &pbproxystate.PassthroughEndpointGroupConfig{
+							ConnectTimeout: durationpb.New(10 * time.Second),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b.proxyStateTemplate.ProxyState.Clusters[cluster.Name] = cluster
+	return b
 }
 
 func (b *ListenerBuilder) addL4RouterForSplit(

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destination_builder.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destination_builder.go
@@ -383,7 +383,7 @@ func (b *Builder) addL4ClusterForDirect(clusterName string) *Builder {
 				Group: &pbproxystate.EndpointGroup_Passthrough{
 					Passthrough: &pbproxystate.PassthroughEndpointGroup{
 						Config: &pbproxystate.PassthroughEndpointGroupConfig{
-							ConnectTimeout: durationpb.New(10 * time.Second),
+							ConnectTimeout: durationpb.New(5 * time.Second),
 						},
 					},
 				},

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-implicit-and-explicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-implicit-and-explicit-destinations-tproxy.golden
@@ -1,6 +1,16 @@
 {
   "proxyState": {
     "clusters": {
+      "original-destination": {
+        "endpointGroup": {
+          "passthrough": {
+            "config": {
+              "connectTimeout": "10s"
+            }
+          }
+        },
+        "name": "original-destination"
+      },
       "tcp.api-1.default.dc1.internal.foo.consul": {
         "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
         "endpointGroup": {
@@ -87,6 +97,14 @@
         "capabilities": [
           "CAPABILITY_TRANSPARENT"
         ],
+        "defaultRouter": {
+          "l4": {
+            "cluster": {
+              "name": "original-destination"
+            },
+            "statPrefix": "upstream.original-destination"
+          }
+        },
         "direction": "DIRECTION_OUTBOUND",
         "hostPort": {
           "host": "127.0.0.1",

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-implicit-and-explicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-implicit-and-explicit-destinations-tproxy.golden
@@ -5,7 +5,7 @@
         "endpointGroup": {
           "passthrough": {
             "config": {
-              "connectTimeout": "10s"
+              "connectTimeout": "5s"
             }
           }
         },

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-multiple-implicit-destinations-tproxy.golden
@@ -1,6 +1,16 @@
 {
   "proxyState": {
     "clusters": {
+      "original-destination": {
+        "endpointGroup": {
+          "passthrough": {
+            "config": {
+              "connectTimeout": "10s"
+            }
+          }
+        },
+        "name": "original-destination"
+      },
       "tcp.api-1.default.dc1.internal.foo.consul": {
         "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
         "endpointGroup": {
@@ -69,6 +79,14 @@
         "capabilities": [
           "CAPABILITY_TRANSPARENT"
         ],
+        "defaultRouter": {
+          "l4": {
+            "cluster": {
+              "name": "original-destination"
+            },
+            "statPrefix": "upstream.original-destination"
+          }
+        },
         "direction": "DIRECTION_OUTBOUND",
         "hostPort": {
           "host": "127.0.0.1",

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-multiple-implicit-destinations-tproxy.golden
@@ -5,7 +5,7 @@
         "endpointGroup": {
           "passthrough": {
             "config": {
-              "connectTimeout": "10s"
+              "connectTimeout": "5s"
             }
           }
         },

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-single-implicit-destination-tproxy.golden
@@ -1,6 +1,16 @@
 {
   "proxyState": {
     "clusters": {
+      "original-destination": {
+        "endpointGroup": {
+          "passthrough": {
+            "config": {
+              "connectTimeout": "10s"
+            }
+          }
+        },
+        "name": "original-destination"
+      },
       "tcp.api-1.default.dc1.internal.foo.consul": {
         "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
         "endpointGroup": {
@@ -42,6 +52,14 @@
         "capabilities": [
           "CAPABILITY_TRANSPARENT"
         ],
+        "defaultRouter": {
+          "l4": {
+            "cluster": {
+              "name": "original-destination"
+            },
+            "statPrefix": "upstream.original-destination"
+          }
+        },
         "direction": "DIRECTION_OUTBOUND",
         "hostPort": {
           "host": "127.0.0.1",

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/l4-single-implicit-destination-tproxy.golden
@@ -5,7 +5,7 @@
         "endpointGroup": {
           "passthrough": {
             "config": {
-              "connectTimeout": "10s"
+              "connectTimeout": "5s"
             }
           }
         },

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-multiple-implicit-destinations-tproxy.golden
@@ -1,6 +1,16 @@
 {
   "proxyState": {
     "clusters": {
+      "original-destination": {
+        "endpointGroup": {
+          "passthrough": {
+            "config": {
+              "connectTimeout": "10s"
+            }
+          }
+        },
+        "name": "original-destination"
+      },
       "http.api-app.default.dc1.internal.foo.consul": {
         "altStatName": "http.api-app.default.dc1.internal.foo.consul",
         "endpointGroup": {
@@ -177,6 +187,14 @@
         "capabilities": [
           "CAPABILITY_TRANSPARENT"
         ],
+        "defaultRouter": {
+          "l4": {
+            "cluster": {
+              "name": "original-destination"
+            },
+            "statPrefix": "upstream.original-destination"
+          }
+        },
         "direction": "DIRECTION_OUTBOUND",
         "hostPort": {
           "host": "127.0.0.1",

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-multiple-implicit-destinations-tproxy.golden
@@ -5,7 +5,7 @@
         "endpointGroup": {
           "passthrough": {
             "config": {
-              "connectTimeout": "10s"
+              "connectTimeout": "5s"
             }
           }
         },

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-tproxy.golden
@@ -1,6 +1,16 @@
 {
   "proxyState": {
     "clusters": {
+      "original-destination": {
+        "endpointGroup": {
+          "passthrough": {
+            "config": {
+              "connectTimeout": "10s"
+            }
+          }
+        },
+        "name": "original-destination"
+      },
       "http.api-app.default.dc1.internal.foo.consul": {
         "altStatName": "http.api-app.default.dc1.internal.foo.consul",
         "endpointGroup": {
@@ -96,6 +106,14 @@
         "capabilities": [
           "CAPABILITY_TRANSPARENT"
         ],
+        "defaultRouter": {
+          "l4": {
+            "cluster": {
+              "name": "original-destination"
+            },
+            "statPrefix": "upstream.original-destination"
+          }
+        },
         "direction": "DIRECTION_OUTBOUND",
         "hostPort": {
           "host": "127.0.0.1",

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-tproxy.golden
@@ -5,7 +5,7 @@
         "endpointGroup": {
           "passthrough": {
             "config": {
-              "connectTimeout": "10s"
+              "connectTimeout": "5s"
             }
           }
         },

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-with-multiple-workloads-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-with-multiple-workloads-tproxy.golden
@@ -1,6 +1,16 @@
 {
   "proxyState": {
     "clusters": {
+      "original-destination": {
+        "endpointGroup": {
+          "passthrough": {
+            "config": {
+              "connectTimeout": "10s"
+            }
+          }
+        },
+        "name": "original-destination"
+      },
       "http.api-app.default.dc1.internal.foo.consul": {
         "altStatName": "http.api-app.default.dc1.internal.foo.consul",
         "endpointGroup": {
@@ -96,6 +106,14 @@
         "capabilities": [
           "CAPABILITY_TRANSPARENT"
         ],
+        "defaultRouter": {
+          "l4": {
+            "cluster": {
+              "name": "original-destination"
+            },
+            "statPrefix": "upstream.original-destination"
+          }
+        },
         "direction": "DIRECTION_OUTBOUND",
         "hostPort": {
           "host": "127.0.0.1",

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-with-multiple-workloads-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-single-implicit-destination-with-multiple-workloads-tproxy.golden
@@ -5,7 +5,7 @@
         "endpointGroup": {
           "passthrough": {
             "config": {
-              "connectTimeout": "10s"
+              "connectTimeout": "5s"
             }
           }
         },


### PR DESCRIPTION
### Description

The tproxy destination builder code does not create this blurb: https://github.com/hashicorp/consul/blob/main/agent/xds/listeners.go#L551 to add the catch-all outbound filter chain to let you send traffic outside of the cluster (i.e. [google.com](http://google.com/)). In effect we’ve inlined MeshDestinationsOnly = true.

We should allow outbound traffic to work.

### Testing & Reproduction steps
Manually verfied in consul-k8s by:
- configuring Tproxy
- using image from this branch
- deploying web and api services per the multiport docs
- execing into web and curling google.com and getting the below response:
<img width="1039" alt="Screenshot 2023-10-10 at 3 54 13 PM" src="https://github.com/hashicorp/consul/assets/2481360/d02e2009-892a-47e2-b440-b5dd7917f8cf">



### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
