### PR TITLE
Make raft-wal default when `resource-apis` is active

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1414,7 +1414,7 @@ func (b *builder) validate(rt RuntimeConfig) error {
 
 		// Raft LogStore validation
 		if rt.RaftLogStoreConfig.Backend != consul.LogStoreBackendBoltDB &&
-			rt.RaftLogStoreConfig.Backend != consul.LogStoreBackendWAL {
+			rt.RaftLogStoreConfig.Backend != consul.LogStoreBackendWAL && rt.RaftLogStoreConfig.Backend != consul.LogStoreBackendDefault {
 			return fmt.Errorf("raft_logstore.backend must be one of '%s' or '%s'",
 				consul.LogStoreBackendBoltDB, consul.LogStoreBackendWAL)
 		}
@@ -2782,7 +2782,7 @@ func (b *builder) parsePrefixFilter(telemetry *Telemetry) ([]string, []string) {
 func (b *builder) raftLogStoreConfigVal(raw *RaftLogStoreRaw) consul.RaftLogStoreConfig {
 	var cfg consul.RaftLogStoreConfig
 	if raw != nil {
-		cfg.Backend = stringValWithDefault(raw.Backend, consul.LogStoreBackendBoltDB)
+		cfg.Backend = stringValWithDefault(raw.Backend, consul.LogStoreBackendDefault)
 		cfg.DisableLogCache = boolVal(raw.DisableLogCache)
 
 		cfg.Verification.Enabled = boolVal(raw.Verification.Enabled)

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -145,7 +145,6 @@ func DefaultSource() Source {
 		raft_snapshot_interval =  "` + cfg.RaftConfig.SnapshotInterval.String() + `"
 		raft_trailing_logs = ` + strconv.Itoa(int(cfg.RaftConfig.TrailingLogs)) + `
 		raft_logstore {
-			backend = "boltdb"
 			wal {
 				segment_size_mb = 64
 			}

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -6010,8 +6010,26 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		hcl:  []string{``},
 		expected: func(rt *RuntimeConfig) {
 			rt.DataDir = dataDir
-			rt.RaftLogStoreConfig.Backend = consul.LogStoreBackendBoltDB
+			rt.RaftLogStoreConfig.Backend = consul.LogStoreBackendDefault
 			rt.RaftLogStoreConfig.WAL.SegmentSize = 64 * 1024 * 1024
+		},
+	})
+	run(t, testCase{
+		desc: "logstore defaults",
+		args: []string{
+			`-data-dir=` + dataDir,
+		},
+		json: []string{`
+			{
+				"experiments": ["resource-apis"]
+			}	
+		`},
+		hcl: []string{`experiments=["resource-apis"]`},
+		expected: func(rt *RuntimeConfig) {
+			rt.DataDir = dataDir
+			rt.RaftLogStoreConfig.Backend = consul.LogStoreBackendDefault
+			rt.RaftLogStoreConfig.WAL.SegmentSize = 64 * 1024 * 1024
+			rt.Experiments = []string{"resource-apis"}
 		},
 	})
 	run(t, testCase{

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -40,8 +40,9 @@ const (
 
 	// LogStoreBackend* are well-known string values used to configure different
 	// log store backends.
-	LogStoreBackendBoltDB = "boltdb"
-	LogStoreBackendWAL    = "wal"
+	LogStoreBackendDefault = "default"
+	LogStoreBackendBoltDB  = "boltdb"
+	LogStoreBackendWAL     = "wal"
 )
 
 var (

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -691,7 +691,7 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 	}
 
 	// Initialize the Raft server.
-	if err := s.setupRaft(); err != nil {
+	if err := s.setupRaft(stringslice.Contains(flat.Experiments, CatalogResourceExperimentName)); err != nil {
 		s.Shutdown()
 		return nil, fmt.Errorf("Failed to start Raft: %v", err)
 	}
@@ -1032,7 +1032,7 @@ func (s *Server) connectCARootsMonitor(ctx context.Context) {
 }
 
 // setupRaft is used to setup and initialize Raft
-func (s *Server) setupRaft() error {
+func (s *Server) setupRaft(isCatalogResourceExperiment bool) error {
 	// If we have an unclean exit then attempt to close the Raft store.
 	defer func() {
 		if s.raft == nil && s.raftStore != nil {
@@ -1091,8 +1091,7 @@ func (s *Server) setupRaft() error {
 			return fmt.Errorf("failed trying to see if raft.db exists not sure how to continue: %w", err)
 		}
 
-		// Only use WAL if there is no existing raft.db, even if it's enabled.
-		if s.config.LogStoreConfig.Backend == LogStoreBackendWAL && !boltFileExists {
+		initWAL := func() error {
 			walDir := filepath.Join(path, "wal")
 			if err := os.MkdirAll(walDir, 0755); err != nil {
 				return err
@@ -1111,13 +1110,25 @@ func (s *Server) setupRaft() error {
 			s.raftStore = wal
 			log = wal
 			stable = wal
+			return nil
+		}
+		// Only use WAL if there is no existing raft.db, even if it's enabled.
+		if s.config.LogStoreConfig.Backend == LogStoreBackendDefault && !boltFileExists && isCatalogResourceExperiment {
+			s.config.LogStoreConfig.Backend = LogStoreBackendWAL
+			if err = initWAL(); err != nil {
+				return err
+			}
+		} else if s.config.LogStoreConfig.Backend == LogStoreBackendWAL && !boltFileExists {
+			if err = initWAL(); err != nil {
+				return err
+			}
 		} else {
 			if s.config.LogStoreConfig.Backend == LogStoreBackendWAL {
 				// User configured the new storage, but still has old raft.db. Warn
 				// them!
 				s.logger.Warn("BoltDB file raft.db found, IGNORING raft_logstore.backend which is set to 'wal'")
 			}
-
+			s.config.LogStoreConfig.Backend = LogStoreBackendBoltDB
 			// Create the backend raft store for logs and stable storage.
 			store, err := raftboltdb.New(raftboltdb.Options{
 				BoltOptions: &bbolt.Options{

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -381,7 +381,9 @@ func getPrometheusDefs(cfg *config.RuntimeConfig, isServer bool) ([]prometheus.G
 		gauges = append(gauges, verifierGauges)
 	}
 
-	if isServer && cfg.RaftLogStoreConfig.Backend == consul.LogStoreBackendWAL {
+	if isServer &&
+		(cfg.RaftLogStoreConfig.Backend == consul.LogStoreBackendWAL ||
+			cfg.RaftLogStoreConfig.Backend == consul.LogStoreBackendDefault) {
 
 		walGauges := make([]prometheus.GaugeDefinition, 0)
 		for _, d := range wal.MetricDefinitions.Gauges {
@@ -452,7 +454,9 @@ func getPrometheusDefs(cfg *config.RuntimeConfig, isServer bool) ([]prometheus.G
 		}
 		counters = append(counters, verifierCounters)
 	}
-	if isServer && cfg.RaftLogStoreConfig.Backend == consul.LogStoreBackendWAL {
+	if isServer &&
+		(cfg.RaftLogStoreConfig.Backend == consul.LogStoreBackendWAL ||
+			cfg.RaftLogStoreConfig.Backend == consul.LogStoreBackendDefault) {
 		walCounters := make([]prometheus.CounterDefinition, 0)
 		for _, d := range wal.MetricDefinitions.Counters {
 			walCounters = append(walCounters, prometheus.CounterDefinition{


### PR DESCRIPTION
### Description

This change the raft backend configuration behaviour as follow:

- If no backend is specified, `experiments=["resource-apis"]` is set  and no boltdb raft file is on disk the backend will be WAL
- If WAL is set and no boltdb raft file is on disk WAL is used (this is haven't changed)
- If Boltdb is set boltDB will be used (this is haven't changed)
- If a db exist on disk using boltdb it will be used (this is haven't changed)


This is still missing the doc part that need to be added, I'm not sure if we add it right away or need to wait for the release.

### Testing & Reproduction steps
Added config tests and manually tested that all the combinations above work as expected.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
