### PR TITLE
testing/deployer: support tproxy in v2 for dataplane

### DIFF
--- a/test-integ/catalogv2/helpers_test.go
+++ b/test-integ/catalogv2/helpers_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package catalogv2
+
+import (
+	"strings"
+
+	"github.com/hashicorp/consul/testing/deployer/topology"
+)
+
+func clusterPrefixForUpstream(u *topology.Upstream) string {
+	if u.Peer == "" {
+		if u.ID.PartitionOrDefault() == "default" {
+			return strings.Join([]string{u.PortName, u.ID.Name, u.ID.Namespace, u.Cluster, "internal"}, ".")
+		} else {
+			return strings.Join([]string{u.PortName, u.ID.Name, u.ID.Namespace, u.ID.Partition, u.Cluster, "internal-v1"}, ".")
+		}
+	} else {
+		return strings.Join([]string{u.ID.Name, u.ID.Namespace, u.Peer, "external"}, ".")
+	}
+}

--- a/test-integ/peering_commontopo/ac3_service_defaults_upstream_test.go
+++ b/test-integ/peering_commontopo/ac3_service_defaults_upstream_test.go
@@ -11,14 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
 	"github.com/hashicorp/consul/testing/deployer/topology"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/itchyny/gojq"
 	"github.com/stretchr/testify/require"
-
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
-	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
 )
 
 var ac3SvcDefaultsSuites []sharedTopoSuite = []sharedTopoSuite{
@@ -185,7 +184,7 @@ func (s *ac3SvcDefaultsSuite) test(t *testing.T, ct *commonTopo) {
 	// TODO: what is default? namespace? partition?
 	clusterName := fmt.Sprintf("%s.default.%s.external", s.upstream.ID.Name, s.upstream.Peer)
 	nonceStatus := http.StatusInsufficientStorage
-	url507 := fmt.Sprintf("http://localhost:%d/fortio/fetch2?url=%s", svcClient.ExposedPort,
+	url507 := fmt.Sprintf("http://localhost:%d/fortio/fetch2?url=%s", svcClient.ExposedPort(""),
 		url.QueryEscape(fmt.Sprintf("http://localhost:%d/?status=%d", s.upstream.LocalPort, nonceStatus)),
 	)
 
@@ -221,7 +220,7 @@ func (s *ac3SvcDefaultsSuite) test(t *testing.T, ct *commonTopo) {
 		require.True(r, resultAsBool)
 	})
 
-	url200 := fmt.Sprintf("http://localhost:%d/fortio/fetch2?url=%s", svcClient.ExposedPort,
+	url200 := fmt.Sprintf("http://localhost:%d/fortio/fetch2?url=%s", svcClient.ExposedPort(""),
 		url.QueryEscape(fmt.Sprintf("http://localhost:%d/", s.upstream.LocalPort)),
 	)
 	retry.RunWith(&retry.Timer{Timeout: time.Minute * 1, Wait: time.Millisecond * 500}, t, func(r *retry.R) {

--- a/test-integ/peering_commontopo/ac4_proxy_defaults_test.go
+++ b/test-integ/peering_commontopo/ac4_proxy_defaults_test.go
@@ -180,11 +180,11 @@ func (s *ac4ProxyDefaultsSuite) test(t *testing.T, ct *commonTopo) {
 	})
 
 	t.Run("HTTP service fails due to connection timeout", func(t *testing.T) {
-		url504 := fmt.Sprintf("http://localhost:%d/fortio/fetch2?url=%s", client.ExposedPort,
+		url504 := fmt.Sprintf("http://localhost:%d/fortio/fetch2?url=%s", client.ExposedPort(""),
 			url.QueryEscape(fmt.Sprintf("http://localhost:%d/?delay=1000ms", s.upstream.LocalPort)),
 		)
 
-		url200 := fmt.Sprintf("http://localhost:%d/fortio/fetch2?url=%s", client.ExposedPort,
+		url200 := fmt.Sprintf("http://localhost:%d/fortio/fetch2?url=%s", client.ExposedPort(""),
 			url.QueryEscape(fmt.Sprintf("http://localhost:%d/", s.upstream.LocalPort)),
 		)
 

--- a/test-integ/topoutil/asserter.go
+++ b/test-integ/topoutil/asserter.go
@@ -234,10 +234,21 @@ func (a *Asserter) fortioFetch2Upstream(
 ) (body []byte, res *http.Response) {
 	t.Helper()
 
-	// TODO: fortioSvc.ID.Normalize()? or should that be up to the caller?
+	var actualURL string
+	if upstream.Implied {
+		actualURL = fmt.Sprintf("http://%s--%s--%s.virtual.consul:%d/%s",
+			upstream.ID.Name,
+			upstream.ID.Namespace,
+			upstream.ID.Partition,
+			upstream.VirtualPort,
+			path,
+		)
+	} else {
+		actualURL = fmt.Sprintf("http://localhost:%d/%s", upstream.LocalPort, path)
+	}
 
 	url := fmt.Sprintf("http://%s/fortio/fetch2?url=%s", addr,
-		url.QueryEscape(fmt.Sprintf("http://localhost:%d/%s", upstream.LocalPort, path)),
+		url.QueryEscape(actualURL),
 	)
 
 	req, err := http.NewRequest(http.MethodPost, url, nil)
@@ -246,6 +257,7 @@ func (a *Asserter) fortioFetch2Upstream(
 	res, err = client.Do(req)
 	require.NoError(t, err)
 	defer res.Body.Close()
+
 	// not sure when these happen, suspect it's when the mesh gateway in the peer is not yet ready
 	require.NotEqual(t, http.StatusServiceUnavailable, res.StatusCode)
 	require.NotEqual(t, http.StatusGatewayTimeout, res.StatusCode)
@@ -281,7 +293,13 @@ func (a *Asserter) FortioFetch2HeaderEcho(t *testing.T, fortioSvc *topology.Serv
 // similar to libassert.AssertFortioName,
 // uses the /fortio/fetch2 endpoint to hit the debug endpoint on the upstream,
 // and assert that the FORTIO_NAME == name
-func (a *Asserter) FortioFetch2FortioName(t *testing.T, fortioSvc *topology.Service, upstream *topology.Upstream, clusterName string, sid topology.ServiceID) {
+func (a *Asserter) FortioFetch2FortioName(
+	t *testing.T,
+	fortioSvc *topology.Service,
+	upstream *topology.Upstream,
+	clusterName string,
+	sid topology.ServiceID,
+) {
 	t.Helper()
 
 	var (
@@ -295,6 +313,7 @@ func (a *Asserter) FortioFetch2FortioName(t *testing.T, fortioSvc *topology.Serv
 
 	retry.RunWith(&retry.Timer{Timeout: 60 * time.Second, Wait: time.Millisecond * 500}, t, func(r *retry.R) {
 		body, res := a.fortioFetch2Upstream(r, client, addr, upstream, path)
+
 		require.Equal(r, http.StatusOK, res.StatusCode)
 
 		// TODO: not sure we should retry these?

--- a/test-integ/topoutil/fixtures.go
+++ b/test-integ/topoutil/fixtures.go
@@ -41,10 +41,14 @@ func NewFortioServiceWithDefaults(
 	}
 
 	if nodeVersion == topology.NodeVersionV2 {
-		svc.Ports = map[string]int{
-			"http":     httpPort,
-			"http-alt": httpPort,
-			"grpc":     grpcPort,
+		svc.Ports = map[string]*topology.Port{
+			// TODO(rb/v2): once L7 works in v2 switch these back
+			"http":     {Number: httpPort, Protocol: "tcp"},
+			"http-alt": {Number: httpPort, Protocol: "tcp"},
+			"grpc":     {Number: grpcPort, Protocol: "tcp"},
+			// "http":     {Number: httpPort, Protocol: "http"},
+			// "http-alt": {Number: httpPort, Protocol: "http"},
+			// "grpc":     {Number: grpcPort, Protocol: "grpc"},
 		}
 	} else {
 		svc.Port = httpPort

--- a/test/integration/consul-container/libs/assert/envoy.go
+++ b/test/integration/consul-container/libs/assert/envoy.go
@@ -118,7 +118,7 @@ func AssertUpstreamEndpointStatusWithClient(
 			clusterName, healthStatus)
 		results, err := utils.JQFilter(clusters, filter)
 		require.NoErrorf(r, err, "could not find cluster name %q: %v \n%s", clusterName, err, clusters)
-		require.Len(r, results, 1) // the final part of the pipeline is "length" which only ever returns 1 result
+		require.Len(r, results, 1, "clusters: "+clusters) // the final part of the pipeline is "length" which only ever returns 1 result
 
 		result, err := strconv.Atoi(results[0])
 		assert.NoError(r, err)

--- a/test/integration/consul-container/libs/assert/service.go
+++ b/test/integration/consul-container/libs/assert/service.go
@@ -63,7 +63,6 @@ func CatalogV2ServiceDoesNotExist(t *testing.T, client pbresource.ResourceServic
 // number of workload endpoints.
 func CatalogV2ServiceHasEndpointCount(t *testing.T, client pbresource.ResourceServiceClient, svc string, tenancy *pbresource.Tenancy, count int) {
 	t.Helper()
-	require.False(t, count == 0)
 
 	ctx := testutil.TestContext(t)
 	retry.Run(t, func(r *retry.R) {

--- a/testing/deployer/sprawl/catalog.go
+++ b/testing/deployer/sprawl/catalog.go
@@ -196,8 +196,9 @@ func (s *Sprawl) registerServicesForDataplaneInstances(cluster *topology.Cluster
 			if node.IsV2() {
 				pending := serviceInstanceToResources(node, svc)
 
-				if _, ok := identityInfo[svc.ID]; !ok {
-					identityInfo[svc.ID] = pending.WorkloadIdentity
+				workloadID := topology.NewServiceID(svc.WorkloadIdentity, svc.ID.Namespace, svc.ID.Partition)
+				if _, ok := identityInfo[workloadID]; !ok {
+					identityInfo[workloadID] = pending.WorkloadIdentity
 				}
 
 				// Write workload
@@ -545,15 +546,13 @@ func serviceInstanceToResources(
 				},
 			},
 		}
-
-		worloadIdentityRes = &Resource[*pbauth.WorkloadIdentity]{
+		workloadIdentityRes = &Resource[*pbauth.WorkloadIdentity]{
 			Resource: &pbresource.Resource{
 				Id: &pbresource.ID{
 					Type:    pbauth.WorkloadIdentityType,
-					Name:    svc.ID.Name,
+					Name:    svc.WorkloadIdentity,
 					Tenancy: tenancy,
 				},
-				Metadata: svc.Meta,
 			},
 			Data: &pbauth.WorkloadIdentity{},
 		}
@@ -646,7 +645,7 @@ func serviceInstanceToResources(
 		Workload:           workloadRes,
 		HealthStatuses:     healthResList,
 		Destinations:       destinationsRes,
-		WorkloadIdentity:   worloadIdentityRes,
+		WorkloadIdentity:   workloadIdentityRes,
 		ProxyConfiguration: proxyConfigRes,
 	}
 }

--- a/testing/deployer/sprawl/catalog.go
+++ b/testing/deployer/sprawl/catalog.go
@@ -230,6 +230,15 @@ func (s *Sprawl) registerServicesForDataplaneInstances(cluster *topology.Cluster
 						return err
 					}
 				}
+				if pending.ProxyConfiguration != nil {
+					res, err := pending.ProxyConfiguration.Build()
+					if err != nil {
+						return fmt.Errorf("error serializing resource %s: %w", util.IDToString(pending.ProxyConfiguration.Resource.Id), err)
+					}
+					if _, err := s.writeResource(cluster, res); err != nil {
+						return err
+					}
+				}
 			} else {
 				if err := s.registerCatalogServiceV1(cluster, node, svc); err != nil {
 					return fmt.Errorf("error registering service: %w", err)
@@ -268,6 +277,7 @@ func (s *Sprawl) registerServicesForDataplaneInstances(cluster *topology.Cluster
 				},
 				Data: svcData,
 			}
+
 			res, err := svcInfo.Build()
 			if err != nil {
 				return fmt.Errorf("error serializing resource %s: %w", util.IDToString(svcInfo.Resource.Id), err)
@@ -482,10 +492,11 @@ func (r *Resource[V]) Build() (*pbresource.Resource, error) {
 }
 
 type ServiceResources struct {
-	Workload         *Resource[*pbcatalog.Workload]
-	HealthStatuses   []*Resource[*pbcatalog.HealthStatus]
-	Destinations     *Resource[*pbmesh.Destinations]
-	WorkloadIdentity *Resource[*pbauth.WorkloadIdentity]
+	Workload           *Resource[*pbcatalog.Workload]
+	HealthStatuses     []*Resource[*pbcatalog.HealthStatus]
+	Destinations       *Resource[*pbmesh.Destinations]
+	WorkloadIdentity   *Resource[*pbauth.WorkloadIdentity]
+	ProxyConfiguration *Resource[*pbmesh.ProxyConfiguration]
 }
 
 func serviceInstanceToResources(
@@ -506,8 +517,8 @@ func serviceInstanceToResources(
 	)
 	for name, port := range svc.Ports {
 		wlPorts[name] = &pbcatalog.WorkloadPort{
-			Port:     uint32(port),
-			Protocol: pbcatalog.Protocol_PROTOCOL_TCP,
+			Port:     uint32(port.Number),
+			Protocol: port.ActualProtocol,
 		}
 	}
 
@@ -549,6 +560,7 @@ func serviceInstanceToResources(
 
 		healthResList   []*Resource[*pbcatalog.HealthStatus]
 		destinationsRes *Resource[*pbmesh.Destinations]
+		proxyConfigRes  *Resource[*pbmesh.ProxyConfiguration]
 	)
 
 	if svc.HasCheck() {
@@ -577,11 +589,6 @@ func serviceInstanceToResources(
 	}
 
 	if !svc.DisableServiceMesh {
-		workloadRes.Data.Ports["mesh"] = &pbcatalog.WorkloadPort{
-			Port:     uint32(svc.EnvoyPublicListenerPort),
-			Protocol: pbcatalog.Protocol_PROTOCOL_MESH,
-		}
-
 		destinationsRes = &Resource[*pbmesh.Destinations]{
 			Resource: &pbresource.Resource{
 				Id: &pbresource.ID{
@@ -615,13 +622,32 @@ func serviceInstanceToResources(
 			}
 			destinationsRes.Data.Destinations = append(destinationsRes.Data.Destinations, dest)
 		}
+
+		if svc.EnableTransparentProxy {
+			proxyConfigRes = &Resource[*pbmesh.ProxyConfiguration]{
+				Resource: &pbresource.Resource{
+					Id: &pbresource.ID{
+						Type:    pbmesh.ProxyConfigurationType,
+						Name:    svc.Workload,
+						Tenancy: tenancy,
+					},
+				},
+				Data: &pbmesh.ProxyConfiguration{
+					Workloads: selector,
+					DynamicConfig: &pbmesh.DynamicConfig{
+						Mode: pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT,
+					},
+				},
+			}
+		}
 	}
 
 	return &ServiceResources{
-		Workload:         workloadRes,
-		HealthStatuses:   healthResList,
-		Destinations:     destinationsRes,
-		WorkloadIdentity: worloadIdentityRes,
+		Workload:           workloadRes,
+		HealthStatuses:     healthResList,
+		Destinations:       destinationsRes,
+		WorkloadIdentity:   worloadIdentityRes,
+		ProxyConfiguration: proxyConfigRes,
 	}
 }
 

--- a/testing/deployer/sprawl/details.go
+++ b/testing/deployer/sprawl/details.go
@@ -72,7 +72,7 @@ func (s *Sprawl) PrintDetails() error {
 				} else {
 					ports := make(map[string]int)
 					for name, port := range svc.Ports {
-						ports[name] = node.ExposedPort(port)
+						ports[name] = node.ExposedPort(port.Number)
 					}
 					cd.Apps = append(cd.Apps, appDetail{
 						Type:                  "app",

--- a/testing/deployer/sprawl/internal/build/docker.go
+++ b/testing/deployer/sprawl/internal/build/docker.go
@@ -35,6 +35,64 @@ USER 100:0
 ENTRYPOINT []
 `
 
+const dockerfileDataplaneForTProxy = `
+ARG DATAPLANE_IMAGE
+ARG CONSUL_IMAGE
+FROM ${CONSUL_IMAGE} AS consul
+FROM ${DATAPLANE_IMAGE} AS distroless
+FROM debian:bullseye-slim
+
+# undo the distroless aspect
+COPY --from=distroless /usr/local/bin/discover /usr/local/bin/
+COPY --from=distroless /usr/local/bin/envoy /usr/local/bin/
+COPY --from=distroless /usr/local/bin/consul-dataplane /usr/local/bin/
+COPY --from=distroless /licenses/copyright.txt /licenses/
+
+COPY --from=consul /bin/consul /bin/
+
+# Install iptables and sudo, needed for tproxy.
+RUN apt update -y \
+	&& apt install -y iptables sudo curl dnsutils
+
+RUN sed '/_apt/d' /etc/passwd > /etc/passwd.new \
+    && mv -f /etc/passwd.new /etc/passwd \
+    && adduser --uid=100 consul --no-create-home --disabled-password --system \
+	&& adduser consul sudo \
+	&& echo 'consul ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+COPY <<'EOF' /bin/tproxy-startup.sh
+#!/bin/sh
+
+set -ex
+
+# HACK: UID of consul in the consul-client container
+# This is conveniently also the UID of apt in the envoy container
+CONSUL_UID=100
+ENVOY_UID=$(id -u)
+
+# - We allow 19000 so that the test can directly visit the envoy admin page.
+# - We allow 20000 so that envoy can receive mTLS traffic from other nodes.
+# - We (reluctantly) allow 8080 so that we can bypass envoy and talk to fortio
+#   to do test assertions.
+sudo consul connect redirect-traffic \
+    -proxy-uid $ENVOY_UID \
+    -exclude-uid $CONSUL_UID \
+	-proxy-inbound-port=15001 \
+	-exclude-inbound-port=19000 \
+	-exclude-inbound-port=20000 \
+	-exclude-inbound-port=8080
+exec "$@"
+EOF
+
+RUN chmod +x /bin/tproxy-startup.sh \
+	&& chown 100:0 /bin/tproxy-startup.sh
+
+RUN echo 'consul ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER 100:0
+ENTRYPOINT []
+`
+
 func DockerImages(
 	logger hclog.Logger,
 	run *runner.Runner,
@@ -79,6 +137,25 @@ func DockerImages(
 				}
 
 				built[cdp] = struct{}{}
+			}
+
+			cdpTproxy := n.Images.LocalDataplaneTProxyImage()
+			if _, ok := built[cdpTproxy]; cdpTproxy != "" && !ok {
+				logger.Info("building image", "image", cdpTproxy)
+				err := run.DockerExec(context.TODO(), []string{
+					"build",
+					"--build-arg",
+					"DATAPLANE_IMAGE=" + n.Images.Dataplane,
+					"--build-arg",
+					"CONSUL_IMAGE=" + n.Images.Consul,
+					"-t", cdpTproxy,
+					"-",
+				}, logw, strings.NewReader(dockerfileDataplaneForTProxy))
+				if err != nil {
+					return err
+				}
+
+				built[cdpTproxy] = struct{}{}
 			}
 		}
 	}

--- a/testing/deployer/sprawl/internal/tfgen/dns.go
+++ b/testing/deployer/sprawl/internal/tfgen/dns.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+
+	"golang.org/x/exp/maps"
 
 	"github.com/hashicorp/consul/testing/deployer/topology"
 	"github.com/hashicorp/consul/testing/deployer/util"
@@ -63,17 +66,36 @@ func (g *Generator) writeCoreDNSFiles(net *topology.Network, dnsIPAddress string
 			}
 		}
 
+		// Until Consul DNS understands v2, simulate it.
+		//
+		// NOTE: this DNS is not quite what consul normally does. It's simpler
+		// to simulate this format here.
+		virtualNames := make(map[string][]string)
+		for id, svcData := range cluster.Services {
+			if len(svcData.VirtualIps) == 0 {
+				continue
+			}
+			vips := svcData.VirtualIps
+
+			// <service>--<namespace>--<partition>.virtual.<domain>
+			name := fmt.Sprintf("%s--%s--%s", id.Name, id.Namespace, id.Partition)
+			virtualNames[name] = vips
+		}
+
 		var (
 			clusterDNSName = cluster.Name + "-consulcluster.lan"
-		)
+			virtualDNSName = "virtual.consul"
 
-		corefilePath := filepath.Join(rootdir, "Corefile")
-		zonefilePath := filepath.Join(rootdir, "servers")
+			corefilePath        = filepath.Join(rootdir, "Corefile")
+			zonefilePath        = filepath.Join(rootdir, "servers")
+			virtualZonefilePath = filepath.Join(rootdir, "virtual")
+		)
 
 		_, err := UpdateFileIfDifferent(
 			g.logger,
 			generateCoreDNSConfigFile(
 				clusterDNSName,
+				virtualDNSName,
 				addrs,
 			),
 			corefilePath,
@@ -105,7 +127,25 @@ func (g *Generator) writeCoreDNSFiles(net *topology.Network, dnsIPAddress string
 			return false, nil, fmt.Errorf("error hashing %q: %w", zonefilePath, err)
 		}
 
-		return true, []string{corefileHash, zonefileHash}, nil
+		_, err = UpdateFileIfDifferent(
+			g.logger,
+			generateCoreDNSVirtualZoneFile(
+				dnsIPAddress,
+				virtualDNSName,
+				virtualNames,
+			),
+			virtualZonefilePath,
+			0644,
+		)
+		if err != nil {
+			return false, nil, fmt.Errorf("error writing %q: %w", virtualZonefilePath, err)
+		}
+		virtualZonefileHash, err := util.HashFile(virtualZonefilePath)
+		if err != nil {
+			return false, nil, fmt.Errorf("error hashing %q: %w", virtualZonefilePath, err)
+		}
+
+		return true, []string{corefileHash, zonefileHash, virtualZonefileHash}, nil
 	}
 
 	return false, nil, nil
@@ -113,6 +153,7 @@ func (g *Generator) writeCoreDNSFiles(net *topology.Network, dnsIPAddress string
 
 func generateCoreDNSConfigFile(
 	clusterDNSName string,
+	virtualDNSName string,
 	addrs []string,
 ) []byte {
 	serverPart := ""
@@ -139,7 +180,14 @@ consul:53 {
   whoami
 }
 
-%[2]s
+%[2]s:53 {
+  file /config/virtual %[2]s
+  log
+  errors
+  whoami
+}
+
+%[3]s
 
 .:53 {
   forward . 8.8.8.8:53
@@ -147,7 +195,7 @@ consul:53 {
   errors
   whoami
 }
-`, clusterDNSName, serverPart))
+`, clusterDNSName, virtualDNSName, serverPart))
 }
 
 func generateCoreDNSZoneFile(
@@ -174,6 +222,41 @@ ns IN A  %[2]s     ; self
 		buf.WriteString(fmt.Sprintf(`
 server IN A %s ; Consul server
 `, addr))
+	}
+
+	return buf.Bytes()
+}
+
+func generateCoreDNSVirtualZoneFile(
+	dnsIPAddress string,
+	virtualDNSName string,
+	nameToAddr map[string][]string,
+) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf(`
+$TTL 60
+$ORIGIN %[1]s.
+@                   IN	SOA ns.%[1]s. webmaster.%[1]s. (
+          2017042745 ; serial
+          7200       ; refresh (2 hours)				
+          3600       ; retry (1 hour)			
+          1209600    ; expire (2 weeks)				
+          3600       ; minimum (1 hour)				
+          )
+@  IN NS ns.%[1]s. ; Name server
+ns IN A  %[2]s     ; self
+`, virtualDNSName, dnsIPAddress))
+
+	names := maps.Keys(nameToAddr)
+	sort.Strings(names)
+
+	for _, name := range names {
+		vips := nameToAddr[name]
+		for _, vip := range vips {
+			buf.WriteString(fmt.Sprintf(`
+%s IN A %s ; Consul server
+`, name, vip))
+		}
 	}
 
 	return buf.Bytes()

--- a/testing/deployer/sprawl/internal/tfgen/gen.go
+++ b/testing/deployer/sprawl/internal/tfgen/gen.go
@@ -122,8 +122,10 @@ func (s Step) String() string {
 	}
 }
 
-func (s Step) StartServers() bool  { return s >= StepServers }
-func (s Step) StartAgents() bool   { return s >= StepAgents }
+func (s Step) StartServers() bool { return s >= StepServers }
+
+func (s Step) StartAgents() bool { return s >= StepAgents }
+
 func (s Step) StartServices() bool { return s >= StepServices }
 
 // func (s Step) InitiatePeering() bool { return s >= StepPeering }
@@ -260,6 +262,7 @@ func (g *Generator) Generate(step Step) error {
 				addImage("", node.Images.Consul)
 				addImage("", node.Images.EnvoyConsulImage())
 				addImage("", node.Images.LocalDataplaneImage())
+				addImage("", node.Images.LocalDataplaneTProxyImage())
 
 				if node.IsAgent() {
 					addVolume(node.DockerName())

--- a/testing/deployer/sprawl/internal/tfgen/nodes.go
+++ b/testing/deployer/sprawl/internal/tfgen/nodes.go
@@ -125,7 +125,11 @@ func (g *Generator) generateNodeContainers(
 			var img string
 			if node.IsDataplane() {
 				tmpl = tfAppDataplaneT
-				img = DockerImageResourceName(node.Images.LocalDataplaneImage())
+				if svc.EnableTransparentProxy {
+					img = DockerImageResourceName(node.Images.LocalDataplaneTProxyImage())
+				} else {
+					img = DockerImageResourceName(node.Images.LocalDataplaneImage())
+				}
 			} else {
 				img = DockerImageResourceName(node.Images.EnvoyConsulImage())
 			}

--- a/testing/deployer/sprawl/internal/tfgen/templates/container-app-dataplane.tf.tmpl
+++ b/testing/deployer/sprawl/internal/tfgen/templates/container-app-dataplane.tf.tmpl
@@ -17,6 +17,13 @@ resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}-sidec
     read_only      = true
   }
 
+{{ if .Service.EnableTransparentProxy }}
+  capabilities {
+    add = ["NET_ADMIN"]
+  }
+  entrypoint = [ "/bin/tproxy-startup.sh" ]
+{{ end }}
+
   env = [
     "DP_CONSUL_ADDRESSES=server.{{.Node.Cluster}}-consulcluster.lan",
 {{ if .Node.IsV2 }}
@@ -37,6 +44,10 @@ resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}-sidec
 {{ if .Token }}
     "DP_CREDENTIAL_TYPE=static",
     "DP_CREDENTIAL_STATIC_TOKEN={{.Token}}",
+{{ end }}
+
+{{ if .Service.EnableTransparentProxy }}
+    "REDIRECT_TRAFFIC_ARGS=-exclude-inbound-port=19000",
 {{ end }}
 
     // for demo purposes

--- a/testing/deployer/topology/compile.go
+++ b/testing/deployer/topology/compile.go
@@ -502,14 +502,14 @@ func compile(logger hclog.Logger, raw *Config, prev *Topology) (*Topology, error
 						}
 					}
 
-					if len(svc.WorkloadIdentities) == 0 {
-						svc.WorkloadIdentities = []string{svc.ID.Name}
+					if svc.WorkloadIdentity == "" {
+						svc.WorkloadIdentity = svc.ID.Name
 					}
 				} else {
 					if len(svc.V2Services) > 0 {
 						return nil, fmt.Errorf("cannot specify v2 services for v1")
 					}
-					if len(svc.WorkloadIdentities) > 0 {
+					if svc.WorkloadIdentity != "" {
 						return nil, fmt.Errorf("cannot specify workload identities for v1")
 					}
 				}

--- a/testing/deployer/topology/compile.go
+++ b/testing/deployer/topology/compile.go
@@ -448,7 +448,9 @@ func compile(logger hclog.Logger, raw *Config, prev *Topology) (*Topology, error
 						}
 					}
 				} else {
-					return nil, fmt.Errorf("v1 does not support implied upstreams yet")
+					if len(svc.ImpliedUpstreams) > 0 {
+						return nil, fmt.Errorf("v1 does not support implied upstreams yet")
+					}
 				}
 
 				if err := svc.Validate(); err != nil {

--- a/testing/deployer/topology/images.go
+++ b/testing/deployer/topology/images.go
@@ -38,13 +38,21 @@ func (i Images) LocalDataplaneImage() string {
 	return "local/" + name + ":" + tag
 }
 
+func (i Images) LocalDataplaneTProxyImage() string {
+	return spliceImageNamesAndTags(i.Dataplane, i.Consul, "tproxy")
+}
+
 func (i Images) EnvoyConsulImage() string {
-	if i.Consul == "" || i.Envoy == "" {
+	return spliceImageNamesAndTags(i.Consul, i.Envoy, "")
+}
+
+func spliceImageNamesAndTags(base1, base2, nameSuffix string) string {
+	if base1 == "" || base2 == "" {
 		return ""
 	}
 
-	img1, tag1, ok1 := strings.Cut(i.Consul, ":")
-	img2, tag2, ok2 := strings.Cut(i.Envoy, ":")
+	img1, tag1, ok1 := strings.Cut(base1, ":")
+	img2, tag2, ok2 := strings.Cut(base2, ":")
 	if !ok1 {
 		tag1 = "latest"
 	}
@@ -66,8 +74,12 @@ func (i Images) EnvoyConsulImage() string {
 		name2 = repo2
 	}
 
+	if nameSuffix != "" {
+		nameSuffix = "-" + nameSuffix
+	}
+
 	// ex: local/hashicorp-consul-and-envoyproxy-envoy:1.15.0-with-v1.26.2
-	return "local/" + name1 + "-and-" + name2 + ":" + tag1 + "-with-" + tag2
+	return "local/" + name1 + "-and-" + name2 + nameSuffix + ":" + tag1 + "-with-" + tag2
 }
 
 // TODO: what is this for and why do we need to do this and why is it named this?

--- a/testing/deployer/topology/topology.go
+++ b/testing/deployer/topology/topology.go
@@ -767,14 +767,14 @@ type Service struct {
 	// This only applies for multi-port (v2).
 	V2Services []string `json:",omitempty"`
 
-	// WorkloadIdentities contains named WorkloadIdentities to assign to this
+	// WorkloadIdentity contains named WorkloadIdentity to assign to this
 	// workload.
 	//
 	// If omitted it is inferred that the ID.Name field is the singular
 	// identity for this workload.
 	//
 	// This only applies for multi-port (v2).
-	WorkloadIdentities []string `json:",omitempty"`
+	WorkloadIdentity string `json:",omitempty"`
 
 	Disabled bool `json:",omitempty"` // TODO
 

--- a/testing/deployer/topology/topology.go
+++ b/testing/deployer/topology/topology.go
@@ -868,6 +868,9 @@ func (s *Service) HasCheck() bool {
 
 func (s *Service) DigestExposedPorts(ports map[int]int) {
 	s.ExposedPort = ports[s.Port]
+	for portName, port := range s.Ports {
+		s.ExposedPorts[portName] = ports[port.Number]
+	}
 	if s.EnvoyAdminPort > 0 {
 		s.ExposedEnvoyAdminPort = ports[s.EnvoyAdminPort]
 	} else {


### PR DESCRIPTION
### Description

This is dependent upon https://github.com/hashicorp/consul/pull/19046.

This updates the testing/deployer (aka "topology test") framework to allow for a v2-oriented topology to opt services into enabling TransparentProxy. The restrictions are similar to that of #19046 

The multiport `Ports` map that was added in #19046 was changed to allow for the protocol to be specified at this time, but for now the only supported protocol is TCP as only L4 functions currently on main.

As part of making transparent proxy work, the DNS server needed a new zonefile for responding to `virtual.consul` requests, since there is no Kubernetes DNS and the Consul DNS work for v2 has not happened yet. Once Consul DNS supports v2 we should switch over. For now the format of queries is:
```
<service>--<namespace>--<partition>.virtual.consul
```
Additionally:
- All transparent proxy enabled services are assigned a virtual ip in the `10.244.0/24` range. This is something Consul will do in v2 at a later date, likely during 1.18.
- All services with exposed ports (non-mesh) are assigned a virtual port number for use with tproxy
- The `consul-dataplane` image has been made un-distroless, and gotten the necessary tools to execute `consul connect redirect-traffic` before running dataplane, thus simulating a kubernetes init container in plain docker.

There is an example test added.

NET-5735

