### PR TITLE
Activate verifier when running WAL with experimental features

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1115,6 +1115,8 @@ func (s *Server) setupRaft(isCatalogResourceExperiment bool) error {
 		// Only use WAL if there is no existing raft.db, even if it's enabled.
 		if s.config.LogStoreConfig.Backend == LogStoreBackendDefault && !boltFileExists && isCatalogResourceExperiment {
 			s.config.LogStoreConfig.Backend = LogStoreBackendWAL
+			s.config.LogStoreConfig.Verification.Enabled = true
+			s.config.LogStoreConfig.Verification.Interval = 1 * time.Minute
 			if err = initWAL(); err != nil {
 				return err
 			}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1115,8 +1115,10 @@ func (s *Server) setupRaft(isCatalogResourceExperiment bool) error {
 		// Only use WAL if there is no existing raft.db, even if it's enabled.
 		if s.config.LogStoreConfig.Backend == LogStoreBackendDefault && !boltFileExists && isCatalogResourceExperiment {
 			s.config.LogStoreConfig.Backend = LogStoreBackendWAL
-			s.config.LogStoreConfig.Verification.Enabled = true
-			s.config.LogStoreConfig.Verification.Interval = 1 * time.Minute
+			if !s.config.LogStoreConfig.Verification.Enabled {
+				s.config.LogStoreConfig.Verification.Enabled = true
+				s.config.LogStoreConfig.Verification.Interval = 1 * time.Minute
+			}
 			if err = initWAL(); err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description

This a complement to https://github.com/hashicorp/consul/pull/19090.
After discussing with @banks he pointed that it would be better if we activate the verifier when WAL is active with the experimental feature so if any bug is discovered we will have data to debug. 

We will need to revise this when resource-apis is not an experimental feature anymore.