### PR TITLE
docs: Fix example control-plane-request-limit HCL and JSON

### DIFF
--- a/website/content/docs/connect/config-entries/control-plane-request-limit.mdx
+++ b/website/content/docs/connect/config-entries/control-plane-request-limit.mdx
@@ -40,48 +40,48 @@ When every field is defined, a control plane request limit configuration entry h
 <CodeTabs>
 
 ```hcl
-kind = "control-plane-request-limit"
-name = "<name-for-the-entry>"
+Kind = "control-plane-request-limit"
+Name = "<name-for-the-entry>"
 
-mode = "permissive"
+Mode = "permissive"
 
-read_rate =  100
-write_rate = 100
+ReadRate =  100
+WriteRate = 100
 
-kv = {
-  read_rate =  100
-  write_rate = 100
+KV = {
+  ReadRate =  100
+  WriteRate = 100
 }
 
-acl = {
-  read_rate =  100
-  write_rate = 100
+ACL = {
+  ReadRate =  100
+  WriteRate = 100
 }
 
-catalog = {
-  read_rate =  100
-  write_rate = 100
+Catalog = {
+  ReadRate =  100
+  WriteRate = 100
 }
 ```
 
 ```json
 {
-  "kind": "control-plane-request-limit",
-  "name": "<name-for-the-entry>",
-  "mode": "permissive",
-  "read_rate":  100,
-  "write_rate": 100,
-  "kv": {
-    "read_rate": 100,
-    "write_rate": 100
+  "Kind": "control-plane-request-limit",
+  "Name": "<name-for-the-entry>",
+  "Mode": "permissive",
+  "ReadRate":  100,
+  "WriteRate": 100,
+  "KV": {
+    "ReadRate": 100,
+    "WriteRate": 100
     },
-  "acl": {
-    "read_rate": 100,
-    "write_rate": 100
+  "ACL": {
+    "ReadRate": 100,
+    "WriteRate": 100
     },
-  "catalog": {
-    "read_rate": 100,
-    "write_rate": 100
+  "Catalog": {
+    "ReadRate": 100,
+    "WriteRate": 100
   }
 }
 ```


### PR DESCRIPTION
### Description

The control-plane-request-limit config entry does not support specifying parameter names in snake case format.

This commit updates the HCL and JSON examples to use the supported camel case key format.

### Testing & Reproduction steps

1. Create `control-plane-request-limit-snake_case.hcl` with the following configuration.

   ```hcl
   kind = "control-plane-request-limit"
   name = "global-limits"

   mode = "permissive"

   read_rate =  100
   write_rate = 100

   kv = {
     read_rate =  100
     write_rate = 100
   }

   acl = {
     read_rate =  100
     write_rate = 100
   }

   catalog = {
     read_rate =  100
     write_rate = 100
   }
   ```

1. Attempt to save the configuration using `consul config write`.

   ```shell-session
   $ consul config write control-plane-request-limit-snake_case.hcl
   Failed to decode config entry input: 8 errors occurred:
	* invalid config key "ACL.read_rate"
	* invalid config key "ACL.write_rate"
	* invalid config key "Catalog.read_rate"
	* invalid config key "Catalog.write_rate"
	* invalid config key "KV.read_rate"
	* invalid config key "KV.write_rate"
	* invalid config key "read_rate"
	* invalid config key "write_rate"
   ```

1. Create `control-plane-request-limit-CamelCase.hcl` with the following configuration.

   ```hcl
   kind = "control-plane-request-limit"
   name = "global-limits"

   mode = "permissive"

   ReadRate =  100
   WriteRate = 100

   kv = {
     ReadRate =  100
     WriteRate = 100
   }

   acl = {
     ReadRate =  100
     WriteRate = 100
   }

   catalog = {
     ReadRate =  100
     WriteRate = 100
   }
   ```

1. Attempt to save the configuration using `consul config write`.

   ```shell-session
   $ consul config write control-plane-request-limit-CamelCase.hcl
   Config entry written: control-plane-request-limit/global-limits
   ```

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
