### PR TITLE
Stop windows integration tests

### DIFF
--- a/.github/workflows/test-integrations-windows.yml
+++ b/.github/workflows/test-integrations-windows.yml
@@ -4,10 +4,6 @@
 name: test-integrations-windows
 
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    # Run nightly at 12AM UTC/8PM EST/5PM PST.
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
### Description

Stops integration tests for windows.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
