### PR TITLE
Remove old build tags

### DIFF
--- a/acl/acl_ce.go
+++ b/acl/acl_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package acl
 

--- a/acl/authorizer_ce.go
+++ b/acl/authorizer_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package acl
 

--- a/acl/enterprisemeta_ce.go
+++ b/acl/enterprisemeta_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package acl
 

--- a/acl/errors_ce.go
+++ b/acl/errors_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package acl
 

--- a/acl/policy_authorizer_ce.go
+++ b/acl/policy_authorizer_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package acl
 

--- a/acl/policy_ce.go
+++ b/acl/policy_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package acl
 

--- a/acl/policy_merger_ce.go
+++ b/acl/policy_merger_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package acl
 

--- a/agent/acl_ce.go
+++ b/agent/acl_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/agent_ce.go
+++ b/agent/agent_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/agent_ce_test.go
+++ b/agent/agent_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/agent_endpoint_ce.go
+++ b/agent/agent_endpoint_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/agent_endpoint_ce_test.go
+++ b/agent/agent_endpoint_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/auto-config/auto_config_ce.go
+++ b/agent/auto-config/auto_config_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package autoconf
 

--- a/agent/auto-config/auto_config_ce_test.go
+++ b/agent/auto-config/auto_config_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package autoconf
 

--- a/agent/auto-config/config_ce.go
+++ b/agent/auto-config/config_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package autoconf
 

--- a/agent/auto-config/mock_ce_test.go
+++ b/agent/auto-config/mock_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package autoconf
 

--- a/agent/catalog_endpoint_ce.go
+++ b/agent/catalog_endpoint_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/checks/check_windows_test.go
+++ b/agent/checks/check_windows_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build windows
-// +build windows
 
 package checks
 

--- a/agent/checks/docker_unix.go
+++ b/agent/checks/docker_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !windows
-// +build !windows
 
 package checks
 

--- a/agent/checks/os_service_unix.go
+++ b/agent/checks/os_service_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !windows
-// +build !windows
 
 package checks
 

--- a/agent/checks/os_service_windows.go
+++ b/agent/checks/os_service_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build windows
-// +build windows
 
 package checks
 

--- a/agent/config/builder_ce.go
+++ b/agent/config/builder_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package config
 

--- a/agent/config/builder_ce_test.go
+++ b/agent/config/builder_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package config
 

--- a/agent/config/config_ce.go
+++ b/agent/config/config_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package config
 

--- a/agent/config/default_ce.go
+++ b/agent/config/default_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package config
 

--- a/agent/config/limits.go
+++ b/agent/config/limits.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !windows
-// +build !windows
 
 package config
 

--- a/agent/config/limits_windows.go
+++ b/agent/config/limits_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build windows
-// +build windows
 
 package config
 

--- a/agent/config/runtime_ce.go
+++ b/agent/config/runtime_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package config
 

--- a/agent/config/runtime_ce_test.go
+++ b/agent/config/runtime_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package config
 

--- a/agent/config/segment_ce.go
+++ b/agent/config/segment_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package config
 

--- a/agent/config/segment_ce_test.go
+++ b/agent/config/segment_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package config
 

--- a/agent/connect/uri_agent_ce.go
+++ b/agent/connect/uri_agent_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package connect
 

--- a/agent/connect/uri_agent_ce_test.go
+++ b/agent/connect/uri_agent_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package connect
 

--- a/agent/connect/uri_mesh_gateway_ce.go
+++ b/agent/connect/uri_mesh_gateway_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package connect
 

--- a/agent/connect/uri_mesh_gateway_ce_test.go
+++ b/agent/connect/uri_mesh_gateway_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package connect
 

--- a/agent/connect/uri_service_ce.go
+++ b/agent/connect/uri_service_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package connect
 

--- a/agent/connect/uri_service_ce_test.go
+++ b/agent/connect/uri_service_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package connect
 

--- a/agent/connect/uri_workload_identity_ce.go
+++ b/agent/connect/uri_workload_identity_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package connect
 

--- a/agent/connect/uri_workload_identity_ce_test.go
+++ b/agent/connect/uri_workload_identity_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package connect
 

--- a/agent/consul/acl_authmethod_ce.go
+++ b/agent/consul/acl_authmethod_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/acl_ce.go
+++ b/agent/consul/acl_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/acl_ce_test.go
+++ b/agent/consul/acl_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/acl_endpoint_ce.go
+++ b/agent/consul/acl_endpoint_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/acl_server_ce.go
+++ b/agent/consul/acl_server_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/auth/binder_ce.go
+++ b/agent/consul/auth/binder_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package auth
 

--- a/agent/consul/auth/token_writer_ce.go
+++ b/agent/consul/auth/token_writer_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package auth
 

--- a/agent/consul/authmethod/authmethods_ce.go
+++ b/agent/consul/authmethod/authmethods_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package authmethod
 

--- a/agent/consul/authmethod/kubeauth/k8s_ce.go
+++ b/agent/consul/authmethod/kubeauth/k8s_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package kubeauth
 

--- a/agent/consul/authmethod/ssoauth/sso_ce.go
+++ b/agent/consul/authmethod/ssoauth/sso_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package ssoauth
 

--- a/agent/consul/authmethod/testauth/testing_ce.go
+++ b/agent/consul/authmethod/testauth/testing_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package testauth
 

--- a/agent/consul/autopilot_ce.go
+++ b/agent/consul/autopilot_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/config_ce.go
+++ b/agent/consul/config_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/discoverychain/compile_ce.go
+++ b/agent/consul/discoverychain/compile_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package discoverychain
 

--- a/agent/consul/enterprise_client_ce.go
+++ b/agent/consul/enterprise_client_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/enterprise_config_ce.go
+++ b/agent/consul/enterprise_config_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/enterprise_server_ce.go
+++ b/agent/consul/enterprise_server_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/enterprise_server_ce_test.go
+++ b/agent/consul/enterprise_server_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/fsm/snapshot_ce_test.go
+++ b/agent/consul/fsm/snapshot_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package fsm
 

--- a/agent/consul/gateways/controller_gateways_ce.go
+++ b/agent/consul/gateways/controller_gateways_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package gateways
 

--- a/agent/consul/leader_ce_test.go
+++ b/agent/consul/leader_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/leader_intentions_ce.go
+++ b/agent/consul/leader_intentions_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/leader_intentions_ce_test.go
+++ b/agent/consul/leader_intentions_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/merge_ce.go
+++ b/agent/consul/merge_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/merge_ce_test.go
+++ b/agent/consul/merge_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/options_ce.go
+++ b/agent/consul/options_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/peering_backend_ce.go
+++ b/agent/consul/peering_backend_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/peering_backend_ce_test.go
+++ b/agent/consul/peering_backend_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/prepared_query/walk_ce_test.go
+++ b/agent/consul/prepared_query/walk_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package prepared_query
 

--- a/agent/consul/prepared_query_endpoint_ce.go
+++ b/agent/consul/prepared_query_endpoint_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/prepared_query_endpoint_ce_test.go
+++ b/agent/consul/prepared_query_endpoint_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/rate/handler_ce.go
+++ b/agent/consul/rate/handler_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package rate
 

--- a/agent/consul/reporting/reporting_ce.go
+++ b/agent/consul/reporting/reporting_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package reporting
 

--- a/agent/consul/segment_ce.go
+++ b/agent/consul/segment_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/server_ce.go
+++ b/agent/consul/server_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/server_ce_test.go
+++ b/agent/consul/server_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/state/acl_ce.go
+++ b/agent/consul/state/acl_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/acl_ce_test.go
+++ b/agent/consul/state/acl_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/catalog_ce.go
+++ b/agent/consul/state/catalog_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/catalog_ce_test.go
+++ b/agent/consul/state/catalog_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/catalog_events_ce.go
+++ b/agent/consul/state/catalog_events_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/catalog_events_ce_test.go
+++ b/agent/consul/state/catalog_events_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/config_entry_ce.go
+++ b/agent/consul/state/config_entry_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/config_entry_ce_test.go
+++ b/agent/consul/state/config_entry_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/config_entry_exported_services_ce.go
+++ b/agent/consul/state/config_entry_exported_services_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/config_entry_intention_ce.go
+++ b/agent/consul/state/config_entry_intention_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/config_entry_sameness_group_ce.go
+++ b/agent/consul/state/config_entry_sameness_group_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/config_entry_sameness_group_ce_test.go
+++ b/agent/consul/state/config_entry_sameness_group_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/coordinate_ce.go
+++ b/agent/consul/state/coordinate_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/coordinate_ce_test.go
+++ b/agent/consul/state/coordinate_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/delay_ce.go
+++ b/agent/consul/state/delay_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/graveyard_ce.go
+++ b/agent/consul/state/graveyard_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/intention_ce.go
+++ b/agent/consul/state/intention_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/kvs_ce.go
+++ b/agent/consul/state/kvs_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/kvs_ce_test.go
+++ b/agent/consul/state/kvs_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/operations_ce.go
+++ b/agent/consul/state/operations_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/peering_ce.go
+++ b/agent/consul/state/peering_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/peering_ce_test.go
+++ b/agent/consul/state/peering_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/query_ce.go
+++ b/agent/consul/state/query_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/schema_ce.go
+++ b/agent/consul/state/schema_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/schema_ce_test.go
+++ b/agent/consul/state/schema_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/session_ce.go
+++ b/agent/consul/state/session_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/state_store_ce_test.go
+++ b/agent/consul/state/state_store_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/state/usage_ce.go
+++ b/agent/consul/state/usage_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package state
 

--- a/agent/consul/tenancy_bridge_ce.go
+++ b/agent/consul/tenancy_bridge_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package consul
 

--- a/agent/consul/usagemetrics/usagemetrics_ce.go
+++ b/agent/consul/usagemetrics/usagemetrics_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package usagemetrics
 

--- a/agent/consul/usagemetrics/usagemetrics_ce_test.go
+++ b/agent/consul/usagemetrics/usagemetrics_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package usagemetrics
 

--- a/agent/dns_ce.go
+++ b/agent/dns_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/dns_ce_test.go
+++ b/agent/dns_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/enterprise_delegate_ce.go
+++ b/agent/enterprise_delegate_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/exec/exec_unix.go
+++ b/agent/exec/exec_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !windows
-// +build !windows
 
 package exec
 

--- a/agent/exec/exec_windows.go
+++ b/agent/exec/exec_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build windows
-// +build windows
 
 package exec
 

--- a/agent/grpc-external/services/resource/server_ce.go
+++ b/agent/grpc-external/services/resource/server_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package resource
 

--- a/agent/grpc-external/services/resource/server_ce_test.go
+++ b/agent/grpc-external/services/resource/server_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package resource
 

--- a/agent/grpc-external/services/resource/testing/testing_ce.go
+++ b/agent/grpc-external/services/resource/testing/testing_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package testing
 

--- a/agent/http_ce.go
+++ b/agent/http_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/intentions_endpoint_ce_test.go
+++ b/agent/intentions_endpoint_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/operator_endpoint_ce.go
+++ b/agent/operator_endpoint_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/operator_endpoint_ce_test.go
+++ b/agent/operator_endpoint_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/peering_endpoint_ce_test.go
+++ b/agent/peering_endpoint_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/proxycfg-glue/intentions_ce.go
+++ b/agent/proxycfg-glue/intentions_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package proxycfgglue
 

--- a/agent/proxycfg-sources/catalog/config_source_oss.go
+++ b/agent/proxycfg-sources/catalog/config_source_oss.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package catalog
 

--- a/agent/proxycfg/api_gateway_ce.go
+++ b/agent/proxycfg/api_gateway_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package proxycfg
 

--- a/agent/proxycfg/data_sources_ce.go
+++ b/agent/proxycfg/data_sources_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package proxycfg
 

--- a/agent/proxycfg/mesh_gateway_ce.go
+++ b/agent/proxycfg/mesh_gateway_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package proxycfg
 

--- a/agent/proxycfg/naming_ce.go
+++ b/agent/proxycfg/naming_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package proxycfg
 

--- a/agent/proxycfg/state_ce_test.go
+++ b/agent/proxycfg/state_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package proxycfg
 

--- a/agent/proxycfg/testing_ce.go
+++ b/agent/proxycfg/testing_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package proxycfg
 

--- a/agent/proxycfg/testing_upstreams_ce.go
+++ b/agent/proxycfg/testing_upstreams_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package proxycfg
 

--- a/agent/rpc/peering/service_ce_test.go
+++ b/agent/rpc/peering/service_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package peering_test
 

--- a/agent/rpc/peering/testutil_ce_test.go
+++ b/agent/rpc/peering/testutil_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package peering_test
 

--- a/agent/setup_ce.go
+++ b/agent/setup_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/signal_unix.go
+++ b/agent/signal_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !windows
-// +build !windows
 
 package agent
 

--- a/agent/signal_windows.go
+++ b/agent/signal_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build windows
-// +build windows
 
 package agent
 

--- a/agent/structs/acl_ce.go
+++ b/agent/structs/acl_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/autopilot_ce.go
+++ b/agent/structs/autopilot_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/catalog_ce.go
+++ b/agent/structs/catalog_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_apigw_jwt_ce.go
+++ b/agent/structs/config_entry_apigw_jwt_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_ce.go
+++ b/agent/structs/config_entry_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_ce_test.go
+++ b/agent/structs/config_entry_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_discoverychain_ce.go
+++ b/agent/structs/config_entry_discoverychain_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_discoverychain_ce_test.go
+++ b/agent/structs/config_entry_discoverychain_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_exports_ce.go
+++ b/agent/structs/config_entry_exports_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_exports_ce_test.go
+++ b/agent/structs/config_entry_exports_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_intentions_ce.go
+++ b/agent/structs/config_entry_intentions_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_intentions_ce_test.go
+++ b/agent/structs/config_entry_intentions_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_jwt_provider_ce.go
+++ b/agent/structs/config_entry_jwt_provider_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_mesh_ce.go
+++ b/agent/structs/config_entry_mesh_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/config_entry_sameness_group_ce.go
+++ b/agent/structs/config_entry_sameness_group_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/connect_ce.go
+++ b/agent/structs/connect_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/connect_proxy_config_ce.go
+++ b/agent/structs/connect_proxy_config_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/discovery_chain_ce.go
+++ b/agent/structs/discovery_chain_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/intention_ce.go
+++ b/agent/structs/intention_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/structs.deepcopy_ce.go
+++ b/agent/structs/structs.deepcopy_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/structs_ce.go
+++ b/agent/structs/structs_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/structs/structs_ce_test.go
+++ b/agent/structs/structs_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package structs
 

--- a/agent/token/store_ce.go
+++ b/agent/token/store_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package token
 

--- a/agent/ui_endpoint_ce_test.go
+++ b/agent/ui_endpoint_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package agent
 

--- a/agent/xds/delta_envoy_extender_ce_test.go
+++ b/agent/xds/delta_envoy_extender_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package xds
 

--- a/agent/xds/extensionruntime/runtime_config_ce_test.go
+++ b/agent/xds/extensionruntime/runtime_config_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package extensionruntime
 

--- a/agent/xds/failover_policy_ce.go
+++ b/agent/xds/failover_policy_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package xds
 

--- a/agent/xds/gw_per_route_filters_ce.go
+++ b/agent/xds/gw_per_route_filters_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package xds
 

--- a/agent/xds/jwt_authn_ce.go
+++ b/agent/xds/jwt_authn_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package xds
 

--- a/agent/xds/locality_policy_ce.go
+++ b/agent/xds/locality_policy_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package xds
 

--- a/agent/xds/platform/net_fallback.go
+++ b/agent/xds/platform/net_fallback.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !linux
-// +build !linux
 
 package platform
 

--- a/agent/xds/platform/net_linux.go
+++ b/agent/xds/platform/net_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux
-// +build linux
 
 package platform
 

--- a/agent/xds/proxystateconverter/failover_policy_ce.go
+++ b/agent/xds/proxystateconverter/failover_policy_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package proxystateconverter
 

--- a/agent/xds/proxystateconverter/locality_policy_ce.go
+++ b/agent/xds/proxystateconverter/locality_policy_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package proxystateconverter
 

--- a/agent/xds/resources_ce_test.go
+++ b/agent/xds/resources_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package xds
 

--- a/agent/xds/server_ce.go
+++ b/agent/xds/server_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package xds
 

--- a/api/ce_test.go
+++ b/api/ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !consulent
-// +build !consulent
 
 package api
 

--- a/api/namespace_test.go
+++ b/api/namespace_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build consulent
-// +build consulent
 
 package api
 

--- a/command/acl/authmethod/create/authmethod_create_ce.go
+++ b/command/acl/authmethod/create/authmethod_create_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package authmethodcreate
 

--- a/command/acl/authmethod/update/authmethod_update_ce.go
+++ b/command/acl/authmethod/update/authmethod_update_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package authmethodupdate
 

--- a/command/acl/templatedpolicy/formatter_ce_test.go
+++ b/command/acl/templatedpolicy/formatter_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package templatedpolicy
 

--- a/command/acl/token/formatter_ce_test.go
+++ b/command/acl/token/formatter_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package token
 

--- a/command/catalog/helpers_ce.go
+++ b/command/catalog/helpers_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package catalog
 

--- a/command/connect/envoy/envoy_ce_test.go
+++ b/command/connect/envoy/envoy_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package envoy
 

--- a/command/connect/envoy/exec_supported.go
+++ b/command/connect/envoy/exec_supported.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux || darwin || windows
-// +build linux darwin windows
 
 package envoy
 

--- a/command/connect/envoy/exec_test.go
+++ b/command/connect/envoy/exec_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux || darwin
-// +build linux darwin
 
 package envoy
 

--- a/command/connect/envoy/exec_unix.go
+++ b/command/connect/envoy/exec_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux || darwin
-// +build linux darwin
 
 package envoy
 

--- a/command/connect/envoy/exec_unsupported.go
+++ b/command/connect/envoy/exec_unsupported.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !linux && !darwin && !windows
-// +build !linux,!darwin,!windows
 
 package envoy
 

--- a/command/connect/envoy/exec_windows.go
+++ b/command/connect/envoy/exec_windows.go
@@ -1,7 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 //go:build windows && !fips
-// +build windows,!fips
 
 package envoy
 

--- a/command/lock/util_unix.go
+++ b/command/lock/util_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !windows
-// +build !windows
 
 package lock
 

--- a/command/lock/util_windows.go
+++ b/command/lock/util_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build windows
-// +build windows
 
 package lock
 

--- a/command/login/login_ce.go
+++ b/command/login/login_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package login
 

--- a/command/operator/usage/instances/usage_instances_ce.go
+++ b/command/operator/usage/instances/usage_instances_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package instances
 

--- a/command/operator/usage/instances/usage_instances_ce_test.go
+++ b/command/operator/usage/instances/usage_instances_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package instances
 

--- a/command/registry_ce.go
+++ b/command/registry_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package command
 

--- a/internal/resource/authz_ce.go
+++ b/internal/resource/authz_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package resource
 

--- a/internal/resource/authz_ce_test.go
+++ b/internal/resource/authz_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package resource
 

--- a/internal/resource/tenancy_bridge_ce.go
+++ b/internal/resource/tenancy_bridge_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package resource
 

--- a/internal/tenancy/internal/types/types_ce.go
+++ b/internal/tenancy/internal/types/types_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package types
 

--- a/internal/tools/protoc-gen-consul-rate-limit/postprocess/main.go
+++ b/internal/tools/protoc-gen-consul-rate-limit/postprocess/main.go
@@ -27,7 +27,6 @@ import "github.com/hashicorp/consul/agent/consul/rate"
 `
 
 	entTags = `//go:build consulent
-// +build consulent
 `
 )
 

--- a/logging/logfile_bsd.go
+++ b/logging/logfile_bsd.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build darwin || freebsd || netbsd || openbsd
-// +build darwin freebsd netbsd openbsd
 
 package logging
 

--- a/logging/logfile_linux.go
+++ b/logging/logfile_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build dragonfly || linux
-// +build dragonfly linux
 
 package logging
 

--- a/logging/logfile_solaris.go
+++ b/logging/logfile_solaris.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build solaris
-// +build solaris
 
 package logging
 

--- a/logging/syslog_test.go
+++ b/logging/syslog_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd || solaris
-// +build linux darwin dragonfly freebsd netbsd openbsd solaris
 
 package logging
 

--- a/logging/syslog_unsupported_test.go
+++ b/logging/syslog_unsupported_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build windows || plan9 || nacl
-// +build windows plan9 nacl
 
 package logging
 

--- a/proto/private/pbautoconf/auto_config_ce.go
+++ b/proto/private/pbautoconf/auto_config_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package pbautoconf
 

--- a/proto/private/pbcommon/common_ce.go
+++ b/proto/private/pbcommon/common_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package pbcommon
 

--- a/proto/private/pbconfigentry/config_entry_ce.go
+++ b/proto/private/pbconfigentry/config_entry_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package pbconfigentry
 

--- a/proto/private/pbpeering/peering_ce.go
+++ b/proto/private/pbpeering/peering_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package pbpeering
 

--- a/proto/private/pbservice/convert_ce.go
+++ b/proto/private/pbservice/convert_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package pbservice
 

--- a/proto/private/pbservice/convert_ce_test.go
+++ b/proto/private/pbservice/convert_ce_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package pbservice
 

--- a/sdk/freeport/ephemeral_darwin.go
+++ b/sdk/freeport/ephemeral_darwin.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build darwin
-// +build darwin
 
 package freeport
 

--- a/sdk/freeport/ephemeral_darwin_test.go
+++ b/sdk/freeport/ephemeral_darwin_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build darwin
-// +build darwin
 
 package freeport
 

--- a/sdk/freeport/ephemeral_fallback.go
+++ b/sdk/freeport/ephemeral_fallback.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !linux && !darwin
-// +build !linux,!darwin
 
 package freeport
 

--- a/sdk/freeport/ephemeral_linux.go
+++ b/sdk/freeport/ephemeral_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build linux
-// +build linux
 
 package freeport
 

--- a/sdk/freeport/ephemeral_linux_test.go
+++ b/sdk/freeport/ephemeral_linux_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build linux
-// +build linux
 
 package freeport
 

--- a/sdk/freeport/systemlimit.go
+++ b/sdk/freeport/systemlimit.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows
-// +build !windows
 
 package freeport
 

--- a/sdk/freeport/systemlimit_windows.go
+++ b/sdk/freeport/systemlimit_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows
-// +build windows
 
 package freeport
 

--- a/sdk/iptables/iptables_executor_linux.go
+++ b/sdk/iptables/iptables_executor_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build linux
-// +build linux
 
 package iptables
 

--- a/sdk/iptables/iptables_executor_unsupported.go
+++ b/sdk/iptables/iptables_executor_unsupported.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !linux
-// +build !linux
 
 package iptables
 

--- a/sentinel/sentinel_ce.go
+++ b/sentinel/sentinel_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package sentinel
 

--- a/service_os/service_windows.go
+++ b/service_os/service_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build windows
-// +build windows
 
 package service_os
 

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build integration
-// +build integration
 
 package envoy
 

--- a/test/integration/consul-container/libs/utils/version_ce.go
+++ b/test/integration/consul-container/libs/utils/version_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package utils
 

--- a/test/integration/consul-container/test/gateways/tenancy_ce.go
+++ b/test/integration/consul-container/test/gateways/tenancy_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !consulent
-// +build !consulent
 
 package gateways
 

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -1,7 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 //go:build !fips
-// +build !fips
 
 package tlsutil
 


### PR DESCRIPTION
### Description

I've noticed these tags get copy-pasted in new files and thought it would be best to clean them up.
This style of build tags has not been used since go1.18 and since our latest supported version is on Consul 1.20 it's safe to remove them moving forwards. 

