### PR TITLE
server: when the v2 catalog experiment is enabled reject api and rpc requests that are for the v1 catalog

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -22,8 +22,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/consul/lib/stringslice"
-
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
 	"github.com/hashicorp/go-connlimit"
@@ -73,6 +71,7 @@ import (
 	"github.com/hashicorp/consul/lib/file"
 	"github.com/hashicorp/consul/lib/mutex"
 	"github.com/hashicorp/consul/lib/routine"
+	"github.com/hashicorp/consul/lib/stringslice"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/proto/private/pboperator"
@@ -623,6 +622,9 @@ func (a *Agent) Start(ctx context.Context) error {
 	// create the state synchronization manager which performs
 	// regular and on-demand state synchronizations (anti-entropy).
 	a.sync = ae.NewStateSyncer(a.State, c.AEInterval, a.shutdownCh, a.logger)
+	if a.useV2Resources() {
+		a.sync.HardDisableSync()
+	}
 
 	err = validateFIPSConfig(a.config)
 	if err != nil {

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -79,6 +79,34 @@ func createACLTokenWithAgentReadPolicy(t *testing.T, srv *HTTPHandlers) string {
 	return svcToken.SecretID
 }
 
+func TestAgentEndpointsFailInV2(t *testing.T) {
+	t.Parallel()
+
+	a := NewTestAgent(t, `experiments = ["resource-apis"]`)
+
+	checkRequest := func(method, url string) {
+		t.Run(method+" "+url, func(t *testing.T) {
+			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url, `{}`)
+		})
+	}
+
+	checkRequest("PUT", "/v1/agent/maintenance")
+	checkRequest("GET", "/v1/agent/services")
+	checkRequest("GET", "/v1/agent/service/web")
+	checkRequest("GET", "/v1/agent/checks")
+	checkRequest("GET", "/v1/agent/health/service/id/web")
+	checkRequest("GET", "/v1/agent/health/service/name/web")
+	checkRequest("PUT", "/v1/agent/check/register")
+	checkRequest("PUT", "/v1/agent/check/deregister/web")
+	checkRequest("PUT", "/v1/agent/check/pass/web")
+	checkRequest("PUT", "/v1/agent/check/warn/web")
+	checkRequest("PUT", "/v1/agent/check/fail/web")
+	checkRequest("PUT", "/v1/agent/check/update/web")
+	checkRequest("PUT", "/v1/agent/service/register")
+	checkRequest("PUT", "/v1/agent/service/deregister/web")
+	checkRequest("PUT", "/v1/agent/service/maintenance/web")
+}
+
 func TestAgent_Services(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -32,7 +32,7 @@ func TestCatalogEndpointsFailInV2(t *testing.T) {
 
 	checkRequest := func(method, url string) {
 		t.Run(method+" "+url, func(t *testing.T) {
-			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url)
+			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url, "{}")
 		})
 	}
 
@@ -48,11 +48,11 @@ func TestCatalogEndpointsFailInV2(t *testing.T) {
 	checkRequest("GET", "/v1/catalog/gateway-services/")
 }
 
-func assertV1CatalogEndpointDoesNotWorkWithV2(t *testing.T, a *TestAgent, method, url string) {
+func assertV1CatalogEndpointDoesNotWorkWithV2(t *testing.T, a *TestAgent, method, url string, requestBody string) {
 	var body io.Reader
 	switch method {
 	case http.MethodPost, http.MethodPut:
-		body = strings.NewReader("{}\n")
+		body = strings.NewReader(requestBody + "\n")
 	}
 
 	req, err := http.NewRequest(method, url, body)

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -6,23 +6,67 @@ package agent
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
-
-	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/api"
 
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 )
+
+func TestCatalogEndpointsFailInV2(t *testing.T) {
+	t.Parallel()
+
+	a := NewTestAgent(t, `experiments = ["resource-apis"]`)
+
+	checkRequest := func(method, url string) {
+		t.Run(method+" "+url, func(t *testing.T) {
+			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url)
+		})
+	}
+
+	checkRequest("PUT", "/v1/catalog/register")
+	checkRequest("GET", "/v1/catalog/connect/")
+	checkRequest("PUT", "/v1/catalog/deregister")
+	checkRequest("GET", "/v1/catalog/datacenters")
+	checkRequest("GET", "/v1/catalog/nodes")
+	checkRequest("GET", "/v1/catalog/services")
+	checkRequest("GET", "/v1/catalog/service/")
+	checkRequest("GET", "/v1/catalog/node/")
+	checkRequest("GET", "/v1/catalog/node-services/")
+	checkRequest("GET", "/v1/catalog/gateway-services/")
+}
+
+func assertV1CatalogEndpointDoesNotWorkWithV2(t *testing.T, a *TestAgent, method, url string) {
+	var body io.Reader
+	switch method {
+	case http.MethodPost, http.MethodPut:
+		body = strings.NewReader("{}\n")
+	}
+
+	req, err := http.NewRequest(method, url, body)
+	require.NoError(t, err)
+
+	resp := httptest.NewRecorder()
+	a.srv.h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Contains(t, string(got), structs.ErrUsingV2CatalogExperiment.Error())
+}
 
 func TestCatalogRegister_PeeringRegistration(t *testing.T) {
 	if testing.Short() {

--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -19,6 +19,23 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 )
 
+func TestConfigEndpointsFailInV2(t *testing.T) {
+	t.Parallel()
+
+	a := NewTestAgent(t, `experiments = ["resource-apis"]`)
+
+	checkRequest := func(method, url string) {
+		t.Run(method+" "+url, func(t *testing.T) {
+			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url, `{"kind":"service-defaults", "name":"web"}`)
+		})
+	}
+
+	checkRequest("GET", "/v1/config/service-defaults")
+	checkRequest("GET", "/v1/config/service-defaults/web")
+	checkRequest("DELETE", "/v1/config/service-defaults/web")
+	checkRequest("PUT", "/v1/config")
+}
+
 func TestConfig_Get(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/consul/options.go
+++ b/agent/consul/options.go
@@ -4,6 +4,7 @@
 package consul
 
 import (
+	"github.com/hashicorp/consul/lib/stringslice"
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
@@ -46,6 +47,15 @@ type Deps struct {
 	Experiments []string
 
 	EnterpriseDeps
+}
+
+// useV2Resources returns true if "resource-apis" is present in the Experiments
+// array of the agent config.
+func (d Deps) UseV2Resources() bool {
+	if stringslice.Contains(d.Experiments, CatalogResourceExperimentName) {
+		return true
+	}
+	return false
 }
 
 type GRPCClientConner interface {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -590,7 +590,10 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 	}
 
 	isV1CatalogRPC := func(name string) bool {
-		if strings.HasPrefix(name, "Catalog.") || strings.HasPrefix(name, "Health.") {
+		switch {
+		case strings.HasPrefix(name, "Catalog."),
+			strings.HasPrefix(name, "Health."),
+			strings.HasPrefix(name, "ConfigEntry."):
 			return true
 		}
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -555,6 +555,7 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 		incomingRPCLimiter:      incomingRPCLimiter,
 		routineManager:          routine.NewManager(logger.Named(logging.ConsulServer)),
 		registry:                flat.Registry,
+		useV2Resources:          flat.UseV2Resources(),
 	}
 	incomingRPCLimiter.Register(s)
 
@@ -929,9 +930,7 @@ func isV1CatalogRequest(rpcName string) bool {
 }
 
 func (s *Server) registerControllers(deps Deps, proxyUpdater ProxyUpdater) error {
-	if stringslice.Contains(deps.Experiments, CatalogResourceExperimentName) {
-		s.useV2Resources = true
-
+	if s.useV2Resources {
 		catalog.RegisterControllers(s.controllerManager, catalog.DefaultControllerDependencies())
 
 		defaultAllow, err := s.config.ACLResolverSettings.IsDefaultAllow()

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -28,6 +28,25 @@ import (
 	"github.com/hashicorp/consul/types"
 )
 
+func TestHealthEndpointsFailInV2(t *testing.T) {
+	t.Parallel()
+
+	a := NewTestAgent(t, `experiments = ["resource-apis"]`)
+
+	checkRequest := func(method, url string) {
+		t.Run(method+" "+url, func(t *testing.T) {
+			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url)
+		})
+	}
+
+	checkRequest("GET", "/v1/health/node/web")
+	checkRequest("GET", "/v1/health/checks/web")
+	checkRequest("GET", "/v1/health/state/web")
+	checkRequest("GET", "/v1/health/service/web")
+	checkRequest("GET", "/v1/health/connect/web")
+	checkRequest("GET", "/v1/health/ingress/web")
+}
+
 func TestHealthChecksInState(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -35,7 +35,7 @@ func TestHealthEndpointsFailInV2(t *testing.T) {
 
 	checkRequest := func(method, url string) {
 		t.Run(method+" "+url, func(t *testing.T) {
-			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url)
+			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url, "{}")
 		})
 	}
 

--- a/agent/http.go
+++ b/agent/http.go
@@ -396,41 +396,7 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 
 		rejectCatalogV1Endpoint := false
 		if s.agent.useV2Resources() {
-			switch {
-			case strings.HasPrefix(logURL, "/v1/catalog/"),
-				strings.HasPrefix(logURL, "/v1/health/"),
-				strings.HasPrefix(logURL, "/v1/config/"):
-				rejectCatalogV1Endpoint = true
-
-			case strings.HasPrefix(logURL, "/v1/agent/token/"),
-				logURL == "/v1/agent/self",
-				logURL == "/v1/agent/host",
-				logURL == "/v1/agent/version",
-				logURL == "/v1/agent/reload",
-				logURL == "/v1/agent/monitor",
-				logURL == "/v1/agent/metrics",
-				logURL == "/v1/agent/metrics/stream",
-				logURL == "/v1/agent/members",
-				strings.HasPrefix(logURL, "/v1/agent/join/"),
-				logURL == "/v1/agent/leave",
-				strings.HasPrefix(logURL, "/v1/agent/force-leave/"),
-				logURL == "/v1/agent/connect/authorize",
-				logURL == "/v1/agent/connect/ca/roots",
-				strings.HasPrefix(logURL, "/v1/agent/connect/ca/leaf/"):
-				rejectCatalogV1Endpoint = false
-
-			case strings.HasPrefix(logURL, "/v1/agent/"):
-				rejectCatalogV1Endpoint = true
-
-			case logURL == "/v1/internal/acl/authorize",
-				logURL == "/v1/internal/service-virtual-ip",
-				logURL == "/v1/internal/ui/oidc-auth-methods",
-				strings.HasPrefix(logURL, "/v1/internal/ui/metrics-proxy/"):
-				rejectCatalogV1Endpoint = false
-
-			case strings.HasPrefix(logURL, "/v1/internal/"):
-				rejectCatalogV1Endpoint = true
-			}
+			rejectCatalogV1Endpoint = isV1CatalogRequest(logURL)
 		}
 
 		if s.denylist.Block(req.URL.Path) {
@@ -661,6 +627,46 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 		resp.Header().Set("Content-Type", contentType)
 		resp.WriteHeader(httpCode)
 		resp.Write(buf)
+	}
+}
+
+func isV1CatalogRequest(logURL string) bool {
+	switch {
+	case strings.HasPrefix(logURL, "/v1/catalog/"),
+		strings.HasPrefix(logURL, "/v1/health/"),
+		strings.HasPrefix(logURL, "/v1/config/"):
+		return true
+
+	case strings.HasPrefix(logURL, "/v1/agent/token/"),
+		logURL == "/v1/agent/self",
+		logURL == "/v1/agent/host",
+		logURL == "/v1/agent/version",
+		logURL == "/v1/agent/reload",
+		logURL == "/v1/agent/monitor",
+		logURL == "/v1/agent/metrics",
+		logURL == "/v1/agent/metrics/stream",
+		logURL == "/v1/agent/members",
+		strings.HasPrefix(logURL, "/v1/agent/join/"),
+		logURL == "/v1/agent/leave",
+		strings.HasPrefix(logURL, "/v1/agent/force-leave/"),
+		logURL == "/v1/agent/connect/authorize",
+		logURL == "/v1/agent/connect/ca/roots",
+		strings.HasPrefix(logURL, "/v1/agent/connect/ca/leaf/"):
+		return false
+
+	case strings.HasPrefix(logURL, "/v1/agent/"):
+		return true
+
+	case logURL == "/v1/internal/acl/authorize",
+		logURL == "/v1/internal/service-virtual-ip",
+		logURL == "/v1/internal/ui/oidc-auth-methods",
+		strings.HasPrefix(logURL, "/v1/internal/ui/metrics-proxy/"):
+		return false
+
+	case strings.HasPrefix(logURL, "/v1/internal/"):
+		return true
+	default:
+		return false
 	}
 }
 

--- a/agent/http.go
+++ b/agent/http.go
@@ -395,7 +395,7 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 		logURL = aclEndpointRE.ReplaceAllString(logURL, "$1<hidden>$4")
 
 		rejectCatalogV1Endpoint := false
-		if s.agent.useV2Resources() {
+		if s.agent.baseDeps.UseV2Resources() {
 			rejectCatalogV1Endpoint = isV1CatalogRequest(logURL)
 		}
 
@@ -1147,7 +1147,7 @@ func (s *HTTPHandlers) parseToken(req *http.Request, token *string) {
 }
 
 func (s *HTTPHandlers) rejectV1RequestWhenV2Enabled() error {
-	if s.agent.useV2Resources() {
+	if s.agent.baseDeps.UseV2Resources() {
 		return newRejectV1RequestWhenV2EnabledError()
 	}
 	return nil

--- a/agent/http.go
+++ b/agent/http.go
@@ -398,11 +398,33 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 		if s.agent.useV2Resources() {
 			switch {
 			case strings.HasPrefix(logURL, "/v1/catalog/"),
-				strings.HasPrefix(logURL, "/v1/health/"):
+				strings.HasPrefix(logURL, "/v1/health/"),
+				strings.HasPrefix(logURL, "/v1/config/"):
 				rejectCatalogV1Endpoint = true
-			case strings.HasPrefix(logURL, "/v1/internal/acl/authorize"),
-				strings.HasPrefix(logURL, "/v1/internal/service-virtual-ip"),
-				strings.HasPrefix(logURL, "/v1/internal/ui/oidc-auth-methods"),
+
+			case strings.HasPrefix(logURL, "/v1/agent/token/"),
+				logURL == "/v1/agent/self",
+				logURL == "/v1/agent/host",
+				logURL == "/v1/agent/version",
+				logURL == "/v1/agent/reload",
+				logURL == "/v1/agent/monitor",
+				logURL == "/v1/agent/metrics",
+				logURL == "/v1/agent/metrics/stream",
+				logURL == "/v1/agent/members",
+				strings.HasPrefix(logURL, "/v1/agent/join/"),
+				logURL == "/v1/agent/leave",
+				strings.HasPrefix(logURL, "/v1/agent/force-leave/"),
+				logURL == "/v1/agent/connect/authorize",
+				logURL == "/v1/agent/connect/ca/roots",
+				strings.HasPrefix(logURL, "/v1/agent/connect/ca/leaf/"):
+				rejectCatalogV1Endpoint = false
+
+			case strings.HasPrefix(logURL, "/v1/agent/"):
+				rejectCatalogV1Endpoint = true
+
+			case logURL == "/v1/internal/acl/authorize",
+				logURL == "/v1/internal/service-virtual-ip",
+				logURL == "/v1/internal/ui/oidc-auth-methods",
 				strings.HasPrefix(logURL, "/v1/internal/ui/metrics-proxy/"):
 				rejectCatalogV1Endpoint = false
 

--- a/agent/structs/errors.go
+++ b/agent/structs/errors.go
@@ -23,6 +23,7 @@ const (
 	errRateLimited                = "Rate limit reached, try again later" // Note: we depend on this error message in the gRPC ConnectCA.Sign endpoint (see: isRateLimitError).
 	errNotPrimaryDatacenter       = "not the primary datacenter"
 	errStateReadOnly              = "CA Provider State is read-only"
+	errUsingV2CatalogExperiment   = "V1 catalog is disabled when V2 is enabled"
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 	ErrRateLimited                = errors.New(errRateLimited) // Note: we depend on this error message in the gRPC ConnectCA.Sign endpoint (see: isRateLimitError).
 	ErrNotPrimaryDatacenter       = errors.New(errNotPrimaryDatacenter)
 	ErrStateReadOnly              = errors.New(errStateReadOnly)
+	ErrUsingV2CatalogExperiment   = errors.New(errUsingV2CatalogExperiment)
 )
 
 func IsErrNoDCPath(err error) bool {
@@ -59,4 +61,8 @@ func IsErrRPCRateExceeded(err error) bool {
 
 func IsErrServiceNotFound(err error) bool {
 	return err != nil && strings.Contains(err.Error(), errServiceNotFound)
+}
+
+func IsErrUsingV2CatalogExperiment(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errUsingV2CatalogExperiment)
 }

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -286,6 +286,22 @@ func (a *TestAgent) waitForUp() error {
 			continue // fail, try again
 		}
 		if a.Config.Bootstrap && a.Config.ServerMode {
+			if a.useV2Resources() {
+				args := structs.DCSpecificRequest{
+					Datacenter: "dc1",
+				}
+				var leader string
+				if err := a.RPC(context.Background(), "Status.Leader", args, &leader); err != nil {
+					retErr = fmt.Errorf("Status.Leader failed: %v", err)
+					continue // fail, try again
+				}
+				if leader == "" {
+					retErr = fmt.Errorf("No leader")
+					continue // fail, try again
+				}
+				return nil // success
+			}
+
 			// Ensure we have a leader and a node registration.
 			args := &structs.DCSpecificRequest{
 				Datacenter: a.Config.Datacenter,

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -286,7 +286,7 @@ func (a *TestAgent) waitForUp() error {
 			continue // fail, try again
 		}
 		if a.Config.Bootstrap && a.Config.ServerMode {
-			if a.useV2Resources() {
+			if a.baseDeps.UseV2Resources() {
 				args := structs.DCSpecificRequest{
 					Datacenter: "dc1",
 				}

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -32,6 +32,28 @@ import (
 	"github.com/hashicorp/consul/types"
 )
 
+func TestUIEndpointsFailInV2(t *testing.T) {
+	t.Parallel()
+
+	a := NewTestAgent(t, `experiments = ["resource-apis"]`)
+
+	checkRequest := func(method, url string) {
+		t.Run(method+" "+url, func(t *testing.T) {
+			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url)
+		})
+	}
+
+	checkRequest("GET", "/v1/internal/ui/nodes")
+	checkRequest("GET", "/v1/internal/ui/node/web")
+	checkRequest("GET", "/v1/internal/ui/services")
+	checkRequest("GET", "/v1/internal/ui/exported-services")
+	checkRequest("GET", "/v1/internal/ui/catalog-overview")
+	checkRequest("GET", "/v1/internal/ui/gateway-services-nodes/web")
+	checkRequest("GET", "/v1/internal/ui/gateway-intentions/web")
+	checkRequest("GET", "/v1/internal/ui/service-topology/web")
+	checkRequest("PUT", "/v1/internal/service-virtual-ip")
+}
+
 func TestUIIndex(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -39,7 +39,7 @@ func TestUIEndpointsFailInV2(t *testing.T) {
 
 	checkRequest := func(method, url string) {
 		t.Run(method+" "+url, func(t *testing.T) {
-			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url)
+			assertV1CatalogEndpointDoesNotWorkWithV2(t, a, method, url, "{}")
 		})
 	}
 


### PR DESCRIPTION
### Description

When the v2 catalog experiment is enabled the old v1 catalog apis will be forcibly disabled at both the API (json) layer and the RPC (msgpack) layer. This will also disable anti-entropy as it uses the v1 api.

This includes all of `/v1/catalog/*`, `/v1/health/*`, most of `/v1/agent/*`, `/v1/config/*`, and most of `/v1/internal/*`.


NET-5581
