### PR TITLE
NET-5799 - ensure catalog controllers and dependency mappers function correctly for tenancy fields

### DIFF
--- a/internal/catalog/internal/controllers/workloadhealth/controller.go
+++ b/internal/catalog/internal/controllers/workloadhealth/controller.go
@@ -32,6 +32,9 @@ type NodeMapper interface {
 	// for all Workloads associated with the Node.
 	MapNodeToWorkloads(ctx context.Context, rt controller.Runtime, res *pbresource.Resource) ([]controller.Request, error)
 
+	// WorkloadIDsByNode will take a Node resource and all Workloads associated with the Node.
+	WorkloadIDsByNode(nodeID *pbresource.ID) []*pbresource.ID
+
 	// TrackWorkload instructs the NodeMapper to associate the given workload
 	// ID with the given node ID.
 	TrackWorkload(workloadID *pbresource.ID, nodeID *pbresource.ID)

--- a/internal/catalog/internal/controllers/workloadhealth/controller.go
+++ b/internal/catalog/internal/controllers/workloadhealth/controller.go
@@ -32,9 +32,6 @@ type NodeMapper interface {
 	// for all Workloads associated with the Node.
 	MapNodeToWorkloads(ctx context.Context, rt controller.Runtime, res *pbresource.Resource) ([]controller.Request, error)
 
-	// WorkloadIDsByNode will take a Node resource and all Workloads associated with the Node.
-	WorkloadIDsByNode(nodeID *pbresource.ID) []*pbresource.ID
-
 	// TrackWorkload instructs the NodeMapper to associate the given workload
 	// ID with the given node ID.
 	TrackWorkload(workloadID *pbresource.ID, nodeID *pbresource.ID)

--- a/internal/catalog/internal/mappers/nodemapper/node_mapper.go
+++ b/internal/catalog/internal/mappers/nodemapper/node_mapper.go
@@ -46,11 +46,9 @@ func (m *NodeMapper) WorkloadIDsByNode(nodeID *pbresource.ID) []*pbresource.ID {
 // TrackWorkload instructs the NodeMapper to associate the given workload
 // ID with the given node ID.
 func (m *NodeMapper) TrackWorkload(workloadID *pbresource.ID, nodeID *pbresource.ID) {
-	nodesAsIDsOrRefs := []resource.ReferenceOrID{
+	m.b.TrackItem(workloadID, []resource.ReferenceOrID{
 		nodeID,
-	}
-
-	m.b.TrackItem(workloadID, nodesAsIDsOrRefs)
+	})
 }
 
 // UntrackWorkload will cause the node mapper to forget about the specified

--- a/internal/catalog/internal/mappers/nodemapper/node_mapper.go
+++ b/internal/catalog/internal/mappers/nodemapper/node_mapper.go
@@ -5,24 +5,20 @@ package nodemapper
 
 import (
 	"context"
-	"sync"
-
 	"github.com/hashicorp/consul/internal/controller"
 	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/mappers/bimapper"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
 type NodeMapper struct {
-	lock             sync.Mutex
-	nodesToWorkloads map[string][]controller.Request
-	workloadsToNodes map[string]string
+	b *bimapper.Mapper
 }
 
 func New() *NodeMapper {
 	return &NodeMapper{
-		workloadsToNodes: make(map[string]string),
-		nodesToWorkloads: make(map[string][]controller.Request),
+		b: bimapper.New(pbcatalog.WorkloadType, pbcatalog.NodeType),
 	}
 }
 
@@ -39,68 +35,26 @@ func (m *NodeMapper) NodeIDFromWorkload(workload *pbresource.Resource, workloadD
 // MapNodeToWorkloads will take a Node resource and return controller requests
 // for all Workloads associated with the Node.
 func (m *NodeMapper) MapNodeToWorkloads(_ context.Context, _ controller.Runtime, res *pbresource.Resource) ([]controller.Request, error) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	return m.nodesToWorkloads[res.Id.Name], nil
+	ids := m.WorkloadIDsByNode(res.Id)
+	return controller.MakeRequests(pbcatalog.WorkloadType, ids), nil
+}
+
+func (m *NodeMapper) WorkloadIDsByNode(nodeID *pbresource.ID) []*pbresource.ID {
+	return m.b.ItemIDsForLink(nodeID)
 }
 
 // TrackWorkload instructs the NodeMapper to associate the given workload
 // ID with the given node ID.
 func (m *NodeMapper) TrackWorkload(workloadID *pbresource.ID, nodeID *pbresource.ID) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	if previousNode, found := m.workloadsToNodes[workloadID.Name]; found && previousNode == nodeID.Name {
-		return
-	} else if found {
-		// the node association is being changed
-		m.untrackWorkloadFromNode(workloadID, previousNode)
+	nodesAsIDsOrRefs := []resource.ReferenceOrID{
+		nodeID,
 	}
 
-	// Now set up the latest tracking
-	m.nodesToWorkloads[nodeID.Name] = append(m.nodesToWorkloads[nodeID.Name], controller.Request{ID: workloadID})
-	m.workloadsToNodes[workloadID.Name] = nodeID.Name
+	m.b.TrackItem(workloadID, nodesAsIDsOrRefs)
 }
 
 // UntrackWorkload will cause the node mapper to forget about the specified
 // workload if it is currently tracking it.
 func (m *NodeMapper) UntrackWorkload(workloadID *pbresource.ID) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	node, found := m.workloadsToNodes[workloadID.Name]
-	if !found {
-		return
-	}
-	m.untrackWorkloadFromNode(workloadID, node)
-}
-
-// untrackWorkloadFromNode will disassociate the specified workload and node.
-// This method will clean up unnecessary tracking entries if the node name
-// is no longer associated with any workloads.
-func (m *NodeMapper) untrackWorkloadFromNode(workloadID *pbresource.ID, node string) {
-	foundIdx := -1
-	for idx, req := range m.nodesToWorkloads[node] {
-		if resource.EqualID(req.ID, workloadID) {
-			foundIdx = idx
-			break
-		}
-	}
-
-	if foundIdx != -1 {
-		workloads := m.nodesToWorkloads[node]
-		l := len(workloads)
-
-		if l == 1 {
-			delete(m.nodesToWorkloads, node)
-		} else if foundIdx == l-1 {
-			m.nodesToWorkloads[node] = workloads[:foundIdx]
-		} else if foundIdx == 0 {
-			m.nodesToWorkloads[node] = workloads[1:]
-		} else {
-			m.nodesToWorkloads[node] = append(workloads[:foundIdx], workloads[foundIdx+1:]...)
-		}
-	}
-
-	delete(m.workloadsToNodes, workloadID.Name)
+	m.b.UntrackItem(workloadID)
 }

--- a/internal/catalog/internal/mappers/nodemapper/node_mapper.go
+++ b/internal/catalog/internal/mappers/nodemapper/node_mapper.go
@@ -35,12 +35,8 @@ func (m *NodeMapper) NodeIDFromWorkload(workload *pbresource.Resource, workloadD
 // MapNodeToWorkloads will take a Node resource and return controller requests
 // for all Workloads associated with the Node.
 func (m *NodeMapper) MapNodeToWorkloads(_ context.Context, _ controller.Runtime, res *pbresource.Resource) ([]controller.Request, error) {
-	ids := m.WorkloadIDsByNode(res.Id)
+	ids := m.b.ItemIDsForLink(res.Id)
 	return controller.MakeRequests(pbcatalog.WorkloadType, ids), nil
-}
-
-func (m *NodeMapper) WorkloadIDsByNode(nodeID *pbresource.ID) []*pbresource.ID {
-	return m.b.ItemIDsForLink(nodeID)
 }
 
 // TrackWorkload instructs the NodeMapper to associate the given workload


### PR DESCRIPTION
### Description

The initial version of node mapper just used a map based on workload name.  it did not respect tenancy.  this PR replaces the nodemapper internals to use bimapper.

I checked other mappers and did not see any that did not use bimapper.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
