### PR TITLE
release/1.14.x: Manual backport of #19095

### DIFF
--- a/.changelog/19095.txt
+++ b/.changelog/19095.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ca: ensure Vault CA provider respects Vault Enterprise namespace configuration.
+```

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -1352,6 +1352,85 @@ func TestVaultCAProvider_ConsulManaged(t *testing.T) {
 	})
 }
 
+func TestVaultCAProvider_EnterpriseNamespace(t *testing.T) {
+	SkipIfVaultNotPresent(t, vaultRequirements{Enterprise: true})
+	t.Parallel()
+
+	cases := map[string]struct {
+		namespaces map[string]string
+	}{
+		"no configured namespaces":             {},
+		"only base namespace provided":         {namespaces: map[string]string{"Namespace": "base-ns"}},
+		"only root namespace provided":         {namespaces: map[string]string{"RootPKINamespace": "root-pki-ns"}},
+		"only intermediate namespace provided": {namespaces: map[string]string{"IntermediatePKINamespace": "int-pki-ns"}},
+		"base and root namespace provided": {
+			namespaces: map[string]string{
+				"Namespace":        "base-ns",
+				"RootPKINamespace": "root-pki-ns",
+			},
+		},
+		"base and intermediate namespace provided": {
+			namespaces: map[string]string{
+				"Namespace":                "base-ns",
+				"IntermediatePKINamespace": "int-pki-ns",
+			},
+		},
+		"root and intermediate namespace provided": {
+			namespaces: map[string]string{
+				"RootPKINamespace":         "root-pki-ns",
+				"IntermediatePKINamespace": "int-pki-ns",
+			},
+		},
+		"all namespaces provided": {
+			namespaces: map[string]string{
+				"Namespace":                "base-ns",
+				"RootPKINamespace":         "root-pki-ns",
+				"IntermediatePKINamespace": "int-pki-ns",
+			},
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			testVault := NewTestVaultServer(t)
+			token := "root"
+
+			providerConfig := map[string]any{
+				"RootPKIPath":         "pki-root/",
+				"IntermediatePKIPath": "pki-intermediate/",
+			}
+			for k, v := range c.namespaces {
+				providerConfig[k] = v
+			}
+
+			if len(c.namespaces) > 0 {
+				// If explicit namespaces are provided, try to create the provider before any of the namespaces
+				// have been created. Verify that the provider fails to initialize.
+				provider, err := createVaultProviderE(t, true, testVault.Addr, token, providerConfig)
+				require.Error(t, err)
+				require.NotNil(t, provider)
+			}
+
+			// Create the namespaces
+			client := testVault.Client()
+			client.SetToken(token)
+
+			for _, ns := range c.namespaces {
+				_, err := client.Logical().Write(fmt.Sprintf("/sys/namespaces/%s", ns), map[string]any{})
+				require.NoError(t, err)
+			}
+
+			// Verify that once the namespaces have been created we are able to initialize the provider.
+			provider, err := createVaultProviderE(t, true, testVault.Addr, token, providerConfig)
+			require.NoError(t, err)
+			require.NotNil(t, provider)
+		})
+	}
+}
+
 func getIntermediateCertTTL(t *testing.T, caConf *structs.CAConfiguration) time.Duration {
 	t.Helper()
 
@@ -1373,6 +1452,15 @@ func getIntermediateCertTTL(t *testing.T, caConf *structs.CAConfiguration) time.
 
 func createVaultProvider(t *testing.T, isPrimary bool, addr, token string, rawConf map[string]any) *VaultProvider {
 	t.Helper()
+
+	provider, err := createVaultProviderE(t, isPrimary, addr, token, rawConf)
+	require.NoError(t, err)
+
+	return provider
+}
+
+func createVaultProviderE(t *testing.T, isPrimary bool, addr, token string, rawConf map[string]any) (*VaultProvider, error) {
+	t.Helper()
 	cfg := vaultProviderConfig(t, addr, token, rawConf)
 
 	provider := NewVaultProvider(hclog.New(nil))
@@ -1383,15 +1471,19 @@ func createVaultProvider(t *testing.T, isPrimary bool, addr, token string, rawCo
 	}
 
 	t.Cleanup(provider.Stop)
-	require.NoError(t, provider.Configure(cfg))
+	if err := provider.Configure(cfg); err != nil {
+		return provider, err
+	}
 	if isPrimary {
-		_, err := provider.GenerateRoot()
-		require.NoError(t, err)
-		_, err = provider.GenerateIntermediate()
-		require.NoError(t, err)
+		if _, err := provider.GenerateRoot(); err != nil {
+			return provider, err
+		}
+		if _, err := provider.GenerateIntermediate(); err != nil {
+			return provider, err
+		}
 	}
 
-	return provider
+	return provider, nil
 }
 
 func vaultProviderConfig(t *testing.T, addr, token string, rawConf map[string]any) ProviderConfig {

--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -58,6 +58,10 @@ type CASigningKeyTypes struct {
 	CSRKeyBits     int
 }
 
+type vaultRequirements struct {
+	Enterprise bool
+}
+
 // CASigningKeyTypeCases returns the cross-product of the important supported CA
 // key types for generating table tests for CA signing tests (CrossSignCA and
 // SignIntermediate).
@@ -90,7 +94,7 @@ func TestConsulProvider(t testing.T, d ConsulProviderStateDelegate) *ConsulProvi
 //
 // These tests may be skipped in CI. They are run as part of a separate
 // integration test suite.
-func SkipIfVaultNotPresent(t testing.T) {
+func SkipIfVaultNotPresent(t testing.T, reqs ...vaultRequirements) {
 	// Try to safeguard against tests that will never run in CI.
 	// This substring should match the pattern used by the
 	// test-connect-ca-providers CI job.
@@ -106,6 +110,16 @@ func SkipIfVaultNotPresent(t testing.T) {
 	path, err := exec.LookPath(vaultBinaryName)
 	if err != nil || path == "" {
 		t.Skipf("%q not found on $PATH - download and install to run this test", vaultBinaryName)
+	}
+
+	// Check for any additional Vault requirements.
+	for _, r := range reqs {
+		if r.Enterprise {
+			ver := vaultVersion(t, vaultBinaryName)
+			if !strings.Contains(ver, "+ent") {
+				t.Skipf("%q is not a Vault Enterprise version", ver)
+			}
+		}
 	}
 }
 
@@ -361,4 +375,11 @@ func createVaultTokenAndPolicy(t testing.T, client *vaultapi.Client, policyName,
 	})
 	require.NoError(t, err)
 	return tok.Auth.ClientToken
+}
+
+func vaultVersion(t testing.T, vaultBinaryName string) string {
+	cmd := exec.Command(vaultBinaryName, []string{"version"}...)
+	output, err := cmd.Output()
+	require.NoError(t, err)
+	return string(output[:len(output)-1])
 }


### PR DESCRIPTION
This PR manually merges changes to release/1.14.x because of the divergence of that branch from main where the changes were introduced. There are no changes to the `agent/connect/ca/provider_vault.go` file because the existing `setNamespace` func in this branch correctly handles setting the namespace from the configuration.