### PR TITLE
Retry lint fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,15 @@ lint/%:
 	@echo "--> Running enumcover ($*)"
 	@cd $* && GOWORK=off enumcover ./...
 
+.PHONY: lint-consul-retry
+lint-consul-retry: $(foreach mod,$(GO_MODULES),lint-consul-retry/$(mod))
+
+.PHONY: lint-consul-retry/%
+lint-consul-retry/%:
+	@echo "--> Running lint-consul-retry ($*)"
+	@cd $* && GOWORK=off lint-consul-retry
+
+
 # check that the test-container module only imports allowlisted packages
 # from the root consul module. Generally we don't want to allow these imports.
 # In a few specific instances though it is okay to import test definitions and

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1837,7 +1837,7 @@ func TestAgent_ReloadDoesNotTriggerWatch(t *testing.T) {
 	require.NoError(t, a.updateTTLCheck(checkID, api.HealthPassing, "testing-agent-reload-001"))
 
 	checkStr := func(r *retry.R, evaluator func(string) error) {
-		t.Helper()
+		r.Helper()
 		contentsStr := ""
 		// Wait for watch to be populated
 		for i := 1; i < 7; i++ {
@@ -1850,14 +1850,14 @@ func TestAgent_ReloadDoesNotTriggerWatch(t *testing.T) {
 				break
 			}
 			time.Sleep(time.Duration(i) * time.Second)
-			testutil.Logger(t).Info("Watch not yet populated, retrying")
+			testutil.Logger(r).Info("Watch not yet populated, retrying")
 		}
 		if err := evaluator(contentsStr); err != nil {
 			r.Errorf("ERROR: Test failing: %s", err)
 		}
 	}
 	ensureNothingCritical := func(r *retry.R, mustContain string) {
-		t.Helper()
+		r.Helper()
 		eval := func(contentsStr string) error {
 			if strings.Contains(contentsStr, "critical") {
 				return fmt.Errorf("MUST NOT contain critical:= %s", contentsStr)
@@ -1875,7 +1875,7 @@ func TestAgent_ReloadDoesNotTriggerWatch(t *testing.T) {
 	}
 
 	retry.RunWith(retriesWithDelay(), t, func(r *retry.R) {
-		testutil.Logger(t).Info("Consul is now ready")
+		testutil.Logger(r).Info("Consul is now ready")
 		// it should contain the output
 		checkStr(r, func(contentStr string) error {
 			if contentStr == "[]" {
@@ -4300,7 +4300,7 @@ func testDefaultSidecar(svc string, port int, fns ...func(*structs.NodeService))
 }
 
 // testCreateToken creates a Policy for the provided rules and a Token linked to that Policy.
-func testCreateToken(t *testing.T, a *TestAgent, rules string) string {
+func testCreateToken(t testutil.TestingTB, a *TestAgent, rules string) string {
 	policyName, err := uuid.GenerateUUID() // we just need a unique name for the test and UUIDs are definitely unique
 	require.NoError(t, err)
 
@@ -4329,7 +4329,7 @@ func testCreateToken(t *testing.T, a *TestAgent, rules string) string {
 	return aclResp.SecretID
 }
 
-func testCreatePolicy(t *testing.T, a *TestAgent, name, rules string) string {
+func testCreatePolicy(t testutil.TestingTB, a *TestAgent, name, rules string) string {
 	args := map[string]interface{}{
 		"Name":  name,
 		"Rules": rules,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -97,7 +97,7 @@ func requireServiceMissing(t *testing.T, a *TestAgent, id string) {
 	require.Nil(t, getService(a, id), "have service %q (expected missing)", id)
 }
 
-func requireCheckExists(t *testing.T, a *TestAgent, id types.CheckID) *structs.HealthCheck {
+func requireCheckExists(t testutil.TestingTB, a *TestAgent, id types.CheckID) *structs.HealthCheck {
 	t.Helper()
 	chk := getCheck(a, id)
 	require.NotNil(t, chk, "missing check %q", id)
@@ -1895,7 +1895,7 @@ func TestAgent_RestoreServiceWithAliasCheck(t *testing.T) {
 
 	// We do this so that the agent logs and the informational messages from
 	// the test itself are interwoven properly.
-	logf := func(t *testing.T, a *TestAgent, format string, args ...interface{}) {
+	logf := func(a *TestAgent, format string, args ...interface{}) {
 		a.logger.Info("testharness: " + fmt.Sprintf(format, args...))
 	}
 
@@ -1954,12 +1954,12 @@ func TestAgent_RestoreServiceWithAliasCheck(t *testing.T) {
 	retryUntilCheckState := func(t *testing.T, a *TestAgent, checkID string, expectedStatus string) {
 		t.Helper()
 		retry.Run(t, func(r *retry.R) {
-			chk := requireCheckExists(t, a, types.CheckID(checkID))
+			chk := requireCheckExists(r, a, types.CheckID(checkID))
 			if chk.Status != expectedStatus {
-				logf(t, a, "check=%q expected status %q but got %q", checkID, expectedStatus, chk.Status)
+				logf(a, "check=%q expected status %q but got %q", checkID, expectedStatus, chk.Status)
 				r.Fatalf("check=%q expected status %q but got %q", checkID, expectedStatus, chk.Status)
 			}
-			logf(t, a, "check %q has reached desired status %q", checkID, expectedStatus)
+			logf(a, "check %q has reached desired status %q", checkID, expectedStatus)
 		})
 	}
 
@@ -1970,7 +1970,7 @@ func TestAgent_RestoreServiceWithAliasCheck(t *testing.T) {
 	retryUntilCheckState(t, a, "service:ping", api.HealthPassing)
 	retryUntilCheckState(t, a, "service:ping-sidecar-proxy", api.HealthPassing)
 
-	logf(t, a, "==== POWERING DOWN ORIGINAL ====")
+	logf(a, "==== POWERING DOWN ORIGINAL ====")
 
 	require.NoError(t, a.Shutdown())
 
@@ -1992,7 +1992,7 @@ node_name = "` + a.Config.NodeName + `"
 		// reregister during standup; we use an adjustable timing to try and force a race
 		sleepDur := time.Duration(idx+1) * 500 * time.Millisecond
 		time.Sleep(sleepDur)
-		logf(t, a2, "re-registering checks and services after a delay of %v", sleepDur)
+		logf(a2, "re-registering checks and services after a delay of %v", sleepDur)
 		for i := 0; i < 20; i++ { // RACE RACE RACE!
 			registerServicesAndChecks(t, a2)
 			time.Sleep(50 * time.Millisecond)
@@ -2002,7 +2002,7 @@ node_name = "` + a.Config.NodeName + `"
 
 		retryUntilCheckState(t, a2, "service:ping", api.HealthPassing)
 
-		logf(t, a2, "giving the alias check a chance to notice...")
+		logf(a2, "giving the alias check a chance to notice...")
 		time.Sleep(5 * time.Second)
 
 		retryUntilCheckState(t, a2, "service:ping-sidecar-proxy", api.HealthPassing)

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -1123,7 +1123,7 @@ func TestCatalogServiceNodes_DistanceSort(t *testing.T) {
 			r.Fatalf("err: %v", err)
 		}
 
-		assertIndex(t, resp)
+		assertIndex(r, resp)
 		nodes = obj.(structs.ServiceNodes)
 		if len(nodes) != 2 {
 			r.Fatalf("bad: %v", obj)

--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -112,7 +112,7 @@ func SkipIfVaultNotPresent(t testing.T) {
 	}
 }
 
-func NewTestVaultServer(t testing.T) *TestVaultServer {
+func NewTestVaultServer(t retry.TestingTB) *TestVaultServer {
 	vaultBinaryName := os.Getenv("VAULT_BINARY_NAME")
 	if vaultBinaryName == "" {
 		vaultBinaryName = "vault"
@@ -190,7 +190,7 @@ func (v *TestVaultServer) Client() *vaultapi.Client {
 	return v.client
 }
 
-func (v *TestVaultServer) WaitUntilReady(t testing.T) {
+func (v *TestVaultServer) WaitUntilReady(t retry.TestingTB) {
 	var version string
 	retry.Run(t, func(r *retry.R) {
 		resp, err := v.client.Sys().Health()

--- a/agent/connect/testing_spiffe.go
+++ b/agent/connect/testing_spiffe.go
@@ -3,24 +3,22 @@
 
 package connect
 
-import (
-	"github.com/mitchellh/go-testing-interface"
-)
+import "github.com/hashicorp/consul/sdk/testutil"
 
 // TestSpiffeIDService returns a SPIFFE ID representing a service.
-func TestSpiffeIDService(t testing.T, service string) *SpiffeIDService {
+func TestSpiffeIDService(t testutil.TestingTB, service string) *SpiffeIDService {
 	return TestSpiffeIDServiceWithHost(t, service, TestClusterID+".consul")
 }
 
 // TestSpiffeIDServiceWithHost returns a SPIFFE ID representing a service with
 // the specified trust domain.
-func TestSpiffeIDServiceWithHost(t testing.T, service, host string) *SpiffeIDService {
+func TestSpiffeIDServiceWithHost(t testutil.TestingTB, service, host string) *SpiffeIDService {
 	return TestSpiffeIDServiceWithHostDC(t, service, host, "dc1")
 }
 
 // TestSpiffeIDServiceWithHostDC returns a SPIFFE ID representing a service with
 // the specified trust domain for the given datacenter.
-func TestSpiffeIDServiceWithHostDC(t testing.T, service, host, datacenter string) *SpiffeIDService {
+func TestSpiffeIDServiceWithHostDC(t testutil.TestingTB, service, host, datacenter string) *SpiffeIDService {
 	return &SpiffeIDService{
 		Host:       host,
 		Namespace:  "default",

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -509,7 +509,7 @@ func newClient(t *testing.T, config *Config) *Client {
 	return client
 }
 
-func newTestResolverConfig(t *testing.T, suffix string, dc, agentType string) resolver.Config {
+func newTestResolverConfig(t testutil.TestingTB, suffix string, dc, agentType string) resolver.Config {
 	n := t.Name()
 	s := strings.Replace(n, "/", "", -1)
 	s = strings.Replace(s, "_", "", -1)
@@ -520,7 +520,7 @@ func newTestResolverConfig(t *testing.T, suffix string, dc, agentType string) re
 	}
 }
 
-func newDefaultDeps(t *testing.T, c *Config) Deps {
+func newDefaultDeps(t testutil.TestingTB, c *Config) Deps {
 	t.Helper()
 
 	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{

--- a/agent/consul/enterprise_server_ce_test.go
+++ b/agent/consul/enterprise_server_ce_test.go
@@ -7,12 +7,11 @@
 package consul
 
 import (
-	"testing"
-
+	"github.com/hashicorp/consul/sdk/testutil"
 	hclog "github.com/hashicorp/go-hclog"
 )
 
-func newDefaultDepsEnterprise(t *testing.T, _ hclog.Logger, _ *Config) EnterpriseDeps {
+func newDefaultDepsEnterprise(t testutil.TestingTB, _ hclog.Logger, _ *Config) EnterpriseDeps {
 	t.Helper()
 	return EnterpriseDeps{}
 }

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -115,7 +115,7 @@ func waitForLeaderEstablishment(t *testing.T, servers ...*Server) {
 	})
 }
 
-func testServerConfig(t *testing.T) (string, *Config) {
+func testServerConfig(t testutil.TestingTB) (string, *Config) {
 	dir := testutil.TempDir(t, "consul")
 	config := DefaultConfig()
 
@@ -231,7 +231,7 @@ func testServerWithConfig(t *testing.T, configOpts ...func(*Config)) (string, *S
 	var deps Deps
 	// Retry added to avoid cases where bind addr is already in use
 	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
-		dir, config = testServerConfig(t)
+		dir, config = testServerConfig(r)
 		for _, fn := range configOpts {
 			fn(config)
 		}
@@ -244,8 +244,8 @@ func testServerWithConfig(t *testing.T, configOpts ...func(*Config)) (string, *S
 		config.ACLResolverSettings.EnterpriseMeta = *config.AgentEnterpriseMeta()
 
 		var err error
-		deps = newDefaultDeps(t, config)
-		srv, err = newServerWithDeps(t, config, deps)
+		deps = newDefaultDeps(r, config)
+		srv, err = newServerWithDeps(r, config, deps)
 		if err != nil {
 			r.Fatalf("err: %v", err)
 		}
@@ -325,7 +325,7 @@ func newServer(t *testing.T, c *Config) (*Server, error) {
 	return newServerWithDeps(t, c, newDefaultDeps(t, c))
 }
 
-func newServerWithDeps(t *testing.T, c *Config, deps Deps) (*Server, error) {
+func newServerWithDeps(t testutil.TestingTB, c *Config, deps Deps) (*Server, error) {
 	// chain server up notification
 	oldNotify := c.NotifyListen
 	up := make(chan struct{})

--- a/agent/event_endpoint_test.go
+++ b/agent/event_endpoint_test.go
@@ -234,7 +234,7 @@ func TestEventList_ACLFilter(t *testing.T) {
 
 	t.Run("token with access to one event type", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
-			token := testCreateToken(t, a, `
+			token := testCreateToken(r, a, `
 				event "foo" {
 					policy = "read"
 				}

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -690,7 +690,7 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			req := msg.GetRequest()
 			require.NotNil(r, req)
 			require.Equal(r, pbpeerstream.TypeURLExportedService, req.ResourceURL)
-			prototest.AssertDeepEqual(t, expectAck, msg)
+			prototest.AssertDeepEqual(r, expectAck, msg)
 		})
 
 		expect := Status{

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -239,7 +239,7 @@ func TestHealthChecksInState_DistanceSort(t *testing.T) {
 		if err != nil {
 			r.Fatalf("err: %v", err)
 		}
-		assertIndex(t, resp)
+		assertIndex(r, resp)
 		nodes = obj.(structs.HealthChecks)
 		if len(nodes) != 2 {
 			r.Fatalf("bad: %v", nodes)
@@ -592,7 +592,7 @@ func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 		if err != nil {
 			r.Fatalf("err: %v", err)
 		}
-		assertIndex(t, resp)
+		assertIndex(r, resp)
 		nodes = obj.(structs.HealthChecks)
 		if len(nodes) != 2 {
 			r.Fatalf("bad: %v", obj)
@@ -1350,7 +1350,7 @@ func TestHealthServiceNodes_DistanceSort(t *testing.T) {
 		if err != nil {
 			r.Fatalf("err: %v", err)
 		}
-		assertIndex(t, resp)
+		assertIndex(r, resp)
 		nodes = obj.(structs.CheckServiceNodes)
 		if len(nodes) != 2 {
 			r.Fatalf("bad: %v", obj)

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -1628,7 +1628,7 @@ func TestAllowedNets(t *testing.T) {
 }
 
 // assertIndex tests that X-Consul-Index is set and non-zero
-func assertIndex(t *testing.T, resp *httptest.ResponseRecorder) {
+func assertIndex(t testutil.TestingTB, resp *httptest.ResponseRecorder) {
 	t.Helper()
 	require.NoError(t, checkIndex(resp))
 }

--- a/agent/remote_exec_test.go
+++ b/agent/remote_exec_test.go
@@ -358,9 +358,9 @@ func testHandleRemoteExec(t *testing.T, command string, expectedSubstring string
 	retry.Run(t, func(r *retry.R) {
 		event := &remoteExecEvent{
 			Prefix:  "_rexec",
-			Session: makeRexecSession(t, a.Agent, ""),
+			Session: makeRexecSession(r, a.Agent, ""),
 		}
-		defer destroySession(t, a.Agent, event.Session, "")
+		defer destroySession(r, a.Agent, event.Session, "")
 
 		spec := &remoteExecSpec{
 			Command: command,
@@ -429,7 +429,7 @@ func TestHandleRemoteExecFailed(t *testing.T) {
 	testHandleRemoteExec(t, "echo failing;exit 2", "failing", "2")
 }
 
-func makeRexecSession(t *testing.T, a *Agent, token string) string {
+func makeRexecSession(t testutil.TestingTB, a *Agent, token string) string {
 	args := structs.SessionRequest{
 		Datacenter: a.config.Datacenter,
 		Op:         structs.SessionCreate,
@@ -448,7 +448,7 @@ func makeRexecSession(t *testing.T, a *Agent, token string) string {
 	return out
 }
 
-func destroySession(t *testing.T, a *Agent, session string, token string) {
+func destroySession(t testutil.TestingTB, a *Agent, session string, token string) {
 	args := structs.SessionRequest{
 		Datacenter: a.config.Datacenter,
 		Op:         structs.SessionDestroy,

--- a/agent/session_endpoint_test.go
+++ b/agent/session_endpoint_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func verifySession(t *testing.T, r *retry.R, a *TestAgent, want structs.Session) {
+func verifySession(t testutil.TestingTB, a *TestAgent, want structs.Session) {
 	t.Helper()
 
 	args := &structs.SessionSpecificRequest{
@@ -30,10 +30,10 @@ func verifySession(t *testing.T, r *retry.R, a *TestAgent, want structs.Session)
 	}
 	var out structs.IndexedSessions
 	if err := a.RPC(context.Background(), "Session.Get", args, &out); err != nil {
-		r.Fatalf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	if len(out.Sessions) != 1 {
-		r.Fatalf("bad: %#v", out.Sessions)
+		t.Fatalf("bad: %#v", out.Sessions)
 	}
 
 	// Make a copy so we don't modify the state store copy for an in-mem
@@ -123,7 +123,7 @@ func TestSessionCreate(t *testing.T) {
 			LockDelay:  20 * time.Second,
 			Behavior:   structs.SessionKeysRelease,
 		}
-		verifySession(t, r, a, want)
+		verifySession(r, a, want)
 	})
 }
 
@@ -188,7 +188,7 @@ func TestSessionCreate_NodeChecks(t *testing.T) {
 			LockDelay:     20 * time.Second,
 			Behavior:      structs.SessionKeysRelease,
 		}
-		verifySession(t, r, a, want)
+		verifySession(r, a, want)
 	})
 }
 
@@ -250,7 +250,7 @@ func TestSessionCreate_Delete(t *testing.T) {
 			LockDelay:  20 * time.Second,
 			Behavior:   structs.SessionKeysDelete,
 		}
-		verifySession(t, r, a, want)
+		verifySession(r, a, want)
 	})
 }
 
@@ -288,7 +288,7 @@ func TestSessionCreate_DefaultCheck(t *testing.T) {
 			LockDelay:  20 * time.Second,
 			Behavior:   structs.SessionKeysRelease,
 		}
-		verifySession(t, r, a, want)
+		verifySession(r, a, want)
 	})
 }
 
@@ -329,7 +329,7 @@ func TestSessionCreate_NoCheck(t *testing.T) {
 				LockDelay:  20 * time.Second,
 				Behavior:   structs.SessionKeysRelease,
 			}
-			verifySession(t, r, a, want)
+			verifySession(r, a, want)
 		})
 	})
 
@@ -359,7 +359,7 @@ func TestSessionCreate_NoCheck(t *testing.T) {
 				LockDelay:  20 * time.Second,
 				Behavior:   structs.SessionKeysRelease,
 			}
-			verifySession(t, r, a, want)
+			verifySession(r, a, want)
 		})
 	})
 
@@ -391,7 +391,7 @@ func TestSessionCreate_NoCheck(t *testing.T) {
 				LockDelay:  20 * time.Second,
 				Behavior:   structs.SessionKeysRelease,
 			}
-			verifySession(t, r, a, want)
+			verifySession(r, a, want)
 		})
 	})
 }
@@ -430,7 +430,7 @@ func makeTestSessionDelete(t *testing.T, srv *HTTPHandlers) string {
 	return sessResp.ID
 }
 
-func makeTestSessionTTL(t *testing.T, srv *HTTPHandlers, ttl string) string {
+func makeTestSessionTTL(t testutil.TestingTB, srv *HTTPHandlers, ttl string) string {
 	t.Helper()
 	// Create Session with TTL
 	body := bytes.NewBuffer(nil)
@@ -488,7 +488,7 @@ func TestSessionCustomTTL(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	retry.Run(t, func(r *retry.R) {
-		id := makeTestSessionTTL(t, a.srv, ttl.String())
+		id := makeTestSessionTTL(r, a.srv, ttl.String())
 
 		req, _ := http.NewRequest("GET", "/v1/session/info/"+id, nil)
 		resp := httptest.NewRecorder()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -119,7 +119,7 @@ func makeClientWithConfig(
 	var server *testutil.TestServer
 	var err error
 	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
-		server, err = testutil.NewTestServerConfigT(t, cb2)
+		server, err = testutil.NewTestServerConfigT(r, cb2)
 		if err != nil {
 			r.Fatalf("Failed to start server: %v", err.Error())
 		}

--- a/api/lock_test.go
+++ b/api/lock_test.go
@@ -106,7 +106,7 @@ func TestAPI_LockForceInvalidate(t *testing.T) {
 	defer s.Stop()
 
 	retry.Run(t, func(r *retry.R) {
-		lock, session := createTestLock(t, c, "test/lock")
+		lock, session := createTestLock(r, c, "test/lock")
 		defer session.Destroy(lock.opts.Session, nil)
 
 		// Should work

--- a/connect/proxy/proxy_test.go
+++ b/connect/proxy/proxy_test.go
@@ -98,7 +98,7 @@ func TestProxy_public(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		conn, err = svc.Dial(context.Background(), &connect.StaticResolver{
 			Addr:    TestLocalAddr(ports[0]),
-			CertURI: agConnect.TestSpiffeIDService(t, "echo"),
+			CertURI: agConnect.TestSpiffeIDService(r, "echo"),
 		})
 		if err != nil {
 			r.Fatalf("err: %s", err)

--- a/connect/service_test.go
+++ b/connect/service_test.go
@@ -246,7 +246,7 @@ func TestService_HTTPClient(t *testing.T) {
 			//require.Equal(t,"https://backend.service.consul:443", addr)
 			return &StaticResolver{
 				Addr:    testSvr.Addr,
-				CertURI: connect.TestSpiffeIDService(t, "backend"),
+				CertURI: connect.TestSpiffeIDService(r, "backend"),
 			}, nil
 		}
 

--- a/sdk/testutil/retry/doc.go
+++ b/sdk/testutil/retry/doc.go
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package retry provides support for repeating operations in tests.
+//
+// A sample retry operation looks like this:
+//
+//	func TestX(t *testing.T) {
+//	    retry.Run(t, func(r *retry.R) {
+//	        if err := foo(); err != nil {
+//				r.Errorf("foo: %s", err)
+//				return
+//	        }
+//	    })
+//	}
+//
+// Run uses the DefaultFailer, which is a Timer with a Timeout of 7s,
+// and a Wait of 25ms. To customize, use RunWith.
+//
+// WARNING: unlike *testing.T, *retry.R#Fatal and FailNow *do not*
+// fail the test function entirely, only the current run the retry func
+package retry

--- a/sdk/testutil/retry/interface.go
+++ b/sdk/testutil/retry/interface.go
@@ -1,0 +1,35 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package retry
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var nilInf TestingTB = nil
+
+// Assertion that our TestingTB can be passed to
+var _ require.TestingT = nilInf
+var _ assert.TestingT = nilInf
+
+// TestingTB is an interface that describes the implementation of the testing object.
+// Using an interface that describes testing.TB instead of the actual implementation
+// makes testutil usable in a wider variety of contexts (e.g. use with ginkgo : https://godoc.org/github.com/onsi/ginkgo#GinkgoT)
+type TestingTB interface {
+	Cleanup(func())
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Helper()
+	Log(args ...any)
+	Logf(format string, args ...any)
+	Name() string
+	Setenv(key, value string)
+	TempDir() string
+}

--- a/sdk/testutil/retry/output.go
+++ b/sdk/testutil/retry/output.go
@@ -1,0 +1,39 @@
+package retry
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+func dedup(a []string) string {
+	if len(a) == 0 {
+		return ""
+	}
+	seen := map[string]struct{}{}
+	var b bytes.Buffer
+	for _, s := range a {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		b.WriteString(s)
+		b.WriteRune('\n')
+	}
+	return b.String()
+}
+
+func decorate(s string) string {
+	_, file, line, ok := runtime.Caller(3)
+	if ok {
+		n := strings.LastIndex(file, "/")
+		if n >= 0 {
+			file = file[n+1:]
+		}
+	} else {
+		file = "???"
+		line = 1
+	}
+	return fmt.Sprintf("%s:%d: %s", file, line, s)
+}

--- a/sdk/testutil/retry/retry.go
+++ b/sdk/testutil/retry/retry.go
@@ -1,82 +1,138 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
-// Package retry provides support for repeating operations in tests.
-//
-// A sample retry operation looks like this:
-//
-//	func TestX(t *testing.T) {
-//	    retry.Run(t, func(r *retry.R) {
-//	        if err := foo(); err != nil {
-//				r.Errorf("foo: %s", err)
-//				return
-//	        }
-//	    })
-//	}
-//
-// Run uses the DefaultFailer, which is a Timer with a Timeout of 7s,
-// and a Wait of 25ms. To customize, use RunWith.
-//
-// WARNING: unlike *testing.T, *retry.R#Fatal and FailNow *do not*
-// fail the test function entirely, only the current run the retry func
 package retry
 
 import (
-	"bytes"
 	"fmt"
-	"runtime"
-	"strings"
-	"time"
+	"os"
 )
 
-// Failer is an interface compatible with testing.T.
-type Failer interface {
-	Helper()
+var _ TestingTB = &R{}
 
-	// Log is called for the final test output
-	Log(args ...interface{})
-
-	// FailNow is called when the retrying is abandoned.
-	FailNow()
-}
-
-// R provides context for the retryer.
-//
-// Logs from Logf, (Error|Fatal)(f) are gathered in an internal buffer
-// and printed only if the retryer fails. Printed logs are deduped and
-// prefixed with source code line numbers
 type R struct {
-	// fail is set by FailNow and (Fatal|Error)(f). It indicates the pass
-	// did not succeed, and should be retried
-	fail bool
-	// done is set by Stop. It indicates the entire run was a failure,
-	// and triggers t.FailNow()
-	done   bool
-	output []string
+	wrapped TestingTB
+	retryer Retryer
 
-	cleanups []func()
+	done       bool
+	fullOutput bool
+
+	attempts []*attempt
 }
 
-func (r *R) Logf(format string, args ...interface{}) {
-	r.log(fmt.Sprintf(format, args...))
+func (r *R) Cleanup(clean func()) {
+	a := r.getCurrentAttempt()
+	a.cleanups = append(a.cleanups, clean)
 }
 
-func (r *R) Log(args ...interface{}) {
+func (r *R) Error(args ...any) {
+	r.Log(args...)
+	r.Fail()
+}
+
+func (r *R) Errorf(format string, args ...any) {
+	r.Logf(format, args...)
+	r.Fail()
+}
+
+func (r *R) Fail() {
+	r.getCurrentAttempt().failed = true
+}
+
+func (r *R) FailNow() {
+	r.Fail()
+	panic(attemptFailed{})
+}
+
+func (r *R) Failed() bool {
+	return r.getCurrentAttempt().failed
+}
+
+func (r *R) Fatal(args ...any) {
+	r.Log(args...)
+	r.FailNow()
+}
+
+func (r *R) Fatalf(format string, args ...any) {
+	r.Logf(format, args...)
+	r.FailNow()
+}
+
+func (r *R) Helper() {
+	// *testing.T will just record which functions are helpers by their addresses and
+	// it doesn't much matter where where we record that they are helpers
+	r.wrapped.Helper()
+}
+
+func (r *R) Log(args ...any) {
 	r.log(fmt.Sprintln(args...))
 }
 
-func (r *R) Helper() {}
-
-// Cleanup register a function to be run to cleanup resources that
-// were allocated during the retry attempt. These functions are executed
-// after a retry attempt. If they panic, it will not stop further retry
-// attempts but will be cause for the overall test failure.
-func (r *R) Cleanup(fn func()) {
-	r.cleanups = append(r.cleanups, fn)
+func (r *R) Logf(format string, args ...any) {
+	r.log(fmt.Sprintf(format, args...))
 }
 
-func (r *R) runCleanup() {
+// Name will return the name of the underlying TestingT.
+func (r *R) Name() string {
+	return r.wrapped.Name()
+}
 
+// Setenv will save the current value of the specified env var, set it to the
+// specified value and then restore it to the original value in a cleanup function
+// once the retry attempt has finished.
+func (r *R) Setenv(key, value string) {
+	prevValue, ok := os.LookupEnv(key)
+
+	if err := os.Setenv(key, value); err != nil {
+		r.wrapped.Fatalf("cannot set environment variable: %v", err)
+	}
+
+	if ok {
+		r.Cleanup(func() {
+			os.Setenv(key, prevValue)
+		})
+	} else {
+		r.Cleanup(func() {
+			os.Unsetenv(key)
+		})
+	}
+}
+
+// TempDir will use the wrapped TestingT to create a temporary directory
+// that will be cleaned up when ALL RETRYING has finished.
+func (r *R) TempDir() string {
+	return r.wrapped.TempDir()
+}
+
+// Check will call r.Fatal(err) if err is not nil
+func (r *R) Check(err error) {
+	if err != nil {
+		r.Fatal(err)
+	}
+}
+
+func (r *R) Stop(err error) {
+	r.log(err.Error())
+	r.done = true
+}
+
+func (r *R) failCurrentAttempt() {
+	r.getCurrentAttempt().failed = true
+}
+
+func (r *R) log(s string) {
+	a := r.getCurrentAttempt()
+	a.output = append(a.output, decorate(s))
+}
+
+func (r *R) getCurrentAttempt() *attempt {
+	if len(r.attempts) == 0 {
+		panic("no retry attempts have been started yet")
+	}
+
+	return r.attempts[len(r.attempts)-1]
+}
+
+// cleanupAttempt will perform all the register cleanup operations recorded
+// during execution of the single round of the test function.
+func (r *R) cleanupAttempt(a *attempt) {
 	// Make sure that if a cleanup function panics,
 	// we still run the remaining cleanup functions.
 	defer func() {
@@ -84,17 +140,17 @@ func (r *R) runCleanup() {
 		if err != nil {
 			r.Stop(fmt.Errorf("error when performing test cleanup: %v", err))
 		}
-		if len(r.cleanups) > 0 {
-			r.runCleanup()
+		if len(a.cleanups) > 0 {
+			r.cleanupAttempt(a)
 		}
 	}()
 
-	for len(r.cleanups) > 0 {
+	for len(a.cleanups) > 0 {
 		var cleanup func()
-		if len(r.cleanups) > 0 {
-			last := len(r.cleanups) - 1
-			cleanup = r.cleanups[last]
-			r.cleanups = r.cleanups[:last]
+		if len(a.cleanups) > 0 {
+			last := len(a.cleanups) - 1
+			cleanup = a.cleanups[last]
+			a.cleanups = a.cleanups[:last]
 		}
 		if cleanup != nil {
 			cleanup()
@@ -102,162 +158,67 @@ func (r *R) runCleanup() {
 	}
 }
 
-// runFailed is a sentinel value to indicate that the func itself
-// didn't panic, rather that `FailNow` was called.
-type runFailed struct{}
+// runAttempt will execute one round of the test function and handle cleanups and panic recovery
+// of a failed attempt that should not stop retrying.
+func (r *R) runAttempt(f func(r *R)) {
+	r.Helper()
 
-// FailNow stops run execution. It is roughly equivalent to:
-//
-//	r.Error("")
-//	return
-//
-// inside the function being run.
-func (r *R) FailNow() {
-	r.fail = true
-	panic(runFailed{})
-}
+	a := &attempt{}
+	r.attempts = append(r.attempts, a)
 
-// Fatal is equivalent to r.Logf(args) followed by r.FailNow(), i.e. the run
-// function should be exited. Retries on the next run are allowed. Fatal is
-// equivalent to
-//
-//	r.Error(args)
-//	return
-//
-// inside the function being run.
-func (r *R) Fatal(args ...interface{}) {
-	r.log(fmt.Sprint(args...))
-	r.FailNow()
-}
-
-// Fatalf is like Fatal but allows a format string
-func (r *R) Fatalf(format string, args ...interface{}) {
-	r.log(fmt.Sprintf(format, args...))
-	r.FailNow()
-}
-
-// Error indicates the current run encountered an error and should be retried.
-// It *does not* stop execution of the rest of the run function.
-func (r *R) Error(args ...interface{}) {
-	r.log(fmt.Sprint(args...))
-	r.fail = true
-}
-
-// Errorf is like Error but allows a format string
-func (r *R) Errorf(format string, args ...interface{}) {
-	r.log(fmt.Sprintf(format, args...))
-	r.fail = true
-}
-
-// If err is non-nil, equivalent to r.Fatal(err.Error()) followed by
-// r.FailNow(). Otherwise a no-op.
-func (r *R) Check(err error) {
-	if err != nil {
-		r.log(err.Error())
-		r.FailNow()
-	}
-}
-
-func (r *R) log(s string) {
-	r.output = append(r.output, decorate(s))
-}
-
-// Stop retrying, and fail the test, logging the specified error.
-// Does not stop execution, so return should be called after.
-func (r *R) Stop(err error) {
-	r.log(err.Error())
-	r.done = true
-}
-
-func decorate(s string) string {
-	_, file, line, ok := runtime.Caller(3)
-	if ok {
-		n := strings.LastIndex(file, "/")
-		if n >= 0 {
-			file = file[n+1:]
+	defer r.cleanupAttempt(a)
+	defer func() {
+		if p := recover(); p != nil && p != (attemptFailed{}) {
+			panic(p)
 		}
-	} else {
-		file = "???"
-		line = 1
-	}
-	return fmt.Sprintf("%s:%d: %s", file, line, s)
+	}()
+	f(r)
 }
 
-func Run(t Failer, f func(r *R)) {
-	t.Helper()
-	run(DefaultFailer(), t, f)
-}
+func (r *R) run(f func(r *R)) {
+	r.Helper()
 
-func RunWith(r Retryer, t Failer, f func(r *R)) {
-	t.Helper()
-	run(r, t, f)
-}
-
-func dedup(a []string) string {
-	if len(a) == 0 {
-		return ""
-	}
-	seen := map[string]struct{}{}
-	var b bytes.Buffer
-	for _, s := range a {
-		if _, ok := seen[s]; ok {
-			continue
-		}
-		seen[s] = struct{}{}
-		b.WriteString(s)
-		b.WriteRune('\n')
-	}
-	return b.String()
-}
-
-func run(r Retryer, t Failer, f func(r *R)) {
-	t.Helper()
-	rr := &R{}
-
-	fail := func() {
-		t.Helper()
-		out := dedup(rr.output)
-		if out != "" {
-			t.Log(out)
-		}
-		t.FailNow()
-	}
-
-	for r.Continue() {
-		// run f(rr), but if recover yields a runFailed value, we know
-		// FailNow was called.
-		func() {
-			defer rr.runCleanup()
-			defer func() {
-				if p := recover(); p != nil && p != (runFailed{}) {
-					panic(p)
-				}
-			}()
-			f(rr)
-		}()
+	for r.retryer.Continue() {
+		r.runAttempt(f)
 
 		switch {
-		case rr.done:
-			fail()
+		case r.done:
+			r.recordRetryFailure()
 			return
-		case !rr.fail:
+		case !r.Failed():
+			// the current attempt did not fail so we can go ahead and return
 			return
 		}
-		rr.fail = false
 	}
-	fail()
+
+	// We cannot retry any more and no attempt has succeeded yet.
+	r.recordRetryFailure()
 }
 
-// DefaultFailer provides default retry.Run() behavior for unit tests, namely
-// 7s timeout with a wait of 25ms
-func DefaultFailer() *Timer {
-	return &Timer{Timeout: 7 * time.Second, Wait: 25 * time.Millisecond}
+func (r *R) recordRetryFailure() {
+	r.Helper()
+	output := r.getCurrentAttempt().output
+	if r.fullOutput {
+		var combined []string
+		for _, attempt := range r.attempts {
+			combined = append(combined, attempt.output...)
+		}
+		output = combined
+	}
+
+	out := dedup(output)
+	if out != "" {
+		r.wrapped.Log(out)
+	}
+	r.wrapped.FailNow()
 }
 
-// Retryer provides an interface for repeating operations
-// until they succeed or an exit condition is met.
-type Retryer interface {
-	// Continue returns true if the operation should be repeated, otherwise it
-	// returns false to indicate retrying should stop.
-	Continue() bool
+type attempt struct {
+	failed   bool
+	output   []string
+	cleanups []func()
 }
+
+// attemptFailed is a sentinel value to indicate that the func itself
+// didn't panic, rather that `FailNow` was called.
+type attemptFailed struct{}

--- a/sdk/testutil/retry/retry_test.go
+++ b/sdk/testutil/retry/retry_test.go
@@ -62,7 +62,7 @@ func TestBasics(t *testing.T) {
 	t.Run("Fatal returns from func, but does not fail test", func(t *testing.T) {
 		i := 0
 		gotHere := false
-		ft := &fakeT{}
+		ft := &fakeT{T: t}
 		Run(ft, func(r *R) {
 			i++
 			t.Logf("i: %d; r: %#v", i, r)
@@ -97,7 +97,7 @@ func TestBasics(t *testing.T) {
 
 func TestRunWith(t *testing.T) {
 	t.Run("calls FailNow after exceeding retries", func(t *testing.T) {
-		ft := &fakeT{}
+		ft := &fakeT{T: t}
 		iter := 0
 		RunWith(&Counter{Count: 3, Wait: time.Millisecond}, ft, func(r *R) {
 			iter++
@@ -109,7 +109,7 @@ func TestRunWith(t *testing.T) {
 	})
 
 	t.Run("Stop ends the retrying", func(t *testing.T) {
-		ft := &fakeT{}
+		ft := &fakeT{T: t}
 		iter := 0
 		RunWith(&Counter{Count: 5, Wait: time.Millisecond}, ft, func(r *R) {
 			iter++
@@ -130,7 +130,7 @@ func TestRunWith(t *testing.T) {
 
 func TestCleanup(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		ft := &fakeT{}
+		ft := &fakeT{T: t}
 		cleanupsExecuted := 0
 		RunWith(&Counter{Count: 2, Wait: time.Millisecond}, ft, func(r *R) {
 			r.Cleanup(func() {
@@ -142,7 +142,7 @@ func TestCleanup(t *testing.T) {
 		require.Equal(t, 1, cleanupsExecuted)
 	})
 	t.Run("cleanup-panic-recovery", func(t *testing.T) {
-		ft := &fakeT{}
+		ft := &fakeT{T: t}
 		cleanupsExecuted := 0
 		RunWith(&Counter{Count: 2, Wait: time.Millisecond}, ft, func(r *R) {
 			r.Cleanup(func() {
@@ -167,7 +167,7 @@ func TestCleanup(t *testing.T) {
 	})
 
 	t.Run("cleanup-per-retry", func(t *testing.T) {
-		ft := &fakeT{}
+		ft := &fakeT{T: t}
 		iter := 0
 		cleanupsExecuted := 0
 		RunWith(&Counter{Count: 3, Wait: time.Millisecond}, ft, func(r *R) {
@@ -194,6 +194,7 @@ func TestCleanup(t *testing.T) {
 type fakeT struct {
 	fails int
 	out   []string
+	*testing.T
 }
 
 func (f *fakeT) Helper() {}
@@ -206,4 +207,4 @@ func (f *fakeT) FailNow() {
 	f.fails++
 }
 
-var _ Failer = &fakeT{}
+var _ TestingTB = &fakeT{}

--- a/sdk/testutil/retry/retryer.go
+++ b/sdk/testutil/retry/retryer.go
@@ -1,0 +1,33 @@
+package retry
+
+import "time"
+
+// Retryer provides an interface for repeating operations
+// until they succeed or an exit condition is met.
+type Retryer interface {
+	// Continue returns true if the operation should be repeated, otherwise it
+	// returns false to indicate retrying should stop.
+	Continue() bool
+}
+
+// DefaultRetryer provides default retry.Run() behavior for unit tests, namely
+// 7s timeout with a wait of 25ms
+func DefaultRetryer() Retryer {
+	return &Timer{Timeout: 7 * time.Second, Wait: 25 * time.Millisecond}
+}
+
+// ThirtySeconds repeats an operation for thirty seconds and waits 500ms in between.
+// Best for known slower operations like waiting on eventually consistent state.
+func ThirtySeconds() *Timer {
+	return &Timer{Timeout: 30 * time.Second, Wait: 500 * time.Millisecond}
+}
+
+// TwoSeconds repeats an operation for two seconds and waits 25ms in between.
+func TwoSeconds() *Timer {
+	return &Timer{Timeout: 2 * time.Second, Wait: 25 * time.Millisecond}
+}
+
+// ThreeTimes repeats an operation three times and waits 25ms in between.
+func ThreeTimes() *Counter {
+	return &Counter{Count: 3, Wait: 25 * time.Millisecond}
+}

--- a/sdk/testutil/retry/run.go
+++ b/sdk/testutil/retry/run.go
@@ -1,0 +1,34 @@
+package retry
+
+type Option func(r *R)
+
+func WithRetryer(retryer Retryer) Option {
+	return func(r *R) {
+		r.retryer = retryer
+	}
+}
+
+func WithFullOutput() Option {
+	return func(r *R) {
+		r.fullOutput = true
+	}
+}
+
+func Run(t TestingTB, f func(r *R), opts ...Option) {
+	t.Helper()
+	r := &R{
+		wrapped: t,
+		retryer: DefaultRetryer(),
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	r.run(f)
+}
+
+func RunWith(r Retryer, t TestingTB, f func(r *R)) {
+	t.Helper()
+	Run(t, f, WithRetryer(r))
+}

--- a/sdk/testutil/retry/timer.go
+++ b/sdk/testutil/retry/timer.go
@@ -2,22 +2,6 @@ package retry
 
 import "time"
 
-// ThirtySeconds repeats an operation for thirty seconds and waits 500ms in between.
-// Best for known slower operations like waiting on eventually consistent state.
-func ThirtySeconds() *Timer {
-	return &Timer{Timeout: 30 * time.Second, Wait: 500 * time.Millisecond}
-}
-
-// TwoSeconds repeats an operation for two seconds and waits 25ms in between.
-func TwoSeconds() *Timer {
-	return &Timer{Timeout: 2 * time.Second, Wait: 25 * time.Millisecond}
-}
-
-// ThreeTimes repeats an operation three times and waits 25ms in between.
-func ThreeTimes() *Counter {
-	return &Counter{Count: 3, Wait: 25 * time.Millisecond}
-}
-
 // Timer repeats an operation for a given amount
 // of time and waits between subsequent operations.
 type Timer struct {

--- a/test/integration/consul-container/libs/assert/service.go
+++ b/test/integration/consul-container/libs/assert/service.go
@@ -259,7 +259,7 @@ func WaitForFortioNameWithClient(t *testing.T, r retry.Retryer, urlbase string, 
 // It retries with timeout defaultHTTPTimeout and wait defaultHTTPWait.
 //
 // client must be a custom http.Client
-func FortioNameWithClient(t retry.Failer, urlbase string, name string, reqHost string, client *http.Client) (string, error) {
+func FortioNameWithClient(t retry.TestingTB, urlbase string, name string, reqHost string, client *http.Client) (string, error) {
 	t.Helper()
 	var fortioNameRE = regexp.MustCompile("\nFORTIO_NAME=(.+)\n")
 	var body []byte

--- a/test/integration/consul-container/test/envoy_extensions/otel_access_logging_test.go
+++ b/test/integration/consul-container/test/envoy_extensions/otel_access_logging_test.go
@@ -85,10 +85,12 @@ func TestOTELAccessLogging(t *testing.T) {
 	}
 	consul.ConfigEntries().Set(&defaults, nil)
 
+	// doRequest does its own retrying and doesn't need to be within the next retry.RunWith block
+	doRequest(t, fmt.Sprintf("http://localhost:%d", port), http.StatusOK)
+
 	// Make requests from the static-client to the static-server and look for the access logs
 	// to show up in the `otel-collector` container logs.
 	retry.RunWith(&retry.Timer{Timeout: 60 * time.Second, Wait: time.Second}, t, func(r *retry.R) {
-		doRequest(t, fmt.Sprintf("http://localhost:%d", port), http.StatusOK)
 		reader, err := launchInfo.Container.Logs(context.Background())
 		require.NoError(r, err)
 		log, err := io.ReadAll(reader)

--- a/test/integration/consul-container/test/ratelimit/ratelimit_test.go
+++ b/test/integration/consul-container/test/ratelimit/ratelimit_test.go
@@ -166,12 +166,12 @@ func TestServerRequestRateLimit(t *testing.T) {
 			for _, op := range tc.operations {
 				timer := &retry.Timer{Timeout: 15 * time.Second, Wait: 500 * time.Millisecond}
 				retry.RunWith(timer, t, func(r *retry.R) {
-					checkForMetric(t, cluster, op.action.rateLimitOperation, op.action.rateLimitType, tc.mode, op.expectMetric)
+					checkForMetric(r, cluster, op.action.rateLimitOperation, op.action.rateLimitType, tc.mode, op.expectMetric)
 
 					// validate logs
 					// putting this last as there are cases where logs
 					// were not present in consumer when assertion was made.
-					checkLogsForMessage(t, clusterConfig.LogConsumer.Msgs,
+					checkLogsForMessage(r, clusterConfig.LogConsumer.Msgs,
 						fmt.Sprintf("[DEBUG] agent.server.rpc-rate-limit: RPC exceeded allowed rate limit: rpc=%s", op.action.rateLimitOperation),
 						op.action.rateLimitOperation, "exceeded", op.expectExceededLog)
 
@@ -190,7 +190,7 @@ func setupClusterAndClient(t *testing.T, config *libtopology.ClusterConfig, isSe
 	return cluster, client
 }
 
-func checkForMetric(t *testing.T, cluster *libcluster.Cluster, operationName string, expectedLimitType string, expectedMode string, expectMetric bool) {
+func checkForMetric(t testutil.TestingTB, cluster *libcluster.Cluster, operationName string, expectedLimitType string, expectedMode string, expectMetric bool) {
 	// validate metrics
 	server, err := cluster.GetClient(nil, true)
 	require.NoError(t, err)
@@ -228,7 +228,7 @@ func checkForMetric(t *testing.T, cluster *libcluster.Cluster, operationName str
 	}
 }
 
-func checkLogsForMessage(t *testing.T, logs []string, msg string, operationName string, logType string, logShouldExist bool) {
+func checkLogsForMessage(t testutil.TestingTB, logs []string, msg string, operationName string, logType string, logShouldExist bool) {
 	if logShouldExist {
 		found := false
 		for _, log := range logs {


### PR DESCRIPTION
### Description

Fix a bunch of tests that were using retry.Run* methods improperly (accessing the outer testing.T from within the retried function)

Commits:
1. Add a make target to execute just `lint-consul-retry`
2. Refactored the `sdk/testutil/retry` package to clean up the code.
3. Fix all the test bugs

These were found with the updated linter which is PR'ed here: https://github.com/hashicorp/lint-consul-retry/pull/5

### Testing & Reproduction steps

* These are test fixes
