### PR TITLE
Fix BUSL license checker to skip >= 1.17.x target branches

### DIFF
--- a/.github/scripts/license_checker.sh
+++ b/.github/scripts/license_checker.sh
@@ -5,7 +5,6 @@
 if [[ ${GITHUB_BASE_REF} == release/1.14.* ]] || [[ ${GITHUB_BASE_REF} == release/1.15.* ]] || [[ ${GITHUB_BASE_REF} == release/1.16.* ]]; then
     busl_files=$(grep -r 'SPDX-License-Identifier: BUSL' . --exclude-dir .github)
 
-    # If we do not find a file in .changelog/, we fail the check
     if [ -n "$busl_files" ]; then
         echo "Found BUSL occurrences in the PR branch! (See NET-5258 for details)"
         echo -n "$busl_files"

--- a/.github/scripts/license_checker.sh
+++ b/.github/scripts/license_checker.sh
@@ -2,15 +2,20 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+if [[ ${GITHUB_BASE_REF} == release/1.14.* ]] || [[ ${GITHUB_BASE_REF} == release/1.15.* ]] || [[ ${GITHUB_BASE_REF} == release/1.16.* ]]; then
+    busl_files=$(grep -r 'SPDX-License-Identifier: BUSL' . --exclude-dir .github)
 
-busl_files=$(grep -r 'SPDX-License-Identifier: BUSL' . --exclude-dir .github)
-
-# If we do not find a file in .changelog/, we fail the check
-if [ -n "$busl_files" ]; then
-    echo "Found BUSL occurrences in the PR branch! (See NET-5258 for details)"
-    echo -n "$busl_files"
-    exit 1
+    # If we do not find a file in .changelog/, we fail the check
+    if [ -n "$busl_files" ]; then
+        echo "Found BUSL occurrences in the PR branch! (See NET-5258 for details)"
+        echo -n "$busl_files"
+        exit 1
+    else
+        echo "Did not find any occurrences of BUSL in the PR branch"
+        exit 0
+    fi
+    echo "The variable starts with release/1.14, release/1.15, or release/1.17."
 else
-    echo "Did not find any occurrences of BUSL in the PR branch"
+    echo "Skipping BUSL check since ${GITHUB_BASE_REF} not one of release/1.14.*, release/1.15.*, or release/1.16.*."
     exit 0
 fi

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -7,11 +7,8 @@ name: License Checker
 
 on:
   pull_request:
+    # Logic to only apply check 1.1[4,5,6].x branches is in license_checker.sh
     types: [opened, synchronize]
-    branches:
-      - release/1.14.*
-      - release/1.15.*
-      - release/1.16.*
 
 jobs:
   # checks that the diff does not contain any reference to


### PR DESCRIPTION
### Description

Just testing this out on the release branch and then will rubberstamp in all the places.

### Testing & Reproduction steps

```
$ cat crap.sh                                                                                                                                                                                                                                     
#!/bin/bash
# Copyright (c) HashiCorp, Inc.
# SPDX-License-Identifier: BUSL-1.1

if [[ ${GITHUB_BASE_REF} == release/1.14.* ]] || [[ ${GITHUB_BASE_REF} == release/1.15.* ]] || [[ ${GITHUB_BASE_REF} == release/1.16.* ]]; then
    echo "Matched!"
else
    echo "skipped"
fi%                                                                                                                                                                                                                                                                                                                         

$ GITHUB_BASE_REF="release/1.14.x" ./crap.sh
Matched!

$ GITHUB_BASE_REF="release/1.14.2" ./crap.sh
Matched!

$ GITHUB_BASE_REF="release/1.15.x" ./crap.sh
Matched!

$ GITHUB_BASE_REF="release/1.15.4" ./crap.sh
Matched!

$ GITHUB_BASE_REF="release/1.16.x" ./crap.sh
Matched!

$ GITHUB_BASE_REF="release/1.16.4" ./crap.sh
Matched!

$ GITHUB_BASE_REF="release/1.17.x" ./crap.sh
skipped

$ GITHUB_BASE_REF="release/1.17.0" ./crap.sh
skipped
```
