### PR TITLE
Run license-check for all release branches so required CI rules are met

### DIFF
--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -22,5 +22,5 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # by default the checkout action doesn't checkout all branches
       - name: Check for BUSL text in diff
-        if: github.ref_name == 'refs/heads/release/1.14.x' || github.ref_name == 'refs/heads/release/1.15.x' || github.ref_name == 'refs/heads/release/1.16.x'
+        if: startsWith(github.ref_name, 'refs/heads/release/1.14.') || startsWith(github.ref_name, 'refs/heads/release/1.15.') || startsWith(github.ref_name, 'refs/heads/release/1.16.')
         run: ./.github/scripts/license_checker.sh

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -9,9 +9,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches:
-      - release/1.14.*
-      - release/1.15.*
-      - release/1.16.*
+      - release/**
 
 jobs:
   # checks that the diff does not contain any reference to
@@ -24,4 +22,5 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # by default the checkout action doesn't checkout all branches
       - name: Check for BUSL text in diff
+        if: github.ref_name == 'refs/heads/release/1.14.x' || github.ref_name == 'refs/heads/release/1.15.x' || github.ref_name == 'refs/heads/release/1.16.x'
         run: ./.github/scripts/license_checker.sh


### PR DESCRIPTION
### Description
All release branches have a protection rule that requires the `license-check` job to run; however, this currently only runs for Consul 1.14-1.16 release branches.

This changes the job to run for all release branches but skip the actual check for anything that isn't Consul 1.14-1.16 release branches. This will allow the CI requirement to be met even for PRs targeting `release/1.17.x`.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
