### PR TITLE
Fix BUSL license checker to skip >= 1.17.x target branches (#19152)

### DIFF
--- a/.github/scripts/license_checker.sh
+++ b/.github/scripts/license_checker.sh
@@ -2,15 +2,19 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+if [[ ${GITHUB_BASE_REF} == release/1.14.* ]] || [[ ${GITHUB_BASE_REF} == release/1.15.* ]] || [[ ${GITHUB_BASE_REF} == release/1.16.* ]]; then
+    busl_files=$(grep -r 'SPDX-License-Identifier: BUSL' . --exclude-dir .github)
 
-busl_files=$(grep -r 'SPDX-License-Identifier: BUSL' . --exclude-dir .github)
-
-# If we do not find a file in .changelog/, we fail the check
-if [ -n "$busl_files" ]; then
-    echo "Found BUSL occurrences in the PR branch! (See NET-5258 for details)"
-    echo -n "$busl_files"
-    exit 1
+    if [ -n "$busl_files" ]; then
+        echo "Found BUSL occurrences in the PR branch! (See NET-5258 for details)"
+        echo -n "$busl_files"
+        exit 1
+    else
+        echo "Did not find any occurrences of BUSL in the PR branch"
+        exit 0
+    fi
+    echo "The variable starts with release/1.14, release/1.15, or release/1.17."
 else
-    echo "Did not find any occurrences of BUSL in the PR branch"
+    echo "Skipping BUSL check since ${GITHUB_BASE_REF} not one of release/1.14.*, release/1.15.*, or release/1.16.*."
     exit 0
 fi

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -7,11 +7,8 @@ name: License Checker
 
 on:
   pull_request:
+    # Logic to only apply check 1.1[4,5,6].x branches is in license_checker.sh
     types: [opened, synchronize]
-    branches:
-      - release/1.14.*
-      - release/1.15.*
-      - release/1.16.*
 
 jobs:
   # checks that the diff does not contain any reference to


### PR DESCRIPTION
Rubber stamping https://github.com/hashicorp/consul/commit/76f5b71708bd5e7872e809732fd23f59b825cada from `release/1.17.x` and backporting to n-2.

See NET-5935 for tracking.