### PR TITLE
Fix ID vs CheckID parameter to "Register Check" call

### DIFF
--- a/website/content/api-docs/agent/check.mdx
+++ b/website/content/api-docs/agent/check.mdx
@@ -126,7 +126,7 @@ The table below shows this endpoint's support for
 
 - `Name` `(string: <required>)` - Specifies the name of the check.
 
-- `ID` `(string: "")` - Specifies a unique ID for this check on the node.
+- `CheckID` `(string: "")` - Specifies a unique ID for this check on the node.
   This defaults to the `"Name"` parameter, but it may be necessary to provide an
   ID for uniqueness. This value will return in the response as `"CheckId"`.
 
@@ -276,7 +276,7 @@ The check is logged as `critical` if the datagram is sent unsuccessfully.
 
 ```json
 {
-  "ID": "mem",
+  "CheckID": "mem",
   "Name": "Memory utilization",
   "Namespace": "default",
   "Notes": "Ensure we don't oversubscribe memory",


### PR DESCRIPTION
### Description

The documentation for the "Register Check" call is incorrent in that it specifies an "ID" field while this should actually be CheckID

### Links

Fixes https://github.com/hashicorp/consul/issues/7566

### PR Checklist

* [ ] updated test coverage
* [V] external facing docs updated
* [ ] appropriate backport labels added
* [V] not a security concern
