### PR TITLE
NET-5397 - wire up destination golden tests from sidecar-proxy controller for xds controller and xdsv2

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destinations.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destinations.go
@@ -290,7 +290,6 @@ func (b *Builder) buildDestination(
 		clusterName := fmt.Sprintf("%s.%s", portName, sni)
 
 		egName := ""
-
 		if details.FailoverConfig != nil {
 			egName = fmt.Sprintf("%s%d~%s", xdscommon.FailoverClusterNamePrefix, 0, clusterName)
 		}

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -1012,8 +1012,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_SidecarProxyGoldenFileInputs(
 		"destination/l4-multi-destination",
 		"destination/l4-multiple-implicit-destinations-tproxy",
 		"destination/l4-implicit-and-explicit-destinations-tproxy",
-		// TODO(jm): resolve the endpoint group naming issue
-		//"destination/mixed-multi-destination",
+		"destination/mixed-multi-destination",
 		"destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy",
 		"destination/multiport-l4-and-l7-single-implicit-destination-tproxy",
 		"destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy",

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -1080,25 +1080,12 @@ func (suite *xdsControllerTestSuite) addRequiredEndpointsAndRefs(pst *pbmesh.Pro
 	var vp uint32 = 7000
 	requiredEps := make(map[string]*pbproxystate.EndpointRef)
 
-<<<<<<< HEAD
-	// get service name and ports
-=======
 	// iterate through clusters and set up endpoints for cluster/mesh port.
->>>>>>> 158caa2516 (clean up test to use helper.)
 	for clusterName := range pst.ProxyState.Clusters {
 		if clusterName == "null_route_cluster" || clusterName == "original-destination" {
 			continue
 		}
-<<<<<<< HEAD
-		vp++
-		separator := "."
-		if proxyType == "source" {
-			separator = ":"
-		}
-		clusterNameSplit := strings.Split(clusterName, separator)
-		port := clusterNameSplit[0]
-		svcName := clusterNameSplit[1]
-=======
+
 		//increment the random port number.
 		vp++
 		clusterNameSplit := strings.Split(clusterName, ".")
@@ -1106,25 +1093,18 @@ func (suite *xdsControllerTestSuite) addRequiredEndpointsAndRefs(pst *pbmesh.Pro
 		svcName := clusterNameSplit[1]
 
 		// set up service data with port info.
->>>>>>> 158caa2516 (clean up test to use helper.)
 		serviceData.Ports = append(serviceData.Ports, &pbcatalog.ServicePort{
 			TargetPort:  port,
 			VirtualPort: vp,
 			Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
 		})
 
-<<<<<<< HEAD
-=======
 		// create service.
->>>>>>> 158caa2516 (clean up test to use helper.)
 		svc := resourcetest.Resource(pbcatalog.ServiceType, svcName).
 			WithData(suite.T(), &pbcatalog.Service{}).
 			Write(suite.T(), suite.client)
 
-<<<<<<< HEAD
-=======
 		// create endpoints with svc as owner.
->>>>>>> 158caa2516 (clean up test to use helper.)
 		eps := resourcetest.Resource(pbcatalog.ServiceEndpointsType, svcName).
 			WithData(suite.T(), &pbcatalog.ServiceEndpoints{Endpoints: []*pbcatalog.Endpoint{
 				{

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -8,12 +8,13 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/hashicorp/consul/internal/testing/golden"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/encoding/protojson"
-	"strings"
-	"testing"
 
 	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
 	"github.com/hashicorp/consul/agent/leafcert"
@@ -1009,11 +1010,11 @@ func TestXdsController(t *testing.T) {
 // that things that it focuses on are leaf certs, endpoints, and trust bundles,
 // which is just a subset of the ProxyStateTemplate struct.  Prior to XDS controller
 // reconciliation, the sidecar proxy controller will have reconciled the other parts
-// of the ProxyStateTempalte.
+// of the ProxyStateTemplate.
 // Since the XDS controller does act on the ProxyStateTemplate, the tests
 // utilize that entire object rather than just the parts that XDS controller
 // internals reconciles.  Namely, by using checking the full ProxyStateTemplate
-// rather than just endpoints,leafs, and trust bundles, the test also ensures
+// rather than just endpoints, leaf certs, and trust bundles, the test also ensures
 // side effects or change in scope to XDS controller are not introduce mistakenly.
 func (suite *xdsControllerTestSuite) TestReconcile_SidecarProxyGoldenFileInputs() {
 	path := "../sidecarproxy/builder/testdata"

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -1042,9 +1042,8 @@ func (suite *xdsControllerTestSuite) TestReconcile_SidecarProxyGoldenFileInputs(
 				golden.GetBytesAtFilePath(suite.T(), fmt.Sprintf("%s/%s.golden", path, name)))
 
 			// Destinations will need endpoint refs set up.
-			proxyType := strings.Split(name, "/")[0]
-			if proxyType == "destination" && len(pst.ProxyState.Endpoints) == 0 {
-				suite.addRequiredEndpointsAndRefs(pst, proxyType)
+			if strings.Split(name, "/")[0] == "destination" && len(pst.ProxyState.Endpoints) == 0 {
+				suite.addRequiredEndpointsAndRefs(pst)
 			}
 
 			// Store the initial ProxyStateTemplate.
@@ -1088,7 +1087,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_SidecarProxyGoldenFileInputs(
 	}
 }
 
-func (suite *xdsControllerTestSuite) addRequiredEndpointsAndRefs(pst *pbmesh.ProxyStateTemplate, proxyType string) {
+func (suite *xdsControllerTestSuite) addRequiredEndpointsAndRefs(pst *pbmesh.ProxyStateTemplate) {
 	//get service data
 	serviceData := &pbcatalog.Service{}
 	var vp uint32 = 7000

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -1020,48 +1020,47 @@ func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
 			//get service data
 			serviceData := &pbcatalog.Service{}
 			var vp uint32 = 7000
-			svcNames := map[string]map[string]string
+			requiredEps := make(map[string]*pbproxystate.EndpointRef)
 
 			// get service name and ports
-			for name := range pst.RequiredEndpoints {
+			for name := range pst.ProxyState.Clusters {
+				if name == "null_route_cluster" {
+					continue
+				}
 				vp++
 				nameSplit := strings.Split(name, ".")
 				port := nameSplit[0]
-				svcNames[nameSplit[1]] = name
+				svcName := nameSplit[1]
 				serviceData.Ports = append(serviceData.Ports, &pbcatalog.ServicePort{
 					TargetPort:  port,
 					VirtualPort: vp,
 					Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
 				})
-			}
 
-			svc := resourcetest.Resource(pbcatalog.ServiceType, svcName).
-				WithData(suite.T(), &pbcatalog.Service{}).
-				Write(suite.T(), suite.client)
+				svc := resourcetest.Resource(pbcatalog.ServiceType, svcName).
+					WithData(suite.T(), &pbcatalog.Service{}).
+					Write(suite.T(), suite.client)
 
-			eps := resourcetest.Resource(pbcatalog.ServiceEndpointsType, svcName).
-				WithData(suite.T(), &pbcatalog.ServiceEndpoints{Endpoints: []*pbcatalog.Endpoint{
-					{
-						Ports: map[string]*pbcatalog.WorkloadPort{
-							"mesh": {
-								Port:     20000,
-								Protocol: pbcatalog.Protocol_PROTOCOL_MESH,
+				eps := resourcetest.Resource(pbcatalog.ServiceEndpointsType, svcName).
+					WithData(suite.T(), &pbcatalog.ServiceEndpoints{Endpoints: []*pbcatalog.Endpoint{
+						{
+							Ports: map[string]*pbcatalog.WorkloadPort{
+								"mesh": {
+									Port:     20000,
+									Protocol: pbcatalog.Protocol_PROTOCOL_MESH,
+								},
+							},
+							Addresses: []*pbcatalog.WorkloadAddress{
+								{
+									Host:  "10.1.1.1",
+									Ports: []string{"mesh"},
+								},
 							},
 						},
-						Addresses: []*pbcatalog.WorkloadAddress{
-							{
-								Host:  "10.1.1.1",
-								Ports: []string{"mesh"},
-							},
-						},
-					},
-				}}).
-				WithOwner(svc.Id).
-				Write(suite.T(), suite.client)
-			//
-			requiredEps := make(map[string]*pbproxystate.EndpointRef)
-			for epName := range pst.RequiredEndpoints {
-				requiredEps[epName] = &pbproxystate.EndpointRef{
+					}}).
+					WithOwner(svc.Id).
+					Write(suite.T(), suite.client)
+				requiredEps[name] = &pbproxystate.EndpointRef{
 					Id:   eps.Id,
 					Port: "mesh",
 				}
@@ -1093,7 +1092,9 @@ func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
 
 			require.NotNil(suite.T(), proxyStateTemplate)
 
-			actual := prototest.ProtoToJSON(suite.T(), proxyStateTemplate.Data)
+			reconciledPS := suite.updater.Get(proxyStateTemplate.Id.Name)
+			actual := prototest.ProtoToJSON(suite.T(), reconciledPS)
+
 			expected := golden.Get(suite.T(), actual, name+".golden")
 
 			require.JSONEq(suite.T(), expected, actual)

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -1002,13 +1002,24 @@ func TestXdsController(t *testing.T) {
 	suite.Run(t, new(xdsControllerTestSuite))
 }
 
-func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
+func (suite *xdsControllerTestSuite) TestReconcile_SidecarProxyGoldenFileInputs() {
 	path := "../sidecarproxy/builder/testdata"
 	cases := []string{
+		// destinations
 		"destination/l4-single-destination-ip-port-bind-address",
 		"destination/l4-single-destination-unix-socket-bind-address",
+		"destination/l4-single-implicit-destination-tproxy",
 		"destination/l4-multi-destination",
-		"destination/mixed-multi-destination",
+		"destination/l4-multiple-implicit-destinations-tproxy",
+		"destination/l4-implicit-and-explicit-destinations-tproxy",
+		// TODO(jm): resolve the endpoint group naming issue
+		//"destination/mixed-multi-destination",
+		"destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy",
+		"destination/multiport-l4-and-l7-single-implicit-destination-tproxy",
+		"destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy",
+
+		//sources
+
 	}
 
 	for _, name := range cases {
@@ -1024,7 +1035,7 @@ func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
 
 			// get service name and ports
 			for name := range pst.ProxyState.Clusters {
-				if name == "null_route_cluster" {
+				if name == "null_route_cluster" || name == "original-destination" {
 					continue
 				}
 				vp++
@@ -1108,28 +1119,6 @@ func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
 			expected := golden.Get(suite.T(), actual, name+".golden")
 
 			require.JSONEq(suite.T(), expected, actual)
-		})
-	}
-}
-
-func (suite *xdsControllerTestSuite) TestBuildImplicitDestinations() {
-
-	cases := []string{
-		"destination/l4-single-implicit-destination-tproxy",
-		"destination/l4-multiple-implicit-destinations-tproxy",
-		"destination/l4-implicit-and-explicit-destinations-tproxy",
-	}
-
-	for _, name := range cases {
-		suite.Run(name, func() {
-			//proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), "foo.consul", "dc1", false, proxyCfg).
-			//	BuildDestinations(c.destinations).
-			//	Build()
-			//
-			//actual := protoToJSON(t, proxyTmpl)
-			//expected := golden.Get(t, actual, name+".golden")
-			//
-			//require.JSONEq(t, expected, actual)
 		})
 	}
 }

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -1006,9 +1006,9 @@ func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
 	path := "../sidecarproxy/builder/testdata"
 	cases := []string{
 		"destination/l4-single-destination-ip-port-bind-address",
-		//"destination/l4-single-destination-unix-socket-bind-address",
-		//"destination/l4-multi-destination",
-		//"destination/mixed-multi-destination",
+		"destination/l4-single-destination-unix-socket-bind-address",
+		"destination/l4-multi-destination",
+		"destination/mixed-multi-destination",
 	}
 
 	for _, name := range cases {
@@ -1093,8 +1093,18 @@ func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
 			require.NotNil(suite.T(), proxyStateTemplate)
 
 			reconciledPS := suite.updater.Get(proxyStateTemplate.Id.Name)
-			actual := prototest.ProtoToJSON(suite.T(), reconciledPS)
 
+			// Verify leaf cert contents then hard code them for comparison
+			// and downstream tests since they change from test run to test run.
+			require.NotEmpty(suite.T(), reconciledPS.LeafCertificates)
+			reconciledPS.LeafCertificates = map[string]*pbproxystate.LeafCertificate{
+				"test-identity": {
+					Cert: "-----BEGIN CERTIFICATE-----\nMIICDjCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAjAUMRIwEAYDVQQDEwlUZXN0IENB\nIDEwHhcNMjMxMDE2MTYxMzI5WhcNMjMxMDE2MTYyMzI5WjAAMFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9\nta/bGT+5orZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJaOCAQowggEGMA4GA1UdDwEB\n/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/\nBAIwADApBgNVHQ4EIgQg3ogXVz9cqaK2B6xdiJYMa5NtT0KkYv7BA2dR7h9EcwUw\nKwYDVR0jBCQwIoAgq+C1mPlPoGa4lt7sSft1goN5qPGyBIB/3mUHJZKSFY8wbwYD\nVR0RAQH/BGUwY4Zhc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9hcC9kZWZhdWx0L25zL2RlZmF1bHQvaWRlbnRpdHkv\ndGVzdC1pZGVudGl0eTAKBggqhkjOPQQDAgNHADBEAiB6L+t5bzRrBPhiQYNeA7fF\nUCuLWrdjW4Xbv3SLg0IKMgIgfRC5hEx+DqzQxTCP4sexX3hVWMjKoWmHdwiUcg+K\n/IE=\n-----END CERTIFICATE-----\n",
+					Key:  "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIFIFkTIL1iUV4O/RpveVHzHs7ZzhSkvYIzbdXDttz9EooAoGCCqGSM49\nAwEHoUQDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9ta/bGT+5\norZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJQ==\n-----END EC PRIVATE KEY-----\n",
+				},
+			}
+
+			actual := prototest.ProtoToJSON(suite.T(), reconciledPS)
 			expected := golden.Get(suite.T(), actual, name+".golden")
 
 			require.JSONEq(suite.T(), expected, actual)

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
-	"testing"
-
+	"fmt"
+	"github.com/hashicorp/consul/internal/testing/golden"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/encoding/protojson"
+	"testing"
 
 	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
 	"github.com/hashicorp/consul/agent/leafcert"
@@ -997,4 +999,74 @@ func (suite *xdsControllerTestSuite) TestReconcile_prevWatchesToCancel() {
 
 func TestXdsController(t *testing.T) {
 	suite.Run(t, new(xdsControllerTestSuite))
+}
+
+func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
+	path := "../sidecarproxy/builder/testdata"
+	cases := []string{
+		"destination/l4-single-destination-ip-port-bind-address",
+		"destination/l4-single-destination-unix-socket-bind-address",
+		"destination/l4-multi-destination",
+		"destination/mixed-multi-destination",
+	}
+
+	for _, name := range cases {
+		suite.Run(name, func() {
+			// Create ProxyStateTemplate from the golden file.
+			pst := JSONToProxyTemplate(suite.T(),
+				golden.GetBytesAtFilePath(suite.T(), fmt.Sprintf("%s/%s.golden", path, name)))
+
+			// Store the initial ProxyStateTemplate and track it in the mapper.
+			proxyStateTemplate := resourcetest.Resource(pbmesh.ProxyStateTemplateType, "test").
+				WithData(suite.T(), pst).
+				Write(suite.T(), suite.client)
+
+			suite.mapper.TrackItem(proxyStateTemplate.Id, []resource.ReferenceOrID{})
+			for idx, ep := range pst.ProxyState.Endpoints {
+				resourcetest.Resource(pbcatalog.ServiceEndpointsType, fmt.Sprintf("test-%d", idx)).
+					WithData(suite.T(), ep).
+					Write(suite.T(), suite.client)
+			}
+
+			// Run the reconcile, and since no ProxyStateTemplate is stored, this simulates a deletion.
+			err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
+				ID: proxyStateTemplate.Id,
+			})
+			require.NoError(suite.T(), err)
+
+			require.NotNil(suite.T(), proxyStateTemplate)
+			//require.JSONEq(suite.T(), expected, actual)
+		})
+	}
+}
+
+func (suite *xdsControllerTestSuite) TestBuildImplicitDestinations() {
+
+	cases := []string{
+		"destination/l4-single-implicit-destination-tproxy",
+		"destination/l4-multiple-implicit-destinations-tproxy",
+		"destination/l4-implicit-and-explicit-destinations-tproxy",
+	}
+
+	for _, name := range cases {
+		suite.Run(name, func() {
+			//proxyTmpl := New(testProxyStateTemplateID(), testIdentityRef(), "foo.consul", "dc1", false, proxyCfg).
+			//	BuildDestinations(c.destinations).
+			//	Build()
+			//
+			//actual := protoToJSON(t, proxyTmpl)
+			//expected := golden.Get(t, actual, name+".golden")
+			//
+			//require.JSONEq(t, expected, actual)
+		})
+	}
+}
+
+func JSONToProxyTemplate(t *testing.T, json []byte) *pbmesh.ProxyStateTemplate {
+	t.Helper()
+	proxyTemplate := &pbmesh.ProxyStateTemplate{}
+	m := protojson.UnmarshalOptions{}
+	err := m.Unmarshal(json, proxyTemplate)
+	require.NoError(t, err)
+	return proxyTemplate
 }

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/encoding/protojson"
+	"strings"
 	"testing"
 
 	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
@@ -1005,9 +1006,9 @@ func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
 	path := "../sidecarproxy/builder/testdata"
 	cases := []string{
 		"destination/l4-single-destination-ip-port-bind-address",
-		"destination/l4-single-destination-unix-socket-bind-address",
-		"destination/l4-multi-destination",
-		"destination/mixed-multi-destination",
+		//"destination/l4-single-destination-unix-socket-bind-address",
+		//"destination/l4-multi-destination",
+		//"destination/mixed-multi-destination",
 	}
 
 	for _, name := range cases {
@@ -1016,17 +1017,73 @@ func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
 			pst := JSONToProxyTemplate(suite.T(),
 				golden.GetBytesAtFilePath(suite.T(), fmt.Sprintf("%s/%s.golden", path, name)))
 
+			//get service data
+			serviceData := &pbcatalog.Service{}
+			var vp uint32 = 7000
+			svcNames := map[string]map[string]string
+
+			// get service name and ports
+			for name := range pst.RequiredEndpoints {
+				vp++
+				nameSplit := strings.Split(name, ".")
+				port := nameSplit[0]
+				svcNames[nameSplit[1]] = name
+				serviceData.Ports = append(serviceData.Ports, &pbcatalog.ServicePort{
+					TargetPort:  port,
+					VirtualPort: vp,
+					Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
+				})
+			}
+
+			svc := resourcetest.Resource(pbcatalog.ServiceType, svcName).
+				WithData(suite.T(), &pbcatalog.Service{}).
+				Write(suite.T(), suite.client)
+
+			eps := resourcetest.Resource(pbcatalog.ServiceEndpointsType, svcName).
+				WithData(suite.T(), &pbcatalog.ServiceEndpoints{Endpoints: []*pbcatalog.Endpoint{
+					{
+						Ports: map[string]*pbcatalog.WorkloadPort{
+							"mesh": {
+								Port:     20000,
+								Protocol: pbcatalog.Protocol_PROTOCOL_MESH,
+							},
+						},
+						Addresses: []*pbcatalog.WorkloadAddress{
+							{
+								Host:  "10.1.1.1",
+								Ports: []string{"mesh"},
+							},
+						},
+					},
+				}}).
+				WithOwner(svc.Id).
+				Write(suite.T(), suite.client)
+			//
+			requiredEps := make(map[string]*pbproxystate.EndpointRef)
+			for epName := range pst.RequiredEndpoints {
+				requiredEps[epName] = &pbproxystate.EndpointRef{
+					Id:   eps.Id,
+					Port: "mesh",
+				}
+			}
+
+			wiLeafs := make(map[string]*pbproxystate.LeafCertificateRef)
+			wiLeafs["wi-workload-identity"] = &pbproxystate.LeafCertificateRef{
+				Name: "wi-workload-identity",
+			}
+
+			pst.RequiredEndpoints = requiredEps
+
 			// Store the initial ProxyStateTemplate and track it in the mapper.
 			proxyStateTemplate := resourcetest.Resource(pbmesh.ProxyStateTemplateType, "test").
 				WithData(suite.T(), pst).
 				Write(suite.T(), suite.client)
 
+			retry.Run(suite.T(), func(r *retry.R) {
+				suite.client.RequireResourceExists(r, proxyStateTemplate.Id)
+			})
+
 			suite.mapper.TrackItem(proxyStateTemplate.Id, []resource.ReferenceOrID{})
-			for idx, ep := range pst.ProxyState.Endpoints {
-				resourcetest.Resource(pbcatalog.ServiceEndpointsType, fmt.Sprintf("test-%d", idx)).
-					WithData(suite.T(), ep).
-					Write(suite.T(), suite.client)
-			}
 
 			// Run the reconcile, and since no ProxyStateTemplate is stored, this simulates a deletion.
 			err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
@@ -1035,7 +1092,11 @@ func (suite *xdsControllerTestSuite) TestBuildExplicitDestinations() {
 			require.NoError(suite.T(), err)
 
 			require.NotNil(suite.T(), proxyStateTemplate)
-			//require.JSONEq(suite.T(), expected, actual)
+
+			actual := prototest.ProtoToJSON(suite.T(), proxyStateTemplate.Data)
+			expected := golden.Get(suite.T(), actual, name+".golden")
+
+			require.JSONEq(suite.T(), expected, actual)
 		})
 	}
 }

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -1080,11 +1080,16 @@ func (suite *xdsControllerTestSuite) addRequiredEndpointsAndRefs(pst *pbmesh.Pro
 	var vp uint32 = 7000
 	requiredEps := make(map[string]*pbproxystate.EndpointRef)
 
+<<<<<<< HEAD
 	// get service name and ports
+=======
+	// iterate through clusters and set up endpoints for cluster/mesh port.
+>>>>>>> 158caa2516 (clean up test to use helper.)
 	for clusterName := range pst.ProxyState.Clusters {
 		if clusterName == "null_route_cluster" || clusterName == "original-destination" {
 			continue
 		}
+<<<<<<< HEAD
 		vp++
 		separator := "."
 		if proxyType == "source" {
@@ -1093,16 +1098,33 @@ func (suite *xdsControllerTestSuite) addRequiredEndpointsAndRefs(pst *pbmesh.Pro
 		clusterNameSplit := strings.Split(clusterName, separator)
 		port := clusterNameSplit[0]
 		svcName := clusterNameSplit[1]
+=======
+		//increment the random port number.
+		vp++
+		clusterNameSplit := strings.Split(clusterName, ".")
+		port := clusterNameSplit[0]
+		svcName := clusterNameSplit[1]
+
+		// set up service data with port info.
+>>>>>>> 158caa2516 (clean up test to use helper.)
 		serviceData.Ports = append(serviceData.Ports, &pbcatalog.ServicePort{
 			TargetPort:  port,
 			VirtualPort: vp,
 			Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
 		})
 
+<<<<<<< HEAD
+=======
+		// create service.
+>>>>>>> 158caa2516 (clean up test to use helper.)
 		svc := resourcetest.Resource(pbcatalog.ServiceType, svcName).
 			WithData(suite.T(), &pbcatalog.Service{}).
 			Write(suite.T(), suite.client)
 
+<<<<<<< HEAD
+=======
+		// create endpoints with svc as owner.
+>>>>>>> 158caa2516 (clean up test to use helper.)
 		eps := resourcetest.Resource(pbcatalog.ServiceEndpointsType, svcName).
 			WithData(suite.T(), &pbcatalog.ServiceEndpoints{Endpoints: []*pbcatalog.Endpoint{
 				{
@@ -1122,14 +1144,18 @@ func (suite *xdsControllerTestSuite) addRequiredEndpointsAndRefs(pst *pbmesh.Pro
 			}}).
 			WithOwner(svc.Id).
 			Write(suite.T(), suite.client)
+
+		// add to working list of required endpoints.
 		requiredEps[clusterName] = &pbproxystate.EndpointRef{
 			Id:   eps.Id,
 			Port: "mesh",
 		}
 	}
 
+	// set working list of required endpoints as proxy state's RequiredEndpoints.
 	pst.RequiredEndpoints = requiredEps
 }
+
 func JSONToProxyTemplate(t *testing.T, json []byte) *pbmesh.ProxyStateTemplate {
 	t.Helper()
 	proxyTemplate := &pbmesh.ProxyStateTemplate{}

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -1002,6 +1002,19 @@ func TestXdsController(t *testing.T) {
 	suite.Run(t, new(xdsControllerTestSuite))
 }
 
+// TestReconcile_SidecarProxyGoldenFileInputs tests the Reconcile() by using
+// the golden test output/expected files from the sidecar proxy tests as inputs
+// to the XDS controller reconciliation.
+// XDS controller reconciles the full ProxyStateTemplate object.  The fields
+// that things that it focuses on are leaf certs, endpoints, and trust bundles,
+// which is just a subset of the ProxyStateTemplate struct.  Prior to XDS controller
+// reconciliation, the sidecar proxy controller will have reconciled the other parts
+// of the ProxyStateTempalte.
+// Since the XDS controller does act on the ProxyStateTemplate, the tests
+// utilize that entire object rather than just the parts that XDS controller
+// internals reconciles.  Namely, by using checking the full ProxyStateTemplate
+// rather than just endpoints,leafs, and trust bundles, the test also ensures
+// side effects or change in scope to XDS controller are not introduce mistakenly.
 func (suite *xdsControllerTestSuite) TestReconcile_SidecarProxyGoldenFileInputs() {
 	path := "../sidecarproxy/builder/testdata"
 	cases := []string{

--- a/internal/mesh/internal/controllers/xds/testdata/destination/l4-implicit-and-explicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/l4-implicit-and-explicit-destinations-tproxy.golden
@@ -1,0 +1,182 @@
+{
+  "clusters": {
+    "original-destination": {
+      "endpointGroup": {
+        "passthrough": {
+          "config": {
+            "connectTimeout": "5s"
+          }
+        }
+      },
+      "name": "original-destination"
+    },
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-1.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-1.default.dc1.internal.foo.consul"
+    },
+    "tcp.api-2.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-2.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-2.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api2-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-2.default.dc1.internal.foo.consul"
+    }
+  },
+  "identity": {
+    "name": "test-identity",
+    "tenancy": {
+      "namespace": "default",
+      "partition": "default",
+      "peerName": "local"
+    },
+    "type": {
+      "group": "auth",
+      "groupVersion": "v2beta1",
+      "kind": "WorkloadIdentity"
+    }
+  },
+  "listeners": [
+    {
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "1.1.1.1",
+        "port": 1234
+      },
+      "name": "default/local/default/api-1:tcp:1.1.1.1:1234",
+      "routers": [
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-1.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-1.default.default.dc1"
+          }
+        }
+      ]
+    },
+    {
+      "capabilities": [
+        "CAPABILITY_TRANSPARENT"
+      ],
+      "defaultRouter": {
+        "l4": {
+          "cluster": {
+            "name": "original-destination"
+          },
+          "statPrefix": "upstream.original-destination"
+        }
+      },
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "127.0.0.1",
+        "port": 15001
+      },
+      "name": "outbound_listener",
+      "routers": [
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-2.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-2.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 7070,
+            "prefixRanges": [
+              {
+                "addressPrefix": "2.2.2.2",
+                "prefixLen": 32
+              },
+              {
+                "addressPrefix": "3.3.3.3",
+                "prefixLen": 32
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "endpoints": {
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp.api-2.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    }
+  },
+  "trustBundles": {
+    "local": {
+      "roots": [
+        "some-root",
+        "some-other-root"
+      ],
+      "trustDomain": "some-trust-domain"
+    }
+  },
+  "leafCertificates": {
+    "test-identity": {
+      "cert": "-----BEGIN CERTIFICATE-----\nMIICDjCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAjAUMRIwEAYDVQQDEwlUZXN0IENB\nIDEwHhcNMjMxMDE2MTYxMzI5WhcNMjMxMDE2MTYyMzI5WjAAMFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9\nta/bGT+5orZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJaOCAQowggEGMA4GA1UdDwEB\n/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/\nBAIwADApBgNVHQ4EIgQg3ogXVz9cqaK2B6xdiJYMa5NtT0KkYv7BA2dR7h9EcwUw\nKwYDVR0jBCQwIoAgq+C1mPlPoGa4lt7sSft1goN5qPGyBIB/3mUHJZKSFY8wbwYD\nVR0RAQH/BGUwY4Zhc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9hcC9kZWZhdWx0L25zL2RlZmF1bHQvaWRlbnRpdHkv\ndGVzdC1pZGVudGl0eTAKBggqhkjOPQQDAgNHADBEAiB6L+t5bzRrBPhiQYNeA7fF\nUCuLWrdjW4Xbv3SLg0IKMgIgfRC5hEx+DqzQxTCP4sexX3hVWMjKoWmHdwiUcg+K\n/IE=\n-----END CERTIFICATE-----\n",
+      "key": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIFIFkTIL1iUV4O/RpveVHzHs7ZzhSkvYIzbdXDttz9EooAoGCCqGSM49\nAwEHoUQDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9ta/bGT+5\norZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJQ==\n-----END EC PRIVATE KEY-----\n"
+    }
+  }
+}

--- a/internal/mesh/internal/controllers/xds/testdata/destination/l4-multi-destination.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/l4-multi-destination.golden
@@ -63,6 +63,60 @@
         }
       },
       "name": "tcp.api-2.default.dc1.internal.foo.consul"
+    },
+    "tcp2.api-1.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp2.api-1.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp2"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-1.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp2.api-1.default.dc1.internal.foo.consul"
+    },
+    "tcp2.api-2.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp2.api-2.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp2"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-2.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api2-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp2.api-2.default.dc1.internal.foo.consul"
     }
   },
   "identity": {
@@ -109,6 +163,73 @@
           }
         }
       ]
+    },
+    {
+      "direction": "DIRECTION_OUTBOUND",
+      "name": "default/local/default/api-2:tcp:/path/to/socket",
+      "routers": [
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-2.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-2.default.default.dc1"
+          }
+        }
+      ],
+      "unixSocket": {
+        "mode": "0666",
+        "path": "/path/to/socket"
+      }
+    },
+    {
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "1.1.1.1",
+        "port": 2345
+      },
+      "name": "default/local/default/api-1:tcp2:1.1.1.1:2345",
+      "routers": [
+        {
+          "l4": {
+            "statPrefix": "upstream.tcp2.api-1.default.default.dc1",
+            "weightedClusters": {
+              "clusters": [
+                {
+                  "name": "tcp2.api-2.default.dc1.internal.foo.consul",
+                  "weight": 60
+                },
+                {
+                  "name": "tcp2.api-1.default.dc1.internal.foo.consul",
+                  "weight": 40
+                },
+                {
+                  "name": "null_route_cluster",
+                  "weight": 10
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "direction": "DIRECTION_OUTBOUND",
+      "name": "default/local/default/api-2:tcp2:/path/to/socket",
+      "routers": [
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp2.api-2.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp2.api-2.default.default.dc1"
+          }
+        }
+      ],
+      "unixSocket": {
+        "mode": "0666",
+        "path": "/path/to/socket"
+      }
     }
   ],
   "endpoints": {
@@ -124,6 +245,28 @@
       ]
     },
     "tcp.api-2.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp2.api-1.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp2.api-2.default.dc1.internal.foo.consul": {
       "endpoints": [
         {
           "healthStatus": "HEALTH_STATUS_HEALTHY",

--- a/internal/mesh/internal/controllers/xds/testdata/destination/l4-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/l4-multiple-implicit-destinations-tproxy.golden
@@ -1,0 +1,181 @@
+{
+  "clusters": {
+    "original-destination": {
+      "endpointGroup": {
+        "passthrough": {
+          "config": {
+            "connectTimeout": "5s"
+          }
+        }
+      },
+      "name": "original-destination"
+    },
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-1.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-1.default.dc1.internal.foo.consul"
+    },
+    "tcp.api-2.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-2.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-2.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api2-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-2.default.dc1.internal.foo.consul"
+    }
+  },
+  "identity": {
+    "name": "test-identity",
+    "tenancy": {
+      "namespace": "default",
+      "partition": "default",
+      "peerName": "local"
+    },
+    "type": {
+      "group": "auth",
+      "groupVersion": "v2beta1",
+      "kind": "WorkloadIdentity"
+    }
+  },
+  "listeners": [
+    {
+      "capabilities": [
+        "CAPABILITY_TRANSPARENT"
+      ],
+      "defaultRouter": {
+        "l4": {
+          "cluster": {
+            "name": "original-destination"
+          },
+          "statPrefix": "upstream.original-destination"
+        }
+      },
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "127.0.0.1",
+        "port": 15001
+      },
+      "name": "outbound_listener",
+      "routers": [
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-1.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-1.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 7070,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        },
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-2.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-2.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 7070,
+            "prefixRanges": [
+              {
+                "addressPrefix": "2.2.2.2",
+                "prefixLen": 32
+              },
+              {
+                "addressPrefix": "3.3.3.3",
+                "prefixLen": 32
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "endpoints": {
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp.api-2.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    }
+  },
+  "trustBundles": {
+    "local": {
+      "roots": [
+        "some-root",
+        "some-other-root"
+      ],
+      "trustDomain": "some-trust-domain"
+    }
+  },
+  "leafCertificates": {
+    "test-identity": {
+      "cert": "-----BEGIN CERTIFICATE-----\nMIICDjCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAjAUMRIwEAYDVQQDEwlUZXN0IENB\nIDEwHhcNMjMxMDE2MTYxMzI5WhcNMjMxMDE2MTYyMzI5WjAAMFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9\nta/bGT+5orZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJaOCAQowggEGMA4GA1UdDwEB\n/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/\nBAIwADApBgNVHQ4EIgQg3ogXVz9cqaK2B6xdiJYMa5NtT0KkYv7BA2dR7h9EcwUw\nKwYDVR0jBCQwIoAgq+C1mPlPoGa4lt7sSft1goN5qPGyBIB/3mUHJZKSFY8wbwYD\nVR0RAQH/BGUwY4Zhc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9hcC9kZWZhdWx0L25zL2RlZmF1bHQvaWRlbnRpdHkv\ndGVzdC1pZGVudGl0eTAKBggqhkjOPQQDAgNHADBEAiB6L+t5bzRrBPhiQYNeA7fF\nUCuLWrdjW4Xbv3SLg0IKMgIgfRC5hEx+DqzQxTCP4sexX3hVWMjKoWmHdwiUcg+K\n/IE=\n-----END CERTIFICATE-----\n",
+      "key": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIFIFkTIL1iUV4O/RpveVHzHs7ZzhSkvYIzbdXDttz9EooAoGCCqGSM49\nAwEHoUQDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9ta/bGT+5\norZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJQ==\n-----END EC PRIVATE KEY-----\n"
+    }
+  }
+}

--- a/internal/mesh/internal/controllers/xds/testdata/destination/l4-single-destination-ip-port-bind-address.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/l4-single-destination-ip-port-bind-address.golden
@@ -1,162 +1,114 @@
 {
-  "proxyState": {
-    "clusters": {
-      "null_route_cluster": {
-        "endpointGroup": {
-          "static": {
-            "config": {
-              "connectTimeout": "10s"
-            }
+  "clusters": {
+    "null_route_cluster": {
+      "endpointGroup": {
+        "static": {
+          "config": {
+            "connectTimeout": "10s"
           }
-        },
-        "name": "null_route_cluster"
-      },
-      "tcp.api-1.default.dc1.internal.foo.consul": {
-        "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
-        "endpointGroup": {
-          "dynamic": {
-            "config": {
-              "connectTimeout": "5s",
-              "disablePanicThreshold": true
-            },
-            "outboundTls": {
-              "alpnProtocols": [
-                "consul~tcp"
-              ],
-              "outboundMesh": {
-                "identityKey": "test-identity",
-                "sni": "api-1.default.dc1.internal.foo.consul",
-                "validationContext": {
-                  "spiffeIds": [
-                    "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
-                  ],
-                  "trustBundlePeerNameKey": "local"
-                }
-              }
-            }
-          }
-        },
-        "name": "tcp.api-1.default.dc1.internal.foo.consul"
-      },
-      "tcp.api-2.default.dc1.internal.foo.consul": {
-        "altStatName": "tcp.api-2.default.dc1.internal.foo.consul",
-        "endpointGroup": {
-          "dynamic": {
-            "config": {
-              "connectTimeout": "5s",
-              "disablePanicThreshold": true
-            },
-            "outboundTls": {
-              "alpnProtocols": [
-                "consul~tcp"
-              ],
-              "outboundMesh": {
-                "identityKey": "test-identity",
-                "sni": "api-2.default.dc1.internal.foo.consul",
-                "validationContext": {
-                  "spiffeIds": [
-                    "spiffe://foo.consul/ap/default/ns/default/identity/api2-identity"
-                  ],
-                  "trustBundlePeerNameKey": "local"
-                }
-              }
-            }
-          }
-        },
-        "name": "tcp.api-2.default.dc1.internal.foo.consul"
-      }
-    },
-    "identity": {
-      "name": "test-identity",
-      "tenancy": {
-        "namespace": "default",
-        "partition": "default",
-        "peerName": "local"
-      },
-      "type": {
-        "group": "auth",
-        "groupVersion": "v2beta1",
-        "kind": "WorkloadIdentity"
-      }
-    },
-    "listeners": [
-      {
-        "direction": "DIRECTION_OUTBOUND",
-        "hostPort": {
-          "host": "1.1.1.1",
-          "port": 1234
-        },
-        "name": "default/local/default/api-1:tcp:1.1.1.1:1234",
-        "routers": [
-          {
-            "l4": {
-              "statPrefix": "upstream.tcp.api-1.default.default.dc1",
-              "weightedClusters": {
-                "clusters": [
-                  {
-                    "name": "tcp.api-2.default.dc1.internal.foo.consul",
-                    "weight": 60
-                  },
-                  {
-                    "name": "tcp.api-1.default.dc1.internal.foo.consul",
-                    "weight": 40
-                  },
-                  {
-                    "name": "null_route_cluster",
-                    "weight": 10
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }
-    ]
-  },
-  "requiredEndpoints": {
-    "tcp.api-1.default.dc1.internal.foo.consul": {
-      "id": {
-        "name": "api-1",
-        "tenancy": {
-          "namespace": "default",
-          "partition": "default",
-          "peerName": "local"
-        },
-        "type": {
-          "group": "catalog",
-          "groupVersion": "v2beta1",
-          "kind": "ServiceEndpoints"
         }
       },
-      "port": "mesh"
+      "name": "null_route_cluster"
+    },
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-1.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-1.default.dc1.internal.foo.consul"
     },
     "tcp.api-2.default.dc1.internal.foo.consul": {
-      "id": {
-        "name": "api-2",
-        "tenancy": {
-          "namespace": "default",
-          "partition": "default",
-          "peerName": "local"
-        },
-        "type": {
-          "group": "catalog",
-          "groupVersion": "v2beta1",
-          "kind": "ServiceEndpoints"
+      "altStatName": "tcp.api-2.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-2.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api2-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
         }
       },
-      "port": "mesh"
+      "name": "tcp.api-2.default.dc1.internal.foo.consul"
     }
   },
-  "requiredLeafCertificates": {
-    "test-identity": {
-      "name": "test-identity",
+  "identity": {
+    "name": "test-identity",
+    "tenancy": {
       "namespace": "default",
-      "partition": "default"
+      "partition": "default",
+      "peerName": "local"
+    },
+    "type": {
+      "group": "auth",
+      "groupVersion": "v2beta1",
+      "kind": "WorkloadIdentity"
     }
   },
-  "requiredTrustBundles": {
-    "local": {
-      "peer": "local"
+  "listeners": [
+    {
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "1.1.1.1",
+        "port": 1234
+      },
+      "name": "default/local/default/api-1:tcp:1.1.1.1:1234",
+      "routers": [
+        {
+          "l4": {
+            "statPrefix": "upstream.tcp.api-1.default.default.dc1",
+            "weightedClusters": {
+              "clusters": [
+                {
+                  "name": "tcp.api-2.default.dc1.internal.foo.consul",
+                  "weight": 60
+                },
+                {
+                  "name": "tcp.api-1.default.dc1.internal.foo.consul",
+                  "weight": 40
+                },
+                {
+                  "name": "null_route_cluster",
+                  "weight": 10
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
-  }
+  ]
 }

--- a/internal/mesh/internal/controllers/xds/testdata/destination/l4-single-destination-ip-port-bind-address.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/l4-single-destination-ip-port-bind-address.golden
@@ -65,6 +65,30 @@
       "name": "tcp.api-2.default.dc1.internal.foo.consul"
     }
   },
+  "endpoints": {
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp.api-2.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    }
+  },
   "identity": {
     "name": "test-identity",
     "tenancy": {
@@ -76,6 +100,12 @@
       "group": "auth",
       "groupVersion": "v2beta1",
       "kind": "WorkloadIdentity"
+    }
+  },
+  "leafCertificates": {
+    "test-identity": {
+      "cert": "-----BEGIN CERTIFICATE-----\nMIICDzCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAjAUMRIwEAYDVQQDEwlUZXN0IENB\nIDEwHhcNMjMxMDE2MTU0MzQxWhcNMjMxMDE2MTU1MzQxWjAAMFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAECjAS1priKKg5DX2byiWj7rP/javtusIwUXXNZjLcL93d\nt1/TJ3BeGQjcye7Tj4fg7u1xKQe4zzzl9jzhNImDbqOCAQowggEGMA4GA1UdDwEB\n/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/\nBAIwADApBgNVHQ4EIgQgm9EL7d6QLgSa4XcBMrJe254kOIyY4qeEG1XkyHxgNqgw\nKwYDVR0jBCQwIoAgrxX5IdfjyCYUhGtC4FxnuPtk2WpVnEJvN7Tb+0dORfcwbwYD\nVR0RAQH/BGUwY4Zhc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9hcC9kZWZhdWx0L25zL2RlZmF1bHQvaWRlbnRpdHkv\ndGVzdC1pZGVudGl0eTAKBggqhkjOPQQDAgNIADBFAiEAsQylgvCf1TuK7Efng1VZ\nlYyP8fHV3ndNjq7DxGHBp9kCIHkDszWused6R5GAsRBNp3nwzK7fGWncrEQJGetp\nCNtQ\n-----END CERTIFICATE-----\n",
+      "key": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPYFUcC4ZIeQRE/PfF7DsK5CeL4uEh2C6aFIyLYg2734oAoGCCqGSM49\nAwEHoUQDQgAECjAS1priKKg5DX2byiWj7rP/javtusIwUXXNZjLcL93dt1/TJ3Be\nGQjcye7Tj4fg7u1xKQe4zzzl9jzhNImDbg==\n-----END EC PRIVATE KEY-----\n"
     }
   },
   "listeners": [
@@ -110,5 +140,14 @@
         }
       ]
     }
-  ]
+  ],
+  "trustBundles": {
+    "local": {
+      "roots": [
+        "some-root",
+        "some-other-root"
+      ],
+      "trustDomain": "some-trust-domain"
+    }
+  }
 }

--- a/internal/mesh/internal/controllers/xds/testdata/destination/l4-single-destination-ip-port-bind-address.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/l4-single-destination-ip-port-bind-address.golden
@@ -1,0 +1,162 @@
+{
+  "proxyState": {
+    "clusters": {
+      "null_route_cluster": {
+        "endpointGroup": {
+          "static": {
+            "config": {
+              "connectTimeout": "10s"
+            }
+          }
+        },
+        "name": "null_route_cluster"
+      },
+      "tcp.api-1.default.dc1.internal.foo.consul": {
+        "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
+        "endpointGroup": {
+          "dynamic": {
+            "config": {
+              "connectTimeout": "5s",
+              "disablePanicThreshold": true
+            },
+            "outboundTls": {
+              "alpnProtocols": [
+                "consul~tcp"
+              ],
+              "outboundMesh": {
+                "identityKey": "test-identity",
+                "sni": "api-1.default.dc1.internal.foo.consul",
+                "validationContext": {
+                  "spiffeIds": [
+                    "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
+                  ],
+                  "trustBundlePeerNameKey": "local"
+                }
+              }
+            }
+          }
+        },
+        "name": "tcp.api-1.default.dc1.internal.foo.consul"
+      },
+      "tcp.api-2.default.dc1.internal.foo.consul": {
+        "altStatName": "tcp.api-2.default.dc1.internal.foo.consul",
+        "endpointGroup": {
+          "dynamic": {
+            "config": {
+              "connectTimeout": "5s",
+              "disablePanicThreshold": true
+            },
+            "outboundTls": {
+              "alpnProtocols": [
+                "consul~tcp"
+              ],
+              "outboundMesh": {
+                "identityKey": "test-identity",
+                "sni": "api-2.default.dc1.internal.foo.consul",
+                "validationContext": {
+                  "spiffeIds": [
+                    "spiffe://foo.consul/ap/default/ns/default/identity/api2-identity"
+                  ],
+                  "trustBundlePeerNameKey": "local"
+                }
+              }
+            }
+          }
+        },
+        "name": "tcp.api-2.default.dc1.internal.foo.consul"
+      }
+    },
+    "identity": {
+      "name": "test-identity",
+      "tenancy": {
+        "namespace": "default",
+        "partition": "default",
+        "peerName": "local"
+      },
+      "type": {
+        "group": "auth",
+        "groupVersion": "v2beta1",
+        "kind": "WorkloadIdentity"
+      }
+    },
+    "listeners": [
+      {
+        "direction": "DIRECTION_OUTBOUND",
+        "hostPort": {
+          "host": "1.1.1.1",
+          "port": 1234
+        },
+        "name": "default/local/default/api-1:tcp:1.1.1.1:1234",
+        "routers": [
+          {
+            "l4": {
+              "statPrefix": "upstream.tcp.api-1.default.default.dc1",
+              "weightedClusters": {
+                "clusters": [
+                  {
+                    "name": "tcp.api-2.default.dc1.internal.foo.consul",
+                    "weight": 60
+                  },
+                  {
+                    "name": "tcp.api-1.default.dc1.internal.foo.consul",
+                    "weight": 40
+                  },
+                  {
+                    "name": "null_route_cluster",
+                    "weight": 10
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "requiredEndpoints": {
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "id": {
+        "name": "api-1",
+        "tenancy": {
+          "namespace": "default",
+          "partition": "default",
+          "peerName": "local"
+        },
+        "type": {
+          "group": "catalog",
+          "groupVersion": "v2beta1",
+          "kind": "ServiceEndpoints"
+        }
+      },
+      "port": "mesh"
+    },
+    "tcp.api-2.default.dc1.internal.foo.consul": {
+      "id": {
+        "name": "api-2",
+        "tenancy": {
+          "namespace": "default",
+          "partition": "default",
+          "peerName": "local"
+        },
+        "type": {
+          "group": "catalog",
+          "groupVersion": "v2beta1",
+          "kind": "ServiceEndpoints"
+        }
+      },
+      "port": "mesh"
+    }
+  },
+  "requiredLeafCertificates": {
+    "test-identity": {
+      "name": "test-identity",
+      "namespace": "default",
+      "partition": "default"
+    }
+  },
+  "requiredTrustBundles": {
+    "local": {
+      "peer": "local"
+    }
+  }
+}

--- a/internal/mesh/internal/controllers/xds/testdata/destination/l4-single-destination-unix-socket-bind-address.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/l4-single-destination-unix-socket-bind-address.golden
@@ -1,42 +1,5 @@
 {
   "clusters": {
-    "null_route_cluster": {
-      "endpointGroup": {
-        "static": {
-          "config": {
-            "connectTimeout": "10s"
-          }
-        }
-      },
-      "name": "null_route_cluster"
-    },
-    "tcp.api-1.default.dc1.internal.foo.consul": {
-      "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
-      "endpointGroup": {
-        "dynamic": {
-          "config": {
-            "connectTimeout": "5s",
-            "disablePanicThreshold": true
-          },
-          "outboundTls": {
-            "alpnProtocols": [
-              "consul~tcp"
-            ],
-            "outboundMesh": {
-              "identityKey": "test-identity",
-              "sni": "api-1.default.dc1.internal.foo.consul",
-              "validationContext": {
-                "spiffeIds": [
-                  "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
-                ],
-                "trustBundlePeerNameKey": "local"
-              }
-            }
-          }
-        }
-      },
-      "name": "tcp.api-1.default.dc1.internal.foo.consul"
-    },
     "tcp.api-2.default.dc1.internal.foo.consul": {
       "altStatName": "tcp.api-2.default.dc1.internal.foo.consul",
       "endpointGroup": {
@@ -81,48 +44,24 @@
   "listeners": [
     {
       "direction": "DIRECTION_OUTBOUND",
-      "hostPort": {
-        "host": "1.1.1.1",
-        "port": 1234
-      },
-      "name": "default/local/default/api-1:tcp:1.1.1.1:1234",
+      "name": "default/local/default/api-2:tcp:/path/to/socket",
       "routers": [
         {
           "l4": {
-            "statPrefix": "upstream.tcp.api-1.default.default.dc1",
-            "weightedClusters": {
-              "clusters": [
-                {
-                  "name": "tcp.api-2.default.dc1.internal.foo.consul",
-                  "weight": 60
-                },
-                {
-                  "name": "tcp.api-1.default.dc1.internal.foo.consul",
-                  "weight": 40
-                },
-                {
-                  "name": "null_route_cluster",
-                  "weight": 10
-                }
-              ]
-            }
+            "cluster": {
+              "name": "tcp.api-2.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-2.default.default.dc1"
           }
         }
-      ]
+      ],
+      "unixSocket": {
+        "mode": "0666",
+        "path": "/path/to/socket"
+      }
     }
   ],
   "endpoints": {
-    "tcp.api-1.default.dc1.internal.foo.consul": {
-      "endpoints": [
-        {
-          "healthStatus": "HEALTH_STATUS_HEALTHY",
-          "hostPort": {
-            "host": "10.1.1.1",
-            "port": 20000
-          }
-        }
-      ]
-    },
     "tcp.api-2.default.dc1.internal.foo.consul": {
       "endpoints": [
         {

--- a/internal/mesh/internal/controllers/xds/testdata/destination/l4-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/l4-single-implicit-destination-tproxy.golden
@@ -1,0 +1,122 @@
+{
+  "clusters": {
+    "original-destination": {
+      "endpointGroup": {
+        "passthrough": {
+          "config": {
+            "connectTimeout": "5s"
+          }
+        }
+      },
+      "name": "original-destination"
+    },
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-1.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-1.default.dc1.internal.foo.consul"
+    }
+  },
+  "identity": {
+    "name": "test-identity",
+    "tenancy": {
+      "namespace": "default",
+      "partition": "default",
+      "peerName": "local"
+    },
+    "type": {
+      "group": "auth",
+      "groupVersion": "v2beta1",
+      "kind": "WorkloadIdentity"
+    }
+  },
+  "listeners": [
+    {
+      "capabilities": [
+        "CAPABILITY_TRANSPARENT"
+      ],
+      "defaultRouter": {
+        "l4": {
+          "cluster": {
+            "name": "original-destination"
+          },
+          "statPrefix": "upstream.original-destination"
+        }
+      },
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "127.0.0.1",
+        "port": 15001
+      },
+      "name": "outbound_listener",
+      "routers": [
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-1.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-1.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 7070,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "endpoints": {
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    }
+  },
+  "trustBundles": {
+    "local": {
+      "roots": [
+        "some-root",
+        "some-other-root"
+      ],
+      "trustDomain": "some-trust-domain"
+    }
+  },
+  "leafCertificates": {
+    "test-identity": {
+      "cert": "-----BEGIN CERTIFICATE-----\nMIICDjCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAjAUMRIwEAYDVQQDEwlUZXN0IENB\nIDEwHhcNMjMxMDE2MTYxMzI5WhcNMjMxMDE2MTYyMzI5WjAAMFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9\nta/bGT+5orZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJaOCAQowggEGMA4GA1UdDwEB\n/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/\nBAIwADApBgNVHQ4EIgQg3ogXVz9cqaK2B6xdiJYMa5NtT0KkYv7BA2dR7h9EcwUw\nKwYDVR0jBCQwIoAgq+C1mPlPoGa4lt7sSft1goN5qPGyBIB/3mUHJZKSFY8wbwYD\nVR0RAQH/BGUwY4Zhc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9hcC9kZWZhdWx0L25zL2RlZmF1bHQvaWRlbnRpdHkv\ndGVzdC1pZGVudGl0eTAKBggqhkjOPQQDAgNHADBEAiB6L+t5bzRrBPhiQYNeA7fF\nUCuLWrdjW4Xbv3SLg0IKMgIgfRC5hEx+DqzQxTCP4sexX3hVWMjKoWmHdwiUcg+K\n/IE=\n-----END CERTIFICATE-----\n",
+      "key": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIFIFkTIL1iUV4O/RpveVHzHs7ZzhSkvYIzbdXDttz9EooAoGCCqGSM49\nAwEHoUQDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9ta/bGT+5\norZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJQ==\n-----END EC PRIVATE KEY-----\n"
+    }
+  }
+}

--- a/internal/mesh/internal/controllers/xds/testdata/destination/mixed-multi-destination.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/mixed-multi-destination.golden
@@ -1,0 +1,371 @@
+{
+  "clusters": {
+    "http.api-1.default.dc1.internal.foo.consul": {
+      "altStatName": "http.api-1.default.dc1.internal.foo.consul",
+      "failoverGroup": {
+        "config": {
+          "connectTimeout": "55s",
+          "useAltStatName": true
+        },
+        "endpointGroups": [
+          {
+            "dynamic": {
+              "config": {
+                "connectTimeout": "55s",
+                "disablePanicThreshold": true
+              },
+              "outboundTls": {
+                "alpnProtocols": [
+                  "consul~http"
+                ],
+                "outboundMesh": {
+                  "identityKey": "test-identity",
+                  "sni": "api-1.default.dc1.internal.foo.consul",
+                  "validationContext": {
+                    "spiffeIds": [
+                      "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
+                    ],
+                    "trustBundlePeerNameKey": "local"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "dynamic": {
+              "config": {
+                "connectTimeout": "5s",
+                "disablePanicThreshold": true
+              },
+              "outboundTls": {
+                "alpnProtocols": [
+                  "consul~http"
+                ],
+                "outboundMesh": {
+                  "identityKey": "test-identity",
+                  "sni": "backup-1.default.dc1.internal.foo.consul",
+                  "validationContext": {
+                    "spiffeIds": [
+                      "spiffe://foo.consul/ap/default/ns/default/identity/backup1-identity"
+                    ],
+                    "trustBundlePeerNameKey": "local"
+                  }
+                }
+              }
+            },
+            "name": "failover-target~0~http.api-1.default.dc1.internal.foo.consul"
+          }
+        ]
+      },
+      "name": "http.api-1.default.dc1.internal.foo.consul"
+    },
+    "http.api-2.default.dc1.internal.foo.consul": {
+      "altStatName": "http.api-2.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~http"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-2.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api2-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "http.api-2.default.dc1.internal.foo.consul"
+    },
+    "null_route_cluster": {
+      "endpointGroup": {
+        "static": {
+          "config": {
+            "connectTimeout": "10s"
+          }
+        }
+      },
+      "name": "null_route_cluster"
+    },
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-1.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-1.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api1-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-1.default.dc1.internal.foo.consul"
+    },
+    "tcp.api-2.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-2.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-2.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api2-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-2.default.dc1.internal.foo.consul"
+    }
+  },
+  "identity": {
+    "name": "test-identity",
+    "tenancy": {
+      "namespace": "default",
+      "partition": "default",
+      "peerName": "local"
+    },
+    "type": {
+      "group": "auth",
+      "groupVersion": "v2beta1",
+      "kind": "WorkloadIdentity"
+    }
+  },
+  "listeners": [
+    {
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "1.1.1.1",
+        "port": 1234
+      },
+      "name": "default/local/default/api-1:tcp:1.1.1.1:1234",
+      "routers": [
+        {
+          "l4": {
+            "statPrefix": "upstream.tcp.api-1.default.default.dc1",
+            "weightedClusters": {
+              "clusters": [
+                {
+                  "name": "tcp.api-2.default.dc1.internal.foo.consul",
+                  "weight": 60
+                },
+                {
+                  "name": "tcp.api-1.default.dc1.internal.foo.consul",
+                  "weight": 40
+                },
+                {
+                  "name": "null_route_cluster",
+                  "weight": 10
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "direction": "DIRECTION_OUTBOUND",
+      "name": "default/local/default/api-2:tcp:/path/to/socket",
+      "routers": [
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-2.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-2.default.default.dc1"
+          }
+        }
+      ],
+      "unixSocket": {
+        "mode": "0666",
+        "path": "/path/to/socket"
+      }
+    },
+    {
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "1.1.1.1",
+        "port": 1234
+      },
+      "name": "default/local/default/api-1:http:1.1.1.1:1234",
+      "routers": [
+        {
+          "l7": {
+            "route": {
+              "name": "default/local/default/api-1:http:1.1.1.1:1234"
+            },
+            "statPrefix": "upstream."
+          }
+        }
+      ]
+    }
+  ],
+  "routes": {
+    "default/local/default/api-1:http:1.1.1.1:1234": {
+      "virtualHosts": [
+        {
+          "name": "default/local/default/api-1:http:1.1.1.1:1234",
+          "routeRules": [
+            {
+              "destination": {
+                "destinationConfiguration": {
+                  "timeoutConfig": {
+                    "timeout": "77s"
+                  }
+                },
+                "weightedClusters": {
+                  "clusters": [
+                    {
+                      "name": "http.api-2.default.dc1.internal.foo.consul",
+                      "weight": 60
+                    },
+                    {
+                      "name": "http.api-1.default.dc1.internal.foo.consul",
+                      "weight": 40
+                    },
+                    {
+                      "name": "null_route_cluster",
+                      "weight": 10
+                    }
+                  ]
+                }
+              },
+              "match": {
+                "pathMatch": {
+                  "prefix": "/split"
+                }
+              }
+            },
+            {
+              "destination": {
+                "cluster": {
+                  "name": "http.api-1.default.dc1.internal.foo.consul"
+                },
+                "destinationConfiguration": {
+                  "retryPolicy": {
+                    "numRetries": 4,
+                    "retryOn": "connect-failure"
+                  },
+                  "timeoutConfig": {
+                    "timeout": "606s"
+                  }
+                }
+              },
+              "match": {
+                "pathMatch": {
+                  "prefix": "/"
+                }
+              }
+            },
+            {
+              "destination": {
+                "cluster": {
+                  "name": "null_route_cluster"
+                }
+              },
+              "match": {
+                "pathMatch": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "endpoints": {
+    "tcp.api-1.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp.api-2.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp2.api-1.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp2.api-2.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    }
+  },
+  "trustBundles": {
+    "local": {
+      "roots": [
+        "some-root",
+        "some-other-root"
+      ],
+      "trustDomain": "some-trust-domain"
+    }
+  },
+  "leafCertificates": {
+    "test-identity": {
+      "cert": "-----BEGIN CERTIFICATE-----\nMIICDjCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAjAUMRIwEAYDVQQDEwlUZXN0IENB\nIDEwHhcNMjMxMDE2MTYxMzI5WhcNMjMxMDE2MTYyMzI5WjAAMFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9\nta/bGT+5orZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJaOCAQowggEGMA4GA1UdDwEB\n/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/\nBAIwADApBgNVHQ4EIgQg3ogXVz9cqaK2B6xdiJYMa5NtT0KkYv7BA2dR7h9EcwUw\nKwYDVR0jBCQwIoAgq+C1mPlPoGa4lt7sSft1goN5qPGyBIB/3mUHJZKSFY8wbwYD\nVR0RAQH/BGUwY4Zhc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9hcC9kZWZhdWx0L25zL2RlZmF1bHQvaWRlbnRpdHkv\ndGVzdC1pZGVudGl0eTAKBggqhkjOPQQDAgNHADBEAiB6L+t5bzRrBPhiQYNeA7fF\nUCuLWrdjW4Xbv3SLg0IKMgIgfRC5hEx+DqzQxTCP4sexX3hVWMjKoWmHdwiUcg+K\n/IE=\n-----END CERTIFICATE-----\n",
+      "key": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIFIFkTIL1iUV4O/RpveVHzHs7ZzhSkvYIzbdXDttz9EooAoGCCqGSM49\nAwEHoUQDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9ta/bGT+5\norZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJQ==\n-----END EC PRIVATE KEY-----\n"
+    }
+  }
+}

--- a/internal/mesh/internal/controllers/xds/testdata/destination/mixed-multi-destination.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/mixed-multi-destination.golden
@@ -29,7 +29,8 @@
                   }
                 }
               }
-            }
+            },
+            "name": "failover-target~0~http.api-1.default.dc1.internal.foo.consul"
           },
           {
             "dynamic": {
@@ -53,7 +54,7 @@
                 }
               }
             },
-            "name": "failover-target~0~http.api-1.default.dc1.internal.foo.consul"
+            "name": "failover-target~1~http.api-1.default.dc1.internal.foo.consul"
           }
         ]
       },
@@ -330,7 +331,7 @@
         }
       ]
     },
-    "tcp2.api-1.default.dc1.internal.foo.consul": {
+    "http.api-1.default.dc1.internal.foo.consul": {
       "endpoints": [
         {
           "healthStatus": "HEALTH_STATUS_HEALTHY",
@@ -341,7 +342,7 @@
         }
       ]
     },
-    "tcp2.api-2.default.dc1.internal.foo.consul": {
+    "http.api-2.default.dc1.internal.foo.consul": {
       "endpoints": [
         {
           "healthStatus": "HEALTH_STATUS_HEALTHY",

--- a/internal/mesh/internal/controllers/xds/testdata/destination/mixed-multi-destination.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/mixed-multi-destination.golden
@@ -238,6 +238,7 @@
     "default/local/default/api-1:http:1.1.1.1:1234": {
       "virtualHosts": [
         {
+          "domains": ["*"],
           "name": "default/local/default/api-1:http:1.1.1.1:1234",
           "routeRules": [
             {

--- a/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
@@ -1,0 +1,453 @@
+{
+  "clusters": {
+    "http.api-app.default.dc1.internal.foo.consul": {
+      "altStatName": "http.api-app.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~http"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "http.api-app.default.dc1.internal.foo.consul"
+    },
+    "http.api-app2.default.dc1.internal.foo.consul": {
+      "altStatName": "http.api-app2.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~http"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app2.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app2-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "http.api-app2.default.dc1.internal.foo.consul"
+    },
+    "original-destination": {
+      "endpointGroup": {
+        "passthrough": {
+          "config": {
+            "connectTimeout": "5s"
+          }
+        }
+      },
+      "name": "original-destination"
+    },
+    "tcp.api-app.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-app.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-app.default.dc1.internal.foo.consul"
+    },
+    "tcp.api-app2.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-app2.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app2.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app2-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-app2.default.dc1.internal.foo.consul"
+    },
+    "tcp2.api-app.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp2.api-app.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp2"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp2.api-app.default.dc1.internal.foo.consul"
+    },
+    "tcp2.api-app2.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp2.api-app2.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp2"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app2.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app2-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp2.api-app2.default.dc1.internal.foo.consul"
+    }
+  },
+  "identity": {
+    "name": "test-identity",
+    "tenancy": {
+      "namespace": "default",
+      "partition": "default",
+      "peerName": "local"
+    },
+    "type": {
+      "group": "auth",
+      "groupVersion": "v2beta1",
+      "kind": "WorkloadIdentity"
+    }
+  },
+  "listeners": [
+    {
+      "capabilities": [
+        "CAPABILITY_TRANSPARENT"
+      ],
+      "defaultRouter": {
+        "l4": {
+          "cluster": {
+            "name": "original-destination"
+          },
+          "statPrefix": "upstream.original-destination"
+        }
+      },
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "127.0.0.1",
+        "port": 15001
+      },
+      "name": "outbound_listener",
+      "routers": [
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-app.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-app.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 7070,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        },
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-app2.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-app2.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 7070,
+            "prefixRanges": [
+              {
+                "addressPrefix": "2.2.2.2",
+                "prefixLen": 32
+              },
+              {
+                "addressPrefix": "3.3.3.3",
+                "prefixLen": 32
+              }
+            ]
+          }
+        },
+        {
+          "l7": {
+            "route": {
+              "name": "default/local/default/api-app"
+            },
+            "statPrefix": "upstream."
+          },
+          "match": {
+            "destinationPort": 8080,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        },
+        {
+          "l7": {
+            "route": {
+              "name": "default/local/default/api-app2"
+            },
+            "statPrefix": "upstream."
+          },
+          "match": {
+            "destinationPort": 8080,
+            "prefixRanges": [
+              {
+                "addressPrefix": "2.2.2.2",
+                "prefixLen": 32
+              },
+              {
+                "addressPrefix": "3.3.3.3",
+                "prefixLen": 32
+              }
+            ]
+          }
+        },
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp2.api-app.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp2.api-app.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 8081,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        },
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp2.api-app2.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp2.api-app2.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 8081,
+            "prefixRanges": [
+              {
+                "addressPrefix": "2.2.2.2",
+                "prefixLen": 32
+              },
+              {
+                "addressPrefix": "3.3.3.3",
+                "prefixLen": 32
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "routes": {
+    "default/local/default/api-app": {
+      "virtualHosts": [
+        {
+          "name": "default/local/default/api-app",
+          "routeRules": [
+            {
+              "destination": {
+                "cluster": {
+                  "name": "http.api-app.default.dc1.internal.foo.consul"
+                }
+              },
+              "match": {
+                "pathMatch": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "default/local/default/api-app2": {
+      "virtualHosts": [
+        {
+          "name": "default/local/default/api-app2",
+          "routeRules": [
+            {
+              "destination": {
+                "cluster": {
+                  "name": "http.api-app2.default.dc1.internal.foo.consul"
+                }
+              },
+              "match": {
+                "pathMatch": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "endpoints": {
+    "tcp.api-app.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp.api-app2.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp2.api-app.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp2.api-app2.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "http.api-app.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "http.api-app2.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    }
+  },
+  "trustBundles": {
+    "local": {
+      "roots": [
+        "some-root",
+        "some-other-root"
+      ],
+      "trustDomain": "some-trust-domain"
+    }
+  },
+  "leafCertificates": {
+    "test-identity": {
+      "cert": "-----BEGIN CERTIFICATE-----\nMIICDjCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAjAUMRIwEAYDVQQDEwlUZXN0IENB\nIDEwHhcNMjMxMDE2MTYxMzI5WhcNMjMxMDE2MTYyMzI5WjAAMFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9\nta/bGT+5orZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJaOCAQowggEGMA4GA1UdDwEB\n/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/\nBAIwADApBgNVHQ4EIgQg3ogXVz9cqaK2B6xdiJYMa5NtT0KkYv7BA2dR7h9EcwUw\nKwYDVR0jBCQwIoAgq+C1mPlPoGa4lt7sSft1goN5qPGyBIB/3mUHJZKSFY8wbwYD\nVR0RAQH/BGUwY4Zhc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9hcC9kZWZhdWx0L25zL2RlZmF1bHQvaWRlbnRpdHkv\ndGVzdC1pZGVudGl0eTAKBggqhkjOPQQDAgNHADBEAiB6L+t5bzRrBPhiQYNeA7fF\nUCuLWrdjW4Xbv3SLg0IKMgIgfRC5hEx+DqzQxTCP4sexX3hVWMjKoWmHdwiUcg+K\n/IE=\n-----END CERTIFICATE-----\n",
+      "key": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIFIFkTIL1iUV4O/RpveVHzHs7ZzhSkvYIzbdXDttz9EooAoGCCqGSM49\nAwEHoUQDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9ta/bGT+5\norZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJQ==\n-----END EC PRIVATE KEY-----\n"
+    }
+  }
+}

--- a/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
@@ -247,7 +247,7 @@
         {
           "l7": {
             "route": {
-              "name": "default/local/default/api-app"
+              "name": "default/local/default/api-app:http"
             },
             "statPrefix": "upstream."
           },
@@ -264,7 +264,7 @@
         {
           "l7": {
             "route": {
-              "name": "default/local/default/api-app2"
+              "name": "default/local/default/api-app2:http"
             },
             "statPrefix": "upstream."
           },
@@ -324,10 +324,11 @@
     }
   ],
   "routes": {
-    "default/local/default/api-app": {
+    "default/local/default/api-app:http": {
       "virtualHosts": [
         {
-          "name": "default/local/default/api-app",
+          "domains": ["*"],
+          "name": "default/local/default/api-app:http",
           "routeRules": [
             {
               "destination": {
@@ -345,10 +346,11 @@
         }
       ]
     },
-    "default/local/default/api-app2": {
+    "default/local/default/api-app2:http": {
       "virtualHosts": [
         {
-          "name": "default/local/default/api-app2",
+          "domains": ["*"],
+          "name": "default/local/default/api-app2:http",
           "routeRules": [
             {
               "destination": {

--- a/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
@@ -1,0 +1,255 @@
+{
+  "clusters": {
+    "http.api-app.default.dc1.internal.foo.consul": {
+      "altStatName": "http.api-app.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~http"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "http.api-app.default.dc1.internal.foo.consul"
+    },
+    "original-destination": {
+      "endpointGroup": {
+        "passthrough": {
+          "config": {
+            "connectTimeout": "5s"
+          }
+        }
+      },
+      "name": "original-destination"
+    },
+    "tcp.api-app.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-app.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-app.default.dc1.internal.foo.consul"
+    },
+    "tcp2.api-app.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp2.api-app.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp2"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp2.api-app.default.dc1.internal.foo.consul"
+    }
+  },
+  "identity": {
+    "name": "test-identity",
+    "tenancy": {
+      "namespace": "default",
+      "partition": "default",
+      "peerName": "local"
+    },
+    "type": {
+      "group": "auth",
+      "groupVersion": "v2beta1",
+      "kind": "WorkloadIdentity"
+    }
+  },
+  "listeners": [
+    {
+      "capabilities": [
+        "CAPABILITY_TRANSPARENT"
+      ],
+      "defaultRouter": {
+        "l4": {
+          "cluster": {
+            "name": "original-destination"
+          },
+          "statPrefix": "upstream.original-destination"
+        }
+      },
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "127.0.0.1",
+        "port": 15001
+      },
+      "name": "outbound_listener",
+      "routers": [
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-app.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-app.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 7070,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        },
+        {
+          "l7": {
+            "route": {
+              "name": "default/local/default/api-app"
+            },
+            "statPrefix": "upstream."
+          },
+          "match": {
+            "destinationPort": 8080,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        },
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp2.api-app.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp2.api-app.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 8081,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "routes": {
+    "default/local/default/api-app": {
+      "virtualHosts": [
+        {
+          "name": "default/local/default/api-app",
+          "routeRules": [
+            {
+              "destination": {
+                "cluster": {
+                  "name": "http.api-app.default.dc1.internal.foo.consul"
+                }
+              },
+              "match": {
+                "pathMatch": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "endpoints": {
+    "tcp.api-app.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp2.api-app.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "http.api-app.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    }
+  },
+  "trustBundles": {
+    "local": {
+      "roots": [
+        "some-root",
+        "some-other-root"
+      ],
+      "trustDomain": "some-trust-domain"
+    }
+  },
+  "leafCertificates": {
+    "test-identity": {
+      "cert": "-----BEGIN CERTIFICATE-----\nMIICDjCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAjAUMRIwEAYDVQQDEwlUZXN0IENB\nIDEwHhcNMjMxMDE2MTYxMzI5WhcNMjMxMDE2MTYyMzI5WjAAMFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9\nta/bGT+5orZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJaOCAQowggEGMA4GA1UdDwEB\n/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/\nBAIwADApBgNVHQ4EIgQg3ogXVz9cqaK2B6xdiJYMa5NtT0KkYv7BA2dR7h9EcwUw\nKwYDVR0jBCQwIoAgq+C1mPlPoGa4lt7sSft1goN5qPGyBIB/3mUHJZKSFY8wbwYD\nVR0RAQH/BGUwY4Zhc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9hcC9kZWZhdWx0L25zL2RlZmF1bHQvaWRlbnRpdHkv\ndGVzdC1pZGVudGl0eTAKBggqhkjOPQQDAgNHADBEAiB6L+t5bzRrBPhiQYNeA7fF\nUCuLWrdjW4Xbv3SLg0IKMgIgfRC5hEx+DqzQxTCP4sexX3hVWMjKoWmHdwiUcg+K\n/IE=\n-----END CERTIFICATE-----\n",
+      "key": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIFIFkTIL1iUV4O/RpveVHzHs7ZzhSkvYIzbdXDttz9EooAoGCCqGSM49\nAwEHoUQDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9ta/bGT+5\norZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJQ==\n-----END EC PRIVATE KEY-----\n"
+    }
+  }
+}

--- a/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
@@ -145,7 +145,7 @@
         {
           "l7": {
             "route": {
-              "name": "default/local/default/api-app"
+              "name": "default/local/default/api-app:http"
             },
             "statPrefix": "upstream."
           },
@@ -180,10 +180,11 @@
     }
   ],
   "routes": {
-    "default/local/default/api-app": {
+    "default/local/default/api-app:http": {
       "virtualHosts": [
         {
-          "name": "default/local/default/api-app",
+          "domains": ["*"],
+          "name": "default/local/default/api-app:http",
           "routeRules": [
             {
               "destination": {

--- a/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
@@ -1,0 +1,255 @@
+{
+  "clusters": {
+    "http.api-app.default.dc1.internal.foo.consul": {
+      "altStatName": "http.api-app.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~http"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "http.api-app.default.dc1.internal.foo.consul"
+    },
+    "original-destination": {
+      "endpointGroup": {
+        "passthrough": {
+          "config": {
+            "connectTimeout": "5s"
+          }
+        }
+      },
+      "name": "original-destination"
+    },
+    "tcp.api-app.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp.api-app.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp.api-app.default.dc1.internal.foo.consul"
+    },
+    "tcp2.api-app.default.dc1.internal.foo.consul": {
+      "altStatName": "tcp2.api-app.default.dc1.internal.foo.consul",
+      "endpointGroup": {
+        "dynamic": {
+          "config": {
+            "connectTimeout": "5s",
+            "disablePanicThreshold": true
+          },
+          "outboundTls": {
+            "alpnProtocols": [
+              "consul~tcp2"
+            ],
+            "outboundMesh": {
+              "identityKey": "test-identity",
+              "sni": "api-app.default.dc1.internal.foo.consul",
+              "validationContext": {
+                "spiffeIds": [
+                  "spiffe://foo.consul/ap/default/ns/default/identity/api-app-identity"
+                ],
+                "trustBundlePeerNameKey": "local"
+              }
+            }
+          }
+        }
+      },
+      "name": "tcp2.api-app.default.dc1.internal.foo.consul"
+    }
+  },
+  "identity": {
+    "name": "test-identity",
+    "tenancy": {
+      "namespace": "default",
+      "partition": "default",
+      "peerName": "local"
+    },
+    "type": {
+      "group": "auth",
+      "groupVersion": "v2beta1",
+      "kind": "WorkloadIdentity"
+    }
+  },
+  "listeners": [
+    {
+      "capabilities": [
+        "CAPABILITY_TRANSPARENT"
+      ],
+      "defaultRouter": {
+        "l4": {
+          "cluster": {
+            "name": "original-destination"
+          },
+          "statPrefix": "upstream.original-destination"
+        }
+      },
+      "direction": "DIRECTION_OUTBOUND",
+      "hostPort": {
+        "host": "127.0.0.1",
+        "port": 15001
+      },
+      "name": "outbound_listener",
+      "routers": [
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp.api-app.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp.api-app.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 7070,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        },
+        {
+          "l7": {
+            "route": {
+              "name": "default/local/default/api-app"
+            },
+            "statPrefix": "upstream."
+          },
+          "match": {
+            "destinationPort": 8080,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        },
+        {
+          "l4": {
+            "cluster": {
+              "name": "tcp2.api-app.default.dc1.internal.foo.consul"
+            },
+            "statPrefix": "upstream.tcp2.api-app.default.default.dc1"
+          },
+          "match": {
+            "destinationPort": 8081,
+            "prefixRanges": [
+              {
+                "addressPrefix": "1.1.1.1",
+                "prefixLen": 32
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "routes": {
+    "default/local/default/api-app": {
+      "virtualHosts": [
+        {
+          "name": "default/local/default/api-app",
+          "routeRules": [
+            {
+              "destination": {
+                "cluster": {
+                  "name": "http.api-app.default.dc1.internal.foo.consul"
+                }
+              },
+              "match": {
+                "pathMatch": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "endpoints": {
+    "tcp.api-app.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "tcp2.api-app.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    },
+    "http.api-app.default.dc1.internal.foo.consul": {
+      "endpoints": [
+        {
+          "healthStatus": "HEALTH_STATUS_HEALTHY",
+          "hostPort": {
+            "host": "10.1.1.1",
+            "port": 20000
+          }
+        }
+      ]
+    }
+  },
+  "trustBundles": {
+    "local": {
+      "roots": [
+        "some-root",
+        "some-other-root"
+      ],
+      "trustDomain": "some-trust-domain"
+    }
+  },
+  "leafCertificates": {
+    "test-identity": {
+      "cert": "-----BEGIN CERTIFICATE-----\nMIICDjCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAjAUMRIwEAYDVQQDEwlUZXN0IENB\nIDEwHhcNMjMxMDE2MTYxMzI5WhcNMjMxMDE2MTYyMzI5WjAAMFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9\nta/bGT+5orZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJaOCAQowggEGMA4GA1UdDwEB\n/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/\nBAIwADApBgNVHQ4EIgQg3ogXVz9cqaK2B6xdiJYMa5NtT0KkYv7BA2dR7h9EcwUw\nKwYDVR0jBCQwIoAgq+C1mPlPoGa4lt7sSft1goN5qPGyBIB/3mUHJZKSFY8wbwYD\nVR0RAQH/BGUwY4Zhc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9hcC9kZWZhdWx0L25zL2RlZmF1bHQvaWRlbnRpdHkv\ndGVzdC1pZGVudGl0eTAKBggqhkjOPQQDAgNHADBEAiB6L+t5bzRrBPhiQYNeA7fF\nUCuLWrdjW4Xbv3SLg0IKMgIgfRC5hEx+DqzQxTCP4sexX3hVWMjKoWmHdwiUcg+K\n/IE=\n-----END CERTIFICATE-----\n",
+      "key": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIFIFkTIL1iUV4O/RpveVHzHs7ZzhSkvYIzbdXDttz9EooAoGCCqGSM49\nAwEHoUQDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9ta/bGT+5\norZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJQ==\n-----END EC PRIVATE KEY-----\n"
+    }
+  }
+}

--- a/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
@@ -145,7 +145,7 @@
         {
           "l7": {
             "route": {
-              "name": "default/local/default/api-app"
+              "name": "default/local/default/api-app:http"
             },
             "statPrefix": "upstream."
           },
@@ -180,10 +180,11 @@
     }
   ],
   "routes": {
-    "default/local/default/api-app": {
+    "default/local/default/api-app:http": {
       "virtualHosts": [
         {
-          "name": "default/local/default/api-app",
+          "domains": ["*"],
+          "name": "default/local/default/api-app:http",
           "routeRules": [
             {
               "destination": {

--- a/internal/testing/golden/golden.go
+++ b/internal/testing/golden/golden.go
@@ -42,7 +42,15 @@ func GetBytes(t *testing.T, actual, filename string) []byte {
 		require.NoError(t, err)
 	}
 
-	expected, err := os.ReadFile(path)
+	return GetBytesAtFilePath(t, path)
+}
+
+// GetBytes reads the expected value from the file at filepath and returns the
+// value as a byte array. filepath is relative to the ./testdata directory.
+func GetBytesAtFilePath(t *testing.T, filepath string) []byte {
+	t.Helper()
+
+	expected, err := os.ReadFile(filepath)
 	require.NoError(t, err)
 	return expected
 }


### PR DESCRIPTION
### Description
TestReconcile_SidecarProxyGoldenFileInputs tests the Reconcile() by using the golden test output/expected files from the sidecar proxy tests as inputs to the XDS controller reconciliation.   The golden files added here for the expected output really only need to be verified for the correctness of the following proxyState fields:
- endpoints
- trustBundles
- leafCertificates

Destination proxy tests cases are tested in this PR.  Sources are added in a follow up PR: https://github.com/hashicorp/consul/pull/19241

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
