### PR TITLE
catalog: block unsupported failover policy settings for now

### DIFF
--- a/internal/catalog/internal/types/failover_policy.go
+++ b/internal/catalog/internal/types/failover_policy.go
@@ -173,6 +173,14 @@ func validateFailoverConfig(config *pbcatalog.FailoverConfig, ported bool, wrapE
 			Wrapped: fmt.Errorf("not supported in this release"),
 		}))
 	}
+
+	if len(config.Regions) > 0 {
+		merr = multierror.Append(merr, wrapErr(resource.ErrInvalidField{
+			Name:    "regions",
+			Wrapped: fmt.Errorf("not supported in this release"),
+		}))
+	}
+
 	// TODO(peering/v2): remove this bypass when we know what to do with
 
 	if (len(config.Destinations) > 0) == (config.SamenessGroup != "") {
@@ -194,17 +202,25 @@ func validateFailoverConfig(config *pbcatalog.FailoverConfig, ported bool, wrapE
 		}
 	}
 
-	switch config.Mode {
-	case pbcatalog.FailoverMode_FAILOVER_MODE_UNSPECIFIED:
-		// means pbcatalog.FailoverMode_FAILOVER_MODE_SEQUENTIAL
-	case pbcatalog.FailoverMode_FAILOVER_MODE_SEQUENTIAL:
-	case pbcatalog.FailoverMode_FAILOVER_MODE_ORDER_BY_LOCALITY:
-	default:
+	if config.Mode != pbcatalog.FailoverMode_FAILOVER_MODE_UNSPECIFIED {
 		merr = multierror.Append(merr, wrapErr(resource.ErrInvalidField{
 			Name:    "mode",
-			Wrapped: fmt.Errorf("not a supported enum value: %v", config.Mode),
+			Wrapped: fmt.Errorf("not supported in this release"),
 		}))
 	}
+
+	// TODO(v2): uncomment after this is supported
+	// switch config.Mode {
+	// case pbcatalog.FailoverMode_FAILOVER_MODE_UNSPECIFIED:
+	// 	// means pbcatalog.FailoverMode_FAILOVER_MODE_SEQUENTIAL
+	// case pbcatalog.FailoverMode_FAILOVER_MODE_SEQUENTIAL:
+	// case pbcatalog.FailoverMode_FAILOVER_MODE_ORDER_BY_LOCALITY:
+	// default:
+	// 	merr = multierror.Append(merr, wrapErr(resource.ErrInvalidField{
+	// 		Name:    "mode",
+	// 		Wrapped: fmt.Errorf("not a supported enum value: %v", config.Mode),
+	// 	}))
+	// }
 
 	// TODO: validate sameness group requirements
 

--- a/internal/catalog/internal/types/failover_policy_test.go
+++ b/internal/catalog/internal/types/failover_policy_test.go
@@ -253,15 +253,30 @@ func TestValidateFailoverPolicy(t *testing.T) {
 			// TODO(v2): remove after this is supported
 			expectErr: `invalid "sameness_group" field: not supported in this release`,
 		},
-		"mode: invalid": {
+		"regions without dest": {
 			config: &pbcatalog.FailoverConfig{
-				Mode: 99,
-				Destinations: []*pbcatalog.FailoverDestination{
-					{Ref: newRef(pbcatalog.ServiceType, "api-backup")},
-				},
+				Regions: []string{"us-east1", "us-west2"},
 			},
-			expectErr: `invalid "mode" field: not a supported enum value: 99`,
+			// TODO(v2): remove after this is supported
+			expectErr: `invalid "regions" field: not supported in this release`,
 		},
+		"mode without dest": {
+			config: &pbcatalog.FailoverConfig{
+				Mode: pbcatalog.FailoverMode_FAILOVER_MODE_SEQUENTIAL,
+			},
+			// TODO(v2): remove after this is supported
+			expectErr: `invalid "mode" field: not supported in this release`,
+		},
+		// TODO(v2): uncomment after this is supported
+		// "mode: invalid": {
+		// 	config: &pbcatalog.FailoverConfig{
+		// 		Mode: 99,
+		// 		Destinations: []*pbcatalog.FailoverDestination{
+		// 			{Ref: newRef(pbcatalog.ServiceType, "api-backup")},
+		// 		},
+		// 	},
+		// 	expectErr: `invalid "mode" field: not a supported enum value: 99`,
+		// },
 		"dest: no ref": {
 			config: &pbcatalog.FailoverConfig{
 				Destinations: []*pbcatalog.FailoverDestination{


### PR DESCRIPTION
### Description

FailoverPolicy does not support `mode`, `regions`, or `sameness_group` yet, so block them during validation.

NET-5698
