### PR TITLE
get-envoy-bootstrap-params: when v2 is enabled, use computed proxy configuration

### DIFF
--- a/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
+++ b/agent/grpc-external/services/dataplane/get_envoy_bootstrap_params.go
@@ -12,9 +12,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/hashicorp/consul/internal/resource"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
@@ -85,46 +85,33 @@ func (s *Server) GetEnvoyBootstrapParams(ctx context.Context, req *pbdataplane.G
 			return nil, err
 		}
 
-		// Get all proxy configurations for this workload. Currently we're only looking
-		// for proxy configurations in the same tenancy as the workload.
-		// todo (ishustava): we need to support wildcard proxy configurations as well.
+		computedProxyConfig, err := resource.GetDecodedResource[*pbmesh.ComputedProxyConfiguration](
+			ctx,
+			s.ResourceAPIClient,
+			resource.ReplaceType(pbmesh.ComputedProxyConfigurationType, workloadId))
 
-		proxyCfgList, err := s.ResourceAPIClient.List(ctx, &pbresource.ListRequest{
-			Tenancy: workloadRsp.Resource.Id.GetTenancy(),
-			Type:    pbmesh.ProxyConfigurationType,
-		})
 		if err != nil {
-			logger.Error("Error looking up proxyConfiguration", "error", err)
+			logger.Error("Error looking up ComputedProxyConfiguration for this workload", "error", err)
 			return nil, err
 		}
 
-		// Collect and merge proxy configs.
-		// todo (ishustava): sorting and conflict resolution.
-		bootstrapCfg := &pbmesh.BootstrapConfig{}
-		dynamicCfg := &pbmesh.DynamicConfig{}
-		for _, cfgResource := range proxyCfgList.Resources {
-			var proxyCfg pbmesh.ProxyConfiguration
-			err = cfgResource.Data.UnmarshalTo(&proxyCfg)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "failed to parse proxy configuration data: %q", cfgResource.Id.Name)
-			}
-			if isWorkloadSelected(req.ProxyId, proxyCfg.Workloads) {
-				proto.Merge(bootstrapCfg, proxyCfg.BootstrapConfig)
-				proto.Merge(dynamicCfg, proxyCfg.DynamicConfig)
-			}
+		rsp := &pbdataplane.GetEnvoyBootstrapParamsResponse{
+			Identity:   workload.Identity,
+			Partition:  workloadRsp.Resource.Id.Tenancy.Partition,
+			Namespace:  workloadRsp.Resource.Id.Tenancy.Namespace,
+			Datacenter: s.Datacenter,
+			NodeName:   workload.NodeName,
 		}
 
-		accessLogs := makeAccessLogs(dynamicCfg.GetAccessLogs(), logger)
+		if computedProxyConfig != nil {
+			if computedProxyConfig.GetData().GetDynamicConfig() != nil {
+				rsp.AccessLogs = makeAccessLogs(computedProxyConfig.GetData().GetDynamicConfig().GetAccessLogs(), logger)
+			}
 
-		return &pbdataplane.GetEnvoyBootstrapParamsResponse{
-			Identity:        workload.Identity,
-			Partition:       workloadRsp.Resource.Id.Tenancy.Partition,
-			Namespace:       workloadRsp.Resource.Id.Tenancy.Namespace,
-			BootstrapConfig: bootstrapCfg,
-			Datacenter:      s.Datacenter,
-			NodeName:        workload.NodeName,
-			AccessLogs:      accessLogs,
-		}, nil
+			rsp.BootstrapConfig = computedProxyConfig.GetData().GetBootstrapConfig()
+		}
+
+		return rsp, nil
 	}
 
 	// The remainder of this file focuses on v1 implementation of this endpoint.
@@ -214,20 +201,4 @@ func makeAccessLogs(logs structs.AccessLogs, logger hclog.Logger) []string {
 	}
 
 	return accessLogs
-}
-
-func isWorkloadSelected(name string, selector *pbcatalog.WorkloadSelector) bool {
-	for _, prefix := range selector.Prefixes {
-		if strings.Contains(name, prefix) {
-			return true
-		}
-	}
-
-	for _, selectorName := range selector.Names {
-		if name == selectorName {
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
### Description

Previously this endpoint was listing all proxy configs and combining them into one. Now we can re-use the computed resource so that we get the sorting and easy lookup.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
