### PR TITLE
Relplat 897 copywrite bot workarounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,9 @@ codegen: codegen-tools ## Deep copy
 	@$(SHELL) $(CURDIR)/agent/consul/state/deep-copy.sh
 	@$(SHELL) $(CURDIR)/agent/config/deep-copy.sh
 	copywrite headers
+	# Special case for MPL headers in /api and /sdk
+	cd api && $(CURDIR)/build-support/scripts/copywrite-exceptions.sh
+	cd sdk && $(CURDIR)/build-support/scripts/copywrite-exceptions.sh
 
 print-%  : ; @echo $($*) ## utility to echo a makefile variable (i.e. 'make print-GOPATH')
 

--- a/api/.copywrite.hcl
+++ b/api/.copywrite.hcl
@@ -1,0 +1,8 @@
+schema_version = 1
+
+project {
+  license		= "MPL-2.0"
+  copyright_year	= 2023
+
+  header_ignore		= []
+}

--- a/api/config_entry_routes_test.go
+++ b/api/config_entry_routes_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (

--- a/api/config_entry_status_test.go
+++ b/api/config_entry_status_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import "testing"

--- a/api/internal.go
+++ b/api/internal.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import "context"

--- a/api/internal_test.go
+++ b/api/internal_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (

--- a/api/operator_audit.go
+++ b/api/operator_audit.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MPL-2.0
+
 
 // The /v1/operator/audit-hash endpoint is available only in Consul Enterprise and
 // interact with its audit logging subsystem.

--- a/build-support/scripts/copywrite-exceptions.sh
+++ b/build-support/scripts/copywrite-exceptions.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Used as a stopgap for copywrite bot in MPL-licensed subdirs, detects BUSL licensed
+# headers and deletes them, then runs the copywrite bot to utilize local subdir config
+# to inject correct headers.
+
+find . -type f -name '*.go' | while read line; do
+  if grep "SPDX-License-Identifier: BUSL-1.1" $line; then
+    sed -i '/SPDX-License-Identifier: BUSL-1.1/d' $line
+    sed -i '/Copyright (c) HashiCorp, Inc./d' $line
+  fi
+done
+
+copywrite headers

--- a/sdk/.copywrite.hcl
+++ b/sdk/.copywrite.hcl
@@ -1,0 +1,8 @@
+schema_version = 1
+
+project {
+  license		= "MPL-2.0"
+  copyright_year	= 2023
+
+  header_ignore		= []
+}

--- a/sdk/testutil/retry/counter.go
+++ b/sdk/testutil/retry/counter.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package retry
 
 import "time"

--- a/sdk/testutil/retry/timer.go
+++ b/sdk/testutil/retry/timer.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package retry
 
 import "time"


### PR DESCRIPTION
### Description

This enables a workaround for the copywrite tooling that lets us correctly automate license compliance in subdirectories that utilize MPL. New copywrite configuration files are added to the impacted subdirs, and the copywrite make target is expanded so that the tool is run locally in those subdirs preceded by a script that removes incorrect license headers (the copywrite tool is currently unable to do this on its own, and this is a workaround until it can be improved).

### Testing & Reproduction steps

The new build target can be run locally - all results of a local run as of the time of this change are included as the header updates in this PR.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
