### PR TITLE
test: add test helper to detect if the current build is enterprise

### DIFF
--- a/internal/catalog/internal/controllers/nodehealth/controller_test.go
+++ b/internal/catalog/internal/controllers/nodehealth/controller_test.go
@@ -6,7 +6,6 @@ package nodehealth
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/consul/agent/structs"
 	"testing"
 
 	"github.com/oklog/ulid/v2"
@@ -25,6 +24,7 @@ import (
 	"github.com/hashicorp/consul/proto/private/prototest"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 var (
@@ -94,7 +94,7 @@ func (suite *nodeHealthControllerTestSuite) SetupTest() {
 	client := svctest.RunResourceServiceWithConfig(suite.T(), cfg, types.Register, types.RegisterDNSPolicy)
 	suite.resourceClient = resourcetest.NewClient(client)
 	suite.runtime = controller.Runtime{Client: suite.resourceClient, Logger: testutil.Logger(suite.T())}
-	suite.isEnterprise = structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default"
+	suite.isEnterprise = versiontest.IsEnterprise()
 }
 
 func (suite *nodeHealthControllerTestSuite) TestGetNodeHealthListError() {
@@ -320,6 +320,7 @@ func (suite *nodeHealthControllerTestSuite) waitForReconciliation(id *pbresource
 		require.Equal(r, reason, nodeHealthStatus.Conditions[0].Reason)
 	})
 }
+
 func (suite *nodeHealthControllerTestSuite) TestController() {
 	suite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
 

--- a/internal/catalog/internal/controllers/workloadhealth/controller_test.go
+++ b/internal/catalog/internal/controllers/workloadhealth/controller_test.go
@@ -9,27 +9,26 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/internal/resource"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-
 	svc "github.com/hashicorp/consul/agent/grpc-external/services/resource"
 	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/internal/catalog/internal/controllers/nodehealth"
 	"github.com/hashicorp/consul/internal/catalog/internal/mappers/nodemapper"
 	"github.com/hashicorp/consul/internal/catalog/internal/types"
 	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/proto/private/prototest"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 var (
@@ -104,7 +103,7 @@ func (suite *controllerSuite) SetupTest() {
 
 	suite.client = svctest.RunResourceServiceWithConfig(suite.T(), svc.Config{TenancyBridge: mockTenancyBridge}, types.Register)
 	suite.runtime = controller.Runtime{Client: suite.client, Logger: testutil.Logger(suite.T())}
-	suite.isEnterprise = (structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default")
+	suite.isEnterprise = versiontest.IsEnterprise()
 }
 
 // injectNodeWithStatus is a helper method to write a Node resource and synthesize its status

--- a/internal/catalog/internal/types/failover_policy_test.go
+++ b/internal/catalog/internal/types/failover_policy_test.go
@@ -11,13 +11,13 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/proto/private/prototest"
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 func TestMutateFailoverPolicy(t *testing.T) {
@@ -749,7 +749,7 @@ func TestFailoverPolicyACLs(t *testing.T) {
 		})
 	}
 
-	isEnterprise := (structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default")
+	isEnterprise := versiontest.IsEnterprise()
 
 	serviceRead := func(partition, namespace, name string) string {
 		if isEnterprise {

--- a/internal/mesh/internal/types/destination_policy_test.go
+++ b/internal/mesh/internal/types/destination_policy_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/proto/private/prototest"
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 func TestValidateDestinationPolicy(t *testing.T) {
@@ -545,7 +545,7 @@ func TestDestinationPolicyACLs(t *testing.T) {
 		})
 	}
 
-	isEnterprise := (structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default")
+	isEnterprise := versiontest.IsEnterprise()
 
 	serviceRead := func(partition, namespace, name string) string {
 		if isEnterprise {

--- a/internal/mesh/internal/types/xroute_test.go
+++ b/internal/mesh/internal/types/xroute_test.go
@@ -12,12 +12,12 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 type xRouteParentRefMutateTestcase struct {
@@ -441,7 +441,7 @@ func testXRouteACLs[R XRouteData](t *testing.T, newRoute func(t *testing.T, pare
 		})
 	}
 
-	isEnterprise := (structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default")
+	isEnterprise := versiontest.IsEnterprise()
 
 	serviceRead := func(partition, namespace, name string) string {
 		if isEnterprise {

--- a/internal/multicluster/internal/controllers/exportedservices/controller_test.go
+++ b/internal/multicluster/internal/controllers/exportedservices/controller_test.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
+
 	svc "github.com/hashicorp/consul/agent/grpc-external/services/resource"
 	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
-	"github.com/hashicorp/consul/agent/structs"
 	cat "github.com/hashicorp/consul/internal/catalog"
 	"github.com/hashicorp/consul/internal/controller"
 	"github.com/hashicorp/consul/internal/multicluster/internal/types"
@@ -20,11 +23,8 @@ import (
 	pbmulticluster "github.com/hashicorp/consul/proto-public/pbmulticluster/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/proto/private/prototest"
-	"google.golang.org/protobuf/proto"
-
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 type controllerSuite struct {
@@ -60,7 +60,7 @@ func (suite *controllerSuite) SetupTest() {
 		Logger: testutil.Logger(suite.T()),
 	}
 	suite.reconciler = &reconciler{}
-	suite.isEnterprise = (structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default")
+	suite.isEnterprise = versiontest.IsEnterprise()
 }
 
 func (suite *controllerSuite) TestReconcile() {

--- a/internal/multicluster/internal/types/computed_exported_services_test.go
+++ b/internal/multicluster/internal/types/computed_exported_services_test.go
@@ -5,13 +5,15 @@ package types
 
 import (
 	"errors"
-	"github.com/hashicorp/consul/agent/structs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbmulticluster "github.com/hashicorp/consul/proto-public/pbmulticluster/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
-	"github.com/stretchr/testify/require"
-	"testing"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 func computedExportedServicesWithPartition(partitionName string) *pbmulticluster.ComputedExportedServices {
@@ -123,7 +125,7 @@ func TestComputedExportedServicesValidations(t *testing.T) {
 		expectErrorENT []string
 	}
 
-	isEnterprise := structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default"
+	isEnterprise := versiontest.IsEnterprise()
 
 	run := func(t *testing.T, tc testcase) {
 		expectError := tc.expectErrorCE

--- a/internal/multicluster/internal/types/exported_services_test.go
+++ b/internal/multicluster/internal/types/exported_services_test.go
@@ -5,13 +5,15 @@ package types
 
 import (
 	"errors"
-	"github.com/hashicorp/consul/agent/structs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbmulticluster "github.com/hashicorp/consul/proto-public/pbmulticluster/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
-	"github.com/stretchr/testify/require"
-	"testing"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 func inValidExportedServices() *pbmulticluster.ExportedServices {
@@ -149,7 +151,7 @@ func TestExportedServicesValidation(t *testing.T) {
 		expectErrorENT []string
 	}
 
-	isEnterprise := structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default"
+	isEnterprise := versiontest.IsEnterprise()
 
 	run := func(t *testing.T, tc testcase) {
 		expectError := tc.expectErrorCE

--- a/internal/multicluster/internal/types/namespace_exported_services_test.go
+++ b/internal/multicluster/internal/types/namespace_exported_services_test.go
@@ -4,13 +4,15 @@
 package types
 
 import (
-	"github.com/hashicorp/consul/agent/structs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbmulticluster "github.com/hashicorp/consul/proto-public/pbmulticluster/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
-	"github.com/stretchr/testify/require"
-	"testing"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 func validNamespaceExportedServicesWithPeer(peerName string) *pbmulticluster.NamespaceExportedServices {
@@ -51,6 +53,7 @@ func validNamespaceExportedServicesWithSamenessGroup(samenessGroupName string) *
 		Consumers: consumers,
 	}
 }
+
 func TestNamespaceExportedServicesACLs(t *testing.T) {
 	// Wire up a registry to generically invoke hooks
 	registry := resource.NewRegistry()
@@ -115,7 +118,7 @@ func TestNamespaceExportedServicesValidations(t *testing.T) {
 		expectErrorENT []string
 	}
 
-	isEnterprise := structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default"
+	isEnterprise := versiontest.IsEnterprise()
 
 	run := func(t *testing.T, tc testcase) {
 		expectError := tc.expectErrorCE

--- a/internal/multicluster/internal/types/partition_exported_services_test.go
+++ b/internal/multicluster/internal/types/partition_exported_services_test.go
@@ -4,13 +4,15 @@
 package types
 
 import (
-	"github.com/hashicorp/consul/agent/structs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbmulticluster "github.com/hashicorp/consul/proto-public/pbmulticluster/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
-	"github.com/stretchr/testify/require"
-	"testing"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 func validPartitionExportedServicesWithPeer(peerName string) *pbmulticluster.PartitionExportedServices {
@@ -116,7 +118,7 @@ func TestPartitionExportedServicesValidations(t *testing.T) {
 		expectErrorENT []string
 	}
 
-	isEnterprise := structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default"
+	isEnterprise := versiontest.IsEnterprise()
 
 	run := func(t *testing.T, tc testcase) {
 		expectError := tc.expectErrorCE

--- a/internal/resource/resourcetest/tenancy.go
+++ b/internal/resource/resourcetest/tenancy.go
@@ -7,15 +7,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/hashicorp/consul/version/versiontest"
 )
 
 // TestTenancies returns a list of tenancies which represent
 // the namespace and partition combinations that can be used in unit tests
 func TestTenancies() []*pbresource.Tenancy {
-	isEnterprise := structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty() == "default"
+	isEnterprise := versiontest.IsEnterprise()
 
 	tenancies := []*pbresource.Tenancy{Tenancy("default.default")}
 	if isEnterprise {

--- a/version/versiontest/versiontest.go
+++ b/version/versiontest/versiontest.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package versiontest
+
+import "github.com/hashicorp/consul/version"
+
+// IsEnterprise returns true if the current build is a Consul Enterprise build.
+//
+// This should only be called from test code.
+func IsEnterprise() bool {
+	return version.VersionMetadata == "ent"
+}


### PR DESCRIPTION
### Description

This can help conditionally change test behavior if the test is executing in enterprise without the need to split the test with build tags.