### PR TITLE
server: run the api checks against the path without params

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -90,6 +90,18 @@ func TestAgentEndpointsFailInV2(t *testing.T) {
 		})
 	}
 
+	t.Run("agent-self-with-params", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/v1/agent/self?dc=dc1", nil)
+		require.NoError(t, err)
+
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
+
+		_, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+	})
+
 	checkRequest("PUT", "/v1/agent/maintenance")
 	checkRequest("GET", "/v1/agent/services")
 	checkRequest("GET", "/v1/agent/service/web")

--- a/agent/http.go
+++ b/agent/http.go
@@ -396,7 +396,7 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 
 		rejectCatalogV1Endpoint := false
 		if s.agent.baseDeps.UseV2Resources() {
-			rejectCatalogV1Endpoint = isV1CatalogRequest(logURL)
+			rejectCatalogV1Endpoint = isV1CatalogRequest(req.URL.Path)
 		}
 
 		if s.denylist.Block(req.URL.Path) {


### PR DESCRIPTION
### Description

Fixes a bug in https://github.com/hashicorp/consul/pull/19129 where `/v1/agent/self` was allowed but `/v1/agent/self?dc=dc1` was not.

