### PR TITLE
Add reason why port 53 is not used by default

### DIFF
--- a/website/content/docs/services/discovery/dns-configuration.mdx
+++ b/website/content/docs/services/discovery/dns-configuration.mdx
@@ -16,7 +16,7 @@ The Consul DNS is the primary interface for querying records when Consul service
 By default, the Consul DNS listens for queries at `127.0.0.1:8600` and uses the `consul` domain. Specify the following parameters in the agent configuration to determine DNS behavior when querying services:
 
 - [`client_addr`](/consul/docs/agent/config/config-files#client_addr)
-- [`ports.dns`](/consul/docs/agent/config/config-files#dns_port)
+- [`ports.dns`](/consul/docs/agent/config/config-files#dns_port) : Port `53`, which is typically reserved for the default port for DNS resolvers, is not used by default because it requires an escalated privilege to bind to. 
 - [`recursors`](/consul/docs/agent/config/config-files#recursors)
 - [`domain`](/consul/docs/agent/config/config-files#domain)
 - [`alt_domain`](/consul/docs/agent/config/config-files#alt_domain)

--- a/website/content/docs/services/discovery/dns-configuration.mdx
+++ b/website/content/docs/services/discovery/dns-configuration.mdx
@@ -16,7 +16,7 @@ The Consul DNS is the primary interface for querying records when Consul service
 By default, the Consul DNS listens for queries at `127.0.0.1:8600` and uses the `consul` domain. Specify the following parameters in the agent configuration to determine DNS behavior when querying services:
 
 - [`client_addr`](/consul/docs/agent/config/config-files#client_addr)
-- [`ports.dns`](/consul/docs/agent/config/config-files#dns_port) : Port `53`, which is typically reserved for the default port for DNS resolvers, is not used by default because it requires an escalated privilege to bind to. 
+- [`ports.dns`](/consul/docs/agent/config/config-files#dns_port) : Consul does not use port `53`, which is typically reserved for the default port for DNS resolvers, by default because it requires an escalated privilege to bind to. 
 - [`recursors`](/consul/docs/agent/config/config-files#recursors)
 - [`domain`](/consul/docs/agent/config/config-files#domain)
 - [`alt_domain`](/consul/docs/agent/config/config-files#alt_domain)


### PR DESCRIPTION
### Description

Add  reason in docs why port 53 is not used by default.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
