### PR TITLE
NET-6097 - sidecar proxy controller - give name to first failover policy target

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destinations.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destinations.go
@@ -287,7 +287,12 @@ func (b *Builder) buildDestination(
 		)
 		clusterName := fmt.Sprintf("%s.%s", portName, sni)
 
-		egBase := b.newClusterEndpointGroup("", sni, portName, details.IdentityRefs, connectTimeout, loadBalancer)
+		egName := ""
+
+		if details.FailoverConfig != nil {
+			egName = fmt.Sprintf("%s%d~%s", xdscommon.FailoverClusterNamePrefix, 0, clusterName)
+		}
+		egBase := b.newClusterEndpointGroup(egName, sni, portName, details.IdentityRefs, connectTimeout, loadBalancer)
 
 		var endpointGroups []*pbproxystate.EndpointGroup
 
@@ -319,7 +324,10 @@ func (b *Builder) buildDestination(
 					destDC,
 					b.trustDomain,
 				)
-				destClusterName := fmt.Sprintf("%s%d~%s", xdscommon.FailoverClusterNamePrefix, i, clusterName)
+
+				// index 0 was already given to non-fail original
+				failoverGroupIndex := i + 1
+				destClusterName := fmt.Sprintf("%s%d~%s", xdscommon.FailoverClusterNamePrefix, failoverGroupIndex, clusterName)
 
 				egDest := b.newClusterEndpointGroup(destClusterName, destSNI, destPortName, destDetails.IdentityRefs, destConnectTimeout, destLoadBalancer)
 

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/mixed-multi-destination.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/mixed-multi-destination.golden
@@ -30,7 +30,8 @@
                     }
                   }
                 }
-              }
+              },
+              "name": "failover-target~0~http.api-1.default.dc1.internal.foo.consul"
             },
             {
               "dynamic": {
@@ -54,7 +55,7 @@
                   }
                 }
               },
-              "name": "failover-target~0~http.api-1.default.dc1.internal.foo.consul"
+              "name": "failover-target~1~http.api-1.default.dc1.internal.foo.consul"
             }
           ]
         },
@@ -310,7 +311,7 @@
     }
   },
   "requiredEndpoints": {
-    "failover-target~0~http.api-1.default.dc1.internal.foo.consul": {
+    "failover-target~1~http.api-1.default.dc1.internal.foo.consul": {
       "id": {
         "name": "backup-1",
         "tenancy": {


### PR DESCRIPTION
### Description
This fixes a small issue where the failover endpoint group had the first element for the original destination but it did not have a name.  It needs to carry the failover target naming convention and use the index of 0.  destinations specified in the FailoverPolicy then start with an index of 1 and higher.

### Testing & Reproduction steps
See unit test.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
