### PR TITLE
Downgrading node on CI to support v1.15.X

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -39,7 +39,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # pin@v3.6.0
       with:
-        node-version: '16'
+        node-version: '14'
 
     - name: Install Yarn
       run: npm install -g yarn
@@ -59,7 +59,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # pin@v3.6.0
       with:
-        node-version: '16'
+        node-version: '14'
 
     - name: Install Yarn
       run: npm install -g yarn
@@ -88,7 +88,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # pin@v3.6.0
       with:
-        node-version: '16'
+        node-version: '14'
 
     - name: Install Yarn
       run: npm install -g yarn


### PR DESCRIPTION
### Description
CI has been failing for V1.15.X, which isn't good!
We're planning on just downgrading the node version on CI until next quarter when v1.15.X is no longer supported!

We also only want this change on v1.15.X branch, since we don't want to downgrade node for main.

### Testing & Reproduction steps
- Run CI
- Note that the [frontend tasks don't fail](https://github.com/hashicorp/consul/actions/runs/6152797280/job/16696147709?pr=18750)
- 
### Links
- [Jira](https://hashicorp.atlassian.net/browse/CC-6363)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

### References
![image](https://github.com/hashicorp/consul/assets/4359781/cb4059b1-193d-49fb-a15b-514944a26523)
