### PR TITLE
fix expose paths

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/builder/expose_paths.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/expose_paths.go
@@ -29,7 +29,7 @@ func (b *Builder) buildExposePaths(workload *pbcatalog.Workload) {
 }
 
 func (b *Builder) addExposePathsListener(workload *pbcatalog.Workload, exposePath *pbmesh.ExposePath) *ListenerBuilder {
-	listenerName := fmt.Sprintf("exposed_path_%s", exposePathName(exposePath))
+	listenerName := exposePathListenerName(exposePath)
 
 	listener := &pbproxystate.Listener{
 		Name:      listenerName,
@@ -44,7 +44,7 @@ func (b *Builder) addExposePathsListener(workload *pbcatalog.Workload, exposePat
 	listener.BindAddress = &pbproxystate.Listener_HostPort{
 		HostPort: &pbproxystate.HostPortAddress{
 			Host: meshAddress.Host,
-			Port: exposePath.LocalPathPort,
+			Port: exposePath.ListenerPort,
 		},
 	}
 
@@ -120,12 +120,21 @@ func (b *Builder) addExposePathsRoute(exposePath *pbmesh.ExposePath, clusterName
 
 func exposePathName(exposePath *pbmesh.ExposePath) string {
 	r := regexp.MustCompile(`[^a-zA-Z0-9]+`)
-	return r.ReplaceAllString(exposePath.Path, "")
+	// The regex removes anything not a letter or number from the path.
+	path := r.ReplaceAllString(exposePath.Path, "")
+	return path
+}
+
+func exposePathListenerName(exposePath *pbmesh.ExposePath) string {
+	// The path could be empty, so the unique name for this exposed path is the path and listener port.
+	pathPort := fmt.Sprintf("%s%d", exposePathName(exposePath), exposePath.ListenerPort)
+	listenerName := fmt.Sprintf("exposed_path_%s", pathPort)
+	return listenerName
 }
 
 func exposePathDestinationName(exposePath *pbmesh.ExposePath) string {
-	path := exposePathName(exposePath)
-	return fmt.Sprintf("exposed_path_filter_%s_%d", path, exposePath.ListenerPort)
+	// The destination of the expose path is to the local port.
+	return fmt.Sprintf("exposed_path_destination_%s%d", exposePathName(exposePath), exposePath.LocalPathPort)
 }
 
 func exposePathClusterName(exposePath *pbmesh.ExposePath) string {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/expose_paths.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/expose_paths.go
@@ -55,7 +55,7 @@ func (b *ListenerBuilder) addExposePathsRouter(exposePath *pbmesh.ExposePath) *L
 	if b.listener == nil {
 		return b
 	}
-	destinationName := exposePathDestinationName(exposePath)
+	destinationName := exposePathRouteName(exposePath)
 
 	var l7Protocol pbproxystate.L7Protocol
 
@@ -88,7 +88,7 @@ func (b *ListenerBuilder) addExposePathsRouter(exposePath *pbmesh.ExposePath) *L
 }
 
 func (b *Builder) addExposePathsRoute(exposePath *pbmesh.ExposePath, clusterName string) *Builder {
-	routeName := exposePathDestinationName(exposePath)
+	routeName := exposePathRouteName(exposePath)
 	routeRule := &pbproxystate.RouteRule{
 		Match: &pbproxystate.RouteMatch{
 			PathMatch: &pbproxystate.PathMatch{
@@ -132,9 +132,10 @@ func exposePathListenerName(exposePath *pbmesh.ExposePath) string {
 	return listenerName
 }
 
-func exposePathDestinationName(exposePath *pbmesh.ExposePath) string {
-	// The destination of the expose path is to the local port.
-	return fmt.Sprintf("exposed_path_destination_%s%d", exposePathName(exposePath), exposePath.LocalPathPort)
+func exposePathRouteName(exposePath *pbmesh.ExposePath) string {
+	// The path could be empty, so the unique name for this exposed path is the path and listener port.
+	pathPort := fmt.Sprintf("%s%d", exposePathName(exposePath), exposePath.ListenerPort)
+	return fmt.Sprintf("exposed_path_route_%s", pathPort)
 }
 
 func exposePathClusterName(exposePath *pbmesh.ExposePath) string {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/l7-expose-paths.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/l7-expose-paths.golden
@@ -107,16 +107,16 @@
         "direction": "DIRECTION_INBOUND",
         "hostPort": {
           "host": "10.0.0.1",
-          "port": 9090
+          "port": 1234
         },
-        "name": "exposed_path_health",
+        "name": "exposed_path_health1234",
         "routers": [
           {
             "l7": {
               "route": {
-                "name": "exposed_path_filter_health_1234"
+                "name": "exposed_path_destination_health9090"
               },
-              "statPrefix": "exposed_path_filter_health_1234",
+              "statPrefix": "exposed_path_destination_health9090",
               "staticRoute": true
             }
           }
@@ -126,17 +126,17 @@
         "direction": "DIRECTION_INBOUND",
         "hostPort": {
           "host": "10.0.0.1",
-          "port": 9091
+          "port": 1235
         },
-        "name": "exposed_path_GetHealth",
+        "name": "exposed_path_GetHealth1235",
         "routers": [
           {
             "l7": {
               "protocol": "L7_PROTOCOL_HTTP2",
               "route": {
-                "name": "exposed_path_filter_GetHealth_1235"
+                "name": "exposed_path_destination_GetHealth9091"
               },
-              "statPrefix": "exposed_path_filter_GetHealth_1235",
+              "statPrefix": "exposed_path_destination_GetHealth9091",
               "staticRoute": true
             }
           }
@@ -144,13 +144,13 @@
       }
     ],
     "routes": {
-      "exposed_path_filter_GetHealth_1235": {
+      "exposed_path_destination_GetHealth9091": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "exposed_path_filter_GetHealth_1235",
+            "name": "exposed_path_destination_GetHealth9091",
             "routeRules": [
               {
                 "destination": {
@@ -168,13 +168,13 @@
           }
         ]
       },
-      "exposed_path_filter_health_1234": {
+      "exposed_path_destination_health9090": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "exposed_path_filter_health_1234",
+            "name": "exposed_path_destination_health9090",
             "routeRules": [
               {
                 "destination": {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/l7-expose-paths.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/l7-expose-paths.golden
@@ -114,9 +114,9 @@
           {
             "l7": {
               "route": {
-                "name": "exposed_path_destination_health9090"
+                "name": "exposed_path_route_health1234"
               },
-              "statPrefix": "exposed_path_destination_health9090",
+              "statPrefix": "exposed_path_route_health1234",
               "staticRoute": true
             }
           }
@@ -134,9 +134,9 @@
             "l7": {
               "protocol": "L7_PROTOCOL_HTTP2",
               "route": {
-                "name": "exposed_path_destination_GetHealth9091"
+                "name": "exposed_path_route_GetHealth1235"
               },
-              "statPrefix": "exposed_path_destination_GetHealth9091",
+              "statPrefix": "exposed_path_route_GetHealth1235",
               "staticRoute": true
             }
           }
@@ -144,13 +144,13 @@
       }
     ],
     "routes": {
-      "exposed_path_destination_GetHealth9091": {
+      "exposed_path_route_GetHealth1235": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "exposed_path_destination_GetHealth9091",
+            "name": "exposed_path_route_GetHealth1235",
             "routeRules": [
               {
                 "destination": {
@@ -168,13 +168,13 @@
           }
         ]
       },
-      "exposed_path_destination_health9090": {
+      "exposed_path_route_health1234": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "exposed_path_destination_health9090",
+            "name": "exposed_path_route_health1234",
             "routeRules": [
               {
                 "destination": {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/local-and-inbound-connections.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/local-and-inbound-connections.golden
@@ -176,9 +176,9 @@
           {
             "l7": {
               "route": {
-                "name": "exposed_path_destination_health9090"
+                "name": "exposed_path_route_health1234"
               },
-              "statPrefix": "exposed_path_destination_health9090",
+              "statPrefix": "exposed_path_route_health1234",
               "staticRoute": true
             }
           }
@@ -196,9 +196,9 @@
             "l7": {
               "protocol": "L7_PROTOCOL_HTTP2",
               "route": {
-                "name": "exposed_path_destination_GetHealth9091"
+                "name": "exposed_path_route_GetHealth1235"
               },
-              "statPrefix": "exposed_path_destination_GetHealth9091",
+              "statPrefix": "exposed_path_route_GetHealth1235",
               "staticRoute": true
             }
           }
@@ -206,13 +206,13 @@
       }
     ],
     "routes": {
-      "exposed_path_destination_GetHealth9091": {
+      "exposed_path_route_GetHealth1235": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "exposed_path_destination_GetHealth9091",
+            "name": "exposed_path_route_GetHealth1235",
             "routeRules": [
               {
                 "destination": {
@@ -230,13 +230,13 @@
           }
         ]
       },
-      "exposed_path_destination_health9090": {
+      "exposed_path_route_health1234": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "exposed_path_destination_health9090",
+            "name": "exposed_path_route_health1234",
             "routeRules": [
               {
                 "destination": {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/local-and-inbound-connections.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/local-and-inbound-connections.golden
@@ -169,16 +169,16 @@
         "direction": "DIRECTION_INBOUND",
         "hostPort": {
           "host": "10.0.0.1",
-          "port": 9090
+          "port": 1234
         },
-        "name": "exposed_path_health",
+        "name": "exposed_path_health1234",
         "routers": [
           {
             "l7": {
               "route": {
-                "name": "exposed_path_filter_health_1234"
+                "name": "exposed_path_destination_health9090"
               },
-              "statPrefix": "exposed_path_filter_health_1234",
+              "statPrefix": "exposed_path_destination_health9090",
               "staticRoute": true
             }
           }
@@ -188,17 +188,17 @@
         "direction": "DIRECTION_INBOUND",
         "hostPort": {
           "host": "10.0.0.1",
-          "port": 9091
+          "port": 1235
         },
-        "name": "exposed_path_GetHealth",
+        "name": "exposed_path_GetHealth1235",
         "routers": [
           {
             "l7": {
               "protocol": "L7_PROTOCOL_HTTP2",
               "route": {
-                "name": "exposed_path_filter_GetHealth_1235"
+                "name": "exposed_path_destination_GetHealth9091"
               },
-              "statPrefix": "exposed_path_filter_GetHealth_1235",
+              "statPrefix": "exposed_path_destination_GetHealth9091",
               "staticRoute": true
             }
           }
@@ -206,13 +206,13 @@
       }
     ],
     "routes": {
-      "exposed_path_filter_GetHealth_1235": {
+      "exposed_path_destination_GetHealth9091": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "exposed_path_filter_GetHealth_1235",
+            "name": "exposed_path_destination_GetHealth9091",
             "routeRules": [
               {
                 "destination": {
@@ -230,13 +230,13 @@
           }
         ]
       },
-      "exposed_path_filter_health_1234": {
+      "exposed_path_destination_health9090": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "exposed_path_filter_health_1234",
+            "name": "exposed_path_destination_health9090",
             "routeRules": [
               {
                 "destination": {


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
* When testing adding http probes to apps, I ran into some issues which I fixed here:
  * The listener should be listening on the exposed listener port, updated that.
  * The listener and route names were pointing to the path of the exposed path. In my test, the path was "/" resulting in an empty string path. Also, the path may not be unique across exposed path listeners, so I decided to use the path+exposed port as the unique identifier. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
