### PR TITLE
acls,catalog,mesh: properly authorize workload selectors on writes

### DIFF
--- a/acl/MockAuthorizer.go
+++ b/acl/MockAuthorizer.go
@@ -224,6 +224,11 @@ func (m *MockAuthorizer) ServiceReadAll(ctx *AuthorizerContext) EnforcementDecis
 	return ret.Get(0).(EnforcementDecision)
 }
 
+func (m *MockAuthorizer) ServiceReadPrefix(prefix string, ctx *AuthorizerContext) EnforcementDecision {
+	ret := m.Called(ctx)
+	return ret.Get(0).(EnforcementDecision)
+}
+
 // ServiceWrite checks for permission to create or update a given
 // service
 func (m *MockAuthorizer) ServiceWrite(segment string, ctx *AuthorizerContext) EnforcementDecision {

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -300,6 +300,14 @@ func checkDenyServiceReadAll(t *testing.T, authz Authorizer, _ string, entCtx *A
 	require.Equal(t, Deny, authz.ServiceReadAll(entCtx))
 }
 
+func checkAllowServiceReadPrefix(t *testing.T, authz Authorizer, prefix string, entCtx *AuthorizerContext) {
+	require.Equal(t, Allow, authz.ServiceReadPrefix(prefix, entCtx))
+}
+
+func checkDenyServiceReadPrefix(t *testing.T, authz Authorizer, prefix string, entCtx *AuthorizerContext) {
+	require.Equal(t, Deny, authz.ServiceReadPrefix(prefix, entCtx))
+}
+
 func checkDenyServiceWrite(t *testing.T, authz Authorizer, prefix string, entCtx *AuthorizerContext) {
 	require.Equal(t, Deny, authz.ServiceWrite(prefix, entCtx))
 }
@@ -454,6 +462,10 @@ func checkDefaultServiceRead(t *testing.T, authz Authorizer, prefix string, entC
 
 func checkDefaultServiceReadAll(t *testing.T, authz Authorizer, _ string, entCtx *AuthorizerContext) {
 	require.Equal(t, Default, authz.ServiceReadAll(entCtx))
+}
+
+func checkDefaultServiceReadPrefix(t *testing.T, authz Authorizer, prefix string, entCtx *AuthorizerContext) {
+	require.Equal(t, Default, authz.ServiceReadPrefix(prefix, entCtx))
 }
 
 func checkDefaultServiceWrite(t *testing.T, authz Authorizer, prefix string, entCtx *AuthorizerContext) {

--- a/acl/authorizer.go
+++ b/acl/authorizer.go
@@ -171,6 +171,9 @@ type Authorizer interface {
 	// ServiceReadAll checks for permission to read all services
 	ServiceReadAll(*AuthorizerContext) EnforcementDecision
 
+	// ServiceReadPrefix checks for permission to read services within the given prefix.
+	ServiceReadPrefix(string, *AuthorizerContext) EnforcementDecision
+
 	// ServiceWrite checks for permission to create or update a given
 	// service
 	ServiceWrite(string, *AuthorizerContext) EnforcementDecision
@@ -503,6 +506,14 @@ func (a AllowAuthorizer) ServiceReadAllAllowed(ctx *AuthorizerContext) error {
 	if a.Authorizer.ServiceReadAll(ctx) != Allow {
 		// This is only used to gate certain UI functions right now (e.g metrics)
 		return PermissionDeniedByACL(a, ctx, ResourceService, AccessRead, "all services") // read
+	}
+	return nil
+}
+
+// ServiceReadPrefixAllowed checks for permission to read services within the given prefix
+func (a AllowAuthorizer) ServiceReadPrefixAllowed(prefix string, ctx *AuthorizerContext) error {
+	if a.Authorizer.ServiceReadPrefix(prefix, ctx) != Allow {
+		return PermissionDeniedByACL(a, ctx, ResourceService, AccessRead, prefix) // read
 	}
 	return nil
 }

--- a/acl/chained_authorizer.go
+++ b/acl/chained_authorizer.go
@@ -275,6 +275,12 @@ func (c *ChainedAuthorizer) ServiceReadAll(entCtx *AuthorizerContext) Enforcemen
 	})
 }
 
+func (c *ChainedAuthorizer) ServiceReadPrefix(prefix string, entCtx *AuthorizerContext) EnforcementDecision {
+	return c.executeChain(func(authz Authorizer) EnforcementDecision {
+		return authz.ServiceReadPrefix(prefix, entCtx)
+	})
+}
+
 // ServiceWrite checks for permission to create or update a given
 // service
 func (c *ChainedAuthorizer) ServiceWrite(name string, entCtx *AuthorizerContext) EnforcementDecision {

--- a/acl/chained_authorizer_test.go
+++ b/acl/chained_authorizer_test.go
@@ -107,6 +107,9 @@ func (authz testAuthorizer) ServiceRead(string, *AuthorizerContext) EnforcementD
 func (authz testAuthorizer) ServiceReadAll(*AuthorizerContext) EnforcementDecision {
 	return EnforcementDecision(authz)
 }
+func (authz testAuthorizer) ServiceReadPrefix(string, *AuthorizerContext) EnforcementDecision {
+	return EnforcementDecision(authz)
+}
 func (authz testAuthorizer) ServiceWrite(string, *AuthorizerContext) EnforcementDecision {
 	return EnforcementDecision(authz)
 }

--- a/acl/policy_authorizer_test.go
+++ b/acl/policy_authorizer_test.go
@@ -64,6 +64,8 @@ func TestPolicyAuthorizer(t *testing.T) {
 				{name: "DefaultPreparedQueryRead", prefix: "foo", check: checkDefaultPreparedQueryRead},
 				{name: "DefaultPreparedQueryWrite", prefix: "foo", check: checkDefaultPreparedQueryWrite},
 				{name: "DefaultServiceRead", prefix: "foo", check: checkDefaultServiceRead},
+				{name: "DefaultServiceReadAll", prefix: "foo", check: checkDefaultServiceReadAll},
+				{name: "DefaultServiceReadPrefix", prefix: "foo", check: checkDefaultServiceReadPrefix},
 				{name: "DefaultServiceWrite", prefix: "foo", check: checkDefaultServiceWrite},
 				{name: "DefaultServiceWriteAny", prefix: "", check: checkDefaultServiceWriteAny},
 				{name: "DefaultSessionRead", prefix: "foo", check: checkDefaultSessionRead},
@@ -396,6 +398,7 @@ func TestPolicyAuthorizer(t *testing.T) {
 				{name: "ServiceReadDenied", prefix: "football", check: checkDenyServiceRead},
 				{name: "ServiceWriteDenied", prefix: "football", check: checkDenyServiceWrite},
 				{name: "ServiceWriteAnyAllowed", prefix: "", check: checkAllowServiceWriteAny},
+				{name: "ServiceReadWithinPrefixDenied", prefix: "foot", check: checkDenyServiceReadPrefix},
 
 				{name: "IdentityReadPrefixAllowed", prefix: "fo", check: checkAllowIdentityRead},
 				{name: "IdentityWritePrefixDenied", prefix: "fo", check: checkDenyIdentityWrite},
@@ -568,6 +571,214 @@ func TestPolicyAuthorizer(t *testing.T) {
 			checks: []aclCheck{
 				{name: "AnyDefault", prefix: "*", check: checkDefaultIntentionRead},
 				{name: "AllDenied", prefix: "*", check: checkDenyIntentionWrite},
+			},
+		},
+		"Service Read Prefix - read allowed with write policy and exact prefix": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "foo",
+						Policy: PolicyWrite,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixAllowed", prefix: "foo", check: checkAllowServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - read allowed with read policy and exact prefix": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "foo",
+						Policy: PolicyRead,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixAllowed", prefix: "foo", check: checkAllowServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - read denied with deny policy and exact prefix": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "foo",
+						Policy: PolicyDeny,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixDenied", prefix: "foo", check: checkDenyServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - read allowed with write policy and shorter prefix": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "foo",
+						Policy: PolicyWrite,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixAllowed", prefix: "foo1", check: checkAllowServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - read allowed with read policy and shorter prefix": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "foo",
+						Policy: PolicyRead,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixAllowed", prefix: "foo1", check: checkAllowServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - read denied with deny policy and shorter prefix": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "foo",
+						Policy: PolicyDeny,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixDenied", prefix: "foo1", check: checkDenyServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - default with write policy and longer prefix": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "foo1",
+						Policy: PolicyWrite,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixDefault", prefix: "foo", check: checkDefaultServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - default with read policy and longer prefix": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "foo1",
+						Policy: PolicyRead,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixDefault", prefix: "foo", check: checkDefaultServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - deny with deny policy and longer prefix": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "foo1",
+						Policy: PolicyDeny,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixDenied", prefix: "foo", check: checkDenyServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - allow with two shorter prefixes - more specific one allowing read and less specific denying": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "fo",
+						Policy: PolicyDeny,
+					},
+					{
+						Name:   "foo",
+						Policy: PolicyRead,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixAllowed", prefix: "foo", check: checkAllowServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - deny with two shorter prefixes - more specific one denying and less specific allowing read": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "fo",
+						Policy: PolicyRead,
+					},
+					{
+						Name:   "foo",
+						Policy: PolicyDeny,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixDenied", prefix: "foo", check: checkDenyServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - deny with exact match denying": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "fo",
+						Policy: PolicyRead,
+					},
+				},
+				Services: []*ServiceRule{
+					{
+						Name:   "foo-123",
+						Policy: PolicyDeny,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixDenied", prefix: "foo", check: checkDenyServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - allow with exact match allowing read": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "fo",
+						Policy: PolicyRead,
+					},
+				},
+				Services: []*ServiceRule{
+					{
+						Name:   "foo-123",
+						Policy: PolicyRead,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixAllowed", prefix: "foo", check: checkAllowServiceReadPrefix},
+			},
+		},
+		"Service Read Prefix - deny with exact match allowing read but prefix match denying": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "fo",
+						Policy: PolicyDeny,
+					},
+				},
+				Services: []*ServiceRule{
+					{
+						Name:   "foo-123",
+						Policy: PolicyRead,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "ServiceReadPrefixDenied", prefix: "foo", check: checkDenyServiceReadPrefix},
 			},
 		},
 	}

--- a/acl/static_authorizer.go
+++ b/acl/static_authorizer.go
@@ -257,6 +257,13 @@ func (s *staticAuthorizer) ServiceReadAll(*AuthorizerContext) EnforcementDecisio
 	return Deny
 }
 
+func (s *staticAuthorizer) ServiceReadPrefix(string, *AuthorizerContext) EnforcementDecision {
+	if s.defaultAllow {
+		return Allow
+	}
+	return Deny
+}
+
 func (s *staticAuthorizer) ServiceWrite(string, *AuthorizerContext) EnforcementDecision {
 	if s.defaultAllow {
 		return Allow

--- a/internal/catalog/internal/types/acl_hooks.go
+++ b/internal/catalog/internal/types/acl_hooks.go
@@ -38,7 +38,7 @@ func aclWriteHookResourceWithWorkloadSelector[T WorkloadSelecting](authorizer ac
 	}
 
 	for _, prefix := range decodedService.GetData().GetWorkloads().GetPrefixes() {
-		err = authorizer.ToAllowAuthorizer().ServiceReadAllowed(prefix, authzContext)
+		err = authorizer.ToAllowAuthorizer().ServiceReadPrefixAllowed(prefix, authzContext)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

To properly enforce writes on resources that have workload selectors with prefixes, we need another `service` authorization rule that allows us to check whether read is allowed within a given prefix. Specifically we need to only allow writes if the policy prefix allows for a wider set of names than the prefix selector on the resource. We should also not allow policies with exact names for prefix matches.

Part of [NET-3993]

Examples:
(when default is deny)

**Decision: deny**
selector:
```
Workloads: { Prefixes = ["api"] }
```
policy:

```
...
service "api" { policy = "read" }
```

**Decision: allow**
selector:
```
Workloads: { Prefixes = ["api"] }
```
policy:

```
...
service_prefix "api" { policy = "read" }
```

**Decision: deny**
selector:
```
Workloads: { Prefixes = ["api"] }
```
policy:

```
...
service_prefix "api1" { policy = "read" }
```

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [] not a security concern


[NET-3993]: https://hashicorp.atlassian.net/browse/NET-3993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ