### PR TITLE
docs: Fix multi-port install

### DIFF
--- a/website/content/docs/k8s/multiport/configure.mdx
+++ b/website/content/docs/k8s/multiport/configure.mdx
@@ -285,14 +285,14 @@ spec:
 To apply these services to your Kubernetes deployment and register them with Consul, run the following command:
 
 ```shell-session
-$ kubectl apply -f api.yaml -f web.yaml --namespace consul
+$ kubectl apply -f api.yaml -f web.yaml
 ```
 
 ## Configure traffic permissions
 
 Consul uses traffic permissions to validate communication between services based on L4 identity. In the beta release of the v2 catalog API, traffic permissions allow all services by default. In order to verify that services function correctly on each port, create CRDs that deny traffic to each port.
 
-The following examples create Consul CRDs that allow traffic to only one port of the multi-port service. Each resource separately denies `web` permission when it is a source of traffic to one of the services. These traffic permissions work with either method for defining a multi-port service.
+The following examples create Consul CRDs that allow traffic to only one port of the multi-port service. Each resource separately denies `web` permission when it is a source of traffic to one of the services. These traffic permissions work with either method for defining a multi-port service. The resources will be applied invidually in the steps below. 
 
 <CodeTabs tabs={[ "Deny port 80", "Deny port 90" ]}>
 
@@ -342,13 +342,16 @@ spec:
 To open a shell to the `web` container, you need the name of the Pod it currently runs on. Run the following command to return a list of Pods:
 
 ```shell-session
-$ kubectl get pods --namespace consul
+$ kubectl get pods 
 NAME                                           READY   STATUS    RESTARTS   AGE
 api-5784b54bcc-tp98l                           3/3     Running   0          6m55s
-consul-connect-injector-54865fbcbf-sfjsl       1/1     Running   0          8m33s
-consul-server-0                                1/1     Running   0          8m33s
-consul-webhook-cert-manager-666676bd5b-cdbxc   1/1     Running   0          8m33s
 web-6dcbd684bc-gk8n5                           2/2     Running   0          6m55s
+```
+
+Set environment variables to remember the pod name for the web workload for use in future commands. 
+
+```shell-session
+$ export WEB_POD=web-6dcbd684bc-gk8n5
 ```
 
 ### Validate both ports
@@ -360,14 +363,14 @@ Use the `web` Pod's name to open a shell session and test the `api` service on p
 <Tab heading="Method 1" group="method1">
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:80
+$ kubectl exec -it ${WEB_POD} -c web -- curl api:80
 hello world
 ```
 
 Then test the `api` service on port 90.
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:90
+$ kubectl exec -it ${WEB_POD} -c web -- curl api:90
 hello world from 9090 admin
 ```
 
@@ -376,14 +379,14 @@ hello world from 9090 admin
 <Tab heading="Method 2" group="method2">
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:80
+$ kubectl exec -it ${WEB_POD} -c web -- curl api:80
 hello world
 ```
 
 Then test the `api-admin` service on port 90.
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api-admin:90
+$ kubectl exec -it ${WEB_POD} -c web --namespace consul -- curl api-admin:90
 hello world from 9090 admin
 ```
 
@@ -395,7 +398,7 @@ hello world from 9090 admin
 Apply the CRD to allow traffic to port 80 only:
 
 ```shell-session
-$ kubectl apply -f deny-90.yaml --namespace consul
+$ kubectl apply -f deny-90.yaml 
 ```
 
 <Tabs>
@@ -405,14 +408,14 @@ $ kubectl apply -f deny-90.yaml --namespace consul
 Then, open a shell session in the `web` container and test the `api` service on port 80.
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:80
+$ kubectl exec -it ${WEB_POD} -c web -- curl api:80
 hello world
 ```
 
 Test the `api` service on port 90. This command should fail, indicating that the traffic permission is in effect.
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:90
+$ kubectl exec -it ${WEB_POD} -c web -- curl api:90
 ```
 
 </Tab>
@@ -422,14 +425,14 @@ $ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:90
 Then, open a shell session in the `web` container and test the `api` service on port 80.
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:80
+$ kubectl exec -it ${WEB_POD} -c web -- curl api:80
 hello world
 ```
 
 Test the `admin` service on port 90. This command should fail, indicating that the traffic permission is in effect.
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api-admin:90
+$ kubectl exec -it ${WEB_POD} -c web -- curl api-admin:90
 ```
 
 </Tab>
@@ -438,7 +441,7 @@ $ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api-ad
 Before testing the other port, remove the `TrafficPermissions` CRD.
 
 ```shell-session
-$ kubectl delete -f deny-90.yaml --namespace consul
+$ kubectl delete -f deny-90.yaml 
 ```
 
 ### Validate port 90
@@ -446,7 +449,7 @@ $ kubectl delete -f deny-90.yaml --namespace consul
 Apply the CRD to allow traffic to port 90 only:
 
 ```shell-session
-$ kubectl apply -f deny-80.yaml --namespace consul
+$ kubectl apply -f deny-80.yaml 
 ```
 
 <Tabs>
@@ -456,14 +459,14 @@ $ kubectl apply -f deny-80.yaml --namespace consul
 Then, open a shell session in the `web` container and test the `api` service on port 90.
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:90
+$ kubectl exec -it ${WEB_POD} -c web -- curl api:90
 hello world from 9090 admin
 ```
 
 Test the `api` service on port 80. This command should fail, indicating that the traffic permission is in effect.
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:80
+$ kubectl exec -it ${WEB_POD} -c web -- curl api:80
 ```
 
 </Tab>
@@ -473,14 +476,14 @@ $ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:80
 Then, open a shell session in the `web` container and test the `api-admin` service on port 90.
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api-admin:90
+$ kubectl exec -it ${WEB_POD} -c web -- curl api-admin:90
 hello world from 9090 admin
 ```
 
 Test the `api` service on port 80. This command should fail, indicating that the traffic permission is in effect.
 
 ```shell-session
-$ kubectl exec -it web-6dcbd684bc-gk8n5 -c web --namespace consul -- curl api:80
+$ kubectl exec -it ${WEB_POD} -c web  -- curl api:80
 ```
 
 </Tab>

--- a/website/content/docs/k8s/multiport/configure.mdx
+++ b/website/content/docs/k8s/multiport/configure.mdx
@@ -59,7 +59,7 @@ Then install Consul to your Kubernetes cluster using either the `consul-k8s` CLI
 
 <Tab heading="consul-k8s CLI" group="consul-k8s">
 
-For platforms other than Mac OSX amd64, please see [Install a previous version](/consul/docs/k8s/installation/install-cli#install-a-previous-version) for instructions on how to install a specific version of the `consul-k8s` CLI prior to running `consul-k8s install`. 
+For platforms other than Mac OSX amd64, refer to [Install a previous version](/consul/docs/k8s/installation/install-cli#install-a-previous-version) for instructions on how to install a specific version of the `consul-k8s` CLI prior to running `consul-k8s install`. 
 
 ```shell-session
 $ export VERSION=1.3.0-rc1 && \

--- a/website/content/docs/k8s/multiport/configure.mdx
+++ b/website/content/docs/k8s/multiport/configure.mdx
@@ -60,6 +60,10 @@ Then install Consul to your Kubernetes cluster using either the `consul-k8s` CLI
 <Tab heading="consul-k8s CLI" group="consul-k8s">
 
 ```shell-session
+$ export VERSION=1.3.0-rc1 && \
+    curl --location "https://releases.hashicorp.com/consul-k8s/${VERSION}/consul-k8s_${VERSION}_darwin_amd64.zip" --output consul-k8s-cli.zip
+$ unzip -o consul-k8s-cli.zip -d ~/consul-k8s
+$ export PATH=$PATH:$HOME/consul-k8s
 $ consul-k8s install -config-file=values.yaml
 ```
 
@@ -68,7 +72,7 @@ $ consul-k8s install -config-file=values.yaml
 <Tab heading="Helm" group="helm">
 
 ```shell-session
-$ helm install consul hashicorp/consul --create-namespace --namespace consul --values values.yaml
+$ helm install consul hashicorp/consul --create-namespace --namespace consul --version 1.3.0-rc1 --values values.yaml
 ```
 
 </Tab>

--- a/website/content/docs/k8s/multiport/configure.mdx
+++ b/website/content/docs/k8s/multiport/configure.mdx
@@ -56,9 +56,10 @@ ui:
 Then install Consul to your Kubernetes cluster using either the `consul-k8s` CLI or Helm.
 
 <Tabs>
-If you are not installing on Mac OSX AMD64, See [Install a previous version](/consul/docs/k8s/installation/install-cli#install-a-previous-version) for instructions on how to install a specific version of the `consul-k8s` CLI prior to running `consul-k8s install`. 
 
 <Tab heading="consul-k8s CLI" group="consul-k8s">
+
+For platforms other than Mac OSX amd64, please see [Install a previous version](/consul/docs/k8s/installation/install-cli#install-a-previous-version) for instructions on how to install a specific version of the `consul-k8s` CLI prior to running `consul-k8s install`. 
 
 ```shell-session
 $ export VERSION=1.3.0-rc1 && \

--- a/website/content/docs/k8s/multiport/configure.mdx
+++ b/website/content/docs/k8s/multiport/configure.mdx
@@ -56,6 +56,7 @@ ui:
 Then install Consul to your Kubernetes cluster using either the `consul-k8s` CLI or Helm.
 
 <Tabs>
+If you are not installing on Mac OSX AMD64, See [Install a previous version](/consul/docs/k8s/installation/install-cli#install-a-previous-version) for instructions on how to install a specific version of the `consul-k8s` CLI prior to running `consul-k8s install`. 
 
 <Tab heading="consul-k8s CLI" group="consul-k8s">
 

--- a/website/content/docs/k8s/multiport/configure.mdx
+++ b/website/content/docs/k8s/multiport/configure.mdx
@@ -294,7 +294,7 @@ $ kubectl apply -f api.yaml -f web.yaml
 
 Consul uses traffic permissions to validate communication between services based on L4 identity. In the beta release of the v2 catalog API, traffic permissions allow all services by default. In order to verify that services function correctly on each port, create CRDs that deny traffic to each port.
 
-The following examples create Consul CRDs that allow traffic to only one port of the multi-port service. Each resource separately denies `web` permission when it is a source of traffic to one of the services. These traffic permissions work with either method for defining a multi-port service. The resources will be applied invidually in the steps below. 
+The following examples create Consul CRDs that allow traffic to only one port of the multi-port service. Each resource separately denies `web` permission when it is a source of traffic to one of the services. These traffic permissions work with either method for defining a multi-port service. When following the instructions on this page, apply these permissions individually when you validate the ports.
 
 <CodeTabs tabs={[ "Deny port 80", "Deny port 90" ]}>
 


### PR DESCRIPTION
### Description

- Fix install instructions for installing multi-port 1.17-rc1. 
- Add in env variables to make it easier to run commands. 
- Remove `--namespace=consul` from commands related to workloads since that namespaces is reserved just for Consul. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
