### PR TITLE
fix: allow snake case keys for ip based rate limit config entry

### DIFF
--- a/.changelog/_7406.txt
+++ b/.changelog/_7406.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: **(Enterprise Only)** Fixed an issue where snake case keys were rejected when configuring the control-plane-request-limit config entry
+```

--- a/api/config_entry_rate_limit_ip.go
+++ b/api/config_entry_rate_limit_ip.go
@@ -4,8 +4,8 @@
 package api
 
 type ReadWriteRatesConfig struct {
-	ReadRate  float64
-	WriteRate float64
+	ReadRate  float64 `alias:"read_rate"`
+	WriteRate float64 `alias:"write_rate"`
 }
 
 type RateLimitIPConfigEntry struct {
@@ -16,8 +16,8 @@ type RateLimitIPConfigEntry struct {
 
 	Meta map[string]string `json:",omitempty"`
 	// overall limits
-	ReadRate  float64
-	WriteRate float64
+	ReadRate  float64 `alias:"read_rate"`
+	WriteRate float64 `alias:"write_rate"`
 
 	//limits specific to a type of call
 	ACL             *ReadWriteRatesConfig `json:",omitempty"` //	OperationCategoryACL             OperationCategory = "ACL"


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

The counterpart of ENT PR: https://github.com/hashicorp/consul-enterprise/pull/7406

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

See ENT PR.

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [x] appropriate backport labels added
* [ ] ~not a security concern~
