### PR TITLE
Backport/net-5930/fix/rate limit config entry snake case

### DIFF
--- a/.changelog/_7406.txt
+++ b/.changelog/_7406.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: **(Enterprise Only)** Fixed an issue where snake case keys were rejected when configuring the control-plane-request-limit config entry
+```

--- a/api/config_entry_rate_limit_ip.go
+++ b/api/config_entry_rate_limit_ip.go
@@ -4,8 +4,8 @@
 package api
 
 type ReadWriteRatesConfig struct {
-	ReadRate  float64
-	WriteRate float64
+	ReadRate  float64 `alias:"read_rate"`
+	WriteRate float64 `alias:"write_rate"`
 }
 
 type RateLimitIPConfigEntry struct {
@@ -16,8 +16,8 @@ type RateLimitIPConfigEntry struct {
 
 	Meta map[string]string `json:",omitempty"`
 	// overall limits
-	ReadRate  float64
-	WriteRate float64
+	ReadRate  float64 `alias:"read_rate"`
+	WriteRate float64 `alias:"write_rate"`
 
 	//limits specific to a type of call
 	ACL             *ReadWriteRatesConfig `json:",omitempty"` //	OperationCategoryACL             OperationCategory = "ACL"


### PR DESCRIPTION
### Backport

Manual backport of https://github.com/hashicorp/consul/pull/19277

### Description

<!-- Please describe why you're making this change, in plain English. -->

Adds a changelog

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

N/A

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

Counterpart ENT PR: https://github.com/hashicorp/consul-enterprise/pull/7433

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [x] appropriate backport labels added
* [ ] ~not a security concern~
