### PR TITLE
mesh: provide missing domain to route configurations in ProxyStateTemplate

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destinations.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destinations.go
@@ -143,6 +143,7 @@ func (b *Builder) buildDestination(
 		b.addRoute(routeName, &pbproxystate.Route{
 			VirtualHosts: []*pbproxystate.VirtualHost{{
 				Name:       routeName,
+				Domains:    []string{"*"},
 				RouteRules: proxyRouteRules,
 			}},
 		})
@@ -185,6 +186,7 @@ func (b *Builder) buildDestination(
 		b.addRoute(routeName, &pbproxystate.Route{
 			VirtualHosts: []*pbproxystate.VirtualHost{{
 				Name:       routeName,
+				Domains:    []string{"*"},
 				RouteRules: proxyRouteRules,
 			}},
 		})

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/mixed-multi-destination.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/mixed-multi-destination.golden
@@ -239,6 +239,9 @@
       "default/local/default/api-1:http:1.1.1.1:1234": {
         "virtualHosts": [
           {
+            "domains": [
+              "*"
+            ],
             "name": "default/local/default/api-1:http:1.1.1.1:1234",
             "routeRules": [
               {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
@@ -328,6 +328,9 @@
       "default/local/default/api-app": {
         "virtualHosts": [
           {
+            "domains": [
+              "*"
+            ],
             "name": "default/local/default/api-app",
             "routeRules": [
               {
@@ -349,6 +352,9 @@
       "default/local/default/api-app2": {
         "virtualHosts": [
           {
+            "domains": [
+              "*"
+            ],
             "name": "default/local/default/api-app2",
             "routeRules": [
               {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
@@ -184,6 +184,9 @@
       "default/local/default/api-app": {
         "virtualHosts": [
           {
+            "domains": [
+              "*"
+            ],
             "name": "default/local/default/api-app",
             "routeRules": [
               {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
@@ -184,6 +184,9 @@
       "default/local/default/api-app": {
         "virtualHosts": [
           {
+            "domains": [
+              "*"
+            ],
             "name": "default/local/default/api-app",
             "routeRules": [
               {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/local-and-inbound-connections.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/source/local-and-inbound-connections.golden
@@ -17,12 +17,12 @@
         "endpointGroup": {
           "static": {
             "config": {
-              "connectTimeout": "6s",
               "circuitBreakers": {
                 "upstreamLimits": {
                   "maxConnections": 123
                 }
-              }
+              },
+              "connectTimeout": "6s"
             }
           }
         },
@@ -32,12 +32,12 @@
         "endpointGroup": {
           "static": {
             "config": {
-              "connectTimeout": "8s",
               "circuitBreakers": {
                 "upstreamLimits": {
                   "maxConnections": 123
                 }
-              }
+              },
+              "connectTimeout": "8s"
             }
           }
         },
@@ -101,6 +101,7 @@
     },
     "listeners": [
       {
+        "balanceConnections": "BALANCE_CONNECTIONS_EXACT",
         "capabilities": [
           "CAPABILITY_L4_TLS_INSPECTION"
         ],
@@ -110,7 +111,6 @@
           "port": 20000
         },
         "name": "public_listener",
-        "balanceConnections": "BALANCE_CONNECTIONS_EXACT",
         "routers": [
           {
             "inboundTls": {
@@ -127,7 +127,7 @@
               "cluster": {
                 "name": "local_app:port1"
               },
-              "maxInboundConnections": 123,
+              "maxInboundConnections": "123",
               "statPrefix": "public_listener",
               "trafficPermissions": {}
             },
@@ -149,10 +149,10 @@
               }
             },
             "l7": {
+              "maxInboundConnections": "123",
               "route": {
                 "name": "public_listener:port3"
               },
-              "maxInboundConnections": 123,
               "statPrefix": "public_listener",
               "staticRoute": true,
               "trafficPermissions": {}


### PR DESCRIPTION
### Description

* domain was missing, I think it's ok to just hardcode ["*"] for now
  * in v1, we set custom named domains in api gateway or terminating gateway cases, but we don't have any gateway-backed or fronted upstreams in v2 yet.
  * in v1 for discovery chain upstreams we always use ["*"] here: https://github.com/hashicorp/consul/blob/main/agent/xds/routes.go#L64 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
