### PR TITLE
NET-6239: Temporarily disable verify envoy check

### DIFF
--- a/.github/scripts/verify_envoy_version.sh
+++ b/.github/scripts/verify_envoy_version.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-current_branch=$GITHUB_REF
+current_branch=$GITHUB_REF_NAME
 GITHUB_DEFAULT_BRANCH='main'
 
 if [ -z "$GITHUB_TOKEN" ]; then
@@ -13,8 +13,13 @@ if [ -z "$GITHUB_TOKEN" ]; then
 fi
 
 if [ -z "$current_branch" ]; then
-  echo "GITHUB_REF must be set"
+  echo "GITHUB_REF_NAME must be set"
   exit 1
+fi
+
+if [[ "$SKIP_VERIFY_ENVOY_VERSION" = "true" ]]; then
+  echo -e "*************** VERIFY ENVOY VERSION IS DISABLED. To enable, set the environment variable SKIP_VERIFY_ENVOY_VERSION to false in .github/workflows/verify-envoy-version.yml *****************"
+  exit 0
 fi
 
 # Get Consul and Envoy version 
@@ -76,7 +81,6 @@ released_envoy_version=$(get_latest_envoy_version)
 major_released_envoy_version="${released_envoy_version[@]:1:4}"
 
 validate_envoy_version_main(){
-  echo "verify "main" GitHub branch has latest envoy version"
   # Get envoy version for current branch
   ENVOY_VERSIONS=$(sanitize_consul_envoy_version | awk '{print $2}' | tr ',' ' ')
   envoy_version_main_branch=$(get_major_version ${ENVOY_VERSIONS})
@@ -118,8 +122,8 @@ echo checking out branch: "${current_branch}"
 git checkout "${current_branch}"
 
 echo
-echo "Branch ${current_branch} =>Consul version: ${CONSUL_VERSION}; Envoy Version: ${ENVOY_VERSIONS}" 
-echo "Branch ${GITHUB_DEFAULT_BRANCH} =>Consul version: ${CONSUL_VERSION_DEFAULT_BRANCH}; Envoy Version: ${ENVOY_VERSIONS_DEFAULT_BRANCH}" 
+echo "Branch ${current_branch} => Consul version: ${CONSUL_VERSION}; Envoy Version: ${ENVOY_VERSIONS}" 
+echo "Branch ${GITHUB_DEFAULT_BRANCH} => Consul version: ${CONSUL_VERSION_DEFAULT_BRANCH}; Envoy Version: ${ENVOY_VERSIONS_DEFAULT_BRANCH}" 
 
 ## Get major Consul and Envoy versions on release and default branch
 MAJOR_CONSUL_VERSION=$(get_major_version ${CONSUL_VERSION})

--- a/.github/workflows/verify-envoy-version.yml
+++ b/.github/workflows/verify-envoy-version.yml
@@ -13,6 +13,10 @@ on:
     branches:
       - main
       - release/**
+      - NET-6239
+
+env:
+  SKIP_VERIFY_ENVOY_VERSION: "false" ## temporarily disabled; set to false to enable script
 
 jobs:
   verify-envoy-version:

--- a/.github/workflows/verify-envoy-version.yml
+++ b/.github/workflows/verify-envoy-version.yml
@@ -13,10 +13,9 @@ on:
     branches:
       - main
       - release/**
-      - NET-6239
 
 env:
-  SKIP_VERIFY_ENVOY_VERSION: "false" ## temporarily disabled; set to false to enable script
+  SKIP_VERIFY_ENVOY_VERSION: "true" ## temporarily disabled; set to false to enable script
 
 jobs:
   verify-envoy-version:


### PR DESCRIPTION
### Description
Temporarily  disable `Verify Envoy Version` script. 
Script is currently failing in CI because Envoy just released a new version (1.28.0) this AM. The process of updating Envoy versions across branches is currently in progress.
```
Latest released Envoy version is: v1.28.0
ERROR! Branch refs/heads/main; Envoy versions: 1.27.0 1.26.4 1.25.9 1.24.10 needs to be updated.
Error: Process completed with exit code 1.
```

### Testing & Reproduction steps
[CI](https://github.com/hashicorp/consul/actions/runs/6579264966/job/17874749926) of failing Verify Envoy Version
[CI](https://github.com/hashicorp/consul/actions/runs/6579139141/job/17874364219#step:3:8) to skip Verify Envoy version

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
