### PR TITLE
feat: read resource namespace

### DIFF
--- a/internal/tenancy/tenancytest/namespace_test.go
+++ b/internal/tenancy/tenancytest/namespace_test.go
@@ -62,15 +62,6 @@ func TestReadNamespace_Success(t *testing.T) {
 				WithData(t, validNamespace()).
 				Build(),
 		},
-		{
-			name: "tenancy units: empty namespace is allowed",
-			resource: rtest.Resource(pbtenancy.NamespaceType, "ns1").
-				WithTenancy(&pbresource.Tenancy{
-					Namespace: "",
-				}).
-				WithData(t, validNamespace()).
-				Build(),
-		},
 	}
 
 	for _, tc := range cases {

--- a/internal/tenancy/tenancytest/namespace_test.go
+++ b/internal/tenancy/tenancytest/namespace_test.go
@@ -47,7 +47,7 @@ func TestReadNamespace_Success(t *testing.T) {
 	client := svctest.RunResourceServiceWithConfig(t, config, tenancy.RegisterTypes)
 	cl := rtest.NewClient(client)
 
-	writeResp := rtest.Resource(pbtenancy.NamespaceType, "ns1").
+	res := rtest.Resource(pbtenancy.NamespaceType, "ns1").
 		WithData(t, validNamespace()).
 		Write(t, cl)
 
@@ -77,8 +77,8 @@ func TestReadNamespace_Success(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			readRsp, err := cl.Read(context.Background(), &pbresource.ReadRequest{Id: tc.resource.Id})
 			require.NoError(t, err)
-			prototest.AssertDeepEqual(t, writeResp.Id, readRsp.Resource.Id)
-			prototest.AssertDeepEqual(t, writeResp.Data, readRsp.Resource.Data)
+			prototest.AssertDeepEqual(t, res.Id, readRsp.Resource.Id)
+			prototest.AssertDeepEqual(t, res.Data, readRsp.Resource.Data)
 		})
 	}
 }

--- a/internal/tenancy/tenancytest/namespace_test.go
+++ b/internal/tenancy/tenancytest/namespace_test.go
@@ -5,11 +5,13 @@ package tenancytest
 
 import (
 	"context"
+	"fmt"
+	"testing"
+
 	"github.com/hashicorp/consul/agent/grpc-external/services/resource"
 	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
 	resource2 "github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/tenancy"
-	"testing"
 
 	rtest "github.com/hashicorp/consul/internal/resource/resourcetest"
 	"github.com/hashicorp/consul/proto/private/prototest"
@@ -21,19 +23,65 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadNamespace_Success(t *testing.T) {
+func TestWriteNamespace_Success(t *testing.T) {
 	v2TenancyBridge := tenancy.NewV2TenancyBridge()
 	config := resource.Config{TenancyBridge: v2TenancyBridge}
 	client := svctest.RunResourceServiceWithConfig(t, config, tenancy.RegisterTypes)
 	cl := rtest.NewClient(client)
 
 	res := rtest.Resource(pbtenancy.NamespaceType, "ns1").
+		WithTenancy(resource2.DefaultPartitionedTenancy()).
+		WithData(t, validNamespace()).
+		Build()
+
+	writeRsp, err := cl.Write(context.Background(), &pbresource.WriteRequest{Resource: res})
+	require.NoError(t, err)
+	prototest.AssertDeepEqual(t, res.Id.Type, writeRsp.Resource.Id.Type)
+	prototest.AssertDeepEqual(t, res.Id.Tenancy, writeRsp.Resource.Id.Tenancy)
+	prototest.AssertDeepEqual(t, res.Id.Name, writeRsp.Resource.Id.Name)
+	prototest.AssertDeepEqual(t, res.Data, writeRsp.Resource.Data)
+}
+
+func TestReadNamespace_Success(t *testing.T) {
+	v2TenancyBridge := tenancy.NewV2TenancyBridge()
+	config := resource.Config{TenancyBridge: v2TenancyBridge}
+	client := svctest.RunResourceServiceWithConfig(t, config, tenancy.RegisterTypes)
+	cl := rtest.NewClient(client)
+
+	writeResp := rtest.Resource(pbtenancy.NamespaceType, "ns1").
 		WithData(t, validNamespace()).
 		Write(t, cl)
 
-	readRsp, err := cl.Read(context.Background(), &pbresource.ReadRequest{Id: res.Id})
-	require.NoError(t, err)
-	prototest.AssertDeepEqual(t, res.Id, readRsp.Resource.Id)
+	cases := []struct {
+		name     string
+		resource *pbresource.Resource
+		errMsg   string
+	}{
+		{
+			name: "read namespace",
+			resource: rtest.Resource(pbtenancy.NamespaceType, "ns1").
+				WithData(t, validNamespace()).
+				Build(),
+		},
+		{
+			name: "tenancy units: empty namespace is allowed",
+			resource: rtest.Resource(pbtenancy.NamespaceType, "ns1").
+				WithTenancy(&pbresource.Tenancy{
+					Namespace: "",
+				}).
+				WithData(t, validNamespace()).
+				Build(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			readRsp, err := cl.Read(context.Background(), &pbresource.ReadRequest{Id: tc.resource.Id})
+			require.NoError(t, err)
+			prototest.AssertDeepEqual(t, writeResp.Id, readRsp.Resource.Id)
+			prototest.AssertDeepEqual(t, writeResp.Data, readRsp.Resource.Data)
+		})
+	}
 }
 
 func TestReadNamespace_NotFound(t *testing.T) {
@@ -42,12 +90,72 @@ func TestReadNamespace_NotFound(t *testing.T) {
 	client := svctest.RunResourceServiceWithConfig(t, config, tenancy.RegisterTypes)
 	cl := rtest.NewClient(client)
 
-	res := rtest.Resource(pbtenancy.NamespaceType, "ns1").
-		WithData(t, validNamespace()).Build()
+	cases := []struct {
+		name     string
+		resource *pbresource.Resource
+		errMsg   string
+	}{
+		{
+			name: "namespace with the given name not present",
+			resource: rtest.Resource(pbtenancy.NamespaceType, "ns1").
+				WithData(t, validNamespace()).
+				Build(),
+			errMsg: "resource not found",
+		},
+		{
+			name: "tenancy units: partition not present",
+			resource: rtest.Resource(pbtenancy.NamespaceType, "ns1").
+				WithTenancy(&pbresource.Tenancy{
+					Partition: "partition1",
+				}).
+				WithData(t, validNamespace()).
+				Build(),
+			errMsg: "partition not found: partition1",
+		},
+	}
 
-	_, err := cl.Read(context.Background(), &pbresource.ReadRequest{Id: res.Id})
-	require.Error(t, err)
-	require.Equal(t, codes.NotFound.String(), status.Code(err).String())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := cl.Read(context.Background(), &pbresource.ReadRequest{Id: tc.resource.Id})
+			require.Error(t, err)
+			require.Equal(t, codes.NotFound.String(), status.Code(err).String())
+			require.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}
+
+func TestReadNamespace_InvalidArgument(t *testing.T) {
+	v2TenancyBridge := tenancy.NewV2TenancyBridge()
+	config := resource.Config{TenancyBridge: v2TenancyBridge}
+	client := svctest.RunResourceServiceWithConfig(t, config, tenancy.RegisterTypes)
+	cl := rtest.NewClient(client)
+
+	cases := []struct {
+		name     string
+		resource *pbresource.Resource
+		errMsg   string
+	}{
+		{
+			name: "tenancy units: namespace not empty",
+			resource: rtest.Resource(pbtenancy.NamespaceType, "ns1").
+				WithTenancy(&pbresource.Tenancy{
+					Partition: "default",
+					Namespace: "ns2",
+				}).
+				WithData(t, validNamespace()).
+				Build(),
+			errMsg: fmt.Sprintf("partition scoped resource %s.%s.%s cannot have a namespace. got: ns2", pbtenancy.NamespaceType.Group, pbtenancy.NamespaceType.GroupVersion, pbtenancy.NamespaceType.Kind),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := cl.Read(context.Background(), &pbresource.ReadRequest{Id: tc.resource.Id})
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument.String(), status.Code(err).String())
+			require.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
 }
 
 func TestDeleteNamespace_Success(t *testing.T) {

--- a/internal/tenancy/tenancytest/namespace_test.go
+++ b/internal/tenancy/tenancytest/namespace_test.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/consul/agent/grpc-external/services/resource"
+	svc "github.com/hashicorp/consul/agent/grpc-external/services/resource"
 	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
-	resourceTenancy "github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/tenancy"
 
 	rtest "github.com/hashicorp/consul/internal/resource/resourcetest"
@@ -24,12 +24,12 @@ import (
 
 func TestWriteNamespace_Success(t *testing.T) {
 	v2TenancyBridge := tenancy.NewV2TenancyBridge()
-	config := resource.Config{TenancyBridge: v2TenancyBridge}
+	config := svc.Config{TenancyBridge: v2TenancyBridge}
 	client := svctest.RunResourceServiceWithConfig(t, config, tenancy.RegisterTypes)
 	cl := rtest.NewClient(client)
 
 	res := rtest.Resource(pbtenancy.NamespaceType, "ns1").
-		WithTenancy(resourceTenancy.DefaultPartitionedTenancy()).
+		WithTenancy(resource.DefaultPartitionedTenancy()).
 		WithData(t, validNamespace()).
 		Build()
 
@@ -43,7 +43,7 @@ func TestWriteNamespace_Success(t *testing.T) {
 
 func TestReadNamespace_Success(t *testing.T) {
 	v2TenancyBridge := tenancy.NewV2TenancyBridge()
-	config := resource.Config{TenancyBridge: v2TenancyBridge}
+	config := svc.Config{TenancyBridge: v2TenancyBridge}
 	client := svctest.RunResourceServiceWithConfig(t, config, tenancy.RegisterTypes)
 	cl := rtest.NewClient(client)
 
@@ -85,7 +85,7 @@ func TestReadNamespace_Success(t *testing.T) {
 
 func TestDeleteNamespace_Success(t *testing.T) {
 	v2TenancyBridge := tenancy.NewV2TenancyBridge()
-	config := resource.Config{TenancyBridge: v2TenancyBridge}
+	config := svc.Config{TenancyBridge: v2TenancyBridge}
 	client := svctest.RunResourceServiceWithConfig(t, config, tenancy.RegisterTypes)
 	cl := rtest.NewClient(client)
 
@@ -107,7 +107,7 @@ func TestDeleteNamespace_Success(t *testing.T) {
 
 func TestListNamespace_Success(t *testing.T) {
 	v2TenancyBridge := tenancy.NewV2TenancyBridge()
-	config := resource.Config{TenancyBridge: v2TenancyBridge}
+	config := svc.Config{TenancyBridge: v2TenancyBridge}
 	client := svctest.RunResourceServiceWithConfig(t, config, tenancy.RegisterTypes)
 	cl := rtest.NewClient(client)
 
@@ -120,7 +120,7 @@ func TestListNamespace_Success(t *testing.T) {
 
 	require.NotNil(t, res)
 
-	listRsp, err := cl.List(context.Background(), &pbresource.ListRequest{Type: pbtenancy.NamespaceType, Tenancy: resourceTenancy.DefaultPartitionedTenancy()})
+	listRsp, err := cl.List(context.Background(), &pbresource.ListRequest{Type: pbtenancy.NamespaceType, Tenancy: resource.DefaultPartitionedTenancy()})
 	require.NoError(t, err)
 	require.Len(t, listRsp.Resources, 3)
 	names := []string{


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

- This PR just adds the missing tests for the namespace read use case.
~- Update error type to `InvalidArgument` on tenancy check which is now consistent with other endpoints~

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

- Tested manually
- Added tests

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->
See the Acceptance Criteria in [NET-5521](https://hashicorp.atlassian.net/browse/NET-5521)


### PR Checklist

* [x] updated test coverage
* [ ] ~external facing docs updated~
* [x] appropriate backport labels added
* [ ] ~not a security concern~


[NET-5521]: https://hashicorp.atlassian.net/browse/NET-5521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ