### PR TITLE
temporarily disallow L7 traffic permissions

### DIFF
--- a/internal/auth/internal/types/errors.go
+++ b/internal/auth/internal/types/errors.go
@@ -12,4 +12,5 @@ var (
 	errSourceExcludes       = errors.New("must be defined on wildcard sources")
 	errInvalidPrefixValues  = errors.New("prefix values, regex values, and explicit names must not combined")
 	ErrWildcardNotSupported = errors.New("traffic permissions without explicit destinations are not yet supported")
+	ErrL7NotSupported       = errors.New("traffic permissions with L7 rules are not yet supported")
 )

--- a/internal/auth/internal/types/traffic_permissions.go
+++ b/internal/auth/internal/types/traffic_permissions.go
@@ -227,6 +227,13 @@ func validatePermission(p *pbauth.Permission, wrapErr func(error) error) error {
 				Wrapped: err,
 			})
 		}
+		// TODO: remove this when L7 traffic permissions are implemented
+		if len(dest.PathExact) > 0 || len(dest.PathPrefix) > 0 || len(dest.PathRegex) > 0 || len(dest.Methods) > 0 || dest.Header != nil {
+			merr = multierror.Append(merr, wrapDestRuleErr(resource.ErrInvalidListElement{
+				Name:    "destination_rule",
+				Wrapped: ErrL7NotSupported,
+			}))
+		}
 		if (len(dest.PathExact) > 0 && len(dest.PathPrefix) > 0) ||
 			(len(dest.PathRegex) > 0 && len(dest.PathExact) > 0) ||
 			(len(dest.PathRegex) > 0 && len(dest.PathPrefix) > 0) {
@@ -243,6 +250,13 @@ func validatePermission(p *pbauth.Permission, wrapErr func(error) error) error {
 						Index:   e,
 						Wrapped: err,
 					})
+				}
+				// TODO: remove this when L7 traffic permissions are implemented
+				if len(excl.PathExact) > 0 || len(excl.PathPrefix) > 0 || len(excl.PathRegex) > 0 || len(excl.Methods) > 0 || excl.Header != nil {
+					merr = multierror.Append(merr, wrapDestRuleErr(resource.ErrInvalidListElement{
+						Name:    "exclude_permission_rules",
+						Wrapped: ErrL7NotSupported,
+					}))
 				}
 				if (len(excl.PathExact) > 0 && len(excl.PathPrefix) > 0) ||
 					(len(excl.PathRegex) > 0 && len(excl.PathExact) > 0) ||

--- a/internal/auth/internal/types/traffic_permissions_test.go
+++ b/internal/auth/internal/types/traffic_permissions_test.go
@@ -65,17 +65,8 @@ func TestValidateTrafficPermissions(t *testing.T) {
 		},
 		"no-destination": {
 			tp: &pbauth.TrafficPermissions{
-				Action: pbauth.Action_ACTION_ALLOW,
-				Permissions: []*pbauth.Permission{
-					{
-						Sources: nil,
-						DestinationRules: []*pbauth.DestinationRule{
-							{
-								PathExact: "wi2",
-							},
-						},
-					},
-				},
+				Action:      pbauth.Action_ACTION_ALLOW,
+				Permissions: nil,
 			},
 			expectErr: `invalid "data.destination" field: cannot be empty`,
 		},
@@ -99,6 +90,76 @@ func TestValidateTrafficPermissions(t *testing.T) {
 				},
 			},
 			expectErr: `invalid element at index 0 of list "permissions": invalid element at index 0 of list "sources": invalid element at index 0 of list "source": permissions sources may not specify partitions, peers, and sameness_groups together`,
+		},
+		// TODO: remove when L7 traffic permissions are implemented
+		"l7-fields-path": {
+			tp: &pbauth.TrafficPermissions{
+				Destination: &pbauth.Destination{
+					IdentityName: "w1",
+				},
+				Action: pbauth.Action_ACTION_ALLOW,
+				Permissions: []*pbauth.Permission{
+					{
+						Sources: []*pbauth.Source{
+							{
+								Partition: "ap1",
+							},
+						},
+						DestinationRules: []*pbauth.DestinationRule{
+							{
+								PathExact: "wi2",
+							},
+						},
+					},
+				},
+			},
+			expectErr: `invalid element at index 0 of list "permissions": invalid element at index 0 of list "destination_rules": invalid element at index 0 of list "destination_rule": traffic permissions with L7 rules are not yet supported`,
+		},
+		"l7-fields-methods": {
+			tp: &pbauth.TrafficPermissions{
+				Destination: &pbauth.Destination{
+					IdentityName: "w1",
+				},
+				Action: pbauth.Action_ACTION_ALLOW,
+				Permissions: []*pbauth.Permission{
+					{
+						Sources: []*pbauth.Source{
+							{
+								Partition: "ap1",
+							},
+						},
+						DestinationRules: []*pbauth.DestinationRule{
+							{
+								Methods: []string{"PUT"},
+							},
+						},
+					},
+				},
+			},
+			expectErr: `invalid element at index 0 of list "permissions": invalid element at index 0 of list "destination_rules": invalid element at index 0 of list "destination_rule": traffic permissions with L7 rules are not yet supported`,
+		},
+		"l7-fields-header": {
+			tp: &pbauth.TrafficPermissions{
+				Destination: &pbauth.Destination{
+					IdentityName: "w1",
+				},
+				Action: pbauth.Action_ACTION_ALLOW,
+				Permissions: []*pbauth.Permission{
+					{
+						Sources: []*pbauth.Source{
+							{
+								Partition: "ap1",
+							},
+						},
+						DestinationRules: []*pbauth.DestinationRule{
+							{
+								Header: &pbauth.DestinationRuleHeader{Name: "foo"},
+							},
+						},
+					},
+				},
+			},
+			expectErr: `invalid element at index 0 of list "permissions": invalid element at index 0 of list "destination_rules": invalid element at index 0 of list "destination_rule": traffic permissions with L7 rules are not yet supported`,
 		},
 	}
 


### PR DESCRIPTION
Temporarily prohibit L7 rules in Traffic Permissions (hopefully can remove in a week or two when implementation is done)
