### PR TITLE
[1.17.0 manual backport]  mesh: ensure route configs are named uniquely per port 

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destinations.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destinations.go
@@ -94,7 +94,7 @@ func (b *Builder) buildDestination(
 	if destination.Explicit != nil {
 		routeName = lb.listener.Name
 	} else {
-		routeName = DestinationResourceID(cpr.ParentRef.Ref)
+		routeName = DestinationResourceID(cpr.ParentRef.Ref, cpr.ParentRef.Port)
 	}
 
 	var (

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/naming.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/naming.go
@@ -29,7 +29,7 @@ func DestinationStatPrefix(serviceRef *pbresource.Reference, portName, datacente
 }
 
 func DestinationListenerName(destinationRef *pbresource.Reference, portName string, address string, port uint32) string {
-	name := fmt.Sprintf("%s:%s:%s", DestinationResourceID(destinationRef), portName, address)
+	name := fmt.Sprintf("%s:%s", DestinationResourceID(destinationRef, portName), address)
 	if port != 0 {
 		return fmt.Sprintf("%s:%d", name, port)
 	}
@@ -39,8 +39,8 @@ func DestinationListenerName(destinationRef *pbresource.Reference, portName stri
 
 // DestinationResourceID returns a string representation that uniquely identifies the
 // upstream in a canonical but human readable way.
-func DestinationResourceID(destinationRef *pbresource.Reference) string {
+func DestinationResourceID(destinationRef *pbresource.Reference, port string) string {
 	tenancyPrefix := fmt.Sprintf("%s/%s/%s", destinationRef.Tenancy.Partition,
 		destinationRef.Tenancy.PeerName, destinationRef.Tenancy.Namespace)
-	return fmt.Sprintf("%s/%s", tenancyPrefix, destinationRef.Name)
+	return fmt.Sprintf("%s/%s:%s", tenancyPrefix, destinationRef.Name, port)
 }

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
@@ -248,7 +248,7 @@
           {
             "l7": {
               "route": {
-                "name": "default/local/default/api-app"
+                "name": "default/local/default/api-app:http"
               },
               "statPrefix": "upstream."
             },
@@ -265,7 +265,7 @@
           {
             "l7": {
               "route": {
-                "name": "default/local/default/api-app2"
+                "name": "default/local/default/api-app2:http"
               },
               "statPrefix": "upstream."
             },
@@ -325,18 +325,18 @@
       }
     ],
     "routes": {
-      "default/local/default/api-app": {
+      "default/local/default/api-app2:http": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "default/local/default/api-app",
+            "name": "default/local/default/api-app2:http",
             "routeRules": [
               {
                 "destination": {
                   "cluster": {
-                    "name": "http.api-app.default.dc1.internal.foo.consul"
+                    "name": "http.api-app2.default.dc1.internal.foo.consul"
                   }
                 },
                 "match": {
@@ -349,18 +349,18 @@
           }
         ]
       },
-      "default/local/default/api-app2": {
+      "default/local/default/api-app:http": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "default/local/default/api-app2",
+            "name": "default/local/default/api-app:http",
             "routeRules": [
               {
                 "destination": {
                   "cluster": {
-                    "name": "http.api-app2.default.dc1.internal.foo.consul"
+                    "name": "http.api-app.default.dc1.internal.foo.consul"
                   }
                 },
                 "match": {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
@@ -146,7 +146,7 @@
           {
             "l7": {
               "route": {
-                "name": "default/local/default/api-app"
+                "name": "default/local/default/api-app:http"
               },
               "statPrefix": "upstream."
             },
@@ -181,13 +181,13 @@
       }
     ],
     "routes": {
-      "default/local/default/api-app": {
+      "default/local/default/api-app:http": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "default/local/default/api-app",
+            "name": "default/local/default/api-app:http",
             "routeRules": [
               {
                 "destination": {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
@@ -146,7 +146,7 @@
           {
             "l7": {
               "route": {
-                "name": "default/local/default/api-app"
+                "name": "default/local/default/api-app:http"
               },
               "statPrefix": "upstream."
             },
@@ -181,13 +181,13 @@
       }
     ],
     "routes": {
-      "default/local/default/api-app": {
+      "default/local/default/api-app:http": {
         "virtualHosts": [
           {
             "domains": [
               "*"
             ],
-            "name": "default/local/default/api-app",
+            "name": "default/local/default/api-app:http",
             "routeRules": [
               {
                 "destination": {


### PR DESCRIPTION
### Description

Backport of #19323 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
