### PR TITLE
resource: default peername to local in list endpoints

### DIFF
--- a/agent/grpc-external/services/resource/server.go
+++ b/agent/grpc-external/services/resource/server.go
@@ -205,6 +205,11 @@ func validateWildcardTenancy(tenancy *pbresource.Tenancy, namePrefix string) err
 		return status.Errorf(codes.InvalidArgument, "name_prefix invalid: must be lowercase alphanumeric, got: %v", namePrefix)
 	}
 
+	// TODO(spatel): NET-5475 - Remove as part of peer_name moving to PeerTenancy
+	if tenancy.PeerName == "" {
+		tenancy.PeerName = resource.DefaultPeerName
+	}
+
 	return nil
 }
 

--- a/agent/grpc-external/services/resource/server_test.go
+++ b/agent/grpc-external/services/resource/server_test.go
@@ -157,6 +157,15 @@ func wildcardTenancyCases() map[string]struct {
 				PeerName:  "local",
 			},
 		},
+		// TODO(spatel): NET-5475 - Remove as part of peer_name moving to PeerTenancy
+		"namespaced type with empty peername": {
+			typ: demo.TypeV2Artist,
+			tenancy: &pbresource.Tenancy{
+				Partition: resource.DefaultPartitionName,
+				Namespace: resource.DefaultNamespaceName,
+				PeerName:  "",
+			},
+		},
 		"namespaced type with empty partition and namespace": {
 			typ: demo.TypeV2Artist,
 			tenancy: &pbresource.Tenancy{


### PR DESCRIPTION
### Description

CE version of approved ENT PR: https://github.com/hashicorp/consul-enterprise/pull/7478

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
