### PR TITLE
Fix casing in example yaml config

### DIFF
--- a/website/content/docs/connect/config-entries/exported-services.mdx
+++ b/website/content/docs/connect/config-entries/exported-services.mdx
@@ -320,7 +320,7 @@ Services = [
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
-Kind: ExportedServices
+kind: ExportedServices
 metadata:
   name: default
 spec:
@@ -396,7 +396,7 @@ Services = [
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
-Kind: ExportedServices
+kind: ExportedServices
 metadata:
   name: finance
 spec:
@@ -477,7 +477,7 @@ Services = [
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
-Kind: ExportedServices
+kind: ExportedServices
 metadata:
   name: finance
 spec:
@@ -548,7 +548,7 @@ Services = [
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
-Kind: ExportedServices
+kind: ExportedServices
 metadata:
   name: default
 spec:
@@ -607,7 +607,7 @@ Services = [
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
-Kind: ExportedServices
+kind: ExportedServices
 metadata:
   name: default
 spec:
@@ -671,7 +671,7 @@ Services = [
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
-Kind: ExportedServices
+kind: ExportedServices
 metadata:
   name: finance
 spec:
@@ -737,7 +737,7 @@ Services = [
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
-Kind: ExportedServices
+kind: ExportedServices
 metadata:
   name: finance
 spec:


### PR DESCRIPTION
### Description
[This page](https://developer.hashicorp.com/consul/docs/connect/config-entries/exported-services) in the docs has example code that is copy-pastable; however, it has a casing error which prevents the copied code from working for Kubernetes:

```
error: error validating "cluster-2/exported-services.yaml": error validating data: kind not set; if you choose to ignore these errors, turn validation off with --validate=false
```

### Testing & Reproduction steps
Copy-paste the modified examples and attempt to apply them to a Kubernetes cluster using `kubectl apply -f <filename>`. Verify the command completes successfully instead of returning the above error.

### Links
[Page containing broken example code](https://developer.hashicorp.com/consul/docs/connect/config-entries/exported-services)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
