### PR TITLE
test deployer: fix a bug when deploying cluster with various ent images

### DIFF
--- a/testing/deployer/topology/compile.go
+++ b/testing/deployer/topology/compile.go
@@ -203,7 +203,7 @@ func compile(logger hclog.Logger, raw *Config, prev *Topology) (*Topology, error
 			n.Index = nextIndex
 			nextIndex++
 
-			n.Images = c.Images.OverrideWith(n.Images).ChooseNode(n.Kind)
+			n.Images = c.Images.OverrideWith(n.Images.ChooseConsul(c.Enterprise)).ChooseNode(n.Kind)
 
 			n.Cluster = c.Name
 			n.Datacenter = c.Datacenter

--- a/testing/deployer/topology/images.go
+++ b/testing/deployer/topology/images.go
@@ -8,8 +8,12 @@ import (
 )
 
 type Images struct {
-	Consul           string `json:",omitempty"`
-	ConsulCE         string `json:",omitempty"`
+	// Consul is the image used for creating the container,
+	// Use ChooseConsul() to control which image (ConsulCE or ConsulEnterprise) assign to Consul
+	Consul string `json:",omitempty"`
+	// ConsulCE sets the CE image
+	ConsulCE string `json:",omitempty"`
+	// ConsulEnterprise sets the ent image
 	ConsulEnterprise string `json:",omitempty"`
 	Envoy            string
 	Dataplane        string
@@ -82,6 +86,7 @@ func (i Images) ChooseNode(kind NodeKind) Images {
 	return i
 }
 
+// ChooseConsul controls which image assigns to Consul
 func (i Images) ChooseConsul(enterprise bool) Images {
 	if enterprise {
 		i.Consul = i.ConsulEnterprise


### PR DESCRIPTION
### Description

When testing a cluster with different consul versions, the per node `ConsulEnterprise` image should override the default image. Since `c.Images` has been mutated with `ChooseConsul(c.Enterprise)` (see below code), the per node overwrite won't happen

https://github.com/hashicorp/consul/blob/0fefaa649fc7b65c3975bff15f0fc635b33e26fa/testing/deployer/topology/compile.go#L114-L116

To fix this, we need to mutate the per node image as well and then use it to overwrite the default one.

### Testing & Reproduction steps

Create a cluster with server nodes with different `ConsulEnterprise`, and the created cluster will have the same images.

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
