### PR TITLE
Make retry on connect failure filter on gateway http route filter a bool rather than a bool pointer

### DIFF
--- a/agent/consul/discoverychain/gateway_httproute.go
+++ b/agent/consul/discoverychain/gateway_httproute.go
@@ -180,9 +180,8 @@ func httpRouteToDiscoveryChain(route structs.HTTPRouteConfigEntry) (*structs.Ser
 			if rule.Filters.RetryFilter.NumRetries != nil {
 				destination.NumRetries = *rule.Filters.RetryFilter.NumRetries
 			}
-			if rule.Filters.RetryFilter.RetryOnConnectFailure != nil {
-				destination.RetryOnConnectFailure = *rule.Filters.RetryFilter.RetryOnConnectFailure
-			}
+
+			destination.RetryOnConnectFailure = rule.Filters.RetryFilter.RetryOnConnectFailure
 
 			if len(rule.Filters.RetryFilter.RetryOn) > 0 {
 				destination.RetryOn = rule.Filters.RetryFilter.RetryOn

--- a/agent/structs/config_entry_routes.go
+++ b/agent/structs/config_entry_routes.go
@@ -478,7 +478,7 @@ type RetryFilter struct {
 	NumRetries            *uint32
 	RetryOn               []string
 	RetryOnStatusCodes    []uint32
-	RetryOnConnectFailure *bool
+	RetryOnConnectFailure bool
 }
 
 type TimeoutFilter struct {

--- a/agent/structs/structs.deepcopy.go
+++ b/agent/structs/structs.deepcopy.go
@@ -412,10 +412,6 @@ func (o *HTTPRouteConfigEntry) DeepCopy() *HTTPRouteConfigEntry {
 					cp.Rules[i2].Filters.RetryFilter.RetryOnStatusCodes = make([]uint32, len(o.Rules[i2].Filters.RetryFilter.RetryOnStatusCodes))
 					copy(cp.Rules[i2].Filters.RetryFilter.RetryOnStatusCodes, o.Rules[i2].Filters.RetryFilter.RetryOnStatusCodes)
 				}
-				if o.Rules[i2].Filters.RetryFilter.RetryOnConnectFailure != nil {
-					cp.Rules[i2].Filters.RetryFilter.RetryOnConnectFailure = new(bool)
-					*cp.Rules[i2].Filters.RetryFilter.RetryOnConnectFailure = *o.Rules[i2].Filters.RetryFilter.RetryOnConnectFailure
-				}
 			}
 			if o.Rules[i2].Filters.TimeoutFilter != nil {
 				cp.Rules[i2].Filters.TimeoutFilter = new(TimeoutFilter)
@@ -504,10 +500,6 @@ func (o *HTTPRouteConfigEntry) DeepCopy() *HTTPRouteConfigEntry {
 						if o.Rules[i2].Services[i4].Filters.RetryFilter.RetryOnStatusCodes != nil {
 							cp.Rules[i2].Services[i4].Filters.RetryFilter.RetryOnStatusCodes = make([]uint32, len(o.Rules[i2].Services[i4].Filters.RetryFilter.RetryOnStatusCodes))
 							copy(cp.Rules[i2].Services[i4].Filters.RetryFilter.RetryOnStatusCodes, o.Rules[i2].Services[i4].Filters.RetryFilter.RetryOnStatusCodes)
-						}
-						if o.Rules[i2].Services[i4].Filters.RetryFilter.RetryOnConnectFailure != nil {
-							cp.Rules[i2].Services[i4].Filters.RetryFilter.RetryOnConnectFailure = new(bool)
-							*cp.Rules[i2].Services[i4].Filters.RetryFilter.RetryOnConnectFailure = *o.Rules[i2].Services[i4].Filters.RetryFilter.RetryOnConnectFailure
 						}
 					}
 					if o.Rules[i2].Services[i4].Filters.TimeoutFilter != nil {

--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -574,7 +574,7 @@ func getAPIGatewayGoldenTestCases(t *testing.T) []goldenTestCase {
 									NumRetries:            pointer.Uint32(3),
 									RetryOn:               []string{"cancelled"},
 									RetryOnStatusCodes:    []uint32{500},
-									RetryOnConnectFailure: pointer.Bool(true),
+									RetryOnConnectFailure: true,
 								},
 								TimeoutFilter: &structs.TimeoutFilter{
 									IdleTimeout:    time.Second * 30,

--- a/api/config_entry_routes.go
+++ b/api/config_entry_routes.go
@@ -225,7 +225,7 @@ type RetryFilter struct {
 	NumRetries            *uint32
 	RetryOn               []string
 	RetryOnStatusCodes    []uint32
-	RetryOnConnectFailure *bool
+	RetryOnConnectFailure bool
 }
 
 type TimeoutFilter struct {

--- a/proto/private/pbconfigentry/config_entry.gen.go
+++ b/proto/private/pbconfigentry/config_entry.gen.go
@@ -1825,7 +1825,7 @@ func RetryFilterToStructs(s *RetryFilter, t *structs.RetryFilter) {
 	t.NumRetries = &s.NumRetries
 	t.RetryOn = s.RetryOn
 	t.RetryOnStatusCodes = s.RetryOnStatusCodes
-	t.RetryOnConnectFailure = &s.RetryOnConnectFailure
+	t.RetryOnConnectFailure = s.RetryOnConnectFailure
 }
 func RetryFilterFromStructs(t *structs.RetryFilter, s *RetryFilter) {
 	if s == nil {
@@ -1834,7 +1834,7 @@ func RetryFilterFromStructs(t *structs.RetryFilter, s *RetryFilter) {
 	s.NumRetries = *t.NumRetries
 	s.RetryOn = t.RetryOn
 	s.RetryOnStatusCodes = t.RetryOnStatusCodes
-	s.RetryOnConnectFailure = *t.RetryOnConnectFailure
+	s.RetryOnConnectFailure = t.RetryOnConnectFailure
 }
 func RetryPolicyBackOffToStructs(s *RetryPolicyBackOff, t *structs.RetryPolicyBackOff) {
 	if s == nil {


### PR DESCRIPTION
This fixes the `TestHTTPRouteRetryAndTimeout` failure that is blocking https://github.com/hashicorp/consul/pull/19365.

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
