### PR TITLE
Stop use of templated-policy and templated-policy-file simultaneously

### DIFF
--- a/.changelog/19389.txt
+++ b/.changelog/19389.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: stop simultaneous usage of -templated-policy and -templated-policy-file when creating a role or token.
+```

--- a/command/acl/role/create/role_create.go
+++ b/command/acl/role/create/role_create.go
@@ -94,6 +94,13 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
+	if len(c.templatedPolicyFile) != 0 && len(c.templatedPolicy) != 0 {
+		c.UI.Error("Cannot combine the use of templated-policy flag with templated-policy-file. " +
+			"To create a role with a single templated policy and simple use case, use -templated-policy. " +
+			"For multiple templated policies and more complicated use cases, use -templated-policy-file")
+		return 1
+	}
+
 	client, err := c.http.APIClient()
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))

--- a/command/acl/role/create/role_create_test.go
+++ b/command/acl/role/create/role_create_test.go
@@ -115,6 +115,22 @@ func TestRoleCreateCommand_Pretty(t *testing.T) {
 
 		require.Len(t, role.NodeIdentities, 1)
 	})
+
+	t.Run("prevent templated-policy and templated-policy-file simultaneous use", func(t *testing.T) {
+		ui := cli.NewMockUi()
+		cmd := New(ui)
+
+		code := cmd.Run([]string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-token=root",
+			"-name=role-with-node-identity",
+			"-templated-policy=builtin/node",
+			"-var=name:" + a.Config.NodeName,
+			"-templated-policy-file=test.hcl",
+		})
+		require.Equal(t, 1, code)
+		require.Contains(t, ui.ErrorWriter.String(), "Cannot combine the use of templated-policy flag with templated-policy-file.")
+	})
 }
 
 func TestRoleCreateCommand_JSON(t *testing.T) {

--- a/command/acl/token/create/token_create.go
+++ b/command/acl/token/create/token_create.go
@@ -105,6 +105,13 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
+	if len(c.templatedPolicyFile) != 0 && len(c.templatedPolicy) != 0 {
+		c.UI.Error("Cannot combine the use of templated-policy flag with templated-policy-file. " +
+			"To create a token with a single templated policy and simple use case, use -templated-policy. " +
+			"For multiple templated policies and more complicated use cases, use -templated-policy-file")
+		return 1
+	}
+
 	client, err := c.http.APIClient()
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))

--- a/command/acl/token/create/token_create_test.go
+++ b/command/acl/token/create/token_create_test.go
@@ -128,6 +128,21 @@ func TestTokenCreateCommand_Pretty(t *testing.T) {
 		require.Equal(t, a.Config.NodeName, nodes[0].Node)
 	})
 
+	t.Run("prevent templated-policy and templated-policy-file simultaneous use", func(t *testing.T) {
+		ui := cli.NewMockUi()
+		cmd := New(ui)
+
+		code := cmd.Run(append([]string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-token=root",
+			"-templated-policy=builtin/node",
+			"-var=name:" + a.Config.NodeName,
+			"-templated-policy-file=test.hcl",
+		}, "-format=json"))
+		require.Equal(t, 1, code)
+		require.Contains(t, ui.ErrorWriter.String(), "Cannot combine the use of templated-policy flag with templated-policy-file.")
+	})
+
 	// create with accessor and secret
 	t.Run("predefined-ids", func(t *testing.T) {
 		token := run(t, []string{


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

- Prevent usage of `templated-policy` and `templated-policy-file` simultaneously to improve ux for templated policy use

### Testing & Reproduction steps
```
consul acl token create -templated-policy "builtin/service" -templated-policy-file "templatedpolicy.hcl"

Cannot combine the use of templated-policy flag with templated-policy-file. To create a token with a single templated policy and simple use case, use -templated-policy. For multiple templated policies and more complicated use cases, use -templated-policy-file
```

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->


### PR Checklist

* [x] updated test coverage
* [x] appropriate backport labels added
* [x] not a security concern
