### PR TITLE
increasing unit tests timeout from 10m to 30m

### DIFF
--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -130,7 +130,8 @@ jobs:
           --packages="$PACKAGE_NAMES" \
           --junitfile ${{env.TEST_RESULTS}}/gotestsum-report.xml -- \
           -tags="${{env.GOTAGS}}" \
-          -cover -coverprofile=coverage.txt
+          -cover -coverprofile=coverage.txt \
+          -timeout=30m
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -109,7 +109,8 @@ jobs:
               --junitfile ${{env.TEST_RESULTS}}/gotestsum-report.xml -- \
               -tags="${{env.GOTAGS}}" \
               ${GO_TEST_FLAGS-} \
-              -cover -coverprofile=coverage.txt
+              -cover -coverprofile=coverage.txt \
+              -timeout=30m
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault


### PR DESCRIPTION
### Description

CI is failing when a whole test run goes over the default of 10m.  This happens mostly with the agent package when the tests are split.  and this happens more in enterprise with self hosted runners.  

This change is to make it 30m which matches the integration tests setting.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
