### PR TITLE
ui: 1.16.x Back to HCP link conditions

### DIFF
--- a/.changelog/19443.txt
+++ b/.changelog/19443.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: only show hcp link if url is present
+```

--- a/ui/packages/consul-hcp/app/components/consul/hcp/home/index.hbs
+++ b/ui/packages/consul-hcp/app/components/consul/hcp/home/index.hbs
@@ -3,11 +3,13 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<div
-  class="consul-hcp-home"
-  ...attributes
->
-  <a href={{env 'CONSUL_HCP_URL'}} data-native-href="true">
-    Back to HCP
-  </a>
-</div>
+{{#if (env 'CONSUL_HCP_URL')}}
+  <div
+    class="consul-hcp-home"
+    ...attributes
+  >
+    <a href={{env 'CONSUL_HCP_URL'}} data-native-href="true">
+      Back to HCP
+    </a>
+  </div>
+{{/if}}

--- a/ui/packages/consul-hcp/app/components/consul/hcp/home/index.test.js
+++ b/ui/packages/consul-hcp/app/components/consul/hcp/home/index.test.js
@@ -40,4 +40,34 @@ module('Integration | Component | consul hcp home', function(hooks) {
     assert.dom('a').hasAttribute('href', 'http://hcp');
 
   });
+
+  test('it does not output the Back to HCP link if CONSUL_HCP_URL is not present', async function(assert) {
+    // temporary registration until we are running as separate applications
+    this.owner.register(
+      'component:consul/hcp/home',
+      ConsulHcpHome
+    );
+    //
+
+    const Helper = this.owner.resolveRegistration('helper:env');
+    this.owner.register(
+      'helper:env',
+      class extends Helper {
+        compute([name, def]) {
+          switch(name) {
+            case 'CONSUL_HCP_URL':
+              return undefined;
+          }
+          return super.compute(...arguments);
+        }
+      }
+    );
+
+    await render(hbs`
+      <Consul::Hcp::Home />
+    `);
+
+    assert.dom('[data-test-back-to-hcp]').doesNotExist();
+    assert.dom('a').doesNotExist();
+  });
 });


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

Currently the back to hcp link will show whenever `CONSUL_HCP_ENABLE` is set. However, there are times when the `CONSUL_HCP_URL` is not present. My understanding is this could be if you visit the UI directly without accessing it via HCP UI? Either way, we should only show the link if the value is present.

This is handled will be handled in the new sidenav on `main` and `1.17.x` via the side nav updates PR (#19342 ). I am manually backporting this change to 1.16 and 1.15 because of that.

<img width="1686" alt="Screenshot 2023-10-31 at 9 44 53 AM" src="https://github.com/hashicorp/consul/assets/5448834/74dcfad0-4477-48e4-9e74-f2c9cc600de4">
<img width="1686" alt="Screenshot 2023-10-31 at 9 45 15 AM" src="https://github.com/hashicorp/consul/assets/5448834/ae752156-96dc-41fe-9cb4-e3272f4ade8d">


### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

1. Run the UI
2. Run `Scenario('CONSUL_HCP_ENABLE', 1)` in the browser console to enable HCP mode
3. Run `Scenario('CONSUL_HCP_URL', 'url of your choice')` in the browser console to set the HCP url.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
