### PR TITLE
Add kubebuilder annotations to enums

### DIFF
--- a/proto-public/pbcatalog/v2beta1/failover_policy.pb.go
+++ b/proto-public/pbcatalog/v2beta1/failover_policy.pb.go
@@ -24,6 +24,8 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// +kubebuilder:validation:Enum=FAILOVER_MODE_UNSPECIFIED;FAILOVER_MODE_SEQUENTIAL;FAILOVER_MODE_ORDER_BY_LOCALITY
+// +kubebuilder:validation:Type=string
 type FailoverMode int32
 
 const (

--- a/proto-public/pbcatalog/v2beta1/failover_policy.proto
+++ b/proto-public/pbcatalog/v2beta1/failover_policy.proto
@@ -43,6 +43,8 @@ message FailoverDestination {
   string datacenter = 3;
 }
 
+// +kubebuilder:validation:Enum=FAILOVER_MODE_UNSPECIFIED;FAILOVER_MODE_SEQUENTIAL;FAILOVER_MODE_ORDER_BY_LOCALITY
+// +kubebuilder:validation:Type=string
 enum FailoverMode {
   FAILOVER_MODE_UNSPECIFIED = 0;
   FAILOVER_MODE_SEQUENTIAL = 1;

--- a/proto-public/pbcatalog/v2beta1/health.pb.go
+++ b/proto-public/pbcatalog/v2beta1/health.pb.go
@@ -25,6 +25,8 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// +kubebuilder:validation:Enum=HEALTH_ANY;HEALTH_PASSING;HEALTH_WARNING;HEALTH_CRITICAL;HEALTH_MAINTENANCE
+// +kubebuilder:validation:Type=string
 type Health int32
 
 const (

--- a/proto-public/pbcatalog/v2beta1/health.proto
+++ b/proto-public/pbcatalog/v2beta1/health.proto
@@ -23,6 +23,8 @@ message HealthStatus {
   string output = 4;
 }
 
+// +kubebuilder:validation:Enum=HEALTH_ANY;HEALTH_PASSING;HEALTH_WARNING;HEALTH_CRITICAL;HEALTH_MAINTENANCE
+// +kubebuilder:validation:Type=string
 enum Health {
   // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX
   HEALTH_ANY = 0;


### PR DESCRIPTION
Add kubebuilder labels to the enum fields in proto-public for catalog v2beta1 types for proper processing for CRDs.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
