### PR TITLE
added redirect for conf entries 1.8.x

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -207,4 +207,9 @@ module.exports = [
     destination: '/consul/docs/connect/manage-traffic/:slug',
     permanent: true,
   },
+  {
+    source: '/consul/docs/v1.8.x/connect/config-entries/:slug',
+    destination: '/consul/docs/v1.8.x/agent/config-entries/:slug',
+    permanent: true,
+  },
 ]


### PR DESCRIPTION
### Description

Prior to v1.9.x, configuration entries appeared int he /agent dir instead the /connect dir. This PR redirects people who view a conf entry in the current /connect folder and switch to docs v1.8.x so that they land on the conf entry in the /agent folder.  Fixes per this [Slack thread](https://hashicorp.slack.com/archives/C011HP57U0Y/p1698853199142849).
 
### PR Checklist

* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
