### PR TITLE
Net-6291/fix/watch resources

### DIFF
--- a/agent/grpc-external/services/resource/delete.go
+++ b/agent/grpc-external/services/resource/delete.go
@@ -28,7 +28,7 @@ import (
 // - Errors with Aborted if the requested Version does not match the stored Version.
 // - Errors with PermissionDenied if ACL check fails
 func (s *Server) Delete(ctx context.Context, req *pbresource.DeleteRequest) (*pbresource.DeleteResponse, error) {
-	reg, err := s.validateDeleteRequest(req)
+	reg, err := s.ensureDeleteRequestValid(req)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (s *Server) maybeCreateTombstone(ctx context.Context, deleteId *pbresource.
 	}
 }
 
-func (s *Server) validateDeleteRequest(req *pbresource.DeleteRequest) (*resource.Registration, error) {
+func (s *Server) ensureDeleteRequestValid(req *pbresource.DeleteRequest) (*resource.Registration, error) {
 	if req.Id == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id is required")
 	}

--- a/agent/grpc-external/services/resource/list.go
+++ b/agent/grpc-external/services/resource/list.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (s *Server) List(ctx context.Context, req *pbresource.ListRequest) (*pbresource.ListResponse, error) {
-	reg, err := s.validateListRequest(req)
+	reg, err := s.ensureListRequestValid(req)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (s *Server) List(ctx context.Context, req *pbresource.ListRequest) (*pbreso
 	return &pbresource.ListResponse{Resources: result}, nil
 }
 
-func (s *Server) validateListRequest(req *pbresource.ListRequest) (*resource.Registration, error) {
+func (s *Server) ensureListRequestValid(req *pbresource.ListRequest) (*resource.Registration, error) {
 	var field string
 	switch {
 	case req.Type == nil:

--- a/agent/grpc-external/services/resource/list_by_owner.go
+++ b/agent/grpc-external/services/resource/list_by_owner.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *Server) ListByOwner(ctx context.Context, req *pbresource.ListByOwnerRequest) (*pbresource.ListByOwnerResponse, error) {
-	reg, err := s.validateListByOwnerRequest(req)
+	reg, err := s.ensureListByOwnerRequestValid(req)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (s *Server) ListByOwner(ctx context.Context, req *pbresource.ListByOwnerReq
 	return &pbresource.ListByOwnerResponse{Resources: result}, nil
 }
 
-func (s *Server) validateListByOwnerRequest(req *pbresource.ListByOwnerRequest) (*resource.Registration, error) {
+func (s *Server) ensureListByOwnerRequestValid(req *pbresource.ListByOwnerRequest) (*resource.Registration, error) {
 	if req.Owner == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "owner is required")
 	}

--- a/agent/grpc-external/services/resource/read.go
+++ b/agent/grpc-external/services/resource/read.go
@@ -18,7 +18,7 @@ import (
 
 func (s *Server) Read(ctx context.Context, req *pbresource.ReadRequest) (*pbresource.ReadResponse, error) {
 	// Light first pass validation based on what user passed in and not much more.
-	reg, err := s.validateReadRequest(req)
+	reg, err := s.ensureReadRequestValid(req)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (s *Server) Read(ctx context.Context, req *pbresource.ReadRequest) (*pbreso
 	return &pbresource.ReadResponse{Resource: resource}, nil
 }
 
-func (s *Server) validateReadRequest(req *pbresource.ReadRequest) (*resource.Registration, error) {
+func (s *Server) ensureReadRequestValid(req *pbresource.ReadRequest) (*resource.Registration, error) {
 	if req.Id == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id is required")
 	}

--- a/agent/grpc-external/services/resource/read.go
+++ b/agent/grpc-external/services/resource/read.go
@@ -107,31 +107,9 @@ func (s *Server) validateReadRequest(req *pbresource.ReadRequest) (*resource.Reg
 	}
 
 	// Check scope
-	if reg.Scope == resource.ScopePartition && req.Id.Tenancy.Namespace != "" {
-		return nil, status.Errorf(
-			codes.InvalidArgument,
-			"partition scoped resource %s cannot have a namespace. got: %s",
-			resource.ToGVK(req.Id.Type),
-			req.Id.Tenancy.Namespace,
-		)
+	if err = validateScopedTenancy(reg.Scope, req.Id.Type, req.Id.Tenancy); err != nil {
+		return nil, err
 	}
-	if reg.Scope == resource.ScopeCluster {
-		if req.Id.Tenancy.Partition != "" {
-			return nil, status.Errorf(
-				codes.InvalidArgument,
-				"cluster scoped resource %s cannot have a partition: %s",
-				resource.ToGVK(req.Id.Type),
-				req.Id.Tenancy.Partition,
-			)
-		}
-		if req.Id.Tenancy.Namespace != "" {
-			return nil, status.Errorf(
-				codes.InvalidArgument,
-				"cluster scoped resource %s cannot have a namespace: %s",
-				resource.ToGVK(req.Id.Type),
-				req.Id.Tenancy.Namespace,
-			)
-		}
-	}
+
 	return reg, nil
 }

--- a/agent/grpc-external/services/resource/watch.go
+++ b/agent/grpc-external/services/resource/watch.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (s *Server) WatchList(req *pbresource.WatchListRequest, stream pbresource.ResourceService_WatchListServer) error {
-	reg, err := s.validateWatchListRequest(req)
+	reg, err := s.ensureWatchListRequestValid(req)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func (s *Server) WatchList(req *pbresource.WatchListRequest, stream pbresource.R
 	}
 }
 
-func (s *Server) validateWatchListRequest(req *pbresource.WatchListRequest) (*resource.Registration, error) {
+func (s *Server) ensureWatchListRequestValid(req *pbresource.WatchListRequest) (*resource.Registration, error) {
 	if req.Type == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "type is required")
 	}
@@ -104,7 +104,7 @@ func (s *Server) validateWatchListRequest(req *pbresource.WatchListRequest) (*re
 
 	// if no tenancy is passed defaults to wildcard
 	if req.Tenancy == nil {
-		req.Tenancy = getDefaultTenancy(reg.Scope)
+		req.Tenancy = wildcardTenancyFor(reg.Scope)
 	}
 
 	if err = checkV2Tenancy(s.UseV2Tenancy, req.Type); err != nil {
@@ -123,7 +123,7 @@ func (s *Server) validateWatchListRequest(req *pbresource.WatchListRequest) (*re
 	return reg, nil
 }
 
-func getDefaultTenancy(scope resource.Scope) *pbresource.Tenancy {
+func wildcardTenancyFor(scope resource.Scope) *pbresource.Tenancy {
 	var defaultTenancy *pbresource.Tenancy
 
 	switch scope {

--- a/agent/grpc-external/services/resource/watch.go
+++ b/agent/grpc-external/services/resource/watch.go
@@ -92,22 +92,19 @@ func (s *Server) WatchList(req *pbresource.WatchListRequest, stream pbresource.R
 }
 
 func (s *Server) validateWatchListRequest(req *pbresource.WatchListRequest) (*resource.Registration, error) {
-	var field string
-	switch {
-	case req.Type == nil:
-		field = "type"
-	case req.Tenancy == nil:
-		field = "tenancy"
-	}
-
-	if field != "" {
-		return nil, status.Errorf(codes.InvalidArgument, "%s is required", field)
+	if req.Type == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "type is required")
 	}
 
 	// Check type exists.
 	reg, err := s.resolveType(req.Type)
 	if err != nil {
 		return nil, err
+	}
+
+	// if no tenancy is passed defaults to wildcard
+	if req.Tenancy == nil {
+		req.Tenancy = getDefaultTenancy(reg.Scope)
 	}
 
 	if err = checkV2Tenancy(s.UseV2Tenancy, req.Type); err != nil {
@@ -118,15 +115,33 @@ func (s *Server) validateWatchListRequest(req *pbresource.WatchListRequest) (*re
 		return nil, err
 	}
 
-	// Error when partition scoped and namespace not empty.
-	if reg.Scope == resource.ScopePartition && req.Tenancy.Namespace != "" {
-		return nil, status.Errorf(
-			codes.InvalidArgument,
-			"partition scoped type %s cannot have a namespace. got: %s",
-			resource.ToGVK(req.Type),
-			req.Tenancy.Namespace,
-		)
+	// Check scope
+	if err = validateScopedTenancy(reg.Scope, req.Type, req.Tenancy); err != nil {
+		return nil, err
 	}
 
 	return reg, nil
+}
+
+func getDefaultTenancy(scope resource.Scope) *pbresource.Tenancy {
+	var defaultTenancy *pbresource.Tenancy
+
+	switch scope {
+	case resource.ScopeCluster:
+		defaultTenancy = &pbresource.Tenancy{
+			PeerName: storage.Wildcard,
+		}
+	case resource.ScopePartition:
+		defaultTenancy = &pbresource.Tenancy{
+			Partition: storage.Wildcard,
+			PeerName:  storage.Wildcard,
+		}
+	default:
+		defaultTenancy = &pbresource.Tenancy{
+			Partition: storage.Wildcard,
+			PeerName:  storage.Wildcard,
+			Namespace: storage.Wildcard,
+		}
+	}
+	return defaultTenancy
 }

--- a/agent/grpc-external/services/resource/watch_test.go
+++ b/agent/grpc-external/services/resource/watch_test.go
@@ -407,7 +407,6 @@ func TestWatchList_NoTenancy(t *testing.T) {
 	require.NoError(t, err)
 	rspCh := handleResourceStream(t, stream)
 
-	// Testcase will pick one of recordLabel or artist based on scope of type.
 	recordLabel, err := demo.GenerateV1RecordLabel("looney-tunes")
 	require.NoError(t, err)
 

--- a/agent/grpc-external/services/resource/watch_test.go
+++ b/agent/grpc-external/services/resource/watch_test.go
@@ -40,10 +40,6 @@ func TestWatchList_InputValidation(t *testing.T) {
 			modFn:       func(req *pbresource.WatchListRequest) { req.Type = nil },
 			errContains: "type is required",
 		},
-		"no tenancy": {
-			modFn:       func(req *pbresource.WatchListRequest) { req.Tenancy = nil },
-			errContains: "tenancy is required",
-		},
 		"partition mixed case": {
 			modFn:       func(req *pbresource.WatchListRequest) { req.Tenancy.Partition = "Default" },
 			errContains: "tenancy.partition invalid",
@@ -72,6 +68,20 @@ func TestWatchList_InputValidation(t *testing.T) {
 			modFn: func(req *pbresource.WatchListRequest) {
 				req.Type = demo.TypeV1RecordLabel
 				req.Tenancy.Namespace = "bad"
+			},
+			errContains: "cannot have a namespace",
+		},
+		"cluster scope with non-empty partition": {
+			modFn: func(req *pbresource.WatchListRequest) {
+				req.Type = demo.TypeV1Executive
+				req.Tenancy = &pbresource.Tenancy{Partition: "bad"}
+			},
+			errContains: "cannot have a partition",
+		},
+		"cluster scope with non-empty namespace": {
+			modFn: func(req *pbresource.WatchListRequest) {
+				req.Type = demo.TypeV1Executive
+				req.Tenancy = &pbresource.Tenancy{Namespace: "bad"}
 			},
 			errContains: "cannot have a namespace",
 		},
@@ -381,4 +391,32 @@ func handleResourceStream(t *testing.T, stream pbresource.ResourceService_WatchL
 type resourceOrError struct {
 	rsp *pbresource.WatchEvent
 	err error
+}
+
+func TestWatchList_NoTenancy(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	server := testServer(t)
+	client := testClient(t, server)
+	demo.RegisterTypes(server.Registry)
+
+	// Create a watch.
+	stream, err := client.WatchList(ctx, &pbresource.WatchListRequest{
+		Type: demo.TypeV1RecordLabel,
+	})
+	require.NoError(t, err)
+	rspCh := handleResourceStream(t, stream)
+
+	// Testcase will pick one of recordLabel or artist based on scope of type.
+	recordLabel, err := demo.GenerateV1RecordLabel("looney-tunes")
+	require.NoError(t, err)
+
+	// Create and verify upsert event received.
+	recordLabel, err = server.Backend.WriteCAS(ctx, recordLabel)
+	require.NoError(t, err)
+
+	rsp := mustGetResource(t, rspCh)
+
+	require.Equal(t, pbresource.WatchEvent_OPERATION_UPSERT, rsp.Operation)
+	prototest.AssertDeepEqual(t, recordLabel, rsp.Resource)
 }

--- a/agent/grpc-external/services/resource/write.go
+++ b/agent/grpc-external/services/resource/write.go
@@ -37,7 +37,7 @@ import (
 var errUseWriteStatus = status.Error(codes.InvalidArgument, "resource.status can only be set using the WriteStatus endpoint")
 
 func (s *Server) Write(ctx context.Context, req *pbresource.WriteRequest) (*pbresource.WriteResponse, error) {
-	reg, err := s.validateWriteRequest(req)
+	reg, err := s.ensureWriteRequestValid(req)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (s *Server) retryCAS(ctx context.Context, vsn string, cas func() error) err
 	return err
 }
 
-func (s *Server) validateWriteRequest(req *pbresource.WriteRequest) (*resource.Registration, error) {
+func (s *Server) ensureWriteRequestValid(req *pbresource.WriteRequest) (*resource.Registration, error) {
 	var field string
 	switch {
 	case req.Resource == nil:

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/hashicorp/consul/agent/consul/controller/queue"
 	"github.com/hashicorp/consul/internal/resource"
-	"github.com/hashicorp/consul/internal/storage"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
@@ -92,11 +91,6 @@ func runQueue[T queue.ItemType](ctx context.Context, ctrl Controller) queue.Work
 func (c *controllerRunner) watch(ctx context.Context, typ *pbresource.Type, add func(*pbresource.Resource)) error {
 	wl, err := c.client.WatchList(ctx, &pbresource.WatchListRequest{
 		Type: typ,
-		Tenancy: &pbresource.Tenancy{
-			Partition: storage.Wildcard,
-			PeerName:  storage.Wildcard,
-			Namespace: storage.Wildcard,
-		},
 	})
 	if err != nil {
 		c.logger.Error("failed to create watch", "error", err)


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Problem:
Since we were defaulting to watching all tenancy units by passing `*` regardless of the scope of the resource this caused the watch call in the controller to fail the validation check on the watch endpoint.

Solution:
In this PR I moved the defaulting of tenancy wildcards to the watch endpoint where scope is available to make the decision on necessary defaulting. This change also keeps us open to the possibility of allowing the controllers to watch for specific values in the tenancy fields as opposed to watching all (*).

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

Added test that demonstrates watches could be added on the partition and cluster scope resources.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->
Ticket:  [NET-6291](https://hashicorp.atlassian.net/browse/NET-6291)

### PR Checklist

* [x] updated test coverage
* [ ]~external facing docs updated~
* [x] appropriate backport labels added
* [ ] ~not a security concern~


[NET-6291]: https://hashicorp.atlassian.net/browse/NET-6291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ