### PR TITLE
Update typo in l7-traffic service splitting example

### DIFF
--- a/website/content/docs/connect/l7-traffic/index.mdx
+++ b/website/content/docs/connect/l7-traffic/index.mdx
@@ -44,13 +44,13 @@ Apply a [service router configuration entry](/consul/docs/connect/config-entries
 
 ### Splitting
 
-The second stage of the discovery chain is the service splitter. Service splitters split incoming requests and route them to different services or service subsets. Splitters enable staged canary rollouts, versioned releases, and similar use cases.  
+The second stage of the discovery chain is the service splitter. Service splitters split incoming requests and route them to different services or service subsets. Splitters enable staged canary rollouts, versioned releases, and similar use cases.
 
 Apply a [service splitter configuration entry](/consul/docs/connect/config-entries/service-splitter) to implement a splitter. Service splitters configuration entries can only reference other service splitters or service resolver configuration entries.
 
 ![screenshot of service splitter in the UI](/img/l7-routing/Splitter.png)
 
-If multiple service splitters are chained, Consul flattens the splits so that they behave as a single service spitter. In the following equation, `splitter[A]` references `splitter[B]`:
+If multiple service splitters are chained, Consul flattens the splits so that they behave as a single service spitter. In the following equation, `splitter[B]` references `splitter[A]`:
 
 ```text
 splitter[A]:           A_v1=50%, A_v2=50%


### PR DESCRIPTION
### Description

Update a typo in the L7 Traffic splitting example

### Testing & Reproduction steps


### Links


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
