### PR TITLE
NET-6319 - L7 routes have statePrefix of upstream. and should have a full path

### DIFF
--- a/agent/xdsv2/testdata/listeners/destination/mixed-multi-destination.golden
+++ b/agent/xdsv2/testdata/listeners/destination/mixed-multi-destination.golden
@@ -17,7 +17,7 @@
               "name":  "envoy.filters.network.http_connection_manager",
               "typedConfig":  {
                 "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix":  "upstream.",
+                "statPrefix":  "upstream.http.api-1.default.default.dc1",
                 "rds":  {
                   "configSource":  {
                     "ads":  {},

--- a/agent/xdsv2/testdata/listeners/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
+++ b/agent/xdsv2/testdata/listeners/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
@@ -47,7 +47,7 @@
               "name":  "envoy.filters.network.http_connection_manager",
               "typedConfig":  {
                 "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix":  "upstream.",
+                "statPrefix":  "upstream.http.api-app.default.default.dc1",
                 "rds":  {
                   "configSource":  {
                     "ads":  {},
@@ -140,7 +140,7 @@
               "name":  "envoy.filters.network.http_connection_manager",
               "typedConfig":  {
                 "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix":  "upstream.",
+                "statPrefix":  "upstream.http.api-app2.default.default.dc1",
                 "rds":  {
                   "configSource":  {
                     "ads":  {},

--- a/agent/xdsv2/testdata/listeners/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
+++ b/agent/xdsv2/testdata/listeners/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
@@ -47,7 +47,7 @@
               "name":  "envoy.filters.network.http_connection_manager",
               "typedConfig":  {
                 "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix":  "upstream.",
+                "statPrefix":  "upstream.http.api-app.default.default.dc1",
                 "rds":  {
                   "configSource":  {
                     "ads":  {},

--- a/agent/xdsv2/testdata/listeners/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
+++ b/agent/xdsv2/testdata/listeners/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
@@ -47,7 +47,7 @@
               "name":  "envoy.filters.network.http_connection_manager",
               "typedConfig":  {
                 "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix":  "upstream.",
+                "statPrefix":  "upstream.http.api-app.default.default.dc1",
                 "rds":  {
                   "configSource":  {
                     "ads":  {},

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destinations.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destinations.go
@@ -248,7 +248,7 @@ func (b *Builder) buildDestination(
 			panic(fmt.Sprintf("it should not be possible to have a tcp protocol here: %v", effectiveProtocol))
 		}
 
-		rb := lb.addL7Router(routeName, "", effectiveProtocol)
+		rb := lb.addL7Router(routeName, statPrefix, effectiveProtocol)
 		if destination.Explicit == nil {
 			rb.addIPAndPortMatch(destination.VirtualIPs, virtualPortNumber)
 		}
@@ -372,7 +372,7 @@ func (b *ListenerBuilder) addL4RouterForDirect(clusterName, statPrefix string) *
 	router := &pbproxystate.Router{}
 
 	if statPrefix == "" {
-		statPrefix = "upstream."
+		statPrefix = fmt.Sprintf("upstream.%s", clusterName)
 	}
 
 	router.Destination = &pbproxystate.Router_L4{

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/mixed-multi-destination.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/mixed-multi-destination.golden
@@ -234,7 +234,7 @@
               "route": {
                 "name": "default/local/default/api-1:http:1.1.1.1:1234"
               },
-              "statPrefix": "upstream."
+              "statPrefix": "upstream.http.api-1.default.default.dc1"
             }
           }
         ]

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
@@ -257,7 +257,7 @@
               "route": {
                 "name": "default/local/default/api-app:http"
               },
-              "statPrefix": "upstream."
+              "statPrefix": "upstream.http.api-app.default.default.dc1"
             },
             "match": {
               "destinationPort": 8080,
@@ -274,7 +274,7 @@
               "route": {
                 "name": "default/local/default/api-app2:http"
               },
-              "statPrefix": "upstream."
+              "statPrefix": "upstream.http.api-app2.default.default.dc1"
             },
             "match": {
               "destinationPort": 8080,

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
@@ -152,7 +152,7 @@
               "route": {
                 "name": "default/local/default/api-app:http"
               },
-              "statPrefix": "upstream."
+              "statPrefix": "upstream.http.api-app.default.default.dc1"
             },
             "match": {
               "destinationPort": 8080,

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
@@ -152,7 +152,7 @@
               "route": {
                 "name": "default/local/default/api-app:http"
               },
-              "statPrefix": "upstream."
+              "statPrefix": "upstream.http.api-app.default.default.dc1"
             },
             "match": {
               "destinationPort": 8080,

--- a/internal/mesh/internal/controllers/xds/testdata/destination/mixed-multi-destination.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/mixed-multi-destination.golden
@@ -285,7 +285,7 @@
             "route": {
               "name": "default/local/default/api-1:http:1.1.1.1:1234"
             },
-            "statPrefix": "upstream."
+            "statPrefix": "upstream.http.api-1.default.default.dc1"
           }
         }
       ]

--- a/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-multiple-implicit-destinations-tproxy.golden
@@ -330,7 +330,7 @@
             "route": {
               "name": "default/local/default/api-app:http"
             },
-            "statPrefix": "upstream."
+            "statPrefix": "upstream.http.api-app.default.default.dc1"
           },
           "match": {
             "destinationPort": 8080,
@@ -347,7 +347,7 @@
             "route": {
               "name": "default/local/default/api-app2:http"
             },
-            "statPrefix": "upstream."
+            "statPrefix": "upstream.http.api-app2.default.default.dc1"
           },
           "match": {
             "destinationPort": 8080,

--- a/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-tproxy.golden
@@ -192,7 +192,7 @@
             "route": {
               "name": "default/local/default/api-app:http"
             },
-            "statPrefix": "upstream."
+            "statPrefix": "upstream.http.api-app.default.default.dc1"
           },
           "match": {
             "destinationPort": 8080,

--- a/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
+++ b/internal/mesh/internal/controllers/xds/testdata/destination/multiport-l4-and-l7-single-implicit-destination-with-multiple-workloads-tproxy.golden
@@ -192,7 +192,7 @@
             "route": {
               "name": "default/local/default/api-app:http"
             },
-            "statPrefix": "upstream."
+            "statPrefix": "upstream.http.api-app.default.default.dc1"
           },
           "match": {
             "destinationPort": 8080,


### PR DESCRIPTION
### Description

Sidecar proxy's builder is setting L7 destinations to have `statPrefix` of "upstream."  if you search `"statePrefix": ` in V1 golden files, you will not find any set to "upstream.", they have the full path.  

This was from implementing this check form V1 code.  However, if you follow the code further, it will wind up [here](https://github.com/hashicorp/consul/blob/413e2a76002b27c3ab4b0670c5daa11e1d0ff65b/agent/xds/listeners.go#L2468), where further calculates the `statPrefix` that is actually used.


### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
