### PR TITLE
[CI-only] Build darwin artifacts on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
 
   build-darwin:
     needs: set-product-version
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         goos: [ darwin ]
@@ -274,7 +274,7 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |-
-            go build -ldflags="$GOLDFLAGS" -tags netcgo -o "$BIN_PATH" -trimpath -buildvcs=false
+            go build -ldflags="$GOLDFLAGS" -o "$BIN_PATH" -trimpath -buildvcs=false
 
   build-docker:
     name: Docker ${{ matrix.arch }} build


### PR DESCRIPTION
### Description

Version 1.20 of Go fixed a significant issue affecting Consul's ability to resolve DNS correctly on MacOS when cross-compiling from linux: https://github.com/golang/go/issues/12524. Building Consul darwin artifacts on Mac executors, and setting the netcgo flag, was a temporary solution to resolve this limitation in go source (introduced over in https://github.com/hashicorp/consul/pull/12178). Now that Consul is being built with [1.20.10](https://github.com/hashicorp/consul/blob/main/.github/workflows/build.yml#L237), we should be ok to remove this temporary fix. 

More detail is available here: https://danp.net/posts/macos-dns-change-in-go-1-20/ 

### Testing

Pending. Please don't review/merge until tests are complete and shared here. Thanks! 
