### PR TITLE
build: ensure we pull through the hashicorp proxy instead of going directly to the docker hub

### DIFF
--- a/build-support/docker/Consul-Dev-Multiarch.dockerfile
+++ b/build-support/docker/Consul-Dev-Multiarch.dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 ARG CONSUL_IMAGE_VERSION=latest
-FROM hashicorp/consul:${CONSUL_IMAGE_VERSION}
+FROM docker.mirror.hashicorp.services/hashicorp/consul:${CONSUL_IMAGE_VERSION}
 RUN apk update && apk add iptables
 ARG TARGETARCH
 COPY linux_${TARGETARCH}/consul /bin/consul

--- a/build-support/docker/Consul-Dev.dockerfile
+++ b/build-support/docker/Consul-Dev.dockerfile
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 ARG CONSUL_IMAGE_VERSION=latest
-FROM hashicorp/consul:${CONSUL_IMAGE_VERSION}
+FROM docker.mirror.hashicorp.services/hashicorp/consul:${CONSUL_IMAGE_VERSION}
 RUN apk update && apk add iptables
 COPY consul /bin/consul


### PR DESCRIPTION
### Description

This should remove the following reason integration tests can flake:

```
#3 [internal] load metadata for docker.io/hashicorp/consul:latest
#3 ERROR: pulling from host registry-1.docker.io failed with status code [manifests latest]: 429 Too Many Requests
------
 > [internal] load metadata for docker.io/hashicorp/consul:latest:
------
Consul-Dev.dockerfile:5
--------------------
   3 |     
   4 |     ARG CONSUL_IMAGE_VERSION=latest
   5 | >>> FROM hashicorp/consul:${CONSUL_IMAGE_VERSION}
   6 |     RUN apk update && apk add iptables
   7 |     COPY consul /bin/consul
--------------------
ERROR: failed to solve: hashicorp/consul:latest: pulling from host registry-1.docker.io failed with status code [manifests latest]: 4[29](https://github.com/hashicorp/consul/actions/runs/6735998317/job/18310522716?pr=19046#step:7:30) Too Many Requests
Error: Process completed with exit code 1.
```
