### PR TITLE
testing: disable v2 linkage to nodes in integration tests

### DIFF
--- a/testing/deployer/sprawl/catalog.go
+++ b/testing/deployer/sprawl/catalog.go
@@ -297,7 +297,16 @@ func (s *Sprawl) registerCatalogNode(
 	node *topology.Node,
 ) error {
 	if node.IsV2() {
-		return s.registerCatalogNodeV2(cluster, node)
+
+		// TODO(rb): nodes are optional in v2 and won't be used in k8s by
+		// default. There are some scoping issues with the Node Type in 1.17 so
+		// disable it for now.
+		//
+		// To re-enable you also need to link it to the Workload by setting the
+		// NodeName field.
+		//
+		// return s.registerCatalogNodeV2(cluster, node)
+		return nil
 	}
 	return s.registerCatalogNodeV1(cluster, node)
 }
@@ -538,7 +547,8 @@ func serviceInstanceToResources(
 				Metadata: svc.Meta,
 			},
 			Data: &pbcatalog.Workload{
-				NodeName: node.PodName(),
+				// TODO(rb): disabling this until node scoping makes sense again
+				// NodeName: node.PodName(),
 				Identity: svc.ID.Name,
 				Ports:    wlPorts,
 				Addresses: []*pbcatalog.WorkloadAddress{


### PR DESCRIPTION
### Description

In 1.17 the catalog.v2beta1.Node type is of the namespace scope, which is incorrect. It should be a partition scoped type, but it needed to have the same tenancy scoping as the shared health status type for different reasons.

Until we create a new node health status type, update the `deployer` tests to not try and create workload-to-node linkages as they will not work properly in 1.17.
