### PR TITLE
test/deployer: add the method of deregistering services

### DIFF
--- a/test-integ/connect/snapshot_test.go
+++ b/test-integ/connect/snapshot_test.go
@@ -204,7 +204,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 	// Add a new static-server
 	cfg = sp.Config()
 	cluster = cfg.Cluster("dc1")
-	cluster.Nodes[3].Disabled = false //  client 3 -- static-server
+	cluster.Nodes[3].Disabled = false //  client 3 -- new static-server
 	require.NoError(t, sp.Relaunch(cfg))
 
 	// Ensure the static-client connected to static-server


### PR DESCRIPTION
### Description

For certain test scenarios, we need to detect if server agent can update the service endpoint after some instances are removed during relaunch (e.g.,[ the snapshot restore scenario](https://github.com/hashicorp/consul/blob/e5948e8eb4181011639b7f017fc0687135b286fa/test-integ/connect/snapshot_test.go#L197-L202)). In this case, the service instance needs to be removed from the catalog.

This PR adds the method of deregistering the services when a node is disabled during relaunch.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
