### PR TITLE
v2tenancy: register tenancy controller deps

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -937,7 +937,10 @@ func isV1CatalogRequest(rpcName string) bool {
 func (s *Server) registerControllers(deps Deps, proxyUpdater ProxyUpdater) error {
 	// When not enabled, the v1 tenancy bridge is used by default.
 	if s.useV2Tenancy {
-		tenancy.RegisterControllers(s.controllerManager)
+		tenancy.RegisterControllers(
+			s.controllerManager,
+			tenancy.Dependencies{Registry: deps.Registry},
+		)
 	}
 
 	if s.useV2Resources {

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 
-	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
@@ -68,7 +67,7 @@ func (m *Manager) Run(ctx context.Context) {
 	for _, desc := range m.controllers {
 		logger := desc.logger
 		if logger == nil {
-			logger = m.logger.With("managed_type", resource.ToGVK(desc.managedType))
+			logger = m.logger.With("managed_type", desc.managedType.Kind)
 		}
 
 		runner := &controllerRunner{

--- a/internal/resource/resourcetest/client.go
+++ b/internal/resource/resourcetest/client.go
@@ -231,6 +231,17 @@ func (client *Client) WaitForStatusCondition(t T, id *pbresource.ID, statusKey s
 	return res
 }
 
+func (client *Client) WaitForStatusConditionAnyGen(t T, id *pbresource.ID, statusKey string, condition *pbresource.Condition) *pbresource.Resource {
+	t.Helper()
+
+	var res *pbresource.Resource
+	client.retry(t, func(r *retry.R) {
+		res = client.RequireStatusCondition(r, id, statusKey, condition)
+	})
+
+	return res
+}
+
 func (client *Client) WaitForStatusConditions(t T, id *pbresource.ID, statusKey string, conditions ...*pbresource.Condition) *pbresource.Resource {
 	t.Helper()
 

--- a/internal/tenancy/exports.go
+++ b/internal/tenancy/exports.go
@@ -23,10 +23,12 @@ func RegisterTypes(r resource.Registry) {
 
 // RegisterControllers registers controllers for the tenancy types with
 // the given controller manager.
-func RegisterControllers(mgr *controller.Manager) {
-	controllers.Register(mgr)
+func RegisterControllers(mgr *controller.Manager, deps Dependencies) {
+	controllers.Register(mgr, deps)
 }
 
 func NewV2TenancyBridge() *V2TenancyBridge {
 	return bridge.NewV2TenancyBridge()
 }
+
+type Dependencies = controllers.Dependencies

--- a/internal/tenancy/internal/controllers/register.go
+++ b/internal/tenancy/internal/controllers/register.go
@@ -1,0 +1,12 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package controllers
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+)
+
+type Dependencies struct {
+	Registry resource.Registry
+}

--- a/internal/tenancy/internal/controllers/register_ce.go
+++ b/internal/tenancy/internal/controllers/register_ce.go
@@ -9,6 +9,6 @@ import (
 	"github.com/hashicorp/consul/internal/controller"
 )
 
-func Register(mgr *controller.Manager) {
+func Register(mgr *controller.Manager, deps Dependencies) {
 	//mgr.Register(namespace.NamespaceController())
 }


### PR DESCRIPTION
### Description

CE version of merged ENT PR: https://github.com/hashicorp/consul-enterprise/pull/7597

https://hashicorp.atlassian.net/browse/NET-6334

Since the namespace controller (when it is written in CE) will also need access to the registry, I went ahead and exposed the deps in CE.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
