### PR TITLE
Ci upgrade test 1 17

### DIFF
--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -193,10 +193,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consul-version: [ "1.15", "1.16"]
+        consul-version: [ "1.16", "1.17"]
     env:
       CONSUL_LATEST_VERSION: ${{ matrix.consul-version }}
-      ENVOY_VERSION: "1.24.6"
+      ENVOY_VERSION: "1.25.4"
     steps:
       - name: Checkout code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/test/integration/consul-container/test/upgrade/catalog/catalog_test.go
+++ b/test/integration/consul-container/test/upgrade/catalog/catalog_test.go
@@ -60,7 +60,7 @@ func TestCatalogUpgrade(t *testing.T) {
 	cluster, _, _ := topology.NewCluster(t, &topology.ClusterConfig{
 		NumServers:                1,
 		BuildOpts:                 buildOpts,
-		ApplyDefaultProxySettings: true,
+		ApplyDefaultProxySettings: false,
 		Cmd:                       `-hcl=experiments=["resource-apis"]`,
 	})
 


### PR DESCRIPTION
### Description

- Bump upgrade test for 1.17
- In `TestCatalogUpgrade`,  disable V1 API request since this test is for V2

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
