### PR TITLE
test: fix some of the peering topology tests to safely run without tenancy in CE

### DIFF
--- a/test-integ/peering_commontopo/commontopo.go
+++ b/test-integ/peering_commontopo/commontopo.go
@@ -327,8 +327,8 @@ func (ct *commonTopo) ExportService(clu *topology.Cluster, partition string, svc
 	if !found {
 		clu.InitialConfigEntries = append(clu.InitialConfigEntries,
 			&api.ExportedServicesConfigEntry{
-				Name:      partition, // this NEEDs to be "default" in CE
-				Partition: ConfigEntryPartition(partition),
+				Name:      topology.PartitionOrDefault(partition), // this NEEDs to be "default" in CE
+				Partition: topology.DefaultToEmpty(partition),
 				Services:  svcs,
 			},
 		)

--- a/test-integ/topoutil/fixtures.go
+++ b/test-integ/topoutil/fixtures.go
@@ -105,7 +105,7 @@ func NewTopologyMeshGatewaySet(
 
 		node := &topology.Node{
 			Kind:      nodeKind,
-			Partition: partition,
+			Partition: sid.Partition,
 			Name:      name,
 			Services: []*topology.Service{{
 				ID:             sid,

--- a/testing/deployer/sprawl/peering.go
+++ b/testing/deployer/sprawl/peering.go
@@ -208,10 +208,7 @@ func (s *Sprawl) awaitMeshGateways() {
 		logger.Info("awaiting MGW readiness")
 	RETRY:
 		// TODO: not sure if there's a better way to check if the MGW is ready
-		svcs, _, err := cl.Catalog().Service(mgw.ID.Name, "", &api.QueryOptions{
-			Namespace: mgw.ID.Namespace,
-			Partition: mgw.ID.Partition,
-		})
+		svcs, _, err := cl.Catalog().Service(mgw.ID.Name, "", mgw.ID.QueryOptions())
 		if err != nil {
 			logger.Debug("fetching MGW service", "err", err)
 			time.Sleep(time.Second)
@@ -227,10 +224,7 @@ func (s *Sprawl) awaitMeshGateways() {
 			log.Fatalf("expected 1 MGW service, actually: %#v", svcs)
 		}
 
-		entries, _, err := cl.Health().Service(mgw.ID.Name, "", true, &api.QueryOptions{
-			Namespace: mgw.ID.Namespace,
-			Partition: mgw.ID.Partition,
-		})
+		entries, _, err := cl.Health().Service(mgw.ID.Name, "", true, mgw.ID.QueryOptions())
 		if err != nil {
 			logger.Debug("fetching MGW checks", "err", err)
 			time.Sleep(time.Second)

--- a/testing/deployer/topology/ids.go
+++ b/testing/deployer/topology/ids.go
@@ -125,6 +125,13 @@ func (id ServiceID) NamespaceOrDefault() string {
 	return NamespaceOrDefault(id.Namespace)
 }
 
+func (id ServiceID) QueryOptions() *api.QueryOptions {
+	return &api.QueryOptions{
+		Partition: DefaultToEmpty(id.Partition),
+		Namespace: DefaultToEmpty(id.Namespace),
+	}
+}
+
 func PartitionOrDefault(name string) string {
 	if name == "" {
 		return "default"


### PR DESCRIPTION
### Description

https://github.com/hashicorp/consul/pull/19504 promoted some tests authored in enterprise to also run in CE. Since they were not running in both variations a few places were still passing non-empty tenancy fields which does not work in v1.

Additionally these test failures were missed before that PR was merged because these tests are only run nightly.
