### PR TITLE
ui: Clear peer on home link

### DIFF
--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -80,8 +80,8 @@
             <Hds::SideNav::Header::HomeLink
               @icon='consul-color'
               @ariaLabel='Consul'
-              @route='index'
-              @query={{hash peer=undefined}}
+              @href={{href-to 'index' params=(hash peer=undefined)}}
+              @isHrefExternal={{false}}
             />
           </:logo>
           <:actions>


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Clear the peer on home logo link. 

The peer params was not being cleared when returning to consul home page.

![2023-11-07 08-44-38 2023-11-07 08_45_36](https://github.com/hashicorp/consul/assets/5448834/d8505e40-1616-4ff9-8bbf-8830ab6fc1eb)


### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
