### PR TITLE
test: update makefile to include ways to trigger deployer integration tests

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -510,7 +510,7 @@ jobs:
           go-version-file: 'go.mod'
       - run: go env
       - name: Build image
-        run: make test-compat-integ-setup
+        run: make test-deployer-setup
       - name: Integration Tests
         run: |
           mkdir -p "${{ env.TEST_RESULTS_DIR }}"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ SHELL = bash
 
 GO_MODULES := $(shell find . -name go.mod -exec dirname {} \; | grep -v "proto-gen-rpc-glue/e2e" | sort)
 
-
 ###
 # These version variables can either be a valid string for "go install <module>@<version>"
 # or the string @DEV to imply use what is currently installed locally.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SHELL = bash
 
 GO_MODULES := $(shell find . -name go.mod -exec dirname {} \; | grep -v "proto-gen-rpc-glue/e2e" | sort)
 
+
 ###
 # These version variables can either be a valid string for "go install <module>@<version>"
 # or the string @DEV to imply use what is currently installed locally.
@@ -67,6 +68,7 @@ BUILD_CONTAINER_NAME?=consul-builder
 CONSUL_IMAGE_VERSION?=latest
 ENVOY_VERSION?='1.25.4'
 CONSUL_DATAPLANE_IMAGE := $(or $(CONSUL_DATAPLANE_IMAGE),"docker.io/hashicorppreview/consul-dataplane:1.3-dev-ubi")
+DEPLOYER_CONSUL_DATAPLANE_IMAGE := $(or $(DEPLOYER_CONSUL_DATAPLANE_IMAGE), "docker.io/hashicorppreview/consul-dataplane:1.3-dev")
 
 CONSUL_VERSION?=$(shell cat version/VERSION)
 
@@ -339,20 +341,67 @@ other-consul: ## Checking for other consul instances
 # NOTE: Always uses amd64 images, even when running on M1 macs, to match CI/CD environment.
 #       You can also specify the envoy version (example: 1.27.0) setting the environment variable: ENVOY_VERSION=1.27.0
 .PHONY: test-envoy-integ
-test-envoy-integ: $(ENVOY_INTEG_DEPS) ## Run integration tests.
+test-envoy-integ: $(ENVOY_INTEG_DEPS) ## Run envoy integration tests.
 	@go test -v -timeout=30m -tags integration $(GO_TEST_FLAGS) ./test/integration/connect/envoy
 
 # NOTE: Use DOCKER_BUILDKIT=0, if docker build fails to resolve consul:local base image
 .PHONY: test-compat-integ-setup
-test-compat-integ-setup: dev-docker
-	@docker tag consul-dev:latest $(CONSUL_COMPAT_TEST_IMAGE):local
-	@docker run --rm -t $(CONSUL_COMPAT_TEST_IMAGE):local consul version
+test-compat-integ-setup: test-deployer-setup
 	@#  'consul-envoy:target-version' is needed by compatibility integ test
 	@docker build -t consul-envoy:target-version --build-arg CONSUL_IMAGE=$(CONSUL_COMPAT_TEST_IMAGE):local --build-arg ENVOY_VERSION=${ENVOY_VERSION} -f ./test/integration/consul-container/assets/Dockerfile-consul-envoy ./test/integration/consul-container/assets
 	@docker build -t consul-dataplane:local --build-arg CONSUL_IMAGE=$(CONSUL_COMPAT_TEST_IMAGE):local --build-arg CONSUL_DATAPLANE_IMAGE=${CONSUL_DATAPLANE_IMAGE} -f ./test/integration/consul-container/assets/Dockerfile-consul-dataplane ./test/integration/consul-container/assets
 
+# NOTE: Use DOCKER_BUILDKIT=0, if docker build fails to resolve consul:local base image
+.PHONY: test-deployer-setup
+test-deployer-setup: dev-docker
+	@docker tag consul-dev:latest $(CONSUL_COMPAT_TEST_IMAGE):local
+	@docker run --rm -t $(CONSUL_COMPAT_TEST_IMAGE):local consul version
+
+.PHONY: test-deployer
+test-deployer: test-deployer-setup ## Run deployer-based integration tests (skipping peering_commontopo).
+	@cd ./test-integ && \
+		NOLOGBUFFER=1 \
+		TEST_LOG_LEVEL=debug \
+		DEPLOYER_CONSUL_DATAPLANE_IMAGE=$(DEPLOYER_CONSUL_DATAPLANE_IMAGE) \
+		gotestsum \
+		--raw-command \
+		--format=standard-verbose \
+		--debug \
+		-- \
+		go test \
+		-tags "$(GOTAGS)" \
+		-timeout=20m \
+		-json \
+		$(shell sh -c "cd test-integ ; go list -tags \"$(GOTAGS)\" ./... | grep -v peering_commontopo") \
+		--target-image $(CONSUL_COMPAT_TEST_IMAGE) \
+		--target-version local \
+		--latest-image $(CONSUL_COMPAT_TEST_IMAGE) \
+		--latest-version latest
+
+.PHONY: test-deployer-peering
+test-deployer-peering: test-deployer-setup ## Run deployer-based integration tests (just peering_commontopo).
+	@cd ./test-integ/peering_commontopo && \
+		NOLOGBUFFER=1 \
+		TEST_LOG_LEVEL=debug \
+		DEPLOYER_CONSUL_DATAPLANE_IMAGE=$(DEPLOYER_CONSUL_DATAPLANE_IMAGE) \
+		gotestsum \
+		--raw-command \
+		--format=standard-verbose \
+		--debug \
+		-- \
+		go test \
+		-tags "$(GOTAGS)" \
+		-timeout=20m \
+		-json \
+		. \
+		--target-image $(CONSUL_COMPAT_TEST_IMAGE) \
+		--target-version local \
+		--latest-image $(CONSUL_COMPAT_TEST_IMAGE) \
+		--latest-version latest
+
+
 .PHONY: test-compat-integ
-test-compat-integ: test-compat-integ-setup ## Test compat integ
+test-compat-integ: test-compat-integ-setup ## Run consul-container based integration tests.
 ifeq ("$(GOTESTSUM_PATH)","")
 	@cd ./test/integration/consul-container && \
 	go test \

--- a/test-integ/peering_commontopo/README.md
+++ b/test-integ/peering_commontopo/README.md
@@ -5,7 +5,7 @@ These peering tests all use a `commonTopo` (read: "common topology") to enable s
 To run these tests, you will need to have docker installed. Next, make sure that you have all the required consul containers built:
 
 ```
-make test-compat-integ-setup
+make test-deployer-setup
 ```
 
 ## Non-Shared CommonTopo Tests

--- a/test-integ/topoutil/images.go
+++ b/test-integ/topoutil/images.go
@@ -24,7 +24,7 @@ func TargetImages() topology.Images {
 	}
 
 	// We want the image overridden by the local build produced by
-	// 'make test-compat-integ-setup' or 'make dev-docker'.
+	// 'make test-deployer-setup' or 'make dev-docker'.
 	testImages := utils.TargetImages()
 	images = images.OverrideWith(testImages)
 


### PR DESCRIPTION
### Description

```
$ make help | grep deployer
  test-deployer    Run deployer-based integration tests (skipping peering_commontopo).
  test-deployer-peering  Run deployer-based integration tests (just peering_commontopo).
```

It also creates a `make test-deployer-setup` which is like `make test-compat-integ-setup` without the envoy/dataplane steps, which are handled elsewhere with deployer.