### PR TITLE
Fix typo in GatewayClassConfig docs

### DIFF
--- a/website/content/docs/connect/gateways/api-gateway/configuration/gatewayclassconfig.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/gatewayclassconfig.mdx
@@ -38,7 +38,7 @@ The following outline shows how to format the configurations in the `GatewayClas
   * [`consulAPIGateway`](#image-consulapigateway): string | optional
   * [`envoy`](#image-envoy): string | optional
 * [`logLevel`](#loglevel): string | optional
-* [`matchPrivilegedContainerPorts`](#matchPrivilegedContainerPorts): integer | optional
+* [`mapPrivilegedContainerPorts`](#mapPrivilegedContainerPorts): integer | optional
 * [`nodeSelector`](#nodeselector): string | optional
 * [`openshiftSCCName`](#openshiftSCCName): string | optional
 * [`serviceType`](#servicetype): string | optional
@@ -154,8 +154,8 @@ You can specify the following strings:
 * `debug`
 * `trace`
 
-### matchPrivilegedContainerPorts
-Specifies a value that Consul adds to privileged ports defined in the gateway. Privileged ports are port numbers less than 1024 and some platforms, such as Red Hat OpenShift, explicitly configure Kubernetes to avoid running containers on privileged ports. The total value of the configured port number and the `matchPriviledgedContainerPorts` value must not exceed 65535, which is the highest possible TCP port number allowed.
+### mapPrivilegedContainerPorts
+Specifies a value that Consul adds to privileged ports defined in the gateway. Privileged ports are port numbers less than 1024 and some platforms, such as Red Hat OpenShift, explicitly configure Kubernetes to avoid running containers on privileged ports. The total value of the configured port number and the `mapPriviledgedContainerPorts` value must not exceed 65535, which is the highest possible TCP port number allowed.
 for gateway containers
 * Type: Integer
 * Required: optional

--- a/website/content/docs/connect/gateways/api-gateway/configuration/gatewayclassconfig.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/gatewayclassconfig.mdx
@@ -28,8 +28,8 @@ The following outline shows how to format the configurations in the `GatewayClas
     * [`grpc`](#consul-ports-grpc): integer | optional
     * [`http`](#consul-ports-http): integer | optional
   * [`scheme`](#consul-scheme): string  | optional
-* [`copyAnnotations`](#copyAnnotations): object | optional
-  * [`service`](#copyAnnotations-service): array of strings | optional
+* [`copyAnnotations`](#copyannotations): object | optional
+  * [`service`](#copyannotations-service): array of strings | optional
 * [`deployment`](#deployment): object | optional
   * [`defaultInstances`](#deployment-defaultinstances): integer | optional
   * [`maxInstances`](#deployment-maxinstances): integer | optional
@@ -38,9 +38,9 @@ The following outline shows how to format the configurations in the `GatewayClas
   * [`consulAPIGateway`](#image-consulapigateway): string | optional
   * [`envoy`](#image-envoy): string | optional
 * [`logLevel`](#loglevel): string | optional
-* [`mapPrivilegedContainerPorts`](#mapPrivilegedContainerPorts): integer | optional
+* [`mapPrivilegedContainerPorts`](#mapprivilegedcontainerports): integer | optional
 * [`nodeSelector`](#nodeselector): string | optional
-* [`openshiftSCCName`](#openshiftSCCName): string | optional
+* [`openshiftSCCName`](#openshiftsccname): string | optional
 * [`serviceType`](#servicetype): string | optional
 * [`useHostPorts`](#usehostports): boolean | optional
 


### PR DESCRIPTION
### Description
Fixes typo in docs for `GatewayClassConfig`

### Testing & Reproduction steps
Visual inspection

### Links
Typo can be found [here](https://developer.hashicorp.com/consul/docs/connect/gateways/api-gateway/configuration/gatewayclassconfig#matchprivilegedcontainerports)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
