### PR TITLE
Update links and fix route kind for APIGW JWT Docs

### DIFF
--- a/website/content/docs/connect/config-entries/http-route.mdx
+++ b/website/content/docs/connect/config-entries/http-route.mdx
@@ -86,6 +86,12 @@ to view additional details, including default values.
       - [`TimeoutFilter`](#rules-services-filters-timeoutfilter): map
         - [`IdleTimeout`](#rules-services-filters-timeoutfilter): number | `0`
         - [`RequestTimeout`](#rules-services-filters-timeoutfilter): number | `0`
+      - [`JWT`](#rules-filters-jwt): map
+           - [`Providers`](#rules-filters-jwt-providers): list
+              - [`Name`](#rules-filters-jwt-providers): string
+              - [`VerifyClaims`](#rules-filters-jwt-providers): map
+                 - [`Path`](#rules-filters-jwt-providers): list
+                 - [`Value`](#rules-filters-jwt-providers): string
     - [`ResponseFilters`](#rules-services-responsefilters)
       - [`Headers`](#rules-services-responsefilters-headers): list | no default
         - [`Add`](#rules-services-responsefilters-headers-add): map | no default

--- a/website/content/docs/connect/gateways/api-gateway/secure-traffic/verify-jwts-k8s.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/secure-traffic/verify-jwts-k8s.mdx
@@ -6,25 +6,25 @@ description: Learn how to use JSON web tokens (JWT) to verify requests from exte
 
 # Use JWTs to verify requests to API gateways on Kubernetes
 
-This topic describes how to use JSON web tokens (JWT) to verify requests to API gateways deployed to Kubernetes-orchestrated containers. If your API gateway is deployed to virtual machines, refer to [Use JWTs to verify requests to API gateways on VMs](/consu/docs/connect/gateways/api-gateway/secure-traffic/verify-jwts-vms).
+This topic describes how to use JSON web tokens (JWT) to verify requests to API gateways deployed to Kubernetes-orchestrated containers. If your API gateway is deployed to virtual machines, refer to [Use JWTs to verify requests to API gateways on VMs](/consul/docs/connect/gateways/api-gateway/secure-traffic/verify-jwts-vms).
 
 <EnterpriseAlert> This feature is available in Consul Enterprise. </EnterpriseAlert>
 
 ## Overview
- 
+
 You can configure API gateways to use JWTs to verify incoming requests so that you can stop unverified traffic at the gateway. You can configure JWT verification at different levels:
 
 - Listener defaults: Define basic defaults that apply to all routes attached to a listener.
-- HTTP route-specific settings: You can define JWT authentication settings for specific HTTP routes. Route-specific JWT settings override default listener configurations. 
+- HTTP route-specific settings: You can define JWT authentication settings for specific HTTP routes. Route-specific JWT settings override default listener configurations.
 - Listener overrides: Define override settings that take precedence over default and route-specific configurations. This enables you to set enforceable policies for listeners.
 
 
 Complete the following steps to use JWTs to verify requests:
 
-1. Define a policy that specifies default and override settings for API gateway listeners and attach it to the gateway.   
+1. Define a policy that specifies default and override settings for API gateway listeners and attach it to the gateway.
 1. Define an HTTP route auth filter that specifies route-specific JWT verification settings.
-1. Attach the auth filter to the HTTP route values file. 
-1. Apply the configurations. 
+1. Attach the auth filter to the HTTP route values file.
+1. Apply the configurations.
 
 
 ## Requirements
@@ -35,34 +35,34 @@ Complete the following steps to use JWTs to verify requests:
 
 ## Define override and default settings
 
-Create a `GatewayPolicy` values file and configure the following fields to define default and override settings for JWT verification. Refer to [`GatewayPolicy` configuration reference](/consul/docs/connect/gateways/api-gateway/configuration/gatewaypolicy) for details.  
+Create a `GatewayPolicy` values file and configure the following fields to define default and override settings for JWT verification. Refer to [`GatewayPolicy` configuration reference](/consul/docs/connect/gateways/api-gateway/configuration/gatewaypolicy) for details.
 
 - `kind`: Must be set to `GatewayPolicy`
 - `metadata.name`: Specifies a name for the policy.
 - `spec.targetRef.name`: Specifies the name of the API gateway to attach the policy to.
-- `spec.targetRef.kind`: Specifies the kind of resource to attach to the policy to. Must be set to `Gateway`. 
+- `spec.targetRef.kind`: Specifies the kind of resource to attach to the policy to. Must be set to `Gateway`.
 - `spec.targetRef.group`: Specifies the resource group. Unless you have created a custom group, this should be set to `gateway.networking.kuberenetes.io`.
 - `spec.targetRef.sectionName`: Specifies a part of the gateway that the policy applies to.
-- `spec.targetRef.override.jwt.providers`: Specifies a list of providers and claims used to verify requests to the gateway. The override settings take precedence over the default and route-specific JWT verification settings. 
-- `spec.targetRef.default.jwt.providers`: Specifies a list of default providers and claims used to verify requests to the gateway. 
+- `spec.targetRef.override.jwt.providers`: Specifies a list of providers and claims used to verify requests to the gateway. The override settings take precedence over the default and route-specific JWT verification settings.
+- `spec.targetRef.default.jwt.providers`: Specifies a list of default providers and claims used to verify requests to the gateway.
 
 ## Define an HTTP route auth filter
 
-Create an `RouteAuthFilter` values file and configure the following fields. Refer to [`RouteAuthFilter` configuration reference](/consul/docs/connect/gateways/api-gateway/configuration/routeauthfilter) for details.  
+Create an `RouteAuthFilter` values file and configure the following fields. Refer to [`RouteAuthFilter` configuration reference](/consul/docs/connect/gateways/api-gateway/configuration/routeauthfilter) for details.
 
-- `kind`: Must be set to `HTTPRouteAuthFilter`
+- `kind`: Must be set to `RouteAuthFilter`
 - `metadata.name`: Specifies a name for the filter.
 - `metadata.namespace`: Specifies the Consul namespace the filter applies to.
-- `spec.jwt.providers`: Specifies a list of providers and claims used to verify requests to the gateway. The override settings take precedence over the default and route-specific JWT verification settings. 
+- `spec.jwt.providers`: Specifies a list of providers and claims used to verify requests to the gateway. The override settings take precedence over the default and route-specific JWT verification settings.
 
 ## Attach the auth filter to your HTTP routes
 
-In the `filters` field of your HTTP route configuration, add the following fields. Refer to the [`extensionRef` configuration reference](/consul/docs/connect/gateways/api-gateway/configuration/routes#rules-filters-extensionref) for details: 
+In the `filters` field of your HTTP route configuration, add the following fields. Refer to the [`extensionRef` configuration reference](/consul/docs/connect/gateways/api-gateway/configuration/routes#rules-filters-extensionref) for details:
 
-- `type: extensionRef`: Declare list of extension references. 
+- `type: extensionRef`: Declare list of extension references.
 - `extensionRef.group`: Specifies the resource group. Unless you have created a custom group, this should be set to `gateway.networking.kuberenetes.io`.
 - `extensionRef.kind`: Specifies the type of extension reference to attach to the route. Must be `RouteAuthFilter`
-- `extensionRef.name`: Specifies the name of the auth filter. 
+- `extensionRef.name`: Specifies the name of the auth filter.
 
 ## Apply the configurations
 

--- a/website/content/docs/connect/gateways/api-gateway/secure-traffic/verify-jwts-vms.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/secure-traffic/verify-jwts-vms.mdx
@@ -6,22 +6,22 @@ description: Learn how to use JSON web tokens (JWT) to verify requests from exte
 
 # Use JWTs to verify requests to API gateways on virtual machines
 
-This topic describes how to use JSON web tokens (JWT) to verify requests to API gateways on virtual machines (VM). If your services are deployed to Kubernetes-orchestrated containers, refer to [Use JWTs to verify requests to API gateways on Kubernetes](/consul/docs/connect/gateways/api-gateway/secure-traffic/verify-jwts-vms).
+This topic describes how to use JSON web tokens (JWT) to verify requests to API gateways on virtual machines (VM). If your services are deployed to Kubernetes-orchestrated containers, refer to [Use JWTs to verify requests to API gateways on Kubernetes](/consul/docs/connect/gateways/api-gateway/secure-traffic/verify-jwts-k8s).
 
 <EnterpriseAlert> This feature is available in Consul Enterprise. </EnterpriseAlert>
 
 ## Overview
- 
+
 You can configure API gateways to use JWTs to verify incoming requests so that you can stop unverified traffic at the gateway. You can configure JWT verification at different levels:
 
 - Listener defaults: Define basic defaults that apply to all routes attached to a listener.
-- HTTP route-specific settings: You can define JWT authentication settings for specific HTTP routes. Route-specific JWT settings override default configurations. 
+- HTTP route-specific settings: You can define JWT authentication settings for specific HTTP routes. Route-specific JWT settings override default configurations.
 - Listener overrides: Define override settings that take precedence over default and route-specific configurations. This enables you to set enforceable policies for listeners.
 
 Complete the following steps to use JWTs to verify requests:
 
-1. Configure default and override settings for listeners in the API gateway configuration entry. 
-1. Define route-specific JWT verification settings as filters in the HTTP route configuration entries. 
+1. Configure default and override settings for listeners in the API gateway configuration entry.
+1. Define route-specific JWT verification settings as filters in the HTTP route configuration entries.
 1. Write the configuration entries to Consul to begin verifying requests using JWTs.
 
 ## Requirements


### PR DESCRIPTION
### Description

Fixes some jwt docs for a typo in the external filter kind name and links between docs

### Testing & Reproduction steps


### Links



### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
