### PR TITLE
Update telemetry.mdx RPC Metrics

### DIFF
--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -595,7 +595,7 @@ These metrics are used to monitor the health of the Consul servers.
 ** Requirements: **
 * Consul 1.12.0+
 
-Label based RPC metrics were added in Consul 1.12.0 as a Beta feature to better understand the workload on a Consul server and, where that workload is coming from. The following metric(s) provide that insight.
+The following label-based RPC metrics provide insight about the workload on a Consul server and the source of the workload.
 
 All RPC metric method calls are by default blocked via the [`prefix_filter`](/consul/docs/agent/config/config-files#telemetry-prefix_filter) telemetry configuration setting. You can enable all RPC metric server
 calls and/or explicity deny RPC calls using the same configuration setting.

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -597,8 +597,7 @@ These metrics are used to monitor the health of the Consul servers.
 
 The following label-based RPC metrics provide insight about the workload on a Consul server and the source of the workload.
 
-All RPC metric method calls are by default blocked via the [`prefix_filter`](/consul/docs/agent/config/config-files#telemetry-prefix_filter) telemetry configuration setting. You can enable all RPC metric server
-calls and/or explicity deny RPC calls using the same configuration setting.
+The [`prefix_filter`](/consul/docs/agent/config/config-files#telemetry-prefix_filter) telemetry configuration setting blocks or enables all RPC metric method calls. Specify the RPC metrics you want to allow in the `prefix_filter`:
 
 <CodeTabs heading="Example prefix_filter allowing all RPC metrics">
 

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -595,7 +595,30 @@ These metrics are used to monitor the health of the Consul servers.
 ** Requirements: **
 * Consul 1.12.0+
 
-Label based RPC metrics were added in Consul 1.12.0 as a Beta feature to better understand the workload on a Consul server and, where that workload is coming from. The following metric(s) provide that insight
+Label based RPC metrics were added in Consul 1.12.0 as a Beta feature to better understand the workload on a Consul server and, where that workload is coming from. The following metric(s) provide that insight.
+
+All RPC metric method calls are by default blocked via the [`prefix_filter`](/consul/docs/agent/config/config-files#telemetry-prefix_filter) telemetry configuration setting. You can enable all RPC metric server
+calls and/or explicity deny RPC calls using the same configuration setting.
+
+<CodeTabs heading="Example prefix_filter allowing all RPC metrics">
+
+```hcl
+telemetry {
+  prefix_filter = ["+consul.rpc.server.call"]
+}
+```
+
+```json
+{
+  "telemetry": {
+    "prefix_filter": [
+      "+consul.rpc.server.call"
+    ]
+  }
+}
+```
+
+</CodeTabs>
 
 | Metric                                | Description                                               | Unit   | Type      |
 | ------------------------------------- | --------------------------------------------------------- | ------ | --------- |
@@ -644,7 +667,6 @@ Here is a Prometheus style example of an RPC metric and its labels:
 
 </CodeBlockConfig>
 
-Any metric in this section can be turned off with the [`prefix_filter`](/consul/docs/agent/config/config-files#telemetry-prefix_filter).
 
 ## Cluster Health
 


### PR DESCRIPTION
Update Server Workload telemetry section to demonstrate explicitly enabling metric emission as they're [default disabled](https://github.com/hashicorp/consul/blob/f5bf256425e33c0da805eda6a2fc5ea05100d491/agent/config/builder.go#L2763C1-L2763C1).

### Description

Customers need to be aware that if investigating server workload via metrics this needs to be explicitly enabled.

### Testing & Reproduction steps

* Run any support version of Consul or Consul Enterprise
* Enable telemetry in agent config via`prometheus_retention_time` 
* Observe default blocked prefixes showing `consul.rpc.server.call`:

```shell
$ consul agent -dev -node localhost -client 127.0.0.1 -hcl 'telemetry { prometheus_retention_time = "10m" }'

$ curl -s localhost:8500/v1/agent/self | jq -r '.DebugConfig.Telemetry.BlockedPrefixes'                                                                                                                                                                                          
[
  "consul.rpc.server.call"
]
```

* Enable RPC metrics using `telemetry.prefix_filter` and observe permission and emission of desired metrics:

```shell
$ consul agent -dev -node localhost -client 127.0.0.1 -hcl 'telemetry { prometheus_retention_time = "10m" prefix_filter = [ "+consul.rpc.server.call" ]}'

$ curl -s localhost:8500/v1/agent/self | jq -r '.DebugConfig.Telemetry.AllowedPrefixes'                                                                                                                                                                                  
[
  "consul.rpc.server.call"
]
```

### Links

* Consul Telemetry Agent Config [Default Prefix Filter](https://github.com/hashicorp/consul/blob/f5bf256425e33c0da805eda6a2fc5ea05100d491/agent/config/builder.go#L2763C1-L2763C1) default disabling.


### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
