### PR TITLE
ui: move queries for selectors within the dropdowns

### DIFF
--- a/.changelog/19594.txt
+++ b/.changelog/19594.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: move nspace and partitions requests into their selector menus
+```

--- a/ui/packages/consul-nspaces/app/components/consul/nspace/selector/index.hbs
+++ b/ui/packages/consul-nspaces/app/components/consul/nspace/selector/index.hbs
@@ -4,13 +4,6 @@
 }}
 
 {{#if (and (can "use nspaces") (can "choose nspaces"))}}
-  <DataSource
-    @src={{uri
-      "/${partition}/*/${dc}/namespaces"
-      (hash partition=@partition dc=@dc.Name)
-    }}
-    @onchange={{fn (optional @onchange)}}
-  />
   {{#let
     @list
     (if @nspace (hash Name=@nspace) (hash Name="default"))
@@ -34,15 +27,25 @@
         "components.hashicorp-consul.side-nav.nspaces.footer"
       }}
       data-test-nspace-menu
-      as |Dropdown item|
+      as |Selector|
     >
-      <Dropdown.Checkmark
-        @selected={{eq nspace.Name item.Name}}
+      <Selector.Data>
+        <DataSource
+          @src={{uri
+            "/${partition}/*/${dc}/namespaces"
+            (hash partition=@partition dc=@dc.Name)
+          }}
+          @loading="lazy"
+          @onchange={{fn (optional @onchange)}}
+        />
+      </Selector.Data>
+      <Selector.Dropdown.Checkmark
+        @selected={{eq nspace.Name Selector.item.Name}}
         @href={{href-to
           "dc.services.index"
           params=(hash
             partition=(if (gt @partition.length 0) @partition undefined)
-            nspace=item.Name
+            nspace=Selector.item.Name
             peer=undefined
             dc=@dc.Name
           )
@@ -50,8 +53,8 @@
         @isHrefExternal={{false}}
         data-test-nspace-item
       >
-        {{item.Name}}
-      </Dropdown.Checkmark>
+        {{Selector.item.Name}}
+      </Selector.Dropdown.Checkmark>
     </NavSelector>
   {{/let}}
 {{/if}}

--- a/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
+++ b/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
@@ -10,10 +10,6 @@
   (can "choose partitions" dc=@dc)
   as |SNL partition isManaging canChoose|
 }}
-  <DataSource
-    @src={{uri "/*/*/${dc}/partitions" (hash dc=@dc.Name)}}
-    @onchange={{fn (optional @onchange)}}
-  />
   <SNL.Title class="consul-side-nav__selector-title">{{t
       "components.hashicorp-consul.side-nav.partitions.title"
     }}</SNL.Title>
@@ -32,24 +28,31 @@
     }}
     @disabled={{not canChoose}}
     data-test-datacenter-disclosure-menu
-    as |Dropdown item|
+    as |Selector|
   >
+    <Selector.Data>
+      <DataSource
+        @src={{uri "/*/*/${dc}/partitions" (hash dc=@dc.Name)}}
+        @loading="lazy"
+        @onchange={{fn (optional @onchange)}}
+      />
+    </Selector.Data>
     {{#if canChoose}}
-      <Dropdown.Checkmark
-        @selected={{eq partition.Name item.Name}}
+      <Selector.Dropdown.Checkmark
+        @selected={{eq partition.Name Selector.item.Name}}
         @href={{if
-          item.href
-          item.href
+          Selector.item.href
+          Selector.item.href
           (href-to
             "dc.services.index"
-            params=(hash partition=item.Name nspace=undefined peer=undefined dc=@dc.Name)
+            params=(hash partition=Selector.item.Name nspace=undefined peer=undefined dc=@dc.Name)
           )
         }}
         @isHrefExternal={{false}}
         data-test-partiton-item
       >
-        {{item.Name}}
-      </Dropdown.Checkmark>
+        {{Selector.item.Name}}
+      </Selector.Dropdown.Checkmark>
     {{/if}}
   </NavSelector>
 {{/let}}

--- a/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
@@ -16,14 +16,14 @@
       @description={{t "components.hashicorp-consul.side-nav.datacenters.description"}}
       class='consul-datacenter-selector'
       data-test-datacenter-menu
-      as |Dropdown item|
+      as |Selector|
     >
-      <Dropdown.Checkmark
-        @selected={{eq @dc.Name item.Name}}
+      <Selector.Dropdown.Checkmark
+        @selected={{eq @dc.Name Selector.item.Name}}
         @href={{href-to
           '.'
           params=(hash
-            dc=item.Name partition=undefined nspace=(if (gt @nspace.length 0) @nspace undefined)
+            dc=Selector.item.Name partition=undefined nspace=(if (gt @nspace.length 0) @nspace undefined)
           )
         }}
         @isHrefExternal={{false}}
@@ -31,20 +31,20 @@
         data-test-dc-item
       >
         <span class='consul-datacenter-selector__dc-name'>
-          {{item.Name}}
+          {{Selector.item.Name}}
 
-          {{#if (or item.Local item.Primary)}}
+          {{#if (or Selector.item.Local Selector.item.Primary)}}
             <span class='consul-datacenter-selector__badges'>
-              {{#if item.Primary}}
+              {{#if Selector.item.Primary}}
                 <Hds::Badge @text='Primary' />
               {{/if}}
-              {{#if item.Local}}
+              {{#if Selector.item.Local}}
                 <Hds::Badge @text='Local' />
               {{/if}}
             </span>
           {{/if}}
         </span>
-      </Dropdown.Checkmark>
+      </Selector.Dropdown.Checkmark>
     </NavSelector>
   {{else}}
     <SNL.Item class='consul-side-nav__datacenter' data-test-datacenter-single>

--- a/ui/packages/consul-ui/app/components/nav-selector/generic.hbs
+++ b/ui/packages/consul-ui/app/components/nav-selector/generic.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+{{yield}}

--- a/ui/packages/consul-ui/app/components/nav-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/nav-selector/index.hbs
@@ -20,6 +20,7 @@
         disabled={{eq @disabled true}}
       />
       <DD.Header @hasDivider={{true}}>
+        {{yield (hash Data=(component 'nav-selector/generic'))}}
         {{#if @description}}
           <div class='consul-side-nav__selector-description'>
             <Hds::Text::Body @size='100' @color='faint'>{{@description}}</Hds::Text::Body>
@@ -37,7 +38,10 @@
         <DD.Description @text='No results' />
       {{else}}
         {{#each this.filteredItems as |item|}}
-          {{yield DD item}}
+          {{yield (hash
+            Dropdown=DD
+            item=item
+          )}}
         {{/each}}
       {{/if}}
       {{#if @footerLink}}


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
When I was testing the sameness group stuff I saw that the namespaces blocking query was firing right away and timing out after a while. I looked back at what we hhad before and the requests would only load when they were in the DOM, and they were placed inside the old dropdown menu. I've since yielded a slot in the `NavSelector` to place the data sources so that they only request once you open the dropdowns.

![2023-11-09 12-11-04 2023-11-09 12_35_23](https://github.com/hashicorp/consul/assets/5448834/2f47018f-9729-45f1-90cc-3ba1b693399d)


### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
