### PR TITLE
testing/deployer: rename various terms to better align with v2 and avoid confusion

### DIFF
--- a/test-integ/README.md
+++ b/test-integ/README.md
@@ -65,12 +65,11 @@ These are comprised of 4 main parts:
   - **Nodes**: A "box with ip address(es)". This should feel a bit like a VM or
                a Kubernetes Pod as an enclosing entity.
 
-    - **Services/Workloads**: The list of service instances (v1) or workloads
-                              (v2) that will execute on the given node. v2
-                              Services will be implied by similarly named
-                              workloads here unless opted out. This helps
-                              define a v1-compatible topology and repurpose it
-                              for v2 without reworking it.
+    - **Workloads**: The list of service instances (v1) or workloads
+                     (v2) that will execute on the given node. v2 Services will
+                     be implied by similarly named workloads here unless opted
+                     out. This helps define a v1-compatible topology and
+                     repurpose it for v2 without reworking it.
 
   - **Services** (v2): v2 Service definitions to define explicitly, in addition
                        to the inferred ones.
@@ -90,7 +89,7 @@ These are comprised of 4 main parts:
 - **Peerings**: The peering relationships between Clusters to establish.
 
 In the [topoutil](./topoutil) package there are some helpers for defining
-common sets of nodes or services like Consul Servers, Mesh Gateways, or [fortio
+common sets of nodes or workloads like Consul Servers, Mesh Gateways, or [fortio
 servers](https://github.com/fortio/fortio)
 
 #### Useful topology concepts

--- a/test-integ/catalogv2/explicit_destinations_l7_test.go
+++ b/test-integ/catalogv2/explicit_destinations_l7_test.go
@@ -153,7 +153,7 @@ func (c testSplitterFeaturesL7ExplicitDestinationsCreator) topologyConfigAddNode
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Services: []*topology.Service{
+		Workloads: []*topology.Service{
 			topoutil.NewBlankspaceServiceWithDefaults(
 				clusterName,
 				newServiceID("static-server-v1"),
@@ -172,7 +172,7 @@ func (c testSplitterFeaturesL7ExplicitDestinationsCreator) topologyConfigAddNode
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Services: []*topology.Service{
+		Workloads: []*topology.Service{
 			topoutil.NewBlankspaceServiceWithDefaults(
 				clusterName,
 				newServiceID("static-server-v2"),
@@ -191,7 +191,7 @@ func (c testSplitterFeaturesL7ExplicitDestinationsCreator) topologyConfigAddNode
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Services: []*topology.Service{
+		Workloads: []*topology.Service{
 			topoutil.NewBlankspaceServiceWithDefaults(
 				clusterName,
 				newServiceID("static-client"),

--- a/test-integ/catalogv2/explicit_destinations_test.go
+++ b/test-integ/catalogv2/explicit_destinations_test.go
@@ -147,7 +147,7 @@ func (c testBasicL4ExplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Services: []*topology.Service{
+		Workloads: []*topology.Service{
 			topoutil.NewFortioServiceWithDefaults(
 				clusterName,
 				newServiceID("single-server"),
@@ -161,7 +161,7 @@ func (c testBasicL4ExplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Services: []*topology.Service{
+		Workloads: []*topology.Service{
 			topoutil.NewFortioServiceWithDefaults(
 				clusterName,
 				newServiceID("single-client"),
@@ -203,7 +203,7 @@ func (c testBasicL4ExplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Services: []*topology.Service{
+		Workloads: []*topology.Service{
 			topoutil.NewFortioServiceWithDefaults(
 				clusterName,
 				newServiceID("multi-server"),
@@ -217,7 +217,7 @@ func (c testBasicL4ExplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Services: []*topology.Service{
+		Workloads: []*topology.Service{
 			topoutil.NewFortioServiceWithDefaults(
 				clusterName,
 				newServiceID("multi-client"),

--- a/test-integ/catalogv2/explicit_destinations_test.go
+++ b/test-integ/catalogv2/explicit_destinations_test.go
@@ -68,15 +68,15 @@ func TestBasicL4ExplicitDestinations(t *testing.T) {
 	for _, ship := range ships {
 		t.Run("relationship: "+ship.String(), func(t *testing.T) {
 			var (
-				svc = ship.Caller
-				u   = ship.Upstream
+				wrk  = ship.Caller
+				dest = ship.Destination
 			)
 
-			clusterPrefix := clusterPrefixForUpstream(u)
+			clusterPrefix := clusterPrefixForDestination(dest)
 
-			asserter.UpstreamEndpointStatus(t, svc, clusterPrefix+".", "HEALTHY", 1)
-			asserter.HTTPServiceEchoes(t, svc, u.LocalPort, "")
-			asserter.FortioFetch2FortioName(t, svc, u, cluster.Name, u.ID)
+			asserter.DestinationEndpointStatus(t, wrk, clusterPrefix+".", "HEALTHY", 1)
+			asserter.HTTPServiceEchoes(t, wrk, dest.LocalPort, "")
+			asserter.FortioFetch2FortioName(t, wrk, dest, cluster.Name, dest.ID)
 		})
 	}
 }
@@ -128,8 +128,8 @@ func (c testBasicL4ExplicitDestinationsCreator) topologyConfigAddNodes(
 ) {
 	clusterName := cluster.Name
 
-	newServiceID := func(name string) topology.ServiceID {
-		return topology.ServiceID{
+	newID := func(name string) topology.ID {
+		return topology.ID{
 			Partition: partition,
 			Namespace: namespace,
 			Name:      name,
@@ -147,10 +147,10 @@ func (c testBasicL4ExplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Workloads: []*topology.Service{
-			topoutil.NewFortioServiceWithDefaults(
+		Workloads: []*topology.Workload{
+			topoutil.NewFortioWorkloadWithDefaults(
 				clusterName,
-				newServiceID("single-server"),
+				newID("single-server"),
 				topology.NodeVersionV2,
 				nil,
 			),
@@ -161,16 +161,16 @@ func (c testBasicL4ExplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Workloads: []*topology.Service{
-			topoutil.NewFortioServiceWithDefaults(
+		Workloads: []*topology.Workload{
+			topoutil.NewFortioWorkloadWithDefaults(
 				clusterName,
-				newServiceID("single-client"),
+				newID("single-client"),
 				topology.NodeVersionV2,
-				func(svc *topology.Service) {
-					delete(svc.Ports, "grpc")  // v2 mode turns this on, so turn it off
-					delete(svc.Ports, "http2") // v2 mode turns this on, so turn it off
-					svc.Upstreams = []*topology.Upstream{{
-						ID:           newServiceID("single-server"),
+				func(wrk *topology.Workload) {
+					delete(wrk.Ports, "grpc")  // v2 mode turns this on, so turn it off
+					delete(wrk.Ports, "http2") // v2 mode turns this on, so turn it off
+					wrk.Destinations = []*topology.Destination{{
+						ID:           newID("single-server"),
 						PortName:     "http",
 						LocalAddress: "0.0.0.0", // needed for an assertion
 						LocalPort:    5000,
@@ -203,10 +203,10 @@ func (c testBasicL4ExplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Workloads: []*topology.Service{
-			topoutil.NewFortioServiceWithDefaults(
+		Workloads: []*topology.Workload{
+			topoutil.NewFortioWorkloadWithDefaults(
 				clusterName,
-				newServiceID("multi-server"),
+				newID("multi-server"),
 				topology.NodeVersionV2,
 				nil,
 			),
@@ -217,21 +217,21 @@ func (c testBasicL4ExplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Workloads: []*topology.Service{
-			topoutil.NewFortioServiceWithDefaults(
+		Workloads: []*topology.Workload{
+			topoutil.NewFortioWorkloadWithDefaults(
 				clusterName,
-				newServiceID("multi-client"),
+				newID("multi-client"),
 				topology.NodeVersionV2,
-				func(svc *topology.Service) {
-					svc.Upstreams = []*topology.Upstream{
+				func(wrk *topology.Workload) {
+					wrk.Destinations = []*topology.Destination{
 						{
-							ID:           newServiceID("multi-server"),
+							ID:           newID("multi-server"),
 							PortName:     "http",
 							LocalAddress: "0.0.0.0", // needed for an assertion
 							LocalPort:    5000,
 						},
 						{
-							ID:           newServiceID("multi-server"),
+							ID:           newID("multi-server"),
 							PortName:     "http2",
 							LocalAddress: "0.0.0.0", // needed for an assertion
 							LocalPort:    5001,

--- a/test-integ/catalogv2/helpers_test.go
+++ b/test-integ/catalogv2/helpers_test.go
@@ -9,11 +9,16 @@ import (
 	"github.com/hashicorp/consul/testing/deployer/topology"
 )
 
-func clusterPrefixForUpstream(u *topology.Upstream) string {
-	if u.Peer == "" {
-		return clusterPrefix(u.PortName, u.ID, u.Cluster)
+// Deprecated: clusterPrefixForDestination
+func clusterPrefixForUpstream(dest *topology.Destination) string {
+	return clusterPrefixForDestination(dest)
+}
+
+func clusterPrefixForDestination(dest *topology.Destination) string {
+	if dest.Peer == "" {
+		return clusterPrefix(dest.PortName, dest.ID, dest.Cluster)
 	} else {
-		return strings.Join([]string{u.ID.Name, u.ID.Namespace, u.Peer, "external"}, ".")
+		return strings.Join([]string{dest.ID.Name, dest.ID.Namespace, dest.Peer, "external"}, ".")
 	}
 }
 

--- a/test-integ/catalogv2/helpers_test.go
+++ b/test-integ/catalogv2/helpers_test.go
@@ -22,7 +22,7 @@ func clusterPrefixForDestination(dest *topology.Destination) string {
 	}
 }
 
-func clusterPrefix(port string, svcID topology.ServiceID, cluster string) string {
+func clusterPrefix(port string, svcID topology.ID, cluster string) string {
 	if svcID.PartitionOrDefault() == "default" {
 		return strings.Join([]string{port, svcID.Name, svcID.Namespace, cluster, "internal"}, ".")
 	} else {

--- a/test-integ/catalogv2/implicit_destinations_test.go
+++ b/test-integ/catalogv2/implicit_destinations_test.go
@@ -147,7 +147,7 @@ func (c testBasicL4ImplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Services: []*topology.Service{
+		Workloads: []*topology.Service{
 			topoutil.NewFortioServiceWithDefaults(
 				clusterName,
 				newServiceID("static-server"),
@@ -163,7 +163,7 @@ func (c testBasicL4ImplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Services: []*topology.Service{
+		Workloads: []*topology.Service{
 			topoutil.NewFortioServiceWithDefaults(
 				clusterName,
 				newServiceID("static-client"),

--- a/test-integ/catalogv2/implicit_destinations_test.go
+++ b/test-integ/catalogv2/implicit_destinations_test.go
@@ -66,17 +66,17 @@ func TestBasicL4ImplicitDestinations(t *testing.T) {
 	for _, ship := range ships {
 		t.Run("relationship: "+ship.String(), func(t *testing.T) {
 			var (
-				svc = ship.Caller
-				u   = ship.Upstream
+				wrk  = ship.Caller
+				dest = ship.Destination
 			)
 
-			clusterPrefix := clusterPrefixForUpstream(u)
+			clusterPrefix := clusterPrefixForDestination(dest)
 
-			asserter.UpstreamEndpointStatus(t, svc, clusterPrefix+".", "HEALTHY", 1)
-			if u.LocalPort > 0 {
-				asserter.HTTPServiceEchoes(t, svc, u.LocalPort, "")
+			asserter.DestinationEndpointStatus(t, wrk, clusterPrefix+".", "HEALTHY", 1)
+			if dest.LocalPort > 0 {
+				asserter.HTTPServiceEchoes(t, wrk, dest.LocalPort, "")
 			}
-			asserter.FortioFetch2FortioName(t, svc, u, cluster.Name, u.ID)
+			asserter.FortioFetch2FortioName(t, wrk, dest, cluster.Name, dest.ID)
 		})
 	}
 }
@@ -128,8 +128,8 @@ func (c testBasicL4ImplicitDestinationsCreator) topologyConfigAddNodes(
 ) {
 	clusterName := cluster.Name
 
-	newServiceID := func(name string) topology.ServiceID {
-		return topology.ServiceID{
+	newID := func(name string) topology.ID {
+		return topology.ID{
 			Partition: partition,
 			Namespace: namespace,
 			Name:      name,
@@ -147,13 +147,13 @@ func (c testBasicL4ImplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Workloads: []*topology.Service{
-			topoutil.NewFortioServiceWithDefaults(
+		Workloads: []*topology.Workload{
+			topoutil.NewFortioWorkloadWithDefaults(
 				clusterName,
-				newServiceID("static-server"),
+				newID("static-server"),
 				topology.NodeVersionV2,
-				func(svc *topology.Service) {
-					svc.EnableTransparentProxy = true
+				func(wrk *topology.Workload) {
+					wrk.EnableTransparentProxy = true
 				},
 			),
 		},
@@ -163,20 +163,20 @@ func (c testBasicL4ImplicitDestinationsCreator) topologyConfigAddNodes(
 		Version:   topology.NodeVersionV2,
 		Partition: partition,
 		Name:      nodeName(),
-		Workloads: []*topology.Service{
-			topoutil.NewFortioServiceWithDefaults(
+		Workloads: []*topology.Workload{
+			topoutil.NewFortioWorkloadWithDefaults(
 				clusterName,
-				newServiceID("static-client"),
+				newID("static-client"),
 				topology.NodeVersionV2,
-				func(svc *topology.Service) {
-					svc.EnableTransparentProxy = true
-					svc.ImpliedUpstreams = []*topology.Upstream{
+				func(wrk *topology.Workload) {
+					wrk.EnableTransparentProxy = true
+					wrk.ImpliedDestinations = []*topology.Destination{
 						{
-							ID:       newServiceID("static-server"),
+							ID:       newID("static-server"),
 							PortName: "http",
 						},
 						{
-							ID:       newServiceID("static-server"),
+							ID:       newID("static-server"),
 							PortName: "http2",
 						},
 					}

--- a/test-integ/connect/snapshot_test.go
+++ b/test-integ/connect/snapshot_test.go
@@ -27,7 +27,7 @@ import (
 //  1. The test spins up a one-server cluster with static-server and static-client.
 //  2. A snapshot is taken and the cluster is restored from the snapshot
 //  3. A new static-server replaces the old one
-//  4. At the end, we assert the static-client's upstream is updated with the
+//  4. At the end, we assert the static-client's destination is updated with the
 //     new static-server
 func Test_Snapshot_Restore_Agentless(t *testing.T) {
 	t.Parallel()
@@ -88,7 +88,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 									"-http-port", "8080",
 									"-redirect-port", "-disabled",
 								},
-								Upstreams: []*topology.Upstream{
+								Destinations: []*topology.Destination{
 									{
 										ID:        staticServerSID,
 										LocalPort: 5000,

--- a/test-integ/connect/snapshot_test.go
+++ b/test-integ/connect/snapshot_test.go
@@ -32,8 +32,8 @@ import (
 func Test_Snapshot_Restore_Agentless(t *testing.T) {
 	t.Parallel()
 
-	staticServerSID := topology.NewServiceID("static-server", "default", "default")
-	staticClientSID := topology.NewServiceID("static-client", "default", "default")
+	staticServerSID := topology.NewID("static-server", "default", "default")
+	staticClientSID := topology.NewID("static-client", "default", "default")
 
 	clu := &topology.Config{
 		Images: utils.TargetImages(),
@@ -58,7 +58,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 					{
 						Kind: topology.NodeKindDataplane,
 						Name: "dc1-client1",
-						Workloads: []*topology.Service{
+						Workloads: []*topology.Workload{
 							{
 								ID:             staticServerSID,
 								Image:          "docker.mirror.hashicorp.services/fortio/fortio",
@@ -76,7 +76,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 					{
 						Kind: topology.NodeKindDataplane,
 						Name: "dc1-client2",
-						Workloads: []*topology.Service{
+						Workloads: []*topology.Workload{
 							{
 								ID:             staticClientSID,
 								Image:          "docker.mirror.hashicorp.services/fortio/fortio",
@@ -102,7 +102,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 						Kind:     topology.NodeKindDataplane,
 						Name:     "dc1-client3",
 						Disabled: true,
-						Workloads: []*topology.Service{
+						Workloads: []*topology.Workload{
 							{
 								ID:             staticServerSID,
 								Image:          "docker.mirror.hashicorp.services/fortio/fortio",
@@ -148,15 +148,15 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 	sp := sprawltest.Launch(t, clu)
 	asserter := topoutil.NewAsserter(sp)
 
-	staticClient := sp.Topology().Clusters["dc1"].ServiceByID(
+	staticClient := sp.Topology().Clusters["dc1"].WorkloadByID(
 		topology.NewNodeID("dc1-client2", "default"),
 		staticClientSID,
 	)
-	asserter.FortioFetch2HeaderEcho(t, staticClient, &topology.Upstream{
+	asserter.FortioFetch2HeaderEcho(t, staticClient, &topology.Destination{
 		ID:        staticServerSID,
 		LocalPort: 5000,
 	})
-	staticServer := sp.Topology().Clusters["dc1"].ServiceByID(
+	staticServer := sp.Topology().Clusters["dc1"].WorkloadByID(
 		topology.NewNodeID("dc1-client1", "default"),
 		staticServerSID,
 	)

--- a/test-integ/connect/snapshot_test.go
+++ b/test-integ/connect/snapshot_test.go
@@ -6,12 +6,11 @@ package connect
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 	"github.com/hashicorp/consul/testing/deployer/sprawl/sprawltest"
 	"github.com/hashicorp/consul/testing/deployer/topology"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/test-integ/topoutil"
 )
@@ -59,7 +58,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 					{
 						Kind: topology.NodeKindDataplane,
 						Name: "dc1-client1",
-						Services: []*topology.Service{
+						Workloads: []*topology.Service{
 							{
 								ID:             staticServerSID,
 								Image:          "docker.mirror.hashicorp.services/fortio/fortio",
@@ -77,7 +76,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 					{
 						Kind: topology.NodeKindDataplane,
 						Name: "dc1-client2",
-						Services: []*topology.Service{
+						Workloads: []*topology.Service{
 							{
 								ID:             staticClientSID,
 								Image:          "docker.mirror.hashicorp.services/fortio/fortio",
@@ -103,7 +102,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 						Kind:     topology.NodeKindDataplane,
 						Name:     "dc1-client3",
 						Disabled: true,
-						Services: []*topology.Service{
+						Workloads: []*topology.Service{
 							{
 								ID:             staticServerSID,
 								Image:          "docker.mirror.hashicorp.services/fortio/fortio",

--- a/test-integ/peering_commontopo/ac1_basic_test.go
+++ b/test-integ/peering_commontopo/ac1_basic_test.go
@@ -7,9 +7,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/consul/testing/deployer/topology"
-
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testing/deployer/topology"
 )
 
 type ac1BasicSuite struct {
@@ -31,8 +30,8 @@ type ac1BasicSuite struct {
 	sidClientHTTP  topology.ServiceID
 	nodeClientHTTP topology.NodeID
 
-	upstreamHTTP *topology.Upstream
-	upstreamTCP  *topology.Upstream
+	upstreamHTTP *topology.Destination
+	upstreamTCP  *topology.Destination
 }
 
 var ac1BasicSuites []sharedTopoSuite = []sharedTopoSuite{
@@ -66,7 +65,7 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 		Name:      prefix + "server-http",
 		Partition: partition,
 	}
-	upstreamHTTP := &topology.Upstream{
+	upstreamHTTP := &topology.Destination{
 		ID: topology.ServiceID{
 			Name:      httpServerSID.Name,
 			Partition: partition,
@@ -74,7 +73,7 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 		LocalPort: 5001,
 		Peer:      peer,
 	}
-	upstreamTCP := &topology.Upstream{
+	upstreamTCP := &topology.Destination{
 		ID: topology.ServiceID{
 			Name:      tcpServerSID.Name,
 			Partition: partition,
@@ -94,7 +93,7 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 				clu.Datacenter,
 				sid,
 				func(s *topology.Service) {
-					s.Upstreams = []*topology.Upstream{
+					s.Destinations = []*topology.Destination{
 						upstreamTCP,
 						upstreamHTTP,
 					}

--- a/test-integ/peering_commontopo/ac1_basic_test.go
+++ b/test-integ/peering_commontopo/ac1_basic_test.go
@@ -17,17 +17,17 @@ type ac1BasicSuite struct {
 	Peer string
 
 	// test points
-	sidServerHTTP  topology.ServiceID
-	sidServerTCP   topology.ServiceID
+	sidServerHTTP  topology.ID
+	sidServerTCP   topology.ID
 	nodeServerHTTP topology.NodeID
 	nodeServerTCP  topology.NodeID
 
 	// 1.1
-	sidClientTCP  topology.ServiceID
+	sidClientTCP  topology.ID
 	nodeClientTCP topology.NodeID
 
 	// 1.2
-	sidClientHTTP  topology.ServiceID
+	sidClientHTTP  topology.ID
 	nodeClientHTTP topology.NodeID
 
 	upstreamHTTP *topology.Destination
@@ -57,16 +57,16 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 	cluPeerName := LocalPeerName(clu, "default")
 	const prefix = "ac1-"
 
-	tcpServerSID := topology.ServiceID{
+	tcpServerSID := topology.ID{
 		Name:      prefix + "server-tcp",
 		Partition: partition,
 	}
-	httpServerSID := topology.ServiceID{
+	httpServerSID := topology.ID{
 		Name:      prefix + "server-http",
 		Partition: partition,
 	}
 	upstreamHTTP := &topology.Destination{
-		ID: topology.ServiceID{
+		ID: topology.ID{
 			Name:      httpServerSID.Name,
 			Partition: partition,
 		},
@@ -74,7 +74,7 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 		Peer:      peer,
 	}
 	upstreamTCP := &topology.Destination{
-		ID: topology.ServiceID{
+		ID: topology.ID{
 			Name:      tcpServerSID.Name,
 			Partition: partition,
 		},
@@ -84,15 +84,15 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 
 	// Make clients which have server upstreams
 	setupClientServiceAndConfigs := func(protocol string) (serviceExt, *topology.Node) {
-		sid := topology.ServiceID{
+		sid := topology.ID{
 			Name:      prefix + "client-" + protocol,
 			Partition: partition,
 		}
 		svc := serviceExt{
-			Service: NewFortioServiceWithDefaults(
+			Workload: NewFortioServiceWithDefaults(
 				clu.Datacenter,
 				sid,
-				func(s *topology.Service) {
+				func(s *topology.Workload) {
 					s.Destinations = []*topology.Destination{
 						upstreamTCP,
 						upstreamHTTP,
@@ -122,7 +122,7 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 	httpClient, httpClientNode := setupClientServiceAndConfigs("http")
 
 	httpServer := serviceExt{
-		Service: NewFortioServiceWithDefaults(
+		Workload: NewFortioServiceWithDefaults(
 			peerClu.Datacenter,
 			httpServerSID,
 			nil,
@@ -153,7 +153,7 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 		},
 	}
 	tcpServer := serviceExt{
-		Service: NewFortioServiceWithDefaults(
+		Workload: NewFortioServiceWithDefaults(
 			peerClu.Datacenter,
 			tcpServerSID,
 			nil,
@@ -208,20 +208,20 @@ func (s *ac1BasicSuite) test(t *testing.T, ct *commonTopo) {
 	ac := s
 
 	// refresh this from Topology
-	svcClientTCP := dc.ServiceByID(
+	svcClientTCP := dc.WorkloadByID(
 		ac.nodeClientTCP,
 		ac.sidClientTCP,
 	)
-	svcClientHTTP := dc.ServiceByID(
+	svcClientHTTP := dc.WorkloadByID(
 		ac.nodeClientHTTP,
 		ac.sidClientHTTP,
 	)
 	// our ac has the node/sid for server in the peer DC
-	svcServerHTTP := peer.ServiceByID(
+	svcServerHTTP := peer.WorkloadByID(
 		ac.nodeServerHTTP,
 		ac.sidServerHTTP,
 	)
-	svcServerTCP := peer.ServiceByID(
+	svcServerTCP := peer.WorkloadByID(
 		ac.nodeServerTCP,
 		ac.sidServerTCP,
 	)
@@ -235,7 +235,7 @@ func (s *ac1BasicSuite) test(t *testing.T, ct *commonTopo) {
 	tcs := []struct {
 		acSub int
 		proto string
-		svc   *topology.Service
+		svc   *topology.Workload
 	}{
 		{1, "tcp", svcClientTCP},
 		{2, "http", svcClientHTTP},

--- a/test-integ/peering_commontopo/ac2_disco_chain_test.go
+++ b/test-integ/peering_commontopo/ac2_disco_chain_test.go
@@ -16,7 +16,7 @@ type ac2DiscoChainSuite struct {
 	DC   string
 	Peer string
 
-	clientSID topology.ServiceID
+	clientSID topology.ID
 }
 
 var ac2DiscoChainSuites []sharedTopoSuite = []sharedTopoSuite{
@@ -41,7 +41,7 @@ func (s *ac2DiscoChainSuite) setup(t *testing.T, ct *commonTopo) {
 	// Make an HTTP server with discovery chain config entries
 	server := NewFortioServiceWithDefaults(
 		clu.Datacenter,
-		topology.ServiceID{
+		topology.ID{
 			Name:      "ac2-disco-chain-svc",
 			Partition: partition,
 		},
@@ -81,11 +81,11 @@ func (s *ac2DiscoChainSuite) setup(t *testing.T, ct *commonTopo) {
 			},
 		},
 	)
-	ct.AddServiceNode(clu, serviceExt{Service: server})
+	ct.AddServiceNode(clu, serviceExt{Workload: server})
 
 	// Define server as upstream for client
 	upstream := &topology.Destination{
-		ID: topology.ServiceID{
+		ID: topology.ID{
 			Name:      server.ID.Name,
 			Partition: partition, // TODO: iterate over all possible partitions
 		},
@@ -97,14 +97,14 @@ func (s *ac2DiscoChainSuite) setup(t *testing.T, ct *commonTopo) {
 	}
 
 	// Make client which will dial server
-	clientSID := topology.ServiceID{
+	clientSID := topology.ID{
 		Name:      "ac2-client",
 		Partition: partition,
 	}
 	client := NewFortioServiceWithDefaults(
 		clu.Datacenter,
 		clientSID,
-		func(s *topology.Service) {
+		func(s *topology.Workload) {
 			s.Destinations = []*topology.Destination{
 				upstream,
 			}
@@ -120,7 +120,7 @@ func (s *ac2DiscoChainSuite) setup(t *testing.T, ct *commonTopo) {
 			},
 		},
 	)
-	ct.AddServiceNode(clu, serviceExt{Service: client})
+	ct.AddServiceNode(clu, serviceExt{Workload: client})
 
 	clu.InitialConfigEntries = append(clu.InitialConfigEntries,
 		&api.ServiceConfigEntry{
@@ -160,7 +160,7 @@ func (s *ac2DiscoChainSuite) setup(t *testing.T, ct *commonTopo) {
 func (s *ac2DiscoChainSuite) test(t *testing.T, ct *commonTopo) {
 	dc := ct.Sprawl.Topology().Clusters[s.DC]
 
-	svcs := dc.ServicesByID(s.clientSID)
+	svcs := dc.WorkloadsByID(s.clientSID)
 	require.Len(t, svcs, 1, "expected exactly one client in datacenter")
 
 	client := svcs[0]

--- a/test-integ/peering_commontopo/ac3_service_defaults_upstream_test.go
+++ b/test-integ/peering_commontopo/ac3_service_defaults_upstream_test.go
@@ -40,7 +40,7 @@ type ac3SvcDefaultsSuite struct {
 	sidClient  topology.ServiceID
 	nodeClient topology.NodeID
 
-	upstream *topology.Upstream
+	upstream *topology.Destination
 }
 
 func (s *ac3SvcDefaultsSuite) testName() string {
@@ -60,7 +60,7 @@ func (s *ac3SvcDefaultsSuite) setup(t *testing.T, ct *commonTopo) {
 		Name:      "ac3-server",
 		Partition: partition,
 	}
-	upstream := &topology.Upstream{
+	upstream := &topology.Destination{
 		ID: topology.ServiceID{
 			Name:      serverSID.Name,
 			Partition: partition,
@@ -78,7 +78,7 @@ func (s *ac3SvcDefaultsSuite) setup(t *testing.T, ct *commonTopo) {
 			clu.Datacenter,
 			sid,
 			func(s *topology.Service) {
-				s.Upstreams = []*topology.Upstream{
+				s.Destinations = []*topology.Destination{
 					upstream,
 				}
 			},

--- a/test-integ/peering_commontopo/ac3_service_defaults_upstream_test.go
+++ b/test-integ/peering_commontopo/ac3_service_defaults_upstream_test.go
@@ -35,9 +35,9 @@ type ac3SvcDefaultsSuite struct {
 	Peer string
 
 	// test points
-	sidServer  topology.ServiceID
+	sidServer  topology.ID
 	nodeServer topology.NodeID
-	sidClient  topology.ServiceID
+	sidClient  topology.ID
 	nodeClient topology.NodeID
 
 	upstream *topology.Destination
@@ -56,12 +56,12 @@ func (s *ac3SvcDefaultsSuite) setup(t *testing.T, ct *commonTopo) {
 	peer := LocalPeerName(peerClu, "default")
 	cluPeerName := LocalPeerName(clu, "default")
 
-	serverSID := topology.ServiceID{
+	serverSID := topology.ID{
 		Name:      "ac3-server",
 		Partition: partition,
 	}
 	upstream := &topology.Destination{
-		ID: topology.ServiceID{
+		ID: topology.ID{
 			Name:      serverSID.Name,
 			Partition: partition,
 		},
@@ -69,15 +69,15 @@ func (s *ac3SvcDefaultsSuite) setup(t *testing.T, ct *commonTopo) {
 		Peer:      peer,
 	}
 
-	sid := topology.ServiceID{
+	sid := topology.ID{
 		Name:      "ac3-client",
 		Partition: partition,
 	}
 	client := serviceExt{
-		Service: NewFortioServiceWithDefaults(
+		Workload: NewFortioServiceWithDefaults(
 			clu.Datacenter,
 			sid,
-			func(s *topology.Service) {
+			func(s *topology.Workload) {
 				s.Destinations = []*topology.Destination{
 					upstream,
 				}
@@ -112,7 +112,7 @@ func (s *ac3SvcDefaultsSuite) setup(t *testing.T, ct *commonTopo) {
 	clientNode := ct.AddServiceNode(clu, client)
 
 	server := serviceExt{
-		Service: NewFortioServiceWithDefaults(
+		Workload: NewFortioServiceWithDefaults(
 			peerClu.Datacenter,
 			serverSID,
 			nil,
@@ -158,12 +158,12 @@ func (s *ac3SvcDefaultsSuite) test(t *testing.T, ct *commonTopo) {
 	peer := ct.Sprawl.Topology().Clusters[s.Peer]
 
 	// refresh this from Topology
-	svcClient := dc.ServiceByID(
+	svcClient := dc.WorkloadByID(
 		s.nodeClient,
 		s.sidClient,
 	)
 	// our ac has the node/sid for server in the peer DC
-	svcServer := peer.ServiceByID(
+	svcServer := peer.WorkloadByID(
 		s.nodeServer,
 		s.sidServer,
 	)

--- a/test-integ/peering_commontopo/ac4_proxy_defaults_test.go
+++ b/test-integ/peering_commontopo/ac4_proxy_defaults_test.go
@@ -24,7 +24,7 @@ type ac4ProxyDefaultsSuite struct {
 
 	serverSID topology.ServiceID
 	clientSID topology.ServiceID
-	upstream  *topology.Upstream
+	upstream  *topology.Destination
 }
 
 var ac4ProxyDefaultsSuites []sharedTopoSuite = []sharedTopoSuite{
@@ -54,7 +54,7 @@ func (s *ac4ProxyDefaultsSuite) setup(t *testing.T, ct *commonTopo) {
 		Partition: partition,
 	}
 	// Define server as upstream for client
-	upstream := &topology.Upstream{
+	upstream := &topology.Destination{
 		ID:        serverSID,
 		LocalPort: 5000,
 		Peer:      peer,
@@ -70,7 +70,7 @@ func (s *ac4ProxyDefaultsSuite) setup(t *testing.T, ct *commonTopo) {
 			clu.Datacenter,
 			clientSID,
 			func(s *topology.Service) {
-				s.Upstreams = []*topology.Upstream{
+				s.Destinations = []*topology.Destination{
 					upstream,
 				}
 			},
@@ -165,11 +165,11 @@ func (s *ac4ProxyDefaultsSuite) test(t *testing.T, ct *commonTopo) {
 		dcSvcs := dc.ServicesByID(s.clientSID)
 		require.Len(t, dcSvcs, 1, "expected exactly one client")
 		client = dcSvcs[0]
-		require.Len(t, client.Upstreams, 1, "expected exactly one upstream for client")
+		require.Len(t, client.Destinations, 1, "expected exactly one upstream for client")
 
 		server := dc.ServicesByID(s.serverSID)
 		require.Len(t, server, 1, "expected exactly one server")
-		require.Len(t, server[0].Upstreams, 0, "expected no upstream for server")
+		require.Len(t, server[0].Destinations, 0, "expected no upstream for server")
 	})
 
 	t.Run("peered upstream exists in catalog", func(t *testing.T) {

--- a/test-integ/peering_commontopo/ac5_1_no_svc_mesh_test.go
+++ b/test-integ/peering_commontopo/ac5_1_no_svc_mesh_test.go
@@ -5,7 +5,6 @@ package peering
 
 import (
 	"fmt"
-
 	"testing"
 
 	"github.com/hashicorp/consul/api"
@@ -19,8 +18,8 @@ type ac5_1NoSvcMeshSuite struct {
 	DC   string
 	Peer string
 
-	serverSID topology.ServiceID
-	clientSID topology.ServiceID
+	serverSID topology.ID
+	clientSID topology.ID
 }
 
 var (
@@ -47,23 +46,23 @@ func (s *ac5_1NoSvcMeshSuite) setup(t *testing.T, ct *commonTopo) {
 	partition := "default"
 	peer := LocalPeerName(peerClu, partition)
 
-	serverSID := topology.ServiceID{
+	serverSID := topology.ID{
 		Name:      "ac5-server-http",
 		Partition: partition,
 	}
 
 	// Make client which will dial server
-	clientSID := topology.ServiceID{
+	clientSID := topology.ID{
 		Name:      "ac5-http-client",
 		Partition: partition,
 	}
 
 	// disable service mesh for client in s.DC
 	client := serviceExt{
-		Service: NewFortioServiceWithDefaults(
+		Workload: NewFortioServiceWithDefaults(
 			clu.Datacenter,
 			clientSID,
-			func(s *topology.Service) {
+			func(s *topology.Workload) {
 				s.EnvoyAdminPort = 0
 				s.DisableServiceMesh = true
 			},
@@ -79,7 +78,7 @@ func (s *ac5_1NoSvcMeshSuite) setup(t *testing.T, ct *commonTopo) {
 	ct.AddServiceNode(clu, client)
 
 	server := serviceExt{
-		Service: NewFortioServiceWithDefaults(
+		Workload: NewFortioServiceWithDefaults(
 			clu.Datacenter,
 			serverSID,
 			nil,

--- a/test-integ/peering_commontopo/ac5_2_pq_failover_test.go
+++ b/test-integ/peering_commontopo/ac5_2_pq_failover_test.go
@@ -5,9 +5,8 @@ package peering
 
 import (
 	"fmt"
-	"time"
-
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -26,10 +25,11 @@ import (
 // 9. Delete failing health check from step 3
 // 10. Repeat step 2
 type ac5_2PQFailoverSuite struct {
-	clientSID  topology.ServiceID
-	serverSID  topology.ServiceID
+	clientSID  topology.ID
+	serverSID  topology.ID
 	nodeServer topology.NodeID
 }
+
 type nodeKey struct {
 	dc        string
 	partition string
@@ -56,21 +56,21 @@ func (s *ac5_2PQFailoverSuite) setupDC(ct *commonTopo, clu, peerClu *topology.Cl
 	partition := "default"
 	peer := LocalPeerName(peerClu, partition)
 
-	serverSID := topology.ServiceID{
+	serverSID := topology.ID{
 		Name:      "ac5-server-http",
 		Partition: partition,
 	}
 
-	clientSID := topology.ServiceID{
+	clientSID := topology.ID{
 		Name:      "ac5-client-http",
 		Partition: partition,
 	}
 
 	client := serviceExt{
-		Service: NewFortioServiceWithDefaults(
+		Workload: NewFortioServiceWithDefaults(
 			clu.Datacenter,
 			clientSID,
-			func(s *topology.Service) {
+			func(s *topology.Workload) {
 				s.EnvoyAdminPort = 0
 				s.DisableServiceMesh = true
 			},
@@ -87,10 +87,10 @@ func (s *ac5_2PQFailoverSuite) setupDC(ct *commonTopo, clu, peerClu *topology.Cl
 	ct.AddServiceNode(clu, client)
 
 	server := serviceExt{
-		Service: NewFortioServiceWithDefaults(
+		Workload: NewFortioServiceWithDefaults(
 			clu.Datacenter,
 			serverSID,
-			func(s *topology.Service) {
+			func(s *topology.Workload) {
 				s.EnvoyAdminPort = 0
 				s.DisableServiceMesh = true
 			},
@@ -113,22 +113,22 @@ func (s *ac5_2PQFailoverSuite) setupDC3(ct *commonTopo, clu, peer1, peer2 *topol
 	)
 	peers = append(peers, LocalPeerName(peer1, partition), LocalPeerName(peer2, partition))
 
-	serverSID := topology.ServiceID{
+	serverSID := topology.ID{
 		Name:      "ac5-server-http",
 		Partition: partition,
 	}
 
-	clientSID := topology.ServiceID{
+	clientSID := topology.ID{
 		Name:      "ac5-client-http",
 		Partition: partition,
 	}
 
 	// disable service mesh for client in DC3
 	client := serviceExt{
-		Service: NewFortioServiceWithDefaults(
+		Workload: NewFortioServiceWithDefaults(
 			clu.Datacenter,
 			clientSID,
-			func(s *topology.Service) {
+			func(s *topology.Workload) {
 				s.EnvoyAdminPort = 0
 				s.DisableServiceMesh = true
 			},
@@ -153,10 +153,10 @@ func (s *ac5_2PQFailoverSuite) setupDC3(ct *commonTopo, clu, peer1, peer2 *topol
 	ct.AddServiceNode(clu, client)
 
 	server := serviceExt{
-		Service: NewFortioServiceWithDefaults(
+		Workload: NewFortioServiceWithDefaults(
 			clu.Datacenter,
 			serverSID,
-			func(s *topology.Service) {
+			func(s *topology.Workload) {
 				s.EnvoyAdminPort = 0
 				s.DisableServiceMesh = true
 			},

--- a/test-integ/peering_commontopo/ac6_failovers_test.go
+++ b/test-integ/peering_commontopo/ac6_failovers_test.go
@@ -346,8 +346,8 @@ func (s *ac6FailoversSuite) setup(t *testing.T, ct *commonTopo) {
 		nearClu.Datacenter,
 		clientSID,
 		func(s *topology.Service) {
-			// Upstream per partition
-			s.Upstreams = []*topology.Upstream{
+			// Destination per partition
+			s.Destinations = []*topology.Destination{
 				{
 					ID: topology.ServiceID{
 						Name:      nearServerSID.Name,
@@ -436,8 +436,8 @@ func (s *ac6FailoversSuite) test(t *testing.T, ct *commonTopo) {
 	require.Len(t, svcs, 1, "expected exactly one client in datacenter")
 
 	client := svcs[0]
-	require.Len(t, client.Upstreams, 1, "expected one upstream for client")
-	upstream := client.Upstreams[0]
+	require.Len(t, client.Destinations, 1, "expected one upstream for client")
+	upstream := client.Destinations[0]
 
 	fmt.Println("### preconditions")
 

--- a/test-integ/peering_commontopo/ac7_1_rotate_gw_test.go
+++ b/test-integ/peering_commontopo/ac7_1_rotate_gw_test.go
@@ -27,7 +27,7 @@ type suiteRotateGW struct {
 	sidClient  topology.ServiceID
 	nodeClient topology.NodeID
 
-	upstream *topology.Upstream
+	upstream *topology.Destination
 
 	newMGWNodeName string
 }
@@ -70,7 +70,7 @@ func (s *suiteRotateGW) setup(t *testing.T, ct *commonTopo) {
 	)
 
 	// Make clients which have server upstreams
-	upstream := &topology.Upstream{
+	upstream := &topology.Destination{
 		ID: topology.ServiceID{
 			Name:      server.ID.Name,
 			Partition: partition,
@@ -88,7 +88,7 @@ func (s *suiteRotateGW) setup(t *testing.T, ct *commonTopo) {
 			Partition: partition,
 		},
 		func(s *topology.Service) {
-			s.Upstreams = []*topology.Upstream{
+			s.Destinations = []*topology.Destination{
 				upstream,
 			}
 		},

--- a/test-integ/peering_commontopo/ac7_1_rotate_gw_test.go
+++ b/test-integ/peering_commontopo/ac7_1_rotate_gw_test.go
@@ -21,10 +21,10 @@ type suiteRotateGW struct {
 	DC   string
 	Peer string
 
-	sidServer  topology.ServiceID
+	sidServer  topology.ID
 	nodeServer topology.NodeID
 
-	sidClient  topology.ServiceID
+	sidClient  topology.ID
 	nodeClient topology.NodeID
 
 	upstream *topology.Destination
@@ -62,7 +62,7 @@ func (s *suiteRotateGW) setup(t *testing.T, ct *commonTopo) {
 
 	server := NewFortioServiceWithDefaults(
 		peerClu.Datacenter,
-		topology.ServiceID{
+		topology.ID{
 			Name:      prefix + "server-http",
 			Partition: partition,
 		},
@@ -71,7 +71,7 @@ func (s *suiteRotateGW) setup(t *testing.T, ct *commonTopo) {
 
 	// Make clients which have server upstreams
 	upstream := &topology.Destination{
-		ID: topology.ServiceID{
+		ID: topology.ID{
 			Name:      server.ID.Name,
 			Partition: partition,
 		},
@@ -83,17 +83,17 @@ func (s *suiteRotateGW) setup(t *testing.T, ct *commonTopo) {
 	// create client in us
 	client := NewFortioServiceWithDefaults(
 		clu.Datacenter,
-		topology.ServiceID{
+		topology.ID{
 			Name:      prefix + "client",
 			Partition: partition,
 		},
-		func(s *topology.Service) {
+		func(s *topology.Workload) {
 			s.Destinations = []*topology.Destination{
 				upstream,
 			}
 		},
 	)
-	clientNode := ct.AddServiceNode(clu, serviceExt{Service: client,
+	clientNode := ct.AddServiceNode(clu, serviceExt{Workload: client,
 		Config: &api.ServiceConfigEntry{
 			Kind:      api.ServiceDefaults,
 			Name:      client.ID.Name,
@@ -110,7 +110,7 @@ func (s *suiteRotateGW) setup(t *testing.T, ct *commonTopo) {
 	})
 	// actually to be used by the other pairing
 	serverNode := ct.AddServiceNode(peerClu, serviceExt{
-		Service: server,
+		Workload: server,
 		Config: &api.ServiceConfigEntry{
 			Kind:      api.ServiceDefaults,
 			Name:      server.ID.Name,
@@ -161,11 +161,11 @@ func (s *suiteRotateGW) test(t *testing.T, ct *commonTopo) {
 	dc := ct.Sprawl.Topology().Clusters[s.DC]
 	peer := ct.Sprawl.Topology().Clusters[s.Peer]
 
-	svcHTTPServer := peer.ServiceByID(
+	svcHTTPServer := peer.WorkloadByID(
 		s.nodeServer,
 		s.sidServer,
 	)
-	svcHTTPClient := dc.ServiceByID(
+	svcHTTPClient := dc.WorkloadByID(
 		s.nodeClient,
 		s.sidClient,
 	)

--- a/test-integ/peering_commontopo/ac7_2_rotate_leader_test.go
+++ b/test-integ/peering_commontopo/ac7_2_rotate_leader_test.go
@@ -23,10 +23,10 @@ type ac7_2RotateLeaderSuite struct {
 	DC   string
 	Peer string
 
-	sidServer  topology.ServiceID
+	sidServer  topology.ID
 	nodeServer topology.NodeID
 
-	sidClient  topology.ServiceID
+	sidClient  topology.ID
 	nodeClient topology.NodeID
 
 	upstream *topology.Destination
@@ -63,7 +63,7 @@ func (s *ac7_2RotateLeaderSuite) setup(t *testing.T, ct *commonTopo) {
 
 	server := NewFortioServiceWithDefaults(
 		peerClu.Datacenter,
-		topology.ServiceID{
+		topology.ID{
 			Name:      prefix + "server-http",
 			Partition: partition,
 		},
@@ -72,7 +72,7 @@ func (s *ac7_2RotateLeaderSuite) setup(t *testing.T, ct *commonTopo) {
 
 	// Make clients which have server upstreams
 	upstream := &topology.Destination{
-		ID: topology.ServiceID{
+		ID: topology.ID{
 			Name:      server.ID.Name,
 			Partition: partition,
 		},
@@ -82,17 +82,17 @@ func (s *ac7_2RotateLeaderSuite) setup(t *testing.T, ct *commonTopo) {
 	// create client in us
 	client := NewFortioServiceWithDefaults(
 		clu.Datacenter,
-		topology.ServiceID{
+		topology.ID{
 			Name:      prefix + "client",
 			Partition: partition,
 		},
-		func(s *topology.Service) {
+		func(s *topology.Workload) {
 			s.Destinations = []*topology.Destination{
 				upstream,
 			}
 		},
 	)
-	clientNode := ct.AddServiceNode(clu, serviceExt{Service: client,
+	clientNode := ct.AddServiceNode(clu, serviceExt{Workload: client,
 		Config: &api.ServiceConfigEntry{
 			Kind:      api.ServiceDefaults,
 			Name:      client.ID.Name,
@@ -109,7 +109,7 @@ func (s *ac7_2RotateLeaderSuite) setup(t *testing.T, ct *commonTopo) {
 	})
 	// actually to be used by the other pairing
 	serverNode := ct.AddServiceNode(peerClu, serviceExt{
-		Service: server,
+		Workload: server,
 		Config: &api.ServiceConfigEntry{
 			Kind:      api.ServiceDefaults,
 			Name:      server.ID.Name,
@@ -144,8 +144,8 @@ func (s *ac7_2RotateLeaderSuite) test(t *testing.T, ct *commonTopo) {
 	clDC := ct.APIClientForCluster(t, dc)
 	clPeer := ct.APIClientForCluster(t, peer)
 
-	svcServer := peer.ServiceByID(s.nodeServer, s.sidServer)
-	svcClient := dc.ServiceByID(s.nodeClient, s.sidClient)
+	svcServer := peer.WorkloadByID(s.nodeServer, s.sidServer)
+	svcClient := dc.WorkloadByID(s.nodeClient, s.sidClient)
 	ct.Assert.HealthyWithPeer(t, dc.Name, svcServer.ID, LocalPeerName(peer, "default"))
 
 	ct.Assert.FortioFetch2HeaderEcho(t, svcClient, s.upstream)

--- a/test-integ/peering_commontopo/ac7_2_rotate_leader_test.go
+++ b/test-integ/peering_commontopo/ac7_2_rotate_leader_test.go
@@ -8,15 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+	"github.com/hashicorp/consul/testing/deployer/topology"
 	"github.com/mitchellh/copystructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
-	"github.com/hashicorp/consul/testing/deployer/topology"
-
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
 
 // TestAC7_2RotateLeader ensures that after a leader rotation, information continues to replicate to peers
@@ -31,7 +29,7 @@ type ac7_2RotateLeaderSuite struct {
 	sidClient  topology.ServiceID
 	nodeClient topology.NodeID
 
-	upstream *topology.Upstream
+	upstream *topology.Destination
 }
 
 func TestAC7_2RotateLeader(t *testing.T) {
@@ -73,7 +71,7 @@ func (s *ac7_2RotateLeaderSuite) setup(t *testing.T, ct *commonTopo) {
 	)
 
 	// Make clients which have server upstreams
-	upstream := &topology.Upstream{
+	upstream := &topology.Destination{
 		ID: topology.ServiceID{
 			Name:      server.ID.Name,
 			Partition: partition,
@@ -89,7 +87,7 @@ func (s *ac7_2RotateLeaderSuite) setup(t *testing.T, ct *commonTopo) {
 			Partition: partition,
 		},
 		func(s *topology.Service) {
-			s.Upstreams = []*topology.Upstream{
+			s.Destinations = []*topology.Destination{
 				upstream,
 			}
 		},

--- a/test-integ/peering_commontopo/commontopo.go
+++ b/test-integ/peering_commontopo/commontopo.go
@@ -279,7 +279,7 @@ func (ct *commonTopo) AddServiceNode(clu *topology.Cluster, svc serviceExt) *top
 		Addresses: []*topology.Address{
 			{Network: clu.Datacenter},
 		},
-		Services: []*topology.Service{
+		Workloads: []*topology.Service{
 			svc.Service,
 		},
 		Cluster: clusterName,
@@ -521,6 +521,6 @@ func newTopologyMeshGatewaySet(
 	mutateFn func(i int, node *topology.Node),
 ) (topology.ServiceID, []*topology.Node) {
 	nodes := topoutil.NewTopologyMeshGatewaySet(nodeKind, partition, namePrefix, num, networks, mutateFn)
-	sid := nodes[0].Services[0].ID
+	sid := nodes[0].Workloads[0].ID
 	return sid, nodes
 }

--- a/test-integ/peering_commontopo/commontopo.go
+++ b/test-integ/peering_commontopo/commontopo.go
@@ -48,7 +48,7 @@ type commonTopo struct {
 	Assert *topoutil.Asserter
 
 	// track per-DC services to prevent duplicates
-	services map[string]map[topology.ServiceID]struct{}
+	services map[string]map[topology.ID]struct{}
 
 	// if zero, no DCs are agentless
 	agentlessDC string
@@ -107,9 +107,9 @@ func newCommonTopo(t *testing.T, agentlessDC string, includeDC3 bool, peerThroug
 	injectTenancies(dc2)
 	// dc3 doesn't get tenancies
 
-	ct.services = map[string]map[topology.ServiceID]struct{}{}
+	ct.services = map[string]map[topology.ID]struct{}{}
 	for _, dc := range clusters {
-		ct.services[dc.Datacenter] = map[topology.ServiceID]struct{}{}
+		ct.services[dc.Datacenter] = map[topology.ID]struct{}{}
 	}
 
 	peerings := addPeerings(dc1, dc2)
@@ -230,7 +230,7 @@ func LocalPeerName(clu *topology.Cluster, partition string) string {
 // TODO: move these to topology
 // TODO: alternatively, delete it: we only use it in one place, to bundle up args
 type serviceExt struct {
-	*topology.Service
+	*topology.Workload
 
 	Exports    []api.ServiceConsumer
 	Config     *api.ServiceConfigEntry
@@ -245,7 +245,7 @@ func (ct *commonTopo) AddServiceNode(clu *topology.Cluster, svc serviceExt) *top
 	ct.services[clusterName][svc.ID] = struct{}{}
 
 	// TODO: inline
-	serviceHostnameString := func(dc string, id topology.ServiceID) string {
+	serviceHostnameString := func(dc string, id topology.ID) string {
 		n := id.Name
 		// prepend <namespace>- and <partition>- if they are not default/empty
 		// avoids hostname limit of 63 chars in most cases
@@ -279,8 +279,8 @@ func (ct *commonTopo) AddServiceNode(clu *topology.Cluster, svc serviceExt) *top
 		Addresses: []*topology.Address{
 			{Network: clu.Datacenter},
 		},
-		Workloads: []*topology.Service{
-			svc.Service,
+		Workloads: []*topology.Workload{
+			svc.Workload,
 		},
 		Cluster: clusterName,
 	}
@@ -506,9 +506,9 @@ func injectTenancies(clu *topology.Cluster) {
 // Deprecated: topoutil.NewFortioServiceWithDefaults
 func NewFortioServiceWithDefaults(
 	cluster string,
-	sid topology.ServiceID,
-	mut func(s *topology.Service),
-) *topology.Service {
+	sid topology.ID,
+	mut func(s *topology.Workload),
+) *topology.Workload {
 	return topoutil.NewFortioServiceWithDefaults(cluster, sid, topology.NodeVersionV1, mut)
 }
 
@@ -519,7 +519,7 @@ func newTopologyMeshGatewaySet(
 	num int,
 	networks []string,
 	mutateFn func(i int, node *topology.Node),
-) (topology.ServiceID, []*topology.Node) {
+) (topology.ID, []*topology.Node) {
 	nodes := topoutil.NewTopologyMeshGatewaySet(nodeKind, partition, namePrefix, num, networks, mutateFn)
 	sid := nodes[0].Workloads[0].ID
 	return sid, nodes

--- a/test-integ/topoutil/asserter.go
+++ b/test-integ/topoutil/asserter.go
@@ -29,7 +29,7 @@ import (
 // ip/ports if there is only one port that makes sense for the assertion (such
 // as use of the envoy admin port 19000).
 //
-// If it's up to the test (like picking an upstream) leave port as an argument
+// If it's up to the test (like picking a destination) leave port as an argument
 // but still take the service and use that to grab the local ip from the
 // topology.Node.
 type Asserter struct {
@@ -78,22 +78,22 @@ func (a *Asserter) httpClientFor(cluster string) (*http.Client, error) {
 	return client, nil
 }
 
-// UpstreamEndpointStatus validates that proxy was configured with provided clusterName in the healthStatus
+// DestinationEndpointStatus validates that proxy was configured with provided clusterName in the healthStatus
 //
 // Exposes libassert.UpstreamEndpointStatus for use against a Sprawl.
 //
 // NOTE: this doesn't take a port b/c you always want to use the envoy admin port.
-func (a *Asserter) UpstreamEndpointStatus(
+func (a *Asserter) DestinationEndpointStatus(
 	t *testing.T,
-	service *topology.Service,
+	workload *topology.Workload,
 	clusterName string,
 	healthStatus string,
 	count int,
 ) {
 	t.Helper()
-	node := service.Node
+	node := workload.Node
 	ip := node.LocalAddress()
-	port := service.EnvoyAdminPort
+	port := workload.EnvoyAdminPort
 	addr := fmt.Sprintf("%s:%d", ip, port)
 
 	client := a.mustGetHTTPClient(t, node.Cluster)
@@ -106,17 +106,17 @@ func (a *Asserter) UpstreamEndpointStatus(
 //
 // Exposes libassert.HTTPServiceEchoes for use against a Sprawl.
 //
-// NOTE: this takes a port b/c you may want to reach this via your choice of upstream.
+// NOTE: this takes a port b/c you may want to reach this via your choice of destination.
 func (a *Asserter) HTTPServiceEchoes(
 	t *testing.T,
-	service *topology.Service,
+	workload *topology.Workload,
 	port int,
 	path string,
 ) {
 	t.Helper()
 	require.True(t, port > 0)
 
-	node := service.Node
+	node := workload.Node
 	ip := node.LocalAddress()
 	addr := fmt.Sprintf("%s:%d", ip, port)
 
@@ -130,10 +130,10 @@ func (a *Asserter) HTTPServiceEchoes(
 //
 // Exposes libassert.HTTPServiceEchoes for use against a Sprawl.
 //
-// NOTE: this takes a port b/c you may want to reach this via your choice of upstream.
+// NOTE: this takes a port b/c you may want to reach this via your choice of destination.
 func (a *Asserter) HTTPServiceEchoesResHeader(
 	t *testing.T,
-	service *topology.Service,
+	workload *topology.Workload,
 	port int,
 	path string,
 	expectedResHeader map[string]string,
@@ -141,7 +141,7 @@ func (a *Asserter) HTTPServiceEchoesResHeader(
 	t.Helper()
 	require.True(t, port > 0)
 
-	node := service.Node
+	node := workload.Node
 	ip := node.LocalAddress()
 	addr := fmt.Sprintf("%s:%d", ip, port)
 
@@ -151,14 +151,14 @@ func (a *Asserter) HTTPServiceEchoesResHeader(
 
 func (a *Asserter) HTTPStatus(
 	t *testing.T,
-	service *topology.Service,
+	workload *topology.Workload,
 	port int,
 	status int,
 ) {
 	t.Helper()
 	require.True(t, port > 0)
 
-	node := service.Node
+	node := workload.Node
 	ip := node.LocalAddress()
 	addr := fmt.Sprintf("%s:%d", ip, port)
 
@@ -203,30 +203,30 @@ type testingT interface {
 	Helper()
 }
 
-// does a fortio /fetch2 to the given fortio service, targetting the given upstream. Returns
+// does a fortio /fetch2 to the given fortio service, targetting the given destination. Returns
 // the body, and response with response.Body already Closed.
 //
 // We treat 400, 503, and 504s as retryable errors
-func (a *Asserter) fortioFetch2Upstream(
+func (a *Asserter) fortioFetch2Destination(
 	t testingT,
 	client *http.Client,
 	addr string,
-	upstream *topology.Upstream,
+	dest *topology.Destination,
 	path string,
 ) (body []byte, res *http.Response) {
 	t.Helper()
 
 	var actualURL string
-	if upstream.Implied {
+	if dest.Implied {
 		actualURL = fmt.Sprintf("http://%s--%s--%s.virtual.consul:%d/%s",
-			upstream.ID.Name,
-			upstream.ID.Namespace,
-			upstream.ID.Partition,
-			upstream.VirtualPort,
+			dest.ID.Name,
+			dest.ID.Namespace,
+			dest.ID.Partition,
+			dest.VirtualPort,
 			path,
 		)
 	} else {
-		actualURL = fmt.Sprintf("http://localhost:%d/%s", upstream.LocalPort, path)
+		actualURL = fmt.Sprintf("http://localhost:%d/%s", dest.LocalPort, path)
 	}
 
 	url := fmt.Sprintf("http://%s/fortio/fetch2?url=%s", addr,
@@ -243,7 +243,7 @@ func (a *Asserter) fortioFetch2Upstream(
 	// not sure when these happen, suspect it's when the mesh gateway in the peer is not yet ready
 	require.NotEqual(t, http.StatusServiceUnavailable, res.StatusCode)
 	require.NotEqual(t, http.StatusGatewayTimeout, res.StatusCode)
-	// not sure when this happens, suspect it's when envoy hasn't configured the local upstream yet
+	// not sure when this happens, suspect it's when envoy hasn't configured the local destination yet
 	require.NotEqual(t, http.StatusBadRequest, res.StatusCode)
 	body, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
@@ -252,20 +252,20 @@ func (a *Asserter) fortioFetch2Upstream(
 }
 
 // uses the /fortio/fetch2 endpoint to do a header echo check against an
-// upstream fortio
-func (a *Asserter) FortioFetch2HeaderEcho(t *testing.T, fortioSvc *topology.Service, upstream *topology.Upstream) {
+// destination fortio
+func (a *Asserter) FortioFetch2HeaderEcho(t *testing.T, fortioWrk *topology.Workload, dest *topology.Destination) {
 	const kPassphrase = "x-passphrase"
 	const passphrase = "hello"
 	path := (fmt.Sprintf("/?header=%s:%s", kPassphrase, passphrase))
 
 	var (
-		node   = fortioSvc.Node
-		addr   = fmt.Sprintf("%s:%d", node.LocalAddress(), fortioSvc.PortOrDefault(upstream.PortName))
+		node   = fortioWrk.Node
+		addr   = fmt.Sprintf("%s:%d", node.LocalAddress(), fortioWrk.PortOrDefault(dest.PortName))
 		client = a.mustGetHTTPClient(t, node.Cluster)
 	)
 
 	retry.RunWith(&retry.Timer{Timeout: 60 * time.Second, Wait: time.Millisecond * 500}, t, func(r *retry.R) {
-		_, res := a.fortioFetch2Upstream(r, client, addr, upstream, path)
+		_, res := a.fortioFetch2Destination(r, client, addr, dest, path)
 		require.Equal(r, http.StatusOK, res.StatusCode)
 		v := res.Header.Get(kPassphrase)
 		require.Equal(r, passphrase, v)
@@ -273,20 +273,20 @@ func (a *Asserter) FortioFetch2HeaderEcho(t *testing.T, fortioSvc *topology.Serv
 }
 
 // similar to libassert.AssertFortioName,
-// uses the /fortio/fetch2 endpoint to hit the debug endpoint on the upstream,
+// uses the /fortio/fetch2 endpoint to hit the debug endpoint on the destination,
 // and assert that the FORTIO_NAME == name
 func (a *Asserter) FortioFetch2FortioName(
 	t *testing.T,
-	fortioSvc *topology.Service,
-	upstream *topology.Upstream,
+	fortioWrk *topology.Workload,
+	dest *topology.Destination,
 	clusterName string,
-	sid topology.ServiceID,
+	sid topology.ID,
 ) {
 	t.Helper()
 
 	var (
-		node   = fortioSvc.Node
-		addr   = fmt.Sprintf("%s:%d", node.LocalAddress(), fortioSvc.PortOrDefault(upstream.PortName))
+		node   = fortioWrk.Node
+		addr   = fmt.Sprintf("%s:%d", node.LocalAddress(), fortioWrk.PortOrDefault(dest.PortName))
 		client = a.mustGetHTTPClient(t, node.Cluster)
 	)
 
@@ -294,7 +294,7 @@ func (a *Asserter) FortioFetch2FortioName(
 	path := "/debug?env=dump"
 
 	retry.RunWith(&retry.Timer{Timeout: 60 * time.Second, Wait: time.Millisecond * 500}, t, func(r *retry.R) {
-		body, res := a.fortioFetch2Upstream(r, client, addr, upstream, path)
+		body, res := a.fortioFetch2Destination(r, client, addr, dest, path)
 
 		require.Equal(r, http.StatusOK, res.StatusCode)
 

--- a/test-integ/topoutil/asserter.go
+++ b/test-integ/topoutil/asserter.go
@@ -179,7 +179,7 @@ func (a *Asserter) HTTPStatus(
 }
 
 // asserts that the service sid in cluster and exported by peer localPeerName is passing health checks,
-func (a *Asserter) HealthyWithPeer(t *testing.T, cluster string, sid topology.ServiceID, peerName string) {
+func (a *Asserter) HealthyWithPeer(t *testing.T, cluster string, sid topology.ID, peerName string) {
 	t.Helper()
 	cl := a.mustGetAPIClient(t, cluster)
 	retry.RunWith(&retry.Timer{Timeout: time.Minute * 1, Wait: time.Millisecond * 500}, t, func(r *retry.R) {

--- a/test-integ/topoutil/fixtures.go
+++ b/test-integ/topoutil/fixtures.go
@@ -151,7 +151,7 @@ func NewTopologyMeshGatewaySet(
 			Kind:      nodeKind,
 			Partition: sid.Partition,
 			Name:      name,
-			Services: []*topology.Service{{
+			Workloads: []*topology.Service{{
 				ID:             sid,
 				Port:           8443,
 				EnvoyAdminPort: 19000,

--- a/test-integ/topoutil/naming_shim.go
+++ b/test-integ/topoutil/naming_shim.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package topoutil
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/testing/deployer/topology"
+)
+
+// Deprecated: DestinationEndpointStatus
+func (a *Asserter) UpstreamEndpointStatus(
+	t *testing.T,
+	workload *topology.Workload,
+	clusterName string,
+	healthStatus string,
+	count int,
+) {
+	a.DestinationEndpointStatus(t, workload, clusterName, healthStatus, count)
+}
+
+// Deprecated: NewFortioWorkloadWithDefaults
+func NewFortioServiceWithDefaults(
+	cluster string,
+	sid topology.ID,
+	nodeVersion topology.NodeVersion,
+	mut func(*topology.Workload),
+) *topology.Workload {
+	return NewFortioWorkloadWithDefaults(cluster, sid, nodeVersion, mut)
+}
+
+// Deprecated: NewBlankspaceWorkloadWithDefaults
+func NewBlankspaceServiceWithDefaults(
+	cluster string,
+	sid topology.ID,
+	nodeVersion topology.NodeVersion,
+	mut func(*topology.Workload),
+) *topology.Workload {
+	return NewBlankspaceWorkloadWithDefaults(cluster, sid, nodeVersion, mut)
+}

--- a/testing/deployer/sprawl/acl.go
+++ b/testing/deployer/sprawl/acl.go
@@ -219,11 +219,12 @@ func (s *Sprawl) createServiceTokens(cluster *topology.Cluster) error {
 
 	sids := make(map[topology.ServiceID]struct{})
 	for _, node := range cluster.Nodes {
-		if !node.RunsWorkloads() || len(node.Services) == 0 || node.Disabled {
+		if !node.RunsWorkloads() || len(node.Workloads) == 0 || node.Disabled {
 			continue
 		}
 
-		for _, svc := range node.Services {
+		for _, wrk := range node.Workloads {
+			svc := wrk // TODO
 			sid := svc.ID
 
 			if _, done := sids[sid]; done {

--- a/testing/deployer/sprawl/acl.go
+++ b/testing/deployer/sprawl/acl.go
@@ -202,59 +202,56 @@ func (s *Sprawl) createCrossNamespaceCatalogReadPolicies(cluster *topology.Clust
 	return nil
 }
 
-func (s *Sprawl) createAllServiceTokens() error {
+func (s *Sprawl) createAllWorkloadTokens() error {
 	for _, cluster := range s.topology.Clusters {
-		if err := s.createServiceTokens(cluster); err != nil {
-			return fmt.Errorf("createServiceTokens[%s]: %w", cluster.Name, err)
+		if err := s.createWorkloadTokens(cluster); err != nil {
+			return fmt.Errorf("createWorkloadTokens[%s]: %w", cluster.Name, err)
 		}
 	}
 	return nil
 }
 
-func (s *Sprawl) createServiceTokens(cluster *topology.Cluster) error {
+func (s *Sprawl) createWorkloadTokens(cluster *topology.Cluster) error {
 	var (
 		client = s.clients[cluster.Name]
 		logger = s.logger.With("cluster", cluster.Name)
 	)
 
-	sids := make(map[topology.ServiceID]struct{})
+	workloadIDs := make(map[topology.ID]struct{})
 	for _, node := range cluster.Nodes {
 		if !node.RunsWorkloads() || len(node.Workloads) == 0 || node.Disabled {
 			continue
 		}
 
 		for _, wrk := range node.Workloads {
-			svc := wrk // TODO
-			sid := svc.ID
-
-			if _, done := sids[sid]; done {
+			if _, done := workloadIDs[wrk.ID]; done {
 				continue
 			}
 
 			var overridePolicy *api.ACLPolicy
-			if svc.IsMeshGateway {
+			if wrk.IsMeshGateway {
 				var err error
-				overridePolicy, err = CreateOrUpdatePolicy(client, policyForMeshGateway(svc, cluster.Enterprise))
+				overridePolicy, err = CreateOrUpdatePolicy(client, policyForMeshGateway(wrk, cluster.Enterprise))
 				if err != nil {
 					return fmt.Errorf("could not create policy: %w", err)
 				}
 			}
 
-			token, err := CreateOrUpdateToken(client, tokenForService(svc, overridePolicy, cluster.Enterprise))
+			token, err := CreateOrUpdateToken(client, tokenForWorkload(wrk, overridePolicy, cluster.Enterprise))
 			if err != nil {
 				return fmt.Errorf("could not create token: %w", err)
 			}
 
-			logger.Debug("created service token",
-				"service", svc.ID.Name,
-				"namespace", svc.ID.Namespace,
-				"partition", svc.ID.Partition,
+			logger.Debug("created workload token",
+				"workload", wrk.ID.Name,
+				"namespace", wrk.ID.Namespace,
+				"partition", wrk.ID.Partition,
 				"token", token.SecretID,
 			)
 
-			s.secrets.SaveServiceToken(cluster.Name, sid, token.SecretID)
+			s.secrets.SaveWorkloadToken(cluster.Name, wrk.ID, token.SecretID)
 
-			sids[sid] = struct{}{}
+			workloadIDs[wrk.ID] = struct{}{}
 		}
 	}
 

--- a/testing/deployer/sprawl/acl_rules.go
+++ b/testing/deployer/sprawl/acl_rules.go
@@ -86,29 +86,34 @@ func tokenForNode(node *topology.Node, enterprise bool) *api.ACLToken {
 	return token
 }
 
-func tokenForService(svc *topology.Service, overridePolicy *api.ACLPolicy, enterprise bool) *api.ACLToken {
+// Deprecated: tokenForWorkload
+func tokenForService(wrk *topology.Workload, overridePolicy *api.ACLPolicy, enterprise bool) *api.ACLToken {
+	return tokenForWorkload(wrk, overridePolicy, enterprise)
+}
+
+func tokenForWorkload(wrk *topology.Workload, overridePolicy *api.ACLPolicy, enterprise bool) *api.ACLToken {
 	token := &api.ACLToken{
-		Description: "service--" + svc.ID.ACLString(),
+		Description: "service--" + wrk.ID.ACLString(),
 		Local:       false,
 	}
 	if overridePolicy != nil {
 		token.Policies = []*api.ACLTokenPolicyLink{{ID: overridePolicy.ID}}
-	} else if svc.IsV2() {
+	} else if wrk.IsV2() {
 		token.TemplatedPolicies = []*api.ACLTemplatedPolicy{{
 			TemplateName: api.ACLTemplatedPolicyWorkloadIdentityName,
 			TemplateVariables: &api.ACLTemplatedPolicyVariables{
-				Name: svc.ID.Name,
+				Name: wrk.ID.Name,
 			},
 		}}
 	} else {
 		token.ServiceIdentities = []*api.ACLServiceIdentity{{
-			ServiceName: svc.ID.Name,
+			ServiceName: wrk.ID.Name,
 		}}
 	}
 
 	if enterprise {
-		token.Namespace = svc.ID.Namespace
-		token.Partition = svc.ID.Partition
+		token.Namespace = wrk.ID.Namespace
+		token.Partition = wrk.ID.Partition
 	}
 
 	return token
@@ -176,20 +181,20 @@ mesh = "write"
 `
 )
 
-func policyForMeshGateway(svc *topology.Service, enterprise bool) *api.ACLPolicy {
-	policyName := "mesh-gateway--" + svc.ID.ACLString()
+func policyForMeshGateway(wrk *topology.Workload, enterprise bool) *api.ACLPolicy {
+	policyName := "mesh-gateway--" + wrk.ID.ACLString()
 
 	policy := &api.ACLPolicy{
 		Name:        policyName,
 		Description: policyName,
 	}
 	if enterprise {
-		policy.Partition = svc.ID.Partition
+		policy.Partition = wrk.ID.Partition
 		policy.Namespace = "default"
 	}
 
 	if enterprise {
-		if svc.ID.Partition == "default" {
+		if wrk.ID.Partition == "default" {
 			policy.Rules = meshGatewayEntDefaultRules
 		} else {
 			policy.Rules = meshGatewayEntNonDefaultRules

--- a/testing/deployer/sprawl/boot.go
+++ b/testing/deployer/sprawl/boot.go
@@ -299,8 +299,8 @@ func (s *Sprawl) createFirstTime() error {
 
 	// Ideally we start services WITH a token initially, so we pre-create them
 	// before running terraform for them.
-	if err := s.createAllServiceTokens(); err != nil {
-		return fmt.Errorf("createAllServiceTokens: %w", err)
+	if err := s.createAllWorkloadTokens(); err != nil {
+		return fmt.Errorf("createAllWorkloadTokens: %w", err)
 	}
 
 	if err := s.syncAllServicesForDataplaneInstances(); err != nil {
@@ -367,8 +367,8 @@ func (s *Sprawl) preRegenTasks() error {
 
 	// Ideally we start services WITH a token initially, so we pre-create them
 	// before running terraform for them.
-	if err := s.createAllServiceTokens(); err != nil {
-		return fmt.Errorf("createAllServiceTokens: %w", err)
+	if err := s.createAllWorkloadTokens(); err != nil {
+		return fmt.Errorf("createAllWorkloadTokens: %w", err)
 	}
 
 	if err := s.syncAllServicesForDataplaneInstances(); err != nil {

--- a/testing/deployer/sprawl/catalog.go
+++ b/testing/deployer/sprawl/catalog.go
@@ -929,7 +929,7 @@ func workloadToSidecarCatalogRegistration(
 	cluster *topology.Cluster,
 	node *topology.Node,
 	wrk *topology.Workload,
-) (topology.ServiceID, *api.CatalogRegistration) {
+) (topology.ID, *api.CatalogRegistration) {
 	if node.IsV2() {
 		panic("don't call this")
 	}

--- a/testing/deployer/sprawl/catalog.go
+++ b/testing/deployer/sprawl/catalog.go
@@ -42,7 +42,7 @@ func (s *Sprawl) syncAllServicesForDataplaneInstances() error {
 
 func (s *Sprawl) registerServicesToAgents(cluster *topology.Cluster) error {
 	for _, node := range cluster.Nodes {
-		if !node.RunsWorkloads() || len(node.Services) == 0 || node.Disabled {
+		if !node.RunsWorkloads() || len(node.Workloads) == 0 || node.Disabled {
 			continue
 		}
 
@@ -63,8 +63,8 @@ func (s *Sprawl) registerServicesToAgents(cluster *topology.Cluster) error {
 			return err
 		}
 
-		for _, svc := range node.Services {
-			if err := s.registerAgentService(agentClient, cluster, node, svc); err != nil {
+		for _, wrk := range node.Workloads {
+			if err := s.registerAgentService(agentClient, cluster, node, wrk); err != nil {
 				return err
 			}
 		}
@@ -264,7 +264,7 @@ func (s *Sprawl) syncServicesForDataplaneInstances(cluster *topology.Cluster) er
 	var syncService func(node *topology.Node, svc *topology.Service) error
 
 	for _, node := range cluster.Nodes {
-		if !node.RunsWorkloads() || len(node.Services) == 0 {
+		if !node.RunsWorkloads() || len(node.Workloads) == 0 {
 			continue
 		}
 
@@ -280,13 +280,13 @@ func (s *Sprawl) syncServicesForDataplaneInstances(cluster *topology.Cluster) er
 		}
 
 		// Register/deregister services on the node
-		for _, svc := range node.Services {
+		for _, wrk := range node.Workloads {
 			if !node.Disabled {
 				syncService = registerServiceAtNode
 			} else {
 				syncService = deregisterServiceAtNode
 			}
-			syncService(node, svc)
+			syncService(node, wrk)
 		}
 
 		// Deregister the virtual node if node is disabled

--- a/testing/deployer/sprawl/catalog.go
+++ b/testing/deployer/sprawl/catalog.go
@@ -33,8 +33,8 @@ func (s *Sprawl) registerAllServicesToAgents() error {
 
 func (s *Sprawl) syncAllServicesForDataplaneInstances() error {
 	for _, cluster := range s.topology.Clusters {
-		if err := s.syncServicesForDataplaneInstances(cluster); err != nil {
-			return fmt.Errorf("syncServicesForDataplaneInstances[%s]: %w", cluster.Name, err)
+		if err := s.syncWorkloadsForDataplaneInstances(cluster); err != nil {
+			return fmt.Errorf("syncWorkloadsForDataplaneInstances[%s]: %w", cluster.Name, err)
 		}
 	}
 	return nil
@@ -77,7 +77,7 @@ func (s *Sprawl) registerAgentService(
 	agentClient *api.Client,
 	cluster *topology.Cluster,
 	node *topology.Node,
-	svc *topology.Service,
+	wrk *topology.Workload,
 ) error {
 	if !node.IsAgent() {
 		panic("called wrong method type")
@@ -86,7 +86,7 @@ func (s *Sprawl) registerAgentService(
 		panic("don't call this")
 	}
 
-	if svc.IsMeshGateway {
+	if wrk.IsMeshGateway {
 		return nil // handled at startup time for agent-ful, but won't be for agent-less
 	}
 
@@ -95,19 +95,19 @@ func (s *Sprawl) registerAgentService(
 	)
 
 	reg := &api.AgentServiceRegistration{
-		ID:   svc.ID.Name,
-		Name: svc.ID.Name,
-		Port: svc.Port,
-		Meta: svc.Meta,
+		ID:   wrk.ID.Name,
+		Name: wrk.ID.Name,
+		Port: wrk.Port,
+		Meta: wrk.Meta,
 	}
 	if cluster.Enterprise {
-		reg.Namespace = svc.ID.Namespace
-		reg.Partition = svc.ID.Partition
+		reg.Namespace = wrk.ID.Namespace
+		reg.Partition = wrk.ID.Partition
 	}
 
-	if !svc.DisableServiceMesh {
+	if !wrk.DisableServiceMesh {
 		var upstreams []api.Upstream
-		for _, dest := range svc.Destinations {
+		for _, dest := range wrk.Destinations {
 			uAPI := api.Upstream{
 				DestinationPeer:  dest.Peer,
 				DestinationName:  dest.ID.Name,
@@ -134,18 +134,18 @@ func (s *Sprawl) registerAgentService(
 	}
 
 	switch {
-	case svc.CheckTCP != "":
+	case wrk.CheckTCP != "":
 		chk := &api.AgentServiceCheck{
 			Name:     "up",
-			TCP:      svc.CheckTCP,
+			TCP:      wrk.CheckTCP,
 			Interval: "5s",
 			Timeout:  "1s",
 		}
 		reg.Checks = append(reg.Checks, chk)
-	case svc.CheckHTTP != "":
+	case wrk.CheckHTTP != "":
 		chk := &api.AgentServiceCheck{
 			Name:     "up",
-			HTTP:     svc.CheckHTTP,
+			HTTP:     wrk.CheckHTTP,
 			Method:   "GET",
 			Interval: "5s",
 			Timeout:  "1s",
@@ -155,7 +155,7 @@ func (s *Sprawl) registerAgentService(
 
 	// Switch token for every request.
 	hdr := make(http.Header)
-	hdr.Set("X-Consul-Token", s.secrets.ReadServiceToken(cluster.Name, svc.ID))
+	hdr.Set("X-Consul-Token", s.secrets.ReadWorkloadToken(cluster.Name, wrk.ID))
 	agentClient.SetHeaders(hdr)
 
 RETRY:
@@ -164,29 +164,29 @@ RETRY:
 			time.Sleep(50 * time.Millisecond)
 			goto RETRY
 		}
-		return fmt.Errorf("failed to register service %q to node %q: %w", svc.ID, node.ID(), err)
+		return fmt.Errorf("failed to register workload %q to node %q: %w", wrk.ID, node.ID(), err)
 	}
 
-	logger.Debug("registered service to client agent",
-		"service", svc.ID.Name,
+	logger.Debug("registered workload to client agent",
+		"workload", wrk.ID.Name,
 		"node", node.Name,
-		"namespace", svc.ID.Namespace,
-		"partition", svc.ID.Partition,
+		"namespace", wrk.ID.Namespace,
+		"partition", wrk.ID.Partition,
 	)
 
 	return nil
 }
 
-// syncServicesForDataplaneInstances register/deregister services in the given cluster
-func (s *Sprawl) syncServicesForDataplaneInstances(cluster *topology.Cluster) error {
-	identityInfo := make(map[topology.ServiceID]*Resource[*pbauth.WorkloadIdentity])
+// syncWorkloadsForDataplaneInstances register/deregister services in the given cluster
+func (s *Sprawl) syncWorkloadsForDataplaneInstances(cluster *topology.Cluster) error {
+	identityInfo := make(map[topology.ID]*Resource[*pbauth.WorkloadIdentity])
 
-	// registerServiceAtNode is called when node is not disabled
-	registerServiceAtNode := func(node *topology.Node, svc *topology.Service) error {
+	// registerWorkloadToNode is called when node is not disabled
+	registerWorkloadToNode := func(node *topology.Node, wrk *topology.Workload) error {
 		if node.IsV2() {
-			pending := serviceInstanceToResources(node, svc)
+			pending := workloadInstanceToResources(node, wrk)
 
-			workloadID := topology.NewServiceID(svc.WorkloadIdentity, svc.ID.Namespace, svc.ID.Partition)
+			workloadID := topology.NewID(wrk.WorkloadIdentity, wrk.ID.Namespace, wrk.ID.Partition)
 			if _, ok := identityInfo[workloadID]; !ok {
 				identityInfo[workloadID] = pending.WorkloadIdentity
 			}
@@ -231,11 +231,11 @@ func (s *Sprawl) syncServicesForDataplaneInstances(cluster *topology.Cluster) er
 				}
 			}
 		} else {
-			if err := s.registerCatalogServiceV1(cluster, node, svc); err != nil {
+			if err := s.registerCatalogServiceV1(cluster, node, wrk); err != nil {
 				return fmt.Errorf("error registering service: %w", err)
 			}
-			if !svc.DisableServiceMesh {
-				if err := s.registerCatalogSidecarServiceV1(cluster, node, svc); err != nil {
+			if !wrk.DisableServiceMesh {
+				if err := s.registerCatalogSidecarServiceV1(cluster, node, wrk); err != nil {
 					return fmt.Errorf("error registering sidecar service: %w", err)
 				}
 			}
@@ -243,17 +243,17 @@ func (s *Sprawl) syncServicesForDataplaneInstances(cluster *topology.Cluster) er
 		return nil
 	}
 
-	// deregisterServiceAtNode is called when node is disabled
-	deregisterServiceAtNode := func(node *topology.Node, svc *topology.Service) error {
+	// deregisterWorkloadFromNode is called when node is disabled
+	deregisterWorkloadFromNode := func(node *topology.Node, wrk *topology.Workload) error {
 		if node.IsV2() {
-			// TODO: implement deregister services for v2
-			panic("deregister services is not implemented for V2")
+			// TODO: implement deregister workload for v2
+			panic("deregister workload is not implemented for V2")
 		} else {
-			if err := s.deregisterCatalogServiceV1(cluster, node, svc); err != nil {
+			if err := s.deregisterCatalogServiceV1(cluster, node, wrk); err != nil {
 				return fmt.Errorf("error deregistering service: %w", err)
 			}
-			if !svc.DisableServiceMesh {
-				if err := s.deregisterCatalogSidecarServiceV1(cluster, node, svc); err != nil {
+			if !wrk.DisableServiceMesh {
+				if err := s.deregisterCatalogSidecarServiceV1(cluster, node, wrk); err != nil {
 					return fmt.Errorf("error deregistering sidecar service: %w", err)
 				}
 			}
@@ -261,7 +261,7 @@ func (s *Sprawl) syncServicesForDataplaneInstances(cluster *topology.Cluster) er
 		return nil
 	}
 
-	var syncService func(node *topology.Node, svc *topology.Service) error
+	var syncWorkload func(node *topology.Node, wrk *topology.Workload) error
 
 	for _, node := range cluster.Nodes {
 		if !node.RunsWorkloads() || len(node.Workloads) == 0 {
@@ -282,11 +282,11 @@ func (s *Sprawl) syncServicesForDataplaneInstances(cluster *topology.Cluster) er
 		// Register/deregister services on the node
 		for _, wrk := range node.Workloads {
 			if !node.Disabled {
-				syncService = registerServiceAtNode
+				syncWorkload = registerWorkloadToNode
 			} else {
-				syncService = deregisterServiceAtNode
+				syncWorkload = deregisterWorkloadFromNode
 			}
-			syncService(node, wrk)
+			syncWorkload(node, wrk)
 		}
 
 		// Deregister the virtual node if node is disabled
@@ -508,7 +508,7 @@ RETRY:
 func (s *Sprawl) deregisterCatalogServiceV1(
 	cluster *topology.Cluster,
 	node *topology.Node,
-	svc *topology.Service,
+	wrk *topology.Workload,
 ) error {
 	if !node.IsDataplane() {
 		panic("called wrong method type")
@@ -524,7 +524,7 @@ func (s *Sprawl) deregisterCatalogServiceV1(
 
 	dereg := &api.CatalogDeregistration{
 		Node:      node.PodName(),
-		ServiceID: svc.ID.Name,
+		ServiceID: wrk.ID.Name,
 	}
 RETRY:
 	if _, err := client.Catalog().Deregister(dereg, nil); err != nil {
@@ -532,11 +532,11 @@ RETRY:
 			time.Sleep(50 * time.Millisecond)
 			goto RETRY
 		}
-		return fmt.Errorf("error deregistering service %s at node %s: %w", svc.ID, node.ID(), err)
+		return fmt.Errorf("error deregistering service %s at node %s: %w", wrk.ID, node.ID(), err)
 	}
 
 	logger.Info("dataplane service removed",
-		"service", svc.ID,
+		"service", wrk.ID,
 		"node", node.ID(),
 	)
 
@@ -546,7 +546,7 @@ RETRY:
 func (s *Sprawl) registerCatalogServiceV1(
 	cluster *topology.Cluster,
 	node *topology.Node,
-	svc *topology.Service,
+	wrk *topology.Workload,
 ) error {
 	if !node.IsDataplane() {
 		panic("called wrong method type")
@@ -560,7 +560,7 @@ func (s *Sprawl) registerCatalogServiceV1(
 		logger = s.logger.With("cluster", cluster.Name)
 	)
 
-	reg := serviceToCatalogRegistration(cluster, node, svc)
+	reg := workloadToCatalogRegistration(cluster, node, wrk)
 
 RETRY:
 	if _, err := client.Catalog().Register(reg, nil); err != nil {
@@ -568,11 +568,11 @@ RETRY:
 			time.Sleep(50 * time.Millisecond)
 			goto RETRY
 		}
-		return fmt.Errorf("error registering service %s to node %s: %w", svc.ID, node.ID(), err)
+		return fmt.Errorf("error registering service %s to node %s: %w", wrk.ID, node.ID(), err)
 	}
 
 	logger.Debug("dataplane service created",
-		"service", svc.ID,
+		"service", wrk.ID,
 		"node", node.ID(),
 	)
 
@@ -582,12 +582,12 @@ RETRY:
 func (s *Sprawl) deregisterCatalogSidecarServiceV1(
 	cluster *topology.Cluster,
 	node *topology.Node,
-	svc *topology.Service,
+	wrk *topology.Workload,
 ) error {
 	if !node.IsDataplane() {
 		panic("called wrong method type")
 	}
-	if svc.DisableServiceMesh {
+	if wrk.DisableServiceMesh {
 		panic("not valid")
 	}
 	if node.IsV2() {
@@ -599,7 +599,7 @@ func (s *Sprawl) deregisterCatalogSidecarServiceV1(
 		logger = s.logger.With("cluster", cluster.Name)
 	)
 
-	pid := svc.ID
+	pid := wrk.ID
 	pid.Name += "-sidecar-proxy"
 	dereg := &api.CatalogDeregistration{
 		Node:      node.PodName(),
@@ -612,7 +612,7 @@ RETRY:
 			time.Sleep(50 * time.Millisecond)
 			goto RETRY
 		}
-		return fmt.Errorf("error deregistering service %s to node %s: %w", svc.ID, node.ID(), err)
+		return fmt.Errorf("error deregistering service %s to node %s: %w", wrk.ID, node.ID(), err)
 	}
 
 	logger.Info("dataplane sidecar service removed",
@@ -626,12 +626,12 @@ RETRY:
 func (s *Sprawl) registerCatalogSidecarServiceV1(
 	cluster *topology.Cluster,
 	node *topology.Node,
-	svc *topology.Service,
+	wrk *topology.Workload,
 ) error {
 	if !node.IsDataplane() {
 		panic("called wrong method type")
 	}
-	if svc.DisableServiceMesh {
+	if wrk.DisableServiceMesh {
 		panic("not valid")
 	}
 	if node.IsV2() {
@@ -643,14 +643,14 @@ func (s *Sprawl) registerCatalogSidecarServiceV1(
 		logger = s.logger.With("cluster", cluster.Name)
 	)
 
-	pid, reg := serviceToSidecarCatalogRegistration(cluster, node, svc)
+	pid, reg := workloadToSidecarCatalogRegistration(cluster, node, wrk)
 RETRY:
 	if _, err := client.Catalog().Register(reg, nil); err != nil {
 		if isACLNotFound(err) {
 			time.Sleep(50 * time.Millisecond)
 			goto RETRY
 		}
-		return fmt.Errorf("error registering service %s to node %s: %w", svc.ID, node.ID(), err)
+		return fmt.Errorf("error registering service %s to node %s: %w", wrk.ID, node.ID(), err)
 	}
 
 	logger.Debug("dataplane sidecar service created",
@@ -683,23 +683,23 @@ type ServiceResources struct {
 	ProxyConfiguration *Resource[*pbmesh.ProxyConfiguration]
 }
 
-func serviceInstanceToResources(
+func workloadInstanceToResources(
 	node *topology.Node,
-	svc *topology.Service,
+	wrk *topology.Workload,
 ) *ServiceResources {
-	if svc.IsMeshGateway {
+	if wrk.IsMeshGateway {
 		panic("v2 does not yet support mesh gateways")
 	}
 
 	tenancy := &pbresource.Tenancy{
-		Partition: svc.ID.Partition,
-		Namespace: svc.ID.Namespace,
+		Partition: wrk.ID.Partition,
+		Namespace: wrk.ID.Namespace,
 	}
 
 	var (
 		wlPorts = map[string]*pbcatalog.WorkloadPort{}
 	)
-	for name, port := range svc.Ports {
+	for name, port := range wrk.Ports {
 		wlPorts[name] = &pbcatalog.WorkloadPort{
 			Port:     uint32(port.Number),
 			Protocol: port.ActualProtocol,
@@ -708,22 +708,22 @@ func serviceInstanceToResources(
 
 	var (
 		selector = &pbcatalog.WorkloadSelector{
-			Names: []string{svc.Workload},
+			Names: []string{wrk.Workload},
 		}
 
 		workloadRes = &Resource[*pbcatalog.Workload]{
 			Resource: &pbresource.Resource{
 				Id: &pbresource.ID{
 					Type:    pbcatalog.WorkloadType,
-					Name:    svc.Workload,
+					Name:    wrk.Workload,
 					Tenancy: tenancy,
 				},
-				Metadata: svc.Meta,
+				Metadata: wrk.Meta,
 			},
 			Data: &pbcatalog.Workload{
 				// TODO(rb): disabling this until node scoping makes sense again
 				// NodeName: node.PodName(),
-				Identity: svc.ID.Name,
+				Identity: wrk.ID.Name,
 				Ports:    wlPorts,
 				Addresses: []*pbcatalog.WorkloadAddress{
 					{Host: node.LocalAddress()},
@@ -734,7 +734,7 @@ func serviceInstanceToResources(
 			Resource: &pbresource.Resource{
 				Id: &pbresource.ID{
 					Type:    pbauth.WorkloadIdentityType,
-					Name:    svc.WorkloadIdentity,
+					Name:    wrk.WorkloadIdentity,
 					Tenancy: tenancy,
 				},
 			},
@@ -746,13 +746,13 @@ func serviceInstanceToResources(
 		proxyConfigRes  *Resource[*pbmesh.ProxyConfiguration]
 	)
 
-	if svc.HasCheck() {
+	if wrk.HasCheck() {
 		// TODO: needs ownerId
 		checkRes := &Resource[*pbcatalog.HealthStatus]{
 			Resource: &pbresource.Resource{
 				Id: &pbresource.ID{
 					Type:    pbcatalog.HealthStatusType,
-					Name:    svc.Workload + "-check-0",
+					Name:    wrk.Workload + "-check-0",
 					Tenancy: tenancy,
 				},
 			},
@@ -771,12 +771,12 @@ func serviceInstanceToResources(
 		)
 	}
 
-	if !svc.DisableServiceMesh {
+	if !wrk.DisableServiceMesh {
 		destinationsRes = &Resource[*pbmesh.Destinations]{
 			Resource: &pbresource.Resource{
 				Id: &pbresource.ID{
 					Type:    pbmesh.DestinationsType,
-					Name:    svc.Workload,
+					Name:    wrk.Workload,
 					Tenancy: tenancy,
 				},
 			},
@@ -785,7 +785,7 @@ func serviceInstanceToResources(
 			},
 		}
 
-		for _, dest := range svc.Destinations {
+		for _, dest := range wrk.Destinations {
 			meshDest := &pbmesh.Destination{
 				DestinationRef: &pbresource.Reference{
 					Type: pbcatalog.ServiceType,
@@ -806,12 +806,12 @@ func serviceInstanceToResources(
 			destinationsRes.Data.Destinations = append(destinationsRes.Data.Destinations, meshDest)
 		}
 
-		if svc.EnableTransparentProxy {
+		if wrk.EnableTransparentProxy {
 			proxyConfigRes = &Resource[*pbmesh.ProxyConfiguration]{
 				Resource: &pbresource.Resource{
 					Id: &pbresource.ID{
 						Type:    pbmesh.ProxyConfigurationType,
-						Name:    svc.Workload,
+						Name:    wrk.Workload,
 						Tenancy: tenancy,
 					},
 				},
@@ -834,10 +834,10 @@ func serviceInstanceToResources(
 	}
 }
 
-func serviceToCatalogRegistration(
+func workloadToCatalogRegistration(
 	cluster *topology.Cluster,
 	node *topology.Node,
-	svc *topology.Service,
+	wrk *topology.Workload,
 ) *api.CatalogRegistration {
 	if node.IsV2() {
 		panic("don't call this")
@@ -847,14 +847,14 @@ func serviceToCatalogRegistration(
 		SkipNodeUpdate: true,
 		Service: &api.AgentService{
 			Kind:    api.ServiceKindTypical,
-			ID:      svc.ID.Name,
-			Service: svc.ID.Name,
-			Meta:    svc.Meta,
-			Port:    svc.Port,
+			ID:      wrk.ID.Name,
+			Service: wrk.ID.Name,
+			Meta:    wrk.Meta,
+			Port:    wrk.Port,
 			Address: node.LocalAddress(),
 		},
 	}
-	if svc.IsMeshGateway {
+	if wrk.IsMeshGateway {
 		reg.Service.Kind = api.ServiceKindMeshGateway
 		reg.Service.Proxy = &api.AgentServiceConnectProxyConfig{
 			Config: map[string]interface{}{
@@ -878,46 +878,46 @@ func serviceToCatalogRegistration(
 		reg.Service.TaggedAddresses = map[string]api.ServiceAddress{
 			"lan": {
 				Address: node.LocalAddress(),
-				Port:    svc.Port,
+				Port:    wrk.Port,
 			},
 			"lan_ipv4": {
 				Address: node.LocalAddress(),
-				Port:    svc.Port,
+				Port:    wrk.Port,
 			},
 			"wan": {
 				Address: node.PublicAddress(),
-				Port:    svc.Port,
+				Port:    wrk.Port,
 			},
 			"wan_ipv4": {
 				Address: node.PublicAddress(),
-				Port:    svc.Port,
+				Port:    wrk.Port,
 			},
 		}
 	}
 	if cluster.Enterprise {
-		reg.Partition = svc.ID.Partition
-		reg.Service.Namespace = svc.ID.Namespace
-		reg.Service.Partition = svc.ID.Partition
+		reg.Partition = wrk.ID.Partition
+		reg.Service.Namespace = wrk.ID.Namespace
+		reg.Service.Partition = wrk.ID.Partition
 	}
 
-	if svc.HasCheck() {
+	if wrk.HasCheck() {
 		chk := &api.HealthCheck{
 			Name: "external sync",
 			// Type:      "external-sync",
 			Status:      "passing", //  TODO
-			ServiceID:   svc.ID.Name,
-			ServiceName: svc.ID.Name,
+			ServiceID:   wrk.ID.Name,
+			ServiceName: wrk.ID.Name,
 			Output:      "",
 		}
 		if cluster.Enterprise {
-			chk.Namespace = svc.ID.Namespace
-			chk.Partition = svc.ID.Partition
+			chk.Namespace = wrk.ID.Namespace
+			chk.Partition = wrk.ID.Partition
 		}
 		switch {
-		case svc.CheckTCP != "":
-			chk.Definition.TCP = svc.CheckTCP
-		case svc.CheckHTTP != "":
-			chk.Definition.HTTP = svc.CheckHTTP
+		case wrk.CheckTCP != "":
+			chk.Definition.TCP = wrk.CheckTCP
+		case wrk.CheckHTTP != "":
+			chk.Definition.HTTP = wrk.CheckHTTP
 			chk.Definition.Method = "GET"
 		}
 		reg.Checks = append(reg.Checks, chk)
@@ -925,15 +925,15 @@ func serviceToCatalogRegistration(
 	return reg
 }
 
-func serviceToSidecarCatalogRegistration(
+func workloadToSidecarCatalogRegistration(
 	cluster *topology.Cluster,
 	node *topology.Node,
-	svc *topology.Service,
+	wrk *topology.Workload,
 ) (topology.ServiceID, *api.CatalogRegistration) {
 	if node.IsV2() {
 		panic("don't call this")
 	}
-	pid := svc.ID
+	pid := wrk.ID
 	pid.Name += "-sidecar-proxy"
 	reg := &api.CatalogRegistration{
 		Node:           node.PodName(),
@@ -942,13 +942,13 @@ func serviceToSidecarCatalogRegistration(
 			Kind:    api.ServiceKindConnectProxy,
 			ID:      pid.Name,
 			Service: pid.Name,
-			Meta:    svc.Meta,
-			Port:    svc.EnvoyPublicListenerPort,
+			Meta:    wrk.Meta,
+			Port:    wrk.EnvoyPublicListenerPort,
 			Address: node.LocalAddress(),
 			Proxy: &api.AgentServiceConnectProxyConfig{
-				DestinationServiceName: svc.ID.Name,
-				DestinationServiceID:   svc.ID.Name,
-				LocalServicePort:       svc.Port,
+				DestinationServiceName: wrk.ID.Name,
+				DestinationServiceID:   wrk.ID.Name,
+				LocalServicePort:       wrk.Port,
 			},
 		},
 		Checks: []*api.HealthCheck{{
@@ -958,7 +958,7 @@ func serviceToSidecarCatalogRegistration(
 			ServiceID:   pid.Name,
 			ServiceName: pid.Name,
 			Definition: api.HealthCheckDefinition{
-				TCP: fmt.Sprintf("%s:%d", node.LocalAddress(), svc.EnvoyPublicListenerPort),
+				TCP: fmt.Sprintf("%s:%d", node.LocalAddress(), wrk.EnvoyPublicListenerPort),
 			},
 			Output: "",
 		}},
@@ -979,7 +979,7 @@ func serviceToSidecarCatalogRegistration(
 		reg.Checks[0].Partition = pid.Partition
 	}
 
-	for _, dest := range svc.Destinations {
+	for _, dest := range wrk.Destinations {
 		pu := api.Upstream{
 			DestinationName:  dest.ID.Name,
 			DestinationPeer:  dest.Peer,

--- a/testing/deployer/sprawl/details.go
+++ b/testing/deployer/sprawl/details.go
@@ -60,29 +60,28 @@ func (s *Sprawl) PrintDetails() error {
 			}
 
 			for _, wrk := range node.Workloads {
-				svc := wrk // TODO
-				if svc.IsMeshGateway {
+				if wrk.IsMeshGateway {
 					cd.Apps = append(cd.Apps, appDetail{
 						Type:                  "mesh-gateway",
 						Container:             node.DockerName(),
-						ExposedPort:           node.ExposedPort(svc.Port),
-						ExposedEnvoyAdminPort: node.ExposedPort(svc.EnvoyAdminPort),
+						ExposedPort:           node.ExposedPort(wrk.Port),
+						ExposedEnvoyAdminPort: node.ExposedPort(wrk.EnvoyAdminPort),
 						Addresses:             addrs,
-						Service:               svc.ID.String(),
+						Service:               wrk.ID.String(),
 					})
 				} else {
 					ports := make(map[string]int)
-					for name, port := range svc.Ports {
+					for name, port := range wrk.Ports {
 						ports[name] = node.ExposedPort(port.Number)
 					}
 					cd.Apps = append(cd.Apps, appDetail{
 						Type:                  "app",
 						Container:             node.DockerName(),
-						ExposedPort:           node.ExposedPort(svc.Port),
+						ExposedPort:           node.ExposedPort(wrk.Port),
 						ExposedPorts:          ports,
-						ExposedEnvoyAdminPort: node.ExposedPort(svc.EnvoyAdminPort),
+						ExposedEnvoyAdminPort: node.ExposedPort(wrk.EnvoyAdminPort),
 						Addresses:             addrs,
-						Service:               svc.ID.String(),
+						Service:               wrk.ID.String(),
 					})
 				}
 			}

--- a/testing/deployer/sprawl/details.go
+++ b/testing/deployer/sprawl/details.go
@@ -59,7 +59,8 @@ func (s *Sprawl) PrintDetails() error {
 				})
 			}
 
-			for _, svc := range node.Services {
+			for _, wrk := range node.Workloads {
+				svc := wrk // TODO
 				if svc.IsMeshGateway {
 					cd.Apps = append(cd.Apps, appDetail{
 						Type:                  "mesh-gateway",

--- a/testing/deployer/sprawl/internal/secrets/store.go
+++ b/testing/deployer/sprawl/internal/secrets/store.go
@@ -37,12 +37,22 @@ func (s *Store) ReadAgentToken(cluster string, nid topology.NodeID) string {
 	return s.read(encode(cluster, "agent", nid.String()))
 }
 
-func (s *Store) SaveServiceToken(cluster string, sid topology.ServiceID, value string) {
-	s.save(encode(cluster, "service", sid.String()), value)
+// Deprecated: SaveWorkloadToken
+func (s *Store) SaveServiceToken(cluster string, wid topology.ID, value string) {
+	s.SaveWorkloadToken(cluster, wid, value)
 }
 
-func (s *Store) ReadServiceToken(cluster string, sid topology.ServiceID) string {
-	return s.read(encode(cluster, "service", sid.String()))
+func (s *Store) SaveWorkloadToken(cluster string, wid topology.ID, value string) {
+	s.save(encode(cluster, "workload", wid.String()), value)
+}
+
+// Deprecated: ReadWorkloadToken
+func (s *Store) ReadServiceToken(cluster string, wid topology.ID) string {
+	return s.ReadWorkloadToken(cluster, wid)
+}
+
+func (s *Store) ReadWorkloadToken(cluster string, wid topology.ID) string {
+	return s.read(encode(cluster, "workload", wid.String()))
 }
 
 func (s *Store) save(key, value string) {

--- a/testing/deployer/sprawl/internal/tfgen/gen.go
+++ b/testing/deployer/sprawl/internal/tfgen/gen.go
@@ -270,8 +270,8 @@ func (g *Generator) Generate(step Step) error {
 					addVolume(node.DockerName())
 				}
 
-				for _, svc := range node.Services {
-					addImage("", svc.Image)
+				for _, wrk := range node.Workloads {
+					addImage("", wrk.Image)
 				}
 
 				myContainers, err := g.generateNodeContainers(step, c, node)

--- a/testing/deployer/sprawl/internal/tfgen/templates/container-app-dataplane.tf.tmpl
+++ b/testing/deployer/sprawl/internal/tfgen/templates/container-app-dataplane.tf.tmpl
@@ -1,5 +1,5 @@
-resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}-sidecar" {
-	name = "{{.Node.DockerName}}-{{.Service.ID.TFString}}-sidecar"
+resource "docker_container" "{{.Node.DockerName}}-{{.Workload.ID.TFString}}-sidecar" {
+	name = "{{.Node.DockerName}}-{{.Workload.ID.TFString}}-sidecar"
     network_mode = "container:${docker_container.{{.PodName}}.id}"
     image        = docker_image.{{.ImageResource}}.image_id
     restart      = "on-failure"
@@ -17,7 +17,7 @@ resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}-sidec
     read_only      = true
   }
 
-{{ if .Service.EnableTransparentProxy }}
+{{ if .Workload.EnableTransparentProxy }}
   capabilities {
     add = ["NET_ADMIN"]
   }
@@ -27,17 +27,17 @@ resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}-sidec
   env = [
     "DP_CONSUL_ADDRESSES=server.{{.Node.Cluster}}-consulcluster.lan",
 {{ if .Node.IsV2 }}
-    "DP_PROXY_ID={{.Service.Workload}}",
+    "DP_PROXY_ID={{.Workload.Workload}}",
 {{ if .Enterprise }}
-    "DP_PROXY_NAMESPACE={{.Service.ID.Namespace}}",
-    "DP_PROXY_PARTITION={{.Service.ID.Partition}}",
+    "DP_PROXY_NAMESPACE={{.Workload.ID.Namespace}}",
+    "DP_PROXY_PARTITION={{.Workload.ID.Partition}}",
 {{ end }}
 {{ else }}
     "DP_SERVICE_NODE_NAME={{.Node.PodName}}",
-    "DP_PROXY_SERVICE_ID={{.Service.ID.Name}}-sidecar-proxy",
+    "DP_PROXY_SERVICE_ID={{.Workload.ID.Name}}-sidecar-proxy",
 {{ if .Enterprise }}
-    "DP_SERVICE_NAMESPACE={{.Service.ID.Namespace}}",
-    "DP_SERVICE_PARTITION={{.Service.ID.Partition}}",
+    "DP_SERVICE_NAMESPACE={{.Workload.ID.Namespace}}",
+    "DP_SERVICE_PARTITION={{.Workload.ID.Partition}}",
 {{ end }}
 {{ end }}
 
@@ -46,7 +46,7 @@ resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}-sidec
     "DP_CREDENTIAL_STATIC_TOKEN={{.Token}}",
 {{ end }}
 
-{{ if .Service.EnableTransparentProxy }}
+{{ if .Workload.EnableTransparentProxy }}
     "REDIRECT_TRAFFIC_ARGS=-exclude-inbound-port=19000",
 {{ end }}
 

--- a/testing/deployer/sprawl/internal/tfgen/templates/container-app-sidecar.tf.tmpl
+++ b/testing/deployer/sprawl/internal/tfgen/templates/container-app-sidecar.tf.tmpl
@@ -1,5 +1,5 @@
-resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}-sidecar" {
-	name = "{{.Node.DockerName}}-{{.Service.ID.TFString}}-sidecar"
+resource "docker_container" "{{.Node.DockerName}}-{{.Workload.ID.TFString}}-sidecar" {
+	name = "{{.Node.DockerName}}-{{.Workload.ID.TFString}}-sidecar"
     network_mode = "container:${docker_container.{{.PodName}}.id}"
     image        = docker_image.{{.ImageResource}}.image_id
     restart  = "on-failure"
@@ -19,13 +19,13 @@ resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}-sidec
 
   command = [
     "consul", "connect", "envoy",
-    "-sidecar-for={{.Service.ID.Name}}",
+    "-sidecar-for={{.Workload.ID.Name}}",
     "-grpc-addr=http://127.0.0.1:8502",
     // for demo purposes (TODO: huh?)
-    "-admin-bind=0.0.0.0:{{.Service.EnvoyAdminPort}}",
+    "-admin-bind=0.0.0.0:{{.Workload.EnvoyAdminPort}}",
   {{if .Enterprise}} 
-    "-partition={{.Service.ID.Partition}}",
-    "-namespace={{.Service.ID.Namespace}}",
+    "-partition={{.Workload.ID.Partition}}",
+    "-namespace={{.Workload.ID.Namespace}}",
   {{end}}
   {{if .Token }}
     "-token={{.Token}}",

--- a/testing/deployer/sprawl/internal/tfgen/templates/container-app.tf.tmpl
+++ b/testing/deployer/sprawl/internal/tfgen/templates/container-app.tf.tmpl
@@ -1,5 +1,5 @@
-resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}" {
-	name = "{{.Node.DockerName}}-{{.Service.ID.TFString}}"
+resource "docker_container" "{{.Node.DockerName}}-{{.Workload.ID.TFString}}" {
+	name = "{{.Node.DockerName}}-{{.Workload.ID.TFString}}"
     network_mode = "container:${docker_container.{{.PodName}}.id}"
     image        = docker_image.{{.ImageResource}}.image_id
     restart  = "on-failure"
@@ -12,13 +12,13 @@ resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}" {
 {{- end }}
 
   env = [
-{{- range .Service.Env }}
+{{- range .Workload.Env }}
       "{{.}}",
 {{- end}}
   ]
 
   command = [
-{{- range .Service.Command }}
+{{- range .Workload.Command }}
     "{{.}}",
 {{- end }}
   ]

--- a/testing/deployer/sprawl/internal/tfgen/templates/container-mgw-dataplane.tf.tmpl
+++ b/testing/deployer/sprawl/internal/tfgen/templates/container-mgw-dataplane.tf.tmpl
@@ -1,5 +1,5 @@
-resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}" {
-	name = "{{.Node.DockerName}}-{{.Service.ID.TFString}}"
+resource "docker_container" "{{.Node.DockerName}}-{{.Workload.ID.TFString}}" {
+	name = "{{.Node.DockerName}}-{{.Workload.ID.TFString}}"
     network_mode = "container:${docker_container.{{.PodName}}.id}"
     image        = docker_image.{{.ImageResource}}.image_id
     restart      = "on-failure"
@@ -20,10 +20,10 @@ resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}" {
   env = [
 			"DP_CONSUL_ADDRESSES=server.{{.Node.Cluster}}-consulcluster.lan",
 			"DP_SERVICE_NODE_NAME={{.Node.PodName}}",
-			"DP_PROXY_SERVICE_ID={{.Service.ID.Name}}",
+			"DP_PROXY_SERVICE_ID={{.Workload.ID.Name}}",
     {{ if .Enterprise }}
-      "DP_SERVICE_NAMESPACE={{.Service.ID.Namespace}}",
-      "DP_SERVICE_PARTITION={{.Service.ID.Partition}}",
+      "DP_SERVICE_NAMESPACE={{.Workload.ID.Namespace}}",
+      "DP_SERVICE_PARTITION={{.Workload.ID.Partition}}",
     {{ end }}
     {{ if .Token }}
       "DP_CREDENTIAL_TYPE=static",

--- a/testing/deployer/sprawl/internal/tfgen/templates/container-mgw.tf.tmpl
+++ b/testing/deployer/sprawl/internal/tfgen/templates/container-mgw.tf.tmpl
@@ -1,5 +1,5 @@
-resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}" {
-    name = "{{.Node.DockerName}}-{{.Service.ID.TFString}}"
+resource "docker_container" "{{.Node.DockerName}}-{{.Workload.ID.TFString}}" {
+    name = "{{.Node.DockerName}}-{{.Workload.ID.TFString}}"
     network_mode = "container:${docker_container.{{.PodName}}.id}"
     image        = docker_image.{{.ImageResource}}.image_id
     restart  = "on-failure"
@@ -21,13 +21,13 @@ resource "docker_container" "{{.Node.DockerName}}-{{.Service.ID.TFString}}" {
     "consul", "connect", "envoy",
     "-register",
     "-mesh-gateway",
-    "-address={{`{{ GetInterfaceIP \"eth0\" }}`}}:{{.Service.Port}}",
-    "-wan-address={{`{{ GetInterfaceIP \"eth1\" }}`}}:{{.Service.Port}}",
+    "-address={{`{{ GetInterfaceIP \"eth0\" }}`}}:{{.Workload.Port}}",
+    "-wan-address={{`{{ GetInterfaceIP \"eth1\" }}`}}:{{.Workload.Port}}",
     "-grpc-addr=http://127.0.0.1:8502",
     // for demo purposes (TODO: huh?)
-    "-admin-bind=0.0.0.0:{{.Service.EnvoyAdminPort}}",
+    "-admin-bind=0.0.0.0:{{.Workload.EnvoyAdminPort}}",
   {{ if .Enterprise }} 
-    "-partition={{.Service.ID.Partition}}",
+    "-partition={{.Workload.ID.Partition}}",
   {{end}}
   {{ if .Token }}
     "-token={{.Token}}",

--- a/testing/deployer/sprawl/peering.go
+++ b/testing/deployer/sprawl/peering.go
@@ -193,9 +193,9 @@ func (s *Sprawl) awaitMeshGateways() {
 	mgws := []*topology.Service{}
 	for _, clu := range s.topology.Clusters {
 		for _, node := range clu.Nodes {
-			for _, svc := range node.Services {
-				if svc.IsMeshGateway {
-					mgws = append(mgws, svc)
+			for _, wrk := range node.Workloads {
+				if wrk.IsMeshGateway {
+					mgws = append(mgws, wrk)
 				}
 			}
 		}

--- a/testing/deployer/sprawl/peering.go
+++ b/testing/deployer/sprawl/peering.go
@@ -190,7 +190,7 @@ func (s *Sprawl) awaitMeshGateways() {
 	startTime := time.Now()
 	s.logger.Info("awaiting mesh gateways")
 	// TODO: maybe a better way to do this
-	mgws := []*topology.Service{}
+	mgws := []*topology.Workload{}
 	for _, clu := range s.topology.Clusters {
 		for _, node := range clu.Nodes {
 			for _, wrk := range node.Workloads {

--- a/testing/deployer/sprawl/sprawl.go
+++ b/testing/deployer/sprawl/sprawl.go
@@ -390,11 +390,12 @@ func (s *Sprawl) SnapshotEnvoy(ctx context.Context) error {
 			if n.Disabled {
 				continue
 			}
-			for _, s := range n.Services {
-				if s.Disabled || s.EnvoyAdminPort <= 0 {
+			for _, wrk := range n.Workloads {
+				s := wrk // TODO
+				if wrk.Disabled || wrk.EnvoyAdminPort <= 0 {
 					continue
 				}
-				prefix := fmt.Sprintf("http://%s:%d", n.LocalAddress(), s.EnvoyAdminPort)
+				prefix := fmt.Sprintf("http://%s:%d", n.LocalAddress(), wrk.EnvoyAdminPort)
 
 				for fn, target := range targets {
 					u := prefix + "/" + target
@@ -402,7 +403,7 @@ func (s *Sprawl) SnapshotEnvoy(ctx context.Context) error {
 					body, err := scrapeURL(client, u)
 					if err != nil {
 						merr = multierror.Append(merr, fmt.Errorf("could not scrape %q for %s on %s: %w",
-							target, s.ID.String(), n.ID().String(), err,
+							target, wrk.ID.String(), n.ID().String(), err,
 						))
 						continue
 					}

--- a/testing/deployer/sprawl/sprawl.go
+++ b/testing/deployer/sprawl/sprawl.go
@@ -391,7 +391,6 @@ func (s *Sprawl) SnapshotEnvoy(ctx context.Context) error {
 				continue
 			}
 			for _, wrk := range n.Workloads {
-				s := wrk // TODO
 				if wrk.Disabled || wrk.EnvoyAdminPort <= 0 {
 					continue
 				}
@@ -408,18 +407,18 @@ func (s *Sprawl) SnapshotEnvoy(ctx context.Context) error {
 						continue
 					}
 
-					outFn := filepath.Join(snapDir, n.DockerName()+"--"+s.ID.TFString()+"."+fn)
+					outFn := filepath.Join(snapDir, n.DockerName()+"--"+wrk.ID.TFString()+"."+fn)
 
 					if err := os.WriteFile(outFn+".tmp", body, 0644); err != nil {
 						merr = multierror.Append(merr, fmt.Errorf("could not write output %q for %s on %s: %w",
-							target, s.ID.String(), n.ID().String(), err,
+							target, wrk.ID.String(), n.ID().String(), err,
 						))
 						continue
 					}
 
 					if err := os.Rename(outFn+".tmp", outFn); err != nil {
 						merr = multierror.Append(merr, fmt.Errorf("could not write output %q for %s on %s: %w",
-							target, s.ID.String(), n.ID().String(), err,
+							target, wrk.ID.String(), n.ID().String(), err,
 						))
 						continue
 					}

--- a/testing/deployer/sprawl/sprawltest/test_test.go
+++ b/testing/deployer/sprawl/sprawltest/test_test.go
@@ -40,9 +40,9 @@ func TestSprawl_CatalogV2(t *testing.T) {
 						Kind:    topology.NodeKindDataplane,
 						Version: topology.NodeVersionV2,
 						Name:    "dc1-client1",
-						Workloads: []*topology.Service{
+						Workloads: []*topology.Workload{
 							{
-								ID:             topology.ServiceID{Name: "ping"},
+								ID:             topology.ID{Name: "ping"},
 								Image:          "rboyer/pingpong:latest",
 								Port:           8080,
 								EnvoyAdminPort: 19000,
@@ -53,8 +53,8 @@ func TestSprawl_CatalogV2(t *testing.T) {
 									"-dialfreq", "250ms",
 									"-name", "ping",
 								},
-								Upstreams: []*topology.Upstream{{
-									ID:        topology.ServiceID{Name: "pong"},
+								Destinations: []*topology.Destination{{
+									ID:        topology.ID{Name: "pong"},
 									LocalPort: 9090,
 								}},
 							},
@@ -64,9 +64,9 @@ func TestSprawl_CatalogV2(t *testing.T) {
 						Kind:    topology.NodeKindDataplane,
 						Version: topology.NodeVersionV2,
 						Name:    "dc1-client2",
-						Workloads: []*topology.Service{
+						Workloads: []*topology.Workload{
 							{
-								ID:             topology.ServiceID{Name: "pong"},
+								ID:             topology.ID{Name: "pong"},
 								Image:          "rboyer/pingpong:latest",
 								Port:           8080,
 								EnvoyAdminPort: 19000,
@@ -77,8 +77,8 @@ func TestSprawl_CatalogV2(t *testing.T) {
 									"-dialfreq", "250ms",
 									"-name", "pong",
 								},
-								Upstreams: []*topology.Upstream{{
-									ID:        topology.ServiceID{Name: "ping"},
+								Destinations: []*topology.Destination{{
+									ID:        topology.ID{Name: "ping"},
 									LocalPort: 9090,
 								}},
 							},
@@ -174,9 +174,9 @@ func TestSprawl(t *testing.T) {
 					{
 						Kind: topology.NodeKindClient,
 						Name: "dc1-client1",
-						Workloads: []*topology.Service{
+						Workloads: []*topology.Workload{
 							{
-								ID:             topology.ServiceID{Name: "mesh-gateway"},
+								ID:             topology.ID{Name: "mesh-gateway"},
 								Port:           8443,
 								EnvoyAdminPort: 19000,
 								IsMeshGateway:  true,
@@ -186,9 +186,9 @@ func TestSprawl(t *testing.T) {
 					{
 						Kind: topology.NodeKindClient,
 						Name: "dc1-client2",
-						Workloads: []*topology.Service{
+						Workloads: []*topology.Workload{
 							{
-								ID:             topology.ServiceID{Name: "ping"},
+								ID:             topology.ID{Name: "ping"},
 								Image:          "rboyer/pingpong:latest",
 								Port:           8080,
 								EnvoyAdminPort: 19000,
@@ -199,8 +199,8 @@ func TestSprawl(t *testing.T) {
 									"-dialfreq", "250ms",
 									"-name", "ping",
 								},
-								Upstreams: []*topology.Upstream{{
-									ID:        topology.ServiceID{Name: "pong"},
+								Destinations: []*topology.Destination{{
+									ID:        topology.ID{Name: "pong"},
 									LocalPort: 9090,
 									Peer:      "peer-dc2-default",
 								}},
@@ -226,9 +226,9 @@ func TestSprawl(t *testing.T) {
 					{
 						Kind: topology.NodeKindClient,
 						Name: "dc2-client1",
-						Workloads: []*topology.Service{
+						Workloads: []*topology.Workload{
 							{
-								ID:             topology.ServiceID{Name: "mesh-gateway"},
+								ID:             topology.ID{Name: "mesh-gateway"},
 								Port:           8443,
 								EnvoyAdminPort: 19000,
 								IsMeshGateway:  true,
@@ -238,9 +238,9 @@ func TestSprawl(t *testing.T) {
 					{
 						Kind: topology.NodeKindDataplane,
 						Name: "dc2-client2",
-						Workloads: []*topology.Service{
+						Workloads: []*topology.Workload{
 							{
-								ID:             topology.ServiceID{Name: "pong"},
+								ID:             topology.ID{Name: "pong"},
 								Image:          "rboyer/pingpong:latest",
 								Port:           8080,
 								EnvoyAdminPort: 19000,
@@ -251,8 +251,8 @@ func TestSprawl(t *testing.T) {
 									"-dialfreq", "250ms",
 									"-name", "pong",
 								},
-								Upstreams: []*topology.Upstream{{
-									ID:        topology.ServiceID{Name: "ping"},
+								Destinations: []*topology.Destination{{
+									ID:        topology.ID{Name: "ping"},
 									LocalPort: 9090,
 									Peer:      "peer-dc1-default",
 								}},
@@ -263,9 +263,9 @@ func TestSprawl(t *testing.T) {
 						Kind:    topology.NodeKindDataplane,
 						Version: topology.NodeVersionV2,
 						Name:    "dc2-client3",
-						Workloads: []*topology.Service{
+						Workloads: []*topology.Workload{
 							{
-								ID:             topology.ServiceID{Name: "pong"},
+								ID:             topology.ID{Name: "pong"},
 								Image:          "rboyer/pingpong:latest",
 								Port:           8080,
 								EnvoyAdminPort: 19000,
@@ -276,8 +276,8 @@ func TestSprawl(t *testing.T) {
 									"-dialfreq", "250ms",
 									"-name", "pong",
 								},
-								Upstreams: []*topology.Upstream{{
-									ID:        topology.ServiceID{Name: "ping"},
+								Destinations: []*topology.Destination{{
+									ID:        topology.ID{Name: "ping"},
 									LocalPort: 9090,
 									Peer:      "peer-dc1-default",
 								}},

--- a/testing/deployer/sprawl/sprawltest/test_test.go
+++ b/testing/deployer/sprawl/sprawltest/test_test.go
@@ -40,7 +40,7 @@ func TestSprawl_CatalogV2(t *testing.T) {
 						Kind:    topology.NodeKindDataplane,
 						Version: topology.NodeVersionV2,
 						Name:    "dc1-client1",
-						Services: []*topology.Service{
+						Workloads: []*topology.Service{
 							{
 								ID:             topology.ServiceID{Name: "ping"},
 								Image:          "rboyer/pingpong:latest",
@@ -64,7 +64,7 @@ func TestSprawl_CatalogV2(t *testing.T) {
 						Kind:    topology.NodeKindDataplane,
 						Version: topology.NodeVersionV2,
 						Name:    "dc1-client2",
-						Services: []*topology.Service{
+						Workloads: []*topology.Service{
 							{
 								ID:             topology.ServiceID{Name: "pong"},
 								Image:          "rboyer/pingpong:latest",
@@ -174,7 +174,7 @@ func TestSprawl(t *testing.T) {
 					{
 						Kind: topology.NodeKindClient,
 						Name: "dc1-client1",
-						Services: []*topology.Service{
+						Workloads: []*topology.Service{
 							{
 								ID:             topology.ServiceID{Name: "mesh-gateway"},
 								Port:           8443,
@@ -186,7 +186,7 @@ func TestSprawl(t *testing.T) {
 					{
 						Kind: topology.NodeKindClient,
 						Name: "dc1-client2",
-						Services: []*topology.Service{
+						Workloads: []*topology.Service{
 							{
 								ID:             topology.ServiceID{Name: "ping"},
 								Image:          "rboyer/pingpong:latest",
@@ -226,7 +226,7 @@ func TestSprawl(t *testing.T) {
 					{
 						Kind: topology.NodeKindClient,
 						Name: "dc2-client1",
-						Services: []*topology.Service{
+						Workloads: []*topology.Service{
 							{
 								ID:             topology.ServiceID{Name: "mesh-gateway"},
 								Port:           8443,
@@ -238,7 +238,7 @@ func TestSprawl(t *testing.T) {
 					{
 						Kind: topology.NodeKindDataplane,
 						Name: "dc2-client2",
-						Services: []*topology.Service{
+						Workloads: []*topology.Service{
 							{
 								ID:             topology.ServiceID{Name: "pong"},
 								Image:          "rboyer/pingpong:latest",
@@ -263,7 +263,7 @@ func TestSprawl(t *testing.T) {
 						Kind:    topology.NodeKindDataplane,
 						Version: topology.NodeVersionV2,
 						Name:    "dc2-client3",
-						Services: []*topology.Service{
+						Workloads: []*topology.Service{
 							{
 								ID:             topology.ServiceID{Name: "pong"},
 								Image:          "rboyer/pingpong:latest",

--- a/testing/deployer/topology/compile.go
+++ b/testing/deployer/topology/compile.go
@@ -332,45 +332,44 @@ func compile(logger hclog.Logger, raw *Config, prev *Topology) (*Topology, error
 
 			seenServices := make(map[ID]struct{})
 			for _, wrk := range n.Workloads {
-				svc := wrk // TODO
 				if n.IsAgent() {
 					// Default to that of the enclosing node.
-					svc.ID.Partition = n.Partition
+					wrk.ID.Partition = n.Partition
 				}
-				svc.ID.Normalize()
+				wrk.ID.Normalize()
 
 				// Denormalize
-				svc.Node = n
-				svc.NodeVersion = n.Version
+				wrk.Node = n
+				wrk.NodeVersion = n.Version
 				if n.IsV2() {
-					svc.Workload = svc.ID.Name + "-" + n.PodName()
+					wrk.Workload = wrk.ID.Name + "-" + n.PodName()
 				}
 
-				if !IsValidLabel(svc.ID.Partition) {
-					return nil, fmt.Errorf("service partition is not valid: %s", svc.ID.Partition)
+				if !IsValidLabel(wrk.ID.Partition) {
+					return nil, fmt.Errorf("service partition is not valid: %s", wrk.ID.Partition)
 				}
-				if !IsValidLabel(svc.ID.Namespace) {
-					return nil, fmt.Errorf("service namespace is not valid: %s", svc.ID.Namespace)
+				if !IsValidLabel(wrk.ID.Namespace) {
+					return nil, fmt.Errorf("service namespace is not valid: %s", wrk.ID.Namespace)
 				}
-				if !IsValidLabel(svc.ID.Name) {
-					return nil, fmt.Errorf("service name is not valid: %s", svc.ID.Name)
+				if !IsValidLabel(wrk.ID.Name) {
+					return nil, fmt.Errorf("service name is not valid: %s", wrk.ID.Name)
 				}
-				if svc.ID.Partition != n.Partition {
+				if wrk.ID.Partition != n.Partition {
 					return nil, fmt.Errorf("service %s on node %s has mismatched partitions: %s != %s",
-						svc.ID.Name, n.Name, svc.ID.Partition, n.Partition)
+						wrk.ID.Name, n.Name, wrk.ID.Partition, n.Partition)
 				}
-				addTenancy(svc.ID.Partition, svc.ID.Namespace)
+				addTenancy(wrk.ID.Partition, wrk.ID.Namespace)
 
-				if _, exists := seenServices[svc.ID]; exists {
-					return nil, fmt.Errorf("cannot have two services on the same node %q in the same cluster %q with the same name %q", n.ID(), c.Name, svc.ID)
+				if _, exists := seenServices[wrk.ID]; exists {
+					return nil, fmt.Errorf("cannot have two services on the same node %q in the same cluster %q with the same name %q", n.ID(), c.Name, wrk.ID)
 				}
-				seenServices[svc.ID] = struct{}{}
+				seenServices[wrk.ID] = struct{}{}
 
-				if !svc.DisableServiceMesh && n.IsDataplane() {
-					if svc.EnvoyPublicListenerPort <= 0 {
+				if !wrk.DisableServiceMesh && n.IsDataplane() {
+					if wrk.EnvoyPublicListenerPort <= 0 {
 						if _, ok := n.usedPorts[20000]; !ok {
 							// For convenience the FIRST service on a node can get 20000 for free.
-							svc.EnvoyPublicListenerPort = 20000
+							wrk.EnvoyPublicListenerPort = 20000
 						} else {
 							return nil, fmt.Errorf("envoy public listener port is required")
 						}
@@ -378,103 +377,102 @@ func compile(logger hclog.Logger, raw *Config, prev *Topology) (*Topology, error
 				}
 
 				// add all of the service ports
-				for _, port := range svc.ports() {
+				for _, port := range wrk.ports() {
 					if ok := exposePort(port); !ok {
 						return nil, fmt.Errorf("port used more than once on cluster %q node %q: %d", c.Name, n.ID(), port)
 					}
 				}
 
 				// TODO(rb): re-expose?
-				// switch svc.Protocol {
+				// switch wrk.Protocol {
 				// case "":
-				// 	svc.Protocol = "tcp"
+				// 	wrk.Protocol = "tcp"
 				// 	fallthrough
 				// case "tcp":
-				// 	if svc.CheckHTTP != "" {
+				// 	if wrk.CheckHTTP != "" {
 				// 		return nil, fmt.Errorf("cannot set CheckHTTP for tcp service")
 				// 	}
 				// case "http":
-				// 	if svc.CheckTCP != "" {
+				// 	if wrk.CheckTCP != "" {
 				// 		return nil, fmt.Errorf("cannot set CheckTCP for tcp service")
 				// 	}
 				// default:
-				// 	return nil, fmt.Errorf("service has invalid protocol: %s", svc.Protocol)
+				// 	return nil, fmt.Errorf("service has invalid protocol: %s", wrk.Protocol)
 				// }
 
 				defaultDestination := func(dest *Destination) error {
-					u := dest //TODO
 					// Default to that of the enclosing service.
-					if u.Peer == "" {
-						if u.ID.Partition == "" {
-							u.ID.Partition = svc.ID.Partition
+					if dest.Peer == "" {
+						if dest.ID.Partition == "" {
+							dest.ID.Partition = wrk.ID.Partition
 						}
-						if u.ID.Namespace == "" {
-							u.ID.Namespace = svc.ID.Namespace
+						if dest.ID.Namespace == "" {
+							dest.ID.Namespace = wrk.ID.Namespace
 						}
 					} else {
-						if u.ID.Partition != "" {
-							u.ID.Partition = "" // irrelevant here; we'll set it to the value of the OTHER side for plumbing purposes in tests
+						if dest.ID.Partition != "" {
+							dest.ID.Partition = "" // irrelevant here; we'll set it to the value of the OTHER side for plumbing purposes in tests
 						}
-						u.ID.Namespace = NamespaceOrDefault(u.ID.Namespace)
-						foundPeerNames[c.Name][u.Peer] = struct{}{}
+						dest.ID.Namespace = NamespaceOrDefault(dest.ID.Namespace)
+						foundPeerNames[c.Name][dest.Peer] = struct{}{}
 					}
 
-					addTenancy(u.ID.Partition, u.ID.Namespace)
+					addTenancy(dest.ID.Partition, dest.ID.Namespace)
 
-					if u.Implied {
-						if u.PortName == "" {
+					if dest.Implied {
+						if dest.PortName == "" {
 							return fmt.Errorf("implicit destinations must use port names in v2")
 						}
 					} else {
-						if u.LocalAddress == "" {
+						if dest.LocalAddress == "" {
 							// v1 defaults to 127.0.0.1 but v2 does not. Safe to do this generally though.
-							u.LocalAddress = "127.0.0.1"
+							dest.LocalAddress = "127.0.0.1"
 						}
-						if u.PortName != "" && n.IsV1() {
+						if dest.PortName != "" && n.IsV1() {
 							return fmt.Errorf("explicit destinations cannot use port names in v1")
 						}
-						if u.PortName == "" && n.IsV2() {
+						if dest.PortName == "" && n.IsV2() {
 							// Assume this is a v1->v2 conversion and name it.
-							u.PortName = "legacy"
+							dest.PortName = "legacy"
 						}
 					}
 
 					return nil
 				}
 
-				for _, dest := range svc.Destinations {
+				for _, dest := range wrk.Destinations {
 					if err := defaultDestination(dest); err != nil {
 						return nil, err
 					}
 				}
 
 				if n.IsV2() {
-					for _, dest := range svc.ImpliedDestinations {
+					for _, dest := range wrk.ImpliedDestinations {
 						dest.Implied = true
 						if err := defaultDestination(dest); err != nil {
 							return nil, err
 						}
 					}
 				} else {
-					if len(svc.ImpliedDestinations) > 0 {
+					if len(wrk.ImpliedDestinations) > 0 {
 						return nil, fmt.Errorf("v1 does not support implied destinations yet")
 					}
 				}
 
-				if err := svc.Validate(); err != nil {
-					return nil, fmt.Errorf("cluster %q node %q service %q is not valid: %w", c.Name, n.Name, svc.ID.String(), err)
+				if err := wrk.Validate(); err != nil {
+					return nil, fmt.Errorf("cluster %q node %q service %q is not valid: %w", c.Name, n.Name, wrk.ID.String(), err)
 				}
 
-				if svc.EnableTransparentProxy && !n.IsDataplane() {
+				if wrk.EnableTransparentProxy && !n.IsDataplane() {
 					return nil, fmt.Errorf("cannot enable tproxy on a non-dataplane node")
 				}
 
 				if n.IsV2() {
 					if implicitV2Services {
-						svc.V2Services = []string{svc.ID.Name}
+						wrk.V2Services = []string{wrk.ID.Name}
 
 						var svcPorts []*pbcatalog.ServicePort
-						for name, cfg := range svc.Ports {
+						for name, cfg := range wrk.Ports {
 							svcPorts = append(svcPorts, &pbcatalog.ServicePort{
 								TargetPort: name,
 								Protocol:   cfg.ActualProtocol,
@@ -486,40 +484,40 @@ func compile(logger hclog.Logger, raw *Config, prev *Topology) (*Topology, error
 							Ports:     svcPorts,
 						}
 
-						prev, ok := c.Services[svc.ID]
+						prev, ok := c.Services[wrk.ID]
 						if !ok {
-							c.Services[svc.ID] = v2svc
+							c.Services[wrk.ID] = v2svc
 							prev = v2svc
 						}
 						if prev.Workloads == nil {
 							prev.Workloads = &pbcatalog.WorkloadSelector{}
 						}
-						prev.Workloads.Names = append(prev.Workloads.Names, svc.Workload)
+						prev.Workloads.Names = append(prev.Workloads.Names, wrk.Workload)
 
 					} else {
-						for _, name := range svc.V2Services {
-							v2ID := NewServiceID(name, svc.ID.Namespace, svc.ID.Partition)
+						for _, name := range wrk.V2Services {
+							v2ID := NewServiceID(name, wrk.ID.Namespace, wrk.ID.Partition)
 
 							v2svc, ok := c.Services[v2ID]
 							if !ok {
 								return nil, fmt.Errorf("cluster %q node %q service %q has a v2 service reference that does not exist %q",
-									c.Name, n.Name, svc.ID.String(), name)
+									c.Name, n.Name, wrk.ID.String(), name)
 							}
 							if v2svc.Workloads == nil {
 								v2svc.Workloads = &pbcatalog.WorkloadSelector{}
 							}
-							v2svc.Workloads.Names = append(v2svc.Workloads.Names, svc.Workload)
+							v2svc.Workloads.Names = append(v2svc.Workloads.Names, wrk.Workload)
 						}
 					}
 
-					if svc.WorkloadIdentity == "" {
-						svc.WorkloadIdentity = svc.ID.Name
+					if wrk.WorkloadIdentity == "" {
+						wrk.WorkloadIdentity = wrk.ID.Name
 					}
 				} else {
-					if len(svc.V2Services) > 0 {
+					if len(wrk.V2Services) > 0 {
 						return nil, fmt.Errorf("cannot specify v2 services for v1")
 					}
-					if svc.WorkloadIdentity != "" {
+					if wrk.WorkloadIdentity != "" {
 						return nil, fmt.Errorf("cannot specify workload identities for v1")
 					}
 				}
@@ -662,36 +660,34 @@ func compile(logger hclog.Logger, raw *Config, prev *Topology) (*Topology, error
 		for _, n := range c.Nodes {
 			for _, wrk := range n.Workloads {
 				for _, dest := range wrk.Destinations {
-					u := dest //TODO
-					if u.Peer == "" {
-						u.Cluster = c.Name
-						u.Peering = nil
+					if dest.Peer == "" {
+						dest.Cluster = c.Name
+						dest.Peering = nil
 						continue
 					}
-					remotePeer, ok := c.Peerings[u.Peer]
+					remotePeer, ok := c.Peerings[dest.Peer]
 					if !ok {
 						return nil, fmt.Errorf("not possible")
 					}
-					u.Cluster = remotePeer.Link.Name
-					u.Peering = remotePeer.Link
+					dest.Cluster = remotePeer.Link.Name
+					dest.Peering = remotePeer.Link
 					// this helps in generating fortio assertions; otherwise field is ignored
-					u.ID.Partition = remotePeer.Link.Partition
+					dest.ID.Partition = remotePeer.Link.Partition
 				}
 				for _, dest := range wrk.ImpliedDestinations {
-					u := dest //TODO
-					if u.Peer == "" {
-						u.Cluster = c.Name
-						u.Peering = nil
+					if dest.Peer == "" {
+						dest.Cluster = c.Name
+						dest.Peering = nil
 						continue
 					}
-					remotePeer, ok := c.Peerings[u.Peer]
+					remotePeer, ok := c.Peerings[dest.Peer]
 					if !ok {
 						return nil, fmt.Errorf("not possible")
 					}
-					u.Cluster = remotePeer.Link.Name
-					u.Peering = remotePeer.Link
+					dest.Cluster = remotePeer.Link.Name
+					dest.Peering = remotePeer.Link
 					// this helps in generating fortio assertions; otherwise field is ignored
-					u.ID.Partition = remotePeer.Link.Partition
+					dest.ID.Partition = remotePeer.Link.Partition
 				}
 			}
 		}

--- a/testing/deployer/topology/ids.go
+++ b/testing/deployer/topology/ids.go
@@ -9,41 +9,6 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-type NodeServiceID struct {
-	Node      string
-	Service   string `json:",omitempty"`
-	Namespace string `json:",omitempty"`
-	Partition string `json:",omitempty"`
-}
-
-func NewNodeServiceID(node, service, namespace, partition string) NodeServiceID {
-	id := NodeServiceID{
-		Node:      node,
-		Service:   service,
-		Namespace: namespace,
-		Partition: partition,
-	}
-	id.Normalize()
-	return id
-}
-
-func (id NodeServiceID) NodeID() NodeID {
-	return NewNodeID(id.Node, id.Partition)
-}
-
-func (id NodeServiceID) ServiceID() ServiceID {
-	return NewServiceID(id.Service, id.Namespace, id.Partition)
-}
-
-func (id *NodeServiceID) Normalize() {
-	id.Namespace = NamespaceOrDefault(id.Namespace)
-	id.Partition = PartitionOrDefault(id.Partition)
-}
-
-func (id NodeServiceID) String() string {
-	return fmt.Sprintf("%s/%s/%s/%s", id.Partition, id.Node, id.Namespace, id.Service)
-}
-
 type NodeID struct {
 	Name      string `json:",omitempty"`
 	Partition string `json:",omitempty"`
@@ -74,14 +39,14 @@ func (id NodeID) TFString() string {
 	return id.ACLString()
 }
 
-type ServiceID struct {
+type ID struct {
 	Name      string `json:",omitempty"`
 	Namespace string `json:",omitempty"`
 	Partition string `json:",omitempty"`
 }
 
-func NewServiceID(name, namespace, partition string) ServiceID {
-	id := ServiceID{
+func NewID(name, namespace, partition string) ID {
+	id := ID{
 		Name:      name,
 		Namespace: namespace,
 		Partition: partition,
@@ -90,7 +55,7 @@ func NewServiceID(name, namespace, partition string) ServiceID {
 	return id
 }
 
-func (id ServiceID) Less(other ServiceID) bool {
+func (id ID) Less(other ID) bool {
 	if id.Partition != other.Partition {
 		return id.Partition < other.Partition
 	}
@@ -100,32 +65,32 @@ func (id ServiceID) Less(other ServiceID) bool {
 	return id.Name < other.Name
 }
 
-func (id *ServiceID) Normalize() {
+func (id *ID) Normalize() {
 	id.Namespace = NamespaceOrDefault(id.Namespace)
 	id.Partition = PartitionOrDefault(id.Partition)
 }
 
-func (id ServiceID) String() string {
+func (id ID) String() string {
 	return fmt.Sprintf("%s/%s/%s", id.Partition, id.Namespace, id.Name)
 }
 
-func (id ServiceID) ACLString() string {
+func (id ID) ACLString() string {
 	return fmt.Sprintf("%s--%s--%s", id.Partition, id.Namespace, id.Name)
 }
 
-func (id ServiceID) TFString() string {
+func (id ID) TFString() string {
 	return id.ACLString()
 }
 
-func (id ServiceID) PartitionOrDefault() string {
+func (id ID) PartitionOrDefault() string {
 	return PartitionOrDefault(id.Partition)
 }
 
-func (id ServiceID) NamespaceOrDefault() string {
+func (id ID) NamespaceOrDefault() string {
 	return NamespaceOrDefault(id.Namespace)
 }
 
-func (id ServiceID) QueryOptions() *api.QueryOptions {
+func (id ID) QueryOptions() *api.QueryOptions {
 	return &api.QueryOptions{
 		Partition: DefaultToEmpty(id.Partition),
 		Namespace: DefaultToEmpty(id.Namespace),

--- a/testing/deployer/topology/naming_shim.go
+++ b/testing/deployer/topology/naming_shim.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package topology
+
+// Deprecated: SortedWorkloads
+func (n *Node) SortedServices() []*Service {
+	return n.SortedWorkloads()
+}
+
+// Deprecated: mapifyWorkloads
+func mapifyServices(services []*Service) map[ServiceID]*Service {
+	return mapifyWorkloads(services)
+}

--- a/testing/deployer/topology/naming_shim.go
+++ b/testing/deployer/topology/naming_shim.go
@@ -38,3 +38,6 @@ type ServiceID = ID
 func NewServiceID(name, namespace, partition string) ID {
 	return NewID(name, namespace, partition)
 }
+
+// Deprecated: Destination
+type Upstream = Destination

--- a/testing/deployer/topology/naming_shim.go
+++ b/testing/deployer/topology/naming_shim.go
@@ -4,11 +4,37 @@
 package topology
 
 // Deprecated: SortedWorkloads
-func (n *Node) SortedServices() []*Service {
+func (n *Node) SortedServices() []*Workload {
 	return n.SortedWorkloads()
 }
 
 // Deprecated: mapifyWorkloads
-func mapifyServices(services []*Service) map[ServiceID]*Service {
+func mapifyServices(services []*Workload) map[ServiceID]*Workload {
 	return mapifyWorkloads(services)
+}
+
+// Deprecated: WorkloadByID
+func (c *Cluster) ServiceByID(nid NodeID, sid ServiceID) *Workload {
+	return c.WorkloadByID(nid, sid)
+}
+
+// Deprecated: WorkloadsByID
+func (c *Cluster) ServicesByID(sid ServiceID) []*Workload {
+	return c.WorkloadsByID(sid)
+}
+
+// Deprecated: WorkloadByID
+func (n *Node) ServiceByID(sid ServiceID) *Workload {
+	return n.WorkloadByID(sid)
+}
+
+// Deprecated: Workload
+type Service = Workload
+
+// Deprecated: ID
+type ServiceID = ID
+
+// Deprecated: NewID
+func NewServiceID(name, namespace, partition string) ID {
+	return NewID(name, namespace, partition)
 }

--- a/testing/deployer/topology/relationships.go
+++ b/testing/deployer/topology/relationships.go
@@ -16,14 +16,14 @@ func (t *Topology) ComputeRelationships() []Relationship {
 	for _, cluster := range t.Clusters {
 		for _, n := range cluster.Nodes {
 			for _, w := range n.Workloads {
-				for _, dest := range w.Upstreams {
+				for _, dest := range w.Destinations {
 					out = append(out, Relationship{
 						Caller:      w,
 						Destination: dest,
 						Upstream:    dest,
 					})
 				}
-				for _, dest := range w.ImpliedUpstreams {
+				for _, dest := range w.ImpliedDestinations {
 					out = append(out, Relationship{
 						Caller:      w,
 						Destination: dest,

--- a/testing/deployer/topology/relationships.go
+++ b/testing/deployer/topology/relationships.go
@@ -15,16 +15,16 @@ func (t *Topology) ComputeRelationships() []Relationship {
 	var out []Relationship
 	for _, cluster := range t.Clusters {
 		for _, n := range cluster.Nodes {
-			for _, s := range n.Services {
-				for _, u := range s.Upstreams {
+			for _, w := range n.Workloads {
+				for _, u := range w.Upstreams {
 					out = append(out, Relationship{
-						Caller:   s,
+						Caller:   w,
 						Upstream: u,
 					})
 				}
-				for _, u := range s.ImpliedUpstreams {
+				for _, u := range w.ImpliedUpstreams {
 					out = append(out, Relationship{
-						Caller:   s,
+						Caller:   w,
 						Upstream: u,
 					})
 				}

--- a/testing/deployer/topology/topology.go
+++ b/testing/deployer/topology/topology.go
@@ -851,7 +851,7 @@ func (w *Workload) ports() []int {
 		seen := make(map[int]struct{})
 		for _, port := range w.Ports {
 			if _, ok := seen[port.Number]; !ok {
-				// It'w totally fine to expose the same port twice in a workload.
+				// It's totally fine to expose the same port twice in a workload.
 				seen[port.Number] = struct{}{}
 				out = append(out, port.Number)
 			}

--- a/testing/deployer/topology/topology.go
+++ b/testing/deployer/topology/topology.go
@@ -427,7 +427,7 @@ func (c *Cluster) ServicesByID(sid ServiceID) []*Service {
 
 	var out []*Service
 	for _, n := range c.Nodes {
-		for _, svc := range n.Services {
+		for _, svc := range n.Workloads {
 			if svc.ID == sid {
 				out = append(out, svc)
 			}
@@ -504,7 +504,9 @@ type Node struct {
 	Disabled bool `json:",omitempty"`
 
 	Addresses []*Address
-	Services  []*Service
+	Workloads []*Service
+	// Deprecated: use Workloads
+	Services []*Service
 
 	// denormalized at topology compile
 	Cluster    string
@@ -663,9 +665,9 @@ func (n *Node) IsDataplane() bool {
 	return n.Kind == NodeKindDataplane
 }
 
-func (n *Node) SortedServices() []*Service {
+func (n *Node) SortedWorkloads() []*Service {
 	var out []*Service
-	out = append(out, n.Services...)
+	out = append(out, n.Workloads...)
 	sort.Slice(out, func(i, j int) bool {
 		mi := out[i].IsMeshGateway
 		mj := out[j].IsMeshGateway
@@ -680,7 +682,7 @@ func (n *Node) SortedServices() []*Service {
 }
 
 func (n *Node) NeedsTransparentProxy() bool {
-	for _, svc := range n.Services {
+	for _, svc := range n.Workloads {
 		if svc.EnableTransparentProxy {
 			return true
 		}
@@ -705,7 +707,7 @@ func (n *Node) DigestExposedPorts(ports map[int]int) bool {
 			))
 		}
 	}
-	for _, svc := range n.Services {
+	for _, svc := range n.Workloads {
 		svc.DigestExposedPorts(ports)
 	}
 
@@ -714,7 +716,7 @@ func (n *Node) DigestExposedPorts(ports map[int]int) bool {
 
 func (n *Node) ServiceByID(sid ServiceID) *Service {
 	sid.Normalize()
-	for _, svc := range n.Services {
+	for _, svc := range n.Workloads {
 		if svc.ID == sid {
 			return svc
 		}

--- a/testing/deployer/topology/topology.go
+++ b/testing/deployer/topology/topology.go
@@ -410,19 +410,11 @@ func (c *Cluster) SortedNodes() []*Node {
 	return out
 }
 
-func (c *Cluster) FindService(id NodeServiceID) *Service {
-	id.Normalize()
-
-	nid := id.NodeID()
-	sid := id.ServiceID()
-	return c.ServiceByID(nid, sid)
+func (c *Cluster) WorkloadByID(nid NodeID, sid ServiceID) *Workload {
+	return c.NodeByID(nid).WorkloadByID(sid)
 }
 
-func (c *Cluster) ServiceByID(nid NodeID, sid ServiceID) *Service {
-	return c.NodeByID(nid).ServiceByID(sid)
-}
-
-func (c *Cluster) ServicesByID(sid ServiceID) []*Service {
+func (c *Cluster) WorkloadsByID(sid ServiceID) []*Workload {
 	sid.Normalize()
 
 	var out []*Service
@@ -714,7 +706,7 @@ func (n *Node) DigestExposedPorts(ports map[int]int) bool {
 	return true
 }
 
-func (n *Node) ServiceByID(sid ServiceID) *Service {
+func (n *Node) WorkloadByID(sid ServiceID) *Service {
 	sid.Normalize()
 	for _, svc := range n.Workloads {
 		if svc.ID == sid {
@@ -756,7 +748,7 @@ type Port struct {
 }
 
 // TODO(rb): really this should now be called "workload" or "instance"
-type Service struct {
+type Workload struct {
 	ID    ServiceID
 	Image string
 
@@ -816,7 +808,8 @@ type Service struct {
 	Workload    string      `json:"-"`
 }
 
-func (s *Service) ExposedPort(name string) int {
+func (w *Workload) ExposedPort(name string) int {
+	s := w // TODO
 	if s.Node == nil {
 		panic("ExposedPort cannot be called until after Compile")
 	}
@@ -835,26 +828,27 @@ func (s *Service) ExposedPort(name string) int {
 	return s.Node.ExposedPort(internalPort)
 }
 
-func (s *Service) PortOrDefault(name string) int {
-	if len(s.Ports) > 0 {
-		return s.Ports[name].Number
+func (w *Workload) PortOrDefault(name string) int {
+	if len(w.Ports) > 0 {
+		return w.Ports[name].Number
 	}
-	return s.Port
+	return w.Port
 }
 
-func (s *Service) IsV2() bool {
-	return s.NodeVersion == NodeVersionV2
+func (w *Workload) IsV2() bool {
+	return w.NodeVersion == NodeVersionV2
 }
 
-func (s *Service) IsV1() bool {
-	return !s.IsV2()
+func (w *Workload) IsV1() bool {
+	return !w.IsV2()
 }
 
-func (s *Service) inheritFromExisting(existing *Service) {
-	s.ExposedEnvoyAdminPort = existing.ExposedEnvoyAdminPort
+func (w *Workload) inheritFromExisting(existing *Service) {
+	w.ExposedEnvoyAdminPort = existing.ExposedEnvoyAdminPort
 }
 
-func (s *Service) ports() []int {
+func (w *Workload) ports() []int {
+	s := w // TODO
 	var out []int
 	if len(s.Ports) > 0 {
 		seen := make(map[int]struct{})
@@ -882,19 +876,20 @@ func (s *Service) ports() []int {
 	return out
 }
 
-func (s *Service) HasCheck() bool {
-	return s.CheckTCP != "" || s.CheckHTTP != ""
+func (w *Workload) HasCheck() bool {
+	return w.CheckTCP != "" || w.CheckHTTP != ""
 }
 
-func (s *Service) DigestExposedPorts(ports map[int]int) {
-	if s.EnvoyAdminPort > 0 {
-		s.ExposedEnvoyAdminPort = ports[s.EnvoyAdminPort]
+func (w *Workload) DigestExposedPorts(ports map[int]int) {
+	if w.EnvoyAdminPort > 0 {
+		w.ExposedEnvoyAdminPort = ports[w.EnvoyAdminPort]
 	} else {
-		s.ExposedEnvoyAdminPort = 0
+		w.ExposedEnvoyAdminPort = 0
 	}
 }
 
-func (s *Service) Validate() error {
+func (w *Workload) Validate() error {
+	s := w // TODO
 	if s.ID.Name == "" {
 		return fmt.Errorf("service name is required")
 	}


### PR DESCRIPTION
### Description

Conceptually renaming the following topology terms to avoid confusion with v2 and to better align with it:

- ServiceID -> ID
  - it's a generic namespace-scoped identifier
- Service -> Workload
  - Most places it implies "instance of a service" except for a few stray ones where the original nomenclature remains in place.
- Upstream -> Destination

Methods, functions, and types using the old names were retained as shims to avoid having to babysit the ce/enterprise merge, but the use of the deprecated words will be removed in follow up commits to each repository.
