### PR TITLE
Merge args from cmd and file while service register

### DIFF
--- a/.changelog/19609.txt
+++ b/.changelog/19609.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Combine inputs from cli arguments and service definition file while registering services.
+```

--- a/command/services/register/register.go
+++ b/command/services/register/register.go
@@ -118,10 +118,10 @@ func (c *cmd) Run(args []string) int {
 		}
 	}
 
-	// Merge or Sync argument values, if argument is provided in cmd arg,
+	// Combine or Sync argument values, if argument is provided in cmd arg,
 	// but not in file.
 	for _, svc := range svcsFromFiles {
-		MergeArgs(svc, svcFromFlags[0])
+		CombineArgs(svc, svcFromFlags[0])
 	}
 
 	// Create and test the HTTP client
@@ -160,9 +160,9 @@ func (c *cmd) Help() string {
 }
 
 // If arguments and service file both are input while registering services,
-// this function merges the values from both sources.
+// this function combines the inputs from both sources.
 // A argument value from cmd flag is taken, if it is not specified in service file definition.
-func MergeArgs(svcFile *api.AgentServiceRegistration, svcFlag *api.AgentServiceRegistration) {
+func CombineArgs(svcFile *api.AgentServiceRegistration, svcFlag *api.AgentServiceRegistration) {
 	if svcFlag.ID != "" && svcFile.ID == "" {
 		svcFile.ID = svcFlag.ID
 	}

--- a/command/services/register/register_test.go
+++ b/command/services/register/register_test.go
@@ -191,6 +191,7 @@ func TestCommand_FileWithUnnamedCheck(t *testing.T) {
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
+		"-meta=foo=bar",
 		f.Name(),
 	}
 
@@ -206,6 +207,8 @@ func TestCommand_FileWithUnnamedCheck(t *testing.T) {
 	checks, err := client.Agent().Checks()
 	require.NoError(t, err)
 	require.Len(t, checks, 1)
+
+	require.Contains(t, svc.Meta, "foo")
 }
 
 func testFile(t *testing.T, suffix string) *os.File {


### PR DESCRIPTION
### Description

fixes #19572 

### Testing & Reproduction steps

While registering service using cmd :
consul services register -meta foo=bar svc.hcl

svc.hcl :
service = {
  name = "svc"
  id = "svc1"
  port = 5555
}

=> Service svc is created with meta.

### Root cause
Currently in the [command/services/register/register.go](https://github.com/hashicorp/consul/compare/main...vijayraghav-io:consul:fix_%2319572_svc_reg_meta?expand=1#diff-6e98f036cce3289b8251aba0c70c118749bc6f16d6b045eff5b981fbfd373aeb) , 
1. Args in cmd is parsed.
2. If file is also provided as input, then service is created with only inputs from file, ignoring arg inputs.

### Proposed Solution:
The args from both cmd and file are merged.


### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
