### PR TITLE
unhack: fix broken `make lint` on macbooks

### DIFF
--- a/logging/logfile_bsd.go
+++ b/logging/logfile_bsd.go
@@ -14,5 +14,5 @@ import (
 func (l *LogFile) createTime(stat os.FileInfo) time.Time {
 	stat_t := stat.Sys().(*syscall.Stat_t)
 	createTime := stat_t.Ctimespec
-	return time.Unix(int64(createTime.Sec), int64(createTime.Nsec))
+	return time.Unix(int64(createTime.Sec), int64(createTime.Nsec)) //nolint:unconvert
 }


### PR DESCRIPTION
### Description
Fixes:
```
make lint                                                                                                                                                                                                                                                                              ✔  17s  
--> Running golangci-lint (.)
logging/logfile_bsd.go:17:24: unnecessary conversion (unconvert)
        return time.Unix(int64(createTime.Sec), int64(createTime.Nsec))
                              ^
make: *** [lint/.] Error 1
```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
