### PR TITLE
unhack: add pre-commit guidelines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 #
+# Opt-in to running pre-commit hooks by running `make tools`.
+#
 # Guidelines for adding new pre-commit hooks
 # ====================================================================
 # A hook SHOULD be blazingly fast (<2s) to impose minimal latency on
@@ -22,7 +24,7 @@ repos:
     # Formats go imports into deterministic sections.
     # `pre-commit run gci` to run in isolation.
     -   id: my-cmd
-        name: Formatting go imports
+        name: Format go imports
         alias: gci
         # skip all generated go files
         exclude: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,8 @@ repos:
     # Formats go imports into deterministic sections
     # `pre-commit run gci` to run in isolation
     -   id: my-cmd
-        name: gci
+        name: Formating go imports
+        alias: gci
         # skip all generated go files
         exclude: |
             (?x)(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,24 @@
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+#
+# Guidelines for adding new pre-commit hooks
+# ====================================================================
+# A hook SHOULD be blazingly fast (<2s) to impose minimal latency on
+# developer workflows (e.g. golangci-lint takes > 8s)
+#
+# A hook SHOULD attempt to fix errors, not just identify them.
+#
+# A hook SHOULD address common errors in files that tend to change
+# frequently. While surfacing esoteric issues is nice, hooks that have a
+# wider impact are preferred.
+#
 repos:
 -   repo: https://github.com/tekwizely/pre-commit-golang
     rev: v1.0.0-rc.1
     hooks:
-    # Formats go imports into deterministic sections
-    # `pre-commit run gci` to run in isolation
+    # Formats go imports into deterministic sections.
+    # `pre-commit run gci` to run in isolation.
     -   id: my-cmd
         name: Formatting go imports
         alias: gci
@@ -38,9 +50,3 @@ repos:
         - "prefix(github.com/hashicorp/)"
         - "--section"
         - "prefix(github.com/hashicorp/consul/)"
-
--   repo: https://github.com/golangci/golangci-lint
-    # Keep in sync with GOLANGCI_LINT_VERSION in Makefile
-    rev: v1.51.1
-    hooks:
-      - id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     # Formats go imports into deterministic sections
     # `pre-commit run gci` to run in isolation
     -   id: my-cmd
-        name: Formating go imports
+        name: Formatting go imports
         alias: gci
         # skip all generated go files
         exclude: |
@@ -38,3 +38,9 @@ repos:
         - "prefix(github.com/hashicorp/)"
         - "--section"
         - "prefix(github.com/hashicorp/consul/)"
+
+-   repo: https://github.com/golangci/golangci-lint
+    # Keep in sync with GOLANGCI_LINT_VERSION in Makefile
+    rev: v1.51.1
+    hooks:
+      - id: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ GO_MODULES := $(shell find . -name go.mod -exec dirname {} \; | grep -v "proto-g
 # These version variables can either be a valid string for "go install <module>@<version>"
 # or the string @DEV to imply use what is currently installed locally.
 ###
-# Keep in sync with golangci-lint hook in .pre-commit-config.yaml
 GOLANGCI_LINT_VERSION='v1.51.1'
 MOCKERY_VERSION='v2.20.0'
 BUF_VERSION='v1.26.0'

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ GO_MODULES := $(shell find . -name go.mod -exec dirname {} \; | grep -v "proto-g
 # These version variables can either be a valid string for "go install <module>@<version>"
 # or the string @DEV to imply use what is currently installed locally.
 ###
+# Keep in sync with golangci-lint hook in .pre-commit-config.yaml
 GOLANGCI_LINT_VERSION='v1.51.1'
 MOCKERY_VERSION='v2.20.0'
 BUF_VERSION='v1.26.0'


### PR DESCRIPTION
### Description

This was intended to add `golangci-lint` as a precommit hook, but it takes way too long to run (see https://hashicorp.atlassian.net/browse/NET-6562 for the details).  Instead, I figured it was a good opportunity to codify some of the guidelines for adding hooks so that it doesn't turn into a dumping ground for "all the things".

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
