### PR TITLE
fix runner count logic in set_test_package_matrix.sh from adding an additional runner

### DIFF
--- a/.github/scripts/set_test_package_matrix.sh
+++ b/.github/scripts/set_test_package_matrix.sh
@@ -5,7 +5,17 @@
 set -euo pipefail
 export RUNNER_COUNT=$1
 
+if ((RUNNER_COUNT == 1 ))
+then
+  EFFECTIVE_RUNNER_COUNT=$RUNNER_COUNT
+elif ((RUNNER_COUNT > 1 ))
+then
+  EFFECTIVE_RUNNER_COUNT=$((RUNNER_COUNT-1))
+else
+  echo ERROR: RUNNER_COUNT must be greater than zero.
+  exit 1 # terminate and indicate error
+fi
 # set matrix var to list of unique packages containing tests
-matrix="$(go list -json="ImportPath,TestGoFiles" ./... | jq --compact-output '. | select(.TestGoFiles != null) | .ImportPath' | shuf | jq --slurp --compact-output '.' | jq --argjson runnercount $RUNNER_COUNT  -cM '[_nwise(length / $runnercount | floor)]'))"
+matrix="$(go list -json="ImportPath,TestGoFiles" ./... | jq --compact-output '. | select(.TestGoFiles != null) | .ImportPath' | shuf | jq --slurp --compact-output '.' | jq --argjson runnercount $EFFECTIVE_RUNNER_COUNT  -cM '[_nwise(length / $runnercount | floor)]'))"
 
 echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"

--- a/.github/scripts/set_test_package_matrix.sh
+++ b/.github/scripts/set_test_package_matrix.sh
@@ -5,17 +5,13 @@
 set -euo pipefail
 export RUNNER_COUNT=$1
 
-if ((RUNNER_COUNT == 1 ))
+if ((RUNNER_COUNT < 1 ))
 then
-  EFFECTIVE_RUNNER_COUNT=$RUNNER_COUNT
-elif ((RUNNER_COUNT > 1 ))
-then
-  EFFECTIVE_RUNNER_COUNT=$((RUNNER_COUNT-1))
-else
   echo ERROR: RUNNER_COUNT must be greater than zero.
   exit 1 # terminate and indicate error
 fi
+
 # set matrix var to list of unique packages containing tests
-matrix="$(go list -json="ImportPath,TestGoFiles" ./... | jq --compact-output '. | select(.TestGoFiles != null) | .ImportPath' | shuf | jq --slurp --compact-output '.' | jq --argjson runnercount $EFFECTIVE_RUNNER_COUNT  -cM '[_nwise(length / $runnercount | floor)]'))"
+matrix="$(go list -json="ImportPath,TestGoFiles" ./... | jq --compact-output '. | select(.TestGoFiles != null) | .ImportPath' | shuf | jq --slurp --compact-output '.' | jq --argjson runnercount $RUNNER_COUNT  -cM '[_nwise(length / $runnercount | ceil)]'))"
 
 echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
### Description

CI currently specifies 12 runners, but 13 actually gets spun up in the logic to split the runners using `_nwise()` function.  This PR corrects that behavior.

### How to verify
[Previous runs in CI ](https://github.com/hashicorp/consul/actions/runs/6852852764) shows 13 jobs
<img width="209" alt="Screenshot 2023-11-13 at 5 45 28 PM" src="https://github.com/hashicorp/consul/assets/2481360/a08da8ee-405a-41e0-9684-6d6e8bf06978">

[Run for this PR](https://github.com/hashicorp/consul/actions/runs/6857604553?pr=19620) show 12 jobs
<img width="215" alt="Screenshot 2023-11-13 at 5 46 06 PM" src="https://github.com/hashicorp/consul/assets/2481360/7d2f2d05-8e06-4e48-86a9-c5900958707d">


### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
