### PR TITLE
Fix parts of admin-partitions guide

### DIFF
--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -89,9 +89,10 @@ All Consul clients must be able to initiate Gossip, HTTPS, and RPC connections t
 For Consul on Kubernetes, a dedicated `partition` Kubernetes `LoadBalancer` service is deployed to allow communication from clients to servers for admin partitions support (refer to [Kubernetes Requirements](#kubernetes-requirements) for additional information).
 
 For other runtimes, refer to the documentation for your infrastructure environment for instructions on how to allow communication on the following ports:
+- 443 (HTTPS API requests)
 - 8300 (RPC)
 - 8301 (Gossip)
-- 443 (HTTPS API requests)
+- 8502 (gRPC from [Consul Dataplane](/consul/docs/connect/dataplane/consul-dataplane))
 
 ### Security Configurations
 
@@ -154,14 +155,14 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
 1. Create the license secret in server cluster.
 
   ```shell-session
-  $ kubectl create --context ${SERVER_CONTEXT} ns consul
+  $ kubectl create --context ${SERVER_CONTEXT} namespace consul
   $ kubectl create secret --context ${SERVER_CONTEXT} --namespace consul generic license --from-file=key=./path/to/license.hclic
   ```
 
 1. Create the license secret in the non-default partition cluster for your workloads. This step must be repeated for every additional non-default partition cluster.
 
   ```shell-session
-  $ kubectl create --context ${CLIENT_CONTEXT} ns consul
+  $ kubectl create --context ${CLIENT_CONTEXT} namespace consul
   $ kubectl create secret --context ${CLIENT_CONTEXT} --namespace consul generic license --from-file=key=./path/to/license.hclic
   ```
 
@@ -184,7 +185,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
     enableConsulNamespaces: true
     tls:
       enabled: true
-    image: hashicorp/consul-enterprise:1.14.0-ent
+    image: hashicorp/consul-enterprise:1.16.3-ent
     adminPartitions:
       enabled: true
     acls:
@@ -207,7 +208,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
   $ helm install ${HELM_RELEASE_SERVER} hashicorp/consul --version "1.0.0" --create-namespace --namespace consul --values server.yaml
   ```
 
-1. After the server starts, get the external IP address for partition service so that it can be added to the client configuration. The IP address is used to bootstrap connectivity between servers and workload pods on the non-default partition cluster. <a name="get-external-ip-address"/>
+1. After the server starts, get the external IP address for partition service so that it can be added to the client configuration (`externalServers.hosts`). The IP address is used to bootstrap connectivity between servers and workload pods on the non-default partition cluster. <a name="get-external-ip-address"/>
 
   ```shell-session
   $ kubectl get services --selector="app=consul,component=server" --namespace consul --output jsonpath="{range .items[*]}{@.status.loadBalancer.ingress[*].ip}{end}"
@@ -220,7 +221,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
   $ kubectl config view --output "jsonpath={.clusters[?(@.name=='${CLIENT_CONTEXT}')].cluster.server}"
   ```
 
-  Use the IP address printed to the console to configure the `k8sAuthMethodHost` parameter in the workload configuration file for your non-default partition cluster running your workloads.
+  Use the IP address printed to the console to configure the `externalServers.k8sAuthMethodHost` parameter in the workload configuration file for your non-default partition cluster running your workloads.
 
 1. Copy the server certificate to the non-default partition cluster running your workloads.
 
@@ -228,13 +229,13 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
   $ kubectl get secret ${HELM_RELEASE_SERVER}-consul-ca-cert --context ${SERVER_CONTEXT} -n consul --output yaml | kubectl apply --namespace consul --context ${CLIENT_CONTEXT} --filename -
   ```
 
-1. Copy the server key to the non-default partition cluster running your workloads.
+1. Copy the server key to the non-default partition cluster running your workloads:
 
   ```shell-session
   $ kubectl get secret ${HELM_RELEASE_SERVER}-consul-ca-key --context ${SERVER_CONTEXT} --namespace consul --output yaml | kubectl apply --namespace consul --context ${CLIENT_CONTEXT} --filename -
   ```
 
-1. If ACLs were enabled in the server configuration values file, copy the token to the non-default partition cluster running your workloads.
+1. If ACLs were enabled in the server configuration values file, copy the token to the non-default partition cluster running your workloads:
 
   ```shell-session
   $ kubectl get secret ${HELM_RELEASE_SERVER}-consul-partitions-acl-token --context ${SERVER_CONTEXT} --namespace consul --output yaml | kubectl apply --namespace consul --context ${CLIENT_CONTEXT} --filename -
@@ -250,7 +251,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
 
 1. Create a configuration for each non-default admin partition.
 
-  <CodeTabs heading="partition-workload.yaml">
+  <CodeTabs heading="client.yaml">
 
   <CodeBlockConfig lineNumbers highlight="2,12,15,20,27,29,33">
 
@@ -259,10 +260,10 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
     name: consul
     enabled: false
     enableConsulNamespaces: true
-    image: hashicorp/consul-enterprise:1.14.0-ent
+    image: hashicorp/consul-enterprise:1.16.3-ent
     adminPartitions:
       enabled: true
-      name: partition-workload
+      name: clients
     tls:
       enabled: true
       caCert:
@@ -310,12 +311,13 @@ You can log into the Consul UI to verify that the partitions appear as expected.
 1. If ACLs are enabled, you will need the partitions ACL token, which can be read from the Kubernetes secret. The token is an encoded string that must be decoded in base64, e.g.:
 
   ```shell-session
-  $ kubectl get secret --namespace consul ${HELM_RELEASE_SERVER}-consul-bootstrap-acl-token --template "{{ .data.token | base64decode }}"
+  $ kubectl get secret --namespace consul --context ${SERVER_CONTEXT} --template "{{ .data.token | base64decode }}" ${HELM_RELEASE_SERVER}-consul-bootstrap-acl-token
   ```
 
-  The example command gets the token using the secret name configured in the values file (`bootstrap.secretName`), decodes the secret, and prints the usable token to the console in JSON format.
+  The example command gets the secret from the default partition cluster, decodes the secret, and prints the token to the console.
 
-1. Open the Consul UI in a browser using the external IP address and port number described in a previous step (see [step 5](#get-external-ip-address)).
+1. Open the Consul UI in a browser using the external IP address and port number described in a previous step (see [step 4](#get-external-ip-address)).
+
 1. Click **Log in** and enter the decoded token when prompted.
 
 You will see the `default` and `clients` partitions available in the **Admin Partition** drop-down menu.

--- a/website/content/docs/install/ports.mdx
+++ b/website/content/docs/install/ports.mdx
@@ -13,13 +13,13 @@ port.
 
 ## Ports Table
 
-Before running Consul, you should ensure the following bind ports are accessible.
+Before running Consul, you should ensure the following bind ports are accessible:
 
 | Use                                                                                                           | Default Ports     |
 | ------------------------------------------------------------------------------------------------------------- | ----------------- |
 | DNS: The DNS server (TCP and UDP)                                                                             | 8600              |
 | HTTP: The HTTP API (TCP Only)                                                                                 | 8500              |
-| HTTPS: The HTTPs API                                                                                          | disabled (8501)\* |
+| HTTPS: The HTTPS API                                                                                          | disabled (8501)\* |
 | gRPC: The gRPC API                                                                                            | disabled (8502)\* |
 | gRPC TLS: The gRPC API with TLS connections                                                                   | disabled (8503)\* |
 | LAN Serf: The Serf LAN port (TCP and UDP)                                                                     | 8301              |


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

This fixes some of the admin partitions guide. It still does not work for Kind for a couple reasons:

1. we need to use the internal IP of the K8s API (not the external LoadBalanced one):

```
# not
kubectl config view --output "jsonpath={.clusters[?(@.name=='${CLIENT_CONTEXT}')].cluster.server}"
```

2. we get TLS issues on the K8s server certs:

```txt
2023-11-14T02:56:54.305Z [ERROR] consul-server-connection-manager: ACL auth method login failed: error="rpc error: code = Unauthenticated desc = Post \"https://10.96.0.1/apis/authentication.k8s.io/v1/tokenreviews\": tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"kubernetes\")"
2023-11-14T02:56:54.305Z [ERROR] consul-server-connection-manager: connection error: error="rpc error: code = Unauthenticated desc = Post \"https://10.96.0.1/apis/authentication.k8s.io/v1/tokenreviews\": tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"kubernetes\")"
unable to start Consul server watcher: context canceled
```

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
