### PR TITLE
Backport/UI/feature/make global read only policy non editable/instantly hardy chamois 2

### DIFF
--- a/ui/packages/consul-ui/app/abilities/policy.js
+++ b/ui/packages/consul-ui/app/abilities/policy.js
@@ -15,7 +15,8 @@ export default class PolicyAbility extends BaseAbility {
   get canWrite() {
     return (
       this.env.var('CONSUL_ACLS_ENABLED') &&
-      (typeof this.item === 'undefined' || typeOf([this.item]) !== 'policy-management') &&
+      (typeof this.item === 'undefined' ||
+        !['policy-management', 'read-only'].includes(typeOf([this.item]))) &&
       super.canWrite
     );
   }

--- a/ui/packages/consul-ui/app/components/consul/policy/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/policy/list/index.hbs
@@ -3,13 +3,19 @@
   @items={{@items}}
 as |item|>
     <BlockSlot @name="header">
-{{#if (eq (policy/typeof item) 'policy-management')}}
+{{#if (or (eq (policy/typeof item) 'policy-management') (eq (policy/typeof item) 'read-only'))}}
         <dl class="policy-management">
           <dt>Type</dt>
           <dd>
-            <Tooltip>
-              Global Management Policy
-            </Tooltip>
+            {{#if (eq (policy/typeof item) 'policy-management')}}
+              <Tooltip>
+                Global Management Policy
+              </Tooltip>
+            {{else}}
+              <Tooltip>
+                Global Read-only Policy
+              </Tooltip>
+            {{/if}}
           </dd>
         </dl>
 {{/if}}

--- a/ui/packages/consul-ui/app/helpers/policy/typeof.js
+++ b/ui/packages/consul-ui/app/helpers/policy/typeof.js
@@ -1,6 +1,7 @@
 import { helper } from '@ember/component/helper';
 import { get } from '@ember/object';
 const MANAGEMENT_ID = '00000000-0000-0000-0000-000000000001';
+const READ_ONLY_ID = '00000000-0000-0000-0000-000000000002';
 export function typeOf(params, hash) {
   const item = params[0];
   const template = get(item, 'template');
@@ -13,6 +14,8 @@ export function typeOf(params, hash) {
       return 'policy-node-identity';
     case get(item, 'ID') === MANAGEMENT_ID:
       return 'policy-management';
+    case get(item, 'ID') === READ_ONLY_ID:
+      return 'read-only';
     default:
       return 'policy';
   }

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/edit.hbs
@@ -91,11 +91,11 @@ as |dc partition nspace id item create|}}
         @type="none"
         as |notice|>
         <notice.Header>
-          <h3>Read-only</h3>
+          <h3>Built-in policy</h3>
         </notice.Header>
         <notice.Body>
           <p>
-            This global-read-only token is built into Consul's policy system. You can apply this special policy to tokens for full access. This policy is not editable or removeable, but can be ignored by not applying it to any tokens. Learn more in our <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl.html#builtin-policies" target="_blank" rel="noopener noreferrer">documentation</a>.
+            This global-read-only policy is built into Consul's policy system. You can apply this special policy to tokens for read-only access to all Consul components. This policy is not editable or removable, but can be ignored by not applying it to any tokens. Learn more in our <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl.html#builtin-policies" target="_blank" rel="noopener noreferrer">documentation</a>.
           </p>
         </notice.Body>
       </Notice>

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/edit.hbs
@@ -70,12 +70,13 @@ as |dc partition nspace id item create|}}
             </dl>
         </div>
   {{/if}}
-  {{#if (eq (policy/typeof item) 'policy-management')}}
-    <Notice
+  {{#if (or (eq (policy/typeof item) 'policy-management') (eq (policy/typeof item) 'read-only'))}}
+    {{#if (eq (policy/typeof item) 'policy-management')}}
+      <Notice
       class="policy-management"
       @type="none"
     as |notice|>
-      <notice.Header>
+        <notice.Header>
         <h3>Management</h3>
       </notice.Header>
       <notice.Body>
@@ -83,7 +84,22 @@ as |dc partition nspace id item create|}}
           This global-management token is built into Consul's policy system. You can apply this special policy to tokens for full access. This policy is not editable or removeable, but can be ignored by not applying it to any tokens. Learn more in our <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl.html#builtin-policies" target="_blank" rel="noopener noreferrer">documentation</a>.
         </p>
       </notice.Body>
-    </Notice>
+      </Notice>
+    {{else}}
+      <Notice
+        class="policy-management"
+        @type="none"
+        as |notice|>
+        <notice.Header>
+          <h3>Read-only</h3>
+        </notice.Header>
+        <notice.Body>
+          <p>
+            This global-read-only token is built into Consul's policy system. You can apply this special policy to tokens for full access. This policy is not editable or removeable, but can be ignored by not applying it to any tokens. Learn more in our <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl.html#builtin-policies" target="_blank" rel="noopener noreferrer">documentation</a>.
+          </p>
+        </notice.Body>
+      </Notice>
+    {{/if}}
     <div class="definition-table">
       <dl>
         <dt>Name</dt>

--- a/ui/packages/consul-ui/mock-api/v1/acl/policies
+++ b/ui/packages/consul-ui/mock-api/v1/acl/policies
@@ -29,6 +29,23 @@ ${typeof location.search.partition !== 'undefined' ? `
             }
           `
         }
+        if(i === 2) {
+          return `
+            {
+              "ID": "00000000-0000-0000-0000-000000000002",
+              "Name": "global-read-only",
+${typeof location.search.ns !== 'undefined' ? `
+              "Namespace": "${location.search.ns}",
+` : ``}
+${typeof location.search.partition !== 'undefined' ? `
+            "Partition": "${location.search.partition}",
+` : ``}
+              "Description": "Built-In Read-only Policy",
+              "CreateIndex": 10,
+              "ModifyIndex": 10
+            }
+          `
+        }
         return `
           {
             "ID": "${fake.random.uuid()}",

--- a/ui/packages/consul-ui/mock-api/v1/acl/policy/_
+++ b/ui/packages/consul-ui/mock-api/v1/acl/policy/_
@@ -11,6 +11,6 @@ ${ location.pathname.get(3) !== '00000000-0000-0000-0000-000000000001' ? `
   policy = "write"
 }`)},
 ` : "" }
-  "Name": "${location.pathname.get(3) === '00000000-0000-0000-0000-000000000001' ? 'global-management' : fake.hacker.noun() + '-policy'}"
+  "Name": "${location.pathname.get(3) === '00000000-0000-0000-0000-000000000001' ? 'global-management' : location.pathname.get(3) === '00000000-0000-0000-0000-000000000002' ? 'global-read-only': fake.hacker.noun() + '-policy'}"
 }
 

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/view-read-only.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/view-read-only.feature
@@ -1,0 +1,20 @@
+@setupApplicationTest
+Feature: dc / acls / policies / view read-only policy: Readonly management policy
+  Background:
+    Given 1 datacenter model with the value "datacenter"
+    And 1 policy model from yaml
+    ---
+      ID: 00000000-0000-0000-0000-000000000002
+    ---
+  Scenario:
+    When I visit the policy page for yaml
+    ---
+      dc: datacenter
+      policy: 00000000-0000-0000-0000-000000000002
+    ---
+    Then the url should be /datacenter/acls/policies/00000000-0000-0000-0000-000000000002
+    Then I see the text "View Policy" in "h1"
+    Then I don't see confirmDelete
+    Then I don't see cancel
+    And I see tokens
+

--- a/ui/packages/consul-ui/tests/acceptance/steps/dc/acls/policies/view-read-only-steps.js
+++ b/ui/packages/consul-ui/tests/acceptance/steps/dc/acls/policies/view-read-only-steps.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import steps from '../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function (assert) {
+  return steps(assert).then('I should find a file', function () {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui/packages/consul-ui/tests/acceptance/steps/dc/acls/policies/view-read-only-steps.js
+++ b/ui/packages/consul-ui/tests/acceptance/steps/dc/acls/policies/view-read-only-steps.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: BUSL-1.1
- */
-
 import steps from '../../../steps';
 
 // step definitions that are shared between features should be moved to the

--- a/ui/packages/consul-ui/tests/integration/helpers/policy/typeof-test.js
+++ b/ui/packages/consul-ui/tests/integration/helpers/policy/typeof-test.js
@@ -7,11 +7,11 @@ module('Integration | Helper | policy/typeof', function (hooks) {
   setupRenderingTest(hooks);
 
   // Replace this with your real tests.
-  test('it renders', async function (assert) {
-    this.set('inputValue', '1234');
+  test('it render read-only cluster', async function (assert) {
+    this.set('inputValue', { ID: '00000000-0000-0000-0000-000000000002' });
 
     await render(hbs`{{policy/typeof inputValue}}`);
 
-    assert.equal(this.element.textContent.trim(), 'role');
+    assert.equal(this.element.textContent.trim(), 'read-only');
   });
 });

--- a/ui/packages/consul-ui/tests/integration/helpers/policy/typeof-test.js
+++ b/ui/packages/consul-ui/tests/integration/helpers/policy/typeof-test.js
@@ -6,9 +6,11 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Helper | policy/typeof', function (hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
-  test('it render read-only cluster', async function (assert) {
-    this.set('inputValue', { ID: '00000000-0000-0000-0000-000000000002' });
+  test('it renders read-only cluster', async function (assert) {
+    this.set('inputValue', {
+      ID: '00000000-0000-0000-0000-000000000002',
+      template: 'some-template',
+    });
 
     await render(hbs`{{policy/typeof inputValue}}`);
 


### PR DESCRIPTION
### Description
PR is manually created to backport https://github.com/hashicorp/consul/pull/18602

<img width="1254" alt="image" src="https://github.com/hashicorp/consul/assets/10027860/877f4dac-7831-4560-9619-d972c1a381b7">

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps
1. set up CONSUL_ACLS_ENABLE to 1 in session storage
2. set CONSUL_POLICY_COUNT = 10
3. go to Policies
4. log in with any securId
5. check list of items to see global-read-only policy
6. go to the policy details and check that form is non-editable
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links
[JIRA](https://hashicorp.atlassian.net/browse/CC-5792)
[Figma](https://www.figma.com/file/oMJ1VqcRzb2EP1mqfaohDz/View-Builtin-Token?type=design&node-id=916-8806&mode=design&t=ZRNWWdS4Bb0fhced-0)
<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
