### PR TITLE
notify on go-tests failure on main and release branches.

### DIFF
--- a/.github/scripts/notify_slack.sh
+++ b/.github/scripts/notify_slack.sh
@@ -5,25 +5,20 @@
 set -uo pipefail
 
 # This script is used in GitHub Actions pipelines to notify Slack of a job failure.
-
-if [[ $GITHUB_REF_NAME == "main" ]]; then
-	GITHUB_ENDPOINT="https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
-	GITHUB_ACTIONS_ENDPOINT="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-	COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -n1)
-	SHORT_REF=$(git rev-parse --short "${GITHUB_SHA}")
-	curl -X POST -H 'Content-type: application/json' \
-		--data \
-		"{ \
-	\"attachments\": [ \
-		{ \
-		\"fallback\": \"GitHub Actions workflow failed!\", \
-		\"text\": \"❌ Failed: \`${GITHUB_ACTOR}\`'s <${GITHUB_ACTIONS_ENDPOINT}|${GITHUB_JOB}> job failed for commit <${GITHUB_ENDPOINT}|${SHORT_REF}> on \`${GITHUB_REF_NAME}\`!\n\n- <${COMMIT_MESSAGE}\", \
-		\"footer\": \"${GITHUB_REPOSITORY}\", \
-		\"ts\": \"$(date +%s)\", \
-		\"color\": \"danger\" \
-		} \
-	] \
-	}" "${FEED_CONSUL_GH_URL}"
-else
-	echo "Not posting slack failure notifications for non-main branch"
-fi
+GITHUB_ENDPOINT="https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+GITHUB_ACTIONS_ENDPOINT="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -n1)
+SHORT_REF=$(git rev-parse --short "${GITHUB_SHA}")
+curl -X POST -H 'Content-type: application/json' \
+  --data \
+  "{ \
+\"attachments\": [ \
+  { \
+  \"fallback\": \"GitHub Actions workflow failed!\", \
+  \"text\": \"❌ Failed: \`${GITHUB_ACTOR}\`'s <${GITHUB_ACTIONS_ENDPOINT}> workflow failed for commit <${GITHUB_ENDPOINT}|${SHORT_REF}> on \`${GITHUB_REF_NAME}\`!\n\n- <${COMMIT_MESSAGE}\", \
+  \"footer\": \"${GITHUB_REPOSITORY}\", \
+  \"ts\": \"$(date +%s)\", \
+  \"color\": \"danger\" \
+  } \
+] \
+}" "${SLACK_WEBHOOK_URL}"

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -512,6 +512,7 @@ jobs:
         with:
           payload: |
             {
+              "message: "❌ Failed: `${{ github.event.sender.login }}`'s <${GITHUB_ACTIONS_ENDPOINT}> workflow failed for commit <${GITHUB_ENDPOINT}|${SHORT_REF}> on `${{ github.ref_name }}`!\n\n- <${COMMIT_MESSAGE}",
               "attachments": [
                 {
                   "fallback": "GitHub Actions workflow failed!",

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -499,7 +499,7 @@ jobs:
 #        if: github.ref_name == 'main' || startsWith(github.ref_name, 'release/')
         id: slack
         run: |
-          # notify slack if any upstream job failed.
+          # notify slack if any upstream job failed
           if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure)\"'; then
             .github/scripts/notify_slack.sh
           fi

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -512,3 +512,28 @@ jobs:
             printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
             exit 1
           fi
+      - name: set environment variables for commit message and short ref
+        run: |
+          export COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -n1)
+          export SHORT_REF=$(git rev-parse --short "${{ github.ref_name }}")
+      - name: Notify Slack
+        if: ${{ failure() }} # github.ref_name == 'main' || startsWith(github.ref_name, 'release/')
+        id: slack
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "fallback": "GitHub Actions workflow failed!",
+                  "text": "❌ Failed: `${{ github.event.sender.login }}`'s <${GITHUB_ACTIONS_ENDPOINT}> workflow failed for commit <${GITHUB_ENDPOINT}|${SHORT_REF}> on `${{ github.ref_name }}`!\n\n- <${COMMIT_MESSAGE}",
+                  "footer": "${GITHUB_REPOSITORY}",
+                  "ts": "$(date +%s)",
+                  "color": "danger"
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}
+          GITHUB_ENDPOINT: "https://github.com/${{ github.event.repository.name }}/commit/${{ github.sha }}"
+          GITHUB_ACTIONS_ENDPOINT: "https://github.com/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -523,7 +523,7 @@ jobs:
         with:
           payload: |
             {
-              "message": "One or more nightly integration tests have failed on ${{ github.ref_name }} branch. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "message": "One or more tests have failed on ${{ github.ref_name }} branch. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -501,7 +501,7 @@ jobs:
         run: |
           # notify slack if any upstream job failed.
           if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure)\"'; then
-            sh .github/scripts/notify_slack.sh
+            .github/scripts/notify_slack.sh
           fi
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -180,15 +180,15 @@ jobs:
 #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 
   # create a development build
-  dev-build:
-    needs:
-    - setup
-    uses: ./.github/workflows/reusable-dev-build.yml
-    with:
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#  dev-build:
+#    needs:
+#    - setup
+#    uses: ./.github/workflows/reusable-dev-build.yml
+#    with:
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 
   # dev-build-s390x:
   #   if: ${{ endsWith(github.repository, '-enterprise') }}
@@ -236,24 +236,24 @@ jobs:
   #     consul-license: ${{secrets.CONSUL_LICENSE}}
   #     datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
-  go-test-ce:
-    needs:
-    - setup
-    - dev-build
-    uses: ./.github/workflows/reusable-unit-split.yml
-    with:
-      directory: .
-      runner-count: 12
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-      go-tags: ""
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      consul-license: ${{secrets.CONSUL_LICENSE}}
-      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+#  go-test-ce:
+#    needs:
+#    - setup
+#    - dev-build
+#    uses: ./.github/workflows/reusable-unit-split.yml
+#    with:
+#      directory: .
+#      runner-count: 12
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#      go-tags: ""
+#    permissions:
+#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+#      contents: read
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#      consul-license: ${{secrets.CONSUL_LICENSE}}
+#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
 #  go-test-enterprise:
 #    if: ${{ endsWith(github.repository, '-enterprise') }}
@@ -491,7 +491,7 @@ jobs:
 #    - go-test-sdk-1-20
 #    - go-test-32bit
     # - go-test-s390x
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+    runs-on: ubuntu-latest
     if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
       - name: Notify Slack
@@ -500,10 +500,10 @@ jobs:
         run: .github/scripts/notify_slack.sh
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}
-      - name: evaluate upstream job results
-        run: |
-          # exit 1 if failure or cancelled result for any upstream job
-          if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure|cancelled)\"'; then
-            printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
-            exit 1
-          fi
+#      - name: evaluate upstream job results
+#        run: |
+#          # exit 1 if failure or cancelled result for any upstream job
+#          if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure|cancelled)\"'; then
+#            printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
+#            exit 1
+#          fi

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -31,14 +31,14 @@ concurrency:
 
 jobs:
   conditional-skip:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     name: Get files changed and conditionally skip CI
     outputs:
       skip-ci: ${{ steps.read-files.outputs.skip-ci }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
-          fetch-depth: 0  
+          fetch-depth: 0
       - name: Get changed files
         id: read-files
         run: ./.github/scripts/filter_changed_files_go_test.sh
@@ -54,141 +54,141 @@ jobs:
       compute-large: ${{ steps.setup-outputs.outputs.compute-large }}
       compute-xl: ${{ steps.setup-outputs.outputs.compute-xl }}
     steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    - id: setup-outputs
-      name: Setup outputs
-      run: ./.github/scripts/get_runner_classes.shit
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - id: setup-outputs
+        name: Setup outputs
+        run: ./.github/scripts/get_runner_classes.shit
 
-#  check-go-mod:
-#    needs:
-#    - setup
-#    uses: ./.github/workflows/reusable-check-go-mod.yml
-#    with:
-#      runs-on: ${{ needs.setup.outputs.compute-small }}
-#      repository-name: ${{ github.repository }}
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#
-#  check-generated-protobuf:
-#    needs:
-#    - setup
-#    runs-on: ${{ fromJSON(needs.setup.outputs.compute-medium) }}
-#    steps:
-#    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-#    - name: Setup Git
-#      if: ${{ endsWith(github.repository, '-enterprise') }}
-#      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-#    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-#      with:
-#        go-version-file: 'go.mod'
-#    - run: make proto-tools
-#      name: Install protobuf
-#    - run: make proto-format
-#      name: "Protobuf Format"
-#    - run: make --always-make proto
-#    - run: |
-#            if ! git diff --exit-code; then
-#              echo "Generated code was not updated correctly"
-#              exit 1
-#            fi
-#    - run: make proto-lint
-#      name: "Protobuf Lint"
-#  check-codegen:
-#     needs:
-#     - setup
-#     runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
-#     steps:
-#     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#     # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-#     - name: Setup Git
-#       if: ${{ endsWith(github.repository, '-enterprise') }}
-#       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-#     - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-#       with:
-#         go-version-file: 'go.mod'
-#     - run: make --always-make codegen
-#     - run: |
-#         if ! git diff --exit-code; then
-#           echo "Generated code was not updated correctly"
-#           exit 1
-#         fi
+  #  check-go-mod:
+  #    needs:
+  #    - setup
+  #    uses: ./.github/workflows/reusable-check-go-mod.yml
+  #    with:
+  #      runs-on: ${{ needs.setup.outputs.compute-small }}
+  #      repository-name: ${{ github.repository }}
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #
+  #  check-generated-protobuf:
+  #    needs:
+  #    - setup
+  #    runs-on: ${{ fromJSON(needs.setup.outputs.compute-medium) }}
+  #    steps:
+  #    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+  #    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+  #    - name: Setup Git
+  #      if: ${{ endsWith(github.repository, '-enterprise') }}
+  #      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+  #    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+  #      with:
+  #        go-version-file: 'go.mod'
+  #    - run: make proto-tools
+  #      name: Install protobuf
+  #    - run: make proto-format
+  #      name: "Protobuf Format"
+  #    - run: make --always-make proto
+  #    - run: |
+  #            if ! git diff --exit-code; then
+  #              echo "Generated code was not updated correctly"
+  #              exit 1
+  #            fi
+  #    - run: make proto-lint
+  #      name: "Protobuf Lint"
+  #  check-codegen:
+  #     needs:
+  #     - setup
+  #     runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
+  #     steps:
+  #     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+  #     # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+  #     - name: Setup Git
+  #       if: ${{ endsWith(github.repository, '-enterprise') }}
+  #       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+  #     - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+  #       with:
+  #         go-version-file: 'go.mod'
+  #     - run: make --always-make codegen
+  #     - run: |
+  #         if ! git diff --exit-code; then
+  #           echo "Generated code was not updated correctly"
+  #           exit 1
+  #         fi
 
-#  lint-enums:
-#    needs:
-#    - setup
-#    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
-#    steps:
-#    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-#    - name: Setup Git
-#      if: ${{ endsWith(github.repository, '-enterprise') }}
-#      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-#    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-#      with:
-#        go-version-file: 'go.mod'
-#    - run: go install github.com/reillywatson/enumcover/cmd/enumcover@master && enumcover ./...
-#
-#  lint-container-test-deps:
-#    needs:
-#    - setup
-#    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-#    steps:
-#    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-#    - name: Setup Git
-#      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-#    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-#      with:
-#        go-version-file: 'go.mod'
-#    - run: make lint-container-test-deps
-#
-#  lint-consul-retry:
-#    needs:
-#    - setup
-#    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-#    steps:
-#    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-#    - name: Setup Git
-#      if: ${{ endsWith(github.repository, '-enterprise') }}
-#      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-#    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-#      with:
-#        go-version-file: 'go.mod'
-#    - run: go install github.com/hashicorp/lint-consul-retry@master && lint-consul-retry
-#
-#  lint:
-#    needs:
-#    - setup
-#    uses: ./.github/workflows/reusable-lint.yml
-#    with:
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#
-#  lint-32bit:
-#    needs:
-#    - setup
-#    uses: ./.github/workflows/reusable-lint.yml
-#    with:
-#      go-arch: "386"
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #  lint-enums:
+  #    needs:
+  #    - setup
+  #    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
+  #    steps:
+  #    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+  #    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+  #    - name: Setup Git
+  #      if: ${{ endsWith(github.repository, '-enterprise') }}
+  #      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+  #    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+  #      with:
+  #        go-version-file: 'go.mod'
+  #    - run: go install github.com/reillywatson/enumcover/cmd/enumcover@master && enumcover ./...
+  #
+  #  lint-container-test-deps:
+  #    needs:
+  #    - setup
+  #    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+  #    steps:
+  #    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+  #    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+  #    - name: Setup Git
+  #      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+  #    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+  #      with:
+  #        go-version-file: 'go.mod'
+  #    - run: make lint-container-test-deps
+  #
+  #  lint-consul-retry:
+  #    needs:
+  #    - setup
+  #    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+  #    steps:
+  #    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+  #    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+  #    - name: Setup Git
+  #      if: ${{ endsWith(github.repository, '-enterprise') }}
+  #      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+  #    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+  #      with:
+  #        go-version-file: 'go.mod'
+  #    - run: go install github.com/hashicorp/lint-consul-retry@master && lint-consul-retry
+  #
+  #  lint:
+  #    needs:
+  #    - setup
+  #    uses: ./.github/workflows/reusable-lint.yml
+  #    with:
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #
+  #  lint-32bit:
+  #    needs:
+  #    - setup
+  #    uses: ./.github/workflows/reusable-lint.yml
+  #    with:
+  #      go-arch: "386"
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 
   # create a development build
-#  dev-build:
-#    needs:
-#    - setup
-#    uses: ./.github/workflows/reusable-dev-build.yml
-#    with:
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #  dev-build:
+  #    needs:
+  #    - setup
+  #    uses: ./.github/workflows/reusable-dev-build.yml
+  #    with:
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 
   # dev-build-s390x:
   #   if: ${{ endsWith(github.repository, '-enterprise') }}
@@ -236,84 +236,84 @@ jobs:
   #     consul-license: ${{secrets.CONSUL_LICENSE}}
   #     datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
-#  go-test-ce:
-#    needs:
-#    - setup
-#    - dev-build
-#    uses: ./.github/workflows/reusable-unit-split.yml
-#    with:
-#      directory: .
-#      runner-count: 12
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#      go-tags: ""
-#    permissions:
-#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-#      contents: read
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#      consul-license: ${{secrets.CONSUL_LICENSE}}
-#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+  #  go-test-ce:
+  #    needs:
+  #    - setup
+  #    - dev-build
+  #    uses: ./.github/workflows/reusable-unit-split.yml
+  #    with:
+  #      directory: .
+  #      runner-count: 12
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #      go-tags: ""
+  #    permissions:
+  #      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+  #      contents: read
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #      consul-license: ${{secrets.CONSUL_LICENSE}}
+  #      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
-#  go-test-enterprise:
-#    if: ${{ endsWith(github.repository, '-enterprise') }}
-#    needs:
-#    - setup
-#    - dev-build
-#    uses: ./.github/workflows/reusable-unit-split.yml
-#    with:
-#      directory: .
-#      runner-count: 12
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-#    permissions:
-#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-#      contents: read
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#      consul-license: ${{secrets.CONSUL_LICENSE}}
-#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-#
-#  go-test-race:
-#    needs:
-#    - setup
-#    - dev-build
-#    uses: ./.github/workflows/reusable-unit.yml
-#    with:
-#      directory: .
-#      go-test-flags: 'GO_TEST_FLAGS="-race -gcflags=all=-d=checkptr=0"'
-#      package-names-command: "go list ./... | grep -E -v '^github.com/hashicorp/consul/agent(/consul|/local|/routine-leak-checker)?$' | grep -E -v '^github.com/hashicorp/consul(/command|/connect|/snapshot)'"
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-#    permissions:
-#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-#      contents: read
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#      consul-license: ${{secrets.CONSUL_LICENSE}}
-#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-#
-#  go-test-32bit:
-#    needs:
-#    - setup
-#    - dev-build
-#    uses: ./.github/workflows/reusable-unit.yml
-#    with:
-#      directory: .
-#      go-arch: "386"
-#      go-test-flags: 'export GO_TEST_FLAGS="-short"'
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-#    permissions:
-#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-#      contents: read
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#      consul-license: ${{secrets.CONSUL_LICENSE}}
-#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+  #  go-test-enterprise:
+  #    if: ${{ endsWith(github.repository, '-enterprise') }}
+  #    needs:
+  #    - setup
+  #    - dev-build
+  #    uses: ./.github/workflows/reusable-unit-split.yml
+  #    with:
+  #      directory: .
+  #      runner-count: 12
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+  #    permissions:
+  #      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+  #      contents: read
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #      consul-license: ${{secrets.CONSUL_LICENSE}}
+  #      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+  #
+  #  go-test-race:
+  #    needs:
+  #    - setup
+  #    - dev-build
+  #    uses: ./.github/workflows/reusable-unit.yml
+  #    with:
+  #      directory: .
+  #      go-test-flags: 'GO_TEST_FLAGS="-race -gcflags=all=-d=checkptr=0"'
+  #      package-names-command: "go list ./... | grep -E -v '^github.com/hashicorp/consul/agent(/consul|/local|/routine-leak-checker)?$' | grep -E -v '^github.com/hashicorp/consul(/command|/connect|/snapshot)'"
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+  #    permissions:
+  #      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+  #      contents: read
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #      consul-license: ${{secrets.CONSUL_LICENSE}}
+  #      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+  #
+  #  go-test-32bit:
+  #    needs:
+  #    - setup
+  #    - dev-build
+  #    uses: ./.github/workflows/reusable-unit.yml
+  #    with:
+  #      directory: .
+  #      go-arch: "386"
+  #      go-test-flags: 'export GO_TEST_FLAGS="-short"'
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+  #    permissions:
+  #      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+  #      contents: read
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #      consul-license: ${{secrets.CONSUL_LICENSE}}
+  #      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
   # go-test-s390x:
   #   if: ${{ endsWith(github.repository, '-enterprise') }}
@@ -336,117 +336,117 @@ jobs:
   #     consul-license: ${{secrets.CONSUL_LICENSE}}
   #     datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
-#  go-test-envoyextensions:
-#    needs:
-#    - setup
-#    - dev-build
-#    uses: ./.github/workflows/reusable-unit.yml
-#    with:
-#      directory: envoyextensions
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-#    permissions:
-#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-#      contents: read
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#      consul-license: ${{secrets.CONSUL_LICENSE}}
-#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-#
-#  go-test-troubleshoot:
-#    needs:
-#    - setup
-#    - dev-build
-#    uses: ./.github/workflows/reusable-unit.yml
-#    with:
-#      directory: troubleshoot
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-#    permissions:
-#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-#      contents: read
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#      consul-license: ${{secrets.CONSUL_LICENSE}}
-#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-#
-#  go-test-api-1-19:
-#    needs:
-#    - setup
-#    - dev-build
-#    uses: ./.github/workflows/reusable-unit.yml
-#    with:
-#      directory: api
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-#      go-version: "1.19"
-#    permissions:
-#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-#      contents: read
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#      consul-license: ${{secrets.CONSUL_LICENSE}}
-#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-#
-#  go-test-api-1-20:
-#    needs:
-#    - setup
-#    - dev-build
-#    uses: ./.github/workflows/reusable-unit.yml
-#    with:
-#      directory: api
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-#      go-version: "1.20"
-#    permissions:
-#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-#      contents: read
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#      consul-license: ${{secrets.CONSUL_LICENSE}}
-#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-#
-#  go-test-sdk-1-19:
-#    needs:
-#    - setup
-#    - dev-build
-#    uses: ./.github/workflows/reusable-unit.yml
-#    with:
-#      directory: sdk
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-#      go-version: "1.19"
-#    permissions:
-#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-#      contents: read
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#      consul-license: ${{secrets.CONSUL_LICENSE}}
-#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-#
-#  go-test-sdk-1-20:
-#    needs:
-#    - setup
-#    - dev-build
-#    uses: ./.github/workflows/reusable-unit.yml
-#    with:
-#      directory: sdk
-#      runs-on: ${{ needs.setup.outputs.compute-large }}
-#      repository-name: ${{ github.repository }}
-#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-#      go-version: "1.20"
-#    permissions:
-#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-#      contents: read
-#    secrets:
-#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-#      consul-license: ${{secrets.CONSUL_LICENSE}}
-#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+  #  go-test-envoyextensions:
+  #    needs:
+  #    - setup
+  #    - dev-build
+  #    uses: ./.github/workflows/reusable-unit.yml
+  #    with:
+  #      directory: envoyextensions
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+  #    permissions:
+  #      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+  #      contents: read
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #      consul-license: ${{secrets.CONSUL_LICENSE}}
+  #      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+  #
+  #  go-test-troubleshoot:
+  #    needs:
+  #    - setup
+  #    - dev-build
+  #    uses: ./.github/workflows/reusable-unit.yml
+  #    with:
+  #      directory: troubleshoot
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+  #    permissions:
+  #      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+  #      contents: read
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #      consul-license: ${{secrets.CONSUL_LICENSE}}
+  #      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+  #
+  #  go-test-api-1-19:
+  #    needs:
+  #    - setup
+  #    - dev-build
+  #    uses: ./.github/workflows/reusable-unit.yml
+  #    with:
+  #      directory: api
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+  #      go-version: "1.19"
+  #    permissions:
+  #      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+  #      contents: read
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #      consul-license: ${{secrets.CONSUL_LICENSE}}
+  #      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+  #
+  #  go-test-api-1-20:
+  #    needs:
+  #    - setup
+  #    - dev-build
+  #    uses: ./.github/workflows/reusable-unit.yml
+  #    with:
+  #      directory: api
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+  #      go-version: "1.20"
+  #    permissions:
+  #      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+  #      contents: read
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #      consul-license: ${{secrets.CONSUL_LICENSE}}
+  #      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+  #
+  #  go-test-sdk-1-19:
+  #    needs:
+  #    - setup
+  #    - dev-build
+  #    uses: ./.github/workflows/reusable-unit.yml
+  #    with:
+  #      directory: sdk
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+  #      go-version: "1.19"
+  #    permissions:
+  #      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+  #      contents: read
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #      consul-license: ${{secrets.CONSUL_LICENSE}}
+  #      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+  #
+  #  go-test-sdk-1-20:
+  #    needs:
+  #    - setup
+  #    - dev-build
+  #    uses: ./.github/workflows/reusable-unit.yml
+  #    with:
+  #      directory: sdk
+  #      runs-on: ${{ needs.setup.outputs.compute-large }}
+  #      repository-name: ${{ github.repository }}
+  #      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+  #      go-version: "1.20"
+  #    permissions:
+  #      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+  #      contents: read
+  #    secrets:
+  #      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+  #      consul-license: ${{secrets.CONSUL_LICENSE}}
+  #      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
   noop:
     runs-on: ubuntu-latest
@@ -469,34 +469,34 @@ jobs:
 
   go-tests-success:
     needs:
-    - conditional-skip
-    - setup
-#    - check-codegen
-#    - check-generated-protobuf
-#    - check-go-mod
-#    - lint-consul-retry
-#    - lint-container-test-deps
-#    - lint-enums
-#    - lint
-#    - lint-32bit
+      - conditional-skip
+      - setup
+    #    - check-codegen
+    #    - check-generated-protobuf
+    #    - check-go-mod
+    #    - lint-consul-retry
+    #    - lint-container-test-deps
+    #    - lint-enums
+    #    - lint
+    #    - lint-32bit
     # - go-test-arm64
-#    - go-test-enterprise
-#    - go-test-ce
-#    - go-test-race
-#    - go-test-envoyextensions
-#    - go-test-troubleshoot
-#    - go-test-api-1-19
-#    - go-test-api-1-20
-#    - go-test-sdk-1-19
-#    - go-test-sdk-1-20
-#    - go-test-32bit
+    #    - go-test-enterprise
+    #    - go-test-ce
+    #    - go-test-race
+    #    - go-test-envoyextensions
+    #    - go-test-troubleshoot
+    #    - go-test-api-1-19
+    #    - go-test-api-1-20
+    #    - go-test-sdk-1-19
+    #    - go-test-sdk-1-20
+    #    - go-test-32bit
     # - go-test-s390x
     runs-on: ubuntu-latest
     if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Notify Slack
-#        if: github.ref_name == 'main' || startsWith(github.ref_name, 'release/')
+        #        if: github.ref_name == 'main' || startsWith(github.ref_name, 'release/')
         id: slack
         run: |
           # notify slack if any upstream job failed

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -495,9 +495,13 @@ jobs:
     if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
       - name: Notify Slack
-        if: ${{ failure() }} #&& (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
+#        if: github.ref_name == 'main' || startsWith(github.ref_name, 'release/')
         id: slack
-        run: .github/scripts/notify_slack.sh
+        run: |
+          # notify slack if any upstream job failed.
+          if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure)\"'; then
+            sh .github/scripts/notify_slack.sh
+          fi
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}
 #      - name: evaluate upstream job results

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -494,6 +494,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Notify Slack
 #        if: github.ref_name == 'main' || startsWith(github.ref_name, 'release/')
         id: slack

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -516,3 +516,14 @@ jobs:
             printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
             exit 1
           fi
+      - name: Notify Slack
+        if: ${{ failure() && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+        id: slack
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        with:
+          payload: |
+            {
+              "message": "One or more nightly integration tests have failed on ${{ github.ref_name }} branch. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -512,15 +512,7 @@ jobs:
         with:
           payload: |
             {
-              "message: "❌ Failed: `${{ github.event.sender.login }}`'s <${GITHUB_ACTIONS_ENDPOINT}> workflow failed for commit <${GITHUB_ENDPOINT}|${SHORT_REF}> on `${{ github.ref_name }}`!\n\n- <${COMMIT_MESSAGE}",
-              "attachments": [
-                {
-                  "fallback": "GitHub Actions workflow failed!",
-                  "text": "❌ Failed: `${{ github.event.sender.login }}`'s <${GITHUB_ACTIONS_ENDPOINT}> workflow failed for commit <${GITHUB_ENDPOINT}|${SHORT_REF}> on `${{ github.ref_name }}`!\n\n- <${COMMIT_MESSAGE}",
-                  "footer": "${GITHUB_REPOSITORY}",
-                  "ts": "$(date +%s)",
-                  "color": "danger"
-                }
+              "message: "❌ Failed: `${{ github.event.sender.login }}`'s <${GITHUB_ACTIONS_ENDPOINT}> workflow failed for commit <${GITHUB_ENDPOINT}|${SHORT_REF}> on `${{ github.ref_name }}`!\n\n- <${COMMIT_MESSAGE}"
               ]
             }
         env:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -505,10 +505,10 @@ jobs:
           fi
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}
-#      - name: evaluate upstream job results
-#        run: |
-#          # exit 1 if failure or cancelled result for any upstream job
-#          if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure|cancelled)\"'; then
-#            printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
-#            exit 1
-#          fi
+      - name: evaluate upstream job results
+        run: |
+          # exit 1 if failure or cancelled result for any upstream job
+          if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure|cancelled)\"'; then
+            printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
+            exit 1
+          fi

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files_go_test.shit
+        run: ./.github/scripts/filter_changed_files_go_test.sh
 
   setup:
     needs: [conditional-skip]
@@ -114,70 +114,70 @@ jobs:
            exit 1
          fi
 
-  lint-enums:
-    needs:
-    - setup
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
-    steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-    - name: Setup Git
-      if: ${{ endsWith(github.repository, '-enterprise') }}
-      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-      with:
-        go-version-file: 'go.mod'
-    - run: go install github.com/reillywatson/enumcover/cmd/enumcover@master && enumcover ./...
-
-  lint-container-test-deps:
-    needs:
-    - setup
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-    steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-    - name: Setup Git
-      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-      with:
-        go-version-file: 'go.mod'
-    - run: make lint-container-test-deps
-
-  lint-consul-retry:
-    needs:
-    - setup
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-    steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-    - name: Setup Git
-      if: ${{ endsWith(github.repository, '-enterprise') }}
-      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-      with:
-        go-version-file: 'go.mod'
-    - run: go install github.com/hashicorp/lint-consul-retry@master && lint-consul-retry
-
-  lint:
-    needs:
-    - setup
-    uses: ./.github/workflows/reusable-lint.yml
-    with:
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-
-  lint-32bit:
-    needs:
-    - setup
-    uses: ./.github/workflows/reusable-lint.yml
-    with:
-      go-arch: "386"
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#  lint-enums:
+#    needs:
+#    - setup
+#    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
+#    steps:
+#    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+#    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+#    - name: Setup Git
+#      if: ${{ endsWith(github.repository, '-enterprise') }}
+#      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+#    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+#      with:
+#        go-version-file: 'go.mod'
+#    - run: go install github.com/reillywatson/enumcover/cmd/enumcover@master && enumcover ./...
+#
+#  lint-container-test-deps:
+#    needs:
+#    - setup
+#    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+#    steps:
+#    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+#    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+#    - name: Setup Git
+#      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+#    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+#      with:
+#        go-version-file: 'go.mod'
+#    - run: make lint-container-test-deps
+#
+#  lint-consul-retry:
+#    needs:
+#    - setup
+#    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+#    steps:
+#    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+#    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+#    - name: Setup Git
+#      if: ${{ endsWith(github.repository, '-enterprise') }}
+#      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+#    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+#      with:
+#        go-version-file: 'go.mod'
+#    - run: go install github.com/hashicorp/lint-consul-retry@master && lint-consul-retry
+#
+#  lint:
+#    needs:
+#    - setup
+#    uses: ./.github/workflows/reusable-lint.yml
+#    with:
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#
+#  lint-32bit:
+#    needs:
+#    - setup
+#    uses: ./.github/workflows/reusable-lint.yml
+#    with:
+#      go-arch: "386"
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 
   # create a development build
   dev-build:
@@ -255,65 +255,65 @@ jobs:
       consul-license: ${{secrets.CONSUL_LICENSE}}
       datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
-  go-test-enterprise:
-    if: ${{ endsWith(github.repository, '-enterprise') }}
-    needs:
-    - setup
-    - dev-build
-    uses: ./.github/workflows/reusable-unit-split.yml
-    with:
-      directory: .
-      runner-count: 12
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      consul-license: ${{secrets.CONSUL_LICENSE}}
-      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-
-  go-test-race:
-    needs:
-    - setup
-    - dev-build
-    uses: ./.github/workflows/reusable-unit.yml
-    with:
-      directory: .
-      go-test-flags: 'GO_TEST_FLAGS="-race -gcflags=all=-d=checkptr=0"'
-      package-names-command: "go list ./... | grep -E -v '^github.com/hashicorp/consul/agent(/consul|/local|/routine-leak-checker)?$' | grep -E -v '^github.com/hashicorp/consul(/command|/connect|/snapshot)'"
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      consul-license: ${{secrets.CONSUL_LICENSE}}
-      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-
-  go-test-32bit:
-    needs:
-    - setup
-    - dev-build
-    uses: ./.github/workflows/reusable-unit.yml
-    with:
-      directory: .
-      go-arch: "386"
-      go-test-flags: 'export GO_TEST_FLAGS="-short"'
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      consul-license: ${{secrets.CONSUL_LICENSE}}
-      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+#  go-test-enterprise:
+#    if: ${{ endsWith(github.repository, '-enterprise') }}
+#    needs:
+#    - setup
+#    - dev-build
+#    uses: ./.github/workflows/reusable-unit-split.yml
+#    with:
+#      directory: .
+#      runner-count: 12
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+#    permissions:
+#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+#      contents: read
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#      consul-license: ${{secrets.CONSUL_LICENSE}}
+#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+#
+#  go-test-race:
+#    needs:
+#    - setup
+#    - dev-build
+#    uses: ./.github/workflows/reusable-unit.yml
+#    with:
+#      directory: .
+#      go-test-flags: 'GO_TEST_FLAGS="-race -gcflags=all=-d=checkptr=0"'
+#      package-names-command: "go list ./... | grep -E -v '^github.com/hashicorp/consul/agent(/consul|/local|/routine-leak-checker)?$' | grep -E -v '^github.com/hashicorp/consul(/command|/connect|/snapshot)'"
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+#    permissions:
+#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+#      contents: read
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#      consul-license: ${{secrets.CONSUL_LICENSE}}
+#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+#
+#  go-test-32bit:
+#    needs:
+#    - setup
+#    - dev-build
+#    uses: ./.github/workflows/reusable-unit.yml
+#    with:
+#      directory: .
+#      go-arch: "386"
+#      go-test-flags: 'export GO_TEST_FLAGS="-short"'
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+#    permissions:
+#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+#      contents: read
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#      consul-license: ${{secrets.CONSUL_LICENSE}}
+#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
   # go-test-s390x:
   #   if: ${{ endsWith(github.repository, '-enterprise') }}
@@ -336,117 +336,117 @@ jobs:
   #     consul-license: ${{secrets.CONSUL_LICENSE}}
   #     datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
-  go-test-envoyextensions:
-    needs:
-    - setup
-    - dev-build
-    uses: ./.github/workflows/reusable-unit.yml
-    with:
-      directory: envoyextensions
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      consul-license: ${{secrets.CONSUL_LICENSE}}
-      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-
-  go-test-troubleshoot:
-    needs:
-    - setup
-    - dev-build
-    uses: ./.github/workflows/reusable-unit.yml
-    with:
-      directory: troubleshoot
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      consul-license: ${{secrets.CONSUL_LICENSE}}
-      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-
-  go-test-api-1-19:
-    needs:
-    - setup
-    - dev-build
-    uses: ./.github/workflows/reusable-unit.yml
-    with:
-      directory: api
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-      go-version: "1.19"
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      consul-license: ${{secrets.CONSUL_LICENSE}}
-      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-
-  go-test-api-1-20:
-    needs:
-    - setup
-    - dev-build
-    uses: ./.github/workflows/reusable-unit.yml
-    with:
-      directory: api
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-      go-version: "1.20"
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      consul-license: ${{secrets.CONSUL_LICENSE}}
-      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-
-  go-test-sdk-1-19:
-    needs:
-    - setup
-    - dev-build
-    uses: ./.github/workflows/reusable-unit.yml
-    with:
-      directory: sdk
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-      go-version: "1.19"
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      consul-license: ${{secrets.CONSUL_LICENSE}}
-      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
-
-  go-test-sdk-1-20:
-    needs:
-    - setup
-    - dev-build
-    uses: ./.github/workflows/reusable-unit.yml
-    with:
-      directory: sdk
-      runs-on: ${{ needs.setup.outputs.compute-large }}
-      repository-name: ${{ github.repository }}
-      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
-      go-version: "1.20"
-    permissions:
-      id-token: write # NOTE: this permission is explicitly required for Vault auth.
-      contents: read
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      consul-license: ${{secrets.CONSUL_LICENSE}}
-      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+#  go-test-envoyextensions:
+#    needs:
+#    - setup
+#    - dev-build
+#    uses: ./.github/workflows/reusable-unit.yml
+#    with:
+#      directory: envoyextensions
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+#    permissions:
+#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+#      contents: read
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#      consul-license: ${{secrets.CONSUL_LICENSE}}
+#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+#
+#  go-test-troubleshoot:
+#    needs:
+#    - setup
+#    - dev-build
+#    uses: ./.github/workflows/reusable-unit.yml
+#    with:
+#      directory: troubleshoot
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+#    permissions:
+#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+#      contents: read
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#      consul-license: ${{secrets.CONSUL_LICENSE}}
+#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+#
+#  go-test-api-1-19:
+#    needs:
+#    - setup
+#    - dev-build
+#    uses: ./.github/workflows/reusable-unit.yml
+#    with:
+#      directory: api
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+#      go-version: "1.19"
+#    permissions:
+#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+#      contents: read
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#      consul-license: ${{secrets.CONSUL_LICENSE}}
+#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+#
+#  go-test-api-1-20:
+#    needs:
+#    - setup
+#    - dev-build
+#    uses: ./.github/workflows/reusable-unit.yml
+#    with:
+#      directory: api
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+#      go-version: "1.20"
+#    permissions:
+#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+#      contents: read
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#      consul-license: ${{secrets.CONSUL_LICENSE}}
+#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+#
+#  go-test-sdk-1-19:
+#    needs:
+#    - setup
+#    - dev-build
+#    uses: ./.github/workflows/reusable-unit.yml
+#    with:
+#      directory: sdk
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+#      go-version: "1.19"
+#    permissions:
+#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+#      contents: read
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#      consul-license: ${{secrets.CONSUL_LICENSE}}
+#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
+#
+#  go-test-sdk-1-20:
+#    needs:
+#    - setup
+#    - dev-build
+#    uses: ./.github/workflows/reusable-unit.yml
+#    with:
+#      directory: sdk
+#      runs-on: ${{ needs.setup.outputs.compute-large }}
+#      repository-name: ${{ github.repository }}
+#      go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consulprem consuldev' || '' }}"
+#      go-version: "1.20"
+#    permissions:
+#      id-token: write # NOTE: this permission is explicitly required for Vault auth.
+#      contents: read
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#      consul-license: ${{secrets.CONSUL_LICENSE}}
+#      datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
   noop:
     runs-on: ubuntu-latest
@@ -474,26 +474,32 @@ jobs:
     - check-codegen
     - check-generated-protobuf
     - check-go-mod
-    - lint-consul-retry
-    - lint-container-test-deps
-    - lint-enums
-    - lint
-    - lint-32bit
+#    - lint-consul-retry
+#    - lint-container-test-deps
+#    - lint-enums
+#    - lint
+#    - lint-32bit
     # - go-test-arm64
-    - go-test-enterprise
+#    - go-test-enterprise
     - go-test-ce
-    - go-test-race
-    - go-test-envoyextensions
-    - go-test-troubleshoot
-    - go-test-api-1-19
-    - go-test-api-1-20
-    - go-test-sdk-1-19
-    - go-test-sdk-1-20
-    - go-test-32bit
+#    - go-test-race
+#    - go-test-envoyextensions
+#    - go-test-troubleshoot
+#    - go-test-api-1-19
+#    - go-test-api-1-20
+#    - go-test-sdk-1-19
+#    - go-test-sdk-1-20
+#    - go-test-32bit
     # - go-test-s390x
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
     if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
+      - name: Notify Slack
+        if: ${{ failure() && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+        id: slack
+        run: .github/scripts/notify_slack.sh
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}
       - name: evaluate upstream job results
         run: |
           # exit 1 if failure or cancelled result for any upstream job
@@ -501,9 +507,3 @@ jobs:
             printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
             exit 1
           fi
-      - name: Notify Slack
-        if: ${{ failure() && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
-        id: slack
-        run: .github/scripts/notify_slack.sh
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -41,78 +41,78 @@ jobs:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files_go_test.sh
+        run: ./.github/scripts/filter_changed_files_go_test.shit
 
-  setup:
-    needs: [conditional-skip]
-    name: Setup
-    if: needs.conditional-skip.outputs.skip-ci != 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      compute-small: ${{ steps.setup-outputs.outputs.compute-small }}
-      compute-medium: ${{ steps.setup-outputs.outputs.compute-medium }}
-      compute-large: ${{ steps.setup-outputs.outputs.compute-large }}
-      compute-xl: ${{ steps.setup-outputs.outputs.compute-xl }}
-    steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    - id: setup-outputs
-      name: Setup outputs
-      run: ./.github/scripts/get_runner_classes.sh
+#  setup:
+#    needs: [conditional-skip]
+#    name: Setup
+#    if: needs.conditional-skip.outputs.skip-ci != 'true'
+#    runs-on: ubuntu-latest
+#    outputs:
+#      compute-small: ${{ steps.setup-outputs.outputs.compute-small }}
+#      compute-medium: ${{ steps.setup-outputs.outputs.compute-medium }}
+#      compute-large: ${{ steps.setup-outputs.outputs.compute-large }}
+#      compute-xl: ${{ steps.setup-outputs.outputs.compute-xl }}
+#    steps:
+#    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+#    - id: setup-outputs
+#      name: Setup outputs
+#      run: ./.github/scripts/get_runner_classes.sh
 
-  check-go-mod:
-    needs:
-    - setup
-    uses: ./.github/workflows/reusable-check-go-mod.yml
-    with:
-      runs-on: ${{ needs.setup.outputs.compute-small }}
-      repository-name: ${{ github.repository }}
-    secrets:
-      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-
-  check-generated-protobuf:
-    needs:
-    - setup
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-medium) }}
-    steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-    - name: Setup Git
-      if: ${{ endsWith(github.repository, '-enterprise') }}
-      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-      with:
-        go-version-file: 'go.mod'
-    - run: make proto-tools
-      name: Install protobuf
-    - run: make proto-format
-      name: "Protobuf Format"
-    - run: make --always-make proto
-    - run: |
-            if ! git diff --exit-code; then
-              echo "Generated code was not updated correctly"
-              exit 1
-            fi
-    - run: make proto-lint
-      name: "Protobuf Lint"
-  check-codegen:
-     needs:
-     - setup
-     runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
-     steps:
-     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-     # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
-     - name: Setup Git
-       if: ${{ endsWith(github.repository, '-enterprise') }}
-       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-     - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-       with:
-         go-version-file: 'go.mod'
-     - run: make --always-make codegen
-     - run: |
-         if ! git diff --exit-code; then
-           echo "Generated code was not updated correctly"
-           exit 1
-         fi
+#  check-go-mod:
+#    needs:
+#    - setup
+#    uses: ./.github/workflows/reusable-check-go-mod.yml
+#    with:
+#      runs-on: ${{ needs.setup.outputs.compute-small }}
+#      repository-name: ${{ github.repository }}
+#    secrets:
+#      elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+#
+#  check-generated-protobuf:
+#    needs:
+#    - setup
+#    runs-on: ${{ fromJSON(needs.setup.outputs.compute-medium) }}
+#    steps:
+#    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+#    # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+#    - name: Setup Git
+#      if: ${{ endsWith(github.repository, '-enterprise') }}
+#      run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+#    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+#      with:
+#        go-version-file: 'go.mod'
+#    - run: make proto-tools
+#      name: Install protobuf
+#    - run: make proto-format
+#      name: "Protobuf Format"
+#    - run: make --always-make proto
+#    - run: |
+#            if ! git diff --exit-code; then
+#              echo "Generated code was not updated correctly"
+#              exit 1
+#            fi
+#    - run: make proto-lint
+#      name: "Protobuf Lint"
+#  check-codegen:
+#     needs:
+#     - setup
+#     runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
+#     steps:
+#     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+#     # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
+#     - name: Setup Git
+#       if: ${{ endsWith(github.repository, '-enterprise') }}
+#       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+#     - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+#       with:
+#         go-version-file: 'go.mod'
+#     - run: make --always-make codegen
+#     - run: |
+#         if ! git diff --exit-code; then
+#           echo "Generated code was not updated correctly"
+#           exit 1
+#         fi
 
 #  lint-enums:
 #    needs:
@@ -470,10 +470,10 @@ jobs:
   go-tests-success:
     needs:
     - conditional-skip
-    - setup
-    - check-codegen
-    - check-generated-protobuf
-    - check-go-mod
+#    - setup
+#    - check-codegen
+#    - check-generated-protobuf
+#    - check-go-mod
 #    - lint-consul-retry
 #    - lint-container-test-deps
 #    - lint-enums
@@ -481,7 +481,7 @@ jobs:
 #    - lint-32bit
     # - go-test-arm64
 #    - go-test-enterprise
-    - go-test-ce
+#    - go-test-ce
 #    - go-test-race
 #    - go-test-envoyextensions
 #    - go-test-troubleshoot
@@ -495,7 +495,7 @@ jobs:
     if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
       - name: Notify Slack
-        if: ${{ failure() && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+        if: ${{ failure() }} #&& (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
         id: slack
         run: .github/scripts/notify_slack.sh
         env:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -494,17 +494,6 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Notify Slack
-        #        if: github.ref_name == 'main' || startsWith(github.ref_name, 'release/')
-        id: slack
-        run: |
-          # notify slack if any upstream job failed
-          if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure)\"'; then
-            .github/scripts/notify_slack.sh
-          fi
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}
       - name: evaluate upstream job results
         run: |
           # exit 1 if failure or cancelled result for any upstream job
@@ -512,7 +501,7 @@ jobs:
             printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
             exit 1
           fi
-      - name: set environment variables for commit message and short ref
+      - name: Set environment variables for COMMIT_MESSAGE and SHORT_REF
         run: |
           export COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -n1)
           export SHORT_REF=$(git rev-parse --short "${{ github.ref_name }}")

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files_go_test.sh
+        run: ./.github/scripts/filter_changed_files_go_test.shit
 
   setup:
     needs: [conditional-skip]
@@ -94,9 +94,6 @@ jobs:
             fi
     - run: make proto-lint
       name: "Protobuf Lint"
-    - name: Notify Slack
-      if: ${{ failure() }}
-      run: .github/scripts/notify_slack.sh
   check-codegen:
      needs:
      - setup
@@ -116,9 +113,6 @@ jobs:
            echo "Generated code was not updated correctly"
            exit 1
          fi
-     - name: Notify Slack
-       if: ${{ failure() }}
-       run: .github/scripts/notify_slack.sh
 
   lint-enums:
     needs:
@@ -134,9 +128,6 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - run: go install github.com/reillywatson/enumcover/cmd/enumcover@master && enumcover ./...
-    - name: Notify Slack
-      if: ${{ failure() }}
-      run: .github/scripts/notify_slack.sh
 
   lint-container-test-deps:
     needs:
@@ -151,9 +142,6 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - run: make lint-container-test-deps
-    - name: Notify Slack
-      if: ${{ failure() }}
-      run: .github/scripts/notify_slack.sh
 
   lint-consul-retry:
     needs:
@@ -169,9 +157,6 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - run: go install github.com/hashicorp/lint-consul-retry@master && lint-consul-retry
-    - name: Notify Slack
-      if: ${{ failure() }}
-      run: .github/scripts/notify_slack.sh
 
   lint:
     needs:
@@ -519,11 +504,6 @@ jobs:
       - name: Notify Slack
         if: ${{ failure() && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
         id: slack
-        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
-        with:
-          payload: |
-            {
-              "message": "One or more tests have failed on ${{ github.ref_name }} branch. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
+        run: .github/scripts/notify_slack.sh
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -41,23 +41,23 @@ jobs:
           fetch-depth: 0  
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files_go_test.shit
+        run: ./.github/scripts/filter_changed_files_go_test.sh
 
-#  setup:
-#    needs: [conditional-skip]
-#    name: Setup
-#    if: needs.conditional-skip.outputs.skip-ci != 'true'
-#    runs-on: ubuntu-latest
-#    outputs:
-#      compute-small: ${{ steps.setup-outputs.outputs.compute-small }}
-#      compute-medium: ${{ steps.setup-outputs.outputs.compute-medium }}
-#      compute-large: ${{ steps.setup-outputs.outputs.compute-large }}
-#      compute-xl: ${{ steps.setup-outputs.outputs.compute-xl }}
-#    steps:
-#    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#    - id: setup-outputs
-#      name: Setup outputs
-#      run: ./.github/scripts/get_runner_classes.sh
+  setup:
+    needs: [conditional-skip]
+    name: Setup
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      compute-small: ${{ steps.setup-outputs.outputs.compute-small }}
+      compute-medium: ${{ steps.setup-outputs.outputs.compute-medium }}
+      compute-large: ${{ steps.setup-outputs.outputs.compute-large }}
+      compute-xl: ${{ steps.setup-outputs.outputs.compute-xl }}
+    steps:
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - id: setup-outputs
+      name: Setup outputs
+      run: ./.github/scripts/get_runner_classes.shit
 
 #  check-go-mod:
 #    needs:
@@ -470,7 +470,7 @@ jobs:
   go-tests-success:
     needs:
     - conditional-skip
-#    - setup
+    - setup
 #    - check-codegen
 #    - check-generated-protobuf
 #    - check-go-mod

--- a/.github/workflows/reusable-check-go-mod.yml
+++ b/.github/workflows/reusable-check-go-mod.yml
@@ -33,6 +33,3 @@ jobs:
           git status -s
           exit 1
         fi
-    - name: Notify Slack
-      if: ${{ failure() }}
-      run: .github/scripts/notify_slack.sh

--- a/.github/workflows/reusable-dev-build-windows.yml
+++ b/.github/workflows/reusable-dev-build-windows.yml
@@ -42,6 +42,3 @@ jobs:
         with:
           name: ${{inputs.uploaded-binary-name}}
           path: consul.exe
-      - name: Notify Slack
-        if: ${{ failure() }}
-        run: .github/scripts/notify_slack.sh

--- a/.github/workflows/reusable-dev-build.yml
+++ b/.github/workflows/reusable-dev-build.yml
@@ -54,6 +54,3 @@ jobs:
         with:
           name: ${{inputs.uploaded-binary-name}}
           path: ./bin/consul
-      - name: Notify Slack
-        if: ${{ failure() }}
-        run: .github/scripts/notify_slack.sh

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -55,6 +55,3 @@ jobs:
           version: v1.51.1
           args: --build-tags="${{ env.GOTAGS }}" -v
           skip-cache: true
-      - name: Notify Slack
-        if: ${{ failure() }}
-        run: .github/scripts/notify_slack.sh

--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -175,6 +175,3 @@ jobs:
       - name: "Re-run fails report"
         run: |
           .github/scripts/rerun_fails_report.sh /tmp/gotestsum-rerun-fails
-      - name: Notify Slack
-        if: ${{ failure() }}
-        run: .github/scripts/notify_slack.sh

--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      - run: mkdir -p ${{env.TEST_RESULTS}}
+      - run: echo "FAIL" && exit 1 && mkdir -p ${{env.TEST_RESULTS}}
       - name: go mod download
         working-directory: ${{inputs.directory}}
         run: go mod download

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -154,6 +154,3 @@ jobs:
       - name: "Re-run fails report"
         run: |
           .github/scripts/rerun_fails_report.sh /tmp/gotestsum-rerun-fails
-      - name: Notify Slack
-        if: ${{ failure() }}
-        run: .github/scripts/notify_slack.sh

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      - run: mkdir -p ${{env.TEST_RESULTS}}
+      - run: echo "FAIL" && exit 1 && mkdir -p ${{env.TEST_RESULTS}}
       - name: go mod download
         working-directory: ${{inputs.directory}}
         run: go mod download


### PR DESCRIPTION
### Description

no slack notifications occur for go-tests on main and release branches when they fail.  related we also would like to move the slow flakey tests to only run on merges to main and release branches, so we need a way to have highly visible notifications of failures so the merging person can be aware and take action.

See https://github.com/hashicorp/consul/pull/19628 for flakey test changes.