### PR TITLE
Skip tests with p95 greater than 30 seconds outside of main and release branches.

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -229,7 +229,7 @@ jobs:
   #     uploaded-binary-name: 'consul-bin-arm64'
   #     runner-count: 12
   #     runs-on: "['self-hosted', 'ondemand', 'os=macos-arm', 'arm64']"
-  #     go-test-flags: 'if ! [[ "$GITHUB_REF_NAME" =~ ^main$|^release/ ]]; then export GO_TEST_FLAGS="-short"; fi'
+  #     go-test-flags: "${{ (github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')) && '-short' || '' }}"
   #     repository-name: ${{ github.repository }}
   #   secrets:
   #     elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
@@ -243,10 +243,11 @@ jobs:
     uses: ./.github/workflows/reusable-unit-split.yml
     with:
       directory: .
-      runner-count: 12
+      runner-count: 6
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: ""
+      go-test-flags: "${{ (github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')) && '-short' || '' }}"
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read
@@ -263,10 +264,11 @@ jobs:
     uses: ./.github/workflows/reusable-unit-split.yml
     with:
       directory: .
-      runner-count: 12
+      runner-count: 6
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consuldev' || '' }}"
+      go-test-flags: "${{ (github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')) && '-short' || '' }}"
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read
@@ -282,7 +284,7 @@ jobs:
     uses: ./.github/workflows/reusable-unit.yml
     with:
       directory: .
-      go-test-flags: 'GO_TEST_FLAGS="-race -gcflags=all=-d=checkptr=0"'
+      go-test-flags: "-race -gcflags=all=-d=checkptr=0"
       package-names-command: "go list ./... | grep -E -v '^github.com/hashicorp/consul/agent(/consul|/local|/routine-leak-checker)?$' | grep -E -v '^github.com/hashicorp/consul(/command|/connect|/snapshot)'"
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
@@ -303,7 +305,7 @@ jobs:
     with:
       directory: .
       go-arch: "386"
-      go-test-flags: 'export GO_TEST_FLAGS="-short"'
+      go-test-flags: "-short"
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consuldev' || '' }}"
@@ -324,7 +326,7 @@ jobs:
   #   with:
   #     uploaded-binary-name: 'consul-bin-s390x'
   #     directory: .
-  #     go-test-flags: 'export GO_TEST_FLAGS="-short"'
+  #     go-test-flags: -short"
   #     runs-on: ${{ needs.setup.outputs.compute-large }}
   #     repository-name: ${{ github.repository }}
   #     go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consuldev' || '' }}"

--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -115,8 +115,6 @@ jobs:
           PACKAGE_NAMES="${{ join(matrix.package, ' ') }}"
           # PACKAGE_NAMES="${{ matrix.package }}"
 
-          ${{inputs.go-test-flags}}
-          
           # some tests expect this umask, and arm images have a different default
           umask 0022
 
@@ -130,6 +128,7 @@ jobs:
           --packages="$PACKAGE_NAMES" \
           --junitfile ${{env.TEST_RESULTS}}/gotestsum-report.xml -- \
           -tags="${{env.GOTAGS}}" \
+          ${{inputs.go-test-flags}} \
           -cover -coverprofile=coverage.txt \
           -timeout=30m
 

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -96,8 +96,6 @@ jobs:
             # some tests expect this umask, and arm images have a different default
             umask 0022
 
-            ${{inputs.go-test-flags}}
-
             go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
               --format=short-verbose \
               --jsonfile /tmp/jsonfile/go-test.log \
@@ -108,7 +106,7 @@ jobs:
               --packages="$PACKAGE_NAMES" \
               --junitfile ${{env.TEST_RESULTS}}/gotestsum-report.xml -- \
               -tags="${{env.GOTAGS}}" \
-              ${GO_TEST_FLAGS-} \
+              ${{inputs.go-test-flags}} \
               -cover -coverprofile=coverage.txt \
               -timeout=30m
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -69,6 +69,9 @@ var defaultGrpcTlsAddr = net.TCPAddrFromAddrPort(netip.MustParseAddrPort("127.0.
 // checks for warnings on deprecated fields and flags.  These tests
 // should check one option at a time if possible
 func TestLoad_IntegrationWithFlags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 	dataDir := testutil.TempDir(t, "config")
 
 	run := func(t *testing.T, tc testCase) {

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -628,6 +628,9 @@ func TestVaultCAProvider_SignLeaf(t *testing.T) {
 }
 
 func TestVaultCAProvider_CrossSignCA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 	SkipIfVaultNotPresent(t)
 
 	t.Parallel()

--- a/command/connect/envoy/exec_test.go
+++ b/command/connect/envoy/exec_test.go
@@ -355,6 +355,9 @@ func patchExecArgs(t *testing.T) {
 }
 
 func TestMakeBootstrapPipe_DoesNotBlockOnAFullPipe(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 	// A named pipe can buffer up to 64k, use a value larger than that
 	bootstrap := bytes.Repeat([]byte("a"), 66000)
 

--- a/internal/resource/sort_test.go
+++ b/internal/resource/sort_test.go
@@ -17,6 +17,9 @@ import (
 )
 
 func TestLessReference(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 	parseTenancy := func(s string) *pbresource.Tenancy {
 		// format is: <partition>.<peerName>.<namespace>
 		parts := strings.Split(s, ".")

--- a/internal/storage/inmem/backend_test.go
+++ b/internal/storage/inmem/backend_test.go
@@ -15,6 +15,9 @@ import (
 )
 
 func TestBackend_Conformance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 	conformance.Test(t, conformance.TestOptions{
 		NewBackend: func(t *testing.T) storage.Backend {
 			backend, err := inmem.NewBackend()

--- a/internal/storage/raft/conformance_test.go
+++ b/internal/storage/raft/conformance_test.go
@@ -23,6 +23,9 @@ import (
 )
 
 func TestBackend_Conformance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 	t.Run("Leader", func(t *testing.T) {
 		conformance.Test(t, conformance.TestOptions{
 			NewBackend: func(t *testing.T) storage.Backend {


### PR DESCRIPTION
### Description

When looking at the slowest tests based on P95, most of them are marked as skip when the -short flag is passed to the test.  We have done this on platform specific test runs like 32bit, arm, etc., but never on the main unit test runs.  

This PR puts in the same logic that skips test that are "marked as too slow" in branches outside of main and release branches.  It also tags any test as too slow that exceeds 30 seconds for P95 for the last 3 months on main in consul CE and enterprise.  I propose a similar policy and evaluation at the end of releases (as well as ad hoc) to move long running tests to be run less frequent...namely on integration to main or the release branch

Some of these are curious why they take so long, but that investigation is for another day.

<img width="800" alt="Screenshot 2023-11-10 at 3 14 46 PM" src="https://github.com/hashicorp/consul-enterprise/assets/2481360/dadebd90-c96d-4ce8-b597-c5f188248ff4">

*there is a bug in the current splitting that adds and additional runner.  for example, when you specify 12, you acutally get 13. It is addressed in https://github.com/hashicorp/consul/pull/19620

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
