### PR TITLE
Fix ACL permissions for ECS controller

### DIFF
--- a/website/content/docs/ecs/deploy/manual.mdx
+++ b/website/content/docs/ecs/deploy/manual.mdx
@@ -247,7 +247,8 @@ On the Consul server, create a policy that grants the following access for the c
 
 - `acl:write` 
 - `operator:write` 
-- `node:write` 
+- `node:write`
+- `service:write`
 
 The policy allows Consul to generate a token linked to the policy. Refer to [Create a service token](/consul/docs/security/acl/tokens/create/create-a-service-token) for instructions.
 

--- a/website/content/docs/ecs/deploy/terraform.mdx
+++ b/website/content/docs/ecs/deploy/terraform.mdx
@@ -212,7 +212,8 @@ Verify that you have completed the prerequisites described in [Secure configurat
 
     - `acl:write`
     - `operator:write` 
-    - `node:write` 
+    - `node:write`
+    - `service:write`
     
     The policy allows Consul to generate a token linked to the policy. Refer to [Create a service token](/consul/docs/security/acl/tokens/create/create-a-service-token) for instructions.
 1. Create a token and link it to the ACL controller policy. Refer to the [ACL tokens documentation](/consul/docs/security/acl/tokens) for instructions.


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->'

Add `service:write` permissions to ACL token passed to the ECS controller

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
