### PR TITLE
NET-6416 Implement ACLs hook for reading + writing MeshGateway type

### DIFF
--- a/internal/mesh/internal/types/mesh_gateway.go
+++ b/internal/mesh/internal/types/mesh_gateway.go
@@ -24,7 +24,7 @@ func RegisterMeshGateway(r resource.Registry) {
 			},
 			List: resource.NoOpACLListHook,
 		},
-		Mutate:   nil, // TODO NET-6425
-		Validate: nil, // TODO NET-6424
+		Mutate:   nil, // TODO NET-6418
+		Validate: nil, // TODO NET-6417
 	})
 }

--- a/internal/mesh/internal/types/mesh_gateway.go
+++ b/internal/mesh/internal/types/mesh_gateway.go
@@ -4,16 +4,26 @@
 package types
 
 import (
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/internal/resource"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
 func RegisterMeshGateway(r resource.Registry) {
 	r.Register(resource.Registration{
-		Type:     pbmesh.MeshGatewayType,
-		Proto:    &pbmesh.MeshGateway{},
-		Scope:    resource.ScopePartition,
-		ACLs:     nil, // TODO NET-6423
+		Type:  pbmesh.MeshGatewayType,
+		Proto: &pbmesh.MeshGateway{},
+		Scope: resource.ScopePartition,
+		ACLs: &resource.ACLHooks{
+			Read: func(authorizer acl.Authorizer, context *acl.AuthorizerContext, _ *pbresource.ID, _ *pbresource.Resource) error {
+				return authorizer.ToAllowAuthorizer().MeshReadAllowed(context)
+			},
+			Write: func(authorizer acl.Authorizer, context *acl.AuthorizerContext, _ *pbresource.Resource) error {
+				return authorizer.ToAllowAuthorizer().MeshWriteAllowed(context)
+			},
+			List: resource.NoOpACLListHook,
+		},
 		Mutate:   nil, // TODO NET-6425
 		Validate: nil, // TODO NET-6424
 	})

--- a/internal/mesh/internal/types/mesh_gateway_test.go
+++ b/internal/mesh/internal/types/mesh_gateway_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package types
 
 import (

--- a/internal/mesh/internal/types/mesh_gateway_test.go
+++ b/internal/mesh/internal/types/mesh_gateway_test.go
@@ -1,0 +1,66 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/resourcetest"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+)
+
+func TestMeshGatewayACLs(t *testing.T) {
+	registry := resource.NewRegistry()
+	Register(registry)
+
+	meshGateway := &pbmesh.MeshGateway{}
+
+	res := resourcetest.Resource(pbmesh.MeshGatewayType, "mesh-gateway").
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		WithData(t, meshGateway).
+		Build()
+
+	testCases := []struct {
+		Name        string
+		Rules       string
+		ExpectList  string
+		ExpectRead  string
+		ExpectWrite string
+	}{
+		{
+			Name:        `no rules`,
+			Rules:       ``,
+			ExpectList:  resourcetest.DEFAULT,
+			ExpectRead:  resourcetest.DENY,
+			ExpectWrite: resourcetest.DENY,
+		},
+		{
+			Name:        `mesh write`,
+			Rules:       `mesh = "write" `,
+			ExpectList:  resourcetest.DEFAULT,
+			ExpectRead:  resourcetest.ALLOW,
+			ExpectWrite: resourcetest.ALLOW,
+		},
+		{
+			Name:        `mesh read only`,
+			Rules:       `mesh = "read"`,
+			ExpectList:  resourcetest.DEFAULT,
+			ExpectRead:  resourcetest.ALLOW,
+			ExpectWrite: resourcetest.DENY,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			tc := resourcetest.ACLTestCase{
+				Rules:                    testCase.Rules,
+				Res:                      res,
+				ListOK:                   testCase.ExpectList,
+				ReadOK:                   testCase.ExpectRead,
+				WriteOK:                  testCase.ExpectWrite,
+				ReadHookRequiresResource: false,
+			}
+
+			resourcetest.RunACLTestCase(t, tc, registry)
+		})
+	}
+}


### PR DESCRIPTION
### Description
- `mesh:write` will be required in order to write a `MeshGateway` via the v2 API
- `mesh:read` will be required in order to read a `MeshGateway` via the v2 API

### Testing & Reproduction steps
Add unit test coverage

### Links
N/A

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
