### PR TITLE
Timeout Docs Update (#19601)

### DIFF
--- a/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
@@ -21,8 +21,8 @@ The following list outlines field hierarchy, data types, and requirements in a `
    - [`name`](#metadata-name): string | required 
    - [`namespace`](#metadata-namespace): string  | `default`
 - [`spec`](#spec): map | required
-  - [`idleTimeout`](#spec-idletimeout): number | `0`
-  - [`requestTimeout`](#spec-retryonconnectfailure): number | `0`
+  - [`idleTimeout`](#spec-idletimeout): string | `""`
+  - [`requestTimeout`](#spec-retryonconnectfailure): string | `""`
 
 ## Complete configuration
 
@@ -97,18 +97,18 @@ Map that contains the details about the gateway policy. The `apiVersion`, `kind`
 
 ### `spec.idleTimeout
 
-Specifies the total amount of time permitted for the request stream to be idle.
+Specifies the total amount of time permitted for the request stream to be idle. Must specify a parseable number and a unit, for example "5s". 
 
 #### Values
 
-- Default: 0
-- Data type: Integer
+- Default: ""
+- Data type: string
 
 ### `spec.requestTimeout`
 
-Specifies the total amount of time in nanoseconds, including retry attempts, Consul permits for the entire downstream request to be processed.
+Specifies the total amount of time in nanoseconds, including retry attempts, Consul permits for the entire downstream request to be processed. Must specify a parseable number and a unit, for example "5s". 
 
 #### Values
 
-- Default: 0
+- Default: ""
 - Data type: Integer

--- a/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
@@ -97,7 +97,7 @@ Map that contains the details about the gateway policy. The `apiVersion`, `kind`
 
 ### `spec.idleTimeout
 
-Specifies the total amount of time permitted for the request stream to be idle. Must specify a parseable number and a unit, for example "5s". 
+Specifies the total amount of time permitted for the request stream to be idle. Format the string as `"<number><unit>"`, for example `"5s"`. Consul uses the `metav1.Duration` package of parse the value. Refer to the [Go documentation](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration) for additional information about defining parseable values.  
 
 #### Values
 

--- a/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
@@ -97,7 +97,7 @@ Map that contains the details about the gateway policy. The `apiVersion`, `kind`
 
 ### `spec.idleTimeout
 
-Specifies the total amount of time permitted for the request stream to be idle. Format the string as `"<number><unit>"`, for example `"5s"`. Consul uses the `metav1.Duration` package of parse the value. Refer to the [Go documentation](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration) for additional information about defining parseable values.  
+Specifies the total amount of time permitted for the request stream to be idle. Format the string as `"<number><unit>"`, for example `"5s"`. Consul uses the `metav1.Duration` package to parse the value. Refer to the [Go documentation](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration) for additional information about defining parseable values.  
 
 #### Values
 

--- a/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
@@ -106,7 +106,7 @@ Specifies the total amount of time permitted for the request stream to be idle. 
 
 ### `spec.requestTimeout`
 
-Specifies the total amount of time in nanoseconds, including retry attempts, Consul permits for the entire downstream request to be processed. Must specify a parseable number and a unit, for example "5s". 
+Specifies the total amount of time in nanoseconds, including retry attempts, Consul permits for the entire downstream request to be processed. Format the string as `"<number><unit>"`, for example `"5s"`. Consul uses the `metav1.Duration` package to parse the value. Refer to the [Go documentation](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration) for additional information about defining parseable values.  
 
 #### Values
 

--- a/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/routetimeoutfilter.mdx
@@ -102,7 +102,7 @@ Specifies the total amount of time permitted for the request stream to be idle. 
 #### Values
 
 - Default: ""
-- Data type: string
+- Data type: String
 
 ### `spec.requestTimeout`
 
@@ -111,4 +111,4 @@ Specifies the total amount of time in nanoseconds, including retry attempts, Con
 #### Values
 
 - Default: ""
-- Data type: Integer
+- Data type: String


### PR DESCRIPTION
### Description

Manual backport of docs fix in this PR into 1.17 https://github.com/hashicorp/consul/pull/19601

### Testing & Reproduction steps


### Links

[Original PR
](https://github.com/hashicorp/consul/pull/19601)
### PR Checklist

* [ ] updated test coverage
* [ X ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
