### PR TITLE
[NET-6600] security: Remove use of sha1 and md5 hash fns

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3535,23 +3535,7 @@ func (a *Agent) loadCheckState(check *structs.HealthCheck) error {
 	buf, err := os.ReadFile(file)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// try the md5 based name. This can be removed once we no longer support upgrades from versions that use MD5 hashing
-			oldFile := filepath.Join(a.config.DataDir, checkStateDir, cid.StringHashMD5())
-			buf, err = os.ReadFile(oldFile)
-			if err != nil {
-				if os.IsNotExist(err) {
-					return nil
-				} else {
-					return fmt.Errorf("failed reading check state %q: %w", file, err)
-				}
-			}
-			if err := os.Rename(oldFile, file); err != nil {
-				a.logger.Error("Failed renaming check state",
-					"file", oldFile,
-					"targetFile", file,
-					"error", err,
-				)
-			}
+			return fmt.Errorf("failed reading check state %q: %w", file, err)
 		} else {
 			return fmt.Errorf("failed reading file %q: %w", file, err)
 		}

--- a/agent/connect/parsing.go
+++ b/agent/connect/parsing.go
@@ -7,7 +7,6 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
@@ -108,9 +107,9 @@ func parseCerts(pemValue string) ([]*x509.Certificate, error) {
 	return out, nil
 }
 
-// CalculateCertFingerprint calculates the SHA-1 fingerprint from the cert bytes.
+// CalculateCertFingerprint calculates the SHA256 checksum from the cert bytes.
 func CalculateCertFingerprint(cert []byte) string {
-	hash := sha1.Sum(cert)
+	hash := sha256.Sum256(cert)
 	return HexString(hash[:])
 }
 

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -73,7 +73,7 @@ func (r IndexedCARoots) Active() *CARoot {
 // CARoot represents a root CA certificate that is trusted.
 type CARoot struct {
 	// ID is a globally unique ID (UUID) representing this CA chain. It is
-	// calculated from the SHA1 of the primary CA certificate.
+	// calculated from the SHA256 checksum of the primary CA certificate.
 	ID string
 
 	// Name is a human-friendly name for this CA root. This value is

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -5,7 +5,6 @@ package structs
 
 import (
 	"bytes"
-	"crypto/md5"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -2257,16 +2256,6 @@ func NewCheckID(id types.CheckID, entMeta *acl.EnterpriseMeta) CheckID {
 	cid.EnterpriseMeta = *entMeta
 	cid.EnterpriseMeta.Normalize()
 	return cid
-}
-
-// StringHashMD5 is used mainly to populate part of the filename of a check
-// definition persisted on the local agent (deprecated in favor of StringHashSHA256)
-// Kept around for backwards compatibility
-func (cid CheckID) StringHashMD5() string {
-	hasher := md5.New()
-	hasher.Write([]byte(cid.ID))
-	cid.EnterpriseMeta.AddToHash(hasher, true)
-	return fmt.Sprintf("%x", hasher.Sum(nil))
 }
 
 // StringHashSHA256 is used mainly to populate part of the filename of a check


### PR DESCRIPTION
Replace or remove uses of insecure hash algorithms.

None of these are currently of particular concern as exploitable, but to avoid future security scan flags and prevent additional tack-on use in the future, we should remove them.

None of the current uses should be represented in persistent state in such a way that would cause backwards-incompabitibility for existing clusters.

### Description

Resolves (and prevents recurrence of) the following security scan items:
* https://github.com/hashicorp/consul/security/code-scanning/616
* https://github.com/hashicorp/consul/security/code-scanning/615
* https://github.com/hashicorp/consul/security/code-scanning/62
* https://github.com/hashicorp/consul/security/code-scanning/61

### Testing & Reproduction steps

Unit tests should continue to pass.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [ ] not a security concern
