### PR TITLE
Default "stats_flush_interval" to 1 minute for Consul Telemetry Collector

### DIFF
--- a/.changelog/19663.txt
+++ b/.changelog/19663.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Default `stats_flush_interval` to 60 seconds when using the Consul Telemetry Collector, unless custom stats sink are present or an explicit flush interval is configured.
+```

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -251,8 +251,9 @@ func (c *BootstrapConfig) ConfigureArgs(args *BootstrapTplArgs, omitDeprecatedTa
 
 	// Setup telemetry collector if needed. This MUST happen after the Static*JSON is set above
 	if c.TelemetryCollectorBindSocketDir != "" {
-		// Unless configured, override StatsFlushInterval as 60 seconds (1 minute) to reduce number of metric flushes.
-		if c.StatsFlushInterval == "" {
+		// Override StatsFlushInterval as 60 seconds (1 minute) to reduce number of metric flushes.
+		// Only perform this override if there is no custom configuration for stats sinks and flush interval.
+		if c.StatsFlushInterval == "" && args.StatsSinksJSON == "" {
 			args.StatsFlushInterval = "60s"
 		}
 		appendTelemetryCollectorConfig(args, c.TelemetryCollectorBindSocketDir)

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -251,6 +251,10 @@ func (c *BootstrapConfig) ConfigureArgs(args *BootstrapTplArgs, omitDeprecatedTa
 
 	// Setup telemetry collector if needed. This MUST happen after the Static*JSON is set above
 	if c.TelemetryCollectorBindSocketDir != "" {
+		// Unless configured, override StatsFlushInterval as 60 seconds (1 minute) to reduce number of metric flushes.
+		if c.StatsFlushInterval == "" {
+			args.StatsFlushInterval = "60s"
+		}
 		appendTelemetryCollectorConfig(args, c.TelemetryCollectorBindSocketDir)
 	}
 

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -628,46 +628,30 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 				TelemetryCollectorBindSocketDir: "/tmp/consul/telemetry-collector",
 			},
 			wantArgs: BootstrapTplArgs{
-				ProxyID:         "web-sidecar-proxy",
-				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `{
-					"name": "envoy.stat_sinks.metrics_service",
-					"typed_config": {
-					  "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
-					  "transport_api_version": "V3",
-					  "grpc_service": {
-						"envoy_grpc": {
-						  "cluster_name": "consul_telemetry_collector_loopback"
-						}
-					  },
-					  "emit_tags_as_labels": true
-					}
-				  }`,
-				StaticClustersJSON: `{
-					"name": "consul_telemetry_collector_loopback",
-					"type": "STATIC",
-					"http2_protocol_options": {},
-					"loadAssignment": {
-					  "clusterName": "consul_telemetry_collector_loopback",
-					  "endpoints": [
-						{
-						  "lbEndpoints": [
-							{
-							  "endpoint": {
-								"address": {
-								  "pipe": {
-									"path": "/tmp/consul/telemetry-collector/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock"
-								  }
-								}
-							  }
-							}
-						  ]
-						}
-					  ]
-					}
-				  }`,
+				StatsFlushInterval: "60s",
+				ProxyID:            "web-sidecar-proxy",
+				StatsConfigJSON:    defaultStatsConfigJSON,
+				StatsSinksJSON:     expectedTelemetryCollectorStatsSink,
+				StaticClustersJSON: expectedTelemetryCollectorCluster,
 			},
 			wantErr: false,
+		},
+		{
+			name: "telemetry-collector-with-flush-interval-configured",
+			baseArgs: BootstrapTplArgs{
+				ProxyID: "web-sidecar-proxy",
+			},
+			input: BootstrapConfig{
+				StatsFlushInterval:              "10s",
+				TelemetryCollectorBindSocketDir: "/tmp/consul/telemetry-collector",
+			},
+			wantArgs: BootstrapTplArgs{
+				StatsFlushInterval: "10s",
+				ProxyID:            "web-sidecar-proxy",
+				StatsConfigJSON:    defaultStatsConfigJSON,
+				StatsSinksJSON:     expectedTelemetryCollectorStatsSink,
+				StaticClustersJSON: expectedTelemetryCollectorCluster,
+			},
 		},
 		{
 			name: "simple-statsd-sink",

--- a/command/connect/envoy/testdata/telemetry-collector.golden
+++ b/command/connect/envoy/testdata/telemetry-collector.golden
@@ -219,6 +219,7 @@
     ],
     "use_all_default_tags": true
   },
+  "stats_flush_interval": "60s",
   "dynamic_resources": {
     "lds_config": {
       "ads": {},

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -193,7 +193,9 @@ the [`sidecar_service`](/consul/docs/connect/proxies/deploy-sidecar-services) bl
 
 - `envoy_telemetry_collector_bind_socket_dir` - Specifies the directory where Envoy creates a Unix socket.
   Envoy sends metrics to the socket where a Consul telemetry collector can collect them.
-  The socket is not configured by default.
+  The socket is not configured by default. 
+  Enabling this feature sets Envoy's [`stats_flush_interval`](https://www.envoyproxy.io/docs/envoy/v1.17.2/api-v3/config/bootstrap/v3/bootstrap.proto#envoy-v3-api-field-config-bootstrap-v3-bootstrap-stats-flush-interval) to 1 minute by default to reduce the number of metric samples.
+  For a custom metric flush interval, configure a `envoy_stats_flush_interval` value explicitly.
 
 The [Advanced Configuration](#advanced-configuration) section describes additional configurations that allow incremental or complete control over the bootstrap configuration generated.
 

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -194,9 +194,7 @@ the [`sidecar_service`](/consul/docs/connect/proxies/deploy-sidecar-services) bl
 - `envoy_telemetry_collector_bind_socket_dir` - Specifies the directory where Envoy creates a Unix socket.
   Envoy sends metrics to the socket where a Consul telemetry collector can collect them.
   The socket is not configured by default. 
-  Enabling this feature sets Envoy's [`stats_flush_interval`](https://www.envoyproxy.io/docs/envoy/v1.17.2/api-v3/config/bootstrap/v3/bootstrap.proto#envoy-v3-api-field-config-bootstrap-v3-bootstrap-stats-flush-interval) to 1 minute by default to reduce the number of metric samples.
-  However, the`stats_flush_interval` default is not applied if a custom stats sink is configured using `envoy_statsd_url`,`envoy_dogstatsd_url` or `envoy_extra_stats_sinks_json`.
-  For a custom metric flush interval, configure a `envoy_stats_flush_interval` value explicitly.
+  Enabling this sets Envoy's [`stats_flush_interval`](https://www.envoyproxy.io/docs/envoy/v1.17.2/api-v3/config/bootstrap/v3/bootstrap.proto#envoy-v3-api-field-config-bootstrap-v3-bootstrap-stats-flush-interval) to one minute if `envoy_stats_flush_interval` is unset and if no other stats sinks are configured, like `envoy_dogstats_url`, for instance.
 
 The [Advanced Configuration](#advanced-configuration) section describes additional configurations that allow incremental or complete control over the bootstrap configuration generated.
 

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -195,6 +195,7 @@ the [`sidecar_service`](/consul/docs/connect/proxies/deploy-sidecar-services) bl
   Envoy sends metrics to the socket where a Consul telemetry collector can collect them.
   The socket is not configured by default. 
   Enabling this feature sets Envoy's [`stats_flush_interval`](https://www.envoyproxy.io/docs/envoy/v1.17.2/api-v3/config/bootstrap/v3/bootstrap.proto#envoy-v3-api-field-config-bootstrap-v3-bootstrap-stats-flush-interval) to 1 minute by default to reduce the number of metric samples.
+  However, the`stats_flush_interval` default is not applied if a custom stats sink is configured using `envoy_statsd_url`,`envoy_dogstatsd_url` or `envoy_extra_stats_sinks_json`.
   For a custom metric flush interval, configure a `envoy_stats_flush_interval` value explicitly.
 
 The [Advanced Configuration](#advanced-configuration) section describes additional configurations that allow incremental or complete control over the bootstrap configuration generated.


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
**Context**
We want to reduce the number of metrics processed by the Consul Telemetry Collector. 
By default, Envoy has a `stats_flush_interval` of 5 seconds ([docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/bootstrap/v3/bootstrap.proto))

**Changes**
- For users that setup the consul telemetry collector, we default the `stats_flush_interval ` to 1 minute (60 seconds). **However, we avoid doing this override in 2 cases**:
  - 1. They have a custom `envoy_stats_flush_interval`, we don't want to override their use case.
  - 2. They have a custom stats sink: we don't want to impact their custom metrics processing. 
    - A custom stats sink can be set in multiple ways: via the `envoy_statsd_url`, `envoy_dogstatsd_url` or `envoy_extra_stats_sinks_json`. In order to address all these cases, we can simply check for an empty `args.StatsSinksJSON` after the stats sinks are built up and before the collector sink is setup.

### Testing & Reproduction steps

#### Setup
1. Ran `Makefile` command to copy bootstrap config in `consul-dataplane` by modifying the url to be my branch.
2. Build custom `consul-dataplane` Docker images that I deployed to my own docker.io.
3. Applied consul-k8s installation with custom docker images to link a HCP self managed cluster to see how the Telemetry Gateway reacts. Essentially, an end to end test of cloud observability.
<details>
<summary> View helm value overrides</summary>

```
==> Consul Installation Summary
    Name: consul
    Namespace: consul
    
    Helm value overrides
    --------------------
    connectInject:
      enabled: true
    controller:
      enabled: true
    global:
      acls:
        bootstrapToken:
          secretKey: token
          secretName: consul-bootstrap-token
        manageSystemACLs: true
      cloud:
        apiHost:
          secretKey: api-hostname
          secretName: consul-hcp-api-host
        authUrl:
          secretKey: auth-url
          secretName: consul-hcp-auth-url
        clientId:
          secretKey: client-id
          secretName: consul-hcp-client-id
        clientSecret:
          secretKey: client-secret
          secretName: consul-hcp-client-secret
        enabled: true
        resourceId:
          secretKey: resource-id
          secretName: consul-hcp-resource-id
        scadaAddress:
          secretKey: scada-address
          secretName: consul-hcp-scada-address
      datacenter: test-flush-60-seconds
      gossipEncryption:
        secretKey: key
        secretName: consul-gossip-key
      image: docker.io/achooo/consul01:latest
      imageConsulDataplane: docker.io/achooo/consul-dataplane:1.4.0-dev
      metrics:
        enableTelemetryCollector: true
      tls:
        caCert:
          secretKey: tls.crt
          secretName: consul-server-ca
        enableAutoEncrypt: true
        enabled: true
    server:
      affinity: null
      replicas: 3
      serverCert:
        secretName: consul-server-cert
    telemetryCollector:
      cloud:
        clientId:
          secretKey: client-id
          secretName: consul-hcp-observability-client-id
        clientSecret:
          secretKey: client-secret
          secretName: consul-hcp-observability-client-secret
      enabled: true
```
</details>

#### Scenario 1: No custom stats sink / no custom flush interval
4.🥳 After the above installation with the new consul-dataplane image and the collector deployed, we see the default `stats_flush_interval` is  `60s`.
<img width="686" alt="Screenshot 2023-11-15 at 9 37 41 PM" src="https://github.com/hashicorp/consul/assets/23405655/cfdd0570-14ce-4bde-a303-35e9d7b22510">

#### Scenario 2: Custom flush interval
5. Applied a ProxyDefaults configuration to set a custom flush interval
```
apiVersion: consul.hashicorp.com/v1alpha1
kind: ProxyDefaults
metadata:
  name: global
spec:
  config:
    envoy_stats_flush_interval: "10s" 
```
```
❯ kubectl apply -f proxydefaults.yaml -n consul
proxydefaults.consul.hashicorp.com/global created
```
6. I then restarted all the pods.
7. 🥳 I verify the “”stats_flush_interval” value again, which is `10s` as expected

<img width="566" alt="Screenshot 2023-11-15 at 9 59 01 PM" src="https://github.com/hashicorp/consul/assets/23405655/33a47829-2dc2-4d95-87f7-aeddf76c3b71">

#### Scenario 3: Custom sinks

8. I re-created the entire cluster again
9. I setup ProxyDefaults with a statsd url
```
apiVersion: consul.hashicorp.com/v1alpha1
kind: ProxyDefaults
metadata:
  name: global
spec:
  config:
    envoy_statsd_url: "udp://127.0.0.1:8125"
```
```
❯ kubectl apply -f proxydefaults.yaml -n consul
proxydefaults.consul.hashicorp.com/global created
```

10.  🥳  Validate no bootstrap “stats_flush_interval” configuration ( as we expect Envoy to use a default of 5s internally), which is empty as we can see:
<img width="577" alt="Screenshot 2023-11-15 at 10 24 17 PM" src="https://github.com/hashicorp/consul/assets/23405655/d3f519e7-2e7a-45f8-a05d-43f628043244">


### Links

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
