### PR TITLE
Switch to github-actions format

### DIFF
--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -46,7 +46,7 @@ on:
         required: true
 env:
   TEST_RESULTS: /tmp/test-results
-  GOTESTSUM_VERSION: "1.10.1"
+  GOTESTSUM_VERSION: "1.11.0"
   GOARCH: ${{inputs.go-arch}}
   TOTAL_RUNNERS: ${{inputs.runner-count}}
   CONSUL_LICENSE: ${{secrets.consul-license}}
@@ -119,11 +119,10 @@ jobs:
           umask 0022
 
           go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
-          --format=short-verbose \
+          --format=github-actions \
+          --format-hide-empty-pkg \
           --jsonfile /tmp/jsonfile/go-test.log \
-          --debug \
-          --rerun-fails=3 \
-          --rerun-fails-max-failures=40 \
+          --rerun-fails \
           --rerun-fails-report=/tmp/gotestsum-rerun-fails \
           --packages="$PACKAGE_NAMES" \
           --junitfile ${{env.TEST_RESULTS}}/gotestsum-report.xml -- \

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -46,7 +46,7 @@ on:
         required: true
 env:
   TEST_RESULTS: /tmp/test-results
-  GOTESTSUM_VERSION: "1.10.1"
+  GOTESTSUM_VERSION: "1.11.0"
   GOARCH: ${{inputs.go-arch}}
   CONSUL_LICENSE: ${{secrets.consul-license}}
   GOTAGS: ${{ inputs.go-tags}}
@@ -97,11 +97,9 @@ jobs:
             umask 0022
 
             go run gotest.tools/gotestsum@v${{env.GOTESTSUM_VERSION}} \
-              --format=short-verbose \
+              --format=github-actions \
               --jsonfile /tmp/jsonfile/go-test.log \
-              --debug \
-              --rerun-fails=3 \
-              --rerun-fails-max-failures=40 \
+              --rerun-fails \
               --rerun-fails-report=/tmp/gotestsum-rerun-fails \
               --packages="$PACKAGE_NAMES" \
               --junitfile ${{env.TEST_RESULTS}}/gotestsum-report.xml -- \


### PR DESCRIPTION
### Description

`gotestsum@v1.11.0` adds a new test output format called `github-actions` which is like `testname` but adds collapsable logging/output which helps scroll-ability of our current test outputs.

Our current copy-pasted default is `short-verbose` which many dislike due to its... verbosity. We end up scrolling through thousands of verbose logging output to find the actual `fail: ` line. It should be fine in 99% of cases to only output testnames unless there is an error or stdout lines

[Kapture 2023-11-20 at 09.10.43.webm](https://github.com/hashicorp/consul/assets/30640057/b61bb3ac-2229-4310-b2d3-1e5d62fc76ba)




### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
