### PR TITLE
resource: preserve deferred deletion metadata on non-CAS writes

### DIFF
--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -67,10 +67,21 @@ func AddFinalizer(res *pbresource.Resource, finalizer string) {
 func RemoveFinalizer(res *pbresource.Resource, finalizer string) {
 	finalizerSet := GetFinalizers(res)
 	finalizerSet.Remove(finalizer)
-	if res.Metadata == nil {
-		res.Metadata = map[string]string{}
+
+	if finalizerSet.Cardinality() == 0 {
+		// Remove key if no finalizers to prevent dual representations of
+		// the same state.
+		_, keyExists := res.Metadata[FinalizerKey]
+		if keyExists {
+			delete(res.Metadata, FinalizerKey)
+		}
+	} else {
+		// Add/update key
+		if res.Metadata == nil {
+			res.Metadata = map[string]string{}
+		}
+		res.Metadata[FinalizerKey] = strings.Join(finalizerSet.ToSlice(), " ")
 	}
-	res.Metadata[FinalizerKey] = strings.Join(finalizerSet.ToSlice(), " ")
 }
 
 // GetFinalizers returns the set of finalizers for the given resource.

--- a/proto-public/pbresource/resource.pb.go
+++ b/proto-public/pbresource/resource.pb.go
@@ -399,6 +399,7 @@ type Resource struct {
 	// can treat its timestamp component as the resource's modification time.
 	Generation string `protobuf:"bytes,4,opt,name=generation,proto3" json:"generation,omitempty"`
 	// Metadata contains key/value pairs of arbitrary metadata about the resource.
+	// "deletionTimestamp" and "finalizers" keys are reserved for internal use.
 	Metadata map[string]string `protobuf:"bytes,5,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Status is used by controllers to communicate the result of attempting to
 	// reconcile and apply the resource (e.g. surface semantic validation errors)

--- a/proto-public/pbresource/resource.proto
+++ b/proto-public/pbresource/resource.proto
@@ -99,6 +99,7 @@ message Resource {
   string generation = 4;
 
   // Metadata contains key/value pairs of arbitrary metadata about the resource.
+  // "deletionTimestamp" and "finalizers" keys are reserved for internal use.
   map<string, string> metadata = 5;
 
   // Status is used by controllers to communicate the result of attempting to


### PR DESCRIPTION
### Description

CE version of merged ENT PR: https://github.com/hashicorp/consul-enterprise/pull/7804

NET-6556

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
