### PR TITLE
fix a panic in the CLI when deleting an acl policy with an unknown name

### DIFF
--- a/.changelog/19679.txt
+++ b/.changelog/19679.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+CLI: fix a panic when deleting a non existing policy by name.
+```

--- a/command/acl/acl_helpers.go
+++ b/command/acl/acl_helpers.go
@@ -105,6 +105,10 @@ func GetPolicyIDByName(client *api.Client, name string) (string, error) {
 		return "", err
 	}
 
+	if policy == nil {
+		return "", fmt.Errorf("No such policy with name: %s", name)
+	}
+
 	return policy.ID, nil
 }
 

--- a/command/acl/acl_test.go
+++ b/command/acl/acl_test.go
@@ -48,6 +48,36 @@ func Test_GetPolicyIDByName_Builtins(t *testing.T) {
 	}
 }
 
+func Test_GetPolicyIDByName_NotFound(t *testing.T) {
+	t.Parallel()
+
+	a := agent.StartTestAgent(t,
+		agent.TestAgent{
+			LogOutput: io.Discard,
+			HCL: `
+				primary_datacenter = "dc1"
+				acl {
+					enabled = true
+					tokens {
+						initial_management = "root"
+					}
+				}
+			`,
+		},
+	)
+
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1", testrpc.WithToken("root"))
+
+	client := a.Client()
+	client.AddHeader("X-Consul-Token", "root")
+
+	id, err := GetPolicyIDByName(client, "not_found")
+	require.Error(t, err)
+	require.Equal(t, "", id)
+
+}
+
 func Test_GetPolicyIDFromPartial_Builtins(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description
This fix a panic in the CLI when deleting a policy using its name and that name do not exist on the server.


```
consul acl policy delete -namespace david-test -datacenter us-east-infra -name namespace-management

panic: runtime error: invalid memory address or nil pointer dereference

[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1012db5]




goroutine 1 [running]:

github.com/hashicorp/consul/command/acl.GetPolicyIDByName(...)

/Users/dayachi/git/consul-enterprise/command/acl/acl_helpers.go:102

github.com/hashicorp/consul/command/acl/policy/delete.(*cmd).Run(0xc000d62050, {0xc000072180?, 0xffffffffffffffff?, 0x0?})

/Users/dayachi/git/consul-enterprise/command/acl/policy/delete/policy_delete.go:62 +0x155

github.com/mitchellh/cli.(*CLI).Run(0xc000fa3400)

/Users/dayachi/go/pkg/mod/github.com/mitchellh/cli@v1.1.5/cli.go:262 +0x5b8

main.realMain()

/Users/dayachi/git/consul-enterprise/main.go:48 +0x469

main.main()

/Users/dayachi/git/consul-enterprise/main.go:18 +0x13

root@hashi-i-0cb3233c55d0fe848:/opt/consul/1.15.6+debug# consul version

Consul v1.15.6+ent

Revision ba04dc46b8+CHANGES

Build Date 2023-09-19T23:47:29Z

Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
```

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
