### PR TITLE
cli: add a string method to gvk struct

### DIFF
--- a/command/resource/helper.go
+++ b/command/resource/helper.go
@@ -185,6 +185,10 @@ type ListResponse struct {
 	Resources []map[string]interface{} `json:"resources"`
 }
 
+func (gvk *GVK) String() string {
+	return fmt.Sprintf("%s.%s.%s", gvk.Group, gvk.Version, gvk.Kind)
+}
+
 func (resource *Resource) Read(gvk *GVK, resourceName string, q *client.QueryOptions) (map[string]interface{}, error) {
 	r := resource.C.NewRequest("GET", strings.ToLower(fmt.Sprintf("/api/%s/%s/%s/%s", gvk.Group, gvk.Version, gvk.Kind, resourceName)))
 	r.SetQueryOptions(q)


### PR DESCRIPTION
### Description

Add a string method to GVK to avoid print out the struct directly

### Testing & Reproduction steps

* Before

`Error reading resources for type &{catalog v2beta1 Service}:`

* After

`Error reading resources for type catalog.v2beta1.Service:`

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
