### PR TITLE
[NET-6232] docs: Update consul-k8s Helm chart docs (1.2.x)

### DIFF
--- a/website/content/docs/k8s/helm.mdx
+++ b/website/content/docs/k8s/helm.mdx
@@ -2587,7 +2587,7 @@ Use these links to navigate to a particular top-level stanza.
 
 ### apiGateway ((#h-apigateway))
 
-- `apiGateway` ((#v-apigateway)) - [DEPRECATED] Use connectInject.apiGateway instead. This stanza will be removed with the release of Consul 1.17
+- `apiGateway` ((#v-apigateway)) - [DEPRECATED] Use connectInject.apiGateway instead.
   Configuration settings for the Consul API Gateway integration
 
   - `enabled` ((#v-apigateway-enabled)) (`boolean: false`) - When true the helm chart will install the Consul API Gateway controller


### PR DESCRIPTION
Sync docs for recent changes to the Helm chart from `consul-k8s`.

### Description

Updates docs for backport of https://github.com/hashicorp/consul-k8s/pull/3180 following https://github.com/hashicorp/consul/pull/19577.

Also includes another minor previous change that wasn't synced.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
