### PR TITLE
[SECVULN-1532] chore: Remove TODO comments for OIDC/JWT auth

### DIFF
--- a/internal/go-sso/oidcauth/config.go
+++ b/internal/go-sso/oidcauth/config.go
@@ -45,7 +45,6 @@ type Config struct {
 
 	// Comma-separated list of 'aud' claims that are valid for login; any match
 	// is sufficient
-	// TODO(sso): actually just send these down as string claims?
 	BoundAudiences []string
 
 	// Mappings of claims (key) that will be copied to a metadata field

--- a/internal/go-sso/oidcauth/oidc.go
+++ b/internal/go-sso/oidcauth/oidc.go
@@ -235,7 +235,8 @@ func (a *Authenticator) verifyOIDCToken(ctx context.Context, rawToken string) (m
 	if err := idToken.Claims(&allClaims); err != nil {
 		return nil, fmt.Errorf("unable to successfully parse all claims from token: %v", err)
 	}
-	// TODO(sso): why isn't this strict for OIDC?
+	// Follows behavior of hashicorp/vault-plugin-auth-jwt (non-strict validation).
+	// See https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/oidc#oidc-configuration-troubleshooting.
 	if err := validateAudience(a.config.BoundAudiences, idToken.Audience, false); err != nil {
 		return nil, fmt.Errorf("error validating claims: %v", err)
 	}


### PR DESCRIPTION
Remove old TODO comments and update remaining comments for clarity.

### Description

Cleanup from security review.

From [docs](https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/oidc#oidc-configuration-troubleshooting):

> [BoundAudiences](https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/oidc#boundaudiences) is optional and typically not required. OIDC providers will use the client_id as the audience and OIDC validation expects this.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
