### PR TITLE
[SECVULN-1533] chore: Clarify iptables Provider interface docs

### DIFF
--- a/sdk/iptables/iptables.go
+++ b/sdk/iptables/iptables.go
@@ -78,8 +78,11 @@ type Provider interface {
 	// ApplyRules executes rules that have been added via AddRule.
 	// This operation is currently not atomic, and if there's an error applying rules,
 	// you may be left in a state where partial rules were applied.
+	// ApplyRules should not be called twice on the same instance in order to avoid
+	// duplicate rule application.
 	ApplyRules() error
-	// Rules returns the list of rules that have been added but not applied yet.
+	// Rules returns the list of rules that have been added (including those not yet
+	// applied).
 	Rules() []string
 }
 


### PR DESCRIPTION
Add docs clarifying constraints on use and return values.

### Description

Clarify docs in response to security assessment informational finding.

* The implementation of `iptablesExecutor.Rules()` returns both rules that have and have not yet been applied
* `iptablesExecutor.ApplyRules()` does not clear out its commands list before returning, leading to misconfiguration (duplicate entries) when called multiple times

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
