### PR TITLE
Backport/UI/net 438 add ent version suffix/privately inspired wolf self

### DIFF
--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -152,7 +152,7 @@
           <disclosure.Menu as |panel|>
             <panel.Menu as |menu|>
               <menu.Separator>
-                Consul v{{env 'CONSUL_VERSION'}}
+                Consul v{{this.consulVersion}}
               </menu.Separator>
               <menu.Item class='docs-link'>
                 <menu.Action @href={{env 'CONSUL_DOCS_URL'}} @external={{true}}>
@@ -202,7 +202,7 @@
 
   <:content-info>
     <p>
-      Consul v{{env 'CONSUL_VERSION'}}
+      Consul v{{this.consulVersion}}
     </p>
     {{{concat '<!-- ' (env 'CONSUL_GIT_SHA') '-->'}}}
   </:content-info>

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.js
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.js
@@ -3,4 +3,10 @@ import { inject as service } from '@ember/service';
 
 export default class HashiCorpConsul extends Component {
   @service('flashMessages') flashMessages;
+  @service('env') env;
+
+  get consulVersion() {
+    const suffix = !['', 'oss'].includes(this.env.var('CONSUL_BINARY_TYPE')) ? '+ent' : '';
+    return `${this.env.var('CONSUL_VERSION')}${suffix}`;
+  }
 }


### PR DESCRIPTION
### Description
Backport for https://github.com/hashicorp/consul/pull/19660

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
