### PR TITLE
NET-5824: Adding Peers Exported Services API

### DIFF
--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -69,6 +69,7 @@ func init() {
 	registerEndpoint("/v1/catalog/node/", []string{"GET"}, (*HTTPHandlers).CatalogNodeServices)
 	registerEndpoint("/v1/catalog/node-services/", []string{"GET"}, (*HTTPHandlers).CatalogNodeServiceList)
 	registerEndpoint("/v1/catalog/gateway-services/", []string{"GET"}, (*HTTPHandlers).CatalogGatewayServices)
+	registerEndpoint("/v1/catalog/exported-services/peers", []string{"GET"}, (*HTTPHandlers).PeerExportedServices)
 	registerEndpoint("/v1/config/", []string{"GET", "DELETE"}, (*HTTPHandlers).Config)
 	registerEndpoint("/v1/config", []string{"PUT"}, (*HTTPHandlers).ConfigApply)
 	registerEndpoint("/v1/connect/ca/configuration", []string{"GET", "PUT"}, (*HTTPHandlers).ConnectCAConfiguration)

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2396,6 +2396,15 @@ type IndexedServiceList struct {
 	QueryMeta
 }
 
+type PeerServiceList struct {
+	Services ServiceList
+	Peer     string
+}
+
+type ServicesByPeersList struct {
+	Peers []PeerServiceList
+}
+
 type IndexedPeeredServiceList struct {
 	Services []PeeredServiceName
 	QueryMeta


### PR DESCRIPTION
### Description

This PR Adds support for listing the exported services to the peers

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
