### PR TITLE
improve client RPC metrics consistency

### DIFF
--- a/.changelog/19721.txt
+++ b/.changelog/19721.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+metrics: modify consul.client.rpc metric to exclude internal retries for consistency with consul.client.rpc.exceeded and consul.client.rpc.failed
+```
+```release-note:improvement
+metrics: increment consul.client.rpc.failed if RPC fails because no servers are accessible
+```

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -294,7 +294,7 @@ TRY:
 	retryCount++
 	manager, server := c.router.FindLANRoute()
 	if server == nil {
-		metrics.IncrCounterWithLabels([]string{"client", "rpc", "failed"}, 1, []metrics.Label{{Name: "server", Value: "nil"}})
+		metrics.IncrCounter([]string{"client", "rpc", "failed"}, 1)
 		return structs.ErrNoServers
 	}
 

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -288,15 +288,17 @@ func (c *Client) RPC(ctx context.Context, method string, args interface{}, reply
 	firstCheck := time.Now()
 	retryCount := 0
 	previousJitter := time.Duration(0)
+
+	metrics.IncrCounter([]string{"client", "rpc"}, 1)
 TRY:
 	retryCount++
 	manager, server := c.router.FindLANRoute()
 	if server == nil {
+		metrics.IncrCounterWithLabels([]string{"client", "rpc", "failed"}, 1, []metrics.Label{{Name: "server", Value: "nil"}})
 		return structs.ErrNoServers
 	}
 
 	// Enforce the RPC limit.
-	metrics.IncrCounter([]string{"client", "rpc"}, 1)
 	if !c.rpcLimiter.Load().(*rate.Limiter).Allow() {
 		metrics.IncrCounter([]string{"client", "rpc", "exceeded"}, 1)
 		return structs.ErrRPCRateExceeded


### PR DESCRIPTION
The client.rpc metric now excludes internal retries for consistency with client.rpc.exceeded and client.rpc.failed. All of these metrics now increment at most once per RPC method call, allowing for accurate calculation of failure / rate limit application occurrence.

Additionally, if an RPC fails because no servers are present, client.rpc.failed is now incremented.

Note: The client.rpc.failed metric used to increment on internal retries as well, but that was changed in [this commit](https://github.com/hashicorp/consul/commit/c48120d005539b687391b6861f24c13d553f5b05) (CC @kisunji).

### Testing & Reproduction steps

Manual testing conducted by reviewer (@rboyer).

1. Set up Consul cluster.
2. Run `curl -sL -XPUT 172.17.0.3:8500/v1/catalog/register -d'{"Node":"foo", "Address":"4.4.4.4", "ID":"blah"}'`. Note: this should succeed on the first try.
3. Run `curl -sL '172.17.0.3:8500/v1/catalog/nodes?filter=^^^''`. Note: this should fail and have several internal retries.
4. Read relevant metrics: `$ curl -sL 172.17.0.3:8500/v1/agent/metrics | jq '.Counters[] | select (.Name | test("^consul\\.client\\.rpc"))'`

Expect:
- `consul.client.rpc`: 2
- `consul.client.rpc.failed`: 1

Actual: Matches expectation

```
{
  "Name": "consul.client.rpc",
  "Count": 2,
  "Rate": 0.2,
  "Sum": 2,
  "Min": 1,
  "Max": 1,
  "Mean": 1,
  "Stddev": 0,
  "Labels": {}
}
{
  "Name": "consul.client.rpc.failed",
  "Count": 1,
  "Rate": 0.1,
  "Sum": 1,
  "Min": 1,
  "Max": 1,
  "Mean": 1,
  "Stddev": 0,
  "Labels": {
    "server": "651d982bed6b"
  }
}
```

### PR Checklist

* [ ] updated test coverage: no - manual test performed, no existing applicable metrics test to modify
* [ ] external facing docs updated: Will be updated in a separate PR if applicable
* [x] appropriate backport labels added
* [x] not a security concern

### Additional Notes

Added the `pr/no-metrics-test` label since the affected metric predates that CI check, currently has no tests, and correct behavior was manually verified as a part of this review.
