### PR TITLE
unflake peering_commontopo AC 7.2

### DIFF
--- a/.github/workflows/nightly-test-integ-peering_commontopo.yml
+++ b/.github/workflows/nightly-test-integ-peering_commontopo.yml
@@ -8,8 +8,6 @@ on:
     # Run nightly at 12AM UTC/8PM EST/5PM PST
     - cron: '* 0 * * *'
   workflow_dispatch: {}
-  # TODO: temp for testing
-  pull_request: {}
 
 env:
   TEST_RESULTS_DIR: /tmp/test-results

--- a/.github/workflows/nightly-test-integ-peering_commontopo.yml
+++ b/.github/workflows/nightly-test-integ-peering_commontopo.yml
@@ -8,6 +8,8 @@ on:
     # Run nightly at 12AM UTC/8PM EST/5PM PST
     - cron: '* 0 * * *'
   workflow_dispatch: {}
+  # TODO: temp for testing
+  pull_request: {}
 
 env:
   TEST_RESULTS_DIR: /tmp/test-results

--- a/test-integ/peering_commontopo/ac7_2_rotate_leader_test.go
+++ b/test-integ/peering_commontopo/ac7_2_rotate_leader_test.go
@@ -181,7 +181,8 @@ func (s *ac7_2RotateLeaderSuite) test(t *testing.T, ct *commonTopo) {
 	})
 
 	// expect health entry in for peer to disappear
-	retry.RunWith(&retry.Timer{Timeout: time.Minute, Wait: time.Millisecond * 500}, t, func(r *retry.R) {
+	// TODO: for whatever reason, this replication can take anywhere from 0 to 10 minutes :(
+	retry.RunWith(&retry.Timer{Timeout: 10 * time.Minute, Wait: time.Millisecond * 500}, t, func(r *retry.R) {
 		svcs, _, err := clDC.Health().Service(s.sidServer.Name, "", true, utils.CompatQueryOpts(&api.QueryOptions{
 			Partition: s.sidServer.Partition,
 			Namespace: s.sidServer.Namespace,


### PR DESCRIPTION
I noticed 7.2 was flaking pretty often. I did some timing of this section, and with N=5, found the following timing:

```
30s
2m30s
8m30s
30s
2m30s
```

(I only had 30s resolution for unrelated reasons.)

I don't know why there would be this much variability; that's for another day.

Based on #19724 just so I could run it manually.

### Testing & Reproduction steps

https://github.com/hashicorp/consul/actions/runs/6974518632/job/18980327887?pr=19727 ✅ 
