### PR TITLE
NET-6251 API gateway templated policy

### DIFF
--- a/.changelog/19728.txt
+++ b/.changelog/19728.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: add api-gateway templated policy
+```

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1407,7 +1407,7 @@ func TestACL_HTTP(t *testing.T) {
 
 			var list map[string]api.ACLTemplatedPolicyResponse
 			require.NoError(t, json.NewDecoder(resp.Body).Decode(&list))
-			require.Len(t, list, 5)
+			require.Len(t, list, 6)
 
 			require.Equal(t, api.ACLTemplatedPolicyResponse{
 				TemplateName: api.ACLTemplatedPolicyServiceName,

--- a/agent/structs/acl_templated_policy.go
+++ b/agent/structs/acl_templated_policy.go
@@ -29,6 +29,9 @@ var ACLTemplatedPolicyServiceSchema string
 //go:embed acltemplatedpolicy/schemas/workload-identity.json
 var ACLTemplatedPolicyWorkloadIdentitySchema string
 
+//go:embed acltemplatedpolicy/schemas/api-gateway.json
+var ACLTemplatedPolicyAPIGatewaySchema string
+
 type ACLTemplatedPolicies []*ACLTemplatedPolicy
 
 const (
@@ -37,6 +40,7 @@ const (
 	ACLTemplatedPolicyDNSID              = "00000000-0000-0000-0000-000000000005"
 	ACLTemplatedPolicyNomadServerID      = "00000000-0000-0000-0000-000000000006"
 	ACLTemplatedPolicyWorkloadIdentityID = "00000000-0000-0000-0000-000000000007"
+	ACLTemplatedPolicyAPIGatewayID       = "00000000-0000-0000-0000-000000000008"
 
 	ACLTemplatedPolicyNoRequiredVariablesSchema = "" // catch-all schema for all templated policy that don't require a schema
 )
@@ -83,6 +87,12 @@ var (
 			TemplateName: api.ACLTemplatedPolicyWorkloadIdentityName,
 			Schema:       ACLTemplatedPolicyWorkloadIdentitySchema,
 			Template:     ACLTemplatedPolicyWorkloadIdentity,
+		},
+		api.ACLTemplatedPolicyAPIGatewayName: {
+			TemplateID:   ACLTemplatedPolicyAPIGatewayID,
+			TemplateName: api.ACLTemplatedPolicyAPIGatewayName,
+			Schema:       ACLTemplatedPolicyAPIGatewaySchema,
+			Template:     ACLTemplatedPolicyAPIGateway,
 		},
 	}
 )

--- a/agent/structs/acl_templated_policy_ce.go
+++ b/agent/structs/acl_templated_policy_ce.go
@@ -22,6 +22,9 @@ var ACLTemplatedPolicyNomadServer string
 //go:embed acltemplatedpolicy/policies/ce/workload-identity.hcl
 var ACLTemplatedPolicyWorkloadIdentity string
 
+//go:embed acltemplatedpolicy/policies/ce/api-gateway.hcl
+var ACLTemplatedPolicyAPIGateway string
+
 func (t *ACLToken) TemplatedPolicyList() []*ACLTemplatedPolicy {
 	if len(t.TemplatedPolicies) == 0 {
 		return nil

--- a/agent/structs/acl_templated_policy_ce_test.go
+++ b/agent/structs/acl_templated_policy_ce_test.go
@@ -98,6 +98,28 @@ query_prefix "" {
 }`,
 			},
 		},
+		"api-gateway-template": {
+			templatedPolicy: &ACLTemplatedPolicy{
+				TemplateID:   ACLTemplatedPolicyAPIGatewayID,
+				TemplateName: api.ACLTemplatedPolicyAPIGatewayName,
+				TemplateVariables: &ACLTemplatedPolicyVariables{
+					Name: "api-gateway",
+				},
+			},
+			expectedPolicy: &ACLPolicy{
+				Description: "synthetic policy generated from templated policy: builtin/api-gateway",
+				Rules: `mesh = "read"
+node_prefix "" {
+	policy = "read"
+}
+service_prefix "" {
+	policy = "read"
+}
+service "api-gateway" {
+	policy = "write"
+}`,
+			},
+		},
 	}
 
 	for name, tcase := range testCases {

--- a/agent/structs/acltemplatedpolicy/policies/ce/api-gateway.hcl
+++ b/agent/structs/acltemplatedpolicy/policies/ce/api-gateway.hcl
@@ -1,0 +1,10 @@
+mesh = "read"
+node_prefix "" {
+	policy = "read"
+}
+service_prefix "" {
+	policy = "read"
+}
+service "{{.Name}}" {
+	policy = "write"
+}

--- a/agent/structs/acltemplatedpolicy/schemas/api-gateway.json
+++ b/agent/structs/acltemplatedpolicy/schemas/api-gateway.json
@@ -1,0 +1,13 @@
+{
+	"type": "object",
+	"properties": {
+		"name": { "type": "string", "$ref": "#/definitions/min-length-one" }
+	},
+	"required": ["name"],
+	"definitions": {
+		"min-length-one": {
+				"type": "string",
+				"minLength": 1
+		}
+	}
+}

--- a/api/acl.go
+++ b/api/acl.go
@@ -26,6 +26,7 @@ const (
 	ACLTemplatedPolicyDNSName              = "builtin/dns"
 	ACLTemplatedPolicyNomadServerName      = "builtin/nomad-server"
 	ACLTemplatedPolicyWorkloadIdentityName = "builtin/workload-identity"
+	ACLTemplatedPolicyAPIGatewayName       = "builtin/api-gateway"
 )
 
 type ACLLink struct {

--- a/command/acl/templatedpolicy/formatter.go
+++ b/command/acl/templatedpolicy/formatter.go
@@ -69,13 +69,13 @@ func (f *prettyFormatter) FormatTemplatedPolicy(templatedPolicy api.ACLTemplated
 	buffer.WriteString("Input variables:")
 	switch templatedPolicy.TemplateName {
 	case api.ACLTemplatedPolicyServiceName:
-		buffer.WriteString(fmt.Sprintf("\n%sName: String - Required - The name of the service.\n", WhitespaceIndent))
-		buffer.WriteString("Example usage:\n")
-		buffer.WriteString(WhitespaceIndent + "consul acl token create -templated-policy builtin/service -var name:api\n")
+		nameRequiredVariableOutput(&buffer, templatedPolicy.TemplateName, "The name of the service", "api")
 	case api.ACLTemplatedPolicyNodeName:
-		buffer.WriteString(fmt.Sprintf("\n%sName: String - Required - The node name.\n", WhitespaceIndent))
-		buffer.WriteString("Example usage:\n")
-		buffer.WriteString(fmt.Sprintf("%sconsul acl token create -templated-policy builtin/node -var name:node-1\n", WhitespaceIndent))
+		nameRequiredVariableOutput(&buffer, templatedPolicy.TemplateName, "The node name", "node-1")
+	case api.ACLTemplatedPolicyWorkloadIdentityName:
+		nameRequiredVariableOutput(&buffer, templatedPolicy.TemplateName, "The workload name", "api")
+	case api.ACLTemplatedPolicyAPIGatewayName:
+		nameRequiredVariableOutput(&buffer, templatedPolicy.TemplateName, "The api gateway service name", "api-gateway")
 	case api.ACLTemplatedPolicyDNSName, api.ACLTemplatedPolicyNomadServerName:
 		noRequiredVariablesOutput(&buffer, templatedPolicy.TemplateName)
 	default:
@@ -96,6 +96,12 @@ func noRequiredVariablesOutput(buffer *bytes.Buffer, templateName string) {
 	buffer.WriteString(" None\n")
 	buffer.WriteString("Example usage:\n")
 	buffer.WriteString(fmt.Sprintf("%sconsul acl token create -templated-policy %s\n", WhitespaceIndent, templateName))
+}
+
+func nameRequiredVariableOutput(buffer *bytes.Buffer, templateName, description, exampleName string) {
+	buffer.WriteString(fmt.Sprintf("\n%sName: String - Required - %s.\n", WhitespaceIndent, description))
+	buffer.WriteString("Example usage:\n")
+	buffer.WriteString(fmt.Sprintf("%sconsul acl token create -templated-policy %s -var name:%s\n", WhitespaceIndent, templateName, exampleName))
 }
 
 func (f *prettyFormatter) FormatTemplatedPolicyList(policies map[string]api.ACLTemplatedPolicyResponse) (string, error) {


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
- Add api gateway templated policy
- Will replace that policy in consul-k8s https://github.com/hashicorp/consul-k8s/pull/3132 
- Template tested through consul-ecs https://github.com/hashicorp/consul-ecs/pull/198/files 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
- create a token with api gateway templated policy
```
consul acl token create -templated-policy "builtin/api-gateway"

AccessorID:       e7d5f058-881d-c218-a5f7-2e2586df2456
SecretID:         3b3dd7b4-ab57-2019-7f33-f6402299b7dc
Partition:        default
Namespace:        default
Description:
Local:            false
Create Time:      2023-10-25 13:33:56.826587 -0400 EDT
Templated Policies:
   builtin/api-gateway
      Datacenters: all

```

- read the token with `-expanded` flag to ensure the 

```
consul acl token read -accessor-id "e7d5f058-881d-c218-a5f7-2e2586df2456" -expanded

AccessorID:       e7d5f058-881d-c218-a5f7-2e2586df2456
SecretID:         3b3dd7b4-ab57-2019-7f33-f6402299b7dc
Partition:        default
Namespace:        default
Description:
Local:            false
Create Time:      2023-10-25 13:33:56.826587 -0400 EDT
Templated Policies:
	builtin/api-gateway
		Datacenters: all
		Description: synthetic policy generated from templated policy: builtin/api-gateway
		Rules:mesh = "read"
			namespace_prefix "" {
				node_prefix "" {
					policy = "read"
				}
				service_prefix "" {
					policy = "write"
				}
			}

=== End of Authorizer Layer 0: Token ===
=== Start of Authorizer Layer 2: Agent Configuration Defaults (Inherited) ===
Description: Defined at request-time by the agent that resolves the ACL token; other agents may have different configuration defaults
Resolved By Agent: "cs01"

Default Policy: deny
	Description: Backstop rule used if no preceding layer has a matching rule (refer to default_policy option in agent configuration)

Down Policy: extend-cache
	Description: Defines what to do if this Token's information cannot be read from the primary_datacenter (refer to down_policy option in agent configuration)
```

- preview templated policy:

```
consul acl templated-policy read -name "builtin/api-gateway"
Name:            builtin/api-gateway
Input variables:
	Name: String - Required - The api gateway service name.
Example usage:
	consul acl token create -templated-policy builtin/api-gateway -var name:api-gateway
```
