### PR TITLE
[1.15.x backport] Fix panic policy delete 

### DIFF
--- a/.changelog/19679.txt
+++ b/.changelog/19679.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+CLI: fix a panic when deleting a non existing policy by name.
+```

--- a/command/acl/acl_helpers.go
+++ b/command/acl/acl_helpers.go
@@ -99,6 +99,10 @@ func GetPolicyIDByName(client *api.Client, name string) (string, error) {
 		return "", err
 	}
 
+	if policy == nil {
+		return "", fmt.Errorf("No such policy with name: %s", name)
+	}
+
 	return policy.ID, nil
 }
 

--- a/command/acl/acl_test.go
+++ b/command/acl/acl_test.go
@@ -48,6 +48,36 @@ func Test_GetPolicyIDByName_Builtins(t *testing.T) {
 	}
 }
 
+func Test_GetPolicyIDByName_NotFound(t *testing.T) {
+	t.Parallel()
+
+	a := agent.StartTestAgent(t,
+		agent.TestAgent{
+			LogOutput: io.Discard,
+			HCL: `
+				primary_datacenter = "dc1"
+				acl {
+					enabled = true
+					tokens {
+						initial_management = "root"
+					}
+				}
+			`,
+		},
+	)
+
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1", testrpc.WithToken("root"))
+
+	client := a.Client()
+	client.AddHeader("X-Consul-Token", "root")
+
+	id, err := GetPolicyIDByName(client, "not_found")
+	require.Error(t, err)
+	require.Equal(t, "", id)
+
+}
+
 func Test_GetPolicyIDFromPartial_Builtins(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description

This is a backport of the fix introduced in https://github.com/hashicorp/consul/pull/19679

<details>
<summary> Overview of commits </summary>

  - f027d610149d7dbb0d486e92a3a1a55f4b948cc3 

</details>