### PR TITLE
Remove Duplicate UBI Tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -321,28 +321,8 @@ jobs:
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor_dev_tag }}-${{ github.sha }}
           smoke_test: .github/scripts/verify_docker.sh v${{ env.version }}
 
-  build-docker-ubi-redhat:
-    name: Docker Build UBI Image for RedHat Registry
-    needs:
-      - set-product-version
-      - build
-    runs-on: ubuntu-latest
-    env:
-      repo: ${{github.event.repository.name}}
-      version: ${{needs.set-product-version.outputs.product-version}}
-
-    steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: hashicorp/actions-docker-build@v1
-        with:
-          version: ${{env.version}}
-          target: ubi
-          arch: amd64
-          redhat_tag: quay.io/redhat-isv-containers/60f9fdbec3a80eac643abedf:${{env.version}}-ubi
-          smoke_test: .github/scripts/verify_docker.sh v${{ env.version }}
-
   build-docker-ubi-dockerhub:
-    name: Docker Build UBI Image for DockerHub
+    name: Docker Build UBI Images
     needs:
       - set-product-version
       - build
@@ -377,6 +357,7 @@ jobs:
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor_dev_tag }}-ubi
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor_dev_tag }}-ubi-${{ github.sha }}
           smoke_test: .github/scripts/verify_docker.sh v${{ env.version }}
+          redhat_tag: quay.io/redhat-isv-containers/60f9fdbec3a80eac643abedf:${{env.version}}-ubi
 
   verify-linux:
     needs:


### PR DESCRIPTION
This PR is intended to avoid a [production incident](https://github.com/hashicorp/releng-support/issues/123) where there are duplicate tags (auto-assigned) to UBI images. The entire issue is described [here](https://github.com/hashicorp/crt-workflows-common/pull/407#issue-1999804835), and can be avoided by building `UBI`s (intended for both `Dockerhub` and `Redhat`) in one step.

### PR Checklist

* [x] appropriate backport labels added
* [x] not a security concern
