### PR TITLE
ci: Run `go mod tidy` check on submodules

### DIFF
--- a/.github/workflows/reusable-check-go-mod.yml
+++ b/.github/workflows/reusable-check-go-mod.yml
@@ -26,7 +26,8 @@ jobs:
     - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version-file: 'go.mod'
-    - run: go mod tidy
+    # Run on all go.mod (include submodules).
+    - run: make go-mod-tidy
     - run: |
         if [[ -n $(git status -s) ]]; then
           echo "Git directory has changes"


### PR DESCRIPTION
Today, we do not enforce a clean `go mod tidy` on submodules. This allows for drift and can eventually lead to `golangci-lint` failures, along with the obvious disadvantage of not having an up-to-date `go.mod`.

Enforce clean `go mod tidy` on all `go.mod` by using our make target rather than the direct root-level command.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
