### PR TITLE
[NET-6420] Add MeshConfiguration Controller stub

### DIFF
--- a/agent/consul/testdata/v2-resource-dependencies.md
+++ b/agent/consul/testdata/v2-resource-dependencies.md
@@ -34,6 +34,7 @@ flowchart TD
   mesh/v2beta1/destinations
   mesh/v2beta1/grpcroute
   mesh/v2beta1/httproute
+  mesh/v2beta1/meshconfiguration
   mesh/v2beta1/meshgateway
   mesh/v2beta1/proxyconfiguration
   mesh/v2beta1/proxystatetemplate --> auth/v2beta1/computedtrafficpermissions

--- a/internal/mesh/internal/controllers/meshconfiguration/controller.go
+++ b/internal/mesh/internal/controllers/meshconfiguration/controller.go
@@ -11,14 +11,19 @@ import (
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 )
 
+// Controller instantiates a new Controller for managing MeshConfiguration resources.
 func Controller() controller.Controller {
 	r := &reconciler{}
 
 	return controller.ForType(pbmesh.MeshConfigurationType).WithReconciler(r)
 }
 
+// reconciler implements the Reconciler interface to modify runtime state based
+// on requests passed into it.
 type reconciler struct{}
 
+// Reconcile takes in the current controller request and updates the runtime state based on
+// the request received.
 func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req controller.Request) error {
 	return errors.New("not implemented")
 }

--- a/internal/mesh/internal/controllers/meshconfiguration/controller.go
+++ b/internal/mesh/internal/controllers/meshconfiguration/controller.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package meshconfiguration
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/consul/internal/controller"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+)
+
+func Controller() controller.Controller {
+	r := &reconciler{}
+
+	return controller.ForType(pbmesh.MeshConfigurationType).WithReconciler(r)
+}
+
+type reconciler struct{}
+
+func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req controller.Request) error {
+	return errors.New("not implemented")
+}

--- a/internal/mesh/internal/controllers/meshconfiguration/controller_test.go
+++ b/internal/mesh/internal/controllers/meshconfiguration/controller_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package meshconfiguration
 
 import (

--- a/internal/mesh/internal/controllers/meshconfiguration/controller_test.go
+++ b/internal/mesh/internal/controllers/meshconfiguration/controller_test.go
@@ -1,0 +1,27 @@
+package meshconfiguration
+
+import (
+	"context"
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestReconciliation ensures that the Reconcile method for the Controller
+// correctly updates the runtime state based on the given request.
+func TestReconcile(t *testing.T) {
+	// This test should be continually updated as we build out the MeshConfiguration controller.
+	// At time of writing, it simply returns a not-implemented error.
+
+	ctx := context.Background()
+	rt := controller.Runtime{
+		Client: nil,
+		Logger: nil,
+	}
+	req := controller.Request{}
+
+	rec := reconciler{}
+
+	err := rec.Reconcile(ctx, rt, req)
+	require.Error(t, err)
+}

--- a/internal/mesh/internal/controllers/register.go
+++ b/internal/mesh/internal/controllers/register.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"github.com/hashicorp/consul/internal/mesh/internal/controllers/meshconfiguration"
 
 	"github.com/hashicorp/consul/agent/leafcert"
 	"github.com/hashicorp/consul/internal/controller"
@@ -51,4 +52,5 @@ func Register(mgr *controller.Manager, deps Dependencies) {
 	mgr.Register(explicitdestinations.Controller(mapper.New()))
 
 	mgr.Register(meshgateways.Controller())
+	mgr.Register(meshconfiguration.Controller())
 }

--- a/internal/mesh/internal/types/mesh_configuration.go
+++ b/internal/mesh/internal/types/mesh_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package types
 
 import (

--- a/internal/mesh/internal/types/mesh_configuration.go
+++ b/internal/mesh/internal/types/mesh_configuration.go
@@ -5,7 +5,8 @@ import (
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 )
 
-// RegisterMeshConfiguration takes
+// RegisterMeshConfiguration takes the resource registry and registers
+// the MeshConfiguration resource to it.
 func RegisterMeshConfiguration(r resource.Registry) {
 	r.Register(resource.Registration{
 		Type:     pbmesh.MeshConfigurationType,

--- a/internal/mesh/internal/types/mesh_configuration.go
+++ b/internal/mesh/internal/types/mesh_configuration.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"github.com/hashicorp/consul/internal/resource"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+)
+
+// RegisterMeshConfiguration takes
+func RegisterMeshConfiguration(r resource.Registry) {
+	r.Register(resource.Registration{
+		Type:     pbmesh.MeshConfigurationType,
+		Proto:    &pbmesh.MeshConfiguration{},
+		Scope:    resource.ScopePartition,
+		ACLs:     nil, // TODO NET-6423
+		Mutate:   nil, // TODO NET-6425
+		Validate: nil, // TODO NET-6424
+	})
+}

--- a/internal/mesh/internal/types/mesh_gateway.go
+++ b/internal/mesh/internal/types/mesh_gateway.go
@@ -13,8 +13,8 @@ func RegisterMeshGateway(r resource.Registry) {
 		Type:     pbmesh.MeshGatewayType,
 		Proto:    &pbmesh.MeshGateway{},
 		Scope:    resource.ScopePartition,
-		ACLs:     nil, // TODO NET-6423
-		Mutate:   nil, // TODO NET-6425
-		Validate: nil, // TODO NET-6424
+		ACLs:     nil, // TODO NET-6416
+		Mutate:   nil, // TODO NET-6418
+		Validate: nil, // TODO NET-6417
 	})
 }

--- a/internal/mesh/internal/types/types.go
+++ b/internal/mesh/internal/types/types.go
@@ -19,6 +19,7 @@ func Register(r resource.Registry) {
 	RegisterDestinationPolicy(r)
 	RegisterComputedRoutes(r)
 	RegisterMeshGateway(r)
+	RegisterMeshConfiguration(r)
 	// todo (v2): uncomment once we implement it.
 	//RegisterDestinationsConfiguration(r)
 }


### PR DESCRIPTION
### Description

This adds a stub for the `MeshConfiguration` Consul controller.

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

There are not any testable changes. This adds simply a stub of the controller for us to add work into.

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
