### PR TITLE
[NET-6725] Move test setup out of subtest

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/controller_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/controller_test.go
@@ -6,19 +6,19 @@ package sidecarproxy
 import (
 	"context"
 	"fmt"
-	mockres "github.com/hashicorp/consul/agent/grpc-external/services/resource"
-	"github.com/hashicorp/consul/internal/mesh/internal/controllers/routes/routestest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	mockres "github.com/hashicorp/consul/agent/grpc-external/services/resource"
 	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
 	"github.com/hashicorp/consul/envoyextensions/xdscommon"
 	"github.com/hashicorp/consul/internal/auth"
 	"github.com/hashicorp/consul/internal/catalog"
 	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/mesh/internal/controllers/routes/routestest"
 	"github.com/hashicorp/consul/internal/mesh/internal/controllers/sidecarproxy/builder"
 	"github.com/hashicorp/consul/internal/mesh/internal/controllers/sidecarproxy/cache"
 	"github.com/hashicorp/consul/internal/mesh/internal/controllers/sidecarproxy/fetcher"
@@ -577,13 +577,11 @@ func (suite *controllerTestSuite) TestController() {
 			webComputedDestinations *pbresource.Resource
 		)
 
-		testutil.RunStep(suite.T(), "proxy state template generation", func(t *testing.T) {
-			// Check that proxy state template resource is generated for both the api and web workloads.
-			retry.Run(t, func(r *retry.R) {
-				suite.client.RequireResourceExists(r, apiProxyStateTemplateID)
-				webProxyStateTemplate = suite.client.RequireResourceExists(r, webProxyStateTemplateID)
-				apiProxyStateTemplate = suite.client.RequireResourceExists(r, apiProxyStateTemplateID)
-			})
+		// Check that proxy state template resource is generated for both the api and web workloads.
+		retry.Run(suite.T(), func(r *retry.R) {
+			suite.client.RequireResourceExists(r, apiProxyStateTemplateID)
+			webProxyStateTemplate = suite.client.RequireResourceExists(r, webProxyStateTemplateID)
+			apiProxyStateTemplate = suite.client.RequireResourceExists(r, apiProxyStateTemplateID)
 		})
 
 		// Write a default ComputedRoutes for api.


### PR DESCRIPTION
1.17.x backport: https://github.com/hashicorp/consul/pull/19754

### Description

Test setup was being run as a subtest (testutil.RunStep) which was skipped when CI tried to rerun a flaking subtest further down the file. The solution is to move the setup out of the subtest so that the codepaths will run before the real subtests.

### Testing & Reproduction steps

Test artificially made to fail and retry; panicked without this patch but passed with it.
```
t.Logf("%#v", webProxyStateTemplate)
webProxyStateTemplate = suite.client.WaitForNewVersion(suite.T(), webProxyStateTemplateID, webProxyStateTemplate.Version)
require.True(suite.T(), false) // add this in any subtest
```

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
