### PR TITLE
ci: fix test failure Slack notifications

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -499,19 +499,33 @@ jobs:
       - name: evaluate upstream job results
         run: |
           # exit 1 if failure or cancelled result for any upstream job
+          # this ensures that we fail the PR check regardless of cancellation, rather than skip-passing it
+          # see https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#overview
           if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure|cancelled)\"'; then
             printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
             exit 1
           fi
+      - name: Set failure Slack commit message summary
+        # failure() ensures this runs even if the test eval step exits 1
+        if: failure()
+        run: |
+          # if failure (not cancelled), notify Slack
+          if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure)\"'; then
+            printf "Tests failed, notifying Slack"
+            echo "FAILED_TESTS=true" >> $GITHUB_ENV
+            echo "COMMIT_MESSAGE_SUMMARY=$(echo ${{ github.event.head_commit.message }} | head -n 1)" >> $GITHUB_ENV
+          fi
       - name: Notify Slack
-        if: ${{ failure() && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+        # failure() ensures this runs even if the test eval step exits 1
+        # FAILED_TESTS must also be checked to avoid running this step on cancellation due to the summary check above
+        if: ${{ failure() && env.FAILED_TESTS == 'true' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
         id: slack
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           # github.event.head_commit.message and github.ref_name both rely on this event occurring on a push / merge
           payload: |
             {
-              "message": "❌ ${{ github.workflow }} workflow failed: \n\n- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \n- Branch: ${{ github.ref_name }} \n- Message: ${{ github.event.head_commit.message }} \n- Author: ${{ github.event.sender.login }}"
+              "message": "❌ ${{ github.workflow }} workflow failed: \n\n- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \n- Branch: ${{ github.ref_name }} \n- Message: ${{ env.COMMIT_MESSAGE_SUMMARY }} \n- Author: ${{ github.event.sender.login }}"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_NIGHTLY_INTEG_TEST_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_PROTECTED_BRANCH_TEST_SLACK_WEBHOOK }}


### PR DESCRIPTION
### Description

- Skip notifications for cancelled workflows. Cancellation can be manual or caused by branch concurrency limits.
- Fix multi-line JSON parsing error by only printing the summary line of the commit message. We do not need more than this in Slack.
- Update Slack webhook name to match purpose
  - Previous: `slack github nightly integration test`
  - Now: [`Tests - protected branches`](https://app.slack.com/workflow-builder/EF1GCKJNM/workflow/Wf068HTD43AP)
  - I've added the new webhook secret to `consul` and `consul-enterprise`, so this should work immediately.

This only addresses the workflow for pushes to protected branches (the only one that runs outside a schedule today). A separate change would be needed to make this form of the job reusable and apply the same fix in nightly integration tests. I've left that for now in order to focus on getting this fix in since I assume nightlies are cancelled less often (recent failures in Slack look real).

### Examples

- Cancellation: https://github.com/hashicorp/consul/actions/runs/7089940273/job/19295857733
- Failure: https://github.com/hashicorp/consul/actions/runs/7089525736
- Success: https://github.com/hashicorp/consul/actions/runs/7089824660/job/19295843910

### Links

Follow-up to https://github.com/hashicorp/consul/pull/19640

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern