### PR TITLE
Docs: FIPS - add cluster peering info

### DIFF
--- a/website/content/docs/enterprise/fips.mdx
+++ b/website/content/docs/enterprise/fips.mdx
@@ -34,7 +34,7 @@ The above naming conventions, which append `.fips1402` to binary names and tags,
 
 ### Cluster Peering support
 
-A Consul cluster running FIPS variants of Consul can peer with any combination of standard (ono-FIPS) Consul clusters and FIPS Consul clusters. All peering-related features are supported between FIPS clusters and non-FIPS clusters.
+A Consul cluster running FIPS variants of Consul can peer with any combination of standard (non-FIPS) Consul clusters and FIPS Consul clusters. All peering-related features are supported between FIPS clusters and non-FIPS clusters.
 
 ### Usage restrictions
 

--- a/website/content/docs/enterprise/fips.mdx
+++ b/website/content/docs/enterprise/fips.mdx
@@ -32,7 +32,7 @@ The FIPS 140-2 variant of Consul uses separate binaries that are available from 
 
 The above naming conventions, which append `.fips1402` to binary names and tags, and `-fips` to registry names, also apply to `consul-k8s`, `consul-k8s-control-plane`, `consul-dataplane`, and `consul-ecs`, which are packaged separately from Consul Enterprise.
 
-### Cluster Peering support
+### Cluster peering support
 
 A Consul cluster running FIPS variants of Consul can peer with any combination of standard (non-FIPS) Consul clusters and FIPS Consul clusters. All peering-related features are supported between FIPS clusters and non-FIPS clusters.
 

--- a/website/content/docs/enterprise/fips.mdx
+++ b/website/content/docs/enterprise/fips.mdx
@@ -32,6 +32,10 @@ The FIPS 140-2 variant of Consul uses separate binaries that are available from 
 
 The above naming conventions, which append `.fips1402` to binary names and tags, and `-fips` to registry names, also apply to `consul-k8s`, `consul-k8s-control-plane`, `consul-dataplane`, and `consul-ecs`, which are packaged separately from Consul Enterprise.
 
+### Cluster Peering support
+
+A Consul cluster running FIPS variants of Consul can peer with any combination of standard (ono-FIPS) Consul clusters and FIPS Consul clusters. All peering-related features are supported between FIPS clusters and non-FIPS clusters.
+
 ### Usage restrictions
 
 When using Consul Enterprise with FIPS 140-2, be aware of the following operation restrictions:

--- a/website/content/docs/enterprise/fips.mdx
+++ b/website/content/docs/enterprise/fips.mdx
@@ -34,7 +34,7 @@ The above naming conventions, which append `.fips1402` to binary names and tags,
 
 ### Cluster peering support
 
-A Consul cluster running FIPS variants of Consul can peer with any combination of standard (non-FIPS) Consul clusters and FIPS Consul clusters. All peering-related features are supported between FIPS clusters and non-FIPS clusters.
+A Consul cluster running FIPS variants of Consul can peer with any combination of standard (non-FIPS) Consul clusters and FIPS Consul clusters. Consul supports all cluster peering features between FIPS clusters and non-FIPS clusters.
 
 ### Usage restrictions
 


### PR DESCRIPTION
### Description

Updates FIPS documentation by adding a section about Cluster Peering on the page. 

### Testing & Reproduction steps

N/A


### Links

None

### PR Checklist

* [N/A] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
