### PR TITLE
docs: Rename locality docs observe section to verification

### DIFF
--- a/website/content/docs/connect/manage-traffic/route-to-local-upstreams.mdx
+++ b/website/content/docs/connect/manage-traffic/route-to-local-upstreams.mdx
@@ -253,7 +253,7 @@ kubectl label node $K8S_NODE topology.kubernetes.io/region="us-east-1" topology.
 
 After setting these values, subsequent service and proxy registrations in your cluster inherit the values from their local Kubernetes node.
 
-## Observe route changes
+## Verification
 
 The routes from each downstream service instance to the nearest set of healthy upstream instances are the most immediately observable routing changes.
 

--- a/website/content/docs/connect/manage-traffic/route-to-local-upstreams.mdx
+++ b/website/content/docs/connect/manage-traffic/route-to-local-upstreams.mdx
@@ -253,7 +253,7 @@ kubectl label node $K8S_NODE topology.kubernetes.io/region="us-east-1" topology.
 
 After setting these values, subsequent service and proxy registrations in your cluster inherit the values from their local Kubernetes node.
 
-## Verification
+## Verify routes
 
 The routes from each downstream service instance to the nearest set of healthy upstream instances are the most immediately observable routing changes.
 


### PR DESCRIPTION
Follow-up to #19605 review.

### Description

See https://github.com/hashicorp/consul/pull/19605#pullrequestreview-1753317957 for more context.

This is a minimal change suggested as a potential alternative to moving this doc into its own section. If preferred, we can move the doc instead; opening PR to prompt that decision. Also happy to merge this as-is and consider a later follow-up.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
