### PR TITLE
Backport of [NET-6725] test: Address occasional flakes in sidecarproxy/controller_test.go into release/1.17.x

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/controller_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/controller_test.go
@@ -553,7 +553,9 @@ func (suite *controllerTestSuite) TestController() {
 	testutil.RunStep(suite.T(), "add explicit destinations and check that new proxy state is generated", func(t *testing.T) {
 		webProxyStateTemplate = suite.client.WaitForNewVersion(suite.T(), webProxyStateTemplateID, webProxyStateTemplate.Version)
 
-		requireExplicitDestinationsFound(t, "api", webProxyStateTemplate)
+		suite.waitForProxyStateTemplateState(t, webProxyStateTemplateID, func(rt resourcetest.T, tmpl *pbmesh.ProxyStateTemplate) {
+			requireExplicitDestinationsFound(rt, "api", tmpl)
+		})
 	})
 
 	testutil.RunStep(suite.T(), "update api's ports to be non-mesh", func(t *testing.T) {
@@ -613,7 +615,9 @@ func (suite *controllerTestSuite) TestController() {
 		// We should get a new web proxy template resource because this destination should be removed.
 		webProxyStateTemplate = suite.client.WaitForNewVersion(suite.T(), webProxyStateTemplateID, webProxyStateTemplate.Version)
 
-		requireExplicitDestinationsNotFound(t, "api", webProxyStateTemplate)
+		suite.waitForProxyStateTemplateState(t, webProxyStateTemplateID, func(rt resourcetest.T, tmpl *pbmesh.ProxyStateTemplate) {
+			requireExplicitDestinationsNotFound(rt, "api", tmpl)
+		})
 	})
 
 	testutil.RunStep(suite.T(), "update ports to be mesh again", func(t *testing.T) {
@@ -641,7 +645,9 @@ func (suite *controllerTestSuite) TestController() {
 		// We should also get a new web proxy template resource as this destination should be added again.
 		webProxyStateTemplate = suite.client.WaitForNewVersion(suite.T(), webProxyStateTemplateID, webProxyStateTemplate.Version)
 
-		requireExplicitDestinationsFound(t, "api", webProxyStateTemplate)
+		suite.waitForProxyStateTemplateState(t, webProxyStateTemplateID, func(rt resourcetest.T, tmpl *pbmesh.ProxyStateTemplate) {
+			requireExplicitDestinationsFound(rt, "api", tmpl)
+		})
 	})
 
 	testutil.RunStep(suite.T(), "delete the proxy state template and check re-generation", func(t *testing.T) {
@@ -651,7 +657,10 @@ func (suite *controllerTestSuite) TestController() {
 		require.NoError(suite.T(), err)
 
 		webProxyStateTemplate = suite.client.WaitForNewVersion(suite.T(), webProxyStateTemplateID, webProxyStateTemplate.Version)
-		requireExplicitDestinationsFound(t, "api", webProxyStateTemplate)
+
+		suite.waitForProxyStateTemplateState(t, webProxyStateTemplateID, func(rt resourcetest.T, tmpl *pbmesh.ProxyStateTemplate) {
+			requireExplicitDestinationsFound(rt, "api", tmpl)
+		})
 	})
 
 	testutil.RunStep(suite.T(), "add implicit upstream and enable tproxy", func(t *testing.T) {
@@ -682,8 +691,10 @@ func (suite *controllerTestSuite) TestController() {
 		webProxyStateTemplate = suite.client.WaitForNewVersion(suite.T(), webProxyStateTemplateID, webProxyStateTemplate.Version)
 		apiProxyStateTemplate = suite.client.WaitForNewVersion(suite.T(), apiProxyStateTemplateID, apiProxyStateTemplate.Version)
 
-		requireImplicitDestinationsFound(t, "api", webProxyStateTemplate)
-		requireImplicitDestinationsFound(t, "db", webProxyStateTemplate)
+		suite.waitForProxyStateTemplateState(t, webProxyStateTemplateID, func(rt resourcetest.T, tmpl *pbmesh.ProxyStateTemplate) {
+			requireImplicitDestinationsFound(rt, "api", tmpl)
+			requireImplicitDestinationsFound(rt, "db", tmpl)
+		})
 	})
 
 	testutil.RunStep(suite.T(), "traffic permissions", func(t *testing.T) {
@@ -754,8 +765,10 @@ func (suite *controllerTestSuite) TestController() {
 
 		webProxyStateTemplate = suite.client.WaitForNewVersion(suite.T(), webProxyStateTemplateID, webProxyStateTemplate.Version)
 
-		requireImplicitDestinationsFound(t, "api", webProxyStateTemplate)
-		requireImplicitDestinationsFound(t, "db", webProxyStateTemplate)
+		suite.waitForProxyStateTemplateState(t, webProxyStateTemplateID, func(rt resourcetest.T, tmpl *pbmesh.ProxyStateTemplate) {
+			requireImplicitDestinationsFound(rt, "api", tmpl)
+			requireImplicitDestinationsFound(rt, "db", tmpl)
+		})
 	})
 }
 
@@ -791,20 +804,16 @@ func TestMeshController(t *testing.T) {
 	suite.Run(t, new(controllerTestSuite))
 }
 
-func requireExplicitDestinationsFound(t *testing.T, name string, tmplResource *pbresource.Resource) {
-	requireExplicitDestinations(t, name, tmplResource, true)
+func requireExplicitDestinationsFound(t resourcetest.T, name string, tmpl *pbmesh.ProxyStateTemplate) {
+	requireExplicitDestinations(t, name, tmpl, true)
 }
 
-func requireExplicitDestinationsNotFound(t *testing.T, name string, tmplResource *pbresource.Resource) {
-	requireExplicitDestinations(t, name, tmplResource, false)
+func requireExplicitDestinationsNotFound(t resourcetest.T, name string, tmpl *pbmesh.ProxyStateTemplate) {
+	requireExplicitDestinations(t, name, tmpl, false)
 }
 
-func requireExplicitDestinations(t *testing.T, name string, tmplResource *pbresource.Resource, found bool) {
+func requireExplicitDestinations(t resourcetest.T, name string, tmpl *pbmesh.ProxyStateTemplate, found bool) {
 	t.Helper()
-
-	var tmpl pbmesh.ProxyStateTemplate
-	err := tmplResource.Data.UnmarshalTo(&tmpl)
-	require.NoError(t, err)
 
 	// Check outbound listener.
 	var foundListener bool
@@ -817,15 +826,11 @@ func requireExplicitDestinations(t *testing.T, name string, tmplResource *pbreso
 
 	require.Equal(t, found, foundListener)
 
-	requireClustersAndEndpoints(t, name, &tmpl, found)
+	requireClustersAndEndpoints(t, name, tmpl, found)
 }
 
-func requireImplicitDestinationsFound(t *testing.T, name string, tmplResource *pbresource.Resource) {
+func requireImplicitDestinationsFound(t resourcetest.T, name string, tmpl *pbmesh.ProxyStateTemplate) {
 	t.Helper()
-
-	var tmpl pbmesh.ProxyStateTemplate
-	err := tmplResource.Data.UnmarshalTo(&tmpl)
-	require.NoError(t, err)
 
 	// Check outbound listener.
 	var foundListener bool
@@ -864,10 +869,10 @@ func requireImplicitDestinationsFound(t *testing.T, name string, tmplResource *p
 	}
 	require.True(t, foundListener)
 
-	requireClustersAndEndpoints(t, name, &tmpl, true)
+	requireClustersAndEndpoints(t, name, tmpl, true)
 }
 
-func requireClustersAndEndpoints(t *testing.T, name string, tmpl *pbmesh.ProxyStateTemplate, found bool) {
+func requireClustersAndEndpoints(t resourcetest.T, name string, tmpl *pbmesh.ProxyStateTemplate, found bool) {
 	t.Helper()
 
 	var foundCluster bool
@@ -889,6 +894,16 @@ func requireClustersAndEndpoints(t *testing.T, name string, tmpl *pbmesh.ProxySt
 	}
 
 	require.Equal(t, found, foundEndpoints)
+}
+
+func (suite *controllerTestSuite) waitForProxyStateTemplateState(t *testing.T, id *pbresource.ID, verify func(resourcetest.T, *pbmesh.ProxyStateTemplate)) {
+	suite.client.WaitForResourceState(t, id, func(rt resourcetest.T, res *pbresource.Resource) {
+		var tmpl pbmesh.ProxyStateTemplate
+		err := res.Data.UnmarshalTo(&tmpl)
+		require.NoError(rt, err)
+
+		verify(rt, &tmpl)
+	})
 }
 
 func resourceID(rtype *pbresource.Type, name string) *pbresource.ID {


### PR DESCRIPTION
### Description

Manual backport of https://github.com/hashicorp/consul/pull/19760

### Links

Original backport PR (failed due to intervening test changes on `main`): https://github.com/hashicorp/consul/pull/19770

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

<details>
<summary> Overview of commits </summary>

  - 5be0c8f89b809b0723677a1ce4f412646315265a 

</details>