### PR TITLE
NET-6692: Ensure 'upload test results' step is always run

### DIFF
--- a/.github/workflows/nightly-test-integ-peering_commontopo.yml
+++ b/.github/workflows/nightly-test-integ-peering_commontopo.yml
@@ -106,12 +106,12 @@ jobs:
           TERM: ansi
 
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ endsWith(github.repository, '-enterprise') && !cancelled() }}
         id: vault-auth
         run: vault-auth
 
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ endsWith(github.repository, '-enterprise') && !cancelled() }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -122,6 +122,7 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: upload test results
+        if: ${{ !cancelled() }}
         continue-on-error: true
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"


### PR DESCRIPTION
## Description
Currently, upload test results step is skipped if there is a failure in one of its preceding steps (this includes tests failure). We should ideally upload the test results for failed tests too.

If a step fails before the workflow reaches the tests execution step, then the upload test results will fail because of unavailability of results.xml file

## Testing & Reproduction steps
https://github.com/hashicorp/consul/actions/runs/7042749371 workflow demonstrating the positive and negative scenario
