### PR TITLE
doc: clarify the portNames used in trafficpermission V2

### DIFF
--- a/website/content/docs/k8s/multiport/reference/trafficpermissions.mdx
+++ b/website/content/docs/k8s/multiport/reference/trafficpermissions.mdx
@@ -189,7 +189,7 @@ When [`spec.action`](#spec-action) _denies traffic_, Consul denies authorization
 
 ### `spec.permissions.destinationRules.portNames`
 
-Specifies a port name that the Kubernetes Service exposes at the destination.
+Specifies a port name that the Kubernetes Pod's container exposes at the destination.
 
 #### Values
 

--- a/website/content/docs/k8s/multiport/reference/trafficpermissions.mdx
+++ b/website/content/docs/k8s/multiport/reference/trafficpermissions.mdx
@@ -26,8 +26,8 @@ The following list outlines field hierarchy, language-specific data types, and r
   - [`permissions`](#spec-permissions): list of maps
     - [`sources`](#spec-permissions-sources): map
       - [`identityName`](#spec-permissions-sources-identityname): string
-    - [`destinationRules`](#spec-permissions-destinationrules):
-      - [`portNames`](#spec-permissions-destinationrules-portNames): array of strings
+    - [`destinationRules`](#spec-permissions-destinationrules): list of maps
+      - [`portNames`](#spec-permissions-destinationrules-portnames): array of strings
 
 ## Complete configuration
 
@@ -185,7 +185,7 @@ When [`spec.action`](#spec-action) _denies traffic_, Consul denies authorization
 #### Values
 
 - Default: None
-- Data type: Map
+- Data type: List of maps
 
 ### `spec.permissions.destinationRules.portNames`
 

--- a/website/content/docs/k8s/multiport/reference/trafficpermissions.mdx
+++ b/website/content/docs/k8s/multiport/reference/trafficpermissions.mdx
@@ -24,7 +24,7 @@ The following list outlines field hierarchy, language-specific data types, and r
     - [`identityName`](#spec-destination-identityname): string
   - [`action`](#spec-action): string
   - [`permissions`](#spec-permissions): list of maps
-    - [`sources`](#spec-permissions-sources): map
+    - [`sources`](#spec-permissions-sources): list of maps
       - [`identityName`](#spec-permissions-sources-identityname): string
     - [`destinationRules`](#spec-permissions-destinationrules): list of maps
       - [`portNames`](#spec-permissions-destinationrules-portnames): array of strings
@@ -45,10 +45,10 @@ spec:
   action: allow
   permissions:
     - sources:
-      identityName: <sourceWorkloadIdentity> 
-    destinationRules:
-      portNames: 
-        - <servicePortName>
+        - identityName: <sourceWorkloadIdentity> 
+      destinationRules:
+        - portNames:
+            - <servicePortName>
 ```
 
 ## Specification
@@ -163,7 +163,7 @@ To specify wildcard references in this block using `*`, omit all other fields. F
 #### Values
 
 - Default: None
-- Data type: Map
+- Data type: List of maps
 
 ### `spec.permissions.sources.identityName`
 
@@ -172,7 +172,7 @@ Specifies the Workload identity for the service that originates the request.
 #### Values
 
 - Default: None
-- Data type: Map
+- Data type: String
 
 ### `spec.permissions.destinationRules`
 


### PR DESCRIPTION
### Description

The `portNames` refers to the exposed pods of Kubernetes pod since a service can point to multiple pods.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
