### PR TITLE
POC: add gotestdoc tool for well-formed test doc comments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.289
 	github.com/coredns/coredns v1.10.1
 	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/deckarep/golang-set/v2 v2.3.1
 	github.com/docker/go-connections v0.4.0
 	github.com/envoyproxy/go-control-plane v0.11.1
@@ -164,7 +165,6 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf // indirect
 	github.com/cosiner/argv v0.1.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/denverdino/aliyungo v0.0.0-20170926055100-d3308649c661 // indirect
 	github.com/digitalocean/godo v1.10.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect

--- a/internal/tools/gotestdoc/lint.sh
+++ b/internal/tools/gotestdoc/lint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+go run . main_test.go

--- a/internal/tools/gotestdoc/main.go
+++ b/internal/tools/gotestdoc/main.go
@@ -1,0 +1,204 @@
+// gotestdoc parses well-formed comments in Go tests to extract BDD-like
+// test specs, without the burden of some goofy DSL.
+
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/doc/comment"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/go-multierror"
+)
+
+type TestDoc struct {
+	Givens      []comment.Block
+	GivenPerms  []Perm
+	Expects     []Expect
+	ExpectPerms []Perm
+}
+
+type Expect struct {
+	When comment.Block
+	Then comment.Block
+}
+
+type Perm comment.Block
+
+const (
+	kwGiven  = "Given"
+	kwExpect = "Expect"
+	kwPerms  = "With permutations:"
+)
+
+const (
+	fsmStart       = "start"
+	fsmGivenBody   = "givenBody"
+	fsmGivenPerms  = "givenPerms"
+	fsmExpectBody  = "expectBody"
+	fsmExpectPerms = "expectPerms"
+)
+
+func parseExpectItem(li *comment.ListItem) (Expect, error) {
+	// TODO
+	return Expect{}, nil
+}
+
+func parseFuncComment(s string) (*TestDoc, error) {
+	docParser := comment.Parser{
+		// TODO: links and symbols
+	}
+	doc := docParser.Parse(s)
+	ret := TestDoc{}
+	var errs error
+	// TODO; probably a better way to do FSM, but meh
+	fsm := fsmStart
+	for _, b := range doc.Content {
+		switch v := b.(type) {
+		case *comment.Heading:
+			// TODO: not sure when len > 1?
+			if len(v.Text) != 1 {
+				errs = multierror.Append(errs, fmt.Errorf("len of heading text != 1: %#v", v))
+				continue
+			}
+			text := v.Text[0]
+			switch fsm {
+			case fsmStart:
+				vt, ok := text.(comment.Plain)
+				if !ok {
+					errs = multierror.Append(errs, fmt.Errorf("given heading should be plain; is: %#v", v))
+					continue
+				}
+				if vt != kwGiven {
+					errs = multierror.Append(errs, fmt.Errorf("given heading should be 'Given'; is: %#v", vt))
+					continue
+				}
+				fsm = fsmGivenBody
+				continue
+			case fsmGivenBody, fsmGivenPerms:
+				vt, ok := text.(comment.Plain)
+				if !ok {
+					errs = multierror.Append(errs, fmt.Errorf("Expect heading should be plain; is: %#v", v))
+					continue
+				}
+				if vt != kwExpect {
+					errs = multierror.Append(errs, fmt.Errorf("Expect heading should be 'Expect'; is: %#v", vt))
+					continue
+				}
+				fsm = fsmExpectBody
+				continue
+			default:
+				log.Printf("unhandled Heading state: %s", fsm)
+				continue
+			}
+		case *comment.Paragraph:
+			switch fsm {
+			case fsmGivenBody:
+				if p, ok := v.Text[0].(comment.Plain); ok && p == kwPerms {
+					fsm = fsmGivenPerms
+					continue
+				}
+				ret.Givens = append(ret.Givens, v)
+			case fsmGivenPerms:
+				// TODO: append? treat as single?
+				log.Printf("unhandled Paragraph in given perms")
+			case fsmExpectBody:
+				if p, ok := v.Text[0].(comment.Plain); ok && p == kwPerms {
+					fsm = fsmExpectPerms
+					continue
+				}
+				errs = multierror.Append(errs, fmt.Errorf("no paragraphs in expect body"))
+				continue
+			case fsmExpectPerms:
+				// TODO: append
+				log.Printf("unhandled Paragraph in expect perms")
+			default:
+				log.Printf("unhandled Paragraph state: %s", fsm)
+				continue
+			}
+		case *comment.List:
+			switch fsm {
+			case fsmExpectBody:
+				for i, li := range v.Items {
+					ex, err := parseExpectItem(li)
+					if err != nil {
+						errs = multierror.Append(errs, fmt.Errorf("parsing expect item %d (%q): %q", i, li.Number, err))
+					}
+					ret.Expects = append(ret.Expects, ex)
+				}
+			case fsmGivenBody:
+				ret.Givens = append(ret.Givens, v)
+			case fsmGivenPerms:
+				ret.GivenPerms = append(ret.GivenPerms, v)
+			case fsmExpectPerms:
+				ret.ExpectPerms = append(ret.ExpectPerms, v)
+			default:
+				log.Printf("unhandled List state: %s", fsm)
+				continue
+			}
+
+		default:
+			switch fsm {
+			case fsmGivenBody:
+				ret.Givens = append(ret.Givens, v)
+			case fsmGivenPerms:
+				ret.GivenPerms = append(ret.GivenPerms, v)
+			case fsmExpectPerms:
+				ret.ExpectPerms = append(ret.ExpectPerms, v)
+			default:
+				log.Printf("unhandled state for misc block type: %s", fsm)
+				continue
+			}
+			log.Printf("unhandled block type: %T", b)
+			continue
+		}
+	}
+	return &ret, errs
+}
+
+func main() {
+	// TODO: real arg parsing
+	filename := os.Args[1]
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	testDocs := map[string]*TestDoc{}
+	errs := map[string]error{}
+
+	for _, d := range file.Decls {
+		switch v := d.(type) {
+		case *ast.FuncDecl:
+			funcname := v.Name.String()
+			// TODO: also check that its signature is (t *testing.T)
+			// TODO: handle duplicates?
+			if strings.HasPrefix(funcname, "Test") {
+				td, err := parseFuncComment(v.Doc.Text())
+				if err != nil {
+					errs[funcname] = err
+					continue
+				}
+				testDocs[funcname] = td
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		spew.Printf("ERRORS: %#v", errs)
+	}
+	if len(testDocs) > 0 {
+		spew.Dump(testDocs)
+	}
+	if len(errs) > 0 {
+		os.Exit(1)
+	}
+
+}

--- a/internal/tools/gotestdoc/main.go
+++ b/internal/tools/gotestdoc/main.go
@@ -70,7 +70,7 @@ func parseExpectItem(li *comment.ListItem) (Expect, error) {
 
 	matches := whenThenRE.FindStringSubmatch(string(contentPlain))
 	if len(matches) != 3 {
-		return Expect{}, fmt.Errorf(`Expect item must be of the form "When: <...>, then": <...>; is: %q`, contentPlain)
+		return Expect{}, fmt.Errorf(`Expect item must be of the form "When: <...>, then: <...>"; is: %q`, contentPlain)
 	}
 
 	return Expect{

--- a/internal/tools/gotestdoc/main_test.go
+++ b/internal/tools/gotestdoc/main_test.go
@@ -1,3 +1,0 @@
-// In gotestdoc's tests, we write in gotestdoc style for dogfooding purposes.
-// Normally gotestdoc would be overkill for unit tests.
-package main

--- a/internal/tools/gotestdoc/main_test.go
+++ b/internal/tools/gotestdoc/main_test.go
@@ -1,0 +1,86 @@
+// NB: tests in gotestdoc are described with gotestdoc-style comments, in order to dogfood.
+// In real, life, this would probably be overkill.
+
+package main
+
+import (
+	"go/doc/comment"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// # Given
+//
+// A basic gotestdoc-style comment.
+//
+// # Expect
+//
+//  1. When: it is parsed, then: it will have no errors
+//  2. When: it is parsed, then: the results will be a TestDoc struct with a particular form
+func TestBasic(t *testing.T) {
+	s := `
+# Given
+
+givenbody
+
+With permutations:
+
+  1. givenperm
+
+# Expect
+
+  1. When: foo, then: bar
+
+With permutations:
+
+  1. expectperm
+	`
+	d, err := parseFuncComment(s)
+	e := TestDoc{
+		Givens: []comment.Block{&comment.Paragraph{
+			Text: []comment.Text{
+				comment.Plain("givenbody"),
+			},
+		}},
+		GivenPerms: []comment.Block{&comment.List{
+			ForceBlankBefore: true,
+			Items: []*comment.ListItem{
+				{
+					Number: "1",
+					Content: []comment.Block{
+						&comment.Paragraph{
+							Text: []comment.Text{comment.Plain("givenperm")},
+						},
+					},
+				},
+			},
+		}},
+		Expects: []Expect{
+			{
+				When: []comment.Text{
+					comment.Plain("foo"),
+				},
+				Then: []comment.Text{
+					comment.Plain("bar"),
+				},
+			},
+		},
+		ExpectPerms: []comment.Block{&comment.List{
+			ForceBlankBefore: true,
+			Items: []*comment.ListItem{
+				{
+					Number: "1",
+					Content: []comment.Block{
+						&comment.Paragraph{
+							Text: []comment.Text{comment.Plain("expectperm")},
+						},
+					},
+				},
+			},
+		}},
+	}
+	require.NoError(t, err)
+	assert.EqualValues(t, &e, d)
+}

--- a/internal/tools/gotestdoc/main_test.go
+++ b/internal/tools/gotestdoc/main_test.go
@@ -1,0 +1,3 @@
+// In gotestdoc's tests, we write in gotestdoc style for dogfooding purposes.
+// Normally gotestdoc would be overkill for unit tests.
+package main

--- a/test-integ/peering_commontopo/ac1_basic_test.go
+++ b/test-integ/peering_commontopo/ac1_basic_test.go
@@ -39,6 +39,29 @@ var ac1BasicSuites []sharedTopoSuite = []sharedTopoSuite{
 	&ac1BasicSuite{DC: "dc2", Peer: "dc1"},
 }
 
+// # Given
+//
+// A 2-DC, peered Consul deployment with the services:
+//
+//  1. in DC B, an HTTP static server service ("HTTP server") that returns its Consul name, exported to DC A
+//  2. in DC B, a TCP static server service ("TCP server") that returns its Consul name, exported to DC A
+//  3. in DC A, an HTTP service ("HTTP client") with upstreams of both servers in DC B
+//  4. in DC A, a TCP service ("TCP client") with upstreams of both servers in DC B
+//
+// With permutations:
+//
+//  1. DC A is the dialing peer, DC B is the listening peer
+//  2. vice versa of (a)
+//  3. DC A and B are agentful
+//  4. DC A is agentful, DC B is agentless
+//
+// # Expect
+//
+//  1. When: an HTTP GET is made to server via client, then: the result is the HTTP server's name
+//
+// With permutations:
+//
+//  1. For each: (server, client) pair
 func TestAC1Basic(t *testing.T) {
 	runShareableSuites(t, ac1BasicSuites)
 }

--- a/test-integ/peering_commontopo/ac1_basic_test.go
+++ b/test-integ/peering_commontopo/ac1_basic_test.go
@@ -51,7 +51,7 @@ var ac1BasicSuites []sharedTopoSuite = []sharedTopoSuite{
 // With permutations:
 //
 //  1. DC A is the dialing peer, DC B is the listening peer
-//  2. vice versa of (a)
+//  2. vice versa of (1)
 //  3. DC A and B are agentful
 //  4. DC A is agentful, DC B is agentless
 //


### PR DESCRIPTION
This tool is used to parse and validate a particular form of [Go Doc comment](https://go.dev/doc/comment) to describe tests, inspired by BDD form. An example comment is in https://github.com/hashicorp/consul/pull/19812/files#diff-da8f4671de74636c4f29eb1275cefd65bc462a6f0aa4436b684877607fcf90aeR42:

```go
// # Given
//
// A 2-DC, peered Consul deployment with the services:
//
//  1. in DC B, an HTTP static server service ("HTTP server") that returns its Consul name, exported to DC A
//  2. in DC B, a TCP static server service ("TCP server") that returns its Consul name, exported to DC A
//  3. in DC A, an HTTP service ("HTTP client") with upstreams of both servers in DC B
//  4. in DC A, a TCP service ("TCP client") with upstreams of both servers in DC B
//
// With permutations:
//
//  1. DC A is the dialing peer, DC B is the listening peer
//  2. vice versa of (1)
//  3. DC A and B are agentful
//  4. DC A is agentful, DC B is agentless
//
// # Expect
//
//  1. When: an HTTP GET is made to server via client, then: the result is the HTTP server's name
//
// With permutations:
//
//  1. For each: (server, client) pair
```

Since this is also a Go Doc comment, we use [`go/doc/comment`](https://pkg.go.dev/go/doc/comment) to do the parsing into a Doc, and then transform their AST to ours. Go Doc comments are a a subset of Markdown that can be canonicalized by `go fmt`.

I'm flexible on the actual format (e.g `# Given` heading vs `Given:` paragraph), but Go Doc comments are restricted in certain ways that make encoding a BDD spec in it in an easily parseable way challenging. We'll need to balance that, along with writability and (in-code) readability.

As a POC, the main program parses the comments in a test file, and then outputs a spruced up Markdown, which looks like this:

```
<h1>TestAC1Basic</h1>

### Given {#hdr-Given}

A 2-DC, peered Consul deployment with the services:

 1. in DC B, an HTTP static server service ("HTTP server") that returns its Consul name, exported to DC A
 2. in DC B, a TCP static server service ("TCP server") that returns its Consul name, exported to DC A
 3. in DC A, an HTTP service ("HTTP client") with upstreams of both servers in DC B
 4. in DC A, a TCP service ("TCP client") with upstreams of both servers in DC B

With permutations:

 1. DC A is the dialing peer, DC B is the listening peer
 2. vice versa of (a)
 3. DC A and B are agentful
 4. DC A is agentful, DC B is agentless

### Expect {#hdr-Expect}

 1. When: an HTTP GET is made to server via client, then: the result is the HTTP server's name

With permutations:

 1. For each: (server, client) pair
```

You can imagine that we could extract the content and put it in a test catalog instead.

# Motivation

The main reason I see people advocating for BDD is that it makes tests read  more English-like. The frameworks usually accomplish this by introducing functions whose names combined with the args, kind of resemble a sentence if you squint. For example, here’s some godog:

```
func InitializeScenario(ctx *godog.ScenarioContext) {
        ctx.Given(`^there are (\d+) godogs$`, thereAreGodogs)
        ctx.When(`^I eat (\d+)$`, iEat)
        ctx.Then(`^there should be (\d+) remaining$`, thereShouldBeRemaining)
}
```

My argument against this is that while it might make the intention of the test clearer, it makes the actual executed code harder to intuit: What exactly does `ctx.Given` do? How are these steps related? What happens if the `Given` step fails?

My answer is “just use comments”. That’s the usual way we summarize code into English. And obviously I have not invented the idea of commenting integration tests :P But the quality and format of these comments vary wildly. Think of `gotestdoc` mostly as a linter that proscribes a fairly flexible format.

# Future ideas

It would be cool to explore a more inline format, where, for example, your Expects comments are above the code itself that ensures the expectations, rather than way up at the top. This would be pretty tricky to do in the face of helper functions and `t.Run` closures and table-driven tests.
