### PR TITLE
Add Name and Fail to retry

### DIFF
--- a/sdk/testutil/retry/retry.go
+++ b/sdk/testutil/retry/retry.go
@@ -54,6 +54,8 @@ type R struct {
 	done   bool
 	output []string
 
+	name string
+
 	cleanups []func()
 }
 
@@ -102,9 +104,23 @@ func (r *R) runCleanup() {
 	}
 }
 
+// Name returns the name field of the retrier.
+// At time of writing it will always return an empty string. This was done to satisfy the Terratest TestingT interface.
+// https://github.com/gruntwork-io/terratest/blob/7d7a7a074d935958f9c9c4474c76897b828a000c/modules/testing/types.go
+// This was required to allow the retries to be passed to Terratest functions which execute Kubernetes API calls
+// as used in the Consul on Kubernetes codebase.
+func (r *R) Name() string {
+	return r.name
+}
+
 // runFailed is a sentinel value to indicate that the func itself
 // didn't panic, rather that `FailNow` was called.
 type runFailed struct{}
+
+// Fail marks the run execution as being in a fail state.
+func (r *R) Fail() {
+	r.fail = true
+}
 
 // FailNow stops run execution. It is roughly equivalent to:
 //


### PR DESCRIPTION
### Description

This PR extends the functionality of the testing Retry struct such that it satisfies the interface for Terratest's `TestingT`. This allows the retry struct to be used in the Consul K8s repository as a testing object that can be passed to Terratest's library for communicating with Kubernetes.

Without this change, functions within a retry block were being passed a `t *testing.T` object that was not compatible with the retry functionality. This issue was caught by an improvement to the associated [linting library](https://github.com/hashicorp/lint-consul-retry/commit/020a1ad76da1d4726832dac465c0617f6564bb6f).

This PR will be followed up with a PR in Consul K8s that replaces usage of `t *testing.T` inside of retries with the proper retry object. [The PR](https://github.com/hashicorp/consul-k8s/pull/3289) is currently in draft form.

### Testing & Reproduction steps


### Links

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
