### PR TITLE
[NET-6251] Nomad client templated policy

### DIFF
--- a/.changelog/19827.txt
+++ b/.changelog/19827.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+acl: Adds nomad client templated policy
+```

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1407,7 +1407,7 @@ func TestACL_HTTP(t *testing.T) {
 
 			var list map[string]api.ACLTemplatedPolicyResponse
 			require.NoError(t, json.NewDecoder(resp.Body).Decode(&list))
-			require.Len(t, list, 6)
+			require.Len(t, list, 7)
 
 			require.Equal(t, api.ACLTemplatedPolicyResponse{
 				TemplateName: api.ACLTemplatedPolicyServiceName,

--- a/agent/structs/acl_templated_policy.go
+++ b/agent/structs/acl_templated_policy.go
@@ -41,6 +41,7 @@ const (
 	ACLTemplatedPolicyNomadServerID      = "00000000-0000-0000-0000-000000000006"
 	ACLTemplatedPolicyWorkloadIdentityID = "00000000-0000-0000-0000-000000000007"
 	ACLTemplatedPolicyAPIGatewayID       = "00000000-0000-0000-0000-000000000008"
+	ACLTemplatedPolicyNomadClientID      = "00000000-0000-0000-0000-000000000009"
 
 	ACLTemplatedPolicyServiceDescription          = "Gives the token or role permissions to register a service and discover services in the Consul catalog. It also gives the specified service's sidecar proxy the permission to discover and route traffic to other services."
 	ACLTemplatedPolicyNodeDescription             = "Gives the token or role permissions for a register an agent/node into the catalog. A node is typically a consul agent but can also be a physical server, cloud instance or a container."
@@ -48,6 +49,7 @@ const (
 	ACLTemplatedPolicyNomadServerDescription      = "Gives the token or role permissions required for integration with a nomad server."
 	ACLTemplatedPolicyWorkloadIdentityDescription = "Gives the token or role permissions for a specific workload identity."
 	ACLTemplatedPolicyAPIGatewayDescription       = "Gives the token or role permissions for a Consul api gateway"
+	ACLTemplatedPolicyNomadClientDescription      = "Gives the token or role permissions required for integration with a nomad client."
 
 	ACLTemplatedPolicyNoRequiredVariablesSchema = "" // catch-all schema for all templated policy that don't require a schema
 )
@@ -107,6 +109,13 @@ var (
 			Schema:       ACLTemplatedPolicyAPIGatewaySchema,
 			Template:     ACLTemplatedPolicyAPIGateway,
 			Description:  ACLTemplatedPolicyAPIGatewayDescription,
+		},
+		api.ACLTemplatedPolicyNomadClientName: {
+			TemplateID:   ACLTemplatedPolicyNomadClientID,
+			TemplateName: api.ACLTemplatedPolicyNomadClientName,
+			Schema:       ACLTemplatedPolicyNoRequiredVariablesSchema,
+			Template:     ACLTemplatedPolicyNomadClient,
+			Description:  ACLTemplatedPolicyNomadClientDescription,
 		},
 	}
 )

--- a/agent/structs/acl_templated_policy_ce.go
+++ b/agent/structs/acl_templated_policy_ce.go
@@ -25,6 +25,9 @@ var ACLTemplatedPolicyWorkloadIdentity string
 //go:embed acltemplatedpolicy/policies/ce/api-gateway.hcl
 var ACLTemplatedPolicyAPIGateway string
 
+//go:embed acltemplatedpolicy/policies/ce/nomad-client.hcl
+var ACLTemplatedPolicyNomadClient string
+
 func (t *ACLToken) TemplatedPolicyList() []*ACLTemplatedPolicy {
 	if len(t.TemplatedPolicies) == 0 {
 		return nil

--- a/agent/structs/acltemplatedpolicy/policies/ce/nomad-client.hcl
+++ b/agent/structs/acltemplatedpolicy/policies/ce/nomad-client.hcl
@@ -1,0 +1,12 @@
+agent_prefix "" {
+  policy = "read"
+}
+node_prefix "" {
+  policy = "read"
+}
+service_prefix "" {
+  policy = "write"
+}
+key_prefix "" {
+  policy = "read"
+}

--- a/api/acl.go
+++ b/api/acl.go
@@ -27,6 +27,7 @@ const (
 	ACLTemplatedPolicyNomadServerName      = "builtin/nomad-server"
 	ACLTemplatedPolicyWorkloadIdentityName = "builtin/workload-identity"
 	ACLTemplatedPolicyAPIGatewayName       = "builtin/api-gateway"
+	ACLTemplatedPolicyNomadClientName      = "builtin/nomad-client"
 )
 
 type ACLLink struct {

--- a/command/acl/templatedpolicy/formatter.go
+++ b/command/acl/templatedpolicy/formatter.go
@@ -77,7 +77,7 @@ func (f *prettyFormatter) FormatTemplatedPolicy(templatedPolicy api.ACLTemplated
 		nameRequiredVariableOutput(&buffer, templatedPolicy.TemplateName, "The workload name", "api")
 	case api.ACLTemplatedPolicyAPIGatewayName:
 		nameRequiredVariableOutput(&buffer, templatedPolicy.TemplateName, "The api gateway service name", "api-gateway")
-	case api.ACLTemplatedPolicyDNSName, api.ACLTemplatedPolicyNomadServerName:
+	case api.ACLTemplatedPolicyDNSName, api.ACLTemplatedPolicyNomadServerName, api.ACLTemplatedPolicyNomadClientName:
 		noRequiredVariablesOutput(&buffer, templatedPolicy.TemplateName)
 	default:
 		buffer.WriteString("   None\n")

--- a/command/acl/templatedpolicy/formatter_test.go
+++ b/command/acl/templatedpolicy/formatter_test.go
@@ -64,6 +64,14 @@ func testFormatTemplatedPolicy(t *testing.T, dirPath string) {
 				Description:  structs.ACLTemplatedPolicyNomadServerDescription,
 			},
 		},
+		"nomad-client-templated-policy": {
+			templatedPolicy: api.ACLTemplatedPolicyResponse{
+				TemplateName: api.ACLTemplatedPolicyNomadClientName,
+				Schema:       structs.ACLTemplatedPolicyNoRequiredVariablesSchema,
+				Template:     structs.ACLTemplatedPolicyNomadClient,
+				Description:  structs.ACLTemplatedPolicyNomadClientDescription,
+			},
+		},
 	}
 
 	formatters := map[string]Formatter{

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/nomad-client-templated-policy.json.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/nomad-client-templated-policy.json.golden
@@ -1,0 +1,6 @@
+{
+    "TemplateName": "builtin/nomad-client",
+    "Schema": "",
+    "Template": "agent_prefix \"\" {\n  policy = \"read\"\n}\nnode_prefix \"\" {\n  policy = \"read\"\n}\nservice_prefix \"\" {\n  policy = \"write\"\n}\nkey_prefix \"\" {\n  policy = \"read\"\n}",
+    "Description": "Gives the token or role permissions required for integration with a nomad client."
+}

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/nomad-client-templated-policy.pretty-meta.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/nomad-client-templated-policy.pretty-meta.golden
@@ -1,0 +1,18 @@
+Name:            builtin/nomad-client
+Description:     Gives the token or role permissions required for integration with a nomad client.
+Input variables: None
+Example usage:
+	consul acl token create -templated-policy builtin/nomad-client
+Raw Template:
+agent_prefix "" {
+  policy = "read"
+}
+node_prefix "" {
+  policy = "read"
+}
+service_prefix "" {
+  policy = "write"
+}
+key_prefix "" {
+  policy = "read"
+}

--- a/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/nomad-client-templated-policy.pretty.golden
+++ b/command/acl/templatedpolicy/testdata/FormatTemplatedPolicy/ce/nomad-client-templated-policy.pretty.golden
@@ -1,0 +1,5 @@
+Name:            builtin/nomad-client
+Description:     Gives the token or role permissions required for integration with a nomad client.
+Input variables: None
+Example usage:
+	consul acl token create -templated-policy builtin/nomad-client


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
- Adding nomad client templated policy 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
```
consul acl token create -templated-policy "builtin/nomad-client"
```

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

- [Testing repo (nomad + consul)](https://github.com/hashicorp/consul-gateway-on-nomad/blob/main/nomad-client-policy.hcl)

### PR Checklist

* [x] updated test coverage
* [x] appropriate backport labels added
* [x] not a security concern
