### PR TITLE
Create HCP management token in HCP manager

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -586,6 +586,53 @@ func (s *Server) initializeManagementToken(name, secretID string) error {
 	return nil
 }
 
+func (s *Server) upsertManagementToken(name, secretID string) error {
+	state := s.fsm.State()
+	if _, err := uuid.ParseUUID(secretID); err != nil {
+		s.logger.Warn("Configuring a non-UUID management token is deprecated")
+	}
+
+	_, token, err := state.ACLTokenGetBySecret(nil, secretID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get %s: %v", name, err)
+	}
+	// Ignoring expiration times to avoid an insertion collision.
+	if token == nil {
+		accessor, err := lib.GenerateUUID(s.checkTokenUUID)
+		if err != nil {
+			return fmt.Errorf("failed to generate the accessor ID for %s: %v", name, err)
+		}
+
+		token := structs.ACLToken{
+			AccessorID:  accessor,
+			SecretID:    secretID,
+			Description: name,
+			Policies: []structs.ACLTokenPolicyLink{
+				{
+					ID: structs.ACLPolicyGlobalManagementID,
+				},
+			},
+			CreateTime:     time.Now(),
+			Local:          false,
+			EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+		}
+
+		token.SetHash(true)
+
+		req := structs.ACLTokenBatchSetRequest{
+			Tokens: structs.ACLTokens{&token},
+			CAS:    false,
+		}
+		if _, err := s.raftApply(structs.ACLTokenSetRequestType, &req); err != nil {
+			return fmt.Errorf("failed to create %s: %v", name, err)
+		}
+
+		s.logger.Info("Created ACL token", "description", name)
+	}
+
+	return nil
+}
+
 func (s *Server) insertAnonymousToken() error {
 	state := s.fsm.State()
 	_, token, err := state.ACLTokenGetBySecret(nil, anonymousToken, nil)

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -590,7 +590,7 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 		TelemetryProvider: flat.HCP.TelemetryProvider,
 		ManagementTokenUpserterFn: func(name, secretId string) error {
 			if s.IsLeader() {
-				return s.initializeManagementToken(name, secretId)
+				return s.upsertManagementToken(name, secretId)
 			}
 			return nil
 		},

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -588,6 +588,12 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 		Logger:            logger.Named("hcp_manager"),
 		SCADAProvider:     flat.HCP.Provider,
 		TelemetryProvider: flat.HCP.TelemetryProvider,
+		InitializeManagementTokenFn: func(name, secretId string) error {
+			if s.IsLeader() {
+				return s.initializeManagementToken(name, secretId)
+			}
+			return nil
+		},
 	})
 
 	var recorder *middleware.RequestRecorder

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -590,6 +590,9 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 		TelemetryProvider: flat.HCP.TelemetryProvider,
 		ManagementTokenUpserterFn: func(name, secretId string) error {
 			if s.IsLeader() {
+				// Idea for improvement: Upsert a token with a well-known accessorId here instead
+				// of a randomly generated one. This would prevent any possible insertion collision between
+				// this and the insertion that happens during the ACL initialization process (initializeACLs function)
 				return s.upsertManagementToken(name, secretId)
 			}
 			return nil

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -588,7 +588,7 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 		Logger:            logger.Named("hcp_manager"),
 		SCADAProvider:     flat.HCP.Provider,
 		TelemetryProvider: flat.HCP.TelemetryProvider,
-		InitializeManagementTokenFn: func(name, secretId string) error {
+		ManagementTokenUpserterFn: func(name, secretId string) error {
 			if s.IsLeader() {
 				return s.initializeManagementToken(name, secretId)
 			}

--- a/agent/hcp/manager.go
+++ b/agent/hcp/manager.go
@@ -26,9 +26,12 @@ type ManagerConfig struct {
 	SCADAProvider     scada.Provider
 	TelemetryProvider *hcpProviderImpl
 
-	StatusFn    StatusCallback
-	MinInterval time.Duration
-	MaxInterval time.Duration
+	StatusFn StatusCallback
+	// Idempotent function to initialize the management token. This will be called periodically in
+	// the manager's main loop.
+	InitializeManagementTokenFn InitializeManagementToken
+	MinInterval                 time.Duration
+	MaxInterval                 time.Duration
 
 	Logger hclog.Logger
 }
@@ -54,6 +57,7 @@ func (cfg *ManagerConfig) nextHeartbeat() time.Duration {
 }
 
 type StatusCallback func(context.Context) (hcpclient.ServerStatus, error)
+type InitializeManagementToken func(name, secretId string) error
 
 type Manager struct {
 	logger hclog.Logger
@@ -111,6 +115,12 @@ func (m *Manager) Run(ctx context.Context) error {
 
 	// main loop
 	for {
+		// Check for configured management token from HCP. It MUST NOT override the user-provided initial management token.
+		if hcpManagement := m.cfg.CloudConfig.ManagementToken; len(hcpManagement) > 0 {
+			initTokenErr := m.cfg.InitializeManagementTokenFn("HCP Management Token", hcpManagement)
+			m.logger.Error("failed to initialize HCP management token", "err", initTokenErr)
+		}
+
 		m.cfgMu.RLock()
 		cfg := m.cfg
 		m.cfgMu.RUnlock()

--- a/agent/hcp/manager.go
+++ b/agent/hcp/manager.go
@@ -118,7 +118,9 @@ func (m *Manager) Run(ctx context.Context) error {
 		// Check for configured management token from HCP and upsert it if found
 		if hcpManagement := m.cfg.CloudConfig.ManagementToken; len(hcpManagement) > 0 {
 			upsertTokenErr := m.cfg.ManagementTokenUpserterFn("HCP Management Token", hcpManagement)
-			m.logger.Error("failed to upsert HCP management token", "err", upsertTokenErr)
+			if upsertTokenErr != nil {
+				m.logger.Error("failed to upsert HCP management token", "err", upsertTokenErr)
+			}
 		}
 
 		m.cfgMu.RLock()

--- a/agent/hcp/manager_test.go
+++ b/agent/hcp/manager_test.go
@@ -22,12 +22,18 @@ func TestManager_Run(t *testing.T) {
 	statusF := func(ctx context.Context) (hcpclient.ServerStatus, error) {
 		return hcpclient.ServerStatus{ID: t.Name()}, nil
 	}
+	initializeManagementTokenFCalled := false
+	initializeManagementTokenF := func(name, secretID string) error {
+		initializeManagementTokenFCalled = true
+		return nil
+	}
 	updateCh := make(chan struct{}, 1)
 	client.EXPECT().PushServerStatus(mock.Anything, &hcpclient.ServerStatus{ID: t.Name()}).Return(nil).Once()
 
 	cloudCfg := config.CloudConfig{
-		ResourceID: "organization/85702e73-8a3d-47dc-291c-379b783c5804/project/8c0547c0-10e8-1ea2-dffe-384bee8da634/hashicorp.consul.global-network-manager.cluster/test",
-		NodeID:     "node-1",
+		ResourceID:      "organization/85702e73-8a3d-47dc-291c-379b783c5804/project/8c0547c0-10e8-1ea2-dffe-384bee8da634/hashicorp.consul.global-network-manager.cluster/test",
+		NodeID:          "node-1",
+		ManagementToken: "fake-token",
 	}
 	scadaM := scada.NewMockProvider(t)
 	scadaM.EXPECT().UpdateHCPConfig(cloudCfg).Return(nil)
@@ -52,12 +58,13 @@ func TestManager_Run(t *testing.T) {
 		mockTelemetryCfg, nil).Maybe()
 
 	mgr := NewManager(ManagerConfig{
-		Client:            client,
-		Logger:            hclog.New(&hclog.LoggerOptions{Output: io.Discard}),
-		StatusFn:          statusF,
-		CloudConfig:       cloudCfg,
-		SCADAProvider:     scadaM,
-		TelemetryProvider: telemetryProvider,
+		Client:                      client,
+		Logger:                      hclog.New(&hclog.LoggerOptions{Output: io.Discard}),
+		StatusFn:                    statusF,
+		InitializeManagementTokenFn: initializeManagementTokenF,
+		CloudConfig:                 cloudCfg,
+		SCADAProvider:               scadaM,
+		TelemetryProvider:           telemetryProvider,
 	})
 	mgr.testUpdateSent = updateCh
 	ctx, cancel := context.WithCancel(context.Background())
@@ -76,6 +83,7 @@ func TestManager_Run(t *testing.T) {
 	require.Equal(t, client, telemetryProvider.hcpClient)
 	require.NotNil(t, telemetryProvider.GetHeader())
 	require.NotNil(t, telemetryProvider.GetHTTPClient())
+	require.True(t, initializeManagementTokenFCalled, "Initialize management token function not called")
 }
 
 func TestManager_SendUpdate(t *testing.T) {

--- a/agent/hcp/manager_test.go
+++ b/agent/hcp/manager_test.go
@@ -22,9 +22,9 @@ func TestManager_Run(t *testing.T) {
 	statusF := func(ctx context.Context) (hcpclient.ServerStatus, error) {
 		return hcpclient.ServerStatus{ID: t.Name()}, nil
 	}
-	upsertManagementTokenCalled := false
+	upsertManagementTokenCalled := make(chan struct{}, 1)
 	upsertManagementTokenF := func(name, secretID string) error {
-		upsertManagementTokenCalled = true
+		upsertManagementTokenCalled <- struct{}{}
 		return nil
 	}
 	updateCh := make(chan struct{}, 1)
@@ -83,7 +83,7 @@ func TestManager_Run(t *testing.T) {
 	require.Equal(t, client, telemetryProvider.hcpClient)
 	require.NotNil(t, telemetryProvider.GetHeader())
 	require.NotNil(t, telemetryProvider.GetHTTPClient())
-	require.True(t, upsertManagementTokenCalled, "upsert management token function not called")
+	require.NotEmpty(t, upsertManagementTokenCalled, "upsert management token function not called")
 }
 
 func TestManager_SendUpdate(t *testing.T) {


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Jira: https://hashicorp.atlassian.net/browse/CC-7043

Previously, the HCP management token was only created when Consul starts up and when there is a leadership change. This was sufficient because the HCP token could not change at runtime.

The Link API will allow users to link to HCP using an API call at runtime. This PR makes it so the HCP management token will also be upserted when the HCP manager runs, which is one part of making it possible to link the cluster to HCP at runtime.

#### Question/concern about timing of ACL initialization

As I mention in a comment below, depending on where I placed this code, I could trigger an error message like: `node is not the leader`. I believe this error is mitigated by running this code inside the main loop of the HCP manager— in the worst case, if this call fails, it will be retried the next time through the loop.

Furthermore, an iteration through the loop will be triggered on any changes to node leadership by the following code: https://github.com/hashicorp/consul/blob/db46b7a12d39659d5e77d133b28b14dc1ab1bfe3/agent/consul/server.go#L2261. This means that any time a node becomes a leader, an update will be triggered and we will make an attempt to initialize the HCP management token.

This feels a bit complicated so please let me know if there's a better way to approach this.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
1. Updated HCP manager unit test to ensure management token function is called.
2. Manually ran Consul cluster and verified GNM was able to make authenticated requests to retrieve catalog:
```
...
2024-01-11T16:18:30.180-0500 [DEBUG] agent.http: Request finished: method=GET url=/v1/internal/ui/catalog-overview from=52.22.119.116:7224 latency=2.436791ms
...
```
and also manually verified the token is there:
```
➜  consul git:(nickcellino/hcp-mgmt-token) consul acl token list
AccessorID:       b31b2654-a59c-6b27-ab62-5765fd39a3f2
SecretID:         <redacted>
Description:      HCP Management Token
Local:            false
Create Time:      2024-01-12 13:28:22.834929 -0500 EST
Policies:
   00000000-0000-0000-0000-000000000001 - global-management

AccessorID:       00000000-0000-0000-0000-000000000002
SecretID:         anonymous
Description:      Anonymous Token
Local:            false
Create Time:      2024-01-12 13:28:22.803764 -0500 EST

AccessorID:       1bb1f71c-7bf9-02f5-0f7f-0bd91662094e
SecretID:         <redacted>
Description:      Initial Management Token
Local:            false
Create Time:      2024-01-12 13:28:22.803622 -0500 EST
Policies:
   00000000-0000-0000-0000-000000000001 - global-management
```

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
