### PR TITLE
ci: fix escaping for Slack failure notifications

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -513,7 +513,7 @@ jobs:
           if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure)\"'; then
             printf "Tests failed, notifying Slack"
             echo "FAILED_TESTS=true" >> $GITHUB_ENV
-            echo "COMMIT_MESSAGE_SUMMARY=$(echo ${{ github.event.head_commit.message }} | head -n 1)" >> $GITHUB_ENV
+            echo "COMMIT_MESSAGE_SUMMARY=$(echo '${{ github.event.head_commit.message }}' | head -n 1)" >> $GITHUB_ENV
           fi
       - name: Notify Slack
         # failure() ensures this runs even if the test eval step exits 1


### PR DESCRIPTION
Allow '()', '#', and other bash-interpretable special characters by properly quoting the commit message when shortening.

Follow-up to https://github.com/hashicorp/consul/pull/19766.

I will plan to batch this fix with the previous notification changes when backporting.

### Description

Previously, these characters would cause a parsing failure, leading to a blank message: 
```shell-session
bash-3.2$ echo "COMMIT_MESSAGE_SUMMARY=$(echo Merge pull request #123 from blah/blah/blah
>
>    [main] words (334de14) | head -n 1)"
bash: command substitution: line 3: syntax error near unexpected token `('
bash: command substitution: line 3: `   [main] words (334de14) | head -n 1'
COMMIT_MESSAGE_SUMMARY=Merge pull request
```
![image](https://github.com/hashicorp/consul/assets/2141941/742fbea5-c91b-4058-899b-65ba7739ab9b)

With fix (tested in separate channel):
```shell-session
bash-3.2$ echo "COMMIT_MESSAGE_SUMMARY=$(echo 'Merge pull request #123 from blah/blah/blah
>
>    [main] words (334de14)' | head -n 1)"
COMMIT_MESSAGE_SUMMARY=Merge pull request #123 from blah/blah/blah
```
![image](https://github.com/hashicorp/consul/assets/2141941/5edd207f-67d8-4f4e-aca8-a3e2a42ab756)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
