### PR TITLE
[NET-6650] Bump go version to 1.20.12

### DIFF
--- a/.changelog/19840.txt
+++ b/.changelog/19840.txt
@@ -1,0 +1,7 @@
+```release-note:security
+Upgrade to use Go 1.20.12. This resolves CVEs
+[CVE-2023-45283](https://nvd.nist.gov/vuln/detail/CVE-2023-45283): (`path/filepath`) recognize \??\ as a Root Local Device path prefix (Windows)
+[CVE-2023-45284](https://nvd.nist.gov/vuln/detail/CVE-2023-45285): recognize device names with trailing spaces and superscripts (Windows)
+[CVE-2023-39326](https://nvd.nist.gov/vuln/detail/CVE-2023-39326): (`net/http`) limit chunked data overhead
+[CVE-2023-45285](https://nvd.nist.gov/vuln/detail/CVE-2023-45285): (`cmd/go`) go get may unexpectedly fallback to insecure git 
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,15 +86,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.20.10", goos: "linux", goarch: "386"}
-          - {go: "1.20.10", goos: "linux", goarch: "amd64"}
-          - {go: "1.20.10", goos: "linux", goarch: "arm"}
-          - {go: "1.20.10", goos: "linux", goarch: "arm64"}
-          - {go: "1.20.10", goos: "freebsd", goarch: "386"}
-          - {go: "1.20.10", goos: "freebsd", goarch: "amd64"}
-          - {go: "1.20.10", goos: "windows", goarch: "386"}
-          - {go: "1.20.10", goos: "windows", goarch: "amd64"}
-          - {go: "1.20.10", goos: "solaris", goarch: "amd64"}
+          - {go: "1.20.12", goos: "linux", goarch: "386"}
+          - {go: "1.20.12", goos: "linux", goarch: "amd64"}
+          - {go: "1.20.12", goos: "linux", goarch: "arm"}
+          - {go: "1.20.12", goos: "linux", goarch: "arm64"}
+          - {go: "1.20.12", goos: "freebsd", goarch: "386"}
+          - {go: "1.20.12", goos: "freebsd", goarch: "amd64"}
+          - {go: "1.20.12", goos: "windows", goarch: "386"}
+          - {go: "1.20.12", goos: "windows", goarch: "amd64"}
+          - {go: "1.20.12", goos: "solaris", goarch: "amd64"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -183,7 +183,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.20.10", goos: "linux", goarch: "s390x"}
+          - {go: "1.20.12", goos: "linux", goarch: "s390x"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -234,7 +234,7 @@ jobs:
       matrix:
         goos: [ darwin ]
         goarch: [ "amd64", "arm64" ]
-        go: [ "1.20.10" ]
+        go: [ "1.20.12" ]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-ARG GOLANG_VERSION=1.20.10
+ARG GOLANG_VERSION=1.20.12
 FROM golang:${GOLANG_VERSION}
 
 WORKDIR /consul


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
- Bump go version to `1.20.12` to fix various cves

- CVE-2023-45283: path/filepath: recognize \??\ as a Root Local Device path prefix (Windows)
- CVE-2023-45284: recognize device names with trailing spaces and superscripts (Windows)
- CVE-2023-39326: net/http: limit chunked data overhead
- CVE-2023-45285: cmd/go: go get may unexpectedly fallback to insecure git 