### PR TITLE
Backport/stats flush interval 1.15.x

### DIFF
--- a/.changelog/19663.txt
+++ b/.changelog/19663.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Default `stats_flush_interval` to 60 seconds when using the Consul Telemetry Collector, unless custom stats sink are present or an explicit flush interval is configured.
+```

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -248,6 +248,11 @@ func (c *BootstrapConfig) ConfigureArgs(args *BootstrapTplArgs, omitDeprecatedTa
 
 	// Setup telemetry collector if needed. This MUST happen after the Static*JSON is set above
 	if c.TelemetryCollectorBindSocketDir != "" {
+		// Override StatsFlushInterval as 60 seconds (1 minute) to reduce number of metric flushes.
+		// Only perform this override if there is no custom configuration for stats sinks and flush interval.
+		if c.StatsFlushInterval == "" && args.StatsSinksJSON == "" {
+			args.StatsFlushInterval = "60s"
+		}
 		appendTelemetryCollectorConfig(args, c.TelemetryCollectorBindSocketDir)
 	}
 

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -2,6 +2,7 @@ package envoy
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -625,46 +626,49 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 				TelemetryCollectorBindSocketDir: "/tmp/consul/telemetry-collector",
 			},
 			wantArgs: BootstrapTplArgs{
-				ProxyID:         "web-sidecar-proxy",
-				StatsConfigJSON: defaultStatsConfigJSON,
-				StatsSinksJSON: `{
-					"name": "envoy.stat_sinks.metrics_service",
-					"typed_config": {
-					  "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
-					  "transport_api_version": "V3",
-					  "grpc_service": {
-						"envoy_grpc": {
-						  "cluster_name": "consul_telemetry_collector_loopback"
-						}
-					  },
-					  "emit_tags_as_labels": true
-					}
-				  }`,
-				StaticClustersJSON: `{
-					"name": "consul_telemetry_collector_loopback",
-					"type": "STATIC",
-					"http2_protocol_options": {},
-					"loadAssignment": {
-					  "clusterName": "consul_telemetry_collector_loopback",
-					  "endpoints": [
-						{
-						  "lbEndpoints": [
-							{
-							  "endpoint": {
-								"address": {
-								  "pipe": {
-									"path": "/tmp/consul/telemetry-collector/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock"
-								  }
-								}
-							  }
-							}
-						  ]
-						}
-					  ]
-					}
-				  }`,
+				StatsFlushInterval: "60s",
+				ProxyID:            "web-sidecar-proxy",
+				StatsConfigJSON:    defaultStatsConfigJSON,
+				StatsSinksJSON:     expectedTelemetryCollectorStatsSink,
+				StaticClustersJSON: expectedTelemetryCollectorCluster,
 			},
 			wantErr: false,
+		},
+		{
+			name: "telemetry-collector-no-default-flush-interval-when-interval-preconfigured",
+			baseArgs: BootstrapTplArgs{
+				ProxyID: "web-sidecar-proxy",
+			},
+			input: BootstrapConfig{
+				// Explicitly defined StatsFlushInterval by end user should not be overriden.
+				StatsFlushInterval:              "10s",
+				TelemetryCollectorBindSocketDir: "/tmp/consul/telemetry-collector",
+			},
+			wantArgs: BootstrapTplArgs{
+				StatsFlushInterval: "10s",
+				ProxyID:            "web-sidecar-proxy",
+				StatsConfigJSON:    defaultStatsConfigJSON,
+				StatsSinksJSON:     expectedTelemetryCollectorStatsSink,
+				StaticClustersJSON: expectedTelemetryCollectorCluster,
+			},
+		},
+		{
+			name: "telemetry-collector-no-default-flush-interval-when-sinks-preconfigured",
+			baseArgs: BootstrapTplArgs{
+				ProxyID: "web-sidecar-proxy",
+			},
+			input: BootstrapConfig{
+				// If stats sinks are explicitly defined by end user, do not default StatsFlushInterval.
+				StatsdURL:                       "udp://127.0.0.1:9125",
+				TelemetryCollectorBindSocketDir: "/tmp/consul/telemetry-collector",
+			},
+			wantArgs: BootstrapTplArgs{
+				StatsFlushInterval: "",
+				ProxyID:            "web-sidecar-proxy",
+				StatsConfigJSON:    defaultStatsConfigJSON,
+				StatsSinksJSON:     fmt.Sprintf(`%s,%s`, expectedStatsdSink, expectedTelemetryCollectorStatsSink),
+				StaticClustersJSON: expectedTelemetryCollectorCluster,
+			},
 		},
 		{
 			name: "simple-statsd-sink",

--- a/command/connect/envoy/testdata/telemetry-collector.golden
+++ b/command/connect/envoy/testdata/telemetry-collector.golden
@@ -219,6 +219,7 @@
     ],
     "use_all_default_tags": true
   },
+  "stats_flush_interval": "60s",
   "dynamic_resources": {
     "lds_config": {
       "ads": {},

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -193,7 +193,8 @@ the [`sidecar_service`](/consul/docs/connect/registration/sidecar-service) block
 - `envoy_telemetry_collector_bind_socket_dir` - Specifies the directory where Envoy creates a Unix socket.
   Envoy sends metrics to the socket where a Consul telemetry collector can collect them.
   The socket is not configured by default.
-  
+  Enabling this sets Envoy's [`stats_flush_interval`](https://www.envoyproxy.io/docs/envoy/v1.17.2/api-v3/config/bootstrap/v3/bootstrap.proto#envoy-v3-api-field-config-bootstrap-v3-bootstrap-stats-flush-interval) to one minute if `envoy_stats_flush_interval` is unset and if no other stats sinks are configured, like `envoy_dogstats_url`, for instance.
+
 The [Advanced Configuration](#advanced-configuration) section describes additional configurations that allow incremental or complete control over the bootstrap configuration generated.
 
 ### Bootstrap Envoy on Windows VMs


### PR DESCRIPTION
### Description

Backport of https://github.com/hashicorp/consul/pull/19663

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
