### PR TITLE
Ensure that the default namespace always exists even prior to resource creation

### DIFF
--- a/internal/tenancy/internal/bridge/tenancy_bridge.go
+++ b/internal/tenancy/internal/bridge/tenancy_bridge.go
@@ -33,6 +33,13 @@ func NewV2TenancyBridge() *V2TenancyBridge {
 }
 
 func (b *V2TenancyBridge) NamespaceExists(partition, namespace string) (bool, error) {
+	if namespace == resource.DefaultNamespaceName {
+		// The default namespace implicitly exists in all partitions regardless of whether
+		// the resource has actually been created yet. Therefore all we need to do is check
+		// if the partition exists to know whether the namespace exists.
+		return b.PartitionExists(partition)
+	}
+
 	_, err := b.client.Read(context.Background(), &pbresource.ReadRequest{
 		Id: &pbresource.ID{
 			Name: namespace,

--- a/internal/tenancy/internal/bridge/tenancy_bridge_ce.go
+++ b/internal/tenancy/internal/bridge/tenancy_bridge_ce.go
@@ -5,8 +5,12 @@
 
 package bridge
 
+import "github.com/hashicorp/consul/internal/resource"
+
 func (b *V2TenancyBridge) PartitionExists(partition string) (bool, error) {
-	if partition == "default" {
+	if partition == resource.DefaultPartitionName {
+		// In CE partition resources are never actually created. However, conceptually
+		// the default partition always exists.
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
### Description

I was running into some flakey integration tests where I was getting partition or namespace not found errors. It turns out that the integration tests were attempting resource writes prior to the creation of the v2 partition/namespace resources. 

This PR fixes that so that the default namespace always exists so that writes into the default namespace are successful even before we create the resource.

### Testing & Reproduction steps

Existing flakey tests pass.
