### PR TITLE
Fix a test flake where a retry timer was being reused causing tests after the first to exit early

### DIFF
--- a/test/integration/consul-container/test/gateways/terminating_gateway_test.go
+++ b/test/integration/consul-container/test/gateways/terminating_gateway_test.go
@@ -22,7 +22,9 @@ import (
 
 const externalServerName = libservice.StaticServerServiceName
 
-var requestRetryTimer = &retry.Timer{Timeout: 120 * time.Second, Wait: 500 * time.Millisecond}
+func requestRetryTimer() *retry.Timer {
+	return &retry.Timer{Timeout: 120 * time.Second, Wait: 500 * time.Millisecond}
+}
 
 // TestTerminatingGateway Summary
 // This test makes sure an external service can be reached via and terminating gateway. External server
@@ -171,7 +173,7 @@ func createTerminatingGatewayConfigEntry(t *testing.T, consulClient *api.Client,
 // in the response.
 func assertHTTPRequestToServiceAddress(t *testing.T, client *libservice.ConnectContainer, serviceName string, port int, expSuccess bool) {
 	upstreamURL := fmt.Sprintf("http://localhost:%d/debug?env=dump", port)
-	retry.RunWith(requestRetryTimer, t, func(r *retry.R) {
+	retry.RunWith(requestRetryTimer(), t, func(r *retry.R) {
 		out, err := client.Exec(context.Background(), []string{"curl", "-s", upstreamURL})
 		r.Logf("curl request to upstream service address: url=%s\nerr = %v\nout = %s", upstreamURL, err, out)
 


### PR DESCRIPTION

### Description

TLDR `retry.Timer` types cannot be reused.

### Testing & Reproduction steps

Fixed the flakes