### PR TITLE
Fix xDS missing endpoint race condition.

### DIFF
--- a/.changelog/19866.txt
+++ b/.changelog/19866.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: ensure child resources are re-sent to Envoy when the parent is updated even if the child already has pending updates.
+```


### PR DESCRIPTION
The following PR is mostly a clone of work done by @ksmiley with some minor tweaks. I would like to thank him for tracking down and describing this complicated situation in such great detail. His work is greatly appreciated.

See the following issues for more context:

https://github.com/hashicorp/consul/issues/17640
https://github.com/hashicorp/consul/pull/17641

This fixes the following race condition:
- Send update endpoints
- Send update cluster
- Recv ACK endpoints
- Recv ACK cluster

Prior to this fix, it would have resulted in the endpoints NOT existing in Envoy. This occurred because the cluster update implicitly clears the endpoints in Envoy, but we would never re-send the endpoint data to compensate for the loss, because we would incorrectly ACK the invalid old endpoint hash. Since the endpoint's hash did not actually change, they would not be resent.

The fix for this is to effectively clear out the invalid pending ACKs for child resources whenever the parent changes. This ensures that we do not store the child's hash as accepted when the race occurs.

An escape-hatch environment variable `XDS_PROTOCOL_LEGACY_CHILD_RESEND` was added so that users can revert back to the old legacy behavior in the event that this produces unknown side-effects. Visit the following thread for some extra context on why certainty around these race conditions is difficult: https://github.com/envoyproxy/envoy/issues/13009