### PR TITLE
[Backport 1.17.x] Add CE version of Gateway Upstream Disambiguation

### DIFF
--- a/.changelog/19860.txt
+++ b/.changelog/19860.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Solves an issue where two upstream services with the same name in different namespaces were not getting routed to correctly by API Gateways.
+```

--- a/agent/consul/discoverychain/gateway.go
+++ b/agent/consul/discoverychain/gateway.go
@@ -257,7 +257,7 @@ func targetForResolverNode(nodeName string, chains []*structs.CompiledDiscoveryC
 	splitterName := splitterPrefix + strings.TrimPrefix(nodeName, resolverPrefix)
 
 	for _, c := range chains {
-		targetChainPrefix := resolverPrefix + c.ServiceName + "."
+		targetChainPrefix := resolverPrefix + c.ID()
 		if strings.HasPrefix(nodeName, targetChainPrefix) && len(c.Nodes) == 1 {
 			// we have a virtual resolver that just maps to another resolver, return
 			// the given node name

--- a/agent/consul/discoverychain/gateway_test.go
+++ b/agent/consul/discoverychain/gateway_test.go
@@ -712,6 +712,7 @@ func TestGatewayChainSynthesizer_Synthesize(t *testing.T) {
 			chain: &structs.CompiledDiscoveryChain{
 				ServiceName: "foo",
 				Namespace:   "default",
+				Partition:   "default",
 				Datacenter:  "dc1",
 				StartNode:   "resolver:foo-2.default.default.dc2",
 				Nodes: map[string]*structs.DiscoveryGraphNode{


### PR DESCRIPTION
## Backport

This PR is manually generated from #19860.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern


---

<details>
<summary> Overview of commits </summary>

  - de7befcd2a12b372b2a0cffde65b9a48b9efe415  - 0167d726a3c7b7d7d216fac4644732e6eaf166f8  - 92f85aeb239a59ca0f4823b02a2bbb0ded51bede  - 3913d5df716fd898607edcd9997b98857ca4cd8c  - b9a4b7b2386f74085640bbd548241a4ce2beb220 

</details>


