### PR TITLE
[NET-5772] Make tcp external service registered on terminating gw reachable from peered cluster

### DIFF
--- a/.changelog/19881.txt
+++ b/.changelog/19881.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: Make TCP external service registered with terminating gateway reachable from peered cluster
+```

--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/hashicorp/consul/agent/xds/testcommon"
 	"github.com/hashicorp/consul/agent/xdsv2"
 	"github.com/hashicorp/consul/envoyextensions/xdscommon"
-	"github.com/hashicorp/consul/proto/private/pbpeering"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/types"
 )
@@ -2281,32 +2280,25 @@ func getTerminatingGatewayPeeringGoldenTestCases() []goldenTestCase {
 		{
 			name: "terminating-gateway-with-peer-trust-bundle",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				roots, _ := proxycfg.TestCerts(t)
+				bundles := proxycfg.TestPeerTrustBundles(t)
 				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "peer-trust-bundle:web",
-						Result: &pbpeering.TrustBundleListByServiceResponse{
-							Bundles: []*pbpeering.PeeringTrustBundle{
-								{
-									TrustDomain: "foo.bar.gov",
-									PeerName:    "dc2",
-									Partition:   "default",
-									RootPEMs: []string{
-										roots.Roots[0].RootCert,
-									},
-									ExportedPartition: "default",
-									CreateIndex:       0,
-									ModifyIndex:       0,
-								},
-							},
-						},
+						Result:        bundles,
 					},
 					{
 						CorrelationID: "service-intentions:web",
 						Result: structs.SimplifiedIntentions{
 							{
 								SourceName:           "source",
-								SourcePeer:           "dc2",
+								SourcePeer:           bundles.Bundles[0].PeerName,
+								DestinationName:      "web",
+								DestinationPartition: "default",
+								Action:               structs.IntentionActionAllow,
+							},
+							{
+								SourceName:           "source",
+								SourcePeer:           bundles.Bundles[1].PeerName,
 								DestinationName:      "web",
 								DestinationPartition: "default",
 								Action:               structs.IntentionActionAllow,

--- a/agent/xds/testdata/listeners/terminating-gateway-with-peer-trust-bundle.latest.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-with-peer-trust-bundle.latest.golden
@@ -163,7 +163,8 @@
         {
           "filterChainMatch": {
             "serverNames": [
-              "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+              "web.default.default.dc2.external.11111111-2222-3333-4444-555555555555.consul"
             ]
           },
           "filters": [
@@ -222,8 +223,25 @@
                 ],
                 "tlsParams": {},
                 "validationContext": {
-                  "trustedCa": {
-                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  "customValidatorConfig": {
+                    "name": "envoy.tls.cert_validator.spiffe",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig",
+                      "trustDomains": [
+                        {
+                          "name": "11111111-2222-3333-4444-555555555555.consul",
+                          "trustBundle": {
+                            "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                          }
+                        },
+                        {
+                          "name": "foo.bar.gov",
+                          "trustBundle": {
+                            "inlineString": "-----BEGIN CERTIFICATE-----\nMIIB4DCCAYagAwIBAgIIJRydRWIBZ/0wCgYIKoZIzj0EAwIwFjEUMBIGA1UEAxML\nVGVzdCBDQSAzNDEwHhcNMjQwMjA4MTYxMDI4WhcNMzQwMjA4MTYxMDI4WjAWMRQw\nEgYDVQQDEwtUZXN0IENBIDM0MTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPhl\newcSudWYzKuobsiXUwsHc4PuzmDEKWqRF0RRCkKPnZfui3gLMKR6a9F2fYTmx9Ba\n+C7dCTq9Iqo9MDBNfFejgb0wgbowDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQF\nMAMBAf8wKQYDVR0OBCIEIH3eL4bcaHvbHYoNlU4YsqHSRSqLIbolaLzbgSbyKlpY\nMCsGA1UdIwQkMCKAIH3eL4bcaHvbHYoNlU4YsqHSRSqLIbolaLzbgSbyKlpYMD8G\nA1UdEQQ4MDaGNHNwaWZmZTovLzExMTExMTExLTIyMjItMzMzMy00NDQ0LTU1NTU1\nNTU1NTU1NS5jb25zdWwwCgYIKoZIzj0EAwIDSAAwRQIgDZiUOpWgVjYjGp8mkXmx\n8hJkB7sumvk6pw+zY4S4omsCIQD1VIaJe88Uo3yoP8a6LYORDlU5d8VcLqmdNggd\neWNHUA==\n-----END CERTIFICATE-----\n"
+                          }
+                        }
+                      ]
+                    }
                   }
                 }
               },

--- a/agent/xds/testdata/listeners/terminating-gateway-with-peer-trust-bundle.latest.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-with-peer-trust-bundle.latest.golden
@@ -164,7 +164,8 @@
           "filterChainMatch": {
             "serverNames": [
               "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-              "web.default.default.dc2.external.11111111-2222-3333-4444-555555555555.consul"
+              "web.default.default.peer-a.external.11111111-2222-3333-4444-555555555555.consul",
+              "web.default.default.peer-b.external.11111111-2222-3333-4444-555555555555.consul"
             ]
           },
           "filters": [
@@ -185,7 +186,16 @@
                           "authenticated": {
                             "principalName": {
                               "safeRegex": {
-                                "regex": "^spiffe://foo.bar.gov/ns/default/dc/[^/]+/svc/source$"
+                                "regex": "^spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/[^/]+/svc/source$"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "authenticated": {
+                            "principalName": {
+                              "safeRegex": {
+                                "regex": "^spiffe://d89ac423-e95a-475d-94f2-1c557c57bf31.consul/ns/default/dc/[^/]+/svc/source$"
                               }
                             }
                           }
@@ -235,9 +245,15 @@
                           }
                         },
                         {
-                          "name": "foo.bar.gov",
+                          "name": "1c053652-8512-4373-90cf-5a7f6263a994.consul",
                           "trustBundle": {
-                            "inlineString": "-----BEGIN CERTIFICATE-----\nMIIB4DCCAYagAwIBAgIIJRydRWIBZ/0wCgYIKoZIzj0EAwIwFjEUMBIGA1UEAxML\nVGVzdCBDQSAzNDEwHhcNMjQwMjA4MTYxMDI4WhcNMzQwMjA4MTYxMDI4WjAWMRQw\nEgYDVQQDEwtUZXN0IENBIDM0MTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPhl\newcSudWYzKuobsiXUwsHc4PuzmDEKWqRF0RRCkKPnZfui3gLMKR6a9F2fYTmx9Ba\n+C7dCTq9Iqo9MDBNfFejgb0wgbowDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQF\nMAMBAf8wKQYDVR0OBCIEIH3eL4bcaHvbHYoNlU4YsqHSRSqLIbolaLzbgSbyKlpY\nMCsGA1UdIwQkMCKAIH3eL4bcaHvbHYoNlU4YsqHSRSqLIbolaLzbgSbyKlpYMD8G\nA1UdEQQ4MDaGNHNwaWZmZTovLzExMTExMTExLTIyMjItMzMzMy00NDQ0LTU1NTU1\nNTU1NTU1NS5jb25zdWwwCgYIKoZIzj0EAwIDSAAwRQIgDZiUOpWgVjYjGp8mkXmx\n8hJkB7sumvk6pw+zY4S4omsCIQD1VIaJe88Uo3yoP8a6LYORDlU5d8VcLqmdNggd\neWNHUA==\n-----END CERTIFICATE-----\n"
+                            "inlineString": "-----BEGIN CERTIFICATE-----\nMIICczCCAdwCCQC3BLnEmLCrSjANBgkqhkiG9w0BAQsFADB+MQswCQYDVQQGEwJV\nUzELMAkGA1UECAwCQVoxEjAQBgNVBAcMCUZsYWdzdGFmZjEMMAoGA1UECgwDRm9v\nMRAwDgYDVQQLDAdleGFtcGxlMQ8wDQYDVQQDDAZwZWVyLWExHTAbBgkqhkiG9w0B\nCQEWDmZvb0BwZWVyLWEuY29tMB4XDTIyMDUyNjAxMDQ0NFoXDTIzMDUyNjAxMDQ0\nNFowfjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkFaMRIwEAYDVQQHDAlGbGFnc3Rh\nZmYxDDAKBgNVBAoMA0ZvbzEQMA4GA1UECwwHZXhhbXBsZTEPMA0GA1UEAwwGcGVl\nci1hMR0wGwYJKoZIhvcNAQkBFg5mb29AcGVlci1hLmNvbTCBnzANBgkqhkiG9w0B\nAQEFAAOBjQAwgYkCgYEA2zFYGTbXDAntT5pLTpZ2+VTiqx4J63VRJH1kdu11f0FV\nc2jl1pqCuYDbQXknDU0Pv1Q5y0+nSAihD2KqGS571r+vHQiPtKYPYRqPEe9FzAhR\n2KhWH6v/tk5DG1HqOjV9/zWRKB12gdFNZZqnw/e7NjLNq3wZ2UAwxXip5uJ8uwMC\nAwEAATANBgkqhkiG9w0BAQsFAAOBgQC/CJ9Syf4aL91wZizKTejwouRYoWv4gRAk\nyto45ZcNMHfJ0G2z+XAMl9ZbQsLgXmzAx4IM6y5Jckq8pKC4PEijCjlKTktLHlEy\n0ggmFxtNB1tid2NC8dOzcQ3l45+gDjDqdILhAvLDjlAIebdkqVqb2CfFNW/I2CQH\nZAuKN1aoKA==\n-----END CERTIFICATE-----\n"
+                          }
+                        },
+                        {
+                          "name": "d89ac423-e95a-475d-94f2-1c557c57bf31.consul",
+                          "trustBundle": {
+                            "inlineString": "-----BEGIN CERTIFICATE-----\nMIICcTCCAdoCCQDyGxC08cD0BDANBgkqhkiG9w0BAQsFADB9MQswCQYDVQQGEwJV\nUzELMAkGA1UECAwCQ0ExETAPBgNVBAcMCENhcmxzYmFkMQwwCgYDVQQKDANGb28x\nEDAOBgNVBAsMB2V4YW1wbGUxDzANBgNVBAMMBnBlZXItYjEdMBsGCSqGSIb3DQEJ\nARYOZm9vQHBlZXItYi5jb20wHhcNMjIwNTI2MDExNjE2WhcNMjMwNTI2MDExNjE2\nWjB9MQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExETAPBgNVBAcMCENhcmxzYmFk\nMQwwCgYDVQQKDANGb28xEDAOBgNVBAsMB2V4YW1wbGUxDzANBgNVBAMMBnBlZXIt\nYjEdMBsGCSqGSIb3DQEJARYOZm9vQHBlZXItYi5jb20wgZ8wDQYJKoZIhvcNAQEB\nBQADgY0AMIGJAoGBAL4i5erdZ5vKk3mzW9Qt6Wvw/WN/IpMDlL0a28wz9oDCtMLN\ncD/XQB9yT5jUwb2s4mD1lCDZtee8MHeD8zygICozufWVB+u2KvMaoA50T9GMQD0E\nz/0nz/Z703I4q13VHeTpltmEpYcfxw/7nJ3leKA34+Nj3zteJ70iqvD/TNBBAgMB\nAAEwDQYJKoZIhvcNAQELBQADgYEAbL04gicH+EIznDNhZJEb1guMBtBBJ8kujPyU\nao8xhlUuorDTLwhLpkKsOhD8619oSS8KynjEBichidQRkwxIaze0a2mrGT+tGBMf\npVz6UeCkqpde6bSJ/ozEe/2seQzKqYvRT1oUjLwYvY7OIh2DzYibOAxh6fewYAmU\n5j5qNLc=\n-----END CERTIFICATE-----\n"
                           }
                         }
                       ]


### PR DESCRIPTION
> [!NOTE]
> This is a followup to #18959 which fixed the same problem specifically when using `http` protocol.

### Description

<!-- Please describe why you're making this change, in plain English. -->

The terminating gateways needs to be able to handle TCP connections from peers which are not TLS-terminated at the local mesh gateway. This amounts to including the target SNI that downstreams from peers would use when building the TLS context for the terminating gateway.

<details>
<summary>Filter chain match before this change</summary>

```yaml
filter_chain_match: {
  server_names: [
    "destination.default.dc2.internal.b81d6ee2-8454-768e-0a06-38a62620f76a.consul"
  ]
}
```
</details>

<details>
<summary>Filter chain match after this change</summary>

```yaml
filter_chain_match: {
  server_names: [
    "destination.default.dc2.internal.b81d6ee2-8454-768e-0a06-38a62620f76a.consul",
    "destination.default.default.dc1.external.b81d6ee2-8454-768e-0a06-38a62620f76a.consul"
  ]
}
```
</details>

### Testing & Reproduction steps
You can test this fix using the setup [here](https://github.com/nathancoleman/consul-lab/blob/main/k8s/terminating-gateway/multi-cluster/README.md), changing the `<ServiceDefaults>.spec.protocol` as necessary in `resources/dc2/external-service.yaml` if you want to see the behavior for `http` services as well.

You will need to pin a build of this branch as `global.image` in `values-dc2.yaml`. I would recommend doing an install without this build to witness things in their current broken state, and then doing a `helm upgrade` with `global.image` set.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
