### PR TITLE
[NET-6842] splitting go version on different lines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,15 +86,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.20.12", goos: "linux", goarch: "386"}
-          - {go: "1.20.12", goos: "linux", goarch: "amd64"}
-          - {go: "1.20.12", goos: "linux", goarch: "arm"}
-          - {go: "1.20.12", goos: "linux", goarch: "arm64"}
-          - {go: "1.20.12", goos: "freebsd", goarch: "386"}
-          - {go: "1.20.12", goos: "freebsd", goarch: "amd64"}
-          - {go: "1.20.12", goos: "windows", goarch: "386"}
-          - {go: "1.20.12", goos: "windows", goarch: "amd64"}
-          - {go: "1.20.12", goos: "solaris", goarch: "amd64"}
+          - {go: "1.20.12",
+            goos: "linux", goarch: "386"}
+          - {go: "1.20.12",
+            goos: "linux", goarch: "amd64"}
+          - {go: "1.20.12",
+            goos: "linux", goarch: "arm"}
+          - {go: "1.20.12",
+            goos: "linux", goarch: "arm64"}
+          - {go: "1.20.12", 
+            goos: "freebsd", goarch: "386"}
+          - {go: "1.20.12",
+            goos: "freebsd", goarch: "amd64"}
+          - {go: "1.20.12", 
+            goos: "windows", goarch: "386"}
+          - {go: "1.20.12",
+            goos: "windows", goarch: "amd64"}
+          - {go: "1.20.12",
+            goos: "solaris", goarch: "amd64"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -183,7 +192,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.20.12", goos: "linux", goarch: "s390x"}
+          - {go: "1.20.12",
+            goos: "linux", goarch: "s390x"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

- Fixing CE to ent merge conflicts moving forward by separating go version to a separate line for smoother go version bumps


