### PR TITLE
[NET-6899] Create name-aligned Service when reconciling MeshGateway resource

### DIFF
--- a/internal/mesh/internal/controllers/meshgateways/controller.go
+++ b/internal/mesh/internal/controllers/meshgateways/controller.go
@@ -40,6 +40,17 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 			// TODO(nathancoleman) Fetch the MeshGateway and use WorkloadSelector from there
 			Prefixes: []string{req.ID.Name},
 		},
+		Ports: []*pbcatalog.ServicePort{
+			{
+				Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
+				TargetPort:  "wan",
+				VirtualPort: 8443,
+			},
+			{
+				Protocol:   pbcatalog.Protocol_PROTOCOL_MESH,
+				TargetPort: "mesh",
+			},
+		},
 	}
 
 	serviceData, err := anypb.New(service)

--- a/internal/mesh/internal/controllers/meshgateways/controller.go
+++ b/internal/mesh/internal/controllers/meshgateways/controller.go
@@ -5,10 +5,14 @@ package meshgateways
 
 import (
 	"context"
-	"errors"
+
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
 const (
@@ -24,7 +28,36 @@ func Controller() *controller.Controller {
 
 type reconciler struct{}
 
+// Reconcile is responsible for creating a Service w/ a MeshGateway owner,
+// in addition to other things discussed in the RFC.
 func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req controller.Request) error {
+	rt.Logger = rt.Logger.With("resource-id", req.ID)
+	rt.Logger.Trace("reconciling mesh gateway")
+
+	service := &pbcatalog.Service{
+		Workloads: &pbcatalog.WorkloadSelector{
+			// Assumes that our MeshGateway Deployment in K8s is named the same as the MeshGateway resource in Consul
+			// TODO(nathancoleman) Fetch the MeshGateway and use WorkloadSelector from there
+			Prefixes: []string{req.ID.Name},
+		},
+	}
+
+	serviceData, err := anypb.New(service)
+	if err != nil {
+		return err
+	}
+
+	_, err = rt.Client.Write(ctx, &pbresource.WriteRequest{
+		Resource: &pbresource.Resource{
+			Id:    resource.ReplaceType(pbcatalog.ServiceType, req.ID),
+			Owner: req.ID,
+			Data:  serviceData,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
 	// TODO NET-6426, NET-6427, NET-6428, NET-6429, NET-6430, NET-6431, NET-6432
-	return errors.New("not implemented")
+	return nil
 }

--- a/internal/mesh/internal/controllers/meshgateways/controller.go
+++ b/internal/mesh/internal/controllers/meshgateways/controller.go
@@ -64,9 +64,10 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 
 	_, err = rt.Client.Write(ctx, &pbresource.WriteRequest{
 		Resource: &pbresource.Resource{
-			Id:    resource.ReplaceType(pbcatalog.ServiceType, req.ID),
-			Owner: req.ID,
-			Data:  serviceData,
+			Data:     serviceData,
+			Id:       resource.ReplaceType(pbcatalog.ServiceType, req.ID),
+			Metadata: map[string]string{"gateway-kind": "mesh-gateway"},
+			Owner:    req.ID,
 		},
 	})
 	if err != nil {

--- a/internal/mesh/internal/controllers/meshgateways/controller.go
+++ b/internal/mesh/internal/controllers/meshgateways/controller.go
@@ -17,6 +17,10 @@ import (
 
 const (
 	ControllerName = "consul.io/mesh-gateway"
+
+	meshPortName = "mesh"
+	wanPort      = 8443
+	wanPortName  = "wan"
 )
 
 func Controller() *controller.Controller {
@@ -34,21 +38,21 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 	rt.Logger = rt.Logger.With("resource-id", req.ID)
 	rt.Logger.Trace("reconciling mesh gateway")
 
+	// TODO NET-6822 The ports and workload selector below are currently hardcoded
+	//  until they are added to the MeshGateway resource and pulled from there.
 	service := &pbcatalog.Service{
 		Workloads: &pbcatalog.WorkloadSelector{
-			// Assumes that our MeshGateway Deployment in K8s is named the same as the MeshGateway resource in Consul
-			// TODO(nathancoleman) Fetch the MeshGateway and use WorkloadSelector from there
 			Prefixes: []string{req.ID.Name},
 		},
 		Ports: []*pbcatalog.ServicePort{
 			{
 				Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
-				TargetPort:  "wan",
-				VirtualPort: 8443,
+				TargetPort:  wanPortName,
+				VirtualPort: wanPort,
 			},
 			{
 				Protocol:   pbcatalog.Protocol_PROTOCOL_MESH,
-				TargetPort: "mesh",
+				TargetPort: meshPortName,
 			},
 		},
 	}


### PR DESCRIPTION
### Description
Create a name-aligned `Service` resource when reconciling a `MeshGateway` resource.
The `Service` has an owner reference added to it indicating that it belongs to a MeshGateway.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
