### PR TITLE
[NET-6426] Add gateway proxy controller that generates empty proxy state template

### DIFF
--- a/agent/consul/testdata/v2-resource-dependencies.md
+++ b/agent/consul/testdata/v2-resource-dependencies.md
@@ -41,6 +41,7 @@ flowchart TD
   mesh/v2beta1/proxyconfiguration
   mesh/v2beta1/proxystatetemplate --> auth/v2beta1/computedtrafficpermissions
   mesh/v2beta1/proxystatetemplate --> catalog/v2beta1/service
+  mesh/v2beta1/proxystatetemplate --> catalog/v2beta1/serviceendpoints
   mesh/v2beta1/proxystatetemplate --> catalog/v2beta1/workload
   mesh/v2beta1/proxystatetemplate --> mesh/v2beta1/computedexplicitdestinations
   mesh/v2beta1/proxystatetemplate --> mesh/v2beta1/computedproxyconfiguration

--- a/internal/mesh/internal/controllers/gatewayproxy/builder/builder.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/builder/builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package builder
 
 import (

--- a/internal/mesh/internal/controllers/gatewayproxy/builder/builder.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/builder/builder.go
@@ -23,7 +23,7 @@ func NewProxyStateTemplateBuilder(workload *types.DecodedWorkload) *proxyStateTe
 
 func (b *proxyStateTemplateBuilder) identity() *pbresource.Reference {
 	return &pbresource.Reference{
-		Name:    b.workload.Id.Name,
+		Name:    b.workload.Data.Identity,
 		Tenancy: b.workload.Id.Tenancy,
 		Type:    pbauth.WorkloadIdentityType,
 	}

--- a/internal/mesh/internal/controllers/gatewayproxy/builder/builder.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/builder/builder.go
@@ -1,0 +1,62 @@
+package builder
+
+import (
+	"github.com/hashicorp/consul/internal/mesh/internal/types"
+	pbauth "github.com/hashicorp/consul/proto-public/pbauth/v2beta1"
+	meshv2beta1 "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbmesh/v2beta1/pbproxystate"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+type proxyStateTemplateBuilder struct {
+	workload *types.DecodedWorkload
+}
+
+func NewProxyStateTemplateBuilder(workload *types.DecodedWorkload) *proxyStateTemplateBuilder {
+	return &proxyStateTemplateBuilder{
+		workload: workload,
+	}
+}
+
+func (b *proxyStateTemplateBuilder) identity() *pbresource.Reference {
+	return &pbresource.Reference{
+		Name:    b.workload.Id.Name,
+		Tenancy: b.workload.Id.Tenancy,
+		Type:    pbauth.WorkloadIdentityType,
+	}
+}
+
+func (b *proxyStateTemplateBuilder) listeners() []*pbproxystate.Listener {
+	// TODO NET-6429
+	return nil
+}
+
+func (b *proxyStateTemplateBuilder) clusters() map[string]*pbproxystate.Cluster {
+	// TODO NET-6430
+	return nil
+}
+
+func (b *proxyStateTemplateBuilder) endpoints() map[string]*pbproxystate.Endpoints {
+	// TODO NET-6431
+	return nil
+}
+
+func (b *proxyStateTemplateBuilder) routes() map[string]*pbproxystate.Route {
+	// TODO NET-6428
+	return nil
+}
+
+func (b *proxyStateTemplateBuilder) Build() *meshv2beta1.ProxyStateTemplate {
+	return &meshv2beta1.ProxyStateTemplate{
+		ProxyState: &meshv2beta1.ProxyState{
+			Identity:  b.identity(),
+			Listeners: b.listeners(),
+			Clusters:  b.clusters(),
+			Endpoints: b.endpoints(),
+			Routes:    b.routes(),
+		},
+		RequiredEndpoints:        make(map[string]*pbproxystate.EndpointRef),
+		RequiredLeafCertificates: make(map[string]*pbproxystate.LeafCertificateRef),
+		RequiredTrustBundles:     make(map[string]*pbproxystate.TrustBundleRef),
+	}
+}

--- a/internal/mesh/internal/controllers/gatewayproxy/controller.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/controller.go
@@ -1,0 +1,115 @@
+package gatewayproxy
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/mesh/internal/controllers/gatewayproxy/fetcher"
+	"github.com/hashicorp/consul/internal/mesh/internal/controllers/sidecarproxy/cache"
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+// ControllerName is the name for this controller. It's used for logging or status keys.
+const ControllerName = "consul.io/gateway-proxy-controller"
+
+// Controller is responsible for triggering reconciler for watched resources
+func Controller(cache *cache.Cache) controller.Controller {
+	// TODO Add the host of other types we should watch
+	return controller.ForType(pbmesh.ProxyStateTemplateType).
+		WithWatch(pbcatalog.ServiceType, controller.ReplaceType(pbmesh.ProxyStateTemplateType)).
+		WithReconciler(&reconciler{
+			cache: cache,
+		})
+}
+
+// reconciler is responsible for managing the ProxyStateTemplate for all
+// gateway types: mesh, api (future) and terminating (future).
+type reconciler struct {
+	cache *cache.Cache
+}
+
+// Reconcile is responsible for creating and updating the pbmesh.ProxyStateTemplate
+// for all gateway types. Since the ProxyStateTemplates managed here will always have
+// an owner reference pointing to the corresponding pbmesh.MeshGateway, deletion is
+// left to the garbage collector.
+func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req controller.Request) error {
+	rt.Logger = rt.Logger.With("resource-id", req.ID, "controller", ControllerName)
+	rt.Logger.Trace("reconciling proxy state template")
+
+	var gatewayType *pbresource.Type
+
+	// If the resource is not owned by a xGateway, let the sidecarproxy reconciler handle it
+	res, err := rt.Client.Read(ctx, &pbresource.ReadRequest{Id: req.ID})
+	if err != nil || res.Resource == nil || res.Resource.Id == nil {
+		rt.Logger.Error("error reading the resource", "error", err)
+		return err
+	} else {
+		switch res.Resource.Id.Type {
+		// FUTURE Add API and terminating gateway types once they exist
+		case pbmesh.MeshGatewayType:
+			gatewayType = res.Resource.Id.Type
+			rt.Logger = rt.Logger.With("gateway-type", gatewayType.String())
+		default:
+			// This reconciler only reconciles ProxyStateTemplates that are owned by a xGateway
+			return nil
+		}
+	}
+
+	// Instantiate a data fetcher to fetch all reconciliation data.
+	dataFetcher := fetcher.New(rt.Client, r.cache)
+
+	// Check if the gateway exists.
+	gatewayID := resource.ReplaceType(gatewayType, req.ID)
+	gateway, err := dataFetcher.FetchMeshGateway(ctx, gatewayID)
+	if err != nil {
+		rt.Logger.Error("error reading the associated gateway", "error", err)
+		return err
+	}
+	if gateway == nil {
+		// If gateway has been deleted, then return as ProxyStateTemplate should be
+		// cleaned up by the garbage collector because of the owner reference.
+		rt.Logger.Trace("gateway doesn't exist; skipping reconciliation", "gateway", gatewayID)
+		return nil
+	}
+
+	proxyStateTemplate, err := dataFetcher.FetchProxyStateTemplate(ctx, req.ID)
+	if err != nil {
+		rt.Logger.Error("error reading proxy state template", "error", err)
+		return nil
+	}
+
+	if proxyStateTemplate == nil {
+		rt.Logger.Trace("proxy state template for this gateway doesn't yet exist; generating a new one")
+	}
+
+	if proxyStateTemplate == nil {
+		req.ID.Uid = ""
+	}
+
+	proxyTemplateData, err := anypb.New(proxyStateTemplate)
+	if err != nil {
+		rt.Logger.Error("error creating proxy state template data", "error", err)
+		return err
+	}
+	rt.Logger.Trace("updating proxy state template")
+
+	// Write the created/updated ProxyStateTemplate with MeshGateway owner
+	_, err = rt.Client.Write(ctx, &pbresource.WriteRequest{
+		Resource: &pbresource.Resource{
+			Id:    req.ID,
+			Owner: resource.ReplaceType(gatewayType, req.ID),
+			Data:  proxyTemplateData,
+		},
+	})
+	if err != nil {
+		rt.Logger.Error("error writing proxy state template", "error", err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/mesh/internal/controllers/gatewayproxy/controller.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/controller.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package gatewayproxy
 
 import (

--- a/internal/mesh/internal/controllers/gatewayproxy/controller.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/controller.go
@@ -120,6 +120,7 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 		Resource: &pbresource.Resource{
 			Id:       req.ID,
 			Metadata: map[string]string{"gateway-kind": workload.Metadata["gateway-kind"]},
+			Owner:    workload.Resource.Id,
 			Data:     proxyTemplateData,
 		},
 	})

--- a/internal/mesh/internal/controllers/gatewayproxy/controller.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/controller.go
@@ -64,6 +64,7 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 	dataFetcher := fetcher.New(rt.Client, r.cache)
 
 	// Check if the gateway exists.
+	// TODO Switch fetch method based on gatewayType
 	gatewayID := resource.ReplaceType(gatewayType, req.ID)
 	gateway, err := dataFetcher.FetchMeshGateway(ctx, gatewayID)
 	if err != nil {

--- a/internal/mesh/internal/controllers/gatewayproxy/fetcher/data_fetcher.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/fetcher/data_fetcher.go
@@ -1,0 +1,56 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fetcher
+
+import (
+	"context"
+
+	"github.com/hashicorp/consul/internal/mesh/internal/controllers/sidecarproxy/cache"
+	"github.com/hashicorp/consul/internal/mesh/internal/types"
+	"github.com/hashicorp/consul/internal/resource"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+type Fetcher struct {
+	client pbresource.ResourceServiceClient
+	cache  *cache.Cache
+}
+
+func New(client pbresource.ResourceServiceClient, cache *cache.Cache) *Fetcher {
+	return &Fetcher{
+		client: client,
+		cache:  cache,
+	}
+}
+
+func (f *Fetcher) FetchMeshGateway(ctx context.Context, id *pbresource.ID) (*types.DecodedMeshGateway, error) {
+	dec, err := resource.GetDecodedResource[*pbmesh.MeshGateway](ctx, f.client, id)
+	if err != nil {
+		return nil, err
+	} else if dec == nil {
+		// We also need to make sure to delete the associated gateway from cache.
+		// TODO f.cache.UntrackMeshGateway(id)
+		return nil, nil
+	}
+
+	// TODO f.cache.TrackMeshGateway(dec)
+
+	return dec, err
+}
+
+func (f *Fetcher) FetchProxyStateTemplate(ctx context.Context, id *pbresource.ID) (*types.DecodedProxyStateTemplate, error) {
+	dec, err := resource.GetDecodedResource[*pbmesh.ProxyStateTemplate](ctx, f.client, id)
+	if err != nil {
+		return nil, err
+	} else if dec == nil {
+		// We also need to make sure to delete the associated proxy from cache.
+		// TODO f.cache.UntrackProxyStateTemplate(id)
+		return nil, nil
+	}
+
+	// TODO f.cache.TrackProxyStateTemplate(dec)
+
+	return dec, err
+}

--- a/internal/mesh/internal/controllers/gatewayproxy/fetcher/data_fetcher.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/fetcher/data_fetcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul/internal/mesh/internal/controllers/sidecarproxy/cache"
 	"github.com/hashicorp/consul/internal/mesh/internal/types"
 	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
@@ -51,6 +52,21 @@ func (f *Fetcher) FetchProxyStateTemplate(ctx context.Context, id *pbresource.ID
 	}
 
 	// TODO f.cache.TrackProxyStateTemplate(dec)
+
+	return dec, err
+}
+
+func (f *Fetcher) FetchWorkload(ctx context.Context, id *pbresource.ID) (*types.DecodedWorkload, error) {
+	dec, err := resource.GetDecodedResource[*pbcatalog.Workload](ctx, f.client, id)
+	if err != nil {
+		return nil, err
+	} else if dec == nil {
+		// We also need to make sure to delete the associated proxy from cache.
+		// TODO f.cache.UntrackWorkload(id)
+		return nil, nil
+	}
+
+	// TODO f.cache.TrackWorkload(dec)
 
 	return dec, err
 }

--- a/internal/mesh/internal/controllers/gatewayproxy/fetcher/data_fetcher.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/fetcher/data_fetcher.go
@@ -31,12 +31,8 @@ func (f *Fetcher) FetchMeshGateway(ctx context.Context, id *pbresource.ID) (*typ
 	if err != nil {
 		return nil, err
 	} else if dec == nil {
-		// We also need to make sure to delete the associated gateway from cache.
-		// TODO f.cache.UntrackMeshGateway(id)
 		return nil, nil
 	}
-
-	// TODO f.cache.TrackMeshGateway(dec)
 
 	return dec, err
 }
@@ -46,12 +42,8 @@ func (f *Fetcher) FetchProxyStateTemplate(ctx context.Context, id *pbresource.ID
 	if err != nil {
 		return nil, err
 	} else if dec == nil {
-		// We also need to make sure to delete the associated proxy from cache.
-		// TODO f.cache.UntrackProxyStateTemplate(id)
 		return nil, nil
 	}
-
-	// TODO f.cache.TrackProxyStateTemplate(dec)
 
 	return dec, err
 }
@@ -61,12 +53,8 @@ func (f *Fetcher) FetchWorkload(ctx context.Context, id *pbresource.ID) (*types.
 	if err != nil {
 		return nil, err
 	} else if dec == nil {
-		// We also need to make sure to delete the associated proxy from cache.
-		// TODO f.cache.UntrackWorkload(id)
 		return nil, nil
 	}
-
-	// TODO f.cache.TrackWorkload(dec)
 
 	return dec, err
 }

--- a/internal/mesh/internal/controllers/register.go
+++ b/internal/mesh/internal/controllers/register.go
@@ -5,6 +5,8 @@ package controllers
 
 import (
 	"context"
+
+	"github.com/hashicorp/consul/internal/mesh/internal/controllers/gatewayproxy"
 	"github.com/hashicorp/consul/internal/mesh/internal/controllers/meshconfiguration"
 
 	"github.com/hashicorp/consul/agent/leafcert"
@@ -45,6 +47,8 @@ func Register(mgr *controller.Manager, deps Dependencies) {
 	mgr.Register(
 		sidecarproxy.Controller(cache.New(), deps.TrustDomainFetcher, deps.LocalDatacenter, deps.DefaultAllow),
 	)
+
+	mgr.Register(gatewayproxy.Controller(cache.New()))
 
 	mgr.Register(routes.Controller())
 

--- a/internal/mesh/internal/types/decoded.go
+++ b/internal/mesh/internal/types/decoded.go
@@ -27,4 +27,5 @@ type (
 	DecodedDestinations               = resource.DecodedResource[*pbmesh.Destinations]
 	DecodedComputedDestinations       = resource.DecodedResource[*pbmesh.ComputedExplicitDestinations]
 	DecodedProxyStateTemplate         = resource.DecodedResource[*pbmesh.ProxyStateTemplate]
+	DecodedMeshGateway                = resource.DecodedResource[*pbmesh.MeshGateway]
 )


### PR DESCRIPTION
### Description
This PR creates the `gatewayproxy.Controller`, analogous to the `sidecarproxy.Controller` but designed to created `ProxyStateTemplate` (PST) resources for xGateways. It relies on `gateway-kind` being set in the metadata of the `Workload` that the PST is being created for.

#19902 introduced logic to have the sidecar proxy controller skip workloads with this piece of metadata so that the two controllers will not be fighting to write the same PST.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
