### PR TITLE
NET-6663 Modify sidecarproxy controller to skip xGateway resources

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/controller.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/controller.go
@@ -130,7 +130,7 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 	}
 
 	// If the workload is for a xGateway, then do nothing + let the gatewayproxy controller reconcile it
-	if gatewayKind := workload.Metadata["gateway-kind"]; gatewayKind != "" {
+	if gatewayKind, ok := workload.Metadata["gateway-kind"]; ok && gatewayKind != "" {
 		rt.Logger.Trace("workload is a gateway; skipping reconciliation", "workload", workloadID, "gateway-kind", gatewayKind)
 		return nil
 	}

--- a/internal/mesh/internal/controllers/sidecarproxy/controller.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/controller.go
@@ -121,6 +121,13 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 		rt.Logger.Error("error reading the associated workload", "error", err)
 		return err
 	}
+
+	// If the workload is for a xGateway, then do nothing + let the gatewayproxy controller reconcile it
+	if gatewayKind := workload.Metadata["gateway-kind"]; gatewayKind != "" {
+		rt.Logger.Trace("workload is a gateway; skipping reconciliation", "workload", workloadID, "gateway-kind", gatewayKind)
+		return nil
+	}
+
 	if workload == nil {
 		// If workload has been deleted, then return as ProxyStateTemplate should be cleaned up
 		// by the garbage collector because of the owner reference.

--- a/internal/mesh/internal/controllers/sidecarproxy/controller.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/controller.go
@@ -122,16 +122,16 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 		return err
 	}
 
-	// If the workload is for a xGateway, then do nothing + let the gatewayproxy controller reconcile it
-	if gatewayKind := workload.Metadata["gateway-kind"]; gatewayKind != "" {
-		rt.Logger.Trace("workload is a gateway; skipping reconciliation", "workload", workloadID, "gateway-kind", gatewayKind)
-		return nil
-	}
-
 	if workload == nil {
 		// If workload has been deleted, then return as ProxyStateTemplate should be cleaned up
 		// by the garbage collector because of the owner reference.
 		rt.Logger.Trace("workload doesn't exist; skipping reconciliation", "workload", workloadID)
+		return nil
+	}
+
+	// If the workload is for a xGateway, then do nothing + let the gatewayproxy controller reconcile it
+	if gatewayKind := workload.Metadata["gateway-kind"]; gatewayKind != "" {
+		rt.Logger.Trace("workload is a gateway; skipping reconciliation", "workload", workloadID, "gateway-kind", gatewayKind)
 		return nil
 	}
 


### PR DESCRIPTION
### Description
The `sidecarproxy.Controller` should skip `Workload` resources with a `gateway-kind` specified in the resource metadata. The forthcoming `gatewayproxy.Controller` will be responsible for managing these.

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps
When combined with https://github.com/hashicorp/consul-k8s/pull/3365, the sidecar proxy controller should skip any Workloads created for a `MeshGateway` when `meshGateway.enabled=true` and `experiments: [resource-apis]` in values.yaml.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
