### PR TITLE
NET-6900: stop reconciling services when peering is enabled

### DIFF
--- a/.changelog/19907.txt
+++ b/.changelog/19907.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: stop manually reconciling services if peering is enabled
+```

--- a/ui/packages/consul-ui/app/services/repository.js
+++ b/ui/packages/consul-ui/app/services/repository.js
@@ -113,6 +113,17 @@ export default class RepositoryService extends Service {
         return false;
       }
     }
+
+    // We were seeing issues where services were all being unloaded after visiting
+    // a peers imported services page. So if you viewes services -> peered imported services -> services
+    // only the peered services would remain as the others were all unloaded. Not certain if
+    // we should be doing any manual reconciling as it is. Not enough historical context
+    // to determine that at this time.
+    //
+    // https://hashicorp.atlassian.net/browse/NET-6900
+    if (this.env.var('CONSUL_PEERINGS_ENABLED') && this.getModelName() === 'service') {
+      return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
If you visited the services page, then a peers imported services list, then back to the services page it would only display the services imported by the peer. It seems like this issue had to do with manual reconciling that was happening when we queried all services for a peer. When you first visit the services list page we set up a Blocking query that is stored as a source in a service. The first visit queries the services and stores this source. When you visit a peers imported services it [queries all the services for that peer.](https://github.com/hashicorp/consul/blob/e13fbc743ea490135e1c182d5c4749e8d8fe673a/ui/packages/consul-ui/app/services/repository/service.js#L33) Part of that process involves [calling](https://github.com/hashicorp/consul/blob/e13fbc743ea490135e1c182d5c4749e8d8fe673a/ui/packages/consul-ui/app/services/repository.js#L183) the [manual reconciling function.](https://github.com/hashicorp/consul/blob/e13fbc743ea490135e1c182d5c4749e8d8fe673a/ui/packages/consul-ui/app/services/repository.js#L119-L134) This function unloads all records of the corresponding model type that aren't a part of the current sync. This unloads all of the other services. When you revisit the services page, it finds the source that was originally created and grabs the data that was cached there. We would expect that to be all the services but the majority of them (all not belonging to that peer) have been unloaded from the store. Therefore only the peered services remain.

I've dug into some of the old PRs around this manual reconciling, but I could not find that much detail on why it was added. There was mention around there being issues with syncing KVs, but not much else. I don't believe having to do this manual reconciling is a good practice, but I am hesitant to rip it out especially before a release. As such, I've added a condition to not reconcile services if peers are enabled to limit the blast radius and bypass the issue we were seeing here. I don't _think_ this was an issue on older builds because I believe we were reloading the pages by using plain anchors in the sidebar... I could be wrong about this assumption, but I've tried it in a 1.16 build pre-sidenav change and it worked as expected.

I've also tested doing this flow and deregistering services from the CLI and the blocking query still updates the data properly.

https://github.com/hashicorp/consul/assets/5448834/b53fdf18-4924-4ad7-8fc6-1ce3ce265fc8

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
1. Build UI `make ui-docker` in the project root
2. Build dev-docker `make dev-docker`
3. use consul-setups to run the build 
4. Go to services page
5. Go to peers and visit a peers imported services
6. Go back to the services page

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->
https://hashicorp.atlassian.net/browse/NET-6900

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
