### PR TITLE
Move enterprise multicluster types to Register function 

### DIFF
--- a/internal/multicluster/exports.go
+++ b/internal/multicluster/exports.go
@@ -21,7 +21,6 @@ var (
 // to the given type registry
 func RegisterTypes(r resource.Registry) {
 	types.Register(r)
-	types.RegisterEnterprise(r)
 }
 
 // RegisterControllers registers controllers for the multicluster types with

--- a/internal/multicluster/internal/controllers/exportedservices/controller_test.go
+++ b/internal/multicluster/internal/controllers/exportedservices/controller_test.go
@@ -72,22 +72,14 @@ func (suite *controllerSuite) TestReconcile_DeleteOldCES_NoExportedServices() {
 						Name:    "svc0",
 					},
 					Consumers: []*pbmulticluster.ComputedExportedServicesConsumer{
-						{
-							ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Peer{
-								Peer: "test-peer",
-							},
-						},
+						suite.constructConsumer("test-peer", "peer"),
 					},
 				},
 			},
 		}
 
 		if suite.isEnterprise {
-			oldCESData.Consumers[0].Consumers = append(oldCESData.Consumers[0].Consumers, &pbmulticluster.ComputedExportedServicesConsumer{
-				ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Partition{
-					Partition: "part-n",
-				},
-			})
+			oldCESData.Consumers[0].Consumers = append(oldCESData.Consumers[0].Consumers, suite.constructConsumer("peer-n", "partition"))
 		}
 
 		oldCES := rtest.Resource(pbmulticluster.ComputedExportedServicesType, "global").
@@ -118,22 +110,14 @@ func (suite *controllerSuite) TestReconcile_DeleteOldCES_NoMatchingServices() {
 						Name:    "svc0",
 					},
 					Consumers: []*pbmulticluster.ComputedExportedServicesConsumer{
-						{
-							ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Peer{
-								Peer: "test-peer",
-							},
-						},
+						suite.constructConsumer("test-peer", "peer"),
 					},
 				},
 			},
 		}
 
 		if suite.isEnterprise {
-			oldCESData.Consumers[0].Consumers = append(oldCESData.Consumers[0].Consumers, &pbmulticluster.ComputedExportedServicesConsumer{
-				ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Partition{
-					Partition: "part-n",
-				},
-			})
+			oldCESData.Consumers[0].Consumers = append(oldCESData.Consumers[0].Consumers, suite.constructConsumer("part-n", "partition"))
 		}
 
 		oldCES := rtest.Resource(pbmulticluster.ComputedExportedServicesType, "global").
@@ -189,22 +173,14 @@ func (suite *controllerSuite) TestReconcile_SkipWritingNewCES() {
 						Name:    "svc-0",
 					},
 					Consumers: []*pbmulticluster.ComputedExportedServicesConsumer{
-						{
-							ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Peer{
-								Peer: "peer-1",
-							},
-						},
+						suite.constructConsumer("peer-1", "peer"),
 					},
 				},
 			},
 		}
 
 		if suite.isEnterprise {
-			oldCESData.Consumers[0].Consumers = append(oldCESData.Consumers[0].Consumers, &pbmulticluster.ComputedExportedServicesConsumer{
-				ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Partition{
-					Partition: "part-n",
-				},
-			})
+			oldCESData.Consumers[0].Consumers = append(oldCESData.Consumers[0].Consumers, suite.constructConsumer("part-n", "partition"))
 		}
 
 		oldCES := rtest.Resource(pbmulticluster.ComputedExportedServicesType, "global").
@@ -312,26 +288,10 @@ func (suite *controllerSuite) TestReconcile_ComputeCES() {
 							Name:    "svc-0",
 						},
 						Consumers: []*pbmulticluster.ComputedExportedServicesConsumer{
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Peer{
-									Peer: "peer-1",
-								},
-							},
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Peer{
-									Peer: "peer-2",
-								},
-							},
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Partition{
-									Partition: "part-1",
-								},
-							},
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Partition{
-									Partition: "part-n",
-								},
-							},
+							suite.constructConsumer("peer-1", "peer"),
+							suite.constructConsumer("peer-2", "peer"),
+							suite.constructConsumer("part-1", "partition"),
+							suite.constructConsumer("part-n", "partition"),
 						},
 					},
 					{
@@ -341,21 +301,9 @@ func (suite *controllerSuite) TestReconcile_ComputeCES() {
 							Name:    "svc-1",
 						},
 						Consumers: []*pbmulticluster.ComputedExportedServicesConsumer{
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Peer{
-									Peer: "peer-2",
-								},
-							},
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Partition{
-									Partition: "part-1",
-								},
-							},
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Partition{
-									Partition: "part-n",
-								},
-							},
+							suite.constructConsumer("peer-2", "peer"),
+							suite.constructConsumer("part-1", "partition"),
+							suite.constructConsumer("part-n", "partition"),
 						},
 					},
 					{
@@ -365,21 +313,9 @@ func (suite *controllerSuite) TestReconcile_ComputeCES() {
 							Name:    "svc-2",
 						},
 						Consumers: []*pbmulticluster.ComputedExportedServicesConsumer{
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Peer{
-									Peer: "peer-2",
-								},
-							},
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Partition{
-									Partition: "part-1",
-								},
-							},
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Partition{
-									Partition: "part-n",
-								},
-							},
+							suite.constructConsumer("peer-2", "peer"),
+							suite.constructConsumer("part-1", "partition"),
+							suite.constructConsumer("part-n", "partition"),
 						},
 					},
 				},
@@ -394,16 +330,8 @@ func (suite *controllerSuite) TestReconcile_ComputeCES() {
 							Name:    "svc-0",
 						},
 						Consumers: []*pbmulticluster.ComputedExportedServicesConsumer{
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Peer{
-									Peer: "peer-1",
-								},
-							},
-							{
-								ConsumerTenancy: &pbmulticluster.ComputedExportedServicesConsumer_Peer{
-									Peer: "peer-2",
-								},
-							},
+							suite.constructConsumer("peer-1", "peer"),
+							suite.constructConsumer("peer-2", "peer"),
 						},
 					},
 				},

--- a/internal/multicluster/internal/types/types.go
+++ b/internal/multicluster/internal/types/types.go
@@ -18,5 +18,5 @@ func Register(r resource.Registry) {
 	RegisterNamespaceExportedServices(r)
 	RegisterPartitionExportedServices(r)
 	RegisterComputedExportedServices(r)
-	RegisterEnterprise(r)
+	RegisterEnterpriseTypes(r)
 }

--- a/internal/multicluster/internal/types/types.go
+++ b/internal/multicluster/internal/types/types.go
@@ -18,4 +18,5 @@ func Register(r resource.Registry) {
 	RegisterNamespaceExportedServices(r)
 	RegisterPartitionExportedServices(r)
 	RegisterComputedExportedServices(r)
+	RegisterEnterprise(r)
 }

--- a/internal/multicluster/internal/types/types.go
+++ b/internal/multicluster/internal/types/types.go
@@ -18,5 +18,6 @@ func Register(r resource.Registry) {
 	RegisterNamespaceExportedServices(r)
 	RegisterPartitionExportedServices(r)
 	RegisterComputedExportedServices(r)
+
 	RegisterEnterpriseTypes(r)
 }

--- a/internal/multicluster/internal/types/types_ce.go
+++ b/internal/multicluster/internal/types/types_ce.go
@@ -7,5 +7,6 @@ package types
 
 import "github.com/hashicorp/consul/internal/resource"
 
-func RegisterEnterprise(r resource.Registry) {
+func RegisterEnterpriseTypes(r resource.Registry) {
+	// no-op in CE
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

1. Move registering enterprise types to the common register function so that tests could use them too.
2. Refactor some exported service controller tests to use the existing function.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
