### PR TITLE
fix actions to no longer use envoy 1.24.x to match supported versions.

### DIFF
--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -65,7 +65,7 @@ jobs:
           # this is further going to multiplied in envoy-integration tests by the 
           # other dimensions in the matrix.  Currently TOTAL_RUNNERS would be
           # multiplied by 8 based on these values:
-          # envoy-version: ["1.24.12", "1.25.11", "1.26.6", "1.27.2"]
+          # envoy-version: ["1.25.11", "1.26.6", "1.27.2", "1.28.0"]
           # xds-target: ["server", "client"]
           TOTAL_RUNNERS: 4 
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        envoy-version: ["1.24.12", "1.25.11", "1.26.6", "1.27.2"]
+        envoy-version: ["1.25.11", "1.26.6", "1.27.2", "1.28.0"]
         xds-target: ["server", "client"]
         test-cases: ${{ fromJSON(needs.generate-envoy-job-matrices.outputs.envoy-matrix) }}
     env:

--- a/.github/workflows/test-integrations-windows.yml
+++ b/.github/workflows/test-integrations-windows.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        envoy-version: [ "1.27.2" ]
+        envoy-version: [ "1.28.0" ]
         xds-target: [ "server", "client" ]
     env:
       ENVOY_VERSION: ${{ matrix.envoy-version }}

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -260,7 +260,7 @@ jobs:
           # this is further going to multiplied in envoy-integration tests by the
           # other dimensions in the matrix.  Currently TOTAL_RUNNERS would be
           # multiplied by 2 based on these values:
-          # envoy-version: ["1.27.2"]
+          # envoy-version: ["1.28.0"]
           # xds-target: ["server", "client"]
           TOTAL_RUNNERS: 4
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
@@ -294,7 +294,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        envoy-version: ["1.27.2"]
+        envoy-version: ["1.28.0"]
         xds-target: ["server", "client"]
         test-cases: ${{ fromJSON(needs.generate-envoy-job-matrices.outputs.envoy-matrix) }}
     env:


### PR DESCRIPTION
### Description

This changes were missing when porting envoy 1.28 update from ENT to CE.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
