### PR TITLE
NET-6317 - update usage of deprecated fields: http2_protocol_options and access_log_path

### DIFF
--- a/.changelog/19940.txt
+++ b/.changelog/19940.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+xds: remove usages of deprecated Envoy fields: `envoy.config.cluster.v3.Cluster.http2_protocol_options`, `envoy.config.bootstrap.v3.Admin.access_log_path`
+```

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -863,7 +863,14 @@ func appendTelemetryCollectorConfig(args *BootstrapTplArgs, telemetryCollectorBi
 	args.StaticClustersJSON += fmt.Sprintf(`{
 		"name": "consul_telemetry_collector_loopback",
 		"type": "STATIC",
-		"http2_protocol_options": {},
+		"typed_extension_protocol_options": {
+		  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+			"@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+			"explicit_http_config": {
+			  "http2_protocol_options": {}
+			}
+		  }
+		},
 		"loadAssignment": {
 		  "clusterName": "consul_telemetry_collector_loopback",
 		  "endpoints": [

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -548,7 +548,14 @@ const (
 	expectedTelemetryCollectorCluster = `{
 	"name": "consul_telemetry_collector_loopback",
 	"type": "STATIC",
-	"http2_protocol_options": {},
+	"typed_extension_protocol_options": {
+	  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+		"@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+		"explicit_http_config": {
+		  "http2_protocol_options": {}
+		}
+	  }
+	},
 	"loadAssignment": {
 	  "clusterName": "consul_telemetry_collector_loopback",
 	  "endpoints": [

--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -161,7 +161,15 @@ type GRPC struct {
 const bootstrapTemplate = `{
   "admin": {
 	{{- if (not .AdminAccessLogConfig) }}
-    "access_log_path": "{{ .AdminAccessLogPath }}",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "{{ .AdminAccessLogPath }}"
+        }
+      }
+    ],
 	{{- end}}
 	{{- if .AdminAccessLogConfig }}
     "access_log": [
@@ -220,7 +228,14 @@ const bootstrapTemplate = `{
           }
         },
         {{- end }}
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+		  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+			"@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+			"explicit_http_config": {
+			  "http2_protocol_options": {}
+			}
+		  }
+		},
         "loadAssignment": {
           "clusterName": "{{ .LocalAgentClusterName }}",
           "endpoints": [

--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -175,7 +175,13 @@ const bootstrapTemplate = `{
     "access_log": [
 	{{- range $index, $element := .AdminAccessLogConfig}}
         {{if $index}},{{end}}
-        {{$element}}
+	  {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "{{$element}}"
+        }
+      }
     {{end}}],
 	{{- end}}
     "address": {

--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -175,13 +175,7 @@ const bootstrapTemplate = `{
     "access_log": [
 	{{- range $index, $element := .AdminAccessLogConfig}}
         {{if $index}},{{end}}
-	  {
-        "name": "envoy.access_loggers.file",
-        "typed_config": {
-          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-          "path": "{{$element}}"
-        }
-      }
+        {{$element}}
     {{end}}],
 	{{- end}}
     "address": {

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -693,7 +693,15 @@ func TestGenerateConfig(t *testing.T) {
 				"envoy_bootstrap_json_tpl": `
 				{
 					"admin": {
-						"access_log_path": "/dev/null",
+						"access_log": [
+						  {
+							"name": "envoy.access_loggers.file",
+							"typed_config": {
+							  "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+							  "path": "/dev/null"
+							}
+						  }
+						],
 						"address": {
 							"socket_address": {
 								"address": "{{ .AdminBindAddress }}",

--- a/command/connect/envoy/testdata/CONSUL_GRPC_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_GRPC_ADDR-with-https-scheme-enables-tls.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -46,7 +54,14 @@
             }
           }
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-does-not-affect-grpc-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-does-not-affect-grpc-tls.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/some/path/access.log",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/some/path/access.log"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/access-logs-enabled-custom.golden
+++ b/command/connect/envoy/testdata/access-logs-enabled-custom.golden
@@ -46,7 +46,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/access-logs-enabled.golden
+++ b/command/connect/envoy/testdata/access-logs-enabled.golden
@@ -68,7 +68,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/acl-enabled-and-token.golden
+++ b/command/connect/envoy/testdata/acl-enabled-and-token.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/acl-enabled-but-no-token.golden
+++ b/command/connect/envoy/testdata/acl-enabled-but-no-token.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-PLAIN-and-CONSUL_GRPC_ADDR-TLS-is-tls.golden
+++ b/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-PLAIN-and-CONSUL_GRPC_ADDR-TLS-is-tls.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -46,7 +54,14 @@
             }
           }
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-TLS-and-CONSUL_GRPC_ADDR-PLAIN-is-plain.golden
+++ b/command/connect/envoy/testdata/both-CONSUL_HTTP_ADDR-TLS-and-CONSUL_GRPC_ADDR-PLAIN-is-plain.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/custom-bootstrap.golden
+++ b/command/connect/envoy/testdata/custom-bootstrap.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/command/connect/envoy/testdata/defaults-nodemeta.golden
+++ b/command/connect/envoy/testdata/defaults-nodemeta.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -34,7 +42,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/envoy-readiness-probe.golden
+++ b/command/connect/envoy/testdata/envoy-readiness-probe.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -46,7 +54,14 @@
             }
           }
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/existing-ca-path.golden
+++ b/command/connect/envoy/testdata/existing-ca-path.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -46,7 +54,14 @@
             }
           }
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/grpc-addr-unix-with-tls.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix-with-tls.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -46,7 +54,14 @@
             }
           }
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/grpc-tls-addr-config.golden
+++ b/command/connect/envoy/testdata/grpc-tls-addr-config.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -46,7 +54,14 @@
             }
           }
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/ingress-gateway-nodemeta.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-nodemeta.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -34,7 +42,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/ingress-gateway.golden
+++ b/command/connect/envoy/testdata/ingress-gateway.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/prometheus-metrics-tls-ca-file.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics-tls-ca-file.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/prometheus-metrics-tls-ca-path.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics-tls-ca-path.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/prometheus-metrics.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/stats-config-override.golden
+++ b/command/connect/envoy/testdata/stats-config-override.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/telemetry-collector.golden
+++ b/command/connect/envoy/testdata/telemetry-collector.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [
@@ -57,7 +72,14 @@
       {
         "name": "consul_telemetry_collector_loopback",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "consul_telemetry_collector_loopback",
           "endpoints": [

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/xds-addr-config.golden
+++ b/command/connect/envoy/testdata/xds-addr-config.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -1,6 +1,14 @@
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
@@ -33,7 +41,14 @@
         "ignore_health_on_host_removal": false,
         "connect_timeout": "1s",
         "type": "STATIC",
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "loadAssignment": {
           "clusterName": "local_agent",
           "endpoints": [

--- a/test/integration/connect/envoy/case-ingress-gateway-sds/service_gateway.hcl
+++ b/test/integration/connect/envoy/case-ingress-gateway-sds/service_gateway.hcl
@@ -7,22 +7,18 @@ services {
 
   proxy {
     config {
-      # Note that http2_protocol_options is a deprecated field and Envoy 1.17
-      # and up would prefer:
-      #     typed_extension_protocol_options:
-      #       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-      #         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-      #         explicit_http_config:
-      #           http2_protocol_options:
-      #
-      # But that breaks 1.15 and 1.16. For now use this which is supported by
-      # all our supported versions to avoid needing to setup different
-      # bootstrap based on the envoy version.
       envoy_extra_static_clusters_json = <<EOF
 {
   "name": "sds-cluster",
   "connect_timeout": "5s",
-  "http2_protocol_options": {},
+  "typed_extension_protocol_options": {
+    "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+      "explicit_http_config": {
+        "http2_protocol_options": {}
+      }
+    }
+  },
   "load_assignment": {
     "cluster_name": "sds-cluster",
     "endpoints": [

--- a/test/integration/consul-container/test/upgrade/ingress_gateway_sds_test.go
+++ b/test/integration/consul-container/test/upgrade/ingress_gateway_sds_test.go
@@ -151,7 +151,14 @@ func TestIngressGateway_SDS_UpgradeToTarget_fromLatest(t *testing.T) {
 {
   "name": "%s",
   "connect_timeout": "5s",
-  "http2_protocol_options": {},
+  "typed_extension_protocol_options": {
+    "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+	  "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+	  "explicit_http_config": {
+	    "http2_protocol_options": {}
+	  }
+    }
+  },
   "type": "LOGICAL_DNS",
   "load_assignment": {
     "cluster_name": "%s",

--- a/troubleshoot/proxy/testdata/config.json
+++ b/troubleshoot/proxy/testdata/config.json
@@ -1711,7 +1711,14 @@
        "name": "consul-dataplane",
        "type": "STATIC",
        "connect_timeout": "1s",
-       "http2_protocol_options": {},
+       "typed_extension_protocol_options": {
+        "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+         "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+         "explicit_http_config": {
+          "http2_protocol_options": {}
+         }
+        }
+       },
        "load_assignment": {
         "cluster_name": "consul-dataplane",
         "endpoints": [
@@ -1761,7 +1768,15 @@
      }
     },
     "admin": {
-     "access_log_path": "/dev/null",
+     "access_log": [
+      {
+       "name": "envoy.access_loggers.file",
+       "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+        "path": "/dev/null"
+       }
+      }
+     ],
      "address": {
       "socket_address": {
        "address": "127.0.0.1",
@@ -1880,7 +1895,14 @@
       "name": "consul-dataplane",
       "type": "STATIC",
       "connect_timeout": "1s",
-      "http2_protocol_options": {},
+      "typed_extension_protocol_options": {
+       "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+        "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+        "explicit_http_config": {
+         "http2_protocol_options": {}
+        }
+       }
+      },
       "load_assignment": {
        "cluster_name": "consul-dataplane",
        "endpoints": [

--- a/website/content/docs/connect/gateways/ingress-gateway/tls-external-service.mdx
+++ b/website/content/docs/connect/gateways/ingress-gateway/tls-external-service.mdx
@@ -6,7 +6,7 @@ description: Learn how to configure ingress gateways to serve TLS certificates f
 
 # Serve custom TLS certificates from an external service
 
-This is an advanced topic that describes how to configure ingress gateways to serve TLS certificates sourced from an external service to inbound traffic using secret discovery service (SDS). SDS is a low-level feature designed for developers building integrations with custom TLS management solutions. For instructions on more common ingress gateway implementations, refer to [Implement an ingress gateway](/consul/docs/connect/gateways/ingress-gateway/usage). 
+This is an advanced topic that describes how to configure ingress gateways to serve TLS certificates sourced from an external service to inbound traffic using secret discovery service (SDS). SDS is a low-level feature designed for developers building integrations with custom TLS management solutions. For instructions on more common ingress gateway implementations, refer to [Implement an ingress gateway](/consul/docs/connect/gateways/ingress-gateway/usage).
 
 ## Overview
 
@@ -17,7 +17,7 @@ The following process describes the general procedure for configuring ingress ga
 1. Configure TLS client authentication
 1. Start Envoy.
 1. Configure SDS settings in an ingress gateway configuration entry.
-1. Register the ingress gateway configuration entry with Consul.  
+1. Register the ingress gateway configuration entry with Consul.
 
 ## Requirements
 
@@ -30,7 +30,7 @@ The following process describes the general procedure for configuring ingress ga
 
 If ACLs are enabled, you must present a token when registering ingress gateways that grant the following permissions:
 
-- `service:write` for the ingress gateway's service name 
+- `service:write` for the ingress gateway's service name
 - `service:read` for all services in the ingress gateway's configuration entry
 - `node:read` for all nodes of the services in the ingress gateway's configuration entry.
 
@@ -40,11 +40,11 @@ These privileges authorize the token to route communications to other services i
 
 You must define one or more additional static clusters in the ingress gateway service definition for each Envoy proxy associated with the gateway. The additional clusters define how Envoy should connect to the required SDS services.
 
-Configure the static clusters in the [`Proxy.Config.envoy_envoy_extra_static_clusters_json`](/consul/docs/connect/proxies/envoy#envoy_extra_static_clusters_json) parameter in the service definition. 
+Configure the static clusters in the [`Proxy.Config.envoy_envoy_extra_static_clusters_json`](/consul/docs/connect/proxies/envoy#envoy_extra_static_clusters_json) parameter in the service definition.
 
 The clusters must provide connection information and any necessary authentication information, such as mTLS credentials.
 
-You must manually register the ingress gateway with Consul proxy to define extra clusters in Envoy's bootstrap configuration. You can not use the `-register` flag with `consul connect envoy -gateway=ingress` to automatically register the proxy to define static clusters. 
+You must manually register the ingress gateway with Consul proxy to define extra clusters in Envoy's bootstrap configuration. You can not use the `-register` flag with `consul connect envoy -gateway=ingress` to automatically register the proxy to define static clusters.
 
 In the following example, the `public-ingress` gateway includes a static cluster named `sds-cluster` that specifies paths to the SDS certificate and SDS certification validation files:
 
@@ -62,7 +62,14 @@ Services {
 {
   "name": "sds-cluster",
   "connect_timeout": "5s",
-  "http2_protocol_options": {},
+  "typed_extension_protocol_options": {
+    "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+      "explicit_http_config": {
+        "http2_protocol_options": {}
+      }
+    }
+  },
   "type": "LOGICAL_DNS",
   "transport_socket": {
     "name":"tls",
@@ -114,9 +121,9 @@ EOF
 
 </CodeBlockConfig>
 
-Refer to the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.17.2/api-v3/config/bootstrap/v3/bootstrap.proto#envoy-v3-api-field-config-bootstrap-v3-bootstrap-staticresources-clusters) for details about configuration parameters for SDS clusters. 
+Refer to the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.17.2/api-v3/config/bootstrap/v3/bootstrap.proto#envoy-v3-api-field-config-bootstrap-v3-bootstrap-staticresources-clusters) for details about configuration parameters for SDS clusters.
 
-## Register the ingress gateway service definition 
+## Register the ingress gateway service definition
 
 Issue the `consul services register` command on the Consul agent on the Envoy proxy's node to register the service. The following example command registers an ingress gateway proxy from a `public-ingress.hcl` file:
 
@@ -193,19 +200,19 @@ Refer to [Consul Connect Envoy](/consul/commands/connect/envoy) for additional i
 Create an ingress gateway configuration entry that enables the gateway to use certificates from SDS. The configuration entry also maps downstream ingress listeners to upstream services. Configure the following fields:
 
 - [`Kind`](/consul/docs/connect/config-entries/ingress-gateway#kind): Set the value to `ingress-gateway`.
-- [`Name`](/consul/docs/connect/config-entries/ingress-gateway#name): Consul applies the configuration entry settings to ingress gateway proxies with names that match the `Name` field.  
-- [`TLS`](/consul/docs/connect/config-entries/ingress-gateway#tls): The main `TLS` parameter for the configuration entry holds the SDS configuration. You can also specify TLS configurations per listener and per service. 
+- [`Name`](/consul/docs/connect/config-entries/ingress-gateway#name): Consul applies the configuration entry settings to ingress gateway proxies with names that match the `Name` field.
+- [`TLS`](/consul/docs/connect/config-entries/ingress-gateway#tls): The main `TLS` parameter for the configuration entry holds the SDS configuration. You can also specify TLS configurations per listener and per service.
   - [`TLS.SDS`](/consul/docs/connect/config-entries/ingress-gateway#tls-sds): The `SDS` map includes the following configuration settings:
-    - [`ClusterName`](/consul/docs/connect/config-entries/ingress-gateway#tls-sds-clustername): Specifies the name of the cluster you specified when [configuring the SDS cluster](#configure-static-SDS-clusters). 
-    - [`CertResource`](/consul/docs/connect/config-entries/ingress-gateway#tls-sds-certresource): Specifies the name of the certificate resource to load.   
+    - [`ClusterName`](/consul/docs/connect/config-entries/ingress-gateway#tls-sds-clustername): Specifies the name of the cluster you specified when [configuring the SDS cluster](#configure-static-SDS-clusters).
+    - [`CertResource`](/consul/docs/connect/config-entries/ingress-gateway#tls-sds-certresource): Specifies the name of the certificate resource to load.
 - [`Listeners`](/consul/docs/connect/config-entries/ingress-gateway#listeners): Specify one or more listeners.
    - [`Listeners.Port`](/consul/docs/connect/config-entries/ingress-gateway#listeners-port): Specify a port for the listener. Each listener is uniquely identified by its port number.
    - [`Listeners.Protocol`](/consul/docs/connect/config-entries/ingress-gateway#listeners-protocol): The default protocol is `tcp`, but you must specify the protocol used by the services you want to allow traffic from.
-   - [`Listeners.Services`](/consul/docs/connect/config-entries/ingress-gateway#listeners-services): The `Services` field contains the services that you want to expose to upstream services. The field contains several options and sub-configurations that enable granular control over ingress traffic, such as health check and TLS configurations.  
+   - [`Listeners.Services`](/consul/docs/connect/config-entries/ingress-gateway#listeners-services): The `Services` field contains the services that you want to expose to upstream services. The field contains several options and sub-configurations that enable granular control over ingress traffic, such as health check and TLS configurations.
 
-For Consul Enterprise service meshes, you may also need to configure the [`Partition`](/consul/docs/connect/config-entries/ingress-gateway#partition) and [`Namespace`](/consul/docs/connect/config-entries/ingress-gateway#namespace) fields for the gateway and for each exposed service. 
+For Consul Enterprise service meshes, you may also need to configure the [`Partition`](/consul/docs/connect/config-entries/ingress-gateway#partition) and [`Namespace`](/consul/docs/connect/config-entries/ingress-gateway#namespace) fields for the gateway and for each exposed service.
 
-Refer to [Ingress gateway configuration entry reference](/consul/docs/connect/config-entries/ingress-gateway) for details about the supported parameters. 
+Refer to [Ingress gateway configuration entry reference](/consul/docs/connect/config-entries/ingress-gateway) for details about the supported parameters.
 
 The following example directs Consul to retrieve `example.com-public-cert` certificates from an SDS cluster named `sds-cluster` and serve them to all listeners:
 

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -224,7 +224,15 @@ Then, open `bootstrap.json` and update the following sections with your ACL toke
 ```json
 {
   "admin": {
-    "access_log_path": "/dev/null",
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
     "address": {
       "socket_address": {
         "address": "127.0.0.1",


### PR DESCRIPTION
### Description
Remove uses of deprecated fields:
- `envoy.config.cluster.v3.Cluster.http2_protocol_options`
- `envoy.config.bootstrap.v3.Admin.access_log_path`

### Testing & Reproduction steps
CI works

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
