### PR TITLE
ci: upload test results to DataDog on test failure

### DIFF
--- a/.github/workflows/nightly-test-integ-peering_commontopo.yml
+++ b/.github/workflows/nightly-test-integ-peering_commontopo.yml
@@ -106,12 +106,12 @@ jobs:
           TERM: ansi
 
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') && !cancelled() }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') && !cancelled() }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:

--- a/.github/workflows/nightly-test-integrations-1.15.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.15.x.yml
@@ -152,13 +152,13 @@ jobs:
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -169,14 +169,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -259,13 +259,13 @@ jobs:
           TERM: ansi
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -276,14 +276,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci

--- a/.github/workflows/nightly-test-integrations-1.16.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.16.x.yml
@@ -155,13 +155,13 @@ jobs:
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -172,14 +172,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -280,13 +280,13 @@ jobs:
           TERM: ansi
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -297,14 +297,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci

--- a/.github/workflows/nightly-test-integrations-1.17.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.17.x.yml
@@ -155,13 +155,13 @@ jobs:
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -172,14 +172,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -280,13 +280,13 @@ jobs:
           TERM: ansi
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -297,14 +297,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -370,13 +370,13 @@ jobs:
           TERM: ansi
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -387,14 +387,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci

--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -152,13 +152,13 @@ jobs:
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -169,14 +169,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -277,13 +277,13 @@ jobs:
           TERM: ansi
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -294,14 +294,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -365,13 +365,13 @@ jobs:
           TERM: ansi
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -382,14 +382,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci

--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -133,13 +133,13 @@ jobs:
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -150,26 +150,29 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: ${{ env.DATADOG_API_KEY}}
+        if: ${{ !cancelled() && env.DATADOG_API_KEY}}
         env:
           DD_ENV: ci
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" ${{env.TEST_RESULTS}}/gotestsum-report.xml
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ !cancelled() }}
         with:
           name: test-results
           path: ${{env.TEST_RESULTS}}
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ !cancelled() }}
         with:
           name: jsonfile
           path: /tmp/jsonfile
       - name: "Re-run fails report"
+        if: ${{ !cancelled() }}
         run: |
           .github/scripts/rerun_fails_report.sh /tmp/gotestsum-rerun-fails

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -110,13 +110,13 @@ jobs:
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -127,26 +127,29 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: ${{ env.DATADOG_API_KEY}}
+        if: ${{ !cancelled() && env.DATADOG_API_KEY}}
         env:
           DD_ENV: ci
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" ${{env.TEST_RESULTS}}/gotestsum-report.xml
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ !cancelled() }}
         with:
           name: test-results
           path: ${{env.TEST_RESULTS}}
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ !cancelled() }}
         with:
           name: jsonfile
           path: /tmp/jsonfile
       - name: "Re-run fails report"
+        if: ${{ !cancelled() }}
         run: |
           .github/scripts/rerun_fails_report.sh /tmp/gotestsum-rerun-fails

--- a/.github/workflows/test-integrations-windows.yml
+++ b/.github/workflows/test-integrations-windows.yml
@@ -1165,13 +1165,13 @@ jobs:
 
         # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -1183,14 +1183,14 @@ jobs:
 
       - name: Prepare datadog-ci
         shell: bash
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/v2.17.2/datadog-ci_win-x64.exe" --output "C:/datadog-ci"
           icacls C:/datadog-ci /grant:rx Everyone:RX
 
       - name: Upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -119,13 +119,13 @@ jobs:
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -136,14 +136,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -200,13 +200,13 @@ jobs:
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -217,14 +217,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -232,7 +232,7 @@ jobs:
 
       - name: upload leader coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -240,7 +240,7 @@ jobs:
 
       - name: upload agent coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -344,13 +344,13 @@ jobs:
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -361,14 +361,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -456,13 +456,13 @@ jobs:
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -473,14 +473,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -538,13 +538,13 @@ jobs:
           TERM: ansi
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: vault-auth
         run: vault-auth
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Fetch Secrets
-        if: ${{ endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && endsWith(github.repository, '-enterprise') }}
         id: secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
@@ -555,14 +555,14 @@ jobs:
               kv/data/github/${{ github.repository }}/datadog apikey | DATADOG_API_KEY;
 
       - name: prepare datadog-ci
-        if: ${{ !endsWith(github.repository, '-enterprise') }}
+        if: ${{ !cancelled() && !endsWith(github.repository, '-enterprise') }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
         # do not run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci


### PR DESCRIPTION
Due to the unintuitive behavior of GHA w.r.t. implicit status check `success()`, test results were only being uploaded on success (failures presumably came from retried tests that passed).

Example skip on `main`: https://github.com/hashicorp/consul/actions/runs/7214020207/job/19655377560#step:13:34655

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
