### PR TITLE
Fix typo in service-defaults documentation

### DIFF
--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -547,7 +547,7 @@ Specifies the Consul namespace that the configuration entry applies to.
 
 ### `Partition` <EnterpriseAlert inline/>
 
-Specifies the name of the name of the Consul admin partition that the configuration entry applies to.  Refer to [Admin Partitions](/consul/docs/enterprise/admin-partitions) for additional information.
+Specifies the name of the Consul admin partition that the configuration entry applies to.  Refer to [Admin Partitions](/consul/docs/enterprise/admin-partitions) for additional information.
 
 #### Values
 


### PR DESCRIPTION
### Description
Noticed a typo in the docs, fixing it

### Testing & Reproduction steps
:eyes:

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

[Location of typo in docs](https://developer.hashicorp.com/consul/docs/connect/config-entries/service-defaults#partition)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
