### PR TITLE
Fix bug with prepared queries using sameness-groups.

### DIFF
--- a/.changelog/_7773.txt
+++ b/.changelog/_7773.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+prepared-query: (Enterprise-only) Fix issue where sameness-group failover targets to peers would attempt to query data from the default partition, rather than the sameness-group's partition always.
+```


### PR DESCRIPTION
Note that this is simply some CE test file changes needed for the corresponding ENT PR.

This commit fixes an issue where the partition was not properly set on the peering query failover target created from sameness-groups. Before this change, it was always empty, meaning that the data would be queried with respect to the default partition always. This resulted in a situation where a PQ that was attempting to use a sameness-group for failover would select peers from the default partition, rather than the partition of the sameness-group itself.

