### PR TITLE
[NET-6969] security: Re-enable Go Module + secrets security scans for release branches

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,88 @@
+name: Security Scan
+
+on:
+  push:
+    branches:
+      - main
+      - release/**
+  pull_request:
+    branches:
+      - main
+      - release/**
+
+# cancel existing runs of the same workflow on the same ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conditional-skip:
+    runs-on: ubuntu-latest
+    name: Get files changed and conditionally skip CI
+    outputs:
+      skip-ci: ${{ steps.read-files.outputs.skip-ci }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: read-files
+        run: ./.github/scripts/filter_changed_files_go_test.sh
+
+  setup:
+    needs: [conditional-skip]
+    name: Setup
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      compute-small: ${{ steps.setup-outputs.outputs.compute-small }}
+      compute-medium: ${{ steps.setup-outputs.outputs.compute-medium }}
+      compute-large: ${{ steps.setup-outputs.outputs.compute-large }}
+      compute-xl: ${{ steps.setup-outputs.outputs.compute-xl }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - id: setup-outputs
+        name: Setup outputs
+        run: ./.github/scripts/get_runner_classes.sh
+
+  scan:
+    needs: [setup]
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
+    # The first check ensures this doesn't run on community-contributed PRs, who
+    # won't have the permissions to run this job.
+    if: ${{ (github.repository != 'hashicorp/consul' || (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name))
+      && (github.actor != 'dependabot[bot]') && (github.actor != 'hc-github-team-consul-core') }}
+
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set up Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          cache: true
+          go-version: 1.20.12  #TODO move CI build config and this to .go-version or .go-mod
+
+      - name: Clone Security Scanner repo
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          repository: hashicorp/security-scanner
+          token: ${{ secrets.HASHIBOT_PRODSEC_GITHUB_TOKEN }}
+          path: security-scanner
+          ref: main
+
+      - name: Scan
+        id: scan
+        uses: ./security-scanner
+        with:
+          repository: "$PWD"
+          # See scan.hcl at repository root for config.
+
+      - name: SARIF Output
+        shell: bash
+        run: |
+          cat results.sarif | jq
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@46a6823b81f2d7c67ddf123851eea88365bc8a67 # codeql-bundle-v2.13.5
+        with:
+          sarif_file: results.sarif

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,17 +1,46 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+# These scan results are run as part of CRT workflows.
+
+# Un-triaged results will block release. See `security-scanner` docs for more
+# information on how to add `triage` config to unblock releases for specific results.
+# In most cases, we should not need to disable the entire scanner to unblock a release.
+
+# To run manually, install scanner and then from the repository root run
+# `SECURITY_SCANNER_CONFIG_FILE=.release/security-scan.hcl scan ...`
+# To scan a local container, add `local_daemon = true` to the `container` block below.
+# See `security-scanner` docs or run with `--help` for scan target syntax.
+
 container {
 	dependencies = true
-	alpine_secdb = false
-	secrets      = false
+	alpine_secdb = true
+
+	secrets {
+		all = true
+	}
+
+	# Triage items that are _safe_ to ignore here. Note that this list should be
+	# periodically cleaned up to remove items that are no longer found by the scanner.
+	triage {
+		suppress {
+			# N.b. `vulnerabilites` is the correct spelling for this tool.
+			vulnerabilites = [
+				"CVE-2023-46218", # curl@8.4.0-r0
+				"CVE-2023-46219", # curl@8.4.0-r0
+				"CVE-2023-5678",  # openssl@3.1.4-r0
+			]
+		}
+	}
 }
 
 binary {
-	secrets      = false
-	go_modules   = false
+	go_modules   = true
 	osv          = true
-	# TODO(spatel): CE refactor
-	oss_index    = true
-	nvd          = true
+	# We can't enable npm for binary targets today because we don't yet embed the relevant file
+	# (yarn.lock) in the Consul binary. This is something we may investigate in the future.
+	
+	secrets {
+		all = true
+	}
 }

--- a/scan.hcl
+++ b/scan.hcl
@@ -1,0 +1,25 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# Configuration for security scanner.
+# Run on PRs and pushes to `main` and `release/**` branches.
+# See .github/workflows/security-scan.yml for CI config.
+
+# To run manually, install scanner and then run `scan repository .`
+
+# Scan results are triaged via the GitHub Security tab for this repo.
+# See `security-scanner` docs for more information on how to add `triage` config
+# for specific results or to exclude paths.
+
+# .release/security-scan.hcl controls scanner config for release artifacts, which
+# unlike the scans configured here, will block releases in CRT.
+
+repository {
+  go_modules   = true
+  npm          = true
+  osv          = true
+
+  secrets {
+    all = true
+  }
+}


### PR DESCRIPTION
### Description

* Re-enable `binary` Go Modules + secrets security scans to block releases automatically in CRT on failure 
  * Previously disabled in the following PRs; all prior issues appear to now be resolved:
    * https://github.com/hashicorp/consul/pull/13614
    * https://github.com/hashicorp/consul/pull/12281
    * https://github.com/hashicorp/consul/pull/12275
  * I also re-enabled secrets in the `container` scans because that seemed like an obvious opportunity
* Introduce PR and merge scans of the repository on `main` and `release/**` branches
  * The goal here is to increase visibility of un-triaged scan results before they block a release; doing so requires scanning more than our [nightly run on `main`](https://github.com/hashicorp/security-scanning/blob/17ff72eb77354fc66cdaa2edcb7c050e3f09c756/.github/workflows/security-scanner-daily-out-of-band-scan.yml#L66).
  * Note that this will result in a one-time increase of new items to triage for the scanned release branches, where scanning was not already done manually. Once we triage the initial set, we just need to maintain it going forward.

### Reviewer Notes

* Security folks: I'd love your input on anything here that seems missing or non-standard. My goal isn't to flip every bit on, so much as to keep up with our expected baseline that was previously disabled, and ensure we're catching things early pre-release. If there are better ways to do that, or specific flags that should be _added_ beyond what's being re-enabled, all ears.
* Consul eng: any concerns or Q&A about this change are welcome. Beyond that, this PR should be pretty straightforward to review.

### Testing & Reproduction steps

* Repo scan and SARIF upload for test branch verified here: https://github.com/hashicorp/consul/actions/runs/7190530738/job/19583818068
* For the binary + container scan, I've verified that this would not block a release today once enabled:
```shell
❯ go version $(which consul)
/Users/michael.zalimeni/go/bin/consul: go1.20.12

❯ SECURITY_SCANNER_CONFIG_FILE=.release/security-scan.hcl scan container hashicorp/consul-enterprise:local
✓ Scanned docker:{owner:"hashicorp" name:"consul-enterprise"} tag:"local" localDaemon:true in 1m4.3s - no results found

❯ consul version | grep Consul
Consul v1.18.0-dev+ent
❯ SECURITY_SCANNER_CONFIG_FILE=.release/security-scan.hcl scan binary $(which consul)
✓ Scanned file:{path:"/Users/michael.zalimeni/go/bin/consul"} in 10.5s - no results found

❯ consul version | grep Consul
Consul v1.17.2-dev+ent
❯ SECURITY_SCANNER_CONFIG_FILE=.release/security-scan.hcl scan binary $(which consul)
✓ Scanned file:{path:"/Users/michael.zalimeni/go/bin/consul"} in 10.3s - no results found

❯ consul version | grep Consul
Consul v1.16.5-dev+ent
❯ SECURITY_SCANNER_CONFIG_FILE=.release/security-scan.hcl scan binary $(which consul)
✓ Scanned file:{path:"/Users/michael.zalimeni/go/bin/consul"} in 13.1s - no results found

❯ consul version | grep Consul
Consul v1.15.9-dev+ent
❯ SECURITY_SCANNER_CONFIG_FILE=.release/security-scan.hcl scan binary $(which consul)
✓ Scanned file:{path:"/Users/michael.zalimeni/go/bin/consul"} in 11.6s - no results found
```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern 🔒 
