### PR TITLE
[NET-5455] Allow disabling request and idle timeouts with -1 in service router and resolver

### DIFF
--- a/.changelog/19992.txt
+++ b/.changelog/19992.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+config-entries: Allow disabling request and idle timeouts with negative values in service router and service resolver config entries.
+```

--- a/agent/proxycfg/testing_upstreams.go
+++ b/agent/proxycfg/testing_upstreams.go
@@ -546,7 +546,7 @@ func setupTestVariationDiscoveryChain(
 					"protocol": "http",
 				},
 			},
-			// Adding a service router to this case allows testing ServiceRoute.Destination timeouts.
+			// Adding a ServiceRouter in this case allows testing ServiceRoute.Destination timeouts.
 			&structs.ServiceRouterConfigEntry{
 				Kind:           structs.ServiceRouter,
 				Name:           "db",
@@ -559,9 +559,24 @@ func setupTestVariationDiscoveryChain(
 							},
 						},
 						Destination: &structs.ServiceRouteDestination{
-							Service:        "big-side",
-							IdleTimeout:    -1 * time.Second,
-							RequestTimeout: -1 * time.Second,
+							Service: "big-side",
+							// Test disabling idle timeout.
+							IdleTimeout: -1 * time.Second,
+							// Test a positive value for request timeout.
+							RequestTimeout: 10 * time.Second,
+						},
+					},
+					{
+						Match: &structs.ServiceRouteMatch{
+							HTTP: &structs.ServiceRouteHTTPMatch{
+								PathPrefix: "/lil-bit-side",
+							},
+						},
+						Destination: &structs.ServiceRouteDestination{
+							Service: "lil-bit-side",
+							// Test zero values for these timeouts.
+							IdleTimeout:    0 * time.Second,
+							RequestTimeout: 0 * time.Second,
 						},
 					},
 				},

--- a/agent/xds/proxystateconverter/routes.go
+++ b/agent/xds/proxystateconverter/routes.go
@@ -6,16 +6,18 @@ package proxystateconverter
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/consul/proto-public/pbmesh/v2beta1/pbproxystate"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/consul/proto-public/pbmesh/v2beta1/pbproxystate"
+
 	"github.com/hashicorp/consul/agent/xds/response"
+
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // routesFromSnapshot returns the xDS API representation of the "routes" in the
@@ -255,23 +257,32 @@ func (s *Converter) makeUpstreamHostForDiscoveryChain(
 			routeRule := &pbproxystate.RouteRule{}
 
 			if destination != nil {
-				configHandle := routeDestination.DestinationConfiguration
+				routeDestinationConfiguration := routeDestination.DestinationConfiguration
 				if destination.PrefixRewrite != "" {
-					configHandle.PrefixRewrite = destination.PrefixRewrite
+					routeDestinationConfiguration.PrefixRewrite = destination.PrefixRewrite
 				}
 
-				if destination.RequestTimeout > 0 || destination.IdleTimeout > 0 {
-					configHandle.TimeoutConfig = &pbproxystate.TimeoutConfig{}
+				if destination.RequestTimeout != 0 || destination.IdleTimeout != 0 {
+					routeDestinationConfiguration.TimeoutConfig = &pbproxystate.TimeoutConfig{}
 				}
 				if destination.RequestTimeout > 0 {
-					configHandle.TimeoutConfig.Timeout = durationpb.New(destination.RequestTimeout)
+					routeDestinationConfiguration.TimeoutConfig.Timeout = durationpb.New(destination.RequestTimeout)
 				}
+				// Disable the timeout if user specifies negative value. Setting 0 disables the timeout in Envoy.
+				if destination.RequestTimeout < 0 {
+					routeDestinationConfiguration.TimeoutConfig.Timeout = durationpb.New(0 * time.Second)
+				}
+
 				if destination.IdleTimeout > 0 {
-					configHandle.TimeoutConfig.IdleTimeout = durationpb.New(destination.IdleTimeout)
+					routeDestinationConfiguration.TimeoutConfig.IdleTimeout = durationpb.New(destination.IdleTimeout)
+				}
+				// Disable the timeout if user specifies negative value. Setting 0 disables the timeout in Envoy.
+				if destination.IdleTimeout < 0 {
+					routeDestinationConfiguration.TimeoutConfig.IdleTimeout = durationpb.New(0 * time.Second)
 				}
 
 				if destination.HasRetryFeatures() {
-					configHandle.RetryPolicy = getRetryPolicyForDestination(destination)
+					routeDestinationConfiguration.RetryPolicy = getRetryPolicyForDestination(destination)
 				}
 
 				if err := injectHeaderManipToRoute(destination, routeRule); err != nil {
@@ -320,9 +331,21 @@ func (s *Converter) makeUpstreamHostForDiscoveryChain(
 			return nil, fmt.Errorf("failed to apply load balancer configuration to route action: %v", err)
 		}
 
+		// A request timeout can be configured on a resolver or router. If configured on a resolver, the timeout will
+		// only apply if the start node is a resolver. This is because the timeout is attached to an (Envoy
+		// RouteAction)[https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-routeaction]
+		// If there is a splitter before this resolver, the branches of the split are configured within the same
+		// RouteAction, and the timeout cannot be shared between branches of a split.
 		if startNode.Resolver.RequestTimeout > 0 {
 			to := &pbproxystate.TimeoutConfig{
 				Timeout: durationpb.New(startNode.Resolver.RequestTimeout),
+			}
+			routeDestination.DestinationConfiguration.TimeoutConfig = to
+		}
+		// Disable the timeout if user specifies negative value. Setting 0 disables the timeout in Envoy.
+		if startNode.Resolver.RequestTimeout < 0 {
+			to := &pbproxystate.TimeoutConfig{
+				Timeout: durationpb.New(0 * time.Second),
 			}
 			routeDestination.DestinationConfiguration.TimeoutConfig = to
 		}

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -696,9 +696,17 @@ func (s *ResourceGenerator) makeUpstreamRouteForDiscoveryChain(
 				if destination.RequestTimeout > 0 {
 					routeAction.Route.Timeout = durationpb.New(destination.RequestTimeout)
 				}
+				// Disable the timeout if user specifies negative value. Setting 0 disables the timeout in Envoy.
+				if destination.RequestTimeout < 0 {
+					routeAction.Route.Timeout = durationpb.New(0 * time.Second)
+				}
 
 				if destination.IdleTimeout > 0 {
 					routeAction.Route.IdleTimeout = durationpb.New(destination.IdleTimeout)
+				}
+				// Disable the timeout if user specifies negative value. Setting 0 disables the timeout in Envoy.
+				if destination.IdleTimeout < 0 {
+					routeAction.Route.IdleTimeout = durationpb.New(0 * time.Second)
 				}
 
 				if destination.HasRetryFeatures() {
@@ -754,8 +762,17 @@ func (s *ResourceGenerator) makeUpstreamRouteForDiscoveryChain(
 			return nil, fmt.Errorf("failed to apply load balancer configuration to route action: %v", err)
 		}
 
+		// A request timeout can be configured on a resolver or router. If configured on a resolver, the timeout will
+		// only apply if the start node is a resolver. This is because the timeout is attached to an (Envoy
+		// RouteAction)[https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-routeaction]
+		// If there is a splitter before this resolver, the branches of the split are configured within the same
+		// RouteAction, and the timeout cannot be shared between branches of a split.
 		if startNode.Resolver.RequestTimeout > 0 {
 			routeAction.Route.Timeout = durationpb.New(startNode.Resolver.RequestTimeout)
+		}
+		// Disable the timeout if user specifies negative value. Setting 0 disables the timeout in Envoy.
+		if startNode.Resolver.RequestTimeout < 0 {
+			routeAction.Route.Timeout = durationpb.New(0 * time.Second)
 		}
 		defaultRoute := &envoy_route_v3.Route{
 			Match:  makeDefaultRouteMatch(),

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-splitter.latest.golden
@@ -51,6 +51,54 @@
     },
     {
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "altStatName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "circuitBreakers": {},
+      "commonLbConfig": {
+        "healthyPanicThreshold": {}
+      },
+      "connectTimeout": "25s",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {},
+          "resourceApiVersion": "V3"
+        }
+      },
+      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "outlierDetection": {},
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsCertificates": [
+              {
+                "certificateChain": {
+                  "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                },
+                "privateKey": {
+                  "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                }
+              }
+            ],
+            "tlsParams": {},
+            "validationContext": {
+              "matchSubjectAltNames": [
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
+                }
+              ],
+              "trustedCa": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+              }
+            }
+          },
+          "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+        }
+      },
+      "type": "EDS"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
       "circuitBreakers": {},
       "connectTimeout": "5s",
       "edsClusterConfig": {

--- a/agent/xds/testdata/clusters/ingress-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-chain-and-splitter.latest.golden
@@ -51,6 +51,54 @@
     },
     {
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "altStatName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "circuitBreakers": {},
+      "commonLbConfig": {
+        "healthyPanicThreshold": {}
+      },
+      "connectTimeout": "25s",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {},
+          "resourceApiVersion": "V3"
+        }
+      },
+      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "outlierDetection": {},
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsCertificates": [
+              {
+                "certificateChain": {
+                  "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                },
+                "privateKey": {
+                  "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                }
+              }
+            ],
+            "tlsParams": {},
+            "validationContext": {
+              "matchSubjectAltNames": [
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
+                }
+              ],
+              "trustedCa": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+              }
+            }
+          },
+          "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+        }
+      },
+      "type": "EDS"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
       "altStatName": "goldilocks-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "circuitBreakers": {},
       "commonLbConfig": {

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-splitter.latest.golden
@@ -3,6 +3,40 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
       "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {

--- a/agent/xds/testdata/endpoints/ingress-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/endpoints/ingress-with-chain-and-splitter.latest.golden
@@ -1,5 +1,41 @@
 {
   "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
   "versionInfo": "00000001"
 }

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-splitter.latest.golden
@@ -14,11 +14,43 @@
           "routes": [
             {
               "match": {
+                "prefix": "/big-side"
+              },
+              "route": {
+                "cluster": "big-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "idleTimeout": "0s",
+                "timeout": "0s"
+              }
+            },
+            {
+              "match": {
                 "prefix": "/"
               },
               "route": {
                 "weightedClusters": {
                   "clusters": [
+                    {
+                      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                      "requestHeadersToAdd": [
+                        {
+                          "append": false,
+                          "header": {
+                            "key": "x-split-leg",
+                            "value": "db"
+                          }
+                        }
+                      ],
+                      "responseHeadersToAdd": [
+                        {
+                          "append": false,
+                          "header": {
+                            "key": "x-split-leg",
+                            "value": "db"
+                          }
+                        }
+                      ],
+                      "weight": 100
+                    },
                     {
                       "name": "big-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                       "requestHeadersToAdd": [
@@ -61,7 +93,7 @@
                           }
                         }
                       ],
-                      "weight": 400
+                      "weight": 300
                     },
                     {
                       "name": "lil-bit-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-splitter.latest.golden
@@ -19,7 +19,15 @@
               "route": {
                 "cluster": "big-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                 "idleTimeout": "0s",
-                "timeout": "0s"
+                "timeout": "10s"
+              }
+            },
+            {
+              "match": {
+                "prefix": "/lil-bit-side"
+              },
+              "route": {
+                "cluster": "lil-bit-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {

--- a/agent/xds/testdata/routes/ingress-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-splitter.latest.golden
@@ -15,11 +15,51 @@
           "routes": [
             {
               "match": {
+                "prefix": "/big-side"
+              },
+              "route": {
+                "cluster": "big-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "idleTimeout": "0s",
+                "timeout": "10s"
+              }
+            },
+            {
+              "match": {
+                "prefix": "/lil-bit-side"
+              },
+              "route": {
+                "cluster": "lil-bit-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            },
+            {
+              "match": {
                 "prefix": "/"
               },
               "route": {
                 "weightedClusters": {
                   "clusters": [
+                    {
+                      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                      "requestHeadersToAdd": [
+                        {
+                          "append": false,
+                          "header": {
+                            "key": "x-split-leg",
+                            "value": "db"
+                          }
+                        }
+                      ],
+                      "responseHeadersToAdd": [
+                        {
+                          "append": false,
+                          "header": {
+                            "key": "x-split-leg",
+                            "value": "db"
+                          }
+                        }
+                      ],
+                      "weight": 100
+                    },
                     {
                       "name": "big-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                       "requestHeadersToAdd": [
@@ -62,7 +102,7 @@
                           }
                         }
                       ],
-                      "weight": 400
+                      "weight": 300
                     },
                     {
                       "name": "lil-bit-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",


### PR DESCRIPTION
### Description
Adds the ability to disable request and idle timeouts in a service router and service resolver.

*Previous Behavior*:
user sets 0s or doesn’t set anything -> results in envoy defaults of 15s (requestTimeout) or 1hr (idleTimeout)
user sets >0s -> results in setting that same value in envoy

*Behavior with this change*:
user sets -1s -> results in setting 0s in envoy (disabling the timeout)
user sets 0s or doesn’t set anything -> result in envoy defaults of 15s or 1hr
user sets >0s ->  results in setting that same value in envoy

* Made changes to xds/routes.go and proxystateconverter/routes.go to support this
* Adds to the chain-with-splitter test cases to test the timeout (picked an arbitrary case with disco chains to add coverage for the timeouts)


### Links

https://hashicorp.atlassian.net/browse/NET-5455 

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
