### PR TITLE
fix: add test which has been removed for metrics to unblock CI

### DIFF
--- a/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
+++ b/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
@@ -27,7 +27,7 @@
       "components.hashicorp-consul.side-nav.partitions.footer"
     }}
     @disabled={{not canChoose}}
-    data-test-datacenter-disclosure-menu
+    data-test-datacenter-menu
     as |Selector|
   >
     <Selector.Data>

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/topology/metrics.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/topology/metrics.feature
@@ -48,3 +48,25 @@ Feature: dc / services / show / topology / metrics
       service: web
     ---
     And I see the "[data-test-sparkline]" element
+  Scenario: Metrics enabled but service source is Consul API Gateway
+    Given 1 datacenter model with the value "datacenter"
+    And the local datacenter is "datacenter"
+    And 1 service model from yaml
+    ---
+      - Service:
+        Name: web
+        Kind: ~
+        Meta:
+        external-source: consul-api-gateway
+    ---
+    And ui_config from yaml
+    ---
+      metrics_proxy_enabled: true
+      metrics_provider: 'prometheus'
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: datacenter
+      service: web
+    ---
+    And I don't see the "[data-test-sparkline]" element


### PR DESCRIPTION
### Description
Duplicate for the pr: https://github.com/hashicorp/consul/pull/19927

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
