### PR TITLE
NET-6946 / NET-6941 - Replace usage of deprecated Envoy fields envoy.config.route.v3.HeaderMatcher.safe_regex_match and envoy.type.matcher.v3.RegexMatcher.google_re2

### DIFF
--- a/.changelog/20013.txt
+++ b/.changelog/20013.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+xds: replace usage of deprecated Envoy field `envoy.config.route.v3.HeaderMatcher.safe_regex_match`
+```

--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -196,7 +196,7 @@ jobs:
         consul-version: [ "1.16", "1.17"]
     env:
       CONSUL_LATEST_VERSION: ${{ matrix.consul-version }}
-      ENVOY_VERSION: "1.25.4"
+      ENVOY_VERSION: "1.28.0"
     steps:
       - name: Checkout code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -196,7 +196,7 @@ jobs:
         consul-version: [ "1.16", "1.17"]
     env:
       CONSUL_LATEST_VERSION: ${{ matrix.consul-version }}
-      ENVOY_VERSION: "1.28.0"
+      ENVOY_VERSION: "1.25.4"
     steps:
       - name: Checkout code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -383,7 +383,7 @@ jobs:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read
     env:
-      ENVOY_VERSION: "1.25.4"
+      ENVOY_VERSION: "1.28.0"
       CONSUL_DATAPLANE_IMAGE: "docker.io/hashicorppreview/consul-dataplane:1.3-dev-ubi"
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -383,7 +383,7 @@ jobs:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read
     env:
-      ENVOY_VERSION: "1.28.0"
+      ENVOY_VERSION: "1.25.4"
       CONSUL_DATAPLANE_IMAGE: "docker.io/hashicorppreview/consul-dataplane:1.3-dev-ubi"
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ GO_BUILD_TAG?=consul-build-go
 UI_BUILD_TAG?=consul-build-ui
 BUILD_CONTAINER_NAME?=consul-builder
 CONSUL_IMAGE_VERSION?=latest
-ENVOY_VERSION?='1.25.4'
+ENVOY_VERSION?='1.28.0'
 CONSUL_DATAPLANE_IMAGE := $(or $(CONSUL_DATAPLANE_IMAGE),"docker.io/hashicorppreview/consul-dataplane:1.3-dev-ubi")
 DEPLOYER_CONSUL_DATAPLANE_IMAGE := $(or $(DEPLOYER_CONSUL_DATAPLANE_IMAGE), "docker.io/hashicorppreview/consul-dataplane:1.3-dev")
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ GO_BUILD_TAG?=consul-build-go
 UI_BUILD_TAG?=consul-build-ui
 BUILD_CONTAINER_NAME?=consul-builder
 CONSUL_IMAGE_VERSION?=latest
-ENVOY_VERSION?='1.28.0'
+ENVOY_VERSION?='1.25.4'
 CONSUL_DATAPLANE_IMAGE := $(or $(CONSUL_DATAPLANE_IMAGE),"docker.io/hashicorppreview/consul-dataplane:1.3-dev-ubi")
 DEPLOYER_CONSUL_DATAPLANE_IMAGE := $(or $(DEPLOYER_CONSUL_DATAPLANE_IMAGE), "docker.io/hashicorppreview/consul-dataplane:1.3-dev")
 

--- a/agent/envoyextensions/builtin/ext-authz/structs.go
+++ b/agent/envoyextensions/builtin/ext-authz/structs.go
@@ -547,8 +547,7 @@ func (s *StringMatcher) toEnvoy() *envoy_type_matcher_v3.StringMatcher {
 		return &envoy_type_matcher_v3.StringMatcher{
 			MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 				SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-					EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
-					Regex:      s.SafeRegex,
+					Regex: s.SafeRegex,
 				},
 			},
 		}

--- a/agent/xds/rbac.go
+++ b/agent/xds/rbac.go
@@ -1107,9 +1107,6 @@ func parseXFCCToDynamicMetaHTTPFilter() (*envoy_http_v3.HttpFilter, error) {
 				RegexValueRewrite: &envoy_matcher_v3.RegexMatchAndSubstitute{
 					Pattern: &envoy_matcher_v3.RegexMatcher{
 						Regex: downstreamServiceIdentityMatcher,
-						EngineType: &envoy_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 					},
 					Substitution: f.sub,
 				},
@@ -1310,8 +1307,12 @@ func convertPermission(perm *structs.IntentionPermission) *envoy_rbac_v3.Permiss
 
 		eh := &envoy_route_v3.HeaderMatcher{
 			Name: ":method",
-			HeaderMatchSpecifier: &envoy_route_v3.HeaderMatcher_SafeRegexMatch{
-				SafeRegexMatch: response.MakeEnvoyRegexMatch(methodHeaderRegex),
+			HeaderMatchSpecifier: &envoy_route_v3.HeaderMatcher_StringMatch{
+				StringMatch: &envoy_matcher_v3.StringMatcher{
+					MatchPattern: &envoy_matcher_v3.StringMatcher_SafeRegex{
+						SafeRegex: response.MakeEnvoyRegexMatch(methodHeaderRegex),
+					},
+				},
 			},
 		}
 

--- a/agent/xds/response/response.go
+++ b/agent/xds/response/response.go
@@ -75,9 +75,7 @@ func MakeBoolValue(n bool) *wrapperspb.BoolValue {
 
 func MakeEnvoyRegexMatch(patt string) *envoy_matcher_v3.RegexMatcher {
 	return &envoy_matcher_v3.RegexMatcher{
-		EngineType: &envoy_matcher_v3.RegexMatcher_GoogleRe2{
-			GoogleRe2: &envoy_matcher_v3.RegexMatcher_GoogleRE2{},
-		},
-		Regex: patt,
+		EngineType: &envoy_matcher_v3.RegexMatcher_GoogleRe2{},
+		Regex:      patt,
 	}
 }

--- a/agent/xds/response/response.go
+++ b/agent/xds/response/response.go
@@ -75,7 +75,6 @@ func MakeBoolValue(n bool) *wrapperspb.BoolValue {
 
 func MakeEnvoyRegexMatch(patt string) *envoy_matcher_v3.RegexMatcher {
 	return &envoy_matcher_v3.RegexMatcher{
-		EngineType: &envoy_matcher_v3.RegexMatcher_GoogleRe2{},
-		Regex:      patt,
+		Regex: patt,
 	}
 }

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -924,8 +924,12 @@ func makeRouteMatchForDiscoveryRoute(discoveryRoute *structs.DiscoveryRoute) *en
 
 		eh := &envoy_route_v3.HeaderMatcher{
 			Name: ":method",
-			HeaderMatchSpecifier: &envoy_route_v3.HeaderMatcher_SafeRegexMatch{
-				SafeRegexMatch: response.MakeEnvoyRegexMatch(methodHeaderRegex),
+			HeaderMatchSpecifier: &envoy_route_v3.HeaderMatcher_StringMatch{
+				StringMatch: &envoy_matcher_v3.StringMatcher{
+					MatchPattern: &envoy_matcher_v3.StringMatcher_SafeRegex{
+						SafeRegex: response.MakeEnvoyRegexMatch(methodHeaderRegex),
+					},
+				},
 			},
 		}
 

--- a/agent/xds/testdata/builtin_extension/clusters/ext-authz-http-local-grpc-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/ext-authz-http-local-grpc-service.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/ext-authz-http-local-http-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/ext-authz-http-local-http-service.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/ext-authz-http-upstream-grpc-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/ext-authz-http-upstream-grpc-service.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/ext-authz-http-upstream-http-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/ext-authz-http-upstream-http-service.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/ext-authz-tcp-local-grpc-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/ext-authz-tcp-local-grpc-service.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/ext-authz-tcp-upstream-grpc-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/ext-authz-tcp-upstream-grpc-service.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lambda-and-lua-connect-proxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lambda-and-lua-connect-proxy.latest.golden
@@ -72,16 +72,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lambda-connect-proxy-opposite-meta.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lambda-connect-proxy-opposite-meta.latest.golden
@@ -72,16 +72,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lambda-connect-proxy-tproxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lambda-connect-proxy-tproxy.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -205,10 +205,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/no-endpoints"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lambda-connect-proxy-with-terminating-gateway-upstream.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lambda-connect-proxy-with-terminating-gateway-upstream.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lambda-connect-proxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lambda-connect-proxy.latest.golden
@@ -72,16 +72,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lua-connect-proxy-with-terminating-gateway-upstream.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lua-connect-proxy-with-terminating-gateway-upstream.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lua-inbound-applies-to-inbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lua-inbound-applies-to-inbound.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lua-inbound-doesnt-apply-to-local-upstreams.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lua-inbound-doesnt-apply-to-local-upstreams.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lua-outbound-applies-to-local-upstreams-tproxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lua-outbound-applies-to-local-upstreams-tproxy.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -86,10 +86,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -136,10 +136,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -186,10 +186,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -236,10 +236,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/google"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -283,16 +283,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lua-outbound-applies-to-local-upstreams.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lua-outbound-applies-to-local-upstreams.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lua-outbound-doesnt-apply-to-inbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lua-outbound-doesnt-apply-to-inbound.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lua-outbound-doesnt-apply-to-local-upstreams-with-consul-constraint-violation.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lua-outbound-doesnt-apply-to-local-upstreams-with-consul-constraint-violation.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/lua-outbound-doesnt-apply-to-local-upstreams-with-envoy-constraint-violation.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/lua-outbound-doesnt-apply-to-local-upstreams-with-envoy-constraint-violation.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/otel-access-logging-http.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/otel-access-logging-http.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-add-keepalive.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-add-keepalive.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -88,16 +88,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-add-outlier-detection-multiple.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-add-outlier-detection-multiple.latest.golden
@@ -39,10 +39,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -89,16 +89,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-add-outlier-detection.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-add-outlier-detection.latest.golden
@@ -38,10 +38,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,16 +87,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-add-round-robin-lb-config.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-add-round-robin-lb-config.latest.golden
@@ -37,10 +37,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -85,16 +85,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-cluster-load-assignment-inbound-add.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-cluster-load-assignment-inbound-add.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-cluster-load-assignment-outbound-add.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-cluster-load-assignment-outbound-add.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-inbound-doesnt-apply-to-outbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-inbound-doesnt-apply-to-outbound.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-listener-inbound-add.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-listener-inbound-add.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-listener-outbound-add.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-listener-outbound-add.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-outbound-doesnt-apply-to-inbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-outbound-doesnt-apply-to-inbound.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-patch-specific-upstream-service-failover.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-patch-specific-upstream-service-failover.latest.golden
@@ -58,10 +58,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -111,10 +111,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/fail"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -158,16 +158,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-patch-specific-upstream-service-splitter.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-patch-specific-upstream-service-splitter.latest.golden
@@ -32,16 +32,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -116,10 +116,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -169,10 +169,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/propertyoverride-remove-outlier-detection.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/propertyoverride-remove-outlier-detection.latest.golden
@@ -35,10 +35,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -81,16 +81,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/wasm-http-local-file.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/wasm-http-local-file.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/wasm-http-remote-file.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/wasm-http-remote-file.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/wasm-tcp-local-file-outbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/wasm-tcp-local-file-outbound.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/wasm-tcp-local-file.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/wasm-tcp-local-file.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/wasm-tcp-remote-file-outbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/wasm-tcp-remote-file-outbound.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/clusters/wasm-tcp-remote-file.latest.golden
+++ b/agent/xds/testdata/builtin_extension/clusters/wasm-tcp-remote-file.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-local-grpc-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-local-grpc-service.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-local-http-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-local-http-service.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-upstream-grpc-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-upstream-grpc-service.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-upstream-http-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-upstream-http-service.latest.golden
@@ -204,7 +204,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -218,7 +217,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -232,7 +230,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -246,7 +243,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -260,7 +256,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-upstream-http-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/ext-authz-http-upstream-http-service.latest.golden
@@ -121,13 +121,11 @@
                             "patterns": [
                               {
                                 "safeRegex": {
-                                  "googleRe2": {},
                                   "regex": "client-ok-header-1"
                                 }
                               },
                               {
                                 "safeRegex": {
-                                  "googleRe2": {},
                                   "regex": "client-ok-header-2"
                                 }
                               }

--- a/agent/xds/testdata/builtin_extension/listeners/lambda-and-lua-connect-proxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lambda-and-lua-connect-proxy.latest.golden
@@ -132,7 +132,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -146,7 +145,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -160,7 +158,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -174,7 +171,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -188,7 +184,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/lua-inbound-applies-to-inbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-inbound-applies-to-inbound.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/lua-inbound-doesnt-apply-to-local-upstreams.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-inbound-doesnt-apply-to-local-upstreams.latest.golden
@@ -123,7 +123,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -137,7 +136,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -151,7 +149,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -165,7 +162,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -179,7 +175,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams-tproxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams-tproxy.latest.golden
@@ -206,7 +206,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -220,7 +219,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -234,7 +232,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -248,7 +245,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -262,7 +258,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams.latest.golden
@@ -132,7 +132,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -146,7 +145,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -160,7 +158,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -174,7 +171,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -188,7 +184,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/lua-outbound-doesnt-apply-to-inbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-outbound-doesnt-apply-to-inbound.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/lua-outbound-doesnt-apply-to-local-upstreams-with-consul-constraint-violation.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-outbound-doesnt-apply-to-local-upstreams-with-consul-constraint-violation.latest.golden
@@ -123,7 +123,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -137,7 +136,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -151,7 +149,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -165,7 +162,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -179,7 +175,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/lua-outbound-doesnt-apply-to-local-upstreams-with-envoy-constraint-violation.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-outbound-doesnt-apply-to-local-upstreams-with-envoy-constraint-violation.latest.golden
@@ -123,7 +123,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -137,7 +136,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -151,7 +149,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -165,7 +162,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -179,7 +175,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/otel-access-logging-http.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/otel-access-logging-http.latest.golden
@@ -137,7 +137,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -151,7 +150,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -165,7 +163,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -179,7 +176,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -193,7 +189,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-add-keepalive.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-add-keepalive.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-add-outlier-detection-multiple.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-add-outlier-detection-multiple.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-add-outlier-detection.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-add-outlier-detection.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-add-round-robin-lb-config.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-add-round-robin-lb-config.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-cluster-load-assignment-inbound-add.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-cluster-load-assignment-inbound-add.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-cluster-load-assignment-outbound-add.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-cluster-load-assignment-outbound-add.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-inbound-doesnt-apply-to-outbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-inbound-doesnt-apply-to-outbound.latest.golden
@@ -89,7 +89,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -103,7 +102,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -117,7 +115,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -131,7 +128,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -145,7 +141,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-listener-inbound-add.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-listener-inbound-add.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-listener-outbound-add.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-listener-outbound-add.latest.golden
@@ -89,7 +89,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -103,7 +102,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -117,7 +115,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -131,7 +128,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -145,7 +141,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-outbound-doesnt-apply-to-inbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-outbound-doesnt-apply-to-inbound.latest.golden
@@ -89,7 +89,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -103,7 +102,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -117,7 +115,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -131,7 +128,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -145,7 +141,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-patch-specific-upstream-service-failover.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-patch-specific-upstream-service-failover.latest.golden
@@ -88,7 +88,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -102,7 +101,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -116,7 +114,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -130,7 +127,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -144,7 +140,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-patch-specific-upstream-service-splitter.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-patch-specific-upstream-service-splitter.latest.golden
@@ -110,7 +110,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -124,7 +123,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -138,7 +136,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -152,7 +149,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -166,7 +162,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-patch-specific-upstream-service.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-patch-specific-upstream-service.latest.golden
@@ -109,7 +109,6 @@
                             "key":  "trust-domain",
                             "regexValueRewrite":  {
                               "pattern":  {
-                                "googleRe2":  {},
                                 "regex":  ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution":  "\\1"
@@ -123,7 +122,6 @@
                             "key":  "partition",
                             "regexValueRewrite":  {
                               "pattern":  {
-                                "googleRe2":  {},
                                 "regex":  ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution":  "\\2"
@@ -137,7 +135,6 @@
                             "key":  "namespace",
                             "regexValueRewrite":  {
                               "pattern":  {
-                                "googleRe2":  {},
                                 "regex":  ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution":  "\\3"
@@ -151,7 +148,6 @@
                             "key":  "datacenter",
                             "regexValueRewrite":  {
                               "pattern":  {
-                                "googleRe2":  {},
                                 "regex":  ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution":  "\\4"
@@ -165,7 +161,6 @@
                             "key":  "service",
                             "regexValueRewrite":  {
                               "pattern":  {
-                                "googleRe2":  {},
                                 "regex":  ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution":  "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/propertyoverride-remove-outlier-detection.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/propertyoverride-remove-outlier-detection.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/wasm-http-local-file.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/wasm-http-local-file.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/builtin_extension/listeners/wasm-http-remote-file.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/wasm-http-remote-file.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/clusters/access-logs-defaults.latest.golden
+++ b/agent/xds/testdata/clusters/access-logs-defaults.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/access-logs-json-file.latest.golden
+++ b/agent/xds/testdata/clusters/access-logs-json-file.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/access-logs-text-stderr-disablelistenerlogs.latest.golden
+++ b/agent/xds/testdata/clusters/access-logs-text-stderr-disablelistenerlogs.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/api-gateway-http-listener-with-http-route.latest.golden
+++ b/agent/xds/testdata/clusters/api-gateway-http-listener-with-http-route.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/http-service"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/api-gateway-tcp-listener-with-tcp-and-http-route.latest.golden
+++ b/agent/xds/testdata/clusters/api-gateway-tcp-listener-with-tcp-and-http-route.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/http-service"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/tcp-service"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/api-gateway-tcp-listener-with-tcp-route.latest.golden
+++ b/agent/xds/testdata/clusters/api-gateway-tcp-listener-with-tcp-route.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/tcp-service"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/api-gateway-with-http-route-timeoutfilter-one-set.latest.golden
+++ b/agent/xds/testdata/clusters/api-gateway-with-http-route-timeoutfilter-one-set.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/service"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/api-gateway-with-http-route.latest.golden
+++ b/agent/xds/testdata/clusters/api-gateway-with-http-route.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/service"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/api-gateway-with-multiple-hostnames.latest.golden
+++ b/agent/xds/testdata/clusters/api-gateway-with-multiple-hostnames.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/backend"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/backend"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/frontend"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/frontend"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/api-gateway-with-multiple-inline-certificates.latest.golden
+++ b/agent/xds/testdata/clusters/api-gateway-with-multiple-inline-certificates.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/service"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/api-gateway-with-tcp-route-and-inline-certificate.latest.golden
+++ b/agent/xds/testdata/clusters/api-gateway-with-tcp-route-and-inline-certificate.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/service"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-lb-in-resolver.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-lb-in-resolver.latest.golden
@@ -41,10 +41,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -88,16 +88,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -170,10 +170,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/something-else"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-resolver-with-lb.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-resolver-with-lb.latest.golden
@@ -41,10 +41,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -88,16 +88,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-route-to-lb-resolver.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-route-to-lb-resolver.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -170,10 +170,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/web"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-splitter-overweight.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-splitter-overweight.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -140,10 +140,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -191,10 +191,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/lil-bit-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/lil-bit-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-upstream-defaults.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-upstream-defaults.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-failover-to-cluster-peer.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-failover-to-cluster-peer.latest.golden
@@ -53,10 +53,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -104,10 +104,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -151,16 +151,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-failover.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-failover.latest.golden
@@ -53,10 +53,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -104,10 +104,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/fail"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -151,16 +151,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -91,16 +91,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-redirect-to-cluster-peer.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-redirect-to-cluster-peer.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-router.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-router.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -138,10 +138,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -189,10 +189,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -240,10 +240,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -287,16 +287,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -344,10 +344,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -395,10 +395,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-exact-with-method"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -446,10 +446,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -497,10 +497,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-not-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -548,10 +548,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -599,10 +599,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -650,10 +650,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -701,10 +701,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-suffix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -752,10 +752,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/header-manip"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -803,10 +803,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/idle-timeout"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -854,10 +854,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/just-methods"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -905,10 +905,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/lil-bit-side"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -981,10 +981,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/nil-match"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1032,10 +1032,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix-rewrite-1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1083,10 +1083,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix-rewrite-2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1134,10 +1134,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1185,10 +1185,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1236,10 +1236,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1287,10 +1287,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1338,10 +1338,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1389,10 +1389,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/req-timeout"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1440,10 +1440,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-all"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1491,10 +1491,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-codes"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1542,10 +1542,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-connect"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1593,10 +1593,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-reset"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-splitter.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -134,16 +134,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -191,10 +191,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -242,10 +242,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/lil-bit-side"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-external-sni.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-external-sni.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-http2.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-http2.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -91,16 +91,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-default-chain-and-custom-cluster.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-default-chain-and-custom-cluster.latest.golden
@@ -32,16 +32,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -121,10 +121,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-grpc-chain.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-grpc-chain.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -91,16 +91,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-grpc-router.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-grpc-router.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -91,16 +91,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -173,10 +173,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-http-chain.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-http-chain.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-http2-chain.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-http2-chain.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -91,16 +91,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-jwt-config-entry-with-local.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-jwt-config-entry-with-local.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-jwt-config-entry-with-remote-jwks.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-jwt-config-entry-with-remote-jwks.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-peered-upstreams-escape-overrides.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-peered-upstreams-escape-overrides.latest.golden
@@ -68,10 +68,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/payments"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -119,10 +119,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/refunds"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-peered-upstreams-http2.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-peered-upstreams-http2.latest.golden
@@ -79,10 +79,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/payments"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -139,10 +139,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/refunds"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-peered-upstreams.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-peered-upstreams.latest.golden
@@ -79,10 +79,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/payments"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -131,10 +131,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/refunds"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.latest.golden
@@ -54,10 +54,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -105,10 +105,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -156,10 +156,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc3/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -203,16 +203,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.latest.golden
@@ -54,10 +54,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -105,10 +105,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -156,10 +156,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc3/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -203,16 +203,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.latest.golden
@@ -54,10 +54,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -105,10 +105,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -156,10 +156,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc3/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -203,16 +203,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.latest.golden
@@ -54,10 +54,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -105,10 +105,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -156,10 +156,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc3/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -203,16 +203,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.latest.golden
@@ -53,10 +53,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -104,10 +104,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -151,16 +151,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway.latest.golden
@@ -53,10 +53,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -104,10 +104,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -151,16 +151,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.latest.golden
@@ -53,10 +53,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -104,10 +104,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -151,16 +151,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway.latest.golden
@@ -53,10 +53,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -104,10 +104,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -151,16 +151,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tls-incoming-cipher-suites.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tls-incoming-cipher-suites.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tls-incoming-max-version.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tls-incoming-max-version.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tls-incoming-min-version.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tls-incoming-min-version.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tls-outgoing-cipher-suites.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tls-outgoing-cipher-suites.latest.golden
@@ -41,10 +41,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -93,16 +93,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tls-outgoing-max-version.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tls-outgoing-max-version.latest.golden
@@ -38,10 +38,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,16 +87,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tls-outgoing-min-version-auto.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tls-outgoing-min-version-auto.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tls-outgoing-min-version.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tls-outgoing-min-version.latest.golden
@@ -38,10 +38,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,16 +87,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tproxy-and-permissive-mtls.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tproxy-and-permissive-mtls.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/connect-proxy-without-tproxy-and-permissive-mtls.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-without-tproxy-and-permissive-mtls.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-limits-max-connections-only.latest.golden
+++ b/agent/xds/testdata/clusters/custom-limits-max-connections-only.latest.golden
@@ -42,10 +42,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -95,16 +95,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-limits-set-to-zero.latest.golden
+++ b/agent/xds/testdata/clusters/custom-limits-set-to-zero.latest.golden
@@ -44,10 +44,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -99,16 +99,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-limits.latest.golden
+++ b/agent/xds/testdata/clusters/custom-limits.latest.golden
@@ -44,10 +44,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -99,16 +99,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-local-app.latest.golden
+++ b/agent/xds/testdata/clusters/custom-local-app.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-max-inbound-connections.latest.golden
+++ b/agent/xds/testdata/clusters/custom-max-inbound-connections.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-passive-healthcheck-zero-consecutive_5xx.latest.golden
+++ b/agent/xds/testdata/clusters/custom-passive-healthcheck-zero-consecutive_5xx.latest.golden
@@ -42,10 +42,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -89,16 +89,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-passive-healthcheck.latest.golden
+++ b/agent/xds/testdata/clusters/custom-passive-healthcheck.latest.golden
@@ -42,10 +42,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -89,16 +89,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-public-listener-http-2.latest.golden
+++ b/agent/xds/testdata/clusters/custom-public-listener-http-2.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-public-listener-http-missing.latest.golden
+++ b/agent/xds/testdata/clusters/custom-public-listener-http-missing.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-public-listener-http.latest.golden
+++ b/agent/xds/testdata/clusters/custom-public-listener-http.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-public-listener.latest.golden
+++ b/agent/xds/testdata/clusters/custom-public-listener.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-timeouts.latest.golden
+++ b/agent/xds/testdata/clusters/custom-timeouts.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-trace-listener.latest.golden
+++ b/agent/xds/testdata/clusters/custom-trace-listener.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-upstream-default-chain.latest.golden
+++ b/agent/xds/testdata/clusters/custom-upstream-default-chain.latest.golden
@@ -32,16 +32,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -121,10 +121,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-upstream-ignored-with-disco-chain.latest.golden
+++ b/agent/xds/testdata/clusters/custom-upstream-ignored-with-disco-chain.latest.golden
@@ -53,10 +53,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -104,10 +104,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/fail"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -151,16 +151,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-upstream-with-prepared-query.latest.golden
+++ b/agent/xds/testdata/clusters/custom-upstream-with-prepared-query.latest.golden
@@ -81,16 +81,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/custom-upstream.latest.golden
+++ b/agent/xds/testdata/clusters/custom-upstream.latest.golden
@@ -32,16 +32,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -121,10 +121,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/defaults.latest.golden
+++ b/agent/xds/testdata/clusters/defaults.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/downstream-service-with-unix-sockets.latest.golden
+++ b/agent/xds/testdata/clusters/downstream-service-with-unix-sockets.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/grpc-public-listener.latest.golden
+++ b/agent/xds/testdata/clusters/grpc-public-listener.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/http-listener-with-timeouts.latest.golden
+++ b/agent/xds/testdata/clusters/http-listener-with-timeouts.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/http-public-listener-no-xfcc.latest.golden
+++ b/agent/xds/testdata/clusters/http-public-listener-no-xfcc.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/http-public-listener.latest.golden
+++ b/agent/xds/testdata/clusters/http-public-listener.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/http-upstream.latest.golden
+++ b/agent/xds/testdata/clusters/http-upstream.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/http2-public-listener.latest.golden
+++ b/agent/xds/testdata/clusters/http2-public-listener.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-gateway-bind-addrs.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-gateway-bind-addrs.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-gateway-with-tls-outgoing-cipher-suites.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-gateway-with-tls-outgoing-cipher-suites.latest.golden
@@ -41,10 +41,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-gateway-with-tls-outgoing-max-version.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-gateway-with-tls-outgoing-max-version.latest.golden
@@ -38,10 +38,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-gateway-with-tls-outgoing-min-version.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-gateway-with-tls-outgoing-min-version.latest.golden
@@ -38,10 +38,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-gateway.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-grpc-multiple-services.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-grpc-multiple-services.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/bar"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -95,10 +95,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/foo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-http-multiple-services.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-http-multiple-services.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/bar"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/baz"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -138,10 +138,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/foo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -189,10 +189,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/qux"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-lb-in-resolver.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-lb-in-resolver.latest.golden
@@ -41,10 +41,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -92,10 +92,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/something-else"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-multiple-listeners-duplicate-service.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-multiple-listeners-duplicate-service.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/bar"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/foo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-splitter-with-resolver-redirect.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-splitter-with-resolver-redirect.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-chain-and-failover-to-cluster-peer.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-chain-and-failover-to-cluster-peer.latest.golden
@@ -54,10 +54,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -105,10 +105,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-chain-and-failover.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-chain-and-failover.latest.golden
@@ -54,10 +54,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -105,10 +105,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/fail"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-chain-and-router-header-manip.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-chain-and-router-header-manip.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -138,10 +138,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-1"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-1"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -189,10 +189,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-2"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-2"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -240,10 +240,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/exact"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/exact"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -291,10 +291,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -342,10 +342,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-exact-with-method"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -393,10 +393,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -444,10 +444,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-not-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -495,10 +495,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -546,10 +546,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -597,10 +597,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -648,10 +648,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-suffix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -699,10 +699,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/header-manip"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -750,10 +750,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/idle-timeout"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -801,10 +801,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/just-methods"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -852,10 +852,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/lil-bit-side"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -903,10 +903,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/nil-match"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -954,10 +954,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix-rewrite-1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1005,10 +1005,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix-rewrite-2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1056,10 +1056,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1107,10 +1107,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1158,10 +1158,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1209,10 +1209,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1260,10 +1260,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1311,10 +1311,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/req-timeout"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1362,10 +1362,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-all"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1413,10 +1413,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-codes"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1464,10 +1464,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-connect"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1515,10 +1515,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-reset"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-chain-and-router.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-chain-and-router.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -138,10 +138,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-1"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-1"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -189,10 +189,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-2"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-2"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -240,10 +240,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/exact"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/exact"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -291,10 +291,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -342,10 +342,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-exact-with-method"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -393,10 +393,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -444,10 +444,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-not-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -495,10 +495,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -546,10 +546,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -597,10 +597,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -648,10 +648,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-suffix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -699,10 +699,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/header-manip"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -750,10 +750,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/idle-timeout"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -801,10 +801,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/just-methods"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -852,10 +852,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/lil-bit-side"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -903,10 +903,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/nil-match"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -954,10 +954,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix-rewrite-1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1005,10 +1005,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix-rewrite-2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1056,10 +1056,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1107,10 +1107,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1158,10 +1158,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1209,10 +1209,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1260,10 +1260,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1311,10 +1311,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/req-timeout"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1362,10 +1362,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-all"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1413,10 +1413,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-codes"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1464,10 +1464,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-connect"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1515,10 +1515,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-reset"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-chain-and-splitter.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -85,13 +85,12 @@
             ],
             "tlsParams": {},
             "validationContext": {
-
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -139,10 +138,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -190,10 +189,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/lil-bit-side"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-chain-external-sni.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-chain-external-sni.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-chain.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-chain.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-defaults-passive-health-check.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-defaults-passive-health-check.latest.golden
@@ -49,10 +49,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-defaults-service-max-connections.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-defaults-service-max-connections.latest.golden
@@ -44,10 +44,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-grpc-router.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-grpc-router.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-grpc-single-tls-listener.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-grpc-single-tls-listener.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -95,10 +95,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-http2-and-grpc-multiple-tls-listener.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-http2-and-grpc-multiple-tls-listener.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -95,10 +95,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-http2-single-tls-listener.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-http2-single-tls-listener.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -95,10 +95,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-overwrite-defaults-passive-health-check.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-overwrite-defaults-passive-health-check.latest.golden
@@ -48,10 +48,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-overwrite-defaults-service-max-connections.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-overwrite-defaults-service-max-connections.latest.golden
@@ -43,10 +43,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-listener+service-level.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-listener+service-level.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-listener-gw-level-http.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-listener-gw-level-http.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/http"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-listener-gw-level-mixed-tls.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-listener-gw-level-mixed-tls.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/insecure"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/secure"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-listener-gw-level.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-listener-gw-level.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-listener-level-wildcard.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-listener-level-wildcard.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/foo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/web"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-listener-level.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-listener-level.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/foo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/web"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-listener-listener-level.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-listener-listener-level.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-service-level-2.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-service-level-2.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/foo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/web"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-service-level-mixed-no-tls.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-service-level-mixed-no-tls.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-service-level-mixed-tls.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-service-level-mixed-tls.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/foo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/web"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-sds-service-level.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-sds-service-level.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-service-max-connections.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-service-max-connections.latest.golden
@@ -42,10 +42,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-service-passive-health-check.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-service-passive-health-check.latest.golden
@@ -46,10 +46,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-single-tls-listener.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-single-tls-listener.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tcp-chain-double-failover-through-local-gateway-triggered.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tcp-chain-double-failover-through-local-gateway-triggered.latest.golden
@@ -55,10 +55,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -106,10 +106,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -157,10 +157,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc3/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tcp-chain-double-failover-through-local-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tcp-chain-double-failover-through-local-gateway.latest.golden
@@ -55,10 +55,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -106,10 +106,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -157,10 +157,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc3/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tcp-chain-double-failover-through-remote-gateway-triggered.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tcp-chain-double-failover-through-remote-gateway-triggered.latest.golden
@@ -55,10 +55,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -106,10 +106,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -157,10 +157,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc3/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tcp-chain-double-failover-through-remote-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tcp-chain-double-failover-through-remote-gateway.latest.golden
@@ -55,10 +55,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -106,10 +106,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -157,10 +157,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc3/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tcp-chain-failover-through-local-gateway-triggered.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tcp-chain-failover-through-local-gateway-triggered.latest.golden
@@ -54,10 +54,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -105,10 +105,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tcp-chain-failover-through-local-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tcp-chain-failover-through-local-gateway.latest.golden
@@ -54,10 +54,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -105,10 +105,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tcp-chain-failover-through-remote-gateway-triggered.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tcp-chain-failover-through-remote-gateway-triggered.latest.golden
@@ -54,10 +54,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -105,10 +105,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tcp-chain-failover-through-remote-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tcp-chain-failover-through-remote-gateway.latest.golden
@@ -54,10 +54,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -105,10 +105,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tls-listener-cipher-suites.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tls-listener-cipher-suites.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tls-listener-max-version.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tls-listener-max-version.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tls-listener-min-version.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tls-listener-min-version.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tls-listener.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tls-listener.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tls-min-version-listeners-gateway-defaults.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tls-min-version-listeners-gateway-defaults.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -138,10 +138,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s3"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -189,10 +189,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s4"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tls-mixed-cipher-suites-listeners.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tls-mixed-cipher-suites-listeners.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tls-mixed-listeners.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tls-mixed-listeners.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tls-mixed-max-version-listeners.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tls-mixed-max-version-listeners.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -138,10 +138,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s3"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/ingress-with-tls-mixed-min-version-listeners.latest.golden
+++ b/agent/xds/testdata/clusters/ingress-with-tls-mixed-min-version-listeners.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -87,10 +87,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -138,10 +138,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/s3"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/listener-balance-inbound-connections.latest.golden
+++ b/agent/xds/testdata/clusters/listener-balance-inbound-connections.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/listener-balance-outbound-connections-bind-port.latest.golden
+++ b/agent/xds/testdata/clusters/listener-balance-outbound-connections-bind-port.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/listener-bind-address-port.latest.golden
+++ b/agent/xds/testdata/clusters/listener-bind-address-port.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/listener-bind-address.latest.golden
+++ b/agent/xds/testdata/clusters/listener-bind-address.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/listener-bind-port.latest.golden
+++ b/agent/xds/testdata/clusters/listener-bind-port.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/listener-max-inbound-connections.latest.golden
+++ b/agent/xds/testdata/clusters/listener-max-inbound-connections.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/listener-unix-domain-socket.latest.golden
+++ b/agent/xds/testdata/clusters/listener-unix-domain-socket.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/local-mesh-gateway-with-peered-upstreams.latest.golden
+++ b/agent/xds/testdata/clusters/local-mesh-gateway-with-peered-upstreams.latest.golden
@@ -79,10 +79,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/payments"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -131,10 +131,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/refunds"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
@@ -75,10 +75,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/alt"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -126,10 +126,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -177,10 +177,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/api"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/mesh-gateway-with-exported-peered-services-http.latest.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-with-exported-peered-services-http.latest.golden
@@ -49,10 +49,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/bar"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -100,10 +100,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/foo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -151,10 +151,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/gir"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/splitter-with-resolver-redirect.latest.golden
+++ b/agent/xds/testdata/clusters/splitter-with-resolver-redirect.latest.golden
@@ -32,16 +32,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -114,10 +114,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -165,10 +165,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/telemetry-collector.latest.golden
+++ b/agent/xds/testdata/clusters/telemetry-collector.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/consul-telemetry-collector"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -95,10 +95,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -142,16 +142,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/terminating-gateway-sni.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-sni.latest.golden
@@ -48,10 +48,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "bar.com"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -144,10 +144,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "foo.com"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/transparent-proxy-catalog-destinations-only.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-catalog-destinations-only.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -140,10 +140,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/google"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -216,10 +216,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/no-endpoints"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/transparent-proxy-destination-http.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-destination-http.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -86,10 +86,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -136,10 +136,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -186,10 +186,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -236,10 +236,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/google"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -283,16 +283,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/transparent-proxy-destination.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-destination.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -86,10 +86,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -136,10 +136,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -186,10 +186,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/google"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -236,10 +236,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/google"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -283,16 +283,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/transparent-proxy-dial-instances-directly.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-dial-instances-directly.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -140,10 +140,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -216,10 +216,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/mongo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -263,10 +263,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -303,10 +303,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/mongo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/transparent-proxy-http-upstream.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-http-upstream.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -140,10 +140,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/google"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -216,10 +216,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/no-endpoints"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/transparent-proxy-terminating-gateway-destinations-only.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-terminating-gateway-destinations-only.latest.golden
@@ -168,10 +168,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "api.test.com"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/transparent-proxy-terminating-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-terminating-gateway.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -140,10 +140,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/google"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -191,10 +191,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/transparent-proxy-with-peered-upstreams.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-with-peered-upstreams.latest.golden
@@ -37,10 +37,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/api-a"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -89,10 +89,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/transparent-proxy-with-resolver-redirect-upstream.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-with-resolver-redirect-upstream.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -140,10 +140,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/google"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/transparent-proxy.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy.latest.golden
@@ -36,10 +36,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -83,16 +83,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -140,10 +140,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/google"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -216,10 +216,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/no-endpoints"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/xds-fetch-timeout-ms-ingress-with-router.latest.golden
+++ b/agent/xds/testdata/clusters/xds-fetch-timeout-ms-ingress-with-router.latest.golden
@@ -37,10 +37,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -89,10 +89,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -141,10 +141,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-1"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-1"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -193,10 +193,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-2"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-2"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -245,10 +245,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/exact"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/exact"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -297,10 +297,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -349,10 +349,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-exact-with-method"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -401,10 +401,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -453,10 +453,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-not-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -505,10 +505,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -557,10 +557,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -609,10 +609,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -661,10 +661,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-suffix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -713,10 +713,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/header-manip"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -765,10 +765,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/idle-timeout"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -817,10 +817,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/just-methods"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -869,10 +869,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/lil-bit-side"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -921,10 +921,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/nil-match"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -973,10 +973,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix-rewrite-1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1025,10 +1025,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix-rewrite-2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1077,10 +1077,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1129,10 +1129,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1181,10 +1181,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1233,10 +1233,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1285,10 +1285,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1337,10 +1337,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/req-timeout"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1389,10 +1389,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-all"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1441,10 +1441,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-codes"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1493,10 +1493,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-connect"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1545,10 +1545,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-reset"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/xds-fetch-timeout-ms-mgw-peering.latest.golden
+++ b/agent/xds/testdata/clusters/xds-fetch-timeout-ms-mgw-peering.latest.golden
@@ -51,10 +51,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/bar"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -103,10 +103,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/foo"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -155,10 +155,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/gir"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/xds-fetch-timeout-ms-sidecar.latest.golden
+++ b/agent/xds/testdata/clusters/xds-fetch-timeout-ms-sidecar.latest.golden
@@ -37,10 +37,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/big-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -89,10 +89,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -141,10 +141,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-1"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-1"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -193,10 +193,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-2"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/empty-match-2"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -245,10 +245,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/exact"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/exact"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -293,16 +293,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -351,10 +351,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
-                    "exact":  "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
-                  }
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/goldilocks-side"
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -403,10 +403,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-exact-with-method"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -455,10 +455,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -507,10 +507,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-not-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -559,10 +559,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -611,10 +611,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -663,10 +663,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -715,10 +715,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/hdr-suffix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -767,10 +767,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/header-manip"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -819,10 +819,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/idle-timeout"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -871,10 +871,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/just-methods"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -923,10 +923,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/lil-bit-side"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1000,10 +1000,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/nil-match"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1052,10 +1052,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix-rewrite-1"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1104,10 +1104,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix-rewrite-2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1156,10 +1156,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prefix"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1208,10 +1208,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-exact"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1260,10 +1260,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-present"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1312,10 +1312,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/prm-regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1364,10 +1364,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/regex"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1416,10 +1416,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/req-timeout"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1468,10 +1468,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-all"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1520,10 +1520,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-codes"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1572,10 +1572,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-connect"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -1624,10 +1624,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/retry-reset"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/xds-fetch-timeout-ms-tproxy-http-peering.latest.golden
+++ b/agent/xds/testdata/clusters/xds-fetch-timeout-ms-tproxy-http-peering.latest.golden
@@ -79,10 +79,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/payments"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -140,10 +140,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/refunds"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/clusters/xds-fetch-timeout-ms-tproxy-passthrough.latest.golden
+++ b/agent/xds/testdata/clusters/xds-fetch-timeout-ms-tproxy-passthrough.latest.golden
@@ -37,10 +37,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -88,10 +88,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -139,10 +139,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -190,10 +190,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/kafka2"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -241,10 +241,10 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/google"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {
@@ -289,16 +289,16 @@
             "validationContext": {
               "matchTypedSubjectAltNames": [
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 },
                 {
-                  "sanType": "URI",
                   "matcher": {
                     "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
-                  }
+                  },
+                  "sanType": "URI"
                 }
               ],
               "trustedCa": {

--- a/agent/xds/testdata/listeners/custom-trace-listener.latest.golden
+++ b/agent/xds/testdata/listeners/custom-trace-listener.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/listeners/http-listener-with-timeouts.latest.golden
+++ b/agent/xds/testdata/listeners/http-listener-with-timeouts.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/listeners/http-public-listener.latest.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.latest.golden
@@ -87,7 +87,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -101,7 +100,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -115,7 +113,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -129,7 +126,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -143,7 +139,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/listeners/http2-public-listener.latest.golden
+++ b/agent/xds/testdata/listeners/http2-public-listener.latest.golden
@@ -88,7 +88,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\1"
@@ -102,7 +101,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\2"
@@ -116,7 +114,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\3"
@@ -130,7 +127,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\4"
@@ -144,7 +140,6 @@
                             "metadataNamespace": "consul",
                             "regexValueRewrite": {
                               "pattern": {
-                                "googleRe2": {},
                                 "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
                               },
                               "substitution": "\\5"

--- a/agent/xds/testdata/listeners/terminating-gateway-with-peer-trust-bundle.latest.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-with-peer-trust-bundle.latest.golden
@@ -184,7 +184,6 @@
                           "authenticated": {
                             "principalName": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^spiffe://foo.bar.gov/ns/default/dc/[^/]+/svc/source$"
                               }
                             }

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow--httpfilter.golden
@@ -19,7 +19,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
@@ -30,7 +29,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
@@ -29,7 +28,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
@@ -40,7 +38,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny--httpfilter.golden
@@ -19,7 +19,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
@@ -30,7 +29,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
@@ -57,7 +55,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
@@ -29,7 +28,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
@@ -40,7 +38,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }

--- a/agent/xds/testdata/rbac/default-allow-kitchen-sink--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-kitchen-sink--httpfilter.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
                   }
                 }
@@ -26,7 +25,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
@@ -39,7 +37,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
@@ -50,7 +47,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
@@ -62,7 +58,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
                           }
                         }
@@ -74,7 +69,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
                           }
                         }

--- a/agent/xds/testdata/rbac/default-allow-kitchen-sink.golden
+++ b/agent/xds/testdata/rbac/default-allow-kitchen-sink.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
                   }
                 }
@@ -26,7 +25,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
@@ -39,7 +37,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
@@ -50,7 +47,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
@@ -62,7 +58,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
                           }
                         }
@@ -74,7 +69,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
                           }
                         }

--- a/agent/xds/testdata/rbac/default-allow-one-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-one-deny--httpfilter.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-one-deny.golden
+++ b/agent/xds/testdata/rbac/default-allow-one-deny.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-path-allow.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-allow.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-path-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-deny--httpfilter.golden
@@ -20,7 +20,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-path-deny.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-deny.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-service-wildcard-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-service-wildcard-deny--httpfilter.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-service-wildcard-deny.golden
+++ b/agent/xds/testdata/rbac/default-allow-service-wildcard-deny.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-single-intention-with-kitchen-sink-perms--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-single-intention-with-kitchen-sink-perms--httpfilter.golden
@@ -39,7 +39,6 @@
                           "urlPath": {
                             "path": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "/v[123]"
                               }
                             }
@@ -50,7 +49,6 @@
                             "name": ":method",
                             "stringMatch": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "GET|HEAD|OPTIONS"
                               }
                             }
@@ -121,7 +119,6 @@
                             "name": "x-zim",
                             "stringMatch": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "gi[rR]"
                               }
                             }
@@ -167,7 +164,6 @@
                             "name": "z-zim",
                             "stringMatch": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "gi[rR]"
                               }
                             }
@@ -184,7 +180,6 @@
                             "urlPath": {
                               "path": {
                                 "safeRegex": {
-                                  "googleRe2": {},
                                   "regex": "/v[123]"
                                 }
                               }
@@ -195,7 +190,6 @@
                               "name": ":method",
                               "stringMatch": {
                                 "safeRegex": {
-                                  "googleRe2": {},
                                   "regex": "GET|HEAD|OPTIONS"
                                 }
                               }
@@ -232,7 +226,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-single-intention-with-kitchen-sink-perms--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-single-intention-with-kitchen-sink-perms--httpfilter.golden
@@ -48,9 +48,11 @@
                         {
                           "header": {
                             "name": ":method",
-                            "safeRegexMatch": {
-                              "googleRe2": {},
-                              "regex": "GET|HEAD|OPTIONS"
+                            "stringMatch": {
+                              "safeRegex": {
+                                "googleRe2": {},
+                                "regex": "GET|HEAD|OPTIONS"
+                              }
                             }
                           }
                         }
@@ -191,9 +193,11 @@
                           {
                             "header": {
                               "name": ":method",
-                              "safeRegexMatch": {
-                                "googleRe2": {},
-                                "regex": "GET|HEAD|OPTIONS"
+                              "stringMatch": {
+                                "safeRegex": {
+                                  "googleRe2": {},
+                                  "regex": "GET|HEAD|OPTIONS"
+                                }
                               }
                             }
                           }

--- a/agent/xds/testdata/rbac/default-allow-single-intention-with-kitchen-sink-perms.golden
+++ b/agent/xds/testdata/rbac/default-allow-single-intention-with-kitchen-sink-perms.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-two-path-deny-and-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-two-path-deny-and-path-allow--httpfilter.golden
@@ -42,7 +42,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-allow-two-path-deny-and-path-allow.golden
+++ b/agent/xds/testdata/rbac/default-allow-two-path-deny-and-path-allow.golden
@@ -16,7 +16,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-deny-allow-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-allow-deny--httpfilter.golden
@@ -18,7 +18,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
@@ -29,7 +28,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }

--- a/agent/xds/testdata/rbac/default-deny-allow-deny.golden
+++ b/agent/xds/testdata/rbac/default-deny-allow-deny.golden
@@ -18,7 +18,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }

--- a/agent/xds/testdata/rbac/default-deny-allow-deny.golden
+++ b/agent/xds/testdata/rbac/default-deny-allow-deny.golden
@@ -28,7 +28,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }

--- a/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow--httpfilter.golden
@@ -19,7 +19,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-deny-kitchen-sink--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-kitchen-sink--httpfilter.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
                   }
                 }
@@ -25,7 +24,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
@@ -38,7 +36,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
@@ -49,7 +46,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
@@ -61,7 +57,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
                           }
                         }
@@ -73,7 +68,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
                           }
                         }

--- a/agent/xds/testdata/rbac/default-deny-kitchen-sink.golden
+++ b/agent/xds/testdata/rbac/default-deny-kitchen-sink.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
                   }
                 }
@@ -25,7 +24,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
@@ -38,7 +36,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
@@ -49,7 +46,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
@@ -61,7 +57,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
                           }
                         }
@@ -73,7 +68,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
                           }
                         }

--- a/agent/xds/testdata/rbac/default-deny-mixed-precedence--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-mixed-precedence--httpfilter.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-deny-mixed-precedence.golden
+++ b/agent/xds/testdata/rbac/default-deny-mixed-precedence.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-deny-one-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-one-allow--httpfilter.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-deny-one-allow.golden
+++ b/agent/xds/testdata/rbac/default-deny-one-allow.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-deny-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-path-allow--httpfilter.golden
@@ -19,7 +19,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink--httpfilter.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
@@ -28,7 +27,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/gateway/mesh/dc/[^/]+$"
                         }
                       }
@@ -42,7 +40,6 @@
                             "name": "x-forwarded-client-cert",
                             "stringMatch": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^[^,]+;URI=spiffe://peer1.domain/ap/part1/ns/default/dc/[^/]+/svc/[^/]+(?:,.*)?$"
                               }
                             }
@@ -54,7 +51,6 @@
                               "name": "x-forwarded-client-cert",
                               "stringMatch": {
                                 "safeRegex": {
-                                  "googleRe2": {},
                                   "regex": "^[^,]+;URI=spiffe://peer1.domain/ap/part1/ns/default/dc/[^/]+/svc/web(?:,.*)?$"
                                 }
                               }

--- a/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink.golden
+++ b/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
@@ -28,7 +27,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://peer1.domain/ap/part1/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
@@ -39,7 +37,6 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "googleRe2": {},
                             "regex": "^spiffe://peer1.domain/ap/part1/ns/default/dc/[^/]+/svc/web$"
                           }
                         }

--- a/agent/xds/testdata/rbac/default-deny-service-wildcard-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-service-wildcard-allow--httpfilter.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-deny-service-wildcard-allow.golden
+++ b/agent/xds/testdata/rbac/default-deny-service-wildcard-allow.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-deny-single-intention-with-kitchen-sink-perms--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-single-intention-with-kitchen-sink-perms--httpfilter.golden
@@ -47,9 +47,11 @@
                         {
                           "header": {
                             "name": ":method",
-                            "safeRegexMatch": {
-                              "googleRe2": {},
-                              "regex": "GET|HEAD|OPTIONS"
+                            "stringMatch": {
+                              "safeRegex": {
+                                "googleRe2": {},
+                                "regex": "GET|HEAD|OPTIONS"
+                              }
                             }
                           }
                         }
@@ -190,9 +192,11 @@
                           {
                             "header": {
                               "name": ":method",
-                              "safeRegexMatch": {
-                                "googleRe2": {},
-                                "regex": "GET|HEAD|OPTIONS"
+                              "stringMatch": {
+                                "safeRegex": {
+                                  "googleRe2": {},
+                                  "regex": "GET|HEAD|OPTIONS"
+                                }
                               }
                             }
                           }

--- a/agent/xds/testdata/rbac/default-deny-single-intention-with-kitchen-sink-perms--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-single-intention-with-kitchen-sink-perms--httpfilter.golden
@@ -38,7 +38,6 @@
                           "urlPath": {
                             "path": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "/v[123]"
                               }
                             }
@@ -49,7 +48,6 @@
                             "name": ":method",
                             "stringMatch": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "GET|HEAD|OPTIONS"
                               }
                             }
@@ -120,7 +118,6 @@
                             "name": "x-zim",
                             "stringMatch": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "gi[rR]"
                               }
                             }
@@ -166,7 +163,6 @@
                             "name": "z-zim",
                             "stringMatch": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "gi[rR]"
                               }
                             }
@@ -183,7 +179,6 @@
                             "urlPath": {
                               "path": {
                                 "safeRegex": {
-                                  "googleRe2": {},
                                   "regex": "/v[123]"
                                 }
                               }
@@ -194,7 +189,6 @@
                               "name": ":method",
                               "stringMatch": {
                                 "safeRegex": {
-                                  "googleRe2": {},
                                   "regex": "GET|HEAD|OPTIONS"
                                 }
                               }
@@ -231,7 +225,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/default-deny-two-path-deny-and-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-two-path-deny-and-path-allow--httpfilter.golden
@@ -43,7 +43,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/empty-top-level-jwt-with-one-permission--httpfilter.golden
+++ b/agent/xds/testdata/rbac/empty-top-level-jwt-with-one-permission--httpfilter.golden
@@ -67,7 +67,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/top-level-jwt-no-permissions--httpfilter.golden
+++ b/agent/xds/testdata/rbac/top-level-jwt-no-permissions--httpfilter.golden
@@ -18,7 +18,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                         }
                       }

--- a/agent/xds/testdata/rbac/top-level-jwt-no-permissions.golden
+++ b/agent/xds/testdata/rbac/top-level-jwt-no-permissions.golden
@@ -15,7 +15,6 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "googleRe2": {},
                     "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }

--- a/agent/xds/testdata/rbac/top-level-jwt-with-multiple-permissions--httpfilter.golden
+++ b/agent/xds/testdata/rbac/top-level-jwt-with-multiple-permissions--httpfilter.golden
@@ -146,7 +146,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                         }
                       }

--- a/agent/xds/testdata/rbac/top-level-jwt-with-one-permission--httpfilter.golden
+++ b/agent/xds/testdata/rbac/top-level-jwt-with-one-permission--httpfilter.golden
@@ -95,7 +95,6 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                         }
                       }

--- a/agent/xds/testdata/rbac/v2-kitchen-sink.golden
+++ b/agent/xds/testdata/rbac/v2-kitchen-sink.golden
@@ -18,7 +18,6 @@
                   "authenticated": {
                     "principalName": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/db$"
                       }
                     }
@@ -28,7 +27,6 @@
                   "authenticated": {
                     "principalName": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
                       }
                     }
@@ -58,7 +56,6 @@
                   "authenticated": {
                     "principalName": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/api$"
                       }
                     }
@@ -71,7 +68,6 @@
                         "authenticated": {
                           "principalName": {
                             "safeRegex": {
-                              "googleRe2": {},
                               "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                             }
                           }
@@ -82,7 +78,6 @@
                           "authenticated": {
                             "principalName": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
                               }
                             }
@@ -105,7 +100,6 @@
                   "authenticated": {
                     "principalName": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
                       }
                     }

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-router.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-router.latest.golden
@@ -31,7 +31,6 @@
             {
               "match": {
                 "safeRegex": {
-                  "googleRe2": {},
                   "regex": "/regex"
                 }
               },
@@ -123,7 +122,6 @@
                     "name": "x-debug",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "regex"
                       }
                     }
@@ -142,7 +140,6 @@
                     "name": ":method",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "GET|PUT"
                       }
                     }
@@ -167,7 +164,6 @@
                     "name": ":method",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "GET|PUT"
                       }
                     }
@@ -203,7 +199,6 @@
                     "name": "secretparam2",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "regex"
                       }
                     }

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-router.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-router.latest.golden
@@ -140,9 +140,11 @@
                 "headers": [
                   {
                     "name": ":method",
-                    "safeRegexMatch": {
-                      "googleRe2": {},
-                      "regex": "GET|PUT"
+                    "stringMatch": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "GET|PUT"
+                      }
                     }
                   }
                 ],
@@ -163,9 +165,11 @@
                   },
                   {
                     "name": ":method",
-                    "safeRegexMatch": {
-                      "googleRe2": {},
-                      "regex": "GET|PUT"
+                    "stringMatch": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "GET|PUT"
+                      }
                     }
                   }
                 ],

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router-header-manip.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router-header-manip.latest.golden
@@ -179,9 +179,11 @@
                 "headers": [
                   {
                     "name": ":method",
-                    "safeRegexMatch": {
-                      "googleRe2": {},
-                      "regex": "GET|PUT"
+                    "stringMatch": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "GET|PUT"
+                      }
                     }
                   }
                 ],
@@ -202,9 +204,11 @@
                   },
                   {
                     "name": ":method",
-                    "safeRegexMatch": {
-                      "googleRe2": {},
-                      "regex": "GET|PUT"
+                    "stringMatch": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "GET|PUT"
+                      }
                     }
                   }
                 ],

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router-header-manip.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router-header-manip.latest.golden
@@ -70,7 +70,6 @@
             {
               "match": {
                 "safeRegex": {
-                  "googleRe2": {},
                   "regex": "/regex"
                 }
               },
@@ -162,7 +161,6 @@
                     "name": "x-debug",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "regex"
                       }
                     }
@@ -181,7 +179,6 @@
                     "name": ":method",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "GET|PUT"
                       }
                     }
@@ -206,7 +203,6 @@
                     "name": ":method",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "GET|PUT"
                       }
                     }
@@ -242,7 +238,6 @@
                     "name": "secretparam2",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "regex"
                       }
                     }

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router.latest.golden
@@ -141,9 +141,11 @@
                 "headers": [
                   {
                     "name": ":method",
-                    "safeRegexMatch": {
-                      "googleRe2": {},
-                      "regex": "GET|PUT"
+                    "stringMatch": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "GET|PUT"
+                      }
                     }
                   }
                 ],
@@ -164,9 +166,11 @@
                   },
                   {
                     "name": ":method",
-                    "safeRegexMatch": {
-                      "googleRe2": {},
-                      "regex": "GET|PUT"
+                    "stringMatch": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "GET|PUT"
+                      }
                     }
                   }
                 ],

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router.latest.golden
@@ -32,7 +32,6 @@
             {
               "match": {
                 "safeRegex": {
-                  "googleRe2": {},
                   "regex": "/regex"
                 }
               },
@@ -124,7 +123,6 @@
                     "name": "x-debug",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "regex"
                       }
                     }
@@ -143,7 +141,6 @@
                     "name": ":method",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "GET|PUT"
                       }
                     }
@@ -168,7 +165,6 @@
                     "name": ":method",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "GET|PUT"
                       }
                     }
@@ -204,7 +200,6 @@
                     "name": "secretparam2",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "regex"
                       }
                     }

--- a/agent/xds/testdata/routes/xds-fetch-timeout-ms-ingress-with-router.latest.golden
+++ b/agent/xds/testdata/routes/xds-fetch-timeout-ms-ingress-with-router.latest.golden
@@ -141,9 +141,11 @@
                 "headers": [
                   {
                     "name": ":method",
-                    "safeRegexMatch": {
-                      "googleRe2": {},
-                      "regex": "GET|PUT"
+                    "stringMatch": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "GET|PUT"
+                      }
                     }
                   }
                 ],
@@ -164,9 +166,11 @@
                   },
                   {
                     "name": ":method",
-                    "safeRegexMatch": {
-                      "googleRe2": {},
-                      "regex": "GET|PUT"
+                    "stringMatch": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "GET|PUT"
+                      }
                     }
                   }
                 ],

--- a/agent/xds/testdata/routes/xds-fetch-timeout-ms-ingress-with-router.latest.golden
+++ b/agent/xds/testdata/routes/xds-fetch-timeout-ms-ingress-with-router.latest.golden
@@ -32,7 +32,6 @@
             {
               "match": {
                 "safeRegex": {
-                  "googleRe2": {},
                   "regex": "/regex"
                 }
               },
@@ -124,7 +123,6 @@
                     "name": "x-debug",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "regex"
                       }
                     }
@@ -143,7 +141,6 @@
                     "name": ":method",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "GET|PUT"
                       }
                     }
@@ -168,7 +165,6 @@
                     "name": ":method",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "GET|PUT"
                       }
                     }
@@ -204,7 +200,6 @@
                     "name": "secretparam2",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "regex"
                       }
                     }

--- a/agent/xds/testdata/routes/xds-fetch-timeout-ms-sidecar.latest.golden
+++ b/agent/xds/testdata/routes/xds-fetch-timeout-ms-sidecar.latest.golden
@@ -31,7 +31,6 @@
             {
               "match": {
                 "safeRegex": {
-                  "googleRe2": {},
                   "regex": "/regex"
                 }
               },
@@ -123,7 +122,6 @@
                     "name": "x-debug",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "regex"
                       }
                     }
@@ -142,7 +140,6 @@
                     "name": ":method",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "GET|PUT"
                       }
                     }
@@ -167,7 +164,6 @@
                     "name": ":method",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "GET|PUT"
                       }
                     }
@@ -203,7 +199,6 @@
                     "name": "secretparam2",
                     "stringMatch": {
                       "safeRegex": {
-                        "googleRe2": {},
                         "regex": "regex"
                       }
                     }

--- a/agent/xds/testdata/routes/xds-fetch-timeout-ms-sidecar.latest.golden
+++ b/agent/xds/testdata/routes/xds-fetch-timeout-ms-sidecar.latest.golden
@@ -140,9 +140,11 @@
                 "headers": [
                   {
                     "name": ":method",
-                    "safeRegexMatch": {
-                      "googleRe2": {},
-                      "regex": "GET|PUT"
+                    "stringMatch": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "GET|PUT"
+                      }
                     }
                   }
                 ],
@@ -163,9 +165,11 @@
                   },
                   {
                     "name": ":method",
-                    "safeRegexMatch": {
-                      "googleRe2": {},
-                      "regex": "GET|PUT"
+                    "stringMatch": {
+                      "safeRegex": {
+                        "googleRe2": {},
+                        "regex": "GET|PUT"
+                      }
                     }
                   }
                 ],

--- a/agent/xdsv2/listener_resources.go
+++ b/agent/xdsv2/listener_resources.go
@@ -1131,9 +1131,6 @@ func parseXFCCToDynamicMetaHTTPFilter() (*envoy_http_v3.HttpFilter, error) {
 				RegexValueRewrite: &envoy_matcher_v3.RegexMatchAndSubstitute{
 					Pattern: &envoy_matcher_v3.RegexMatcher{
 						Regex: downstreamServiceIdentityMatcher,
-						EngineType: &envoy_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 					},
 					Substitution: f.sub,
 				},

--- a/agent/xdsv2/route_resources.go
+++ b/agent/xdsv2/route_resources.go
@@ -111,8 +111,12 @@ func makeEnvoyRouteMatchFromProxystateRouteMatch(psRouteMatch *pbproxystate.Rout
 
 		eh := &envoy_route_v3.HeaderMatcher{
 			Name: ":method",
-			HeaderMatchSpecifier: &envoy_route_v3.HeaderMatcher_SafeRegexMatch{
-				SafeRegexMatch: makeEnvoyRegexMatch(methodHeaderRegex),
+			HeaderMatchSpecifier: &envoy_route_v3.HeaderMatcher_StringMatch{
+				StringMatch: &envoy_matcher_v3.StringMatcher{
+					MatchPattern: &envoy_matcher_v3.StringMatcher_SafeRegex{
+						SafeRegex: response.MakeEnvoyRegexMatch(methodHeaderRegex),
+					},
+				},
 			},
 		}
 
@@ -131,10 +135,8 @@ func makeEnvoyRouteMatchFromProxystateRouteMatch(psRouteMatch *pbproxystate.Rout
 
 func makeEnvoyRegexMatch(pattern string) *envoy_matcher_v3.RegexMatcher {
 	return &envoy_matcher_v3.RegexMatcher{
-		EngineType: &envoy_matcher_v3.RegexMatcher_GoogleRe2{
-			GoogleRe2: &envoy_matcher_v3.RegexMatcher_GoogleRE2{},
-		},
-		Regex: pattern,
+		EngineType: &envoy_matcher_v3.RegexMatcher_GoogleRe2{},
+		Regex:      pattern,
 	}
 }
 

--- a/agent/xdsv2/route_resources.go
+++ b/agent/xdsv2/route_resources.go
@@ -135,8 +135,7 @@ func makeEnvoyRouteMatchFromProxystateRouteMatch(psRouteMatch *pbproxystate.Rout
 
 func makeEnvoyRegexMatch(pattern string) *envoy_matcher_v3.RegexMatcher {
 	return &envoy_matcher_v3.RegexMatcher{
-		EngineType: &envoy_matcher_v3.RegexMatcher_GoogleRe2{},
-		Regex:      pattern,
+		Regex: pattern,
 	}
 }
 

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -50,9 +50,9 @@ func TestEnvoy(t *testing.T) {
 			caseDir := "CASE_DIR=" + tc
 
 			t.Cleanup(func() {
-				//if t.Failed() {
-				runCmd(t, "capture_logs", caseDir)
-				//}
+				if t.Failed() {
+					runCmd(t, "capture_logs", caseDir)
+				}
 
 				runCmd(t, "test_teardown", caseDir)
 			})

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -50,9 +50,9 @@ func TestEnvoy(t *testing.T) {
 			caseDir := "CASE_DIR=" + tc
 
 			t.Cleanup(func() {
-				if t.Failed() {
-					runCmd(t, "capture_logs", caseDir)
-				}
+				//if t.Failed() {
+				runCmd(t, "capture_logs", caseDir)
+				//}
 
 				runCmd(t, "test_teardown", caseDir)
 			})


### PR DESCRIPTION
GoogleRe2 was set as the default regex engine and this field deprecated in [Envoy 1.23.0](https://github.com/envoyproxy/envoy/blob/ce49c7f65668a22b80d1e83c35d170741bb8d46a/api/envoy/config/bootstrap/v3/bootstrap.proto#L335-L337).   COnsul 1.18 will support back to Envoy 1.25.  This change will not be backported.

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
