### PR TITLE
Dockerfile: bump up to `ubi-minimal:9.3`

### DIFF
--- a/.changelog/20014.txt
+++ b/.changelog/20014.txt
@@ -1,0 +1,3 @@
+```release-note:security
+ Upgrade to use `ubi-minimal:9.3` for OpenShift container images.
+ ```

--- a/.changelog/20014.txt
+++ b/.changelog/20014.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-Upgrade OpenShift container images to use `ubi-minimal:9.3` as the base image.
+Upgrade OpenShift container images to use `ubi9-minimal:9.3` as the base image.
 ```

--- a/.changelog/20014.txt
+++ b/.changelog/20014.txt
@@ -1,3 +1,3 @@
 ```release-note:security
- Upgrade to use `ubi-minimal:9.3` for OpenShift container images.
- ```
+Upgrade OpenShift container images to use `ubi-minimal:9.3` as the base image.
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -201,7 +201,7 @@ CMD ["agent", "-dev", "-client", "0.0.0.0"]
 
 # Red Hat UBI-based image
 # This target is used to build a Consul image for use on OpenShift.
-FROM registry.access.redhat.com/ubi9-minimal:9.2 as ubi
+FROM registry.access.redhat.com/ubi9-minimal:9.3 as ubi
 
 ARG PRODUCT_NAME
 ARG PRODUCT_VERSION


### PR DESCRIPTION
### Description

- Dockerfile: bump up to `ubi-minimal:9.3` to remediate vulnerabilities. The current `ubi-minimal:9.2` image is not actively maintained and CVEs fixes are not backported.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
