### PR TITLE
NET-7025 - ci: test-integrations failures in compatibility tests. panics occuring in selectionTracker.TrackIDForSelection

### DIFF
--- a/internal/resource/mappers/selectiontracker/selection_tracker.go
+++ b/internal/resource/mappers/selectiontracker/selection_tracker.go
@@ -72,6 +72,10 @@ func (t *WorkloadSelectionTracker) GetIDsForWorkload(id *pbresource.ID) []*pbres
 // TrackIDForSelector will associate workloads matching the specified workload
 // selector with the given resource id.
 func (t *WorkloadSelectionTracker) TrackIDForSelector(id *pbresource.ID, selector *pbcatalog.WorkloadSelector) {
+	if selector != nil {
+		return
+	}
+
 	t.lock.Lock()
 	defer t.lock.Unlock()
 

--- a/internal/resource/mappers/selectiontracker/selection_tracker.go
+++ b/internal/resource/mappers/selectiontracker/selection_tracker.go
@@ -72,7 +72,7 @@ func (t *WorkloadSelectionTracker) GetIDsForWorkload(id *pbresource.ID) []*pbres
 // TrackIDForSelector will associate workloads matching the specified workload
 // selector with the given resource id.
 func (t *WorkloadSelectionTracker) TrackIDForSelector(id *pbresource.ID, selector *pbcatalog.WorkloadSelector) {
-	if selector != nil {
+	if selector == nil {
 		return
 	}
 


### PR DESCRIPTION
### Description

We are seeing the following panics in CI:
```
Error: sul-server-0-nckhszq0l ~~ 2023-12-21T21:08:23.587Z [ERROR] agent.controller-runtime: controller panic: controller=consul.io/sidecar-proxy-controller managed_type=mesh.v2beta1.ProxyStateTemplate panic="runtime error: invalid memory address or nil pointer dereference"
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/go-hclog.Stacktrace
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/go/pkg/mod/github.com/hashicorp/go-hclog@v1.5.0/stacktrace.go:51
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/consul/internal/controller.(*controllerRunner).handlePanic.func1
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/work/consul/consul/internal/controller/runner.go:254
  dc1-consul-server-0-nckhszq0l ~~ runtime.gopanic
  dc1-consul-server-0-nckhszq0l ~~ 	/opt/hostedtoolcache/go/1.20.12/x64/src/runtime/panic.go:884
  dc1-consul-server-0-nckhszq0l ~~ runtime.panicmem
  dc1-consul-server-0-nckhszq0l ~~ 	/opt/hostedtoolcache/go/1.20.12/x64/src/runtime/panic.go:260
  dc1-consul-server-0-nckhszq0l ~~ runtime.sigpanic
  dc1-consul-server-0-nckhszq0l ~~ 	/opt/hostedtoolcache/go/1.20.12/x64/src/runtime/signal_unix.go:841
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/consul/internal/resource/mappers/selectiontracker.(*WorkloadSelectionTracker).TrackIDForSelector
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/work/consul/consul/internal/resource/mappers/selectiontracker/selection_tracker.go:80
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/consul/internal/mesh/internal/controllers/sidecarproxy/cache.(*Cache).TrackService
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/work/consul/consul/internal/mesh/internal/controllers/sidecarproxy/cache/cache.go:134
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/consul/internal/mesh/internal/controllers/sidecarproxy/cache.(*Cache).MapService
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/work/consul/consul/internal/mesh/internal/controllers/sidecarproxy/cache/cache.go:143
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/consul/internal/controller.(*controllerRunner).run.func3.1
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/work/consul/consul/internal/controller/runner.go:78
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/consul/internal/controller.(*controllerRunner).doMap.func1
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/work/consul/consul/internal/controller/runner.go:206
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/consul/internal/controller.(*controllerRunner).handlePanic
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/work/consul/consul/internal/controller/runner.go:264
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/consul/internal/controller.(*controllerRunner).doMap
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/work/consul/consul/internal/controller/runner.go:204
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/consul/internal/controller.(*controllerRunner).runMapper
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/work/consul/consul/internal/controller/runner.go:165
  dc1-consul-server-0-nckhszq0l ~~ github.com/hashicorp/consul/internal/controller.(*controllerRunner).run.func3
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/work/consul/consul/internal/controller/runner.go:77
  dc1-consul-server-0-nckhszq0l ~~ golang.org/x/sync/errgroup.(*Group).Go.func1
  dc1-consul-server-0-nckhszq0l ~~ 	/home/runner/go/pkg/mod/golang.org/x/sync@v0.3.0/errgroup/errgroup.go:75
```
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
