### PR TITLE
NET-6813: adding resolver default subset test in agentless upgrade test

### DIFF
--- a/test-integ/upgrade/l7_traffic_management/common.go
+++ b/test-integ/upgrade/l7_traffic_management/common.go
@@ -1,0 +1,226 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package l7_traffic_management
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+	"github.com/hashicorp/consul/testing/deployer/sprawl"
+	"github.com/hashicorp/consul/testing/deployer/sprawl/sprawltest"
+	"github.com/hashicorp/consul/testing/deployer/topology"
+
+	"github.com/hashicorp/consul/test-integ/topoutil"
+)
+
+type commonTopo struct {
+	Cfg *topology.Config
+
+	Sprawl *sprawl.Sprawl
+	Assert *topoutil.Asserter
+
+	StaticServerSID topology.ID
+	StaticClientSID topology.ID
+
+	StaticServerWorkload *topology.Workload
+	StaticClientWorkload *topology.Workload
+}
+
+const (
+	defaultNamespace = "default"
+	defaultPartition = "default"
+	dc1              = "dc1"
+)
+
+var (
+	staticServerSID = topology.NewID("static-server", defaultNamespace, defaultPartition)
+	staticClientSID = topology.NewID("static-client", defaultNamespace, defaultPartition)
+)
+
+func NewCommonTopo(t *testing.T) *commonTopo {
+	t.Helper()
+	return newCommonTopo(t)
+}
+
+// create below topology
+// consul server
+//   - consul server on node dc1-server1
+//
+// dataplane
+//   - workload(fortio) static-server on node dc1-client1
+//   - workload(fortio) static-client on node dc1-client2 with destination to static-server
+//   - static-client, static-server are registered at 2 agentless nodes.
+//
+// Intentions
+//   - static-client has destination to static-server
+func newCommonTopo(t *testing.T) *commonTopo {
+	t.Helper()
+
+	ct := &commonTopo{}
+
+	cfg := &topology.Config{
+		Images: topology.Images{
+			// ConsulEnterprise: "hashicorp/consul-enterprise:local",
+		},
+		Networks: []*topology.Network{
+			{Name: dc1},
+		},
+		Clusters: []*topology.Cluster{
+			{
+				Name: dc1,
+				Nodes: []*topology.Node{
+					// consul server on dc1-server1
+					{
+						Kind:   topology.NodeKindServer,
+						Images: utils.LatestImages(),
+						Name:   "dc1-server1",
+						Addresses: []*topology.Address{
+							{Network: dc1},
+						},
+						Meta: map[string]string{
+							"build": "0.0.1",
+						},
+					},
+					// static-server-v1 on dc1-client1
+					{
+						Kind: topology.NodeKindDataplane,
+						Name: "dc1-client1",
+						Workloads: []*topology.Workload{
+							{
+								ID:             staticServerSID,
+								Image:          "docker.mirror.hashicorp.services/fortio/fortio",
+								Port:           8080,
+								EnvoyAdminPort: 19000,
+								CheckTCP:       "127.0.0.1:8080",
+								Meta:           map[string]string{"version": "v2"},
+								Env: []string{
+									"FORTIO_NAME=" + dc1 + "::" + staticServerSID.String(),
+								},
+								Command: []string{
+									"server",
+									"-http-port", "8080",
+									"-redirect-port", "-disabled",
+								},
+							},
+						},
+					},
+					// static-client on dc1-client2 with destination to static-server
+					{
+						Kind: topology.NodeKindDataplane,
+						Name: "dc1-client2",
+						Workloads: []*topology.Workload{
+							{
+								ID:             staticClientSID,
+								Image:          "docker.mirror.hashicorp.services/fortio/fortio",
+								Port:           8080,
+								EnvoyAdminPort: 19000,
+								CheckTCP:       "127.0.0.1:8080",
+								Command: []string{
+									"server",
+									"-http-port", "8080",
+									"-redirect-port", "-disabled",
+								},
+								Destinations: []*topology.Destination{
+									{
+										ID:        staticServerSID, // static-server
+										LocalPort: 5000,
+									},
+								},
+							},
+						},
+					},
+				},
+				Enterprise: utils.IsEnterprise(),
+				InitialConfigEntries: []api.ConfigEntry{
+					&api.ProxyConfigEntry{
+						Kind:      api.ProxyDefaults,
+						Name:      "global",
+						Partition: topoutil.ConfigEntryPartition("default"),
+						Config: map[string]any{
+							"protocol": "http",
+						},
+					},
+					&api.ServiceConfigEntry{
+						Kind:      api.ServiceDefaults,
+						Name:      staticServerSID.Name,
+						Partition: topoutil.ConfigEntryPartition("default"),
+					},
+					&api.ServiceIntentionsConfigEntry{
+						Kind:      api.ServiceIntentions,
+						Name:      staticServerSID.Name,
+						Partition: topoutil.ConfigEntryPartition("default"),
+						Sources: []*api.SourceIntention{
+							{
+								Name:   staticClientSID.Name,
+								Action: api.IntentionActionAllow},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ct.Cfg = cfg
+	ct.StaticClientSID = staticClientSID
+	ct.StaticServerSID = staticServerSID
+
+	return ct
+}
+
+func (ct *commonTopo) Launch(t *testing.T) {
+	t.Helper()
+	if ct.Sprawl != nil {
+		t.Fatalf("Launch must only be called once")
+	}
+	ct.Sprawl = sprawltest.Launch(t, ct.Cfg)
+	ct.ValidateTopology(t)
+}
+
+func (ct *commonTopo) ValidateTopology(t *testing.T) {
+
+	t.Helper()
+	ct.Assert = topoutil.NewAsserter(ct.Sprawl)
+	cluster := ct.Sprawl.Topology().Clusters[dc1]
+
+	cl, err := ct.Sprawl.APIClientForCluster(cluster.Name, "")
+	require.NoError(t, err)
+
+	staticServerWorkload := cluster.WorkloadByID(
+		topology.NewNodeID("dc1-client1", defaultPartition),
+		ct.StaticServerSID,
+	)
+	ct.Assert.HTTPStatus(t, staticServerWorkload, staticServerWorkload.Port, 200)
+	ct.Assert.AssertServiceHealth(t, cl, ct.StaticServerSID.Name, true, 1)
+
+	staticClientWorkload := cluster.WorkloadByID(
+		topology.NewNodeID("dc1-client2", defaultPartition),
+		ct.StaticClientSID,
+	)
+	ct.Assert.AssertServiceHealth(t, cl, ct.StaticClientSID.Name, true, 1)
+
+	// check the service exists in catalog
+	svcs := cluster.WorkloadsByID(ct.StaticClientSID)
+	client := svcs[0]
+	upstream := client.Destinations[0]
+	ct.Assert.CatalogServiceExists(t, cluster.Name, upstream.ID.Name, utils.CompatQueryOpts(&api.QueryOptions{
+		Partition: upstream.ID.Partition,
+		Namespace: upstream.ID.Namespace,
+	}))
+	ct.Assert.CatalogServiceExists(t, cluster.Name, fmt.Sprintf("%s-sidecar-proxy", upstream.ID.Name), utils.CompatQueryOpts(&api.QueryOptions{
+		Partition: upstream.ID.Partition,
+		Namespace: upstream.ID.Namespace,
+	}))
+
+	ct.StaticServerWorkload = staticServerWorkload
+	ct.StaticClientWorkload = staticClientWorkload
+
+	ct.Assert.AssertEnvoyRunningWithClient(t, ct.StaticServerWorkload)
+	ct.Assert.AssertEnvoyRunningWithClient(t, ct.StaticClientWorkload)
+
+	ct.Assert.AssertEnvoyPresentsCertURIWithClient(t, ct.StaticServerWorkload)
+	ct.Assert.AssertEnvoyPresentsCertURIWithClient(t, ct.StaticClientWorkload)
+}

--- a/test-integ/upgrade/l7_traffic_management/common.go
+++ b/test-integ/upgrade/l7_traffic_management/common.go
@@ -177,10 +177,15 @@ func (ct *commonTopo) Launch(t *testing.T) {
 		t.Fatalf("Launch must only be called once")
 	}
 	ct.Sprawl = sprawltest.Launch(t, ct.Cfg)
-	ct.ValidateTopology(t)
+	ct.ValidateWorkloads(t)
 }
 
-func (ct *commonTopo) ValidateTopology(t *testing.T) {
+// ValidateWorkloads validates below
+// - static server, static client workloads are reachable and, static server, static client services are healthy
+// - static client and its sidecar exists in catalog
+// - envoy is running for static server, static client workloads
+// - envoy cert uri is present in for static server, static client workloads
+func (ct *commonTopo) ValidateWorkloads(t *testing.T) {
 
 	t.Helper()
 	ct.Assert = topoutil.NewAsserter(ct.Sprawl)

--- a/test-integ/upgrade/l7_traffic_management/resolver_test.go
+++ b/test-integ/upgrade/l7_traffic_management/resolver_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package l7_traffic_management
 
 import (

--- a/test-integ/upgrade/l7_traffic_management/resolver_test.go
+++ b/test-integ/upgrade/l7_traffic_management/resolver_test.go
@@ -1,0 +1,138 @@
+package l7_traffic_management
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+	"github.com/hashicorp/consul/testing/deployer/sprawl"
+	"github.com/hashicorp/consul/testing/deployer/topology"
+)
+
+// TestTrafficManagement_ResolverDefaultSubset_Agentless tests resolver directs traffic to default subset - agentless
+//   - Create a topology with static-server (meta version V2) and static-client (with static-server upstream)
+//   - Create a service resolver with V2 as default subset
+//   - Resolver directs traffic to the default subset, which is V2
+//   - Do a standard upgrade and validate the traffic is still directed to V2
+//   - Change the default version in serviceResolver to v1 and the client to server request fails
+//     since we only have V2 instance
+//   - Change the default version in serviceResolver to v2 and the client to server request succeeds
+//     (V2 instance is available and traffic is directed to it)
+func TestTrafficManagement_ResolverDefaultSubset_Agentless(t *testing.T) {
+	t.Parallel()
+
+	ct := NewCommonTopo(t)
+	configEntries := ct.Cfg.Clusters[0].InitialConfigEntries
+	configEntries = addServiceResolver(configEntries, staticServerSID.Name, "v2")
+	ct.Cfg.Clusters[0].InitialConfigEntries = configEntries
+	ct.Launch(t)
+
+	resolverV2AssertFn := func() {
+		cluster := ct.Sprawl.Topology().Clusters[dc1]
+		staticClientWorkload := cluster.WorkloadByID(
+			topology.NewNodeID("dc1-client2", defaultPartition),
+			ct.StaticClientSID,
+		)
+		ct.Assert.FortioFetch2HeaderEcho(t, staticClientWorkload, &topology.Destination{
+			ID:        ct.StaticServerSID,
+			LocalPort: 5000,
+		})
+		ct.Assert.FortioFetch2FortioName(t, staticClientWorkload, &topology.Destination{
+			ID:        ct.StaticServerSID,
+			LocalPort: 5000,
+		}, dc1, staticServerSID)
+		ct.Assert.DestinationEndpointStatus(t, staticClientWorkload, "v2.static-server.default", "HEALTHY", 1)
+	}
+	resolverV2AssertFn()
+
+	t.Log("Start standard upgrade ...")
+	sp := ct.Sprawl
+	cfg := sp.Config()
+	require.NoError(t, ct.Sprawl.LoadKVDataToCluster("dc1", 1, &api.WriteOptions{}))
+	require.NoError(t, sp.Upgrade(cfg, "dc1", sprawl.UpgradeTypeStandard, utils.TargetImages(), nil))
+	t.Log("Finished standard upgrade ...")
+
+	// verify data is not lost
+	data, err := ct.Sprawl.GetKV("dc1", "key-0", &api.QueryOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	ct.ValidateTopology(t)
+	resolverV2AssertFn()
+
+	// Change the default version in serviceResolver to v1 and the client to server request fails
+	configEntries = cfg.Clusters[0].InitialConfigEntries
+	configEntries = removeServiceResolvers(configEntries, staticServerSID.Name)
+	configEntries = addServiceResolver(configEntries, staticServerSID.Name, "v1")
+	cfg.Clusters[0].InitialConfigEntries = configEntries
+
+	require.NoError(t, ct.Sprawl.RelaunchWithPhase(cfg, sprawl.LaunchPhaseRegular))
+	t.Log("Finished first relaunch ...")
+	ct.ValidateTopology(t)
+
+	resolverV1AssertFn := func() {
+		cluster := ct.Sprawl.Topology().Clusters[dc1]
+		staticClientWorkload := cluster.WorkloadByID(
+			topology.NewNodeID("dc1-client2", defaultPartition),
+			ct.StaticClientSID,
+		)
+		ct.Assert.FortioFetch2ServiceUnavailable(t, staticClientWorkload, &topology.Destination{
+			ID:        ct.StaticServerSID,
+			LocalPort: 5000,
+		})
+	}
+	resolverV1AssertFn()
+
+	// Change the default version in serviceResolver to v2 and the client to server request succeeds
+	cfg = ct.Sprawl.Config()
+	configEntries = cfg.Clusters[0].InitialConfigEntries
+	configEntries = removeServiceResolvers(configEntries, staticServerSID.Name)
+	configEntries = addServiceResolver(configEntries, staticServerSID.Name, "v2")
+	cfg.Clusters[0].InitialConfigEntries = configEntries
+
+	require.NoError(t, ct.Sprawl.RelaunchWithPhase(cfg, sprawl.LaunchPhaseRegular))
+	t.Log("Finished second relaunch ...")
+	ct.ValidateTopology(t)
+	resolverV2AssertFn()
+}
+
+func addServiceResolver(configEntries []api.ConfigEntry, serviceResolverName string, defaultSubset string) []api.ConfigEntry {
+	configEntries = append(configEntries,
+		&api.ServiceResolverConfigEntry{
+			Kind:          api.ServiceResolver,
+			Name:          serviceResolverName,
+			DefaultSubset: defaultSubset,
+			Subsets: map[string]api.ServiceResolverSubset{
+				"v1": {
+					Filter: "Service.Meta.version == v1",
+				},
+				"v2": {
+					Filter: "Service.Meta.version == v2",
+				},
+			},
+		},
+	)
+	return configEntries
+}
+
+func removeServiceResolvers(configEntries []api.ConfigEntry, serviceResolverNames ...string) []api.ConfigEntry {
+	var resConfigEntries []api.ConfigEntry
+	containsString := func(element string, slice []string) bool {
+		for _, v := range slice {
+			if v == element {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, entry := range configEntries {
+		if entry.GetKind() == api.ServiceResolver && containsString(entry.GetName(), serviceResolverNames) {
+			continue
+		}
+		resConfigEntries = append(resConfigEntries, entry)
+	}
+	return resConfigEntries
+}

--- a/test/integration/consul-container/libs/assert/envoy.go
+++ b/test/integration/consul-container/libs/assert/envoy.go
@@ -250,7 +250,29 @@ func AssertEnvoyPresentsCertURI(t *testing.T, port int, serviceName string) {
 		}
 		require.NotNil(r, dump)
 	})
+	validateEnvoyCertificateURI(t, dump, serviceName)
+}
 
+func AssertEnvoyPresentsCertURIWithClient(t *testing.T, client *http.Client, addr string, serviceName string) {
+	var (
+		dump string
+		err  error
+	)
+	failer := func() *retry.Timer {
+		return &retry.Timer{Timeout: 30 * time.Second, Wait: 1 * time.Second}
+	}
+
+	retry.RunWith(failer(), t, func(r *retry.R) {
+		dump, _, err = GetEnvoyOutputWithClient(client, addr, "certs", nil)
+		if err != nil {
+			r.Fatal("could not fetch envoy configuration")
+		}
+		require.NotNil(r, dump)
+	})
+	validateEnvoyCertificateURI(t, dump, serviceName)
+}
+
+func validateEnvoyCertificateURI(t *testing.T, dump string, serviceName string) {
 	// Validate certificate uri
 	filter := `.certificates[] | .cert_chain[].subject_alt_names[].uri`
 	results, err := utils.JQFilter(dump, filter)
@@ -277,6 +299,22 @@ func AssertEnvoyRunning(t *testing.T, port int) {
 
 	retry.RunWith(failer(), t, func(r *retry.R) {
 		_, _, err = GetEnvoyOutput(port, "stats", nil)
+		if err != nil {
+			r.Fatal("could not fetch envoy stats")
+		}
+	})
+}
+
+func AssertEnvoyRunningWithClient(t *testing.T, client *http.Client, addr string) {
+	var (
+		err error
+	)
+	failer := func() *retry.Timer {
+		return &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+	}
+
+	retry.RunWith(failer(), t, func(r *retry.R) {
+		_, _, err = GetEnvoyOutputWithClient(client, addr, "stats", nil)
 		if err != nil {
 			r.Fatal("could not fetch envoy stats")
 		}

--- a/test/integration/consul-container/test/upgrade/l7_traffic_management/resolver_default_subset_test.go
+++ b/test/integration/consul-container/test/upgrade/l7_traffic_management/resolver_default_subset_test.go
@@ -73,8 +73,8 @@ func TestTrafficManagement_ResolverDefaultSubset(t *testing.T) {
 	assertionFn := func() {
 		_, serverAdminPortV1 := serverConnectProxyV1.GetAdminAddr()
 		_, serverAdminPortV2 := serverConnectProxyV2.GetAdminAddr()
-		_, adminPort := staticClientProxy.GetAdminAddr() // httpPort
-		_, port := staticClientProxy.GetAddr()           // EnvoyAdminPort
+		_, adminPort := staticClientProxy.GetAdminAddr() // EnvoyAdminPort
+		_, port := staticClientProxy.GetAddr()           // httpPort
 
 		libassert.AssertEnvoyRunning(t, serverAdminPortV1)
 		libassert.AssertEnvoyRunning(t, serverAdminPortV2)


### PR DESCRIPTION
### Description

This ticket adds a new test TestTrafficManagement_ResolverDefaultSubset_Agentless in the series for l7 traffic management

Add service resolver subsets defaulting the subset to v2. Verify the traffic is routing to default v2 subset. The behaviour should remain intact after the upgrade too.

### Testing & Reproduction steps

Ran the workflow https://github.com/hashicorp/consul/actions/runs/7299031468 against branch [NET-6813-add-resolver-test](https://github.com/hashicorp/consul/tree/NET-6813-add-resolver-test) which includes TestTrafficManagement_ResolverDefaultSubset_Agentless from the PR

### Links

upgrade/l7_traffic_management.TestTrafficManagement_ResolverDefaultSubset_Agentless from 1.16 to latest: [Link](https://github.com/hashicorp/consul/actions/runs/7299031468/job/19891094038#step:7:52)
upgrade/l7_traffic_management.TestTrafficManagement_ResolverDefaultSubset_Agentless from 1.17 to latest: [Link](https://github.com/hashicorp/consul/actions/runs/7299031468/job/19891094173#step:7:52)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
