### PR TITLE
Backport into 1.15 of NET-6944 - Replace usage of deprecated Envoy field envoy.extensions.filters.http.lua.v3.Lua.inline_code

### DIFF
--- a/.changelog/20012.txt
+++ b/.changelog/20012.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+xds: replace usage of deprecated Envoy field `envoy.extensions.filters.http.lua.v3.Lua.inline_code`
+```

--- a/agent/envoyextensions/builtin/lua/lua.go
+++ b/agent/envoyextensions/builtin/lua/lua.go
@@ -6,6 +6,7 @@ package lua
 import (
 	"errors"
 	"fmt"
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -102,7 +103,11 @@ func (l *lua) PatchFilter(_ *extensioncommon.RuntimeConfig, filter *envoy_listen
 	luaHttpFilter, err := makeEnvoyHTTPFilter(
 		"envoy.filters.http.lua",
 		&envoy_lua_v3.Lua{
-			InlineCode: l.Script,
+			DefaultSourceCode: &envoy_core_v3.DataSource{
+				Specifier: &envoy_core_v3.DataSource_InlineString{
+					InlineString: l.Script,
+				},
+			},
 		},
 	)
 	if err != nil {

--- a/agent/xds/testdata/builtin_extension/listeners/lambda-and-lua-connect-proxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lambda-and-lua-connect-proxy.latest.golden
@@ -49,96 +49,9 @@
                     }
                   },
                   {
-                    "name": "envoy.filters.http.header_to_metadata",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config",
-                      "requestRules": [
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "trust-domain",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\1"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "partition",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\2"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "namespace",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\3"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "datacenter",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\4"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "service",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\5"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "name": "envoy.filters.http.lua",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "defaultSourceCode": {
-                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
-                      }
-                    }
-                  },
-                  {
-                    "name": "envoy.filters.http.router",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    "name":  "envoy.filters.http.router",
+                    "typedConfig":  {
+                      "@type":  "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
                     }
                   }
                 ],
@@ -311,7 +224,9 @@
                     "name":  "envoy.filters.http.lua",
                     "typedConfig":  {
                       "@type":  "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode":  "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      "defaultSourceCode":  {
+                        "inlineString":  "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {

--- a/agent/xds/testdata/builtin_extension/listeners/lambda-and-lua-connect-proxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lambda-and-lua-connect-proxy.latest.golden
@@ -49,9 +49,96 @@
                     }
                   },
                   {
-                    "name":  "envoy.filters.http.router",
-                    "typedConfig":  {
-                      "@type":  "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    "name": "envoy.filters.http.header_to_metadata",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config",
+                      "requestRules": [
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "trust-domain",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\1"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "partition",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\2"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "namespace",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\3"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "datacenter",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\4"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "service",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\5"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.lua",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
                     }
                   }
                 ],

--- a/agent/xds/testdata/builtin_extension/listeners/lua-inbound-applies-to-inbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-inbound-applies-to-inbound.latest.golden
@@ -64,115 +64,13 @@
         {
           "filters":  [
             {
-              "name": "envoy.filters.network.http_connection_manager",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "forwardClientCertDetails": "APPEND_FORWARD",
-                "httpFilters": [
-                  {
-                    "name": "envoy.filters.http.rbac",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                      "rules": {}
-                    }
-                  },
-                  {
-                    "name": "envoy.filters.http.header_to_metadata",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config",
-                      "requestRules": [
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "trust-domain",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\1"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "partition",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\2"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "namespace",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\3"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "datacenter",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\4"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "service",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\5"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "name": "envoy.filters.http.lua",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "defaultSourceCode": {
-                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
-                      }
-                    }
-                  },
-                  {
-                    "name": "envoy.filters.http.router",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-                    }
-                  }
-                ],
-                "routeConfig": {
-                  "name": "public_listener",
-                  "virtualHosts": [
+              "name":  "envoy.filters.network.http_connection_manager",
+              "typedConfig":  {
+                "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix":  "public_listener",
+                "routeConfig":  {
+                  "name":  "public_listener",
+                  "virtualHosts":  [
                     {
                       "name":  "public_listener",
                       "domains":  [
@@ -281,7 +179,9 @@
                     "name":  "envoy.filters.http.lua",
                     "typedConfig":  {
                       "@type":  "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode":  "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      "defaultSourceCode":  {
+                        "inlineString":  "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {

--- a/agent/xds/testdata/builtin_extension/listeners/lua-inbound-applies-to-inbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-inbound-applies-to-inbound.latest.golden
@@ -64,13 +64,115 @@
         {
           "filters":  [
             {
-              "name":  "envoy.filters.network.http_connection_manager",
-              "typedConfig":  {
-                "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix":  "public_listener",
-                "routeConfig":  {
-                  "name":  "public_listener",
-                  "virtualHosts":  [
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "APPEND_FORWARD",
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.rbac",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                      "rules": {}
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.header_to_metadata",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config",
+                      "requestRules": [
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "trust-domain",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\1"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "partition",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\2"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "namespace",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\3"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "datacenter",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\4"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "service",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\5"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.lua",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "routeConfig": {
+                  "name": "public_listener",
+                  "virtualHosts": [
                     {
                       "name":  "public_listener",
                       "domains":  [

--- a/agent/xds/testdata/builtin_extension/listeners/lua-inbound-doesnt-apply-to-local-upstreams.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-inbound-doesnt-apply-to-local-upstreams.latest.golden
@@ -100,13 +100,115 @@
         {
           "filters":  [
             {
-              "name":  "envoy.filters.network.http_connection_manager",
-              "typedConfig":  {
-                "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix":  "public_listener",
-                "routeConfig":  {
-                  "name":  "public_listener",
-                  "virtualHosts":  [
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "APPEND_FORWARD",
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.rbac",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                      "rules": {}
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.header_to_metadata",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config",
+                      "requestRules": [
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "trust-domain",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\1"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "partition",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\2"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "namespace",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\3"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "datacenter",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\4"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "service",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "googleRe2": {},
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\5"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.lua",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "routeConfig": {
+                  "name": "public_listener",
+                  "virtualHosts": [
                     {
                       "name":  "public_listener",
                       "domains":  [

--- a/agent/xds/testdata/builtin_extension/listeners/lua-inbound-doesnt-apply-to-local-upstreams.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-inbound-doesnt-apply-to-local-upstreams.latest.golden
@@ -100,115 +100,13 @@
         {
           "filters":  [
             {
-              "name": "envoy.filters.network.http_connection_manager",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "forwardClientCertDetails": "APPEND_FORWARD",
-                "httpFilters": [
-                  {
-                    "name": "envoy.filters.http.rbac",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                      "rules": {}
-                    }
-                  },
-                  {
-                    "name": "envoy.filters.http.header_to_metadata",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config",
-                      "requestRules": [
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "trust-domain",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\1"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "partition",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\2"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "namespace",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\3"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "datacenter",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\4"
-                            }
-                          }
-                        },
-                        {
-                          "header": "x-forwarded-client-cert",
-                          "onHeaderPresent": {
-                            "key": "service",
-                            "metadataNamespace": "consul",
-                            "regexValueRewrite": {
-                              "pattern": {
-                                "googleRe2": {},
-                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
-                              },
-                              "substitution": "\\5"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "name": "envoy.filters.http.lua",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "defaultSourceCode": {
-                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
-                      }
-                    }
-                  },
-                  {
-                    "name": "envoy.filters.http.router",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-                    }
-                  }
-                ],
-                "routeConfig": {
-                  "name": "public_listener",
-                  "virtualHosts": [
+              "name":  "envoy.filters.network.http_connection_manager",
+              "typedConfig":  {
+                "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix":  "public_listener",
+                "routeConfig":  {
+                  "name":  "public_listener",
+                  "virtualHosts":  [
                     {
                       "name":  "public_listener",
                       "domains":  [
@@ -317,7 +215,9 @@
                     "name":  "envoy.filters.http.lua",
                     "typedConfig":  {
                       "@type":  "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode":  "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      "defaultSourceCode":  {
+                        "inlineString":  "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {

--- a/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams-tproxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams-tproxy.latest.golden
@@ -55,10 +55,12 @@
                 },
                 "httpFilters":  [
                   {
-                    "name":  "envoy.filters.http.lua",
-                    "typedConfig":  {
-                      "@type":  "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode":  "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                    "name": "envoy.filters.http.lua",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {
@@ -99,10 +101,12 @@
                 },
                 "httpFilters":  [
                   {
-                    "name":  "envoy.filters.http.lua",
-                    "typedConfig":  {
-                      "@type":  "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode":  "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                    "name": "envoy.filters.http.lua",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {

--- a/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams.latest.golden
@@ -14,29 +14,13 @@
         {
           "filters":  [
             {
-              "name": "envoy.filters.network.http_connection_manager",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "httpFilters": [
-                  {
-                    "name": "envoy.filters.http.lua",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "defaultSourceCode": {
-                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
-                      }
-                    }
-                  },
-                  {
-                    "name": "envoy.filters.http.router",
-                    "typedConfig": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-                    }
-                  }
-                ],
-                "routeConfig": {
-                  "name": "db",
-                  "virtualHosts": [
+              "name":  "envoy.filters.network.http_connection_manager",
+              "typedConfig":  {
+                "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix":  "upstream.db.default.default.dc1",
+                "routeConfig":  {
+                  "name":  "db",
+                  "virtualHosts":  [
                     {
                       "name":  "db.default.default.dc1",
                       "domains":  [
@@ -60,7 +44,9 @@
                     "name":  "envoy.filters.http.lua",
                     "typedConfig":  {
                       "@type":  "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode":  "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      "defaultSourceCode":  {
+                        "inlineString":  "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {

--- a/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams.latest.golden
@@ -14,13 +14,29 @@
         {
           "filters":  [
             {
-              "name":  "envoy.filters.network.http_connection_manager",
-              "typedConfig":  {
-                "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix":  "upstream.db.default.default.dc1",
-                "routeConfig":  {
-                  "name":  "db",
-                  "virtualHosts":  [
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.lua",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "routeConfig": {
+                  "name": "db",
+                  "virtualHosts": [
                     {
                       "name":  "db.default.default.dc1",
                       "domains":  [


### PR DESCRIPTION

### Description

Manual backport of https://github.com/hashicorp/consul/pull/20012
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
