### PR TITLE
Backport into 1.17 of NET-6944 - Replace usage of deprecated Envoy field envoy.extensions.filters.http.lua.v3.Lua.inline_code

### DIFF
--- a/.changelog/20012.txt
+++ b/.changelog/20012.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+xds: replace usage of deprecated Envoy field `envoy.extensions.filters.http.lua.v3.Lua.inline_code`
+```

--- a/agent/envoyextensions/builtin/lua/lua.go
+++ b/agent/envoyextensions/builtin/lua/lua.go
@@ -6,6 +6,7 @@ package lua
 import (
 	"errors"
 	"fmt"
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
 	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_lua_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
@@ -97,7 +98,11 @@ func (l *lua) PatchFilter(p extensioncommon.FilterPayload) (*envoy_listener_v3.F
 	luaHttpFilter, err := extensioncommon.MakeEnvoyHTTPFilter(
 		"envoy.filters.http.lua",
 		&envoy_lua_v3.Lua{
-			InlineCode: l.Script,
+			DefaultSourceCode: &envoy_core_v3.DataSource{
+				Specifier: &envoy_core_v3.DataSource_InlineString{
+					InlineString: l.Script,
+				},
+			},
 		},
 	)
 	if err != nil {

--- a/agent/xds/testdata/builtin_extension/listeners/lambda-and-lua-connect-proxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lambda-and-lua-connect-proxy.latest.golden
@@ -202,7 +202,9 @@
                     "name": "envoy.filters.http.lua",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {

--- a/agent/xds/testdata/builtin_extension/listeners/lua-inbound-applies-to-inbound.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-inbound-applies-to-inbound.latest.golden
@@ -157,7 +157,9 @@
                     "name": "envoy.filters.http.lua",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {

--- a/agent/xds/testdata/builtin_extension/listeners/lua-inbound-doesnt-apply-to-local-upstreams.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-inbound-doesnt-apply-to-local-upstreams.latest.golden
@@ -193,7 +193,9 @@
                     "name": "envoy.filters.http.lua",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {

--- a/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams-tproxy.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams-tproxy.latest.golden
@@ -49,7 +49,9 @@
                     "name": "envoy.filters.http.lua",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {
@@ -93,7 +95,9 @@
                     "name": "envoy.filters.http.lua",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {

--- a/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams.latest.golden
+++ b/agent/xds/testdata/builtin_extension/listeners/lua-outbound-applies-to-local-upstreams.latest.golden
@@ -21,7 +21,9 @@
                     "name": "envoy.filters.http.lua",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
-                      "inlineCode": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      "defaultSourceCode": {
+                        "inlineString": "\nfunction envoy_on_request(request_handle)\n  request_handle:headers():add(\"test\", \"test\")\nend"
+                      }
                     }
                   },
                   {


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/consul/pull/20012

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
