### PR TITLE
ci: increase runner size for security scans

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -47,7 +47,7 @@ jobs:
 
   scan:
     needs: [setup]
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-xl) }}
     # The first check ensures this doesn't run on community-contributed PRs, who
     # won't have the permissions to run this job.
     if: ${{ (github.repository != 'hashicorp/consul' || (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name))


### PR DESCRIPTION
We've noticed runners appearing to become resource-starved during heavy CI traffic. While we should try to prevent this by limiting the scanner's CPU consumption, increasing the runner size should help in the interim.

Follow-up to https://github.com/hashicorp/consul/pull/19978

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
