### PR TITLE
[CC-7042] Update and enable the HCP metrics sink in the HCP manager

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -586,11 +586,12 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 	})
 
 	s.hcpManager = hcp.NewManager(hcp.ManagerConfig{
-		CloudConfig:   s.config.Cloud,
-		Client:        flat.HCP.Client,
-		StatusFn:      s.hcpServerStatus(flat),
-		Logger:        logger.Named("hcp_manager"),
-		SCADAProvider: flat.HCP.Provider,
+		CloudConfig:       s.config.Cloud,
+		Client:            flat.HCP.Client,
+		StatusFn:          s.hcpServerStatus(flat),
+		Logger:            logger.Named("hcp_manager"),
+		SCADAProvider:     flat.HCP.Provider,
+		TelemetryProvider: flat.HCP.TelemetryProvider,
 	})
 
 	var recorder *middleware.RequestRecorder

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -932,7 +932,13 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 	go s.updateMetrics()
 
 	// Now we are setup, configure the HCP manager
-	go s.hcpManager.Run(&lib.StopChannelContext{StopCh: shutdownCh})
+	go func() {
+		err := s.hcpManager.Run(&lib.StopChannelContext{StopCh: shutdownCh})
+		if err != nil {
+			logger.Error("error starting HCP manager, some HashiCorp Cloud Platform functionality has been disabled",
+				"error", err)
+		}
+	}()
 
 	err = s.runEnterpriseRateLimiterConfigEntryController()
 	if err != nil {

--- a/agent/hcp/client/http_client.go
+++ b/agent/hcp/client/http_client.go
@@ -1,0 +1,60 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package client
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-retryablehttp"
+	"golang.org/x/oauth2"
+)
+
+const (
+	// HTTP Client config
+	defaultStreamTimeout = 15 * time.Second
+
+	// Retry config
+	// TODO: Eventually, we'd like to configure these values dynamically.
+	defaultRetryWaitMin = 1 * time.Second
+	defaultRetryWaitMax = 15 * time.Second
+	// defaultRetryMax is set to 0 to turn off retry functionality, until dynamic configuration is possible.
+	// This is to circumvent any spikes in load that may cause or exacerbate server-side issues for now.
+	defaultRetryMax = 0
+)
+
+// newHTTPClient configures the retryable HTTP client.
+func newHTTPClient(cloudCfg CloudConfig, logger hclog.Logger) (*retryablehttp.Client, error) {
+	hcpCfg, err := cloudCfg.HCPConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	tlsTransport := cleanhttp.DefaultPooledTransport()
+	tlsTransport.TLSClientConfig = hcpCfg.APITLSConfig()
+
+	var transport http.RoundTripper = &oauth2.Transport{
+		Base:   tlsTransport,
+		Source: hcpCfg,
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   defaultStreamTimeout,
+	}
+
+	retryClient := &retryablehttp.Client{
+		HTTPClient:   client,
+		Logger:       logger.Named("hcp_telemetry_client"),
+		RetryWaitMin: defaultRetryWaitMin,
+		RetryWaitMax: defaultRetryWaitMax,
+		RetryMax:     defaultRetryMax,
+		CheckRetry:   retryablehttp.DefaultRetryPolicy,
+		Backoff:      retryablehttp.DefaultBackoff,
+	}
+
+	return retryClient, nil
+}

--- a/agent/hcp/client/http_client_test.go
+++ b/agent/hcp/client/http_client_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/consul/agent/hcp/config"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPClient(t *testing.T) {
+	mockCfg := config.MockCloudCfg{}
+	mockHCPCfg, err := mockCfg.HCPConfig()
+	require.NoError(t, err)
+
+	client := NewHTTPClient(mockHCPCfg.APITLSConfig(), mockHCPCfg, hclog.NewNullLogger())
+	require.NotNil(t, client)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+	}))
+	client.Get(srv.URL)
+}

--- a/agent/hcp/client/http_client_test.go
+++ b/agent/hcp/client/http_client_test.go
@@ -21,8 +21,11 @@ func TestNewHTTPClient(t *testing.T) {
 	client := NewHTTPClient(mockHCPCfg.APITLSConfig(), mockHCPCfg, hclog.NewNullLogger())
 	require.NotNil(t, client)
 
+	var req *http.Request
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		req = r
 	}))
-	client.Get(srv.URL)
+	_, err = client.Get(srv.URL)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
 }

--- a/agent/hcp/client/metrics_client.go
+++ b/agent/hcp/client/metrics_client.go
@@ -57,10 +57,11 @@ func NewMetricsClient(ctx context.Context, cfg CloudConfig, provider telemetry.C
 
 	logger := hclog.FromContext(ctx)
 
-	c, err := newHTTPClient(cfg, logger)
+	hcpCfg, err := cfg.HCPConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to init telemetry client: %v", err)
 	}
+	c := NewHTTPClient(hcpCfg.APITLSConfig(), hcpCfg, logger)
 
 	r, err := cfg.Resource()
 	if err != nil {

--- a/agent/hcp/client/metrics_client.go
+++ b/agent/hcp/client/metrics_client.go
@@ -11,16 +11,12 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-retryablehttp"
-	hcpcfg "github.com/hashicorp/hcp-sdk-go/config"
-	"github.com/hashicorp/hcp-sdk-go/resource"
 	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/hashicorp/consul/agent/hcp/telemetry"
-	"github.com/hashicorp/consul/version"
 )
 
 const (
@@ -29,55 +25,18 @@ const (
 	defaultErrRespBodyLength = 100
 )
 
-// cloudConfig represents cloud config for TLS abstracted in an interface for easy testing.
-type CloudConfig interface {
-	HCPConfig(opts ...hcpcfg.HCPConfigOption) (hcpcfg.HCPConfig, error)
-	Resource() (resource.Resource, error)
-}
-
 // otlpClient is an implementation of MetricsClient with a retryable http client for retries and to honor throttle.
 // It also holds default HTTP headers to add to export requests.
 type otlpClient struct {
-	client *retryablehttp.Client
-	header *http.Header
-
 	provider telemetry.ClientProvider
 }
 
 // NewMetricsClient returns a configured MetricsClient.
 // The current implementation uses otlpClient to provide retry functionality.
-func NewMetricsClient(ctx context.Context, cfg CloudConfig, provider telemetry.ClientProvider) (telemetry.MetricsClient, error) {
-	if cfg == nil {
-		return nil, fmt.Errorf("failed to init telemetry client: provide valid cloudCfg (Cloud Configuration for TLS)")
-	}
-
-	if ctx == nil {
-		return nil, fmt.Errorf("failed to init telemetry client: provide a valid context")
-	}
-
-	logger := hclog.FromContext(ctx)
-
-	hcpCfg, err := cfg.HCPConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to init telemetry client: %v", err)
-	}
-	c := NewHTTPClient(hcpCfg.APITLSConfig(), hcpCfg, logger)
-
-	r, err := cfg.Resource()
-	if err != nil {
-		return nil, fmt.Errorf("failed to init telemetry client: %v", err)
-	}
-
-	header := make(http.Header)
-	header.Set("content-type", "application/x-protobuf")
-	header.Set("x-hcp-resource-id", r.String())
-	header.Set("x-channel", fmt.Sprintf("consul/%s", version.GetHumanVersion()))
-
+func NewMetricsClient(ctx context.Context, provider telemetry.ClientProvider) telemetry.MetricsClient {
 	return &otlpClient{
-		client:   c,
-		header:   &header,
 		provider: provider,
-	}, nil
+	}
 }
 
 // ExportMetrics is the single method exposed by MetricsClient to export OTLP metrics to the desired HCP endpoint.

--- a/agent/hcp/client/metrics_client.go
+++ b/agent/hcp/client/metrics_client.go
@@ -29,7 +29,7 @@ const (
 // by the metrics client.
 type MetricsClientProvider interface {
 	GetHTTPClient() *retryablehttp.Client
-	GetHeader() *http.Header
+	GetHeader() http.Header
 }
 
 // otlpClient is an implementation of MetricsClient with a retryable http client for retries and to honor throttle.
@@ -68,7 +68,7 @@ func (o *otlpClient) ExportMetrics(ctx context.Context, protoMetrics *metricpb.R
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
-	req.Header = *o.provider.GetHeader()
+	req.Header = o.provider.GetHeader()
 
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {

--- a/agent/hcp/client/metrics_client.go
+++ b/agent/hcp/client/metrics_client.go
@@ -25,15 +25,22 @@ const (
 	defaultErrRespBodyLength = 100
 )
 
+// MetricsClientProvider provides the retryable HTTP client and headers to use for exporting metrics
+// by the metrics client.
+type MetricsClientProvider interface {
+	GetHTTPClient() *retryablehttp.Client
+	GetHeader() *http.Header
+}
+
 // otlpClient is an implementation of MetricsClient with a retryable http client for retries and to honor throttle.
 // It also holds default HTTP headers to add to export requests.
 type otlpClient struct {
-	provider telemetry.ClientProvider
+	provider MetricsClientProvider
 }
 
 // NewMetricsClient returns a configured MetricsClient.
 // The current implementation uses otlpClient to provide retry functionality.
-func NewMetricsClient(ctx context.Context, provider telemetry.ClientProvider) telemetry.MetricsClient {
+func NewMetricsClient(ctx context.Context, provider MetricsClientProvider) telemetry.MetricsClient {
 	return &otlpClient{
 		provider: provider,
 	}

--- a/agent/hcp/client/metrics_client_test.go
+++ b/agent/hcp/client/metrics_client_test.go
@@ -24,7 +24,7 @@ type mockClientProvider struct {
 }
 
 func (m *mockClientProvider) GetHTTPClient() *retryablehttp.Client { return m.client }
-func (m *mockClientProvider) GetHeader() *http.Header              { return m.header }
+func (m *mockClientProvider) GetHeader() http.Header               { return m.header.Clone() }
 
 func newMockClientProvider() *mockClientProvider {
 	header := make(http.Header)

--- a/agent/hcp/config/config.go
+++ b/agent/hcp/config/config.go
@@ -11,6 +11,13 @@ import (
 	"github.com/hashicorp/hcp-sdk-go/resource"
 )
 
+// CloudConfigurer abstracts the cloud config methods needed to connect to HCP
+// in an interface for easier testing.
+type CloudConfigurer interface {
+	HCPConfig(opts ...hcpcfg.HCPConfigOption) (hcpcfg.HCPConfig, error)
+	Resource() (resource.Resource, error)
+}
+
 // CloudConfig defines configuration for connecting to HCP services
 type CloudConfig struct {
 	ResourceID   string

--- a/agent/hcp/config/mock_CloudConfig.go
+++ b/agent/hcp/config/mock_CloudConfig.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package client
+package config
 
 import (
 	"crypto/tls"

--- a/agent/hcp/deps.go
+++ b/agent/hcp/deps.go
@@ -38,13 +38,12 @@ func NewDeps(cfg config.CloudConfig, logger hclog.Logger) (Deps, error) {
 		return Deps{}, fmt.Errorf("failed to init scada: %w", err)
 	}
 
-	metricsClient, err := client.NewMetricsClient(ctx, &cfg)
+	metricsProvider := NewHCPProvider(ctx, nil)
+	metricsClient, err := client.NewMetricsClient(ctx, &cfg, metricsProvider)
 	if err != nil {
 		logger.Error("failed to init metrics client", "error", err)
 		return Deps{}, fmt.Errorf("failed to init metrics client: %w", err)
 	}
-
-	metricsProvider := NewHCPProvider(ctx, nil)
 	sink, err := sink(ctx, metricsClient, metricsProvider)
 	if err != nil {
 		// Do not prevent server start if sink init fails, only log error.

--- a/agent/hcp/deps.go
+++ b/agent/hcp/deps.go
@@ -38,7 +38,7 @@ func NewDeps(cfg config.CloudConfig, logger hclog.Logger) (Deps, error) {
 		return Deps{}, fmt.Errorf("failed to init scada: %w", err)
 	}
 
-	metricsProvider, err := NewHCPProvider(ctx, &HCPProviderCfg{HCPConfig: &cfg})
+	metricsProvider, err := NewHCPProvider(ctx, &HCPProviderCfg{})
 	if err != nil {
 		logger.Error("failed to init HCP metrics provider", "error", err)
 		return Deps{}, fmt.Errorf("failed to init HCP metrics provider: %w", err)

--- a/agent/hcp/deps.go
+++ b/agent/hcp/deps.go
@@ -38,12 +38,14 @@ func NewDeps(cfg config.CloudConfig, logger hclog.Logger) (Deps, error) {
 		return Deps{}, fmt.Errorf("failed to init scada: %w", err)
 	}
 
-	metricsProvider := NewHCPProvider(ctx, nil)
-	metricsClient, err := client.NewMetricsClient(ctx, &cfg, metricsProvider)
+	metricsProvider, err := NewHCPProvider(ctx, &HCPProviderCfg{HCPConfig: &cfg})
 	if err != nil {
-		logger.Error("failed to init metrics client", "error", err)
-		return Deps{}, fmt.Errorf("failed to init metrics client: %w", err)
+		logger.Error("failed to init HCP metrics provider", "error", err)
+		return Deps{}, fmt.Errorf("failed to init HCP metrics provider: %w", err)
 	}
+
+	metricsClient := client.NewMetricsClient(ctx, metricsProvider)
+
 	sink, err := sink(ctx, metricsClient, metricsProvider)
 	if err != nil {
 		// Do not prevent server start if sink init fails, only log error.

--- a/agent/hcp/deps.go
+++ b/agent/hcp/deps.go
@@ -38,7 +38,7 @@ func NewDeps(cfg config.CloudConfig, logger hclog.Logger) (Deps, error) {
 		return Deps{}, fmt.Errorf("failed to init scada: %w", err)
 	}
 
-	metricsProvider, err := NewHCPProvider(ctx, &HCPProviderCfg{})
+	metricsProvider := NewHCPProvider(ctx)
 	if err != nil {
 		logger.Error("failed to init HCP metrics provider", "error", err)
 		return Deps{}, fmt.Errorf("failed to init HCP metrics provider: %w", err)

--- a/agent/hcp/manager.go
+++ b/agent/hcp/manager.go
@@ -164,7 +164,7 @@ func (m *Manager) startTelemetryProvider(ctx context.Context) error {
 		return nil
 	}
 
-	go m.cfg.TelemetryProvider.Run(ctx, &HCPProviderCfg{
+	m.cfg.TelemetryProvider.Run(ctx, &HCPProviderCfg{
 		HCPClient: m.cfg.Client,
 		HCPConfig: &m.cfg.CloudConfig,
 	})

--- a/agent/hcp/manager.go
+++ b/agent/hcp/manager.go
@@ -93,8 +93,8 @@ func (m *Manager) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Update the telemetry provider to enable the HCP metrics sink
-	if err := m.updateTelemetryProvider(); err != nil {
+	// Update and start the telemetry provider to enable the HCP metrics sink
+	if err := m.startTelemetryProvider(ctx); err != nil {
 		m.logger.Error("failed to update telemetry config provider", "error", err)
 		return err
 	}
@@ -159,7 +159,7 @@ func (m *Manager) startSCADAProvider() error {
 	return nil
 }
 
-func (m *Manager) updateTelemetryProvider() error {
+func (m *Manager) startTelemetryProvider(ctx context.Context) error {
 	if m.cfg.TelemetryProvider == nil {
 		return nil
 	}
@@ -172,6 +172,8 @@ func (m *Manager) updateTelemetryProvider() error {
 		return err
 	}
 	m.logger.Debug("updated telemetry config provider with HCP configuration")
+
+	go m.cfg.TelemetryProvider.Run(ctx)
 
 	return nil
 }

--- a/agent/hcp/manager.go
+++ b/agent/hcp/manager.go
@@ -164,16 +164,10 @@ func (m *Manager) startTelemetryProvider(ctx context.Context) error {
 		return nil
 	}
 
-	m.cfg.TelemetryProvider.UpdateHCPClient(m.cfg.Client)
-	m.logger.Debug("updated telemetry config provider with HCP client")
-
-	err := m.cfg.TelemetryProvider.UpdateHCPConfig(&m.cfg.CloudConfig)
-	if err != nil {
-		return err
-	}
-	m.logger.Debug("updated telemetry config provider with HCP configuration")
-
-	go m.cfg.TelemetryProvider.Run(ctx)
+	go m.cfg.TelemetryProvider.Run(ctx, &HCPProviderCfg{
+		HCPClient: m.cfg.Client,
+		HCPConfig: &m.cfg.CloudConfig,
+	})
 
 	return nil
 }

--- a/agent/hcp/manager_test.go
+++ b/agent/hcp/manager_test.go
@@ -38,12 +38,15 @@ func TestManager_Run(t *testing.T) {
 	).Return()
 	scadaM.EXPECT().Start().Return(nil)
 
+	telemetryProvider := &hcpProviderImpl{}
+
 	mgr := NewManager(ManagerConfig{
-		Client:        client,
-		Logger:        hclog.New(&hclog.LoggerOptions{Output: io.Discard}),
-		StatusFn:      statusF,
-		CloudConfig:   cloudCfg,
-		SCADAProvider: scadaM,
+		Client:            client,
+		Logger:            hclog.New(&hclog.LoggerOptions{Output: io.Discard}),
+		StatusFn:          statusF,
+		CloudConfig:       cloudCfg,
+		SCADAProvider:     scadaM,
+		TelemetryProvider: telemetryProvider,
 	})
 	mgr.testUpdateSent = updateCh
 	ctx, cancel := context.WithCancel(context.Background())
@@ -59,6 +62,7 @@ func TestManager_Run(t *testing.T) {
 	// Make sure after manager has stopped no more statuses are pushed.
 	cancel()
 	client.AssertExpectations(t)
+	require.Equal(t, client, telemetryProvider.hcpClient)
 }
 
 func TestManager_SendUpdate(t *testing.T) {

--- a/agent/hcp/manager_test.go
+++ b/agent/hcp/manager_test.go
@@ -38,7 +38,10 @@ func TestManager_Run(t *testing.T) {
 	).Return()
 	scadaM.EXPECT().Start().Return(nil)
 
-	telemetryProvider := &hcpProviderImpl{}
+	telemetryProvider := &hcpProviderImpl{
+		httpCfg: &httpCfg{},
+		logger:  hclog.New(&hclog.LoggerOptions{Output: io.Discard}),
+	}
 
 	mgr := NewManager(ManagerConfig{
 		Client:            client,
@@ -63,6 +66,8 @@ func TestManager_Run(t *testing.T) {
 	cancel()
 	client.AssertExpectations(t)
 	require.Equal(t, client, telemetryProvider.hcpClient)
+	require.NotNil(t, telemetryProvider.GetHeader())
+	require.NotNil(t, telemetryProvider.GetHTTPClient())
 }
 
 func TestManager_SendUpdate(t *testing.T) {

--- a/agent/hcp/manager_test.go
+++ b/agent/hcp/manager_test.go
@@ -41,7 +41,15 @@ func TestManager_Run(t *testing.T) {
 	telemetryProvider := &hcpProviderImpl{
 		httpCfg: &httpCfg{},
 		logger:  hclog.New(&hclog.LoggerOptions{Output: io.Discard}),
+		cfg:     defaultDisabledCfg(),
 	}
+
+	mockTelemetryCfg, err := testTelemetryCfg(&testConfig{
+		refreshInterval: 1 * time.Second,
+	})
+	require.NoError(t, err)
+	client.EXPECT().FetchTelemetryConfig(mock.Anything).Return(
+		mockTelemetryCfg, nil).Maybe()
 
 	mgr := NewManager(ManagerConfig{
 		Client:            client,

--- a/agent/hcp/telemetry/otel_exporter.go
+++ b/agent/hcp/telemetry/otel_exporter.go
@@ -6,9 +6,11 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	goMetrics "github.com/armon/go-metrics"
+	"github.com/hashicorp/go-retryablehttp"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -27,6 +29,13 @@ type MetricsClient interface {
 type EndpointProvider interface {
 	Disabled
 	GetEndpoint() *url.URL
+}
+
+// ClientProvider provides the retryable HTTP client and headers to use for exporting metrics
+// by the metrics client.
+type ClientProvider interface {
+	GetHTTPClient() *retryablehttp.Client
+	GetHeader() *http.Header
 }
 
 // otelExporter is a custom implementation of a OTEL Metrics SDK metrics.Exporter.

--- a/agent/hcp/telemetry/otel_exporter.go
+++ b/agent/hcp/telemetry/otel_exporter.go
@@ -6,11 +6,9 @@ package telemetry
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 
 	goMetrics "github.com/armon/go-metrics"
-	"github.com/hashicorp/go-retryablehttp"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -29,13 +27,6 @@ type MetricsClient interface {
 type EndpointProvider interface {
 	Disabled
 	GetEndpoint() *url.URL
-}
-
-// ClientProvider provides the retryable HTTP client and headers to use for exporting metrics
-// by the metrics client.
-type ClientProvider interface {
-	GetHTTPClient() *retryablehttp.Client
-	GetHeader() *http.Header
 }
 
 // otelExporter is a custom implementation of a OTEL Metrics SDK metrics.Exporter.

--- a/agent/hcp/telemetry_provider.go
+++ b/agent/hcp/telemetry_provider.go
@@ -281,11 +281,15 @@ func (h *hcpProviderImpl) updateHTTPConfig(cfg config.CloudConfigurer) error {
 
 // GetHeader acquires a read lock to return the HTTP request headers needed
 // to export metrics.
-func (h *hcpProviderImpl) GetHeader() *http.Header {
+func (h *hcpProviderImpl) GetHeader() http.Header {
 	h.httpCfgRW.RLock()
 	defer h.httpCfgRW.RUnlock()
 
-	return h.httpCfg.header
+	if h.httpCfg.header == nil {
+		return nil
+	}
+
+	return h.httpCfg.header.Clone()
 }
 
 // GetHTTPClient acquires a read lock to return the retryable HTTP client needed

--- a/agent/hcp/telemetry_provider.go
+++ b/agent/hcp/telemetry_provider.go
@@ -114,7 +114,14 @@ func NewHCPProvider(ctx context.Context, c *HCPProviderCfg) (*hcpProviderImpl, e
 }
 
 // Run continously checks for updates to the telemetry configuration by making a request to HCP.
-func (h *hcpProviderImpl) Run(ctx context.Context) {
+func (h *hcpProviderImpl) Run(ctx context.Context, c *HCPProviderCfg) error {
+	// Update the provider with the HCP client and HCP configuration
+	h.UpdateHCPClient(c.HCPClient)
+	err := h.UpdateHCPConfig(c.HCPConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize HCP telemetry provider: %v", err)
+	}
+
 	// Try to initialize config once before starting periodic fetch.
 	h.updateConfig(ctx)
 
@@ -127,7 +134,7 @@ func (h *hcpProviderImpl) Run(ctx context.Context) {
 				ticker.Reset(newRefreshInterval)
 			}
 		case <-ctx.Done():
-			return
+			return nil
 		}
 	}
 }

--- a/agent/hcp/telemetry_provider.go
+++ b/agent/hcp/telemetry_provider.go
@@ -94,23 +94,15 @@ type HCPProviderCfg struct {
 }
 
 // NewHCPProvider initializes and starts a HCP Telemetry provider.
-func NewHCPProvider(ctx context.Context, c *HCPProviderCfg) (*hcpProviderImpl, error) {
+func NewHCPProvider(ctx context.Context) *hcpProviderImpl {
 	h := &hcpProviderImpl{
 		// Initialize with default config values.
-		cfg:       defaultDisabledCfg(),
-		httpCfg:   &httpCfg{},
-		hcpClient: c.HCPClient,
-		logger:    hclog.FromContext(ctx),
+		cfg:     defaultDisabledCfg(),
+		httpCfg: &httpCfg{},
+		logger:  hclog.FromContext(ctx),
 	}
 
-	if c.HCPConfig != nil {
-		err := h.UpdateHCPConfig(c.HCPConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize HCP telemetry provider: %v", err)
-		}
-	}
-
-	return h, nil
+	return h
 }
 
 // Run continously checks for updates to the telemetry configuration by making a request to HCP.

--- a/agent/hcp/telemetry_provider.go
+++ b/agent/hcp/telemetry_provider.go
@@ -37,7 +37,7 @@ var (
 // Ensure hcpProviderImpl implements telemetry provider interfaces.
 var _ telemetry.ConfigProvider = &hcpProviderImpl{}
 var _ telemetry.EndpointProvider = &hcpProviderImpl{}
-var _ telemetry.ClientProvider = &hcpProviderImpl{}
+var _ client.MetricsClientProvider = &hcpProviderImpl{}
 
 // hcpProviderImpl holds telemetry configuration and settings for continuous fetch of new config from HCP.
 // it updates configuration, if changes are detected.

--- a/agent/hcp/telemetry_provider.go
+++ b/agent/hcp/telemetry_provider.go
@@ -110,14 +110,21 @@ func NewHCPProvider(ctx context.Context) *hcpProviderImpl {
 
 // Run continously checks for updates to the telemetry configuration by making a request to HCP.
 func (h *hcpProviderImpl) Run(ctx context.Context, c *HCPProviderCfg) error {
-	h.logger.Debug("starting telemetry config provider")
-
 	// Update the provider with the HCP configurations
 	h.hcpClient = c.HCPClient
 	err := h.updateHTTPConfig(c.HCPConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize HCP telemetry provider: %v", err)
 	}
+
+	go h.run(ctx)
+
+	return nil
+}
+
+// Run continously checks for updates to the telemetry configuration by making a request to HCP.
+func (h *hcpProviderImpl) run(ctx context.Context) error {
+	h.logger.Debug("starting telemetry config provider")
 
 	// Try to initialize config once before starting periodic fetch.
 	h.updateConfig(ctx)

--- a/agent/hcp/telemetry_provider.go
+++ b/agent/hcp/telemetry_provider.go
@@ -110,13 +110,11 @@ func NewHCPProvider(ctx context.Context, c *HCPProviderCfg) (*hcpProviderImpl, e
 		}
 	}
 
-	go h.run(ctx)
-
 	return h, nil
 }
 
-// run continously checks for updates to the telemetry configuration by making a request to HCP.
-func (h *hcpProviderImpl) run(ctx context.Context) {
+// Run continously checks for updates to the telemetry configuration by making a request to HCP.
+func (h *hcpProviderImpl) Run(ctx context.Context) {
 	// Try to initialize config once before starting periodic fetch.
 	h.updateConfig(ctx)
 
@@ -149,6 +147,7 @@ func (h *hcpProviderImpl) updateConfig(ctx context.Context) time.Duration {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
+	logger.Trace("fetching telemetry config")
 	telemetryCfg, err := hcpClient.FetchTelemetryConfig(ctx)
 	if err != nil {
 		// Only disable metrics on 404 or 401 to handle the case of an unlinked cluster.
@@ -164,6 +163,7 @@ func (h *hcpProviderImpl) updateConfig(ctx context.Context) time.Duration {
 		metrics.IncrCounter(internalMetricRefreshFailure, 1)
 		return 0
 	}
+	logger.Trace("successfully fetched telemetry config")
 
 	// newRefreshInterval of 0 or less can cause ticker Reset() panic.
 	newRefreshInterval := telemetryCfg.RefreshConfig.RefreshInterval

--- a/agent/hcp/telemetry_provider.go
+++ b/agent/hcp/telemetry_provider.go
@@ -225,7 +225,7 @@ func (h *hcpProviderImpl) IsDisabled() bool {
 	return h.cfg.disabled
 }
 
-// UpdateHCPClient acquires a read lock to return the HCP client.
+// GetHCPClient acquires a read lock to return the HCP client.
 func (h *hcpProviderImpl) GetHCPClient() client.Client {
 	h.rw.RLock()
 	defer h.rw.RUnlock()

--- a/agent/hcp/telemetry_provider_test.go
+++ b/agent/hcp/telemetry_provider_test.go
@@ -373,7 +373,7 @@ func TestTelemetryConfigProvider_updateHTTPConfig(t *testing.T) {
 			expectedHeader.Set("content-type", "application/x-protobuf")
 			expectedHeader.Set("x-hcp-resource-id", "organization/test-org/project/test-project/test-type/test-id")
 			expectedHeader.Set("x-channel", fmt.Sprintf("consul/%s", version.GetHumanVersion()))
-			require.Equal(t, &expectedHeader, provider.GetHeader())
+			require.Equal(t, expectedHeader, provider.GetHeader())
 		})
 	}
 }

--- a/agent/hcp/telemetry_provider_test.go
+++ b/agent/hcp/telemetry_provider_test.go
@@ -313,8 +313,7 @@ func TestTelemetryConfigProvider_UpdateHCPConfig(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			provider := NewHCPProvider(context.Background())
-
-			err := provider.UpdateHCPConfig(test.cfg))
+			err := provider.updateHTTPConfig(test.cfg)
 
 			if test.wantErr != "" {
 				require.Error(t, err)


### PR DESCRIPTION
### Description
This PR adds support to initialize the HCP metrics sink without an HCP configuration and to then later update the sink with the HCP config at runtime in the HCP manager. The purpose of this change is to eventually support initiating the linking process via an API request, where that API request will start the HCP manager.

This PR is best viewed commit-by-commit. The general strategy is to add update methods to the HCP telemetry config provider and then call those update methods from the HCP manager.

Changes so that the HCP Telemetry Provider can fetch the config from HCP:
1. Remove the requirement to set the HCP client on the HCP telemetry provider and handle the case when it’s unset.
2. Save the telemetry provider as a dependency and pass it to the HCP manager.
3. In the HCP manager, update the telemetry provider with the HCP client.

Changes so that the metrics client can export to HCP:
1. Add a new interface to the HCP telemetry provider that abstracts the HTTP retry client and headers.
2. Move the setup of the HTTP retry client and headers from the metrics client to the HCP telemetry provider.
3. Allow the telemetry provider’s retry client and headers to be updated with a new HCP config.
4. Pass the HCP configuration to the HCP manager.
5. In the HCP manager, update the telemetry provider with the HCP config.

### Testing & Reproduction steps
Updated relevant unit tests and manually e2e tested this using the following steps:

1. Create a cluster in HCP Consul Central.
2. Configure and start Consul with the cloud configuration provided by HCP Consul Central.
3. Inspect that the telemetry export requests are succeeding in the Consul logs.
4. Inspect the Observability dashboard in HCP Consul Central for the cluster and verify that all the metrics are displayed as expected.

```
2023-12-21T13:22:21.801-0600 [DEBUG] agent.hcp_manager: HCP manager starting
2023-12-21T13:22:21.801-0600 [DEBUG] agent.hcp_manager: updated telemetry config provider with HCP client
2023-12-21T13:22:21.801-0600 [DEBUG] agent.hcp_manager: updated telemetry config provider with HCP configuration
…
2023-12-21T13:24:21.683-0600 [DEBUG] agent.hcp.hcp_telemetry_client: performing request: method=POST url=https://consul-telemetry.cloud.hashicorp.com/otlp/v1/metrics
…
2023-12-21T13:25:21.682-0600 [DEBUG] agent.hcp.hcp_telemetry_client: performing request: method=POST url=https://consul-telemetry.cloud.hashicorp.com/otlp/v1/metrics
…
2023-12-21T13:26:21.699-0600 [DEBUG] agent.hcp.hcp_telemetry_client: performing request: method=POST url=https://consul-telemetry.cloud.hashicorp.com/otlp/v1/metrics
```

### Links
- Jira: https://hashicorp.atlassian.net/browse/CC-7042

### PR Checklist

* [x] updated test coverage
* [x] appropriate backport labels added
* [x] not a security concern
