### PR TITLE
Fix upgrade test envoy version

### DIFF
--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -4,7 +4,6 @@
 name: Nightly test-integrations
 
 on:
-  push:
   schedule:
     # Run nightly at 12AM UTC/8PM EST/5PM PST
     - cron: '* 0 * * *'

--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -4,6 +4,7 @@
 name: Nightly test-integrations
 
 on:
+  push:
   schedule:
     # Run nightly at 12AM UTC/8PM EST/5PM PST
     - cron: '* 0 * * *'
@@ -196,7 +197,10 @@ jobs:
         consul-version: [ "1.16", "1.17"]
     env:
       CONSUL_LATEST_VERSION: ${{ matrix.consul-version }}
-      ENVOY_VERSION: "1.28.0"
+      # ENVOY_VERSION should be the latest version upported by all
+      # consul versions in the matrix.consul-version, since we are testing upgrade from
+      # an older consul version, e.g., 1.26.6 is supported by both 1.16 and 1.17.
+      ENVOY_VERSION: "1.26.6"
     steps:
       - name: Checkout code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
### Description

The upgrade test failed due to the envoy config of the latest version of the consul. When doing upgrade test, we should use the envoy version that is supported by both versions.

This PR fixes the version in CI and adds some explanation to the version variable.

### Testing & Reproduction steps

Please see the [passed run](https://github.com/hashicorp/consul/actions/runs/7392008723/job/20109849070).

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
