### PR TITLE
feat: consul api watch support custom QueryOptions

### DIFF
--- a/api/watch/funcs.go
+++ b/api/watch/funcs.go
@@ -340,7 +340,12 @@ func agentServiceWatch(params map[string]interface{}) (WatcherFunc, error) {
 func makeQueryOptionsWithContext(p *Plan, stale bool) consulapi.QueryOptions {
 	ctx, cancel := context.WithCancel(context.Background())
 	p.setCancelFunc(cancel)
-	opts := *p.QueryOptions
+
+	opts := consulapi.QueryOptions{}
+	if p.QueryOptions != nil {
+		opts = *p.QueryOptions
+	}
+
 	opts.AllowStale = stale
 	switch param := p.lastParamVal.(type) {
 	case WaitIndexVal:

--- a/api/watch/funcs.go
+++ b/api/watch/funcs.go
@@ -340,7 +340,8 @@ func agentServiceWatch(params map[string]interface{}) (WatcherFunc, error) {
 func makeQueryOptionsWithContext(p *Plan, stale bool) consulapi.QueryOptions {
 	ctx, cancel := context.WithCancel(context.Background())
 	p.setCancelFunc(cancel)
-	opts := consulapi.QueryOptions{AllowStale: stale}
+	opts := *p.QueryOptions
+	opts.AllowStale = stale
 	switch param := p.lastParamVal.(type) {
 	case WaitIndexVal:
 		opts.WaitIndex = uint64(param)

--- a/api/watch/funcs.go
+++ b/api/watch/funcs.go
@@ -341,12 +341,9 @@ func makeQueryOptionsWithContext(p *Plan, stale bool) consulapi.QueryOptions {
 	ctx, cancel := context.WithCancel(context.Background())
 	p.setCancelFunc(cancel)
 
-	opts := consulapi.QueryOptions{}
-	if p.QueryOptions != nil {
-		opts = *p.QueryOptions
-	}
-
+	opts := p.QueryOptions
 	opts.AllowStale = stale
+
 	switch param := p.lastParamVal.(type) {
 	case WaitIndexVal:
 		opts.WaitIndex = uint64(param)

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -1596,8 +1596,7 @@ func mustParse(t *testing.T, q string) *Plan {
 
 func TestMakeQueryOptionsWithContext(t *testing.T) {
 	p := &Plan{
-		QueryOptions: &api.QueryOptions{
-			AllowStale: true,
+		QueryOptions: api.QueryOptions{
 			Peer:       "dc-1",
 			Datacenter: "dc-1",
 		},

--- a/api/watch/plan_test.go
+++ b/api/watch/plan_test.go
@@ -23,7 +23,7 @@ func noopWatch(params map[string]interface{}) (WatcherFunc, error) {
 	return fn, nil
 }
 
-func mustParse(t *testing.T, q string) *Plan {
+func planMustParse(t *testing.T, q string) *Plan {
 	params := makeParams(t, q)
 	plan, err := Parse(params)
 	if err != nil {
@@ -34,7 +34,7 @@ func mustParse(t *testing.T, q string) *Plan {
 
 func TestRun_Stop(t *testing.T) {
 	t.Parallel()
-	plan := mustParse(t, `{"type":"noop"}`)
+	plan := planMustParse(t, `{"type":"noop"}`)
 
 	var expect uint64 = 1
 	doneCh := make(chan struct{})
@@ -81,7 +81,7 @@ func TestRun_Stop(t *testing.T) {
 
 func TestRun_Stop_Hybrid(t *testing.T) {
 	t.Parallel()
-	plan := mustParse(t, `{"type":"noop"}`)
+	plan := planMustParse(t, `{"type":"noop"}`)
 
 	var expect uint64 = 1
 	doneCh := make(chan struct{})
@@ -133,7 +133,7 @@ func TestRun_Stop_Hybrid(t *testing.T) {
 
 func TestRunWithClientAndLogger_NilLogger(t *testing.T) {
 	t.Parallel()
-	plan := mustParse(t, `{"type":"noop"}`)
+	plan := planMustParse(t, `{"type":"noop"}`)
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/api/watch/watch.go
+++ b/api/watch/watch.go
@@ -42,6 +42,7 @@ type Plan struct {
 	client       *consulapi.Client
 	lastParamVal BlockingParamVal
 	lastResult   interface{}
+	QueryOptions *consulapi.QueryOptions
 
 	stop       bool
 	stopCh     chan struct{}

--- a/api/watch/watch.go
+++ b/api/watch/watch.go
@@ -42,7 +42,7 @@ type Plan struct {
 	client       *consulapi.Client
 	lastParamVal BlockingParamVal
 	lastResult   interface{}
-	QueryOptions *consulapi.QueryOptions
+	QueryOptions consulapi.QueryOptions
 
 	stop       bool
 	stopCh     chan struct{}


### PR DESCRIPTION
### Description
We used the peering in the consul

In the Kratos microservices framework, we provide a Consul based service discovery plugin.
https://github.com/go-kratos/kratos/tree/main/contrib/registry/consul

The service discovery function currently provided in Kratos SDK is a self maintained polling call interface. Currently, we hope to migrate the SDK implementation to the Consul API `Watch`. However, after testing, we found that it cannot support specifying the `peer` parameter in `QueryOptions`, resulting in the inability to directly use the Consul API `Watch`.

This PR supports user specified custom `QueryOptions` by adding a `QueryOptions` field in the `plan`, and uses user-defined `QueryOptions` in the `makeQueryOptionsWithContext` function to build the `QueryOptions` used in the watch

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [ ] not a security concern
