### PR TITLE
Add build architecture output to bootup logs and version command

### DIFF
--- a/.changelog/20084.txt
+++ b/.changelog/20084.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added build architecture information to output in agent logs, api endpoint, and version command.
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -44,6 +44,7 @@ func New(ui cli.Ui) *cmd {
 		version:           consulversion.Version,
 		versionPrerelease: consulversion.VersionPrerelease,
 		versionHuman:      consulversion.GetHumanVersion(),
+		buildArch:         consulversion.BuildArch,
 		buildDate:         buildDate,
 		flags:             flag.NewFlagSet("", flag.ContinueOnError),
 	}
@@ -65,6 +66,7 @@ type cmd struct {
 	version           string
 	versionPrerelease string
 	versionHuman      string
+	buildArch         string
 	buildDate         time.Time
 	configLoadOpts    config.LoadOpts
 	logger            hclog.InterceptLogger
@@ -217,6 +219,7 @@ func (c *cmd) run(args []string) int {
 		ui.Info(fmt.Sprintf("          Revision: '%s'", c.revision))
 	}
 	ui.Info(fmt.Sprintf("        Build Date: '%s'", c.buildDate))
+	ui.Info(fmt.Sprintf("Build Architecture: '%s'", c.buildArch))
 	ui.Info(fmt.Sprintf("           Node ID: '%s'", config.NodeID))
 	ui.Info(fmt.Sprintf("         Node name: '%s'", config.NodeName))
 	if ap := config.PartitionOrEmpty(); ap != "" {

--- a/command/version/formatter.go
+++ b/command/version/formatter.go
@@ -48,7 +48,7 @@ func (_ *prettyFormatter) Format(info *VersionInfo) (string, error) {
 	}
 
 	buffer.WriteString(fmt.Sprintf("Build Date %s\n", info.BuildDate.Format(time.RFC3339)))
-	buffer.WriteString(fmt.Sprintf("Build Architecture: %s\n", info.Arch))
+	buffer.WriteString(fmt.Sprintf("Build Architecture: %s\n", info.BuildArch))
 
 	if info.FIPS != "" {
 		buffer.WriteString(fmt.Sprintf("FIPS: %s\n", info.FIPS))

--- a/command/version/formatter.go
+++ b/command/version/formatter.go
@@ -48,6 +48,7 @@ func (_ *prettyFormatter) Format(info *VersionInfo) (string, error) {
 	}
 
 	buffer.WriteString(fmt.Sprintf("Build Date %s\n", info.BuildDate.Format(time.RFC3339)))
+	buffer.WriteString(fmt.Sprintf("Build Architecture: %s\n", info.Arch))
 
 	if info.FIPS != "" {
 		buffer.WriteString(fmt.Sprintf("FIPS: %s\n", info.FIPS))

--- a/command/version/version.go
+++ b/command/version/version.go
@@ -52,7 +52,7 @@ type VersionInfo struct {
 	Revision     string
 	Prerelease   string
 	FIPS         string `json:",omitempty"`
-	Arch         string
+	BuildArch    string
 	BuildDate    time.Time
 	RPC          RPCVersionInfo
 }
@@ -81,7 +81,7 @@ func (c *cmd) Run(args []string) int {
 		Revision:     version.GitCommit,
 		Prerelease:   version.VersionPrerelease,
 		BuildDate:    buildDate,
-		Arch:         version.BuildArch,
+		BuildArch:    version.BuildArch,
 		FIPS:         version.GetFIPSInfo(),
 		RPC: RPCVersionInfo{
 			Default: consul.DefaultRPCProtocol,

--- a/command/version/version.go
+++ b/command/version/version.go
@@ -52,6 +52,7 @@ type VersionInfo struct {
 	Revision     string
 	Prerelease   string
 	FIPS         string `json:",omitempty"`
+	Arch         string
 	BuildDate    time.Time
 	RPC          RPCVersionInfo
 }
@@ -80,6 +81,7 @@ func (c *cmd) Run(args []string) int {
 		Revision:     version.GitCommit,
 		Prerelease:   version.VersionPrerelease,
 		BuildDate:    buildDate,
+		Arch:         version.BuildArch,
 		FIPS:         version.GetFIPSInfo(),
 		RPC: RPCVersionInfo{
 			Default: consul.DefaultRPCProtocol,

--- a/version/version.go
+++ b/version/version.go
@@ -43,7 +43,7 @@ type BuildInfo struct {
 	BuildDate    string
 	HumanVersion string
 	FIPS         string
-	Arch         string
+	BuildArch    string
 }
 
 // GetHumanVersion composes the parts of the version in a way that's suitable
@@ -76,6 +76,6 @@ func GetBuildInfo() *BuildInfo {
 		BuildDate:    BuildDate,
 		HumanVersion: GetHumanVersion(),
 		FIPS:         GetFIPSInfo(),
-		Arch:         BuildArch,
+		BuildArch:    BuildArch,
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -6,6 +6,7 @@ package version
 import (
 	_ "embed"
 	"fmt"
+	"runtime"
 	"strings"
 )
 
@@ -31,6 +32,9 @@ var (
 	// The date/time of the build (actually the HEAD commit in git, to preserve stability)
 	// This isn't just informational, but is also used by the licensing system. Default is chosen to be flagantly wrong.
 	BuildDate string = "1970-01-01T00:00:01Z"
+
+	// The architecture that the current binary was built for.
+	BuildArch string = runtime.GOARCH
 )
 
 // BuildInfo includes all available version info for this build
@@ -39,6 +43,7 @@ type BuildInfo struct {
 	BuildDate    string
 	HumanVersion string
 	FIPS         string
+	Arch         string
 }
 
 // GetHumanVersion composes the parts of the version in a way that's suitable
@@ -71,5 +76,6 @@ func GetBuildInfo() *BuildInfo {
 		BuildDate:    BuildDate,
 		HumanVersion: GetHumanVersion(),
 		FIPS:         GetFIPSInfo(),
+		Arch:         BuildArch,
 	}
 }


### PR DESCRIPTION
### Description

We've had issues in the past with customers not realizing that they installed a 32-bit binary on a 64-bit system and running into OOM errors. Though we can't fully address installing the wrong binary, this would make it easier to surface binary issues quicker. `runtime.GOARCH` returns the compiled runtime target of the binary, not the actual runtime, thus if you were running on say a 64-bit Linux system capable of running 32-bit binaries or an ARM-based Mac capable of running x86 binaries, you'd get: `386` and `amd64` for running the respective emulated binaries rather than the system-level `amd64` and `arm64` output.

If we want we can also see if we can detect if we're running in an emulated environment, but that'd be a lot more platform specific, and having a user do a quick check on the `consul version` output against their known system architecture seems like pretty low-hanging fruit.

Output looks like this:

`consul version`:

```bash
➜  consul git:(main) ✗ ./consul version
Consul v1.18.0-dev
Build Date 1970-01-01T00:00:01Z
Build Architecture: amd64
Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
```

`consul agent`:

```bash
➜  consul git:(main) ✗ ./consul agent -dev
==> Starting Consul agent...
               Version: '1.18.0-dev'
              Revision: ''
            Build Date: '1970-01-01 00:00:01 +0000 UTC'
    Build Architecture: 'amd64'
               Node ID: 'e24edd23-6819-8e0c-9585-7cb58f13a408'
...
```

Notice the new "Build Architecture" entries. Also:

`/v1/agent/version` endpoint:

```bash
➜  ~ curl localhost:8500/v1/agent/version
{
    "SHA": "",
    "BuildDate": "1970-01-01T00:00:01Z",
    "HumanVersion": "1.18.0-dev",
    "FIPS": "",
    "BuildArch": "amd64"
}
```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
