### PR TITLE
Backport of docs/consul: rename the Vault secret engine for Consul integration into release/1.15.x

### DIFF
--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/bootstrap-token.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/bootstrap-token.mdx
@@ -29,7 +29,7 @@ Prior to setting up the data integration between Vault and Consul on Kubernetes,
 First, generate and store the ACL bootstrap token in Vault. You will only need to perform this action once:
 
 ```shell-session
-$ vault kv put secret/consul/bootstrap-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+$ vault kv put consul-kv/secret/bootstrap-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 ```
 
 ## Create Vault policy
@@ -41,7 +41,7 @@ The path to the secret referenced in the `path` resource is the same value that 
 <CodeBlockConfig filename="bootstrap-token-policy.hcl">
 
 ```HCL
-path "secret/data/consul/bootstrap-token" {
+path "consul-kv/data/secret/bootstrap-token" {
   capabilities = ["read"]
 }
 ```
@@ -88,7 +88,7 @@ global:
       manageSystemACLsRole: consul-server-acl-init
   acls:
     bootstrapToken:
-      secretName: secret/data/consul/bootstrap-token
+      secretName: consul-kv/data/secret/bootstrap-token
       secretKey: token
 ```
 

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/enterprise-license.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/enterprise-license.mdx
@@ -29,7 +29,7 @@ Prior to setting up the data integration between Vault and Consul on Kubernetes,
 First, store the enterprise license in Vault:
 
 ```shell-session
-$ vault kv put secret/consul/license key="<enterprise license>"
+$ vault kv put consul-kv/secret/enterpriselicense key="<enterprise license>"
 ```
 
 ## Create Vault policy
@@ -41,7 +41,7 @@ The path to the secret referenced in the `path` resource is the same value that 
 <CodeBlockConfig filename="license-policy.hcl">
 
 ```HCL
-path "secret/data/consul/license" {
+path "consul-kv/data/secret/enterpriselicense" {
   capabilities = ["read"]
 }
 ```
@@ -103,7 +103,7 @@ global:
       consulServerRole: consul-server
       consulClientRole: consul-client
   enterpriseLicense:
-    secretName: secret/data/consul/enterpriselicense
+    secretName: consul-kv/data/secret/enterpriselicense
     secretKey: key
 ```
 

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/gossip.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/gossip.mdx
@@ -29,7 +29,7 @@ Prior to setting up the data integration between Vault and Consul on Kubernetes,
 First, generate and store the gossip key in Vault. You will only need to perform this action once:
 
 ```shell-session
-$ vault kv put secret/consul/gossip key="$(consul keygen)"
+$ vault kv put consul-kv/secret/gossip key="$(consul keygen)"
 ```
 ## Create Vault policy
 
@@ -40,7 +40,7 @@ The path to the secret referenced in the `path` resource is the same value that 
 <CodeBlockConfig filename="gossip-policy.hcl">
 
 ```HCL
-path "secret/data/consul/gossip" {
+path "consul-kv/data/secret/gossip" {
   capabilities = ["read"]
 }
 ```
@@ -101,7 +101,7 @@ global:
       consulServerRole: consul-server
       consulClientRole: consul-client
   gossipEncryption:
-    secretName: secret/data/consul/gossip
+    secretName: consul-kv/data/secret/gossip
     secretKey: key
 ```
 

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/index.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/index.mdx
@@ -92,10 +92,14 @@ For example, if your Consul on Kubernetes servers need access to [Consul Server 
 
     1. Enterprise License
 
+      <Note>
+      Vault API calls to version 2 of the Key-Value secrets engine require the `data` field in the path configuration. In the following example, the key-value data in `consul-kv/secret/enterpriselicense` becomes accessible for Vault API calls on the `consul-kv/data/secret/enterpriselicense` path.
+      </Note>
+
       <CodeBlockConfig filename="license-policy.hcl">
 
       ```HCL
-      path "secret/data/consul/license" {
+      path "consul-kv/data/secret/enterpriselicense" {
         capabilities = ["read"]
       }
       ```

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/partition-token.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/partition-token.mdx
@@ -30,7 +30,7 @@ Prior to setting up the data integration between Vault and Consul on Kubernetes,
 First, generate and store the ACL partition token in Vault. You will only need to perform this action once:
 
 ```shell-session
-$ vault kv put secret/consul/partition-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+$ vault kv put consul-kv/secret/partition-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 ```
 
 ## Create Vault policy
@@ -42,7 +42,7 @@ The path to the secret referenced in the `path` resource is the same value that 
 <CodeBlockConfig filename="partition-token-policy.hcl">
 
 ```HCL
-path "secret/data/consul/partition-token" {
+path "consul-kv/data/secret/consul/partition-token" {
   capabilities = ["read"]
 }
 ```
@@ -90,7 +90,7 @@ global:
       adminPartitionsRole: consul-partition-init
   acls:
     partitionToken:
-      secretName: secret/data/consul/partition-token
+      secretName: consul-kv/data/secret/partition-token
       secretKey: token
 ```
 

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/replication-token.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/replication-token.mdx
@@ -29,7 +29,7 @@ Prior to setting up the data integration between Vault and Consul on Kubernetes,
 First, generate and store the ACL replication token in Vault. You will only need to perform this action once:
 
 ```shell-session
-$ vault kv put secret/consul/replication-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+$ vault kv put consul-kv/secret/replication-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 ```
 
 ## Create Vault policy
@@ -41,7 +41,7 @@ The path to the secret referenced in the `path` resource is the same value that 
 <CodeBlockConfig filename="replication-token-policy.hcl">
 
 ```HCL
-path "secret/data/consul/replication-token" {
+path "consul-kv/data/secret/replication-token" {
   capabilities = ["read"]
 }
 ```
@@ -88,7 +88,7 @@ global:
       manageSystemACLsRole: consul-server-acl-init
   acls:
     replicationToken:
-      secretName: secret/data/consul/replication-token
+      secretName: consul-kv/data/secret/replication-token
       secretKey: token
 ```
 

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/snapshot-agent-config.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/snapshot-agent-config.mdx
@@ -29,7 +29,7 @@ Before you set up data integration between Vault and Consul on Kubernetes, compl
 First, store the snapshot agent config in Vault:
 
 ```shell-session
-$ vault kv put secret/consul/snapshot-agent-config key="<snapshot agent JSON config>"
+$ vault kv put consul-kv/secret/snapshot-agent-config key="<snapshot agent JSON config>"
 ```
 
 ## Create Vault policy
@@ -41,7 +41,7 @@ The path to the secret referenced in the `path` resource is the same values that
 <CodeBlockConfig filename="snapshot-agent-config-policy.hcl">
 
 ```HCL
-path "secret/data/consul/snapshot-agent-config" {
+path "consul-kv/data/secret/snapshot-agent-config" {
   capabilities = ["read"]
 }
 ```
@@ -91,7 +91,7 @@ global:
 client:
   snapshotAgent:
     configSecret:
-      secretName: secret/data/consul/snapshot-agent-config
+      secretName: consul-kv/data/secret/snapshot-agent-config
       secretKey: key
 ```
 

--- a/website/content/docs/k8s/deployment-configurations/vault/systems-integration.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/systems-integration.mdx
@@ -34,7 +34,7 @@ The following secrets can be stored in Vault KV secrets engine, which is meant t
 In order to store any of these secrets, we must enable the [Vault KV secrets engine - Version 2](/vault/docs/secrets/kv/kv-v2).
 
 ```shell-session
-$ vault secrets enable -path=consul kv-v2
+$ vault secrets enable -path=consul-kv kv-v2
 ```
 
 ## Vault PKI Engine

--- a/website/content/docs/k8s/deployment-configurations/vault/wan-federation.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/wan-federation.mdx
@@ -129,7 +129,7 @@ Repeat the following steps for each datacenter in the cluster:
 1. Enable [Vault KV secrets engine - Version 2](/vault/docs/secrets/kv/kv-v2) in order to store the [Gossip Encryption Key](/consul/docs/k8s/helm#v-global-acls-replicationtoken) and the ACL Replication token ([`global.acls.replicationToken`](/consul/docs/k8s/helm#v-global-acls-replicationtoken)).
 
     ```shell-session
-    $ vault secrets enable -path=consul kv-v2
+    $ vault secrets enable -path=consul-kv kv-v2
     ```
 
 1. Enable Vault PKI Engine in order to leverage Vault for issuing Consul Server TLS certificates.
@@ -314,11 +314,15 @@ Repeat the following steps for each datacenter in the cluster:
 1. Store the ACL Replication Token, Gossip Encryption Key, and Root CA certificate secrets in Vault.
 
     ```shell-session
-    $ vault kv put consul/secret/gossip key="$(consul keygen)"
+    $ vault kv put consul-kv/secret/gossip key="$(consul keygen)"
     ```
 
     ```shell-session
-    $ vault kv put consul/secret/replication token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    $ vault kv put consul-kv/secret/bootstrap token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    ```
+
+    ```shell-session
+    $ vault kv put consul-kv/secret/replication token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
     ```
     ```shell-session
     $ vault write pki/root/generate/internal common_name="Consul CA" ttl=87600h
@@ -328,7 +332,15 @@ Repeat the following steps for each datacenter in the cluster:
 
     ```shell-session
     $ vault policy write gossip - <<EOF
-    path "consul/data/secret/gossip" {
+    path "consul-kv/data/secret/gossip" {
+      capabilities = ["read"]
+    }
+    EOF
+    ```
+
+    ```shell-session
+    $ vault policy write bootstrap-token - <<EOF
+    path "consul-kv/data/secret/bootstrap" {
       capabilities = ["read"]
     }
     EOF
@@ -336,7 +348,7 @@ Repeat the following steps for each datacenter in the cluster:
 
     ```shell-session
     $ vault policy write replication-token - <<EOF
-    path "consul/data/secret/replication" {
+    path "consul-kv/data/secret/replication" {
       capabilities = ["read"]
     }
     EOF
@@ -462,11 +474,15 @@ Repeat the following steps for each datacenter in the cluster:
         enabled: true
       acls:
         manageSystemACLs: true
+        createReplicationToken: true
+        bootstrapToken:
+          secretName: consul-kv/data/secret/bootstrap
+          secretKey: token
         replicationToken:
-          secretName: consul/data/secret/replication
+          secretName: consul-kv/data/secret/replication
           secretKey: token
       gossipEncryption:
-        secretName: consul/data/secret/gossip
+        secretName: consul-kv/data/secret/gossip
         secretKey: key
     server:
       replicas: 1
@@ -643,10 +659,10 @@ Repeat the following steps for each datacenter in the cluster:
       acls:
         manageSystemACLs: true
         replicationToken:
-          secretName: consul/data/secret/replication
+          secretName: consul-kv/data/secret/replication
           secretKey: token
       gossipEncryption:
-        secretName: consul/data/secret/gossip
+        secretName: consul-kv/data/secret/gossip
         secretKey: key
     server:
       replicas: 1


### PR DESCRIPTION
### Description

There was feedback from our Support team about customers facing an issue following the documentation from the [Vault for Consul: System integration](https://developer.hashicorp.com/consul/docs/k8s/deployment-configurations/vault/systems-integration) into the [Vault for Consul: Data integration](https://developer.hashicorp.com/consul/docs/k8s/deployment-configurations/vault/data-integration). The former defines a `consul`-named Vault secret engine, but the latter runs commands and config against a `secrets`-named Vault secret engine - no doubt a leftover from times where the default secret engine from running Vault in `-dev` mode was used to showcase functionality in the docs.

Furthermore, because of the secret engine name `consul`, the customers were confused and expected the secret engine to be of the _Consul_ type and not the _KV_ type.

With that in mind, this PR changes the docs in the following way:

- The Vault secret engine created for use with Consul has been renamed to `consul-kv`
    -  to stress the fact that it is a _KV_ type engine and not a _Consul_ type engine
    - to move away from the default secrets engine as this would be unadvisable to run in Production systems, and possibly even dangerous if the default secrets engine is indeed being used
- The path `secrets` is being used for all token-related configuration so that in Production environments, that specific path can be allowed/disallowed read/write access easier for separate admin and non-admin user roles.

### Testing & Reproduction steps

N/A

### Links

[Related Docs: Vault as the Secrets Backend (K8s)](https://developer.hashicorp.com/consul/docs/k8s/deployment-configurations/vault/)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
