### PR TITLE
Use safeio to write server metadata file

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/hcp-scada-provider/capability"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
+	"github.com/rboyer/safeio"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
@@ -4668,7 +4669,12 @@ func (a *Agent) persistServerMetadata() {
 				continue
 			}
 
-			f.Close()
+			sf := f.(*safeio.File)
+			if err := sf.Commit(); err != nil {
+				a.logger.Error("failed to commit server metadata", "error", err)
+				continue
+			}
+			sf.Close()
 		case <-a.shutdownCh:
 			return
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4669,12 +4669,15 @@ func (a *Agent) persistServerMetadata() {
 				continue
 			}
 
-			sf := f.(*safeio.File)
-			if err := sf.Commit(); err != nil {
-				a.logger.Error("failed to commit server metadata", "error", err)
-				continue
+			// Use safeio.File to ensure the file is written to disk atomically
+			if sf, ok := f.(*safeio.File); ok {
+				if err := sf.Commit(); err != nil {
+					sf.Close()
+					a.logger.Error("failed to commit server metadata", "error", err)
+					continue
+				}
 			}
-			sf.Close()
+			f.Close()
 		case <-a.shutdownCh:
 			return
 		}

--- a/agent/consul/server_metadata.go
+++ b/agent/consul/server_metadata.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"time"
+
+	"github.com/rboyer/safeio"
 )
 
 // ServerMetadataFile is the name of the file on disk that server metadata
@@ -31,7 +33,7 @@ func (md *ServerMetadata) IsLastSeenStale(d time.Duration) bool {
 // OpenServerMetadata is a helper function for opening the server metadata file
 // with the correct permissions.
 func OpenServerMetadata(filename string) (io.WriteCloser, error) {
-	return os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, 0600)
+	return safeio.OpenFile(filename, 0600)
 }
 
 type ServerMetadataReadFunc func(filename string) (*ServerMetadata, error)


### PR DESCRIPTION
### Description

This is a follow-up PR to #19935. The previous PR doesn't solve the problem entirely since failure may occur if agent crashes mid-write then the file is partial.

This PR uses the [safeio](https://pkg.go.dev/github.com/rboyer/safeio)'s write, commit, and close to write the file atomicly.

- [ ] Manual backport to 1.15
- [ ] Manual backport to 1.16

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
