### PR TITLE
Make DNS test run across a matrix of dns and catalog versions.

### DIFF
--- a/agent/dns_node_lookup_test.go
+++ b/agent/dns_node_lookup_test.go
@@ -18,97 +18,101 @@ func TestDNS_NodeLookup(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register node
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "foo",
-		Address:    "127.0.0.1",
-		TaggedAddresses: map[string]string{
-			"wan": "127.0.0.2",
-		},
-		NodeMeta: map[string]string{
-			"key": "value",
-		},
+			// Register node
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "foo",
+				Address:    "127.0.0.1",
+				TaggedAddresses: map[string]string{
+					"wan": "127.0.0.2",
+				},
+				NodeMeta: map[string]string{
+					"key": "value",
+				},
+			}
+
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			m := new(dns.Msg)
+			m.SetQuestion("foo.node.consul.", dns.TypeANY)
+
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			require.NoError(t, err)
+			require.Len(t, in.Answer, 2)
+			require.Len(t, in.Extra, 0)
+
+			aRec, ok := in.Answer[0].(*dns.A)
+			require.True(t, ok, "First answer is not an A record")
+			require.Equal(t, "127.0.0.1", aRec.A.String())
+			require.Equal(t, uint32(0), aRec.Hdr.Ttl)
+
+			txt, ok := in.Answer[1].(*dns.TXT)
+			require.True(t, ok, "Second answer is not a TXT record")
+			require.Len(t, txt.Txt, 1)
+			require.Equal(t, "key=value", txt.Txt[0])
+
+			// Re-do the query, but only for an A RR
+
+			m = new(dns.Msg)
+			m.SetQuestion("foo.node.consul.", dns.TypeA)
+
+			c = new(dns.Client)
+			in, _, err = c.Exchange(m, a.DNSAddr())
+			require.NoError(t, err)
+			require.Len(t, in.Answer, 1)
+			require.Len(t, in.Extra, 1)
+
+			aRec, ok = in.Answer[0].(*dns.A)
+			require.True(t, ok, "Answer is not an A record")
+			require.Equal(t, "127.0.0.1", aRec.A.String())
+			require.Equal(t, uint32(0), aRec.Hdr.Ttl)
+
+			txt, ok = in.Extra[0].(*dns.TXT)
+			require.True(t, ok, "Extra record is not a TXT record")
+			require.Len(t, txt.Txt, 1)
+			require.Equal(t, "key=value", txt.Txt[0])
+
+			// Re-do the query, but specify the DC
+			m = new(dns.Msg)
+			m.SetQuestion("foo.node.dc1.consul.", dns.TypeANY)
+
+			c = new(dns.Client)
+			in, _, err = c.Exchange(m, a.DNSAddr())
+			require.NoError(t, err)
+			require.Len(t, in.Answer, 2)
+			require.Len(t, in.Extra, 0)
+
+			aRec, ok = in.Answer[0].(*dns.A)
+			require.True(t, ok, "First answer is not an A record")
+			require.Equal(t, "127.0.0.1", aRec.A.String())
+			require.Equal(t, uint32(0), aRec.Hdr.Ttl)
+
+			_, ok = in.Answer[1].(*dns.TXT)
+			require.True(t, ok, "Second answer is not a TXT record")
+
+			// lookup a non-existing node, we should receive a SOA
+			m = new(dns.Msg)
+			m.SetQuestion("nofoo.node.dc1.consul.", dns.TypeANY)
+
+			c = new(dns.Client)
+			in, _, err = c.Exchange(m, a.DNSAddr())
+			require.NoError(t, err)
+			require.Len(t, in.Ns, 1)
+			soaRec, ok := in.Ns[0].(*dns.SOA)
+			require.True(t, ok, "NS RR is not a SOA record")
+			require.Equal(t, uint32(0), soaRec.Hdr.Ttl)
+		})
 	}
-
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	m := new(dns.Msg)
-	m.SetQuestion("foo.node.consul.", dns.TypeANY)
-
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	require.NoError(t, err)
-	require.Len(t, in.Answer, 2)
-	require.Len(t, in.Extra, 0)
-
-	aRec, ok := in.Answer[0].(*dns.A)
-	require.True(t, ok, "First answer is not an A record")
-	require.Equal(t, "127.0.0.1", aRec.A.String())
-	require.Equal(t, uint32(0), aRec.Hdr.Ttl)
-
-	txt, ok := in.Answer[1].(*dns.TXT)
-	require.True(t, ok, "Second answer is not a TXT record")
-	require.Len(t, txt.Txt, 1)
-	require.Equal(t, "key=value", txt.Txt[0])
-
-	// Re-do the query, but only for an A RR
-
-	m = new(dns.Msg)
-	m.SetQuestion("foo.node.consul.", dns.TypeA)
-
-	c = new(dns.Client)
-	in, _, err = c.Exchange(m, a.DNSAddr())
-	require.NoError(t, err)
-	require.Len(t, in.Answer, 1)
-	require.Len(t, in.Extra, 1)
-
-	aRec, ok = in.Answer[0].(*dns.A)
-	require.True(t, ok, "Answer is not an A record")
-	require.Equal(t, "127.0.0.1", aRec.A.String())
-	require.Equal(t, uint32(0), aRec.Hdr.Ttl)
-
-	txt, ok = in.Extra[0].(*dns.TXT)
-	require.True(t, ok, "Extra record is not a TXT record")
-	require.Len(t, txt.Txt, 1)
-	require.Equal(t, "key=value", txt.Txt[0])
-
-	// Re-do the query, but specify the DC
-	m = new(dns.Msg)
-	m.SetQuestion("foo.node.dc1.consul.", dns.TypeANY)
-
-	c = new(dns.Client)
-	in, _, err = c.Exchange(m, a.DNSAddr())
-	require.NoError(t, err)
-	require.Len(t, in.Answer, 2)
-	require.Len(t, in.Extra, 0)
-
-	aRec, ok = in.Answer[0].(*dns.A)
-	require.True(t, ok, "First answer is not an A record")
-	require.Equal(t, "127.0.0.1", aRec.A.String())
-	require.Equal(t, uint32(0), aRec.Hdr.Ttl)
-
-	_, ok = in.Answer[1].(*dns.TXT)
-	require.True(t, ok, "Second answer is not a TXT record")
-
-	// lookup a non-existing node, we should receive a SOA
-	m = new(dns.Msg)
-	m.SetQuestion("nofoo.node.dc1.consul.", dns.TypeANY)
-
-	c = new(dns.Client)
-	in, _, err = c.Exchange(m, a.DNSAddr())
-	require.NoError(t, err)
-	require.Len(t, in.Ns, 1)
-	soaRec, ok := in.Ns[0].(*dns.SOA)
-	require.True(t, ok, "NS RR is not a SOA record")
-	require.Equal(t, uint32(0), soaRec.Hdr.Ttl)
 }
 
 func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
@@ -117,33 +121,37 @@ func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register node
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "Foo",
-		Address:    "127.0.0.1",
-	}
+			// Register node
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "Foo",
+				Address:    "127.0.0.1",
+			}
 
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("fOO.node.dc1.consul.", dns.TypeANY)
+			m := new(dns.Msg)
+			m.SetQuestion("fOO.node.dc1.consul.", dns.TypeANY)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("empty lookup: %#v", in)
+			if len(in.Answer) != 1 {
+				t.Fatalf("empty lookup: %#v", in)
+			}
+		})
 	}
 }
 
@@ -153,41 +161,45 @@ func TestDNS_NodeLookup_PeriodName(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register node with period in name
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "foo.bar",
-		Address:    "127.0.0.1",
-	}
+			// Register node with period in name
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "foo.bar",
+				Address:    "127.0.0.1",
+			}
 
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("foo.bar.node.consul.", dns.TypeANY)
+			m := new(dns.Msg)
+			m.SetQuestion("foo.bar.node.consul.", dns.TypeANY)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 1 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	aRec, ok := in.Answer[0].(*dns.A)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if aRec.A.String() != "127.0.0.1" {
-		t.Fatalf("Bad: %#v", in.Answer[0])
+			aRec, ok := in.Answer[0].(*dns.A)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if aRec.A.String() != "127.0.0.1" {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+		})
 	}
 }
 
@@ -197,44 +209,48 @@ func TestDNS_NodeLookup_AAAA(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register node
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "bar",
-		Address:    "::4242:4242",
-	}
+			// Register node
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "bar",
+				Address:    "::4242:4242",
+			}
 
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("bar.node.consul.", dns.TypeAAAA)
+			m := new(dns.Msg)
+			m.SetQuestion("bar.node.consul.", dns.TypeAAAA)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 1 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	aRec, ok := in.Answer[0].(*dns.AAAA)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if aRec.AAAA.String() != "::4242:4242" {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if aRec.Hdr.Ttl != 0 {
-		t.Fatalf("Bad: %#v", in.Answer[0])
+			aRec, ok := in.Answer[0].(*dns.AAAA)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if aRec.AAAA.String() != "::4242:4242" {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if aRec.Hdr.Ttl != 0 {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+		})
 	}
 }
 
@@ -253,53 +269,57 @@ func TestDNS_NodeLookup_CNAME(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register node
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "google",
-		Address:    "www.google.com",
+			// Register node
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "google",
+				Address:    "www.google.com",
+			}
+
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			m := new(dns.Msg)
+			m.SetQuestion("google.node.consul.", dns.TypeANY)
+			m.SetEdns0(8192, true)
+
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			wantAnswer := []dns.RR{
+				&dns.CNAME{
+					Hdr:    dns.RR_Header{Name: "google.node.consul.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 0, Rdlength: 0x10},
+					Target: "www.google.com.",
+				},
+				&dns.CNAME{
+					Hdr:    dns.RR_Header{Name: "www.google.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Rdlength: 0x2},
+					Target: "google.com.",
+				},
+				&dns.A{
+					Hdr: dns.RR_Header{Name: "google.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Rdlength: 0x4},
+					A:   []byte{0x1, 0x2, 0x3, 0x4}, // 1.2.3.4
+				},
+				&dns.TXT{
+					Hdr: dns.RR_Header{Name: "google.com.", Rrtype: dns.TypeTXT, Class: dns.ClassINET, Rdlength: 0xd},
+					Txt: []string{"my_txt_value"},
+				},
+			}
+			require.Equal(t, wantAnswer, in.Answer)
+		})
 	}
-
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	m := new(dns.Msg)
-	m.SetQuestion("google.node.consul.", dns.TypeANY)
-	m.SetEdns0(8192, true)
-
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	wantAnswer := []dns.RR{
-		&dns.CNAME{
-			Hdr:    dns.RR_Header{Name: "google.node.consul.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 0, Rdlength: 0x10},
-			Target: "www.google.com.",
-		},
-		&dns.CNAME{
-			Hdr:    dns.RR_Header{Name: "www.google.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Rdlength: 0x2},
-			Target: "google.com.",
-		},
-		&dns.A{
-			Hdr: dns.RR_Header{Name: "google.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Rdlength: 0x4},
-			A:   []byte{0x1, 0x2, 0x3, 0x4}, // 1.2.3.4
-		},
-		&dns.TXT{
-			Hdr: dns.RR_Header{Name: "google.com.", Rrtype: dns.TypeTXT, Class: dns.ClassINET, Rdlength: 0xd},
-			Txt: []string{"my_txt_value"},
-		},
-	}
-	require.Equal(t, wantAnswer, in.Answer)
 }
 
 func TestDNS_NodeLookup_TXT(t *testing.T) {
@@ -307,48 +327,52 @@ func TestDNS_NodeLookup_TXT(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	a := NewTestAgent(t, ``)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "google",
-		Address:    "127.0.0.1",
-		NodeMeta: map[string]string{
-			"rfc1035-00": "value0",
-			"key0":       "value1",
-		},
-	}
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "google",
+				Address:    "127.0.0.1",
+				NodeMeta: map[string]string{
+					"rfc1035-00": "value0",
+					"key0":       "value1",
+				},
+			}
 
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("google.node.consul.", dns.TypeTXT)
+			m := new(dns.Msg)
+			m.SetQuestion("google.node.consul.", dns.TypeTXT)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	// Should have the 1 TXT record reply
-	if len(in.Answer) != 2 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			// Should have the 1 TXT record reply
+			if len(in.Answer) != 2 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	txtRec, ok := in.Answer[0].(*dns.TXT)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if len(txtRec.Txt) != 1 {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if txtRec.Txt[0] != "value0" && txtRec.Txt[0] != "key0=value1" {
-		t.Fatalf("Bad: %#v", in.Answer[0])
+			txtRec, ok := in.Answer[0].(*dns.TXT)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if len(txtRec.Txt) != 1 {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if txtRec.Txt[0] != "value0" && txtRec.Txt[0] != "key0=value1" {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+		})
 	}
 }
 
@@ -357,48 +381,52 @@ func TestDNS_NodeLookup_TXT_DontSuppress(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false } `+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "google",
-		Address:    "127.0.0.1",
-		NodeMeta: map[string]string{
-			"rfc1035-00": "value0",
-			"key0":       "value1",
-		},
-	}
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "google",
+				Address:    "127.0.0.1",
+				NodeMeta: map[string]string{
+					"rfc1035-00": "value0",
+					"key0":       "value1",
+				},
+			}
 
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("google.node.consul.", dns.TypeTXT)
+			m := new(dns.Msg)
+			m.SetQuestion("google.node.consul.", dns.TypeTXT)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	// Should have the 1 TXT record reply
-	if len(in.Answer) != 2 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			// Should have the 1 TXT record reply
+			if len(in.Answer) != 2 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	txtRec, ok := in.Answer[0].(*dns.TXT)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if len(txtRec.Txt) != 1 {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if txtRec.Txt[0] != "value0" && txtRec.Txt[0] != "key0=value1" {
-		t.Fatalf("Bad: %#v", in.Answer[0])
+			txtRec, ok := in.Answer[0].(*dns.TXT)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if len(txtRec.Txt) != 1 {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if txtRec.Txt[0] != "value0" && txtRec.Txt[0] != "key0=value1" {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+		})
 	}
 }
 
@@ -407,44 +435,48 @@ func TestDNS_NodeLookup_ANY(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	a := NewTestAgent(t, ``)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "bar",
-		Address:    "127.0.0.1",
-		NodeMeta: map[string]string{
-			"key": "value",
-		},
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "bar",
+				Address:    "127.0.0.1",
+				NodeMeta: map[string]string{
+					"key": "value",
+				},
+			}
+
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			m := new(dns.Msg)
+			m.SetQuestion("bar.node.consul.", dns.TypeANY)
+
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			wantAnswer := []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{Name: "bar.node.consul.", Rrtype: dns.TypeA, Class: dns.ClassINET, Rdlength: 0x4},
+					A:   []byte{0x7f, 0x0, 0x0, 0x1}, // 127.0.0.1
+				},
+				&dns.TXT{
+					Hdr: dns.RR_Header{Name: "bar.node.consul.", Rrtype: dns.TypeTXT, Class: dns.ClassINET, Rdlength: 0xa},
+					Txt: []string{"key=value"},
+				},
+			}
+			require.Equal(t, wantAnswer, in.Answer)
+		})
 	}
-
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	m := new(dns.Msg)
-	m.SetQuestion("bar.node.consul.", dns.TypeANY)
-
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	wantAnswer := []dns.RR{
-		&dns.A{
-			Hdr: dns.RR_Header{Name: "bar.node.consul.", Rrtype: dns.TypeA, Class: dns.ClassINET, Rdlength: 0x4},
-			A:   []byte{0x7f, 0x0, 0x0, 0x1}, // 127.0.0.1
-		},
-		&dns.TXT{
-			Hdr: dns.RR_Header{Name: "bar.node.consul.", Rrtype: dns.TypeTXT, Class: dns.ClassINET, Rdlength: 0xa},
-			Txt: []string{"key=value"},
-		},
-	}
-	require.Equal(t, wantAnswer, in.Answer)
 }
 
 func TestDNS_NodeLookup_ANY_DontSuppressTXT(t *testing.T) {
@@ -452,44 +484,48 @@ func TestDNS_NodeLookup_ANY_DontSuppressTXT(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false } `+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "bar",
-		Address:    "127.0.0.1",
-		NodeMeta: map[string]string{
-			"key": "value",
-		},
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "bar",
+				Address:    "127.0.0.1",
+				NodeMeta: map[string]string{
+					"key": "value",
+				},
+			}
+
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			m := new(dns.Msg)
+			m.SetQuestion("bar.node.consul.", dns.TypeANY)
+
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			wantAnswer := []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{Name: "bar.node.consul.", Rrtype: dns.TypeA, Class: dns.ClassINET, Rdlength: 0x4},
+					A:   []byte{0x7f, 0x0, 0x0, 0x1}, // 127.0.0.1
+				},
+				&dns.TXT{
+					Hdr: dns.RR_Header{Name: "bar.node.consul.", Rrtype: dns.TypeTXT, Class: dns.ClassINET, Rdlength: 0xa},
+					Txt: []string{"key=value"},
+				},
+			}
+			require.Equal(t, wantAnswer, in.Answer)
+		})
 	}
-
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	m := new(dns.Msg)
-	m.SetQuestion("bar.node.consul.", dns.TypeANY)
-
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	wantAnswer := []dns.RR{
-		&dns.A{
-			Hdr: dns.RR_Header{Name: "bar.node.consul.", Rrtype: dns.TypeA, Class: dns.ClassINET, Rdlength: 0x4},
-			A:   []byte{0x7f, 0x0, 0x0, 0x1}, // 127.0.0.1
-		},
-		&dns.TXT{
-			Hdr: dns.RR_Header{Name: "bar.node.consul.", Rrtype: dns.TypeTXT, Class: dns.ClassINET, Rdlength: 0xa},
-			Txt: []string{"key=value"},
-		},
-	}
-	require.Equal(t, wantAnswer, in.Answer)
 }
 
 func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
@@ -497,39 +533,43 @@ func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false } `+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "bar",
-		Address:    "127.0.0.1",
-		NodeMeta: map[string]string{
-			"key": "value",
-		},
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "bar",
+				Address:    "127.0.0.1",
+				NodeMeta: map[string]string{
+					"key": "value",
+				},
+			}
+
+			var out struct{}
+			require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+
+			m := new(dns.Msg)
+			m.SetQuestion("bar.node.consul.", dns.TypeA)
+
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			require.NoError(t, err)
+
+			wantAnswer := []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{Name: "bar.node.consul.", Rrtype: dns.TypeA, Class: dns.ClassINET, Rdlength: 0x4},
+					A:   []byte{0x7f, 0x0, 0x0, 0x1}, // 127.0.0.1
+				},
+			}
+			require.Equal(t, wantAnswer, in.Answer)
+
+			// ensure TXT RR suppression
+			require.Len(t, in.Extra, 0)
+		})
 	}
-
-	var out struct{}
-	require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
-
-	m := new(dns.Msg)
-	m.SetQuestion("bar.node.consul.", dns.TypeA)
-
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	require.NoError(t, err)
-
-	wantAnswer := []dns.RR{
-		&dns.A{
-			Hdr: dns.RR_Header{Name: "bar.node.consul.", Rrtype: dns.TypeA, Class: dns.ClassINET, Rdlength: 0x4},
-			A:   []byte{0x7f, 0x0, 0x0, 0x1}, // 127.0.0.1
-		},
-	}
-	require.Equal(t, wantAnswer, in.Answer)
-
-	// ensure TXT RR suppression
-	require.Len(t, in.Extra, 0)
 }
 
 func TestDNS_NodeLookup_TTL(t *testing.T) {
@@ -546,118 +586,122 @@ func TestDNS_NodeLookup_TTL(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
 		dns_config {
 			node_ttl = "10s"
 			allow_stale = true
 			max_stale = "1s"
 		}
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register node
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "foo",
-		Address:    "127.0.0.1",
-	}
+			// Register node
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "foo",
+				Address:    "127.0.0.1",
+			}
 
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("foo.node.consul.", dns.TypeANY)
+			m := new(dns.Msg)
+			m.SetQuestion("foo.node.consul.", dns.TypeANY)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 1 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	aRec, ok := in.Answer[0].(*dns.A)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if aRec.A.String() != "127.0.0.1" {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if aRec.Hdr.Ttl != 10 {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
+			aRec, ok := in.Answer[0].(*dns.A)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if aRec.A.String() != "127.0.0.1" {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if aRec.Hdr.Ttl != 10 {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
 
-	// Register node with IPv6
-	args = &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "bar",
-		Address:    "::4242:4242",
-	}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			// Register node with IPv6
+			args = &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "bar",
+				Address:    "::4242:4242",
+			}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	// Check an IPv6 record
-	m = new(dns.Msg)
-	m.SetQuestion("bar.node.consul.", dns.TypeANY)
+			// Check an IPv6 record
+			m = new(dns.Msg)
+			m.SetQuestion("bar.node.consul.", dns.TypeANY)
 
-	in, _, err = c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			in, _, err = c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 1 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	aaaaRec, ok := in.Answer[0].(*dns.AAAA)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if aaaaRec.AAAA.String() != "::4242:4242" {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if aaaaRec.Hdr.Ttl != 10 {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
+			aaaaRec, ok := in.Answer[0].(*dns.AAAA)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if aaaaRec.AAAA.String() != "::4242:4242" {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if aaaaRec.Hdr.Ttl != 10 {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
 
-	// Register node with CNAME
-	args = &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "google",
-		Address:    "www.google.com",
-	}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			// Register node with CNAME
+			args = &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "google",
+				Address:    "www.google.com",
+			}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	m = new(dns.Msg)
-	m.SetQuestion("google.node.consul.", dns.TypeANY)
+			m = new(dns.Msg)
+			m.SetQuestion("google.node.consul.", dns.TypeANY)
 
-	in, _, err = c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			in, _, err = c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	// Should have the CNAME record + a few A records
-	if len(in.Answer) < 2 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			// Should have the CNAME record + a few A records
+			if len(in.Answer) < 2 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	cnRec, ok := in.Answer[0].(*dns.CNAME)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if cnRec.Target != "www.google.com." {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if cnRec.Hdr.Ttl != 10 {
-		t.Fatalf("Bad: %#v", in.Answer[0])
+			cnRec, ok := in.Answer[0].(*dns.CNAME)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if cnRec.Target != "www.google.com." {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if cnRec.Hdr.Ttl != 10 {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+		})
 	}
 }

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -24,49 +24,53 @@ func TestDNS_ServiceReverseLookup(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-				Address: "127.0.0.2",
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+						Address: "127.0.0.2",
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("2.0.0.127.in-addr.arpa.", dns.TypeANY)
+			m := new(dns.Msg)
+			m.SetQuestion("2.0.0.127.in-addr.arpa.", dns.TypeANY)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 1 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	ptrRec, ok := in.Answer[0].(*dns.PTR)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if ptrRec.Ptr != serviceCanonicalDNSName("db", "service", "dc1", "consul", nil)+"." {
-		t.Fatalf("Bad: %#v", ptrRec)
+			ptrRec, ok := in.Answer[0].(*dns.PTR)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if ptrRec.Ptr != serviceCanonicalDNSName("db", "service", "dc1", "consul", nil)+"." {
+				t.Fatalf("Bad: %#v", ptrRec)
+			}
+		})
 	}
 }
 
@@ -76,49 +80,53 @@ func TestDNS_ServiceReverseLookup_IPV6(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "2001:db8::1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-				Address: "2001:db8::ff00:42:8329",
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "2001:db8::1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+						Address: "2001:db8::ff00:42:8329",
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("9.2.3.8.2.4.0.0.0.0.f.f.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.", dns.TypeANY)
+			m := new(dns.Msg)
+			m.SetQuestion("9.2.3.8.2.4.0.0.0.0.f.f.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.", dns.TypeANY)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 1 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	ptrRec, ok := in.Answer[0].(*dns.PTR)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if ptrRec.Ptr != serviceCanonicalDNSName("db", "service", "dc1", "consul", nil)+"." {
-		t.Fatalf("Bad: %#v", ptrRec)
+			ptrRec, ok := in.Answer[0].(*dns.PTR)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if ptrRec.Ptr != serviceCanonicalDNSName("db", "service", "dc1", "consul", nil)+"." {
+				t.Fatalf("Bad: %#v", ptrRec)
+			}
+		})
 	}
 }
 
@@ -128,51 +136,55 @@ func TestDNS_ServiceReverseLookup_CustomDomain(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		domain = "custom"
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-				Address: "127.0.0.2",
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+						Address: "127.0.0.2",
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("2.0.0.127.in-addr.arpa.", dns.TypeANY)
+			m := new(dns.Msg)
+			m.SetQuestion("2.0.0.127.in-addr.arpa.", dns.TypeANY)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 1 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	ptrRec, ok := in.Answer[0].(*dns.PTR)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if ptrRec.Ptr != serviceCanonicalDNSName("db", "service", "dc1", "custom", nil)+"." {
-		t.Fatalf("Bad: %#v", ptrRec)
+			ptrRec, ok := in.Answer[0].(*dns.PTR)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if ptrRec.Ptr != serviceCanonicalDNSName("db", "service", "dc1", "custom", nil)+"." {
+				t.Fatalf("Bad: %#v", ptrRec)
+			}
+		})
 	}
 }
 
@@ -182,49 +194,53 @@ func TestDNS_ServiceReverseLookupNodeAddress(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-				Address: "127.0.0.1",
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+						Address: "127.0.0.1",
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("1.0.0.127.in-addr.arpa.", dns.TypeANY)
+			m := new(dns.Msg)
+			m.SetQuestion("1.0.0.127.in-addr.arpa.", dns.TypeANY)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 1 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	ptrRec, ok := in.Answer[0].(*dns.PTR)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if ptrRec.Ptr != "foo.node.dc1.consul." {
-		t.Fatalf("Bad: %#v", ptrRec)
+			ptrRec, ok := in.Answer[0].(*dns.PTR)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if ptrRec.Ptr != "foo.node.dc1.consul." {
+				t.Fatalf("Bad: %#v", ptrRec)
+			}
+		})
 	}
 }
 
@@ -234,57 +250,61 @@ func TestDNS_ServiceLookupNoMultiCNAME(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "198.18.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Port:    12345,
-				Address: "foo.node.consul",
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "198.18.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Port:    12345,
+						Address: "foo.node.consul",
+					},
+				}
 
-		var out struct{}
-		require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+				var out struct{}
+				require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+			}
+
+			// Register a second node node with the same service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "bar",
+					Address:    "198.18.0.2",
+					Service: &structs.NodeService{
+						Service: "db",
+						Port:    12345,
+						Address: "bar.node.consul",
+					},
+				}
+
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
+
+			m := new(dns.Msg)
+			m.SetQuestion("db.service.consul.", dns.TypeANY)
+
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			require.NoError(t, err)
+
+			// expect a CNAME and an A RR
+			require.Len(t, in.Answer, 2)
+			require.IsType(t, &dns.CNAME{}, in.Answer[0])
+			require.IsType(t, &dns.A{}, in.Answer[1])
+		})
 	}
-
-	// Register a second node node with the same service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "bar",
-			Address:    "198.18.0.2",
-			Service: &structs.NodeService{
-				Service: "db",
-				Port:    12345,
-				Address: "bar.node.consul",
-			},
-		}
-
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
-	m := new(dns.Msg)
-	m.SetQuestion("db.service.consul.", dns.TypeANY)
-
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	require.NoError(t, err)
-
-	// expect a CNAME and an A RR
-	require.Len(t, in.Answer, 2)
-	require.IsType(t, &dns.CNAME{}, in.Answer[0])
-	require.IsType(t, &dns.A{}, in.Answer[1])
 }
 
 func TestDNS_ServiceLookupPreferNoCNAME(t *testing.T) {
@@ -293,60 +313,64 @@ func TestDNS_ServiceLookupPreferNoCNAME(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "198.18.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Port:    12345,
-				Address: "198.18.0.1",
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "198.18.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Port:    12345,
+						Address: "198.18.0.1",
+					},
+				}
 
-		var out struct{}
-		require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+				var out struct{}
+				require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+			}
+
+			// Register a second node node with the same service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "bar",
+					Address:    "198.18.0.2",
+					Service: &structs.NodeService{
+						Service: "db",
+						Port:    12345,
+						Address: "bar.node.consul",
+					},
+				}
+
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
+
+			m := new(dns.Msg)
+			m.SetQuestion("db.service.consul.", dns.TypeANY)
+
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			require.NoError(t, err)
+
+			// expect a CNAME and an A RR
+			require.Len(t, in.Answer, 1)
+			aRec, ok := in.Answer[0].(*dns.A)
+			require.Truef(t, ok, "Not an A RR")
+
+			require.Equal(t, "db.service.consul.", aRec.Hdr.Name)
+			require.Equal(t, "198.18.0.1", aRec.A.String())
+		})
 	}
-
-	// Register a second node node with the same service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "bar",
-			Address:    "198.18.0.2",
-			Service: &structs.NodeService{
-				Service: "db",
-				Port:    12345,
-				Address: "bar.node.consul",
-			},
-		}
-
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
-	m := new(dns.Msg)
-	m.SetQuestion("db.service.consul.", dns.TypeANY)
-
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	require.NoError(t, err)
-
-	// expect a CNAME and an A RR
-	require.Len(t, in.Answer, 1)
-	aRec, ok := in.Answer[0].(*dns.A)
-	require.Truef(t, ok, "Not an A RR")
-
-	require.Equal(t, "db.service.consul.", aRec.Hdr.Name)
-	require.Equal(t, "198.18.0.1", aRec.A.String())
 }
 
 func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
@@ -355,76 +379,80 @@ func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "198.18.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Port:    12345,
-				Address: "198.18.0.1",
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "198.18.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Port:    12345,
+						Address: "198.18.0.1",
+					},
+				}
 
-		var out struct{}
-		require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+				var out struct{}
+				require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+			}
+
+			// Register a second node node with the same service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "bar",
+					Address:    "198.18.0.2",
+					Service: &structs.NodeService{
+						Service: "db",
+						Port:    12345,
+						Address: "bar.node.consul",
+					},
+				}
+
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
+
+			// Register a second node node with the same service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "baz",
+					Address:    "198.18.0.3",
+					Service: &structs.NodeService{
+						Service: "db",
+						Port:    12345,
+						Address: "198.18.0.3",
+					},
+				}
+
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
+
+			m := new(dns.Msg)
+			m.SetQuestion("db.service.consul.", dns.TypeANY)
+
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			require.NoError(t, err)
+
+			// expect a CNAME and an A RR
+			require.Len(t, in.Answer, 2)
+			require.IsType(t, &dns.A{}, in.Answer[0])
+			require.IsType(t, &dns.A{}, in.Answer[1])
+		})
 	}
-
-	// Register a second node node with the same service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "bar",
-			Address:    "198.18.0.2",
-			Service: &structs.NodeService{
-				Service: "db",
-				Port:    12345,
-				Address: "bar.node.consul",
-			},
-		}
-
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
-	// Register a second node node with the same service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "baz",
-			Address:    "198.18.0.3",
-			Service: &structs.NodeService{
-				Service: "db",
-				Port:    12345,
-				Address: "198.18.0.3",
-			},
-		}
-
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
-	m := new(dns.Msg)
-	m.SetQuestion("db.service.consul.", dns.TypeANY)
-
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	require.NoError(t, err)
-
-	// expect a CNAME and an A RR
-	require.Len(t, in.Answer, 2)
-	require.IsType(t, &dns.A{}, in.Answer[0])
-	require.IsType(t, &dns.A{}, in.Answer[1])
 }
 
 func TestDNS_ServiceLookup(t *testing.T) {
@@ -433,122 +461,125 @@ func TestDNS_ServiceLookup(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"db.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"db.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != "foo.node.dc1.consul." {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != "foo.node.dc1.consul." {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
 
-		aRec, ok := in.Extra[0].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Name != "foo.node.dc1.consul." {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.A.String() != "127.0.0.1" {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-	}
+				aRec, ok := in.Extra[0].(*dns.A)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Name != "foo.node.dc1.consul." {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.A.String() != "127.0.0.1" {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+			}
 
-	// Lookup a non-existing service/query, we should receive an SOA.
-	questions = []string{
-		"nodb.service.consul.",
-		"nope.query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+			// Lookup a non-existing service/query, we should receive an SOA.
+			questions = []string{
+				"nodb.service.consul.",
+				"nope.query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Ns) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Ns) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		soaRec, ok := in.Ns[0].(*dns.SOA)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Ns[0])
-		}
-		if soaRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Ns[0])
-		}
-
+				soaRec, ok := in.Ns[0].(*dns.SOA)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Ns[0])
+				}
+				if soaRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Ns[0])
+				}
+			}
+		})
 	}
 }
 
@@ -558,59 +589,63 @@ func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		node_name = "my.test-node"
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	// The service is using the consul DNS name as service address
-	// which triggers a lookup loop and a subsequent stack overflow
-	// crash.
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "foo",
-		Address:    "127.0.0.1",
-		Service: &structs.NodeService{
-			Service: "db",
-			Address: "db.service.consul",
-			Port:    12345,
-		},
-	}
+			// Register a node with a service.
+			// The service is using the consul DNS name as service address
+			// which triggers a lookup loop and a subsequent stack overflow
+			// crash.
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "foo",
+				Address:    "127.0.0.1",
+				Service: &structs.NodeService{
+					Service: "db",
+					Address: "db.service.consul",
+					Port:    12345,
+				},
+			}
 
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	// Looking up the service should not trigger a loop
-	m := new(dns.Msg)
-	m.SetQuestion("db.service.consul.", dns.TypeSRV)
+			// Looking up the service should not trigger a loop
+			m := new(dns.Msg)
+			m.SetQuestion("db.service.consul.", dns.TypeSRV)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	wantAnswer := []dns.RR{
-		&dns.SRV{
-			Hdr:      dns.RR_Header{Name: "db.service.consul.", Rrtype: 0x21, Class: 0x1, Rdlength: 0x1b},
-			Priority: 0x1,
-			Weight:   0x1,
-			Port:     12345,
-			Target:   "foo.node.dc1.consul.",
-		},
+			wantAnswer := []dns.RR{
+				&dns.SRV{
+					Hdr:      dns.RR_Header{Name: "db.service.consul.", Rrtype: 0x21, Class: 0x1, Rdlength: 0x1b},
+					Priority: 0x1,
+					Weight:   0x1,
+					Port:     12345,
+					Target:   "foo.node.dc1.consul.",
+				},
+			}
+			require.Equal(t, wantAnswer, in.Answer, "answer")
+			wantExtra := []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{Name: "foo.node.dc1.consul.", Rrtype: 0x1, Class: 0x1, Rdlength: 0x4},
+					A:   []byte{0x7f, 0x0, 0x0, 0x1}, // 127.0.0.1
+				},
+			}
+			require.Equal(t, wantExtra, in.Extra, "extra")
+		})
 	}
-	require.Equal(t, wantAnswer, in.Answer, "answer")
-	wantExtra := []dns.RR{
-		&dns.A{
-			Hdr: dns.RR_Header{Name: "foo.node.dc1.consul.", Rrtype: 0x1, Class: 0x1, Rdlength: 0x4},
-			A:   []byte{0x7f, 0x0, 0x0, 0x1}, // 127.0.0.1
-		},
-	}
-	require.Equal(t, wantExtra, in.Extra, "extra")
 }
 
 func TestDNS_ConnectServiceLookup(t *testing.T) {
@@ -620,45 +655,49 @@ func TestDNS_ConnectServiceLookup(t *testing.T) {
 
 	t.Parallel()
 
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register
-	{
-		args := structs.TestRegisterRequestProxy(t)
-		args.Address = "127.0.0.55"
-		args.Service.Proxy.DestinationServiceName = "db"
-		args.Service.Address = ""
-		args.Service.Port = 12345
-		var out struct{}
-		require.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
-	}
+			// Register
+			{
+				args := structs.TestRegisterRequestProxy(t)
+				args.Address = "127.0.0.55"
+				args.Service.Proxy.DestinationServiceName = "db"
+				args.Service.Address = ""
+				args.Service.Port = 12345
+				var out struct{}
+				require.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+			}
 
-	// Look up the service
-	questions := []string{
-		"db.connect.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+			// Look up the service
+			questions := []string{
+				"db.connect.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		require.Nil(t, err)
-		require.Len(t, in.Answer, 1)
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				require.Nil(t, err)
+				require.Len(t, in.Answer, 1)
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		require.True(t, ok)
-		require.Equal(t, uint16(12345), srvRec.Port)
-		require.Equal(t, "foo.node.dc1.consul.", srvRec.Target)
-		require.Equal(t, uint32(0), srvRec.Hdr.Ttl)
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				require.True(t, ok)
+				require.Equal(t, uint16(12345), srvRec.Port)
+				require.Equal(t, "foo.node.dc1.consul.", srvRec.Target)
+				require.Equal(t, uint32(0), srvRec.Hdr.Ttl)
 
-		cnameRec, ok := in.Extra[0].(*dns.A)
-		require.True(t, ok)
-		require.Equal(t, "foo.node.dc1.consul.", cnameRec.Hdr.Name)
-		require.Equal(t, uint32(0), srvRec.Hdr.Ttl)
-		require.Equal(t, "127.0.0.55", cnameRec.A.String())
+				cnameRec, ok := in.Extra[0].(*dns.A)
+				require.True(t, ok)
+				require.Equal(t, "foo.node.dc1.consul.", cnameRec.Hdr.Name)
+				require.Equal(t, uint32(0), srvRec.Hdr.Ttl)
+				require.Equal(t, "127.0.0.55", cnameRec.A.String())
+			}
+		})
 	}
 }
 
@@ -669,102 +708,106 @@ func TestDNS_IngressServiceLookup(t *testing.T) {
 
 	t.Parallel()
 
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register ingress-gateway service
-	{
-		args := structs.TestRegisterIngressGateway(t)
-		var out struct{}
-		require.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
-	}
+			// Register ingress-gateway service
+			{
+				args := structs.TestRegisterIngressGateway(t)
+				var out struct{}
+				require.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+			}
 
-	// Register db service
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Address: "",
-				Port:    80,
-			},
-		}
-
-		var out struct{}
-		require.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
-	}
-
-	// Register proxy-defaults with 'http' protocol
-	{
-		req := structs.ConfigEntryRequest{
-			Op:         structs.ConfigEntryUpsert,
-			Datacenter: "dc1",
-			Entry: &structs.ProxyConfigEntry{
-				Kind: structs.ProxyDefaults,
-				Name: structs.ProxyConfigGlobal,
-				Config: map[string]interface{}{
-					"protocol": "http",
-				},
-			},
-			WriteRequest: structs.WriteRequest{Token: "root"},
-		}
-		var out bool
-		require.Nil(t, a.RPC(context.Background(), "ConfigEntry.Apply", req, &out))
-		require.True(t, out)
-	}
-
-	// Register ingress-gateway config entry
-	{
-		args := &structs.IngressGatewayConfigEntry{
-			Name: "ingress-gateway",
-			Kind: structs.IngressGateway,
-			Listeners: []structs.IngressListener{
-				{
-					Port:     8888,
-					Protocol: "http",
-					Services: []structs.IngressService{
-						{Name: "db"},
-						{Name: "api"},
+			// Register db service
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Address: "",
+						Port:    80,
 					},
-				},
-			},
-		}
+				}
 
-		req := structs.ConfigEntryRequest{
-			Op:         structs.ConfigEntryUpsert,
-			Datacenter: "dc1",
-			Entry:      args,
-		}
-		var out bool
-		require.Nil(t, a.RPC(context.Background(), "ConfigEntry.Apply", req, &out))
-		require.True(t, out)
-	}
+				var out struct{}
+				require.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+			}
 
-	// Look up the service
-	questions := []string{
-		"api.ingress.consul.",
-		"api.ingress.dc1.consul.",
-		"db.ingress.consul.",
-		"db.ingress.dc1.consul.",
-	}
-	for _, question := range questions {
-		t.Run(question, func(t *testing.T) {
-			m := new(dns.Msg)
-			m.SetQuestion(question, dns.TypeA)
+			// Register proxy-defaults with 'http' protocol
+			{
+				req := structs.ConfigEntryRequest{
+					Op:         structs.ConfigEntryUpsert,
+					Datacenter: "dc1",
+					Entry: &structs.ProxyConfigEntry{
+						Kind: structs.ProxyDefaults,
+						Name: structs.ProxyConfigGlobal,
+						Config: map[string]interface{}{
+							"protocol": "http",
+						},
+					},
+					WriteRequest: structs.WriteRequest{Token: "root"},
+				}
+				var out bool
+				require.Nil(t, a.RPC(context.Background(), "ConfigEntry.Apply", req, &out))
+				require.True(t, out)
+			}
 
-			c := new(dns.Client)
-			in, _, err := c.Exchange(m, a.DNSAddr())
-			require.Nil(t, err)
-			require.Len(t, in.Answer, 1)
+			// Register ingress-gateway config entry
+			{
+				args := &structs.IngressGatewayConfigEntry{
+					Name: "ingress-gateway",
+					Kind: structs.IngressGateway,
+					Listeners: []structs.IngressListener{
+						{
+							Port:     8888,
+							Protocol: "http",
+							Services: []structs.IngressService{
+								{Name: "db"},
+								{Name: "api"},
+							},
+						},
+					},
+				}
 
-			cnameRec, ok := in.Answer[0].(*dns.A)
-			require.True(t, ok)
-			require.Equal(t, question, cnameRec.Hdr.Name)
-			require.Equal(t, uint32(0), cnameRec.Hdr.Ttl)
-			require.Equal(t, "127.0.0.1", cnameRec.A.String())
+				req := structs.ConfigEntryRequest{
+					Op:         structs.ConfigEntryUpsert,
+					Datacenter: "dc1",
+					Entry:      args,
+				}
+				var out bool
+				require.Nil(t, a.RPC(context.Background(), "ConfigEntry.Apply", req, &out))
+				require.True(t, out)
+			}
+
+			// Look up the service
+			questions := []string{
+				"api.ingress.consul.",
+				"api.ingress.dc1.consul.",
+				"db.ingress.consul.",
+				"db.ingress.dc1.consul.",
+			}
+			for _, question := range questions {
+				t.Run(question, func(t *testing.T) {
+					m := new(dns.Msg)
+					m.SetQuestion(question, dns.TypeA)
+
+					c := new(dns.Client)
+					in, _, err := c.Exchange(m, a.DNSAddr())
+					require.Nil(t, err)
+					require.Len(t, in.Answer, 1)
+
+					cnameRec, ok := in.Answer[0].(*dns.A)
+					require.True(t, ok)
+					require.Equal(t, question, cnameRec.Hdr.Name)
+					require.Equal(t, uint32(0), cnameRec.Hdr.Ttl)
+					require.Equal(t, "127.0.0.1", cnameRec.A.String())
+				})
+			}
 		})
 	}
 }
@@ -775,59 +818,63 @@ func TestDNS_ExternalServiceLookup(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with an external service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "www.google.com",
-			Service: &structs.NodeService{
-				Service: "db",
-				Port:    12345,
-			},
-		}
+			// Register a node with an external service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "www.google.com",
+					Service: &structs.NodeService{
+						Service: "db",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service
-	questions := []string{
-		"db.service.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+			// Look up the service
+			questions := []string{
+				"db.service.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != "www.google.com." {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != "www.google.com." {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+			}
+		})
 	}
 }
 
@@ -837,100 +884,103 @@ func TestDNS_ExternalServiceToConsulCNAMELookup(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		domain = "CONSUL."
 		node_name = "test node"
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register the initial node with a service
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "web",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "web",
-				Port:    12345,
-			},
-		}
+			// Register the initial node with a service
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "web",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "web",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an external service pointing to the 'web' service
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "alias",
-			Address:    "web.service.consul",
-			Service: &structs.NodeService{
-				Service: "alias",
-				Port:    12345,
-			},
-		}
+			// Register an external service pointing to the 'web' service
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "alias",
+					Address:    "web.service.consul",
+					Service: &structs.NodeService{
+						Service: "alias",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly
-	questions := []string{
-		"alias.service.consul.",
-		"alias.service.CoNsUl.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+			// Look up the service directly
+			questions := []string{
+				"alias.service.consul.",
+				"alias.service.CoNsUl.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != "web.service.consul." {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != "web.service.consul." {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
 
-		if len(in.Extra) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Extra) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		aRec, ok := in.Extra[0].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Name != "web.service.consul." {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.A.String() != "127.0.0.1" {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-
+				aRec, ok := in.Extra[0].(*dns.A)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Name != "web.service.consul." {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.A.String() != "127.0.0.1" {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+			}
+		})
 	}
 }
 
@@ -940,128 +990,132 @@ func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		node_name = "test-node"
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register the initial node with a service
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "web",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "web",
-				Port:    12345,
-			},
-		}
+			// Register the initial node with a service
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "web",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "web",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an external service pointing to the 'web' service
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "alias",
-			Address:    "web.service.consul",
-			Service: &structs.NodeService{
-				Service: "alias",
-				Port:    12345,
-			},
-		}
+			// Register an external service pointing to the 'web' service
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "alias",
+					Address:    "web.service.consul",
+					Service: &structs.NodeService{
+						Service: "alias",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an external service pointing to the 'alias' service
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "alias2",
-			Address:    "alias.service.consul",
-			Service: &structs.NodeService{
-				Service: "alias2",
-				Port:    12345,
-			},
-		}
+			// Register an external service pointing to the 'alias' service
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "alias2",
+					Address:    "alias.service.consul",
+					Service: &structs.NodeService{
+						Service: "alias2",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly
-	questions := []string{
-		"alias2.service.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+			// Look up the service directly
+			questions := []string{
+				"alias2.service.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != "alias.service.consul." {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if len(in.Extra) != 2 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != "alias.service.consul." {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if len(in.Extra) != 2 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		cnameRec, ok := in.Extra[0].(*dns.CNAME)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if cnameRec.Hdr.Name != "alias.service.consul." {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if cnameRec.Target != "web.service.consul." {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if cnameRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
+				cnameRec, ok := in.Extra[0].(*dns.CNAME)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if cnameRec.Hdr.Name != "alias.service.consul." {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if cnameRec.Target != "web.service.consul." {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if cnameRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
 
-		aRec, ok := in.Extra[1].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[1])
-		}
-		if aRec.Hdr.Name != "web.service.consul." {
-			t.Fatalf("Bad: %#v", in.Extra[1])
-		}
-		if aRec.A.String() != "127.0.0.1" {
-			t.Fatalf("Bad: %#v", in.Extra[1])
-		}
-		if aRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Extra[1])
-		}
+				aRec, ok := in.Extra[1].(*dns.A)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[1])
+				}
+				if aRec.Hdr.Name != "web.service.consul." {
+					t.Fatalf("Bad: %#v", in.Extra[1])
+				}
+				if aRec.A.String() != "127.0.0.1" {
+					t.Fatalf("Bad: %#v", in.Extra[1])
+				}
+				if aRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Extra[1])
+				}
+			}
+		})
 	}
 }
 
@@ -1071,94 +1125,98 @@ func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Address: "127.0.0.2",
-				Port:    12345,
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Address: "127.0.0.2",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"db.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"db.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != "7f000002.addr.dc1.consul." {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != "7f000002.addr.dc1.consul." {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
 
-		aRec, ok := in.Extra[0].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Name != "7f000002.addr.dc1.consul." {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.A.String() != "127.0.0.2" {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
+				aRec, ok := in.Extra[0].(*dns.A)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Name != "7f000002.addr.dc1.consul." {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.A.String() != "127.0.0.2" {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+			}
+		})
 	}
 }
 
@@ -1168,101 +1226,105 @@ func TestDNS_AltDomain_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		alt_domain = "test-domain"
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Address: "127.0.0.2",
-				Port:    12345,
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Address: "127.0.0.2",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query.
-	questions := []struct {
-		ask        string
-		wantDomain string
-	}{
-		{"db.service.consul.", "consul."},
-		{id + ".query.consul.", "consul."},
-		{"db.service.test-domain.", "test-domain."},
-		{id + ".query.test-domain.", "test-domain."},
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question.ask, dns.TypeSRV)
+			// Look up the service directly and via prepared query.
+			questions := []struct {
+				ask        string
+				wantDomain string
+			}{
+				{"db.service.consul.", "consul."},
+				{id + ".query.consul.", "consul."},
+				{"db.service.test-domain.", "test-domain."},
+				{id + ".query.test-domain.", "test-domain."},
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question.ask, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != "7f000002.addr.dc1."+question.wantDomain {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != "7f000002.addr.dc1."+question.wantDomain {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
 
-		aRec, ok := in.Extra[0].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Name != "7f000002.addr.dc1."+question.wantDomain {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.A.String() != "127.0.0.2" {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
+				aRec, ok := in.Extra[0].(*dns.A)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Name != "7f000002.addr.dc1."+question.wantDomain {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.A.String() != "127.0.0.2" {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+			}
+		})
 	}
 }
 
@@ -1280,106 +1342,110 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		               recursors = ["`+recursor.Addr+`"]
-		       `)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+		       `+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service whose address isn't an IP.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Address: "www.google.com",
-				Port:    12345,
-			},
-		}
+			// Register a node with a service whose address isn't an IP.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Address: "www.google.com",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	// Specify prepared query name containing "." to test
-	// since that is technically supported (though atypical).
-	var id string
-	preparedQueryName := "query.name.with.dots"
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: preparedQueryName,
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			// Specify prepared query name containing "." to test
+			// since that is technically supported (though atypical).
+			var id string
+			preparedQueryName := "query.name.with.dots"
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: preparedQueryName,
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"db.service.consul.",
-		id + ".query.consul.",
-		preparedQueryName + ".query.consul.",
-		fmt.Sprintf("_%s._tcp.query.consul.", id),
-		fmt.Sprintf("_%s._tcp.query.consul.", preparedQueryName),
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"db.service.consul.",
+				id + ".query.consul.",
+				preparedQueryName + ".query.consul.",
+				fmt.Sprintf("_%s._tcp.query.consul.", id),
+				fmt.Sprintf("_%s._tcp.query.consul.", preparedQueryName),
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != "www.google.com." {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != "www.google.com." {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
 
-		// Should have google CNAME
-		cnRec, ok := in.Extra[0].(*dns.CNAME)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if cnRec.Target != "google.com." {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
+				// Should have google CNAME
+				cnRec, ok := in.Extra[0].(*dns.CNAME)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if cnRec.Target != "google.com." {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
 
-		// Check we recursively resolve
-		aRec, ok := in.Extra[1].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[1])
-		}
-		if aRec.A.String() != "1.2.3.4" {
-			t.Fatalf("Bad: %s", aRec.A.String())
-		}
+				// Check we recursively resolve
+				aRec, ok := in.Extra[1].(*dns.A)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[1])
+				}
+				if aRec.A.String() != "1.2.3.4" {
+					t.Fatalf("Bad: %s", aRec.A.String())
+				}
+			}
+		})
 	}
 }
 
@@ -1389,94 +1455,98 @@ func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Address: "2607:20:4005:808::200e",
-				Port:    12345,
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Address: "2607:20:4005:808::200e",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"db.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"db.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != "2607002040050808000000000000200e.addr.dc1.consul." {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != "2607002040050808000000000000200e.addr.dc1.consul." {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
 
-		aRec, ok := in.Extra[0].(*dns.AAAA)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Name != "2607002040050808000000000000200e.addr.dc1.consul." {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.AAAA.String() != "2607:20:4005:808::200e" {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
+				aRec, ok := in.Extra[0].(*dns.AAAA)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Name != "2607002040050808000000000000200e.addr.dc1.consul." {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.AAAA.String() != "2607:20:4005:808::200e" {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+			}
+		})
 	}
 }
 
@@ -1486,101 +1556,105 @@ func TestDNS_AltDomain_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		alt_domain = "test-domain"
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Address: "2607:20:4005:808::200e",
-				Port:    12345,
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Address: "2607:20:4005:808::200e",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query.
-	questions := []struct {
-		ask  string
-		want string
-	}{
-		{"db.service.consul.", "2607002040050808000000000000200e.addr.dc1.consul."},
-		{"db.service.test-domain.", "2607002040050808000000000000200e.addr.dc1.test-domain."},
-		{id + ".query.consul.", "2607002040050808000000000000200e.addr.dc1.consul."},
-		{id + ".query.test-domain.", "2607002040050808000000000000200e.addr.dc1.test-domain."},
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question.ask, dns.TypeSRV)
+			// Look up the service directly and via prepared query.
+			questions := []struct {
+				ask  string
+				want string
+			}{
+				{"db.service.consul.", "2607002040050808000000000000200e.addr.dc1.consul."},
+				{"db.service.test-domain.", "2607002040050808000000000000200e.addr.dc1.test-domain."},
+				{id + ".query.consul.", "2607002040050808000000000000200e.addr.dc1.consul."},
+				{id + ".query.test-domain.", "2607002040050808000000000000200e.addr.dc1.test-domain."},
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question.ask, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != question.want {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != question.want {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
 
-		aRec, ok := in.Extra[0].(*dns.AAAA)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Name != question.want {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.AAAA.String() != "2607:20:4005:808::200e" {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
+				aRec, ok := in.Extra[0].(*dns.AAAA)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Name != question.want {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.AAAA.String() != "2607:20:4005:808::200e" {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+			}
+		})
 	}
 }
 
@@ -1590,207 +1664,211 @@ func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 	}
 
 	t.Parallel()
-	a1 := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a1 := NewTestAgent(t, `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
-	`)
-	defer a1.Shutdown()
+	`+experimentsHCL)
+			defer a1.Shutdown()
 
-	a2 := NewTestAgent(t, `
+			a2 := NewTestAgent(t, `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
-	`)
-	defer a2.Shutdown()
+	`+experimentsHCL)
+			defer a2.Shutdown()
 
-	// Join WAN cluster
-	addr := fmt.Sprintf("127.0.0.1:%d", a1.Config.SerfPortWAN)
-	_, err := a2.JoinWAN([]string{addr})
-	require.NoError(t, err)
-	retry.Run(t, func(r *retry.R) {
-		require.Len(r, a1.WANMembers(), 2)
-		require.Len(r, a2.WANMembers(), 2)
-	})
-
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc2",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		require.NoError(t, a2.RPC(context.Background(), "PreparedQuery.Apply", args, &id))
-	}
-
-	type testCase struct {
-		nodeTaggedAddresses    map[string]string
-		serviceAddress         string
-		serviceTaggedAddresses map[string]structs.ServiceAddress
-
-		dnsAddr string
-
-		expectedPort    uint16
-		expectedAddress string
-		expectedARRName string
-	}
-
-	cases := map[string]testCase{
-		"node-addr-from-dc1": {
-			dnsAddr:         a1.config.DNSAddrs[0].String(),
-			expectedPort:    8080,
-			expectedAddress: "127.0.0.1",
-			expectedARRName: "foo.node.dc2.consul.",
-		},
-		"node-wan-from-dc1": {
-			dnsAddr: a1.config.DNSAddrs[0].String(),
-			nodeTaggedAddresses: map[string]string{
-				"wan": "127.0.0.2",
-			},
-			expectedPort:    8080,
-			expectedAddress: "127.0.0.2",
-			expectedARRName: "7f000002.addr.dc2.consul.",
-		},
-		"service-addr-from-dc1": {
-			dnsAddr: a1.config.DNSAddrs[0].String(),
-			nodeTaggedAddresses: map[string]string{
-				"wan": "127.0.0.2",
-			},
-			serviceAddress:  "10.0.1.1",
-			expectedPort:    8080,
-			expectedAddress: "10.0.1.1",
-			expectedARRName: "0a000101.addr.dc2.consul.",
-		},
-		"service-wan-from-dc1": {
-			dnsAddr: a1.config.DNSAddrs[0].String(),
-			nodeTaggedAddresses: map[string]string{
-				"wan": "127.0.0.2",
-			},
-			serviceAddress: "10.0.1.1",
-			serviceTaggedAddresses: map[string]structs.ServiceAddress{
-				"wan": {
-					Address: "198.18.0.1",
-					Port:    80,
-				},
-			},
-			expectedPort:    80,
-			expectedAddress: "198.18.0.1",
-			expectedARRName: "c6120001.addr.dc2.consul.",
-		},
-		"node-addr-from-dc2": {
-			dnsAddr:         a2.config.DNSAddrs[0].String(),
-			expectedPort:    8080,
-			expectedAddress: "127.0.0.1",
-			expectedARRName: "foo.node.dc2.consul.",
-		},
-		"node-wan-from-dc2": {
-			dnsAddr: a2.config.DNSAddrs[0].String(),
-			nodeTaggedAddresses: map[string]string{
-				"wan": "127.0.0.2",
-			},
-			expectedPort:    8080,
-			expectedAddress: "127.0.0.1",
-			expectedARRName: "foo.node.dc2.consul.",
-		},
-		"service-addr-from-dc2": {
-			dnsAddr: a2.config.DNSAddrs[0].String(),
-			nodeTaggedAddresses: map[string]string{
-				"wan": "127.0.0.2",
-			},
-			serviceAddress:  "10.0.1.1",
-			expectedPort:    8080,
-			expectedAddress: "10.0.1.1",
-			expectedARRName: "0a000101.addr.dc2.consul.",
-		},
-		"service-wan-from-dc2": {
-			dnsAddr: a2.config.DNSAddrs[0].String(),
-			nodeTaggedAddresses: map[string]string{
-				"wan": "127.0.0.2",
-			},
-			serviceAddress: "10.0.1.1",
-			serviceTaggedAddresses: map[string]structs.ServiceAddress{
-				"wan": {
-					Address: "198.18.0.1",
-					Port:    80,
-				},
-			},
-			expectedPort:    8080,
-			expectedAddress: "10.0.1.1",
-			expectedARRName: "0a000101.addr.dc2.consul.",
-		},
-	}
-
-	for name, tc := range cases {
-		name := name
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			// Register a remote node with a service. This is in a retry since we
-			// need the datacenter to have a route which takes a little more time
-			// beyond the join, and we don't have direct access to the router here.
+			// Join WAN cluster
+			addr := fmt.Sprintf("127.0.0.1:%d", a1.Config.SerfPortWAN)
+			_, err := a2.JoinWAN([]string{addr})
+			require.NoError(t, err)
 			retry.Run(t, func(r *retry.R) {
-				args := &structs.RegisterRequest{
-					Datacenter:      "dc2",
-					Node:            "foo",
-					Address:         "127.0.0.1",
-					TaggedAddresses: tc.nodeTaggedAddresses,
-					Service: &structs.NodeService{
-						Service:         "db",
-						Address:         tc.serviceAddress,
-						Port:            8080,
-						TaggedAddresses: tc.serviceTaggedAddresses,
-					},
-				}
-
-				var out struct{}
-				require.NoError(r, a2.RPC(context.Background(), "Catalog.Register", args, &out))
+				require.Len(r, a1.WANMembers(), 2)
+				require.Len(r, a2.WANMembers(), 2)
 			})
 
-			// Look up the SRV record via service and prepared query.
-			questions := []string{
-				"db.service.dc2.consul.",
-				id + ".query.dc2.consul.",
-			}
-			for _, question := range questions {
-				m := new(dns.Msg)
-				m.SetQuestion(question, dns.TypeSRV)
-
-				c := new(dns.Client)
-
-				addr := tc.dnsAddr
-				in, _, err := c.Exchange(m, addr)
-				require.NoError(t, err)
-				require.Len(t, in.Answer, 1)
-				srvRec, ok := in.Answer[0].(*dns.SRV)
-				require.True(t, ok, "Bad: %#v", in.Answer[0])
-				require.Equal(t, tc.expectedPort, srvRec.Port)
-
-				aRec, ok := in.Extra[0].(*dns.A)
-				require.True(t, ok, "Bad: %#v", in.Extra[0])
-				require.Equal(t, tc.expectedARRName, aRec.Hdr.Name)
-				require.Equal(t, tc.expectedAddress, aRec.A.String())
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc2",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				require.NoError(t, a2.RPC(context.Background(), "PreparedQuery.Apply", args, &id))
 			}
 
-			// Also check the A record directly
-			for _, question := range questions {
-				m := new(dns.Msg)
-				m.SetQuestion(question, dns.TypeA)
+			type testCase struct {
+				nodeTaggedAddresses    map[string]string
+				serviceAddress         string
+				serviceTaggedAddresses map[string]structs.ServiceAddress
 
-				c := new(dns.Client)
-				addr := tc.dnsAddr
-				in, _, err := c.Exchange(m, addr)
-				require.NoError(t, err)
-				require.Len(t, in.Answer, 1)
+				dnsAddr string
 
-				aRec, ok := in.Answer[0].(*dns.A)
-				require.True(t, ok, "Bad: %#v", in.Answer[0])
-				require.Equal(t, question, aRec.Hdr.Name)
-				require.Equal(t, tc.expectedAddress, aRec.A.String())
+				expectedPort    uint16
+				expectedAddress string
+				expectedARRName string
+			}
+
+			cases := map[string]testCase{
+				"node-addr-from-dc1": {
+					dnsAddr:         a1.config.DNSAddrs[0].String(),
+					expectedPort:    8080,
+					expectedAddress: "127.0.0.1",
+					expectedARRName: "foo.node.dc2.consul.",
+				},
+				"node-wan-from-dc1": {
+					dnsAddr: a1.config.DNSAddrs[0].String(),
+					nodeTaggedAddresses: map[string]string{
+						"wan": "127.0.0.2",
+					},
+					expectedPort:    8080,
+					expectedAddress: "127.0.0.2",
+					expectedARRName: "7f000002.addr.dc2.consul.",
+				},
+				"service-addr-from-dc1": {
+					dnsAddr: a1.config.DNSAddrs[0].String(),
+					nodeTaggedAddresses: map[string]string{
+						"wan": "127.0.0.2",
+					},
+					serviceAddress:  "10.0.1.1",
+					expectedPort:    8080,
+					expectedAddress: "10.0.1.1",
+					expectedARRName: "0a000101.addr.dc2.consul.",
+				},
+				"service-wan-from-dc1": {
+					dnsAddr: a1.config.DNSAddrs[0].String(),
+					nodeTaggedAddresses: map[string]string{
+						"wan": "127.0.0.2",
+					},
+					serviceAddress: "10.0.1.1",
+					serviceTaggedAddresses: map[string]structs.ServiceAddress{
+						"wan": {
+							Address: "198.18.0.1",
+							Port:    80,
+						},
+					},
+					expectedPort:    80,
+					expectedAddress: "198.18.0.1",
+					expectedARRName: "c6120001.addr.dc2.consul.",
+				},
+				"node-addr-from-dc2": {
+					dnsAddr:         a2.config.DNSAddrs[0].String(),
+					expectedPort:    8080,
+					expectedAddress: "127.0.0.1",
+					expectedARRName: "foo.node.dc2.consul.",
+				},
+				"node-wan-from-dc2": {
+					dnsAddr: a2.config.DNSAddrs[0].String(),
+					nodeTaggedAddresses: map[string]string{
+						"wan": "127.0.0.2",
+					},
+					expectedPort:    8080,
+					expectedAddress: "127.0.0.1",
+					expectedARRName: "foo.node.dc2.consul.",
+				},
+				"service-addr-from-dc2": {
+					dnsAddr: a2.config.DNSAddrs[0].String(),
+					nodeTaggedAddresses: map[string]string{
+						"wan": "127.0.0.2",
+					},
+					serviceAddress:  "10.0.1.1",
+					expectedPort:    8080,
+					expectedAddress: "10.0.1.1",
+					expectedARRName: "0a000101.addr.dc2.consul.",
+				},
+				"service-wan-from-dc2": {
+					dnsAddr: a2.config.DNSAddrs[0].String(),
+					nodeTaggedAddresses: map[string]string{
+						"wan": "127.0.0.2",
+					},
+					serviceAddress: "10.0.1.1",
+					serviceTaggedAddresses: map[string]structs.ServiceAddress{
+						"wan": {
+							Address: "198.18.0.1",
+							Port:    80,
+						},
+					},
+					expectedPort:    8080,
+					expectedAddress: "10.0.1.1",
+					expectedARRName: "0a000101.addr.dc2.consul.",
+				},
+			}
+
+			for name, tc := range cases {
+				name := name
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					// Register a remote node with a service. This is in a retry since we
+					// need the datacenter to have a route which takes a little more time
+					// beyond the join, and we don't have direct access to the router here.
+					retry.Run(t, func(r *retry.R) {
+						args := &structs.RegisterRequest{
+							Datacenter:      "dc2",
+							Node:            "foo",
+							Address:         "127.0.0.1",
+							TaggedAddresses: tc.nodeTaggedAddresses,
+							Service: &structs.NodeService{
+								Service:         "db",
+								Address:         tc.serviceAddress,
+								Port:            8080,
+								TaggedAddresses: tc.serviceTaggedAddresses,
+							},
+						}
+
+						var out struct{}
+						require.NoError(r, a2.RPC(context.Background(), "Catalog.Register", args, &out))
+					})
+
+					// Look up the SRV record via service and prepared query.
+					questions := []string{
+						"db.service.dc2.consul.",
+						id + ".query.dc2.consul.",
+					}
+					for _, question := range questions {
+						m := new(dns.Msg)
+						m.SetQuestion(question, dns.TypeSRV)
+
+						c := new(dns.Client)
+
+						addr := tc.dnsAddr
+						in, _, err := c.Exchange(m, addr)
+						require.NoError(t, err)
+						require.Len(t, in.Answer, 1)
+						srvRec, ok := in.Answer[0].(*dns.SRV)
+						require.True(t, ok, "Bad: %#v", in.Answer[0])
+						require.Equal(t, tc.expectedPort, srvRec.Port)
+
+						aRec, ok := in.Extra[0].(*dns.A)
+						require.True(t, ok, "Bad: %#v", in.Extra[0])
+						require.Equal(t, tc.expectedARRName, aRec.Hdr.Name)
+						require.Equal(t, tc.expectedAddress, aRec.A.String())
+					}
+
+					// Also check the A record directly
+					for _, question := range questions {
+						m := new(dns.Msg)
+						m.SetQuestion(question, dns.TypeA)
+
+						c := new(dns.Client)
+						addr := tc.dnsAddr
+						in, _, err := c.Exchange(m, addr)
+						require.NoError(t, err)
+						require.Len(t, in.Answer, 1)
+
+						aRec, ok := in.Answer[0].(*dns.A)
+						require.True(t, ok, "Bad: %#v", in.Answer[0])
+						require.Equal(t, question, aRec.Hdr.Name)
+						require.Equal(t, tc.expectedAddress, aRec.A.String())
+					}
+				})
 			}
 		})
 	}
@@ -1819,74 +1897,78 @@ func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 	}
 	for _, tst := range tests {
 		t.Run(fmt.Sprintf("A lookup %v", tst.name), func(t *testing.T) {
-			a := NewTestAgent(t, tst.config)
-			defer a.Shutdown()
-			testrpc.WaitForLeader(t, a.RPC, "dc1")
+			for name, experimentsHCL := range versionHCL {
+				t.Run(name, func(t *testing.T) {
+					a := NewTestAgent(t, fmt.Sprintf("%s %s", tst.config, experimentsHCL))
+					defer a.Shutdown()
+					testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-			// Register a node with a service.
-			{
-				args := &structs.RegisterRequest{
-					Datacenter: "dc1",
-					Node:       "foo",
-					Address:    "127.0.0.1",
-					Service: &structs.NodeService{
-						Service: "Db",
-						Tags:    []string{"Primary"},
-						Port:    12345,
-					},
-				}
+					// Register a node with a service.
+					{
+						args := &structs.RegisterRequest{
+							Datacenter: "dc1",
+							Node:       "foo",
+							Address:    "127.0.0.1",
+							Service: &structs.NodeService{
+								Service: "Db",
+								Tags:    []string{"Primary"},
+								Port:    12345,
+							},
+						}
 
-				var out struct{}
-				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-					t.Fatalf("err: %v", err)
-				}
-			}
-
-			// Register an equivalent prepared query, as well as a name.
-			var id string
-			{
-				args := &structs.PreparedQueryRequest{
-					Datacenter: "dc1",
-					Op:         structs.PreparedQueryCreate,
-					Query: &structs.PreparedQuery{
-						Name: "somequery",
-						Service: structs.ServiceQuery{
-							Service: "db",
-						},
-					},
-				}
-				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-					t.Fatalf("err: %v", err)
-				}
-			}
-
-			// Try some variations to make sure case doesn't matter.
-			questions := []string{
-				"primary.Db.service.consul.",
-				"primary.db.service.consul.",
-				"pRIMARY.dB.service.consul.",
-				"PRIMARY.dB.service.consul.",
-				"db.service.consul.",
-				"DB.service.consul.",
-				"Db.service.consul.",
-				"somequery.query.consul.",
-				"SomeQuery.query.consul.",
-				"SOMEQUERY.query.consul.",
-			}
-
-			for _, question := range questions {
-				m := new(dns.Msg)
-				m.SetQuestion(question, dns.TypeSRV)
-
-				c := new(dns.Client)
-				retry.Run(t, func(r *retry.R) {
-					in, _, err := c.Exchange(m, a.DNSAddr())
-					if err != nil {
-						r.Fatalf("err: %v", err)
+						var out struct{}
+						if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+							t.Fatalf("err: %v", err)
+						}
 					}
 
-					if len(in.Answer) != 1 {
-						r.Fatalf("question %v, empty lookup: %#v", question, in)
+					// Register an equivalent prepared query, as well as a name.
+					var id string
+					{
+						args := &structs.PreparedQueryRequest{
+							Datacenter: "dc1",
+							Op:         structs.PreparedQueryCreate,
+							Query: &structs.PreparedQuery{
+								Name: "somequery",
+								Service: structs.ServiceQuery{
+									Service: "db",
+								},
+							},
+						}
+						if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+							t.Fatalf("err: %v", err)
+						}
+					}
+
+					// Try some variations to make sure case doesn't matter.
+					questions := []string{
+						"primary.Db.service.consul.",
+						"primary.db.service.consul.",
+						"pRIMARY.dB.service.consul.",
+						"PRIMARY.dB.service.consul.",
+						"db.service.consul.",
+						"DB.service.consul.",
+						"Db.service.consul.",
+						"somequery.query.consul.",
+						"SomeQuery.query.consul.",
+						"SOMEQUERY.query.consul.",
+					}
+
+					for _, question := range questions {
+						m := new(dns.Msg)
+						m.SetQuestion(question, dns.TypeSRV)
+
+						c := new(dns.Client)
+						retry.Run(t, func(r *retry.R) {
+							in, _, err := c.Exchange(m, a.DNSAddr())
+							if err != nil {
+								r.Fatalf("err: %v", err)
+							}
+
+							if len(in.Answer) != 1 {
+								r.Fatalf("question %v, empty lookup: %#v", question, in)
+							}
+						})
 					}
 				})
 			}
@@ -1900,73 +1982,77 @@ func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register node
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "foo",
-		Address:    "127.0.0.1",
-		Service: &structs.NodeService{
-			Service: "db",
-			Tags:    []string{"v1.primary"},
-			Port:    12345,
-		},
-	}
+			// Register node
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "foo",
+				Address:    "127.0.0.1",
+				Service: &structs.NodeService{
+					Service: "db",
+					Tags:    []string{"v1.primary"},
+					Port:    12345,
+				},
+			}
 
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	m1 := new(dns.Msg)
-	m1.SetQuestion("v1.primary2.db.service.consul.", dns.TypeSRV)
+			m1 := new(dns.Msg)
+			m1.SetQuestion("v1.primary2.db.service.consul.", dns.TypeSRV)
 
-	c1 := new(dns.Client)
-	in, _, err := c1.Exchange(m1, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c1 := new(dns.Client)
+			in, _, err := c1.Exchange(m1, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 0 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 0 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("v1.primary.db.service.consul.", dns.TypeSRV)
+			m := new(dns.Msg)
+			m.SetQuestion("v1.primary.db.service.consul.", dns.TypeSRV)
 
-	c := new(dns.Client)
-	in, _, err = c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err = c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 1 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	srvRec, ok := in.Answer[0].(*dns.SRV)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if srvRec.Port != 12345 {
-		t.Fatalf("Bad: %#v", srvRec)
-	}
-	if srvRec.Target != "foo.node.dc1.consul." {
-		t.Fatalf("Bad: %#v", srvRec)
-	}
+			srvRec, ok := in.Answer[0].(*dns.SRV)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if srvRec.Port != 12345 {
+				t.Fatalf("Bad: %#v", srvRec)
+			}
+			if srvRec.Target != "foo.node.dc1.consul." {
+				t.Fatalf("Bad: %#v", srvRec)
+			}
 
-	aRec, ok := in.Extra[0].(*dns.A)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Extra[0])
-	}
-	if aRec.Hdr.Name != "foo.node.dc1.consul." {
-		t.Fatalf("Bad: %#v", in.Extra[0])
-	}
-	if aRec.A.String() != "127.0.0.1" {
-		t.Fatalf("Bad: %#v", in.Extra[0])
+			aRec, ok := in.Extra[0].(*dns.A)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Extra[0])
+			}
+			if aRec.Hdr.Name != "foo.node.dc1.consul." {
+				t.Fatalf("Bad: %#v", in.Extra[0])
+			}
+			if aRec.A.String() != "127.0.0.1" {
+				t.Fatalf("Bad: %#v", in.Extra[0])
+			}
+		})
 	}
 }
 
@@ -1976,80 +2062,84 @@ func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Port:    12345,
-			},
-		}
+			// Register a node with a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register a prepared query with a period in the name.
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "some.query.we.like",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
+			// Register a prepared query with a period in the name.
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "some.query.we.like",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
 
-		var id string
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var id string
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	m := new(dns.Msg)
-	m.SetQuestion("some.query.we.like.query.consul.", dns.TypeSRV)
+			m := new(dns.Msg)
+			m.SetQuestion("some.query.we.like.query.consul.", dns.TypeSRV)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 
-	if len(in.Answer) != 1 {
-		t.Fatalf("Bad: %#v", in)
-	}
+			if len(in.Answer) != 1 {
+				t.Fatalf("Bad: %#v", in)
+			}
 
-	srvRec, ok := in.Answer[0].(*dns.SRV)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Answer[0])
-	}
-	if srvRec.Port != 12345 {
-		t.Fatalf("Bad: %#v", srvRec)
-	}
-	if srvRec.Target != "foo.node.dc1.consul." {
-		t.Fatalf("Bad: %#v", srvRec)
-	}
+			srvRec, ok := in.Answer[0].(*dns.SRV)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Answer[0])
+			}
+			if srvRec.Port != 12345 {
+				t.Fatalf("Bad: %#v", srvRec)
+			}
+			if srvRec.Target != "foo.node.dc1.consul." {
+				t.Fatalf("Bad: %#v", srvRec)
+			}
 
-	aRec, ok := in.Extra[0].(*dns.A)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Extra[0])
-	}
-	if aRec.Hdr.Name != "foo.node.dc1.consul." {
-		t.Fatalf("Bad: %#v", in.Extra[0])
-	}
-	if aRec.A.String() != "127.0.0.1" {
-		t.Fatalf("Bad: %#v", in.Extra[0])
+			aRec, ok := in.Extra[0].(*dns.A)
+			if !ok {
+				t.Fatalf("Bad: %#v", in.Extra[0])
+			}
+			if aRec.Hdr.Name != "foo.node.dc1.consul." {
+				t.Fatalf("Bad: %#v", in.Extra[0])
+			}
+			if aRec.A.String() != "127.0.0.1" {
+				t.Fatalf("Bad: %#v", in.Extra[0])
+			}
+		})
 	}
 }
 
@@ -2059,104 +2149,108 @@ func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a single node with multiple instances of a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-		}
+			// Register a single node with multiple instances of a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args = &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				ID:      "db2",
-				Service: "db",
-				Tags:    []string{"replica"},
-				Port:    12345,
-			},
-		}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				args = &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						ID:      "db2",
+						Service: "db",
+						Tags:    []string{"replica"},
+						Port:    12345,
+					},
+				}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args = &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				ID:      "db3",
-				Service: "db",
-				Tags:    []string{"replica"},
-				Port:    12346,
-			},
-		}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				args = &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						ID:      "db3",
+						Service: "db",
+						Tags:    []string{"replica"},
+						Port:    12346,
+					},
+				}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query, make sure only
-	// one IP is returned.
-	questions := []string{
-		"db.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeANY)
+			// Look up the service directly and via prepared query, make sure only
+			// one IP is returned.
+			questions := []string{
+				"db.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeANY)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		aRec, ok := in.Answer[0].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if aRec.A.String() != "127.0.0.1" {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				aRec, ok := in.Answer[0].(*dns.A)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if aRec.A.String() != "127.0.0.1" {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+			}
+		})
 	}
 }
 
@@ -2166,132 +2260,136 @@ func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a single node with multiple instances of a service.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-		}
+			// Register a single node with multiple instances of a service.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args = &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				ID:      "db2",
-				Service: "db",
-				Tags:    []string{"replica"},
-				Port:    12345,
-			},
-		}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				args = &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						ID:      "db2",
+						Service: "db",
+						Tags:    []string{"replica"},
+						Port:    12345,
+					},
+				}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args = &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				ID:      "db3",
-				Service: "db",
-				Tags:    []string{"replica"},
-				Port:    12346,
-			},
-		}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				args = &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						ID:      "db3",
+						Service: "db",
+						Tags:    []string{"replica"},
+						Port:    12346,
+					},
+				}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query, make sure only
-	// one IP is returned and two unique ports are returned.
-	questions := []string{
-		"db.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+			// Look up the service directly and via prepared query, make sure only
+			// one IP is returned and two unique ports are returned.
+			questions := []string{
+				"db.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		if len(in.Answer) != 2 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if len(in.Answer) != 2 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 && srvRec.Port != 12346 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != "foo.node.dc1.consul." {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 && srvRec.Port != 12346 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != "foo.node.dc1.consul." {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
 
-		srvRec, ok = in.Answer[1].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[1])
-		}
-		if srvRec.Port != 12346 && srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Port == in.Answer[0].(*dns.SRV).Port {
-			t.Fatalf("should be a different port")
-		}
-		if srvRec.Target != "foo.node.dc1.consul." {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
+				srvRec, ok = in.Answer[1].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[1])
+				}
+				if srvRec.Port != 12346 && srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Port == in.Answer[0].(*dns.SRV).Port {
+					t.Fatalf("should be a different port")
+				}
+				if srvRec.Target != "foo.node.dc1.consul." {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
 
-		aRec, ok := in.Extra[0].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Name != "foo.node.dc1.consul." {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.A.String() != "127.0.0.1" {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
+				aRec, ok := in.Extra[0].(*dns.A)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Name != "foo.node.dc1.consul." {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.A.String() != "127.0.0.1" {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+			}
+		})
 	}
 }
 
@@ -2301,157 +2399,161 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register nodes with health checks in various states.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-			Check: &structs.HealthCheck{
-				CheckID: "serf",
-				Name:    "serf",
-				Status:  api.HealthCritical,
-			},
-		}
+			// Register nodes with health checks in various states.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+					Check: &structs.HealthCheck{
+						CheckID: "serf",
+						Name:    "serf",
+						Status:  api.HealthCritical,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args2 := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "bar",
-			Address:    "127.0.0.2",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-			Check: &structs.HealthCheck{
-				CheckID: "serf",
-				Name:    "serf",
-				Status:  api.HealthCritical,
-			},
-		}
-		if err := a.RPC(context.Background(), "Catalog.Register", args2, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				args2 := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "bar",
+					Address:    "127.0.0.2",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+					Check: &structs.HealthCheck{
+						CheckID: "serf",
+						Name:    "serf",
+						Status:  api.HealthCritical,
+					},
+				}
+				if err := a.RPC(context.Background(), "Catalog.Register", args2, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args3 := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "bar",
-			Address:    "127.0.0.2",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-			Check: &structs.HealthCheck{
-				CheckID:   "db",
-				Name:      "db",
-				ServiceID: "db",
-				Status:    api.HealthCritical,
-			},
-		}
-		if err := a.RPC(context.Background(), "Catalog.Register", args3, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				args3 := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "bar",
+					Address:    "127.0.0.2",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+					Check: &structs.HealthCheck{
+						CheckID:   "db",
+						Name:      "db",
+						ServiceID: "db",
+						Status:    api.HealthCritical,
+					},
+				}
+				if err := a.RPC(context.Background(), "Catalog.Register", args3, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args4 := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "baz",
-			Address:    "127.0.0.3",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-		}
-		if err := a.RPC(context.Background(), "Catalog.Register", args4, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				args4 := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "baz",
+					Address:    "127.0.0.3",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+				}
+				if err := a.RPC(context.Background(), "Catalog.Register", args4, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args5 := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "quux",
-			Address:    "127.0.0.4",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-			Check: &structs.HealthCheck{
-				CheckID:   "db",
-				Name:      "db",
-				ServiceID: "db",
-				Status:    api.HealthWarning,
-			},
-		}
-		if err := a.RPC(context.Background(), "Catalog.Register", args5, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				args5 := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "quux",
+					Address:    "127.0.0.4",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+					Check: &structs.HealthCheck{
+						CheckID:   "db",
+						Name:      "db",
+						ServiceID: "db",
+						Status:    api.HealthWarning,
+					},
+				}
+				if err := a.RPC(context.Background(), "Catalog.Register", args5, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"db.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeANY)
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"db.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeANY)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		// Only 4 and 5 are not failing, so we should get 2 answers
-		if len(in.Answer) != 2 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				// Only 4 and 5 are not failing, so we should get 2 answers
+				if len(in.Answer) != 2 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		ips := make(map[string]bool)
-		for _, resp := range in.Answer {
-			aRec := resp.(*dns.A)
-			ips[aRec.A.String()] = true
-		}
+				ips := make(map[string]bool)
+				for _, resp := range in.Answer {
+					aRec := resp.(*dns.A)
+					ips[aRec.A.String()] = true
+				}
 
-		if !ips["127.0.0.3"] {
-			t.Fatalf("Bad: %#v should contain 127.0.0.3 (state healthy)", in)
-		}
-		if !ips["127.0.0.4"] {
-			t.Fatalf("Bad: %#v should contain 127.0.0.4 (state warning)", in)
-		}
+				if !ips["127.0.0.3"] {
+					t.Fatalf("Bad: %#v should contain 127.0.0.3 (state healthy)", in)
+				}
+				if !ips["127.0.0.4"] {
+					t.Fatalf("Bad: %#v should contain 127.0.0.4 (state warning)", in)
+				}
+			}
+		})
 	}
 }
 
@@ -2461,114 +2563,118 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register nodes with all health checks in a critical state.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-			Check: &structs.HealthCheck{
-				CheckID: "serf",
-				Name:    "serf",
-				Status:  api.HealthCritical,
-			},
-		}
+			// Register nodes with all health checks in a critical state.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+					Check: &structs.HealthCheck{
+						CheckID: "serf",
+						Name:    "serf",
+						Status:  api.HealthCritical,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args2 := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "bar",
-			Address:    "127.0.0.2",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-			Check: &structs.HealthCheck{
-				CheckID: "serf",
-				Name:    "serf",
-				Status:  api.HealthCritical,
-			},
-		}
-		if err := a.RPC(context.Background(), "Catalog.Register", args2, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				args2 := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "bar",
+					Address:    "127.0.0.2",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+					Check: &structs.HealthCheck{
+						CheckID: "serf",
+						Name:    "serf",
+						Status:  api.HealthCritical,
+					},
+				}
+				if err := a.RPC(context.Background(), "Catalog.Register", args2, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args3 := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "bar",
-			Address:    "127.0.0.2",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-			Check: &structs.HealthCheck{
-				CheckID:   "db",
-				Name:      "db",
-				ServiceID: "db",
-				Status:    api.HealthCritical,
-			},
-		}
-		if err := a.RPC(context.Background(), "Catalog.Register", args3, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				args3 := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "bar",
+					Address:    "127.0.0.2",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+					Check: &structs.HealthCheck{
+						CheckID:   "db",
+						Name:      "db",
+						ServiceID: "db",
+						Status:    api.HealthCritical,
+					},
+				}
+				if err := a.RPC(context.Background(), "Catalog.Register", args3, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "db",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "db",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"db.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeANY)
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"db.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeANY)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		// All 3 are failing, so we should get 0 answers and an NXDOMAIN response
-		if len(in.Answer) != 0 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				// All 3 are failing, so we should get 0 answers and an NXDOMAIN response
+				if len(in.Answer) != 0 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		if in.Rcode != dns.RcodeNameError {
-			t.Fatalf("Bad: %#v", in)
-		}
+				if in.Rcode != dns.RcodeNameError {
+					t.Fatalf("Bad: %#v", in)
+				}
+			}
+		})
 	}
 }
 
@@ -2578,145 +2684,149 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		dns_config {
 			only_passing = true
 		}
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register nodes with health checks in various states.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "foo",
-			Address:    "127.0.0.1",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-			Check: &structs.HealthCheck{
-				CheckID:   "db",
-				Name:      "db",
-				ServiceID: "db",
-				Status:    api.HealthPassing,
-			},
-		}
+			// Register nodes with health checks in various states.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "foo",
+					Address:    "127.0.0.1",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+					Check: &structs.HealthCheck{
+						CheckID:   "db",
+						Name:      "db",
+						ServiceID: "db",
+						Status:    api.HealthPassing,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args2 := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "bar",
-			Address:    "127.0.0.2",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-			Check: &structs.HealthCheck{
-				CheckID:   "db",
-				Name:      "db",
-				ServiceID: "db",
-				Status:    api.HealthWarning,
-			},
-		}
+				args2 := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "bar",
+					Address:    "127.0.0.2",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+					Check: &structs.HealthCheck{
+						CheckID:   "db",
+						Name:      "db",
+						ServiceID: "db",
+						Status:    api.HealthWarning,
+					},
+				}
 
-		if err := a.RPC(context.Background(), "Catalog.Register", args2, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				if err := a.RPC(context.Background(), "Catalog.Register", args2, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		args3 := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "baz",
-			Address:    "127.0.0.3",
-			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-			Check: &structs.HealthCheck{
-				CheckID:   "db",
-				Name:      "db",
-				ServiceID: "db",
-				Status:    api.HealthCritical,
-			},
-		}
+				args3 := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "baz",
+					Address:    "127.0.0.3",
+					Service: &structs.NodeService{
+						Service: "db",
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+					Check: &structs.HealthCheck{
+						CheckID:   "db",
+						Name:      "db",
+						ServiceID: "db",
+						Status:    api.HealthCritical,
+					},
+				}
 
-		if err := a.RPC(context.Background(), "Catalog.Register", args3, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				if err := a.RPC(context.Background(), "Catalog.Register", args3, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
+
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service:     "db",
+							OnlyPassing: true,
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
+
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"db.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeANY)
+
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
+
+				// Only 1 is passing, so we should only get 1 answer
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
+
+				resp := in.Answer[0]
+				aRec := resp.(*dns.A)
+
+				if aRec.A.String() != "127.0.0.1" {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+			}
+
+			newCfg := *a.Config
+			newCfg.DNSOnlyPassing = false
+			err := a.reloadConfigInternal(&newCfg)
+			require.NoError(t, err)
+
+			// only_passing is now false. we should now get two nodes
+			m := new(dns.Msg)
+			m.SetQuestion("db.service.consul.", dns.TypeANY)
+
+			c := new(dns.Client)
+			in, _, err := c.Exchange(m, a.DNSAddr())
+			require.NoError(t, err)
+
+			require.Equal(t, 2, len(in.Answer))
+			ips := []string{in.Answer[0].(*dns.A).A.String(), in.Answer[1].(*dns.A).A.String()}
+			sort.Strings(ips)
+			require.Equal(t, []string{"127.0.0.1", "127.0.0.2"}, ips)
+		})
 	}
-
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service:     "db",
-					OnlyPassing: true,
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"db.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeANY)
-
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		// Only 1 is passing, so we should only get 1 answer
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
-
-		resp := in.Answer[0]
-		aRec := resp.(*dns.A)
-
-		if aRec.A.String() != "127.0.0.1" {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-	}
-
-	newCfg := *a.Config
-	newCfg.DNSOnlyPassing = false
-	err := a.reloadConfigInternal(&newCfg)
-	require.NoError(t, err)
-
-	// only_passing is now false. we should now get two nodes
-	m := new(dns.Msg)
-	m.SetQuestion("db.service.consul.", dns.TypeANY)
-
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m, a.DNSAddr())
-	require.NoError(t, err)
-
-	require.Equal(t, 2, len(in.Answer))
-	ips := []string{in.Answer[0].(*dns.A).A.String(), in.Answer[1].(*dns.A).A.String()}
-	sort.Strings(ips)
-	require.Equal(t, []string{"127.0.0.1", "127.0.0.2"}, ips)
 }
 
 func TestDNS_ServiceLookup_Randomize(t *testing.T) {
@@ -2725,92 +2835,96 @@ func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a large number of nodes.
-	for i := 0; i < generateNumNodes; i++ {
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       fmt.Sprintf("foo%d", i),
-			Address:    fmt.Sprintf("127.0.0.%d", i+1),
-			Service: &structs.NodeService{
-				Service: "web",
-				Port:    8000,
-			},
-		}
+			// Register a large number of nodes.
+			for i := 0; i < generateNumNodes; i++ {
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       fmt.Sprintf("foo%d", i),
+					Address:    fmt.Sprintf("127.0.0.%d", i+1),
+					Service: &structs.NodeService{
+						Service: "web",
+						Port:    8000,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "web",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
-	// Look up the service directly and via prepared query. Ensure the
-	// response is randomized each time.
-	questions := []string{
-		"web.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		uniques := map[string]struct{}{}
-		for i := 0; i < 10; i++ {
-			m := new(dns.Msg)
-			m.SetQuestion(question, dns.TypeANY)
-
-			c := &dns.Client{Net: "udp"}
-			in, _, err := c.Exchange(m, a.DNSAddr())
-			if err != nil {
-				t.Fatalf("err: %v", err)
-			}
-
-			// Response length should be truncated and we should get
-			// an A record for each response.
-			if len(in.Answer) != defaultNumUDPResponses {
-				t.Fatalf("Bad: %#v", len(in.Answer))
-			}
-
-			// Collect all the names.
-			var names []string
-			for _, rec := range in.Answer {
-				switch v := rec.(type) {
-				case *dns.SRV:
-					names = append(names, v.Target)
-				case *dns.A:
-					names = append(names, v.A.String())
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
 				}
 			}
-			nameS := strings.Join(names, "|")
 
-			// Tally the results.
-			uniques[nameS] = struct{}{}
-		}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "web",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-		// Give some wiggle room. Since the responses are randomized and
-		// there is a finite number of combinations, requiring 0
-		// duplicates every test run eventually gives us failures.
-		if len(uniques) < 2 {
-			t.Fatalf("unique response ratio too low: %d/10\n%v", len(uniques), uniques)
-		}
+			// Look up the service directly and via prepared query. Ensure the
+			// response is randomized each time.
+			questions := []string{
+				"web.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				uniques := map[string]struct{}{}
+				for i := 0; i < 10; i++ {
+					m := new(dns.Msg)
+					m.SetQuestion(question, dns.TypeANY)
+
+					c := &dns.Client{Net: "udp"}
+					in, _, err := c.Exchange(m, a.DNSAddr())
+					if err != nil {
+						t.Fatalf("err: %v", err)
+					}
+
+					// Response length should be truncated and we should get
+					// an A record for each response.
+					if len(in.Answer) != defaultNumUDPResponses {
+						t.Fatalf("Bad: %#v", len(in.Answer))
+					}
+
+					// Collect all the names.
+					var names []string
+					for _, rec := range in.Answer {
+						switch v := rec.(type) {
+						case *dns.SRV:
+							names = append(names, v.Target)
+						case *dns.A:
+							names = append(names, v.A.String())
+						}
+					}
+					nameS := strings.Join(names, "|")
+
+					// Tally the results.
+					uniques[nameS] = struct{}{}
+				}
+
+				// Give some wiggle room. Since the responses are randomized and
+				// there is a finite number of combinations, requiring 0
+				// duplicates every test run eventually gives us failures.
+				if len(uniques) < 2 {
+					t.Fatalf("unique response ratio too low: %d/10\n%v", len(uniques), uniques)
+				}
+			}
+		})
 	}
 }
 
@@ -2820,70 +2934,74 @@ func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		dns_config {
 			enable_truncate = true
 		}
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a large number of nodes.
-	for i := 0; i < generateNumNodes; i++ {
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       fmt.Sprintf("foo%d", i),
-			Address:    fmt.Sprintf("127.0.0.%d", i+1),
-			Service: &structs.NodeService{
-				Service: "web",
-				Port:    8000,
-			},
-		}
+			// Register a large number of nodes.
+			for i := 0; i < generateNumNodes; i++ {
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       fmt.Sprintf("foo%d", i),
+					Address:    fmt.Sprintf("127.0.0.%d", i+1),
+					Service: &structs.NodeService{
+						Service: "web",
+						Port:    8000,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "web",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "web",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query. Ensure the
-	// response is truncated each time.
-	questions := []string{
-		"web.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeANY)
+			// Look up the service directly and via prepared query. Ensure the
+			// response is truncated each time.
+			questions := []string{
+				"web.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeANY)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		// Check for the truncate bit
-		if !in.Truncated {
-			t.Fatalf("should have truncate bit")
-		}
+				// Check for the truncate bit
+				if !in.Truncated {
+					t.Fatalf("should have truncate bit")
+				}
+			}
+		})
 	}
 }
 
@@ -2893,118 +3011,122 @@ func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		dns_config {
 			enable_truncate = true
 		}
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	longServiceName := "this-is-a-very-very-very-very-very-long-name-for-a-service"
+			longServiceName := "this-is-a-very-very-very-very-very-long-name-for-a-service"
 
-	// Register a lot of nodes.
-	for i := 0; i < 4; i++ {
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       fmt.Sprintf("foo%d", i),
-			Address:    fmt.Sprintf("127.0.0.%d", i+1),
-			Service: &structs.NodeService{
-				Service: longServiceName,
-				Tags:    []string{"primary"},
-				Port:    12345,
-			},
-		}
+			// Register a lot of nodes.
+			for i := 0; i < 4; i++ {
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       fmt.Sprintf("foo%d", i),
+					Address:    fmt.Sprintf("127.0.0.%d", i+1),
+					Service: &structs.NodeService{
+						Service: longServiceName,
+						Tags:    []string{"primary"},
+						Port:    12345,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
-	// Register an equivalent prepared query.
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: longServiceName,
-				Service: structs.ServiceQuery{
-					Service: longServiceName,
-					Tags:    []string{"primary"},
-				},
-			},
-		}
-		var id string
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"_" + longServiceName + "._primary.service.consul.",
-		longServiceName + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
-
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		if !in.Truncated {
-			t.Fatalf("should have truncate bit")
-		}
-
-		// Make sure the response size is RFC 1035-compliant for UDP messages
-		if in.Len() > 512 {
-			t.Fatalf("Bad: %d", in.Len())
-		}
-
-		// We should only have two answers now
-		if len(in.Answer) != 2 {
-			t.Fatalf("Bad: %d", len(in.Answer))
-		}
-
-		// Make sure the ADDITIONAL section matches the ANSWER section.
-		if len(in.Answer) != len(in.Extra) {
-			t.Fatalf("Bad: %d vs. %d", len(in.Answer), len(in.Extra))
-		}
-		for i := 0; i < len(in.Answer); i++ {
-			srv, ok := in.Answer[i].(*dns.SRV)
-			if !ok {
-				t.Fatalf("Bad: %#v", in.Answer[i])
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 			}
 
-			a, ok := in.Extra[i].(*dns.A)
-			if !ok {
-				t.Fatalf("Bad: %#v", in.Extra[i])
+			// Register an equivalent prepared query.
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: longServiceName,
+						Service: structs.ServiceQuery{
+							Service: longServiceName,
+							Tags:    []string{"primary"},
+						},
+					},
+				}
+				var id string
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 			}
 
-			if srv.Target != a.Hdr.Name {
-				t.Fatalf("Bad: %#v %#v", srv, a)
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"_" + longServiceName + "._primary.service.consul.",
+				longServiceName + ".query.consul.",
 			}
-		}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
 
-		// Check for the truncate bit
-		if !in.Truncated {
-			t.Fatalf("should have truncate bit")
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
+
+				if !in.Truncated {
+					t.Fatalf("should have truncate bit")
+				}
+
+				// Make sure the response size is RFC 1035-compliant for UDP messages
+				if in.Len() > 512 {
+					t.Fatalf("Bad: %d", in.Len())
+				}
+
+				// We should only have two answers now
+				if len(in.Answer) != 2 {
+					t.Fatalf("Bad: %d", len(in.Answer))
+				}
+
+				// Make sure the ADDITIONAL section matches the ANSWER section.
+				if len(in.Answer) != len(in.Extra) {
+					t.Fatalf("Bad: %d vs. %d", len(in.Answer), len(in.Extra))
+				}
+				for i := 0; i < len(in.Answer); i++ {
+					srv, ok := in.Answer[i].(*dns.SRV)
+					if !ok {
+						t.Fatalf("Bad: %#v", in.Answer[i])
+					}
+
+					a, ok := in.Extra[i].(*dns.A)
+					if !ok {
+						t.Fatalf("Bad: %#v", in.Extra[i])
+					}
+
+					if srv.Target != a.Hdr.Name {
+						t.Fatalf("Bad: %#v %#v", srv, a)
+					}
+				}
+
+				// Check for the truncate bit
+				if !in.Truncated {
+					t.Fatalf("should have truncate bit")
+				}
+			}
+		})
 	}
 }
 
 func testDNSServiceLookupResponseLimits(t *testing.T, answerLimit int, qType uint16,
-	expectedService, expectedQuery, expectedQueryID int) (bool, error) {
+	expectedService, expectedQuery, expectedQueryID int, additionalHCL string) (bool, error) {
 	a := NewTestAgent(t, `
 		node_name = "test-node"
 		dns_config {
 			udp_answer_limit = `+fmt.Sprintf("%d", answerLimit)+`
 		}
-	`)
+	`+additionalHCL)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3095,78 +3217,82 @@ func checkDNSService(
 	expectedResultsCount int,
 	udpSize uint16,
 ) {
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		node_name = "test-node"
 		dns_config {
 			a_record_limit = `+fmt.Sprintf("%d", aRecordLimit)+`
 			udp_answer_limit = `+fmt.Sprintf("%d", aRecordLimit)+`
 		}
-	`)
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
-	choices := perfectlyRandomChoices(generateNumNodes, pctNodesWithIPv6)
-	for i := 0; i < generateNumNodes; i++ {
-		nodeAddress := fmt.Sprintf("127.0.0.%d", i+1)
-		if choices[i] {
-			nodeAddress = fmt.Sprintf("fe80::%d", i+1)
-		}
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       fmt.Sprintf("foo%d", i),
-			Address:    nodeAddress,
-			Service: &structs.NodeService{
-				Service: "api-tier",
-				Port:    8080,
-			},
-		}
+			choices := perfectlyRandomChoices(generateNumNodes, pctNodesWithIPv6)
+			for i := 0; i < generateNumNodes; i++ {
+				nodeAddress := fmt.Sprintf("127.0.0.%d", i+1)
+				if choices[i] {
+					nodeAddress = fmt.Sprintf("fe80::%d", i+1)
+				}
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       fmt.Sprintf("foo%d", i),
+					Address:    nodeAddress,
+					Service: &structs.NodeService{
+						Service: "api-tier",
+						Port:    8080,
+					},
+				}
 
-		var out struct{}
-		require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
-	}
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "api-tier",
-				Service: structs.ServiceQuery{
-					Service: "api-tier",
-				},
-			},
-		}
-
-		require.NoError(t, a.RPC(context.Background(), "PreparedQuery.Apply", args, &id))
-	}
-
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"api-tier.service.consul.",
-		"api-tier.query.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		question := question
-		t.Run("question: "+question, func(t *testing.T) {
-
-			m := new(dns.Msg)
-
-			m.SetQuestion(question, qType)
-			protocol := "tcp"
-			if udpSize > 0 {
-				protocol = "udp"
+				var out struct{}
+				require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
 			}
-			if udpSize > 512 {
-				m.SetEdns0(udpSize, true)
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "api-tier",
+						Service: structs.ServiceQuery{
+							Service: "api-tier",
+						},
+					},
+				}
+
+				require.NoError(t, a.RPC(context.Background(), "PreparedQuery.Apply", args, &id))
 			}
-			c := &dns.Client{Net: protocol, UDPSize: 8192}
-			in, _, err := c.Exchange(m, a.DNSAddr())
-			require.NoError(t, err)
 
-			t.Logf("DNS Response for %+v - %+v", m, in)
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"api-tier.service.consul.",
+				"api-tier.query.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				question := question
+				t.Run("question: "+question, func(t *testing.T) {
 
-			require.Equal(t, expectedResultsCount, len(in.Answer),
-				"%d/%d answers received for type %v for %s (%s)", len(in.Answer), expectedResultsCount, qType, question, protocol)
+					m := new(dns.Msg)
+
+					m.SetQuestion(question, qType)
+					protocol := "tcp"
+					if udpSize > 0 {
+						protocol = "udp"
+					}
+					if udpSize > 512 {
+						m.SetEdns0(udpSize, true)
+					}
+					c := &dns.Client{Net: protocol, UDPSize: 8192}
+					in, _, err := c.Exchange(m, a.DNSAddr())
+					require.NoError(t, err)
+
+					t.Logf("DNS Response for %+v - %+v", m, in)
+
+					require.Equal(t, expectedResultsCount, len(in.Answer),
+						"%d/%d answers received for type %v for %s (%s)", len(in.Answer), expectedResultsCount, qType, question, protocol)
+				})
+			}
 		})
 	}
 }
@@ -3257,71 +3383,77 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 	}
 }
 
+// TODO(jmurret):
 func TestDNS_ServiceLookup_AnswerLimits(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
 	t.Parallel()
-	// Build a matrix of config parameters (udpAnswerLimit), and the
-	// length of the response per query type and question.  Negative
-	// values imply the test must return at least the abs(value) number
-	// of records in the answer section.  This is required because, for
-	// example, on OS-X and Linux, the number of answers returned in a
-	// 512B response is different even though both platforms are x86_64
-	// and using the same version of Go.
-	//
-	// TODO(sean@): Why is it not identical everywhere when using the
-	// same compiler?
-	tests := []struct {
-		name                string
-		udpAnswerLimit      int
-		expectedAService    int
-		expectedAQuery      int
-		expectedAQueryID    int
-		expectedAAAAService int
-		expectedAAAAQuery   int
-		expectedAAAAQueryID int
-		expectedANYService  int
-		expectedANYQuery    int
-		expectedANYQueryID  int
-	}{
-		{"0", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		{"1", 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
-		{"2", 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
-		{"3", 3, 3, 3, 3, 3, 3, 3, 3, 3, 3},
-		{"4", 4, 4, 4, 4, 4, 4, 4, 4, 4, 4},
-		{"5", 5, 5, 5, 5, 5, 5, 5, 5, 5, 5},
-		{"6", 6, 6, 6, 6, 6, 6, 5, 6, 6, -5},
-		{"7", 7, 7, 7, 6, 7, 7, 5, 7, 7, -5},
-		{"8", 8, 8, 8, 6, 8, 8, 5, 8, 8, -5},
-		{"9", 9, 8, 8, 6, 8, 8, 5, 8, 8, -5},
-		{"20", 20, 8, 8, 6, 8, 8, 5, 8, -5, -5},
-		{"30", 30, 8, 8, 6, 8, 8, 5, 8, -5, -5},
-	}
-	for _, test := range tests {
-		test := test // capture loop var
-		t.Run(fmt.Sprintf("A lookup %v", test), func(t *testing.T) {
-			t.Parallel()
-			ok, err := testDNSServiceLookupResponseLimits(t, test.udpAnswerLimit, dns.TypeA, test.expectedAService, test.expectedAQuery, test.expectedAQueryID)
-			if !ok {
-				t.Fatalf("Expected service A lookup %s to pass: %v", test.name, err)
-			}
-		})
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
 
-		t.Run(fmt.Sprintf("AAAA lookup %v", test), func(t *testing.T) {
-			t.Parallel()
-			ok, err := testDNSServiceLookupResponseLimits(t, test.udpAnswerLimit, dns.TypeAAAA, test.expectedAAAAService, test.expectedAAAAQuery, test.expectedAAAAQueryID)
-			if !ok {
-				t.Fatalf("Expected service AAAA lookup %s to pass: %v", test.name, err)
+			// Build a matrix of config parameters (udpAnswerLimit), and the
+			// length of the response per query type and question.  Negative
+			// values imply the test must return at least the abs(value) number
+			// of records in the answer section.  This is required because, for
+			// example, on OS-X and Linux, the number of answers returned in a
+			// 512B response is different even though both platforms are x86_64
+			// and using the same version of Go.
+			//
+			// TODO(sean@): Why is it not identical everywhere when using the
+			// same compiler?
+			tests := []struct {
+				name                string
+				udpAnswerLimit      int
+				expectedAService    int
+				expectedAQuery      int
+				expectedAQueryID    int
+				expectedAAAAService int
+				expectedAAAAQuery   int
+				expectedAAAAQueryID int
+				expectedANYService  int
+				expectedANYQuery    int
+				expectedANYQueryID  int
+			}{
+				{"0", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				{"1", 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+				{"2", 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+				{"3", 3, 3, 3, 3, 3, 3, 3, 3, 3, 3},
+				{"4", 4, 4, 4, 4, 4, 4, 4, 4, 4, 4},
+				{"5", 5, 5, 5, 5, 5, 5, 5, 5, 5, 5},
+				{"6", 6, 6, 6, 6, 6, 6, 5, 6, 6, -5},
+				{"7", 7, 7, 7, 6, 7, 7, 5, 7, 7, -5},
+				{"8", 8, 8, 8, 6, 8, 8, 5, 8, 8, -5},
+				{"9", 9, 8, 8, 6, 8, 8, 5, 8, 8, -5},
+				{"20", 20, 8, 8, 6, 8, 8, 5, 8, -5, -5},
+				{"30", 30, 8, 8, 6, 8, 8, 5, 8, -5, -5},
 			}
-		})
+			for _, test := range tests {
+				test := test // capture loop var
+				t.Run(fmt.Sprintf("A lookup %v", test), func(t *testing.T) {
+					t.Parallel()
+					ok, err := testDNSServiceLookupResponseLimits(t, test.udpAnswerLimit, dns.TypeA, test.expectedAService, test.expectedAQuery, test.expectedAQueryID, experimentsHCL)
+					if !ok {
+						t.Fatalf("Expected service A lookup %s to pass: %v", test.name, err)
+					}
+				})
 
-		t.Run(fmt.Sprintf("ANY lookup %v", test), func(t *testing.T) {
-			t.Parallel()
-			ok, err := testDNSServiceLookupResponseLimits(t, test.udpAnswerLimit, dns.TypeANY, test.expectedANYService, test.expectedANYQuery, test.expectedANYQueryID)
-			if !ok {
-				t.Fatalf("Expected service ANY lookup %s to pass: %v", test.name, err)
+				t.Run(fmt.Sprintf("AAAA lookup %v", test), func(t *testing.T) {
+					t.Parallel()
+					ok, err := testDNSServiceLookupResponseLimits(t, test.udpAnswerLimit, dns.TypeAAAA, test.expectedAAAAService, test.expectedAAAAQuery, test.expectedAAAAQueryID, experimentsHCL)
+					if !ok {
+						t.Fatalf("Expected service AAAA lookup %s to pass: %v", test.name, err)
+					}
+				})
+
+				t.Run(fmt.Sprintf("ANY lookup %v", test), func(t *testing.T) {
+					t.Parallel()
+					ok, err := testDNSServiceLookupResponseLimits(t, test.udpAnswerLimit, dns.TypeANY, test.expectedANYService, test.expectedANYQuery, test.expectedANYQueryID, experimentsHCL)
+					if !ok {
+						t.Fatalf("Expected service ANY lookup %s to pass: %v", test.name, err)
+					}
+				})
 			}
 		})
 	}
@@ -3341,90 +3473,94 @@ func TestDNS_ServiceLookup_CNAME(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a name for an address.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "google",
-			Address:    "www.google.com",
-			Service: &structs.NodeService{
-				Service: "search",
-				Port:    80,
-			},
-		}
+			// Register a node with a name for an address.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "google",
+					Address:    "www.google.com",
+					Service: &structs.NodeService{
+						Service: "search",
+						Port:    80,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "search",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "search",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"search.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeANY)
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"search.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeANY)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		// Service CNAME, google CNAME, google A record
-		if len(in.Answer) != 3 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				// Service CNAME, google CNAME, google A record
+				if len(in.Answer) != 3 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		// Should have service CNAME
-		cnRec, ok := in.Answer[0].(*dns.CNAME)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if cnRec.Target != "www.google.com." {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				// Should have service CNAME
+				cnRec, ok := in.Answer[0].(*dns.CNAME)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if cnRec.Target != "www.google.com." {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
 
-		// Should have google CNAME
-		cnRec, ok = in.Answer[1].(*dns.CNAME)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[1])
-		}
-		if cnRec.Target != "google.com." {
-			t.Fatalf("Bad: %#v", in.Answer[1])
-		}
+				// Should have google CNAME
+				cnRec, ok = in.Answer[1].(*dns.CNAME)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[1])
+				}
+				if cnRec.Target != "google.com." {
+					t.Fatalf("Bad: %#v", in.Answer[1])
+				}
 
-		// Check we recursively resolve
-		if _, ok := in.Answer[2].(*dns.A); !ok {
-			t.Fatalf("Bad: %#v", in.Answer[2])
-		}
+				// Check we recursively resolve
+				if _, ok := in.Answer[2].(*dns.A); !ok {
+					t.Fatalf("Bad: %#v", in.Answer[2])
+				}
+			}
+		})
 	}
 }
 
@@ -3442,91 +3578,95 @@ func TestDNS_ServiceLookup_ServiceAddress_CNAME(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	`+experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register a node with a name for an address.
-	{
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       "google",
-			Address:    "1.2.3.4",
-			Service: &structs.NodeService{
-				Service: "search",
-				Port:    80,
-				Address: "www.google.com",
-			},
-		}
+			// Register a node with a name for an address.
+			{
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       "google",
+					Address:    "1.2.3.4",
+					Service: &structs.NodeService{
+						Service: "search",
+						Port:    80,
+						Address: "www.google.com",
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Register an equivalent prepared query.
-	var id string
-	{
-		args := &structs.PreparedQueryRequest{
-			Datacenter: "dc1",
-			Op:         structs.PreparedQueryCreate,
-			Query: &structs.PreparedQuery{
-				Name: "test",
-				Service: structs.ServiceQuery{
-					Service: "search",
-				},
-			},
-		}
-		if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
+			// Register an equivalent prepared query.
+			var id string
+			{
+				args := &structs.PreparedQueryRequest{
+					Datacenter: "dc1",
+					Op:         structs.PreparedQueryCreate,
+					Query: &structs.PreparedQuery{
+						Name: "test",
+						Service: structs.ServiceQuery{
+							Service: "search",
+						},
+					},
+				}
+				if err := a.RPC(context.Background(), "PreparedQuery.Apply", args, &id); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
 
-	// Look up the service directly and via prepared query.
-	questions := []string{
-		"search.service.consul.",
-		id + ".query.consul.",
-	}
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeANY)
+			// Look up the service directly and via prepared query.
+			questions := []string{
+				"search.service.consul.",
+				id + ".query.consul.",
+			}
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeANY)
 
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
 
-		// Service CNAME, google CNAME, google A record
-		if len(in.Answer) != 3 {
-			t.Fatalf("Bad: %#v", in)
-		}
+				// Service CNAME, google CNAME, google A record
+				if len(in.Answer) != 3 {
+					t.Fatalf("Bad: %#v", in)
+				}
 
-		// Should have service CNAME
-		cnRec, ok := in.Answer[0].(*dns.CNAME)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if cnRec.Target != "www.google.com." {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+				// Should have service CNAME
+				cnRec, ok := in.Answer[0].(*dns.CNAME)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if cnRec.Target != "www.google.com." {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
 
-		// Should have google CNAME
-		cnRec, ok = in.Answer[1].(*dns.CNAME)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[1])
-		}
-		if cnRec.Target != "google.com." {
-			t.Fatalf("Bad: %#v", in.Answer[1])
-		}
+				// Should have google CNAME
+				cnRec, ok = in.Answer[1].(*dns.CNAME)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[1])
+				}
+				if cnRec.Target != "google.com." {
+					t.Fatalf("Bad: %#v", in.Answer[1])
+				}
 
-		// Check we recursively resolve
-		if _, ok := in.Answer[2].(*dns.A); !ok {
-			t.Fatalf("Bad: %#v", in.Answer[2])
-		}
+				// Check we recursively resolve
+				if _, ok := in.Answer[2].(*dns.A); !ok {
+					t.Fatalf("Bad: %#v", in.Answer[2])
+				}
+			}
+		})
 	}
 }
 
@@ -3536,7 +3676,9 @@ func TestDNS_ServiceLookup_TTL(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, `
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, `
 		dns_config {
 			service_ttl = {
 				"d*" = "42s"
@@ -3547,69 +3689,71 @@ func TestDNS_ServiceLookup_TTL(t *testing.T) {
 		allow_stale = true
 		max_stale = "1s"
 		}
-	`)
-	defer a.Shutdown()
+	`+experimentsHCL)
+			defer a.Shutdown()
 
-	for idx, service := range []string{"db", "dblb", "dk", "api"} {
-		nodeName := fmt.Sprintf("foo%d", idx)
-		address := fmt.Sprintf("127.0.0.%d", idx)
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       nodeName,
-			Address:    address,
-			Service: &structs.NodeService{
-				Service: service,
-				Tags:    []string{"primary"},
-				Port:    12345 + idx,
-			},
-		}
+			for idx, service := range []string{"db", "dblb", "dk", "api"} {
+				nodeName := fmt.Sprintf("foo%d", idx)
+				address := fmt.Sprintf("127.0.0.%d", idx)
+				args := &structs.RegisterRequest{
+					Datacenter: "dc1",
+					Node:       nodeName,
+					Address:    address,
+					Service: &structs.NodeService{
+						Service: service,
+						Tags:    []string{"primary"},
+						Port:    12345 + idx,
+					},
+				}
 
-		var out struct{}
-		if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
-	c := new(dns.Client)
-	expectResult := func(dnsQuery string, expectedTTL uint32) {
-		t.Run(dnsQuery, func(t *testing.T) {
-			m := new(dns.Msg)
-			m.SetQuestion(dnsQuery, dns.TypeSRV)
-
-			in, _, err := c.Exchange(m, a.DNSAddr())
-			if err != nil {
-				t.Fatalf("err: %v", err)
+				var out struct{}
+				if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+					t.Fatalf("err: %v", err)
+				}
 			}
 
-			if len(in.Answer) != 1 {
-				t.Fatalf("Bad: %#v, len is %d", in, len(in.Answer))
-			}
+			c := new(dns.Client)
+			expectResult := func(dnsQuery string, expectedTTL uint32) {
+				t.Run(dnsQuery, func(t *testing.T) {
+					m := new(dns.Msg)
+					m.SetQuestion(dnsQuery, dns.TypeSRV)
 
-			srvRec, ok := in.Answer[0].(*dns.SRV)
-			if !ok {
-				t.Fatalf("Bad: %#v", in.Answer[0])
-			}
-			if srvRec.Hdr.Ttl != expectedTTL {
-				t.Fatalf("Bad: %#v", in.Answer[0])
-			}
+					in, _, err := c.Exchange(m, a.DNSAddr())
+					if err != nil {
+						t.Fatalf("err: %v", err)
+					}
 
-			aRec, ok := in.Extra[0].(*dns.A)
-			if !ok {
-				t.Fatalf("Bad: %#v", in.Extra[0])
+					if len(in.Answer) != 1 {
+						t.Fatalf("Bad: %#v, len is %d", in, len(in.Answer))
+					}
+
+					srvRec, ok := in.Answer[0].(*dns.SRV)
+					if !ok {
+						t.Fatalf("Bad: %#v", in.Answer[0])
+					}
+					if srvRec.Hdr.Ttl != expectedTTL {
+						t.Fatalf("Bad: %#v", in.Answer[0])
+					}
+
+					aRec, ok := in.Extra[0].(*dns.A)
+					if !ok {
+						t.Fatalf("Bad: %#v", in.Extra[0])
+					}
+					if aRec.Hdr.Ttl != expectedTTL {
+						t.Fatalf("Bad: %#v", in.Extra[0])
+					}
+				})
 			}
-			if aRec.Hdr.Ttl != expectedTTL {
-				t.Fatalf("Bad: %#v", in.Extra[0])
-			}
+			// Should have its exact TTL
+			expectResult("db.service.consul.", 10)
+			// Should match db*
+			expectResult("dblb.service.consul.", 66)
+			// Should match d*
+			expectResult("dk.service.consul.", 42)
+			// Should match *
+			expectResult("api.service.consul.", 5)
 		})
 	}
-	// Should have its exact TTL
-	expectResult("db.service.consul.", 10)
-	// Should match db*
-	expectResult("dblb.service.consul.", 66)
-	// Should match d*
-	expectResult("dk.service.consul.", 42)
-	// Should match *
-	expectResult("api.service.consul.", 5)
 }
 
 func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
@@ -3618,77 +3762,80 @@ func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	for name, experimentsHCL := range versionHCL {
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, experimentsHCL)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// Register node
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "foo",
-		Address:    "127.0.0.1",
-		Service: &structs.NodeService{
-			Service: "db",
-			Tags:    []string{"primary"},
-			Port:    12345,
-		},
+			// Register node
+			args := &structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "foo",
+				Address:    "127.0.0.1",
+				Service: &structs.NodeService{
+					Service: "db",
+					Tags:    []string{"primary"},
+					Port:    12345,
+				},
+			}
+
+			var out struct{}
+			if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			questions := []string{
+				"_db._primary.service.dc1.consul.",
+				"_db._primary.service.consul.",
+				"_db._primary.dc1.consul.",
+				"_db._primary.consul.",
+			}
+
+			for _, question := range questions {
+				m := new(dns.Msg)
+				m.SetQuestion(question, dns.TypeSRV)
+
+				c := new(dns.Client)
+				in, _, err := c.Exchange(m, a.DNSAddr())
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
+
+				if len(in.Answer) != 1 {
+					t.Fatalf("Bad: %#v", in)
+				}
+
+				srvRec, ok := in.Answer[0].(*dns.SRV)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+				if srvRec.Port != 12345 {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Target != "foo.node.dc1.consul." {
+					t.Fatalf("Bad: %#v", srvRec)
+				}
+				if srvRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Answer[0])
+				}
+
+				aRec, ok := in.Extra[0].(*dns.A)
+				if !ok {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Name != "foo.node.dc1.consul." {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.A.String() != "127.0.0.1" {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+				if aRec.Hdr.Ttl != 0 {
+					t.Fatalf("Bad: %#v", in.Extra[0])
+				}
+			}
+		})
 	}
-
-	var out struct{}
-	if err := a.RPC(context.Background(), "Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	questions := []string{
-		"_db._primary.service.dc1.consul.",
-		"_db._primary.service.consul.",
-		"_db._primary.dc1.consul.",
-		"_db._primary.consul.",
-	}
-
-	for _, question := range questions {
-		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
-
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
-
-		srvRec, ok := in.Answer[0].(*dns.SRV)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if srvRec.Port != 12345 {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Target != "foo.node.dc1.consul." {
-			t.Fatalf("Bad: %#v", srvRec)
-		}
-		if srvRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-
-		aRec, ok := in.Extra[0].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Name != "foo.node.dc1.consul." {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.A.String() != "127.0.0.1" {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-		if aRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Extra[0])
-		}
-	}
-
 }
 
 func TestDNS_ServiceLookup_SRV_RFC_TCP_Default(t *testing.T) {

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -3681,7 +3681,6 @@ func TestDNS_ReloadConfig_DuringQuery(t *testing.T) {
 	t.Parallel()
 	for name, experimentsHCL := range versionHCL {
 		t.Run(name, func(t *testing.T) {
-
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
 			testrpc.WaitForLeader(t, a.RPC, "dc1")


### PR DESCRIPTION
### Description

This is an attempt to set up a testing strategy for the v2 dns work.  The majority of the v2 dns tests run a server agent and assert behavior without knowing the inner workings / implementation of the dns code.  This sets up the ability to take the same tests and just change the configuration of the test set up but still use the same actions and assertions.

This PR could be the first step of a testing and implementation strategy that looks like this:

1. **Configure the DNS test to be able to run a matrix based on DNS versions and catalog versions, but still only running DNS v1 tests.  (This PR)**  
  - at this stage, we would have confidence that we have a path to best confirm that the v2 implementation of dns against both v1 and v2 catalog maintains the functionality of dns v1 against v catalog.
2. **Configure the DNS tests to also assert DNS v2 with catalog v1.** 
  - little change to the tests would need to occur other than uncommenting that map entry
  - this would be done during development of dns v2 with catalog v1 as the code to make the tests pass would be required.
  - at this stage, we would have us confidence that the overall v2 dns code worked and would leave really the v2 data fetcher work as the remaining bit.
3. **(Determined to not be easily feasible and better to write new tests.)~~Modify tests to work with v2 catalog.~~** 
  ~~- this would require more work to allow each test to do similar catalog set up based on whether catalog v1 or v2 was being asserted.~~
  ~~- this would be done during development of dns v2 with catalog v2 as the code to make the tests pass would be required.~~
  ~~- this would give us the confidence that dns v2 work is complete and comparable to dns v1.~~
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
