### PR TITLE
[NET-7106] Add kubebuilder validation annotations to ExportedServicesConsumer proto

### DIFF
--- a/proto-public/pbmulticluster/v2beta1/exported_services_consumer.pb.go
+++ b/proto-public/pbmulticluster/v2beta1/exported_services_consumer.pb.go
@@ -23,6 +23,9 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// +kubebuilder:validation:Type=object
+// +kubebuilder:validation:Schemaless
+// +kubebuilder:pruning:PreserveUnknownFields
 type ExportedServicesConsumer struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/proto-public/pbmulticluster/v2beta1/exported_services_consumer.proto
+++ b/proto-public/pbmulticluster/v2beta1/exported_services_consumer.proto
@@ -5,6 +5,9 @@ syntax = "proto3";
 
 package hashicorp.consul.multicluster.v2beta1;
 
+// +kubebuilder:validation:Type=object
+// +kubebuilder:validation:Schemaless
+// +kubebuilder:pruning:PreserveUnknownFields
 message ExportedServicesConsumer {
   oneof consumer_tenancy {
     string peer = 1;


### PR DESCRIPTION
### Description
Kubebuilder validation doesn't handle proto `oneof` fields which generate Go bindings with no `json` tag.
This set of `kubebuilder` annotations will override the inspections when generating CRD manifests so that everything works as expected in consul-k8s.

### Testing & Reproduction steps
This is being tested as part of https://github.com/hashicorp/consul-k8s/pull/3458, where you'll find testing instructions.

### Links
N/A

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
