### PR TITLE
fix: stop re-clicking dc dropdown in dc-switch test

### DIFF
--- a/ui/packages/consul-ui/tests/acceptance/dc/nspaces/manage.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nspaces/manage.feature
@@ -43,7 +43,6 @@ Feature: dc / nspaces / manage : Managing Namespaces
     And I don't see manageNspacesIsVisible on the navigation
     When I click services on the navigation
     Then the url should be /dc-1/services
-    When I click nspace on the navigation
     And I click manageNspaces on the navigation
     Then the url should be /dc-1/namespaces
     And I don't see manageNspacesIsVisible on the navigation

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/dc-switch.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/dc-switch.feature
@@ -32,11 +32,9 @@ Feature: dc / services / dc-switch : Switching Datacenters
     And I click dcs.1.name on the navigation
     Then the url should be /dc-2/services
     Then I see 6 service models
-    When I click dc on the navigation
     And I click dcs.0.name on the navigation
     Then the url should be /dc-1/services
     Then I see 6 service models
-    When I click dc on the navigation
     And I click dcs.1.name on the navigation
     Then the url should be /dc-2/services
     Then I see 6 service models


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Fixes the dc-switch test. The dropdown didn't close and so when we went to reopen it it would then close. [This fix is also in an existing backport](https://github.com/hashicorp/consul/pull/20125) so no need to backport it. 
Fixes the same issue in the nspaces test.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
