### PR TITLE
Fix broken tests.

### DIFF
--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -141,6 +141,7 @@ func TestConfig_Get(t *testing.T) {
 		// Set indexes and EnterpriseMeta to expected values for assertions
 		ce.CreateIndex = 12
 		ce.ModifyIndex = 13
+		ce.Hash = 0
 		ce.EnterpriseMeta = acl.EnterpriseMeta{}
 
 		out, err := a.srv.marshalJSON(req, obj)
@@ -450,6 +451,7 @@ func TestConfig_Apply_IngressGateway(t *testing.T) {
 		// Ignore create and modify indices
 		got.CreateIndex = 0
 		got.ModifyIndex = 0
+		got.Hash = 0
 
 		expect := &structs.IngressGatewayConfigEntry{
 			Name: "ingress",

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -551,7 +551,7 @@ func TestIntentionApply_WithoutIDs(t *testing.T) {
 			},
 			RaftIndex: entry.RaftIndex,
 		}
-
+		entry.Hash = 0
 		require.Equal(t, expect, entry)
 	}
 
@@ -690,7 +690,7 @@ func TestIntentionApply_WithoutIDs(t *testing.T) {
 			},
 			RaftIndex: entry.RaftIndex,
 		}
-
+		entry.Hash = 0
 		require.Equal(t, expect, entry)
 	}
 

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -1281,7 +1281,7 @@ func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {
 
 			RaftIndex: got.RaftIndex,
 		}
-
+		got.Hash = 0
 		require.Equal(t, expect, got)
 	})
 


### PR DESCRIPTION
This fixes some tests that were broken, but not caught, due to the CICD pipeline only running a subset of the overall tests on PRs.