### PR TITLE
[CC-7031] Add initialization support to resource controllers

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -2570,7 +2570,9 @@ func validateAutoConfigAuthorizer(rt RuntimeConfig) error {
 
 func (b *builder) cloudConfigVal(v Config) hcpconfig.CloudConfig {
 	val := hcpconfig.CloudConfig{
-		ResourceID: os.Getenv("HCP_RESOURCE_ID"),
+		ResourceID:   os.Getenv("HCP_RESOURCE_ID"),
+		ClientID:     os.Getenv("HCP_CLIENT_ID"),
+		ClientSecret: os.Getenv("HCP_CLIENT_SECRET"),
 	}
 	// Node id might get overridden in setup.go:142
 	nodeID := stringVal(v.NodeID)
@@ -2581,8 +2583,6 @@ func (b *builder) cloudConfigVal(v Config) hcpconfig.CloudConfig {
 		return val
 	}
 
-	val.ClientID = stringVal(v.Cloud.ClientID)
-	val.ClientSecret = stringVal(v.Cloud.ClientSecret)
 	val.AuthURL = stringVal(v.Cloud.AuthURL)
 	val.Hostname = stringVal(v.Cloud.Hostname)
 	val.ScadaAddress = stringVal(v.Cloud.ScadaAddress)
@@ -2590,6 +2590,15 @@ func (b *builder) cloudConfigVal(v Config) hcpconfig.CloudConfig {
 	if resourceID := stringVal(v.Cloud.ResourceID); resourceID != "" {
 		val.ResourceID = resourceID
 	}
+
+	if clientID := stringVal(v.Cloud.ClientID); clientID != "" {
+		val.ClientID = clientID
+	}
+
+	if clientSecret := stringVal(v.Cloud.ClientSecret); clientSecret != "" {
+		val.ClientSecret = clientSecret
+	}
+
 	return val
 }
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -971,6 +971,7 @@ func (s *Server) registerControllers(deps Deps, proxyUpdater ProxyUpdater) error
 	hcpctl.RegisterControllers(s.controllerManager, hcpctl.ControllerDependencies{
 		ResourceApisEnabled:    s.useV2Resources,
 		HCPAllowV2ResourceApis: s.hcpAllowV2Resources,
+		CloudConfig:            deps.HCP.Config,
 	})
 
 	// When not enabled, the v1 tenancy bridge is used by default.

--- a/agent/hcp/config/config.go
+++ b/agent/hcp/config/config.go
@@ -65,3 +65,9 @@ func (c *CloudConfig) HCPConfig(opts ...hcpcfg.HCPConfigOption) (hcpcfg.HCPConfi
 	opts = append(opts, hcpcfg.FromEnv(), hcpcfg.WithoutBrowserLogin())
 	return hcpcfg.NewHCPConfig(opts...)
 }
+
+// IsConfigured returns whether the cloud configuration has been set either
+// in the configuration file or via environment variables.
+func (c *CloudConfig) IsConfigured() bool {
+	return c.ResourceID != "" && c.ClientID != "" && c.ClientSecret != ""
+}

--- a/agent/hcp/deps.go
+++ b/agent/hcp/deps.go
@@ -18,6 +18,7 @@ import (
 
 // Deps contains the interfaces that the rest of Consul core depends on for HCP integration.
 type Deps struct {
+	Config            config.CloudConfig
 	Client            client.Client
 	Provider          scada.Provider
 	Sink              metrics.MetricSink
@@ -53,6 +54,7 @@ func NewDeps(cfg config.CloudConfig, logger hclog.Logger) (Deps, error) {
 	}
 
 	return Deps{
+		Config:            cfg,
 		Client:            hcpClient,
 		Provider:          provider,
 		Sink:              sink,

--- a/docs/v2-architecture/controller-architecture/controllers.md
+++ b/docs/v2-architecture/controller-architecture/controllers.md
@@ -12,6 +12,7 @@ A controller consists of several parts:
 2. **Additional watched types** - These are additional types a controller may care about in addition to the main watched type.
 3. **Additional custom watches** - These are the watches for things that aren't resources in Consul. 
 4. **Reconciler** - This is the instance that's responsible for reconciling requests whenever there's an event for the main watched type or for any of the watched types.
+5. **Initializer** - This is responsible for anything that needs to be executed when the controller is started.
 
 A basic controller setup could look like this:
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -33,6 +33,7 @@ type DependencyMapper func(
 type Controller struct {
 	name             string
 	reconciler       Reconciler
+	initializer      Initializer
 	managedTypeWatch *watch
 	watches          map[string]*watch
 	queries          map[string]cache.Query
@@ -308,4 +309,16 @@ func (r Request) Key() string {
 		r.ID.Name,
 		r.ID.Uid,
 	)
+}
+
+// Initializer implements the business logic that is executed when the
+// controller is first started.
+type Initializer interface {
+	Initialize(ctx context.Context, rt Runtime) error
+}
+
+// WithInitializer changes the controller's initializer.
+func (c *Controller) WithInitializer(initializer Initializer) *Controller {
+	c.initializer = initializer
+	return c
 }

--- a/internal/controller/runner.go
+++ b/internal/controller/runner.go
@@ -72,7 +72,6 @@ func (c *controllerRunner) run(ctx context.Context) error {
 		c.logger.Debug("controller initializing")
 		err := c.ctrl.initializer.Initialize(ctx, c.runtime(c.logger))
 		if err != nil {
-			c.logger.Error("error initializing controller", "error", err)
 			return err
 		}
 		c.logger.Debug("controller initialized")

--- a/internal/controller/runner.go
+++ b/internal/controller/runner.go
@@ -67,6 +67,17 @@ func (c *controllerRunner) run(ctx context.Context) error {
 	c.logger.Debug("controller running")
 	defer c.logger.Debug("controller stopping")
 
+	// Initialize the controller if required
+	if c.ctrl.initializer != nil {
+		c.logger.Debug("controller initializing")
+		err := c.ctrl.initializer.Initialize(ctx, c.runtime(c.logger))
+		if err != nil {
+			c.logger.Error("error initializing controller", "error", err)
+			return err
+		}
+		c.logger.Debug("controller initialized")
+	}
+
 	c.cache = c.ctrl.buildCache()
 	defer func() {
 		// once no longer running we should nil out the cache

--- a/internal/hcp/internal/controllers/register.go
+++ b/internal/hcp/internal/controllers/register.go
@@ -5,11 +5,13 @@ package controllers
 
 import (
 	hcpclient "github.com/hashicorp/consul/agent/hcp/client"
+	"github.com/hashicorp/consul/agent/hcp/config"
 	"github.com/hashicorp/consul/internal/controller"
 	"github.com/hashicorp/consul/internal/hcp/internal/controllers/link"
 )
 
 type Dependencies struct {
+	CloudConfig            config.CloudConfig
 	ResourceApisEnabled    bool
 	HCPAllowV2ResourceApis bool
 	HCPClient              hcpclient.Client
@@ -20,5 +22,6 @@ func Register(mgr *controller.Manager, deps Dependencies) {
 		deps.ResourceApisEnabled,
 		deps.HCPAllowV2ResourceApis,
 		link.DefaultHCPClientFn,
+		deps.CloudConfig,
 	))
 }

--- a/internal/hcp/internal/types/link.go
+++ b/internal/hcp/internal/types/link.go
@@ -13,6 +13,12 @@ import (
 
 type DecodedLink = resource.DecodedResource[*pbhcp.Link]
 
+const (
+	LinkName             = "global"
+	MetadataSourceKey    = "source"
+	MetadataSourceConfig = "config"
+)
+
 var (
 	linkConfigurationNameError = errors.New("only a single Link resource is allowed and it must be named global")
 )
@@ -31,7 +37,7 @@ var ValidateLink = resource.DecodeAndValidate(validateLink)
 func validateLink(res *DecodedLink) error {
 	var err error
 
-	if res.Id.Name != "global" {
+	if res.Id.Name != LinkName {
 		err = multierror.Append(err, resource.ErrInvalidField{
 			Name:    "name",
 			Wrapped: linkConfigurationNameError,


### PR DESCRIPTION
### Description
This PR adds support to specify initialization logic that is executed when a resource’s controller is first started. Controllers now have an `Initializer` interface with an `Initialize` method to implement this logic.

This PR also implements the initialization logic for the hcp.v2.Link resource, where a link is created if the [cloud configuration](https://developer.hashicorp.com/consul/docs/agent/config/config-files#self-managed-hcp-parameters) is set.

### Testing & Reproduction steps
Added unit tests and manually E2E tested with the following steps:

1. Add a `cloud` stanza in the configuration file
2. Start Consul
3. Observe the logs for the controller initializer
4. Fetch the expected hcp.v2.Link, confirm that it exists and that it has the same values as the configuration stanza and that the metadata indicates the source is config.

```
2024-01-09T13:20:05.529-0600 [DEBUG] agent.controller-runtime: controller running: controller=link managed_type=hcp.v2.Link
2024-01-09T13:20:05.529-0600 [DEBUG] agent.controller-runtime: controller initializing: controller=link managed_type=hcp.v2.Link
…
2024-01-09T13:20:05.609-0600 [DEBUG] agent.controller-runtime: controller initialized: controller=link managed_type=hcp.v2.Link
```

```
$ curl http://127.0.0.1:8500/api/hcp/v2/link/global | jq .
{
  "data": {
    "clientId": "<redacted>",
    "clientSecret": "<redacted>",
    "resourceId": "<redacted>"
  },
  "generation": "01HKQTNV4Y7MPFT48NYHSM8BX9",
  "id": {
    "name": "global",
    "tenancy": {
      "peerName": "local"
    },
    "type": {
      "group": "hcp",
      "groupVersion": "v2",
      "kind": "Link"
    },
    "uid": "01HKQTNV4Y7MPFT48NYGC2HPE0"
  },
  "metadata": {
    "source": "config"
  },
  "status": {
    "consul.io/hcp/link": {
      "conditions": [
        {
          "message": "Successfully linked to cluster '<redacted>'",
          "reason": "SUCCESS",
          "state": "STATE_TRUE",
          "type": "linked"
        }
      ],
      "observedGeneration": "01HKQTNV4Y7MPFT48NYHSM8BX9",
      "updatedAt": "2024-01-09T19:20:05.611953Z"
    }
  },
  "version": "22"
}
```

Also tested:
1. Restarting Consul after the link has been initialization for the first time
2. Updating the link’s data to new values via the API, restarting Consul, and observing that link was updated back to the config values


### Links
- Jira: https://hashicorp.atlassian.net/browse/CC-7031

### PR Checklist

* [x] updated test coverage
* [x] appropriate backport labels added
* [x] not a security concern