### PR TITLE
remove the skipping of slow tests in go-tests-ce and go-test-enterprise

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -270,7 +270,6 @@ jobs:
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: ""
-      go-test-flags: "${{ (github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')) && '-short' || '' }}"
       go-version: ${{ needs.get-go-version.outputs.go-version }}
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
@@ -293,7 +292,6 @@ jobs:
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consuldev' || '' }}"
-      go-test-flags: "${{ (github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')) && '-short' || '' }}"
       go-version: ${{ needs.get-go-version.outputs.go-version }}
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.

--- a/agent/consul/operator_backend_test.go
+++ b/agent/consul/operator_backend_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/consul/acl"
 	external "github.com/hashicorp/consul/agent/grpc-external"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/lib/testhelpers"
 	"github.com/hashicorp/consul/proto/private/pboperator"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"google.golang.org/grpc/credentials/insecure"
@@ -24,6 +25,8 @@ import (
 
 func TestOperatorBackend_TransferLeader(t *testing.T) {
 	t.Parallel()
+
+	testhelpers.SkipFlake(t)
 
 	conf := testClusterConfig{
 		Datacenter: "dc1",

--- a/lib/testhelpers/testhelpers.go
+++ b/lib/testhelpers/testhelpers.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
 package testhelpers
 
 import (

--- a/lib/testhelpers/testhelpers.go
+++ b/lib/testhelpers/testhelpers.go
@@ -1,0 +1,12 @@
+package testhelpers
+
+import (
+	"os"
+	"testing"
+)
+
+func SkipFlake(t *testing.T) {
+	if os.Getenv("RUN_FLAKEY_TESTS") != "true" {
+		t.Skip("Skipped because marked as flake.")
+	}
+}


### PR DESCRIPTION
### Description

We are reverting the change where we skip slow in the main go-tests workflow for CE and Enterprise.  The motivations for reverting this change is that we have found an introduced CI failure that has existed in main and it was not detected.  

This failing test going unnoticed is an indication that we don't currently have the processes and responsibility in place to delay these tests to be run after they are already merged.  Consul is a complex product with many edge cases.  We also need to have confidence that our test coverage is being asserted properly and timely so that we do not have delayed detection of failures.

We are reverting this change based on the idea that the original motivations below were to try to address developer toil with flakes and timely feedback from our CI pipeline, but also stated that the cost to revert was next to zero so should we change our minds, then we would revert. 

So, we are reverting this change and will regroup on how to address the original motivations as well as trying to tackle test flakes.

### Original motivation - Skipping slow (which are also flakey) unit tests from go-tests workflow on non-main/release branches

#### Description of Problem/Symptoms
- unit tests, especially in ENT, are taking longer, need a ridiculous amount of runners (we used to use 1 on CircleCI now we use 12) and it feels like every run requires a re-run to pass
- we have found that we have several unit tests whose P95 exceeds 30 seconds
- The inclusion causes us to be almost unable to scale down our runners from 12 to even 9 without greatly increasing the probability or re-runs and also taking exponentially longer or not ever passing.

#### Action
- we are going to apply the standard action plan that has been done for decades of “run your longest running tests less often”
- we will be merging this PR today
- this PR moves test already tagged as slow (and a few newly tagged slow ones whose p95 exceed 30 seconds) will only run on main and release branches rather than on every push to a PR
- it also is able to reduce the runners from 12 to 6 and still run faster and more reliably :tada:

#### What this means for each engineer
- go-tests should run faster and be less flakey
- all tests are still run in main and release branches
- failures are logged to #feed-consul-ci so merging authors should pay attention to this in case main or the release branches are :failure: (we actually should have been doing this all along).  please check this channel when merging.

#### What if we have concerns about all tests getting run later
- When the cost and time to revert are next to zero and the impact and benefit have huge potential, we should try things.
- These were the overriding factors to implementing this:
- Our current CI feels way to heavy and feels like more of a drag for everyone than a comfort
- We always assume a failure is a flake rather than a true broken test
- This should be a quality of life improvement for everyone.
- If this does not work out, reverting is easy and not costly.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
