### PR TITLE
license: MPL'ify proto-public (manual backport for 1.16.x)

### DIFF
--- a/proto-public/.copywrite.hcl
+++ b/proto-public/.copywrite.hcl
@@ -1,8 +1,14 @@
 schema_version = 1
 
 project {
-  license		= "MPL-2.0"
-  copyright_year	= 2024
+  license        = "MPL-2.0"
+  copyright_year = 2024
 
-  header_ignore		= []
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  header_ignore = [
+    # "vendor/**",
+    # "**autogen**",
+  ]
 }

--- a/troubleshoot/ports/hostport.go
+++ b/troubleshoot/ports/hostport.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ports
 
 type hostPort struct {

--- a/troubleshoot/ports/troubleshoot_ports.go
+++ b/troubleshoot/ports/troubleshoot_ports.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ports
 
 import (

--- a/troubleshoot/ports/troubleshoot_ports_test.go
+++ b/troubleshoot/ports/troubleshoot_ports_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ports
 
 import (

--- a/troubleshoot/ports/troubleshoot_protocol.go
+++ b/troubleshoot/ports/troubleshoot_protocol.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ports
 
 type troubleShootProtocol interface {

--- a/troubleshoot/ports/troubleshoot_tcp.go
+++ b/troubleshoot/ports/troubleshoot_tcp.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ports
 
 import (


### PR DESCRIPTION
Description

Automated backport https://github.com/hashicorp/consul/pull/20145 failed, so this is the manual backport.

Original PR on main: https://github.com/hashicorp/consul/pull/20143