### PR TITLE
license: MPL'ify proto-public (manual backport for 1.15.x)

### DIFF
--- a/proto-public/.copywrite.hcl
+++ b/proto-public/.copywrite.hcl
@@ -1,51 +1,14 @@
 schema_version = 1
 
 project {
-  license		= "MPL-2.0"
-  copyright_year	= 2024
+  license        = "MPL-2.0"
+  copyright_year = 2024
 
-    # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
   # Supports doublestar glob patterns for more flexibility in defining which
   # files or folders should be ignored
   header_ignore = [
-    # Forked and modified UI libs
-    "ui/packages/consul-ui/app/utils/dom/event-target/**",
-    "ui/packages/consul-ui/lib/rehype-prism/**",
-    "ui/packages/consul-ui/lib/block-slots/**",
-
-    # UI file that do not render properly with copyright headers
-    "ui/packages/consul-ui/app/components/brand-loader/enterprise.hbs",
-    "ui/packages/consul-ui/app/components/brand-loader/index.hbs",
-
-    # ignore specific test data files
-    "agent/uiserver/testdata/**",
-
-    # generated files 
-    "agent/structs/structs.deepcopy.go",
-    "agent/proxycfg/proxycfg.deepcopy.go",
-    "agent/grpc-middleware/rate_limit_mappings.gen.go",
-    "agent/uiserver/dist/**",
-    "agent/consul/state/catalog_schema.deepcopy.go",
-    "agent/config/config.deepcopy.go",
-    "agent/grpc-middleware/testutil/testservice/simple.pb.go",
-    "proto-public/annotations/ratelimit/ratelimit.pb.go",
-    "proto-public/pbacl/acl.pb.go",
-    "proto-public/pbconnectca/ca.pb.go",
-    "proto-public/pbdataplane/dataplane.pb.go",
-    "proto-public/pbdns/dns.pb.go",
-    "proto-public/pbserverdiscovery/serverdiscovery.pb.go",
-    "proto/pbacl/acl.pb.go",
-    "proto/pbautoconf/auto_config.pb.go",
-    "proto/pbcommon/common.pb.go",
-    "proto/pbconfig/config.pb.go",
-    "proto/pbconfigentry/config_entry.pb.go",
-    "proto/pbconnect/connect.pb.go",
-    "proto/pboperator/operator.pb.go",
-    "proto/pbpeering/peering.pb.go",
-    "proto/pbpeerstream/peerstream.pb.go",
-    "proto/pbservice/healthcheck.pb.go",
-    "proto/pbservice/node.pb.go",
-    "proto/pbservice/service.pb.go",
-    "proto/pbsubscribe/subscribe.pb.go",
+    # "vendor/**",
+    # "**autogen**",
   ]
 }

--- a/troubleshoot/ports/hostport.go
+++ b/troubleshoot/ports/hostport.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ports
 
 type hostPort struct {

--- a/troubleshoot/ports/troubleshoot_ports.go
+++ b/troubleshoot/ports/troubleshoot_ports.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ports
 
 import (

--- a/troubleshoot/ports/troubleshoot_ports_test.go
+++ b/troubleshoot/ports/troubleshoot_ports_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ports
 
 import (

--- a/troubleshoot/ports/troubleshoot_protocol.go
+++ b/troubleshoot/ports/troubleshoot_protocol.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ports
 
 type troubleShootProtocol interface {

--- a/troubleshoot/ports/troubleshoot_tcp.go
+++ b/troubleshoot/ports/troubleshoot_tcp.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ports
 
 import (


### PR DESCRIPTION
Description

Automated backport https://github.com/hashicorp/consul/pull/20144 failed, so this is the manual backport.

Original PR on main: https://github.com/hashicorp/consul/pull/20143