### PR TITLE
Sort peer list in expander

### DIFF
--- a/internal/multicluster/internal/controllers/exportedservices/expander/expander_ce/expander.go
+++ b/internal/multicluster/internal/controllers/exportedservices/expander/expander_ce/expander.go
@@ -5,6 +5,7 @@ package expander_ce
 
 import (
 	"context"
+	"sort"
 
 	"github.com/hashicorp/consul/internal/controller"
 	expanderTypes "github.com/hashicorp/consul/internal/multicluster/internal/controllers/exportedservices/expander/types"
@@ -28,15 +29,17 @@ func (sg *SamenessGroupExpander) Expand(consumers []*pbmulticluster.ExportedServ
 	for _, c := range consumers {
 		switch c.ConsumerTenancy.(type) {
 		case *pbmulticluster.ExportedServicesConsumer_Peer:
-			_, ok := peersMap[c.GetPeer()]
-			if !ok {
-				peers = append(peers, c.GetPeer())
-				peersMap[c.GetPeer()] = struct{}{}
-			}
+			peersMap[c.GetPeer()] = struct{}{}
 		default:
 			panic("unexpected consumer tenancy type")
 		}
 	}
+
+	for peer := range peersMap {
+		peers = append(peers, peer)
+	}
+	sort.Strings(peers)
+
 	return &expanderTypes.ExpandedConsumers{
 		Peers: peers,
 	}, nil


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Sorts the list of peers in exported services expander to make sure we always return back a deterministic result. This will avoid any flakiness in tests with the consumers that rely on this method.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
