### PR TITLE
NET-6862: adding disk-io and disk usage metrics to k8s grafana dashboard

### DIFF
--- a/grafana/consul-k8s-control-plane-monitoring.json
+++ b/grafana/consul-k8s-control-plane-monitoring.json
@@ -1655,7 +1655,7 @@
                         "type": "prometheus",
                         "uid": "PBFA97CFB590B2093"
                     },
-                    "description": "Gives the filesystem storage used by the container",
+                    "description": "Gives the filesystem storage used by consul servers",
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -1707,14 +1707,14 @@
                             },
                             "editorMode": "code",
                             "exemplar": false,
-                            "expr": "sum(container_fs_usage_bytes) by (instance)",
+                            "expr": "sum(container_fs_usage_bytes{consul_agent_type=\"server\"}) by (consul_agent_type)",
                             "instant": true,
-                            "legendFormat": "__auto",
+                            "legendFormat": "{{consul_agent_type}}",
                             "range": false,
                             "refId": "A"
                         }
                     ],
-                    "title": "Disk usage",
+                    "title": "Disk usage (Consul servers)",
                     "type": "gauge"
                 },
                 {
@@ -1804,7 +1804,7 @@
                             "editorMode": "code",
                             "expr": "sum(rate(container_fs_writes_bytes_total{pod=~\"consul-server-.*\", container=\"consul\"}[5m])) by (pod, device)",
                             "hide": false,
-                            "legendFormat": "writes, {pod=\"{{pod}}\", device=\"{{device}}\"}",
+                            "legendFormat": "writes, {pod=\"{{pod}}\"}",
                             "range": true,
                             "refId": "A"
                         },
@@ -1816,7 +1816,7 @@
                             "editorMode": "code",
                             "expr": "sum(rate(container_fs_reads_bytes_total{pod=~\"consul-server-.*\", container=\"consul\"}[5m])) by (pod, device)",
                             "hide": false,
-                            "legendFormat": "reads, {pod=\"{{pod}}\", device=\"{{device}}\"}",
+                            "legendFormat": "reads, {pod=\"{{pod}}\"}",
                             "range": true,
                             "refId": "B"
                         }

--- a/grafana/consul-k8s-control-plane-monitoring.json
+++ b/grafana/consul-k8s-control-plane-monitoring.json
@@ -1744,6 +1744,180 @@
                     ],
                     "title": "Received bytes total per 5 minutes (Consul servers)",
                     "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PBFA97CFB590B2093"
+                    },
+                    "description": "Gives the filesystem storage used by the container",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "continuous-BlYlRd"
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "bytes"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 9,
+                        "x": 15,
+                        "y": 36
+                    },
+                    "id": 100,
+                    "options": {
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showThresholdLabels": false,
+                        "showThresholdMarkers": true
+                    },
+                    "pluginVersion": "9.5.5",
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PBFA97CFB590B2093"
+                            },
+                            "editorMode": "code",
+                            "exemplar": false,
+                            "expr": "sum(container_fs_usage_bytes)",
+                            "instant": true,
+                            "legendFormat": "__auto",
+                            "range": false,
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Disk usage",
+                    "type": "gauge"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PBFA97CFB590B2093"
+                    },
+                    "description": "",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "auto",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "bytes"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 15,
+                        "x": 0,
+                        "y": 44
+                    },
+                    "id": 101,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "mode": "single",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PBFA97CFB590B2093"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum(rate(container_fs_writes_bytes_total{pod=~\"consul-server-.*\", container=\"consul\"}[5m])) by (container, device)",
+                            "hide": false,
+                            "legendFormat": "writes, {container=\"{{container}}\", device=\"{{device}}\"}",
+                            "range": true,
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PBFA97CFB590B2093"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum(rate(container_fs_reads_bytes_total{pod=~\"consul-server-.*\", container=\"consul\"}[5m])) by (container, device)",
+                            "hide": false,
+                            "legendFormat": "reads, {container=\"{{container}}\", device=\"{{device}}\"}",
+                            "range": true,
+                            "refId": "B"
+                        }
+                    ],
+                    "title": "Disk IO (Consul servers)",
+                    "type": "timeseries"
                 }
             ],
             "title": "Resource Utilization (Consul Servers)",

--- a/grafana/consul-k8s-control-plane-monitoring.json
+++ b/grafana/consul-k8s-control-plane-monitoring.json
@@ -1655,101 +1655,6 @@
                         "type": "prometheus",
                         "uid": "PBFA97CFB590B2093"
                     },
-                    "description": "",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "custom": {
-                                "axisCenteredZero": false,
-                                "axisColorMode": "text",
-                                "axisLabel": "",
-                                "axisPlacement": "auto",
-                                "barAlignment": 0,
-                                "drawStyle": "line",
-                                "fillOpacity": 0,
-                                "gradientMode": "none",
-                                "hideFrom": {
-                                    "legend": false,
-                                    "tooltip": false,
-                                    "viz": false
-                                },
-                                "lineInterpolation": "linear",
-                                "lineWidth": 1,
-                                "pointSize": 5,
-                                "scaleDistribution": {
-                                    "type": "linear"
-                                },
-                                "showPoints": "auto",
-                                "spanNulls": false,
-                                "stacking": {
-                                    "group": "A",
-                                    "mode": "none"
-                                },
-                                "thresholdsStyle": {
-                                    "mode": "off"
-                                }
-                            },
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
-                                    }
-                                ]
-                            },
-                            "unit": "bytes"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 15,
-                        "x": 0,
-                        "y": 36
-                    },
-                    "id": 48,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom",
-                            "showLegend": true
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "datasource": {
-                                "type": "prometheus",
-                                "uid": "PBFA97CFB590B2093"
-                            },
-                            "editorMode": "code",
-                            "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"consul-server-.*\"}[5m])) by (pod)",
-                            "hide": false,
-                            "legendFormat": "__auto",
-                            "range": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Received bytes total per 5 minutes (Consul servers)",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "PBFA97CFB590B2093"
-                    },
                     "description": "Gives the filesystem storage used by the container",
                     "fieldConfig": {
                         "defaults": {
@@ -1802,7 +1707,7 @@
                             },
                             "editorMode": "code",
                             "exemplar": false,
-                            "expr": "sum(container_fs_usage_bytes)",
+                            "expr": "sum(container_fs_usage_bytes) by (instance)",
                             "instant": true,
                             "legendFormat": "__auto",
                             "range": false,
@@ -1875,7 +1780,7 @@
                         "h": 8,
                         "w": 15,
                         "x": 0,
-                        "y": 44
+                        "y": 36
                     },
                     "id": 101,
                     "options": {
@@ -1897,9 +1802,9 @@
                                 "uid": "PBFA97CFB590B2093"
                             },
                             "editorMode": "code",
-                            "expr": "sum(rate(container_fs_writes_bytes_total{pod=~\"consul-server-.*\", container=\"consul\"}[5m])) by (container, device)",
+                            "expr": "sum(rate(container_fs_writes_bytes_total{pod=~\"consul-server-.*\", container=\"consul\"}[5m])) by (pod, device)",
                             "hide": false,
-                            "legendFormat": "writes, {container=\"{{container}}\", device=\"{{device}}\"}",
+                            "legendFormat": "writes, {pod=\"{{pod}}\", device=\"{{device}}\"}",
                             "range": true,
                             "refId": "A"
                         },
@@ -1909,14 +1814,109 @@
                                 "uid": "PBFA97CFB590B2093"
                             },
                             "editorMode": "code",
-                            "expr": "sum(rate(container_fs_reads_bytes_total{pod=~\"consul-server-.*\", container=\"consul\"}[5m])) by (container, device)",
+                            "expr": "sum(rate(container_fs_reads_bytes_total{pod=~\"consul-server-.*\", container=\"consul\"}[5m])) by (pod, device)",
                             "hide": false,
-                            "legendFormat": "reads, {container=\"{{container}}\", device=\"{{device}}\"}",
+                            "legendFormat": "reads, {pod=\"{{pod}}\", device=\"{{device}}\"}",
                             "range": true,
                             "refId": "B"
                         }
                     ],
-                    "title": "Disk IO (Consul servers)",
+                    "title": "Disk Read/Write total per 5 minutes (Consul servers)",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PBFA97CFB590B2093"
+                    },
+                    "description": "",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "auto",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "bytes"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 15,
+                        "x": 0,
+                        "y": 44
+                    },
+                    "id": 48,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "mode": "single",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PBFA97CFB590B2093"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"consul-server-.*\"}[5m])) by (pod)",
+                            "hide": false,
+                            "legendFormat": "__auto",
+                            "range": true,
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Received bytes total per 5 minutes (Consul servers)",
                     "type": "timeseries"
                 }
             ],


### PR DESCRIPTION
### Description

To get disk-io and disk usage of consul server pods and visualise them in the grafana dashboard

disk usage metrics is the sum of all containers in the cluster. There is no way to get disk usage of a specific pod/container using cAdvisor

### Testing & Reproduction steps

- Bring up infra either [locally](https://github.com/hashicorp-education/learn-consul-get-started-kubernetes/tree/main/self-managed/local) using kind or on AWS using [consul-test-infra](https://github.com/hashicorp/consul-test-infra/blob/main/docs/consul-load-test-steps.md) repo
- Import the grafana dashboard from this PR
- You should be able to see new panels related to disk-IO and disk usage under "Resource Utilization (consul-servers)" section in grafana dashboard

### Links
<img width="1718" alt="grafana-disk-metrics" src="https://github.com/hashicorp/consul/assets/3773964/1dfef9d2-cb1b-439d-921d-673968783dc4">


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
