### PR TITLE
Remove unnecessary fetching of gateway

### DIFF
--- a/internal/mesh/internal/controllers/gatewayproxy/controller.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/controller.go
@@ -80,27 +80,6 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 		return nil
 	}
 
-	// TODO NET-7014 Determine what gateway controls this workload
-	// For now, we cheat by knowing the MeshGateway's name, type + tenancy ahead of time
-	gatewayID := &pbresource.ID{
-		Name:    "mesh-gateway",
-		Type:    pbmesh.MeshGatewayType,
-		Tenancy: resource.DefaultPartitionedTenancy(),
-	}
-
-	// Check if the gateway exists.
-	gateway, err := dataFetcher.FetchMeshGateway(ctx, gatewayID)
-	if err != nil {
-		rt.Logger.Error("error reading the associated gateway", "error", err)
-		return err
-	}
-	if gateway == nil {
-		// If gateway has been deleted, then return as ProxyStateTemplate should be
-		// cleaned up by the garbage collector because of the owner reference.
-		rt.Logger.Trace("gateway doesn't exist; skipping reconciliation", "gateway", gatewayID)
-		return nil
-	}
-
 	proxyStateTemplate, err := dataFetcher.FetchProxyStateTemplate(ctx, req.ID)
 	if err != nil {
 		rt.Logger.Error("error reading proxy state template", "error", err)


### PR DESCRIPTION
### Description
The fetched gateway isn't currently used anywhere, so stop fetching it. In addition, the identity of the gateway is assumed, which won't be valid even if we do need to fetch the gateway for the workload in the future.

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps
🤖  tests pass

### Links
N/A

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
