### PR TITLE
ci: detect Go backwards compatibility test version automatically

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -408,9 +408,11 @@ jobs:
       consul-license: ${{secrets.CONSUL_LICENSE}}
       datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
-  go-test-api-1-19:
+  go-test-api-backwards-compatibility:
+    name: go-test-api-${{ needs.get-go-version.outputs.go-version-previous }}
     needs:
     - setup
+    - get-go-version
     - dev-build
     uses: ./.github/workflows/reusable-unit.yml
     with:
@@ -418,7 +420,7 @@ jobs:
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consuldev' || '' }}"
-      go-version: "1.19"
+      go-version: ${{ needs.get-go-version.outputs.go-version-previous }}
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read
@@ -427,9 +429,10 @@ jobs:
       consul-license: ${{secrets.CONSUL_LICENSE}}
       datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
-  go-test-api-1-20:
+  go-test-api:
     needs:
     - setup
+    - get-go-version
     - dev-build
     uses: ./.github/workflows/reusable-unit.yml
     with:
@@ -437,7 +440,7 @@ jobs:
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consuldev' || '' }}"
-      go-version: "1.20"
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read
@@ -446,9 +449,11 @@ jobs:
       consul-license: ${{secrets.CONSUL_LICENSE}}
       datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
-  go-test-sdk-1-19:
+  go-test-sdk-backwards-compatibility:
+    name: go-test-sdk-${{ needs.get-go-version.outputs.go-version-previous }}
     needs:
     - setup
+    - get-go-version
     - dev-build
     uses: ./.github/workflows/reusable-unit.yml
     with:
@@ -456,7 +461,7 @@ jobs:
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consuldev' || '' }}"
-      go-version: "1.19"
+      go-version: ${{ needs.get-go-version.outputs.go-version-previous }}
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read
@@ -465,9 +470,10 @@ jobs:
       consul-license: ${{secrets.CONSUL_LICENSE}}
       datadog-api-key: "${{ !endsWith(github.repository, '-enterprise') && secrets.DATADOG_API_KEY || '' }}"
 
-  go-test-sdk-1-20:
+  go-test-sdk:
     needs:
     - setup
+    - get-go-version
     - dev-build
     uses: ./.github/workflows/reusable-unit.yml
     with:
@@ -475,7 +481,7 @@ jobs:
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       go-tags: "${{ github.event.repository.name == 'consul-enterprise' && 'consulent consuldev' || '' }}"
-      go-version: "1.20"
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read
@@ -521,10 +527,10 @@ jobs:
     - go-test-race
     - go-test-envoyextensions
     - go-test-troubleshoot
-    - go-test-api-1-19
-    - go-test-api-1-20
-    - go-test-sdk-1-19
-    - go-test-sdk-1-20
+    - go-test-api-backwards-compatibility
+    - go-test-api
+    - go-test-sdk-backwards-compatibility
+    - go-test-sdk
     - go-test-32bit
     # - go-test-s390x
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}

--- a/.github/workflows/reusable-get-go-version.yml
+++ b/.github/workflows/reusable-get-go-version.yml
@@ -6,6 +6,9 @@ on:
       go-version:
         description: "The Go version detected by this workflow"
         value: ${{ jobs.get-go-version.outputs.go-version }}
+      go-version-previous:
+        description: "The Go version (MAJOR.MINOR) prior to the current one, used for backwards compatibility testing"
+        value: ${{ jobs.get-go-version.outputs.go-version-previous }}
 
 jobs:
   get-go-version:
@@ -13,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
+      go-version-previous: ${{ steps.get-go-version.outputs.go-version-previous }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Determine Go version
@@ -32,3 +36,7 @@ jobs:
           GO_VERSION=$(head -n 1 .go-version)
           echo "Building with Go ${GO_VERSION}"
           echo "go-version=${GO_VERSION}" >> $GITHUB_OUTPUT
+          GO_MINOR_VERSION=${GO_VERSION%.*}
+          GO_VERSION_PREVIOUS="${GO_MINOR_VERSION%.*}.$((${GO_MINOR_VERSION#*.}-1))"
+          echo "Previous version ${GO_VERSION_PREVIOUS}"
+          echo "go-version-previous=${GO_VERSION_PREVIOUS}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
For our submodules and other places we choose to test against previous Go versions, detect this version automatically from the current one rather than hard-coding it.

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
