### PR TITLE
grpc CLI client read command

### DIFF
--- a/command/registry.go
+++ b/command/registry.go
@@ -119,6 +119,7 @@ import (
 	resourcedelete "github.com/hashicorp/consul/command/resource/delete"
 	resourcelist "github.com/hashicorp/consul/command/resource/list"
 	resourceread "github.com/hashicorp/consul/command/resource/read"
+	resourcereadgrpc "github.com/hashicorp/consul/command/resource/read-grpc"
 	"github.com/hashicorp/consul/command/rtt"
 	"github.com/hashicorp/consul/command/services"
 	svcsderegister "github.com/hashicorp/consul/command/services/deregister"
@@ -261,6 +262,7 @@ func RegisteredCommands(ui cli.Ui) map[string]mcli.CommandFactory {
 		entry{"resource apply", func(ui cli.Ui) (cli.Command, error) { return resourceapply.New(ui), nil }},
 		// will be refactored to resource apply
 		entry{"resource apply-grpc", func(ui cli.Ui) (cli.Command, error) { return resourceapplygrpc.New(ui), nil }},
+		entry{"resource read-grpc", func(ui cli.Ui) (cli.Command, error) { return resourcereadgrpc.New(ui), nil }},
 		entry{"resource list", func(ui cli.Ui) (cli.Command, error) { return resourcelist.New(ui), nil }},
 		entry{"rtt", func(ui cli.Ui) (cli.Command, error) { return rtt.New(ui), nil }},
 		entry{"services", func(cli.Ui) (cli.Command, error) { return services.New(), nil }},

--- a/command/resource/apply-grpc/apply.go
+++ b/command/resource/apply-grpc/apply.go
@@ -83,15 +83,10 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	// write resource
-	gvk := &resource.GVK{
-		Group:   parsedResource.Id.Type.GetGroup(),
-		Version: parsedResource.Id.Type.GetGroupVersion(),
-		Kind:    parsedResource.Id.Type.GetKind(),
-	}
 	res := resource.ResourceGRPC{C: resourceClient}
 	entry, err := res.Apply(parsedResource)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error writing resource %s/%s: %v", gvk, parsedResource.Id.GetName(), err))
+		c.UI.Error(fmt.Sprintf("Error writing resource %s/%s: %v", parsedResource.Id.Type, parsedResource.Id.GetName(), err))
 		return 1
 	}
 
@@ -101,7 +96,7 @@ func (c *cmd) Run(args []string) int {
 		c.UI.Error("Failed to encode output data")
 		return 1
 	}
-	c.UI.Info(fmt.Sprintf("%s.%s.%s '%s' created.", gvk.Group, gvk.Version, gvk.Kind, parsedResource.Id.GetName()))
+	c.UI.Info(fmt.Sprintf("%s.%s.%s '%s' created.", parsedResource.Id.Type.Group, parsedResource.Id.Type.GroupVersion, parsedResource.Id.Type.Kind, parsedResource.Id.GetName()))
 	c.UI.Info(string(b))
 
 	return 0

--- a/command/resource/apply-grpc/apply.go
+++ b/command/resource/apply-grpc/apply.go
@@ -91,7 +91,7 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	// display response
-	b, err := json.MarshalIndent(entry, "", "    ")
+	b, err := json.MarshalIndent(entry, "", resource.OUTPUT_INDENT)
 	if err != nil {
 		c.UI.Error("Failed to encode output data")
 		return 1

--- a/command/resource/apply-grpc/apply.go
+++ b/command/resource/apply-grpc/apply.go
@@ -131,7 +131,7 @@ Usage: consul resource apply [options] <resource>
 
 	Example (from stdin):
 
-	$ consul resource apply -f - < demo.hc
+	$ consul resource apply -f - < demo.hcl
 
 	Sample demo.hcl:
 

--- a/command/resource/apply-grpc/apply.go
+++ b/command/resource/apply-grpc/apply.go
@@ -131,7 +131,7 @@ Usage: consul resource apply [options] <resource>
 
 	Example (from stdin):
 
-	$ consul resource apply -f - < demo.hcl
+	$ consul resource apply -f - < demo.hc
 
 	Sample demo.hcl:
 

--- a/command/resource/apply-grpc/apply.go
+++ b/command/resource/apply-grpc/apply.go
@@ -91,7 +91,7 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	// display response
-	b, err := json.MarshalIndent(entry, "", resource.OUTPUT_INDENT)
+	b, err := json.MarshalIndent(entry, "", resource.JSON_INDENT)
 	if err != nil {
 		c.UI.Error("Failed to encode output data")
 		return 1

--- a/command/resource/client/grpc-flags.go
+++ b/command/resource/client/grpc-flags.go
@@ -17,12 +17,6 @@ type GRPCFlags struct {
 	caPath    TValue[string]
 	token     TValue[string]
 	tokenFile TValue[string]
-
-	// flags that are not merged into GRPCConfig
-	namespace TValue[string]
-	partition TValue[string]
-	peername  TValue[string]
-	stale     TValue[bool]
 }
 
 // MergeFlagsIntoGRPCConfig merges flag values into grpc config
@@ -80,20 +74,6 @@ func (f *GRPCFlags) ClientFlags() *flag.FlagSet {
 		"File containing the ACL token to use in the request instead of one specified "+
 			"via the -token-file argument or CONSUL_GRPC_TOKEN_FILE environment variable. "+
 			"Notice the tokenFile takes precedence over token flag and environment variables.")
-	fs.Var(&f.namespace, "namespace",
-		"Specifies the namespace to query. If not provided, the namespace will be inferred "+
-			"from the request's ACL token, or will default to the `default` namespace. "+
-			"Namespaces are a Consul Enterprise feature.")
-	fs.Var(&f.partition, "partition",
-		"Specifies the admin partition to query. If not provided, the admin partition will be inferred "+
-			"from the request's ACL token, or will default to the `default` admin partition. "+
-			"Admin Partitions are a Consul Enterprise feature.")
-	fs.Var(&f.peername, "peer", "Specifies the name of peer to query. By default, it is `local`.")
-	fs.Var(&f.stale, "stale",
-		"Permit any Consul server (non-leader) to respond to this request. This "+
-			"allows for lower latency and higher throughput, but can result in "+
-			"stale data. This option has no effect on non-read operations. The "+
-			"default value is false.")
 	return fs
 }
 
@@ -107,24 +87,4 @@ func MergeFlags(dst, src *flag.FlagSet) {
 	src.VisitAll(func(f *flag.Flag) {
 		dst.Var(f.Value, f.Name, f.Usage)
 	})
-}
-
-// read the unmerged flag values
-func (f *GRPCFlags) Namespace() string {
-	return f.namespace.String()
-}
-
-func (f *GRPCFlags) Partition() string {
-	return f.partition.String()
-}
-
-func (f *GRPCFlags) Peername() string {
-	return f.peername.String()
-}
-
-func (f *GRPCFlags) Stale() bool {
-	if f.stale.v == nil {
-		return false
-	}
-	return *f.stale.v
 }

--- a/command/resource/client/grpc-resource-flags.go
+++ b/command/resource/client/grpc-resource-flags.go
@@ -15,7 +15,8 @@ type ResourceFlags struct {
 func (f *ResourceFlags) ResourceFlags() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	fs.Var(&f.namespace, "namespace",
-		"Specifies the namespace to query. It will default to the `default` namespace.`")
+		"Specifies the namespace to query. If not provided, the namespace will be inferred "+
+			"from the request's ACL token, or will default to the `default` namespace.")
 	fs.Var(&f.partition, "partition",
 		"Specifies the admin partition to query. If not provided, the admin partition will be inferred "+
 			"from the request's ACL token, or will default to the `default` admin partition. "+

--- a/command/resource/client/grpc-resource-flags.go
+++ b/command/resource/client/grpc-resource-flags.go
@@ -1,0 +1,51 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package client
+
+import "flag"
+
+type ResourceFlags struct {
+	namespace TValue[string]
+	partition TValue[string]
+	peername  TValue[string]
+	stale     TValue[bool]
+}
+
+func (f *ResourceFlags) ResourceFlags() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.Var(&f.namespace, "namespace",
+		"Specifies the namespace to query. If not provided, the namespace will be inferred "+
+			"from the request's ACL token, or will default to the `default` namespace. "+
+			"Namespaces are a Consul Enterprise feature.")
+	fs.Var(&f.partition, "partition",
+		"Specifies the admin partition to query. If not provided, the admin partition will be inferred "+
+			"from the request's ACL token, or will default to the `default` admin partition. "+
+			"Admin Partitions are a Consul Enterprise feature.")
+	fs.Var(&f.peername, "peer", "Specifies the name of peer to query. By default, it is `local`.")
+	fs.Var(&f.stale, "stale",
+		"Permit any Consul server (non-leader) to respond to this request. This "+
+			"allows for lower latency and higher throughput, but can result in "+
+			"stale data. This option has no effect on non-read operations. The "+
+			"default value is false.")
+	return fs
+}
+
+func (f *ResourceFlags) Namespace() string {
+	return f.namespace.String()
+}
+
+func (f *ResourceFlags) Partition() string {
+	return f.partition.String()
+}
+
+func (f *ResourceFlags) Peername() string {
+	return f.peername.String()
+}
+
+func (f *ResourceFlags) Stale() bool {
+	if f.stale.v == nil {
+		return false
+	}
+	return *f.stale.v
+}

--- a/command/resource/client/grpc-resource-flags.go
+++ b/command/resource/client/grpc-resource-flags.go
@@ -15,9 +15,7 @@ type ResourceFlags struct {
 func (f *ResourceFlags) ResourceFlags() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	fs.Var(&f.namespace, "namespace",
-		"Specifies the namespace to query. If not provided, the namespace will be inferred "+
-			"from the request's ACL token, or will default to the `default` namespace. "+
-			"Namespaces are a Consul Enterprise feature.")
+		"Specifies the namespace to query. It will default to the `default` namespace.`")
 	fs.Var(&f.partition, "partition",
 		"Specifies the admin partition to query. If not provided, the admin partition will be inferred "+
 			"from the request's ACL token, or will default to the `default` admin partition. "+

--- a/command/resource/delete/delete.go
+++ b/command/resource/delete/delete.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul/command/flags"
 	"github.com/hashicorp/consul/command/resource"
 	"github.com/hashicorp/consul/command/resource/client"
+	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
 func New(ui cli.Ui) *cmd {
@@ -85,7 +86,13 @@ func (c *cmd) Run(args []string) int {
 		}
 	} else {
 		var err error
-		gvk, resourceName, err = resource.GetTypeAndResourceName(args)
+		var resourceType *pbresource.Type
+		resourceType, resourceName, err = resource.GetTypeAndResourceName(args)
+		gvk = &resource.GVK{
+			Group:   resourceType.GetGroup(),
+			Version: resourceType.GetGroupVersion(),
+			Kind:    resourceType.GetKind(),
+		}
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Incorrect argument format: %s", err))
 			return 1

--- a/command/resource/helper.go
+++ b/command/resource/helper.go
@@ -24,6 +24,8 @@ import (
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
+const OUTPUT_INDENT = "  "
+
 type OuterResource struct {
 	ID         *ID            `json:"id"`
 	Owner      *ID            `json:"owner"`
@@ -162,7 +164,7 @@ func GetTypeAndResourceName(args []string) (resourceType *pbresource.Type, resou
 
 	resourceType, e = inferTypeFromResourceType(args[0])
 
-	return
+	return resourceType, resourceName, e
 }
 
 type Resource struct {

--- a/command/resource/helper.go
+++ b/command/resource/helper.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
-const OUTPUT_INDENT = "  "
+const JSON_INDENT = "  "
 
 type OuterResource struct {
 	ID         *ID            `json:"id"`

--- a/command/resource/helper.go
+++ b/command/resource/helper.go
@@ -150,7 +150,7 @@ func ParseInputParams(inputArgs []string, flags *flag.FlagSet) error {
 	return nil
 }
 
-func GetTypeAndResourceName(args []string) (gvk *GVK, resourceName string, e error) {
+func GetTypeAndResourceName(args []string) (resourceType *pbresource.Type, resourceName string, e error) {
 	if len(args) < 2 {
 		return nil, "", fmt.Errorf("Must specify two arguments: resource type and resource name")
 	}
@@ -160,7 +160,7 @@ func GetTypeAndResourceName(args []string) (gvk *GVK, resourceName string, e err
 	}
 	resourceName = args[1]
 
-	gvk, e = inferGVKFromResourceType(args[0])
+	resourceType, e = inferTypeFromResourceType(args[0])
 
 	return
 }
@@ -267,7 +267,7 @@ func (resource *Resource) List(gvk *GVK, q *client.QueryOptions) (*ListResponse,
 	return out, nil
 }
 
-func inferGVKFromResourceType(resourceType string) (*GVK, error) {
+func inferTypeFromResourceType(resourceType string) (*pbresource.Type, error) {
 	s := strings.Split(resourceType, ".")
 	switch length := len(s); {
 	// only kind is provided
@@ -282,20 +282,20 @@ func inferGVKFromResourceType(resourceType string) (*GVK, error) {
 		case 1:
 			// infer gvk from resource kind
 			gvkSplit := strings.Split(kindToGVKMap[kind][0], ".")
-			return &GVK{
-				Group:   gvkSplit[0],
-				Version: gvkSplit[1],
-				Kind:    gvkSplit[2],
+			return &pbresource.Type{
+				Group:        gvkSplit[0],
+				GroupVersion: gvkSplit[1],
+				Kind:         gvkSplit[2],
 			}, nil
 		// it alerts error if any conflict is found
 		default:
 			return nil, fmt.Errorf("The shorthand name has conflicts %v, please use the full name", kindToGVKMap[s[0]])
 		}
 	case length == 3:
-		return &GVK{
-			Group:   s[0],
-			Version: s[1],
-			Kind:    s[2],
+		return &pbresource.Type{
+			Group:        s[0],
+			GroupVersion: s[1],
+			Kind:         s[2],
 		}, nil
 	default:
 		return nil, fmt.Errorf("Must provide resource type argument with either in group.verion.kind format or its shorthand name")

--- a/command/resource/read-grpc/read.go
+++ b/command/resource/read-grpc/read.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mitchellh/cli"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"
 	"github.com/hashicorp/consul/command/resource"
 	"github.com/hashicorp/consul/command/resource/client"
@@ -25,35 +24,36 @@ func New(ui cli.Ui) *cmd {
 }
 
 type cmd struct {
-	UI    cli.Ui
-	flags *flag.FlagSet
-	http  *flags.HTTPFlags
-	help  string
+	UI        cli.Ui
+	flags     *flag.FlagSet
+	grpcFlags *client.GRPCFlags
+	help      string
 
 	filePath string
 }
 
 func (c *cmd) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
-	c.http = &flags.HTTPFlags{}
-	c.flags.StringVar(&c.filePath, "f", "", "File path with resource definition")
-	flags.Merge(c.flags, c.http.ClientFlags())
-	flags.Merge(c.flags, c.http.ServerFlags())
-	flags.Merge(c.flags, c.http.MultiTenancyFlags())
-	flags.Merge(c.flags, c.http.AddPeerName())
-	c.help = flags.Usage(help, c.flags)
+	c.flags.StringVar(&c.filePath, "f", "",
+		"File path with resource definition")
+
+	c.grpcFlags = &client.GRPCFlags{}
+	client.MergeFlags(c.flags, c.grpcFlags.ClientFlags())
+	c.help = client.Usage(help, c.flags)
 }
 
 func (c *cmd) Run(args []string) int {
-	var gvk *resource.GVK
+	var resourceType *pbresource.Type
+	var resourceTenancy *pbresource.Tenancy
 	var resourceName string
-	var opts *client.QueryOptions
 
 	if err := c.flags.Parse(args); err != nil {
 		if !errors.Is(err, flag.ErrHelp) {
 			c.UI.Error(fmt.Sprintf("Failed to parse args: %v", err))
 			return 1
 		}
+		c.UI.Error(fmt.Sprintf("Failed to run apply command: %v", err))
+		return 1
 	}
 
 	if c.flags.Lookup("f").Value.String() != "" {
@@ -69,32 +69,16 @@ func (c *cmd) Run(args []string) int {
 				return 1
 			}
 
-			gvk = &resource.GVK{
-				Group:   parsedResource.Id.Type.GetGroup(),
-				Version: parsedResource.Id.Type.GetGroupVersion(),
-				Kind:    parsedResource.Id.Type.GetKind(),
-			}
-			resourceName = parsedResource.Id.GetName()
-			opts = &client.QueryOptions{
-				Namespace:         parsedResource.Id.Tenancy.GetNamespace(),
-				Partition:         parsedResource.Id.Tenancy.GetPartition(),
-				Peer:              parsedResource.Id.Tenancy.GetPeerName(),
-				Token:             c.http.Token(),
-				RequireConsistent: !c.http.Stale(),
-			}
+			resourceType = parsedResource.Id.Type
+			resourceTenancy = parsedResource.Id.Tenancy
+			resourceName = parsedResource.Id.Name
 		} else {
 			c.UI.Error(fmt.Sprintf("Please provide an input file with resource definition"))
 			return 1
 		}
 	} else {
 		var err error
-		var resourceType *pbresource.Type
 		resourceType, resourceName, err = resource.GetTypeAndResourceName(args)
-		gvk = &resource.GVK{
-			Group:   resourceType.GetGroup(),
-			Version: resourceType.GetGroupVersion(),
-			Kind:    resourceType.GetKind(),
-		}
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Incorrect argument format: %s", err))
 			return 1
@@ -110,32 +94,35 @@ func (c *cmd) Run(args []string) int {
 			c.UI.Error("Incorrect argument format: File argument is not needed when resource information is provided with the command")
 			return 1
 		}
-		opts = &client.QueryOptions{
-			Namespace:         c.http.Namespace(),
-			Partition:         c.http.Partition(),
-			Peer:              c.http.PeerName(),
-			Token:             c.http.Token(),
-			RequireConsistent: !c.http.Stale(),
+		resourceTenancy = &pbresource.Tenancy{
+			Namespace: c.grpcFlags.Namespace(),
+			Partition: c.grpcFlags.Partition(),
+			PeerName:  c.grpcFlags.Peername(),
 		}
 	}
 
-	config := api.DefaultConfig()
-
-	c.http.MergeOntoConfig(config)
-	resourceClient, err := client.NewClient(config)
+	// initialize client
+	config, err := client.LoadGRPCConfig(nil)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error loading config: %s", err))
+		return 1
+	}
+	c.grpcFlags.MergeFlagsIntoGRPCConfig(config)
+	resourceClient, err := client.NewGRPCClient(config)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error connect to Consul agent: %s", err))
 		return 1
 	}
 
-	res := resource.Resource{C: resourceClient}
-
-	entry, err := res.Read(gvk, resourceName, opts)
+	// read resource
+	res := resource.ResourceGRPC{C: resourceClient}
+	entry, err := res.Read(resourceType, resourceTenancy, resourceName, c.grpcFlags.Stale())
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error reading resource %s/%s: %v", gvk, resourceName, err))
+		c.UI.Error(fmt.Sprintf("Error reading resource %s/%s: %v", resourceType, resourceName, err))
 		return 1
 	}
 
+	// display response
 	b, err := json.MarshalIndent(entry, "", "    ")
 	if err != nil {
 		c.UI.Error("Failed to encode output data")

--- a/command/resource/read-grpc/read.go
+++ b/command/resource/read-grpc/read.go
@@ -56,6 +56,7 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
+	// collect resource type, name and tenancy
 	if c.flags.Lookup("f").Value.String() != "" {
 		if c.filePath != "" {
 			parsedResource, err := resource.ParseResourceFromFile(c.filePath)

--- a/command/resource/read-grpc/read.go
+++ b/command/resource/read-grpc/read.go
@@ -126,7 +126,7 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	// display response
-	b, err := json.MarshalIndent(entry, "", resource.OUTPUT_INDENT)
+	b, err := json.MarshalIndent(entry, "", resource.JSON_INDENT)
 	if err != nil {
 		c.UI.Error("Failed to encode output data")
 		return 1

--- a/command/resource/read-grpc/read_test.go
+++ b/command/resource/read-grpc/read_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+package read
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/command/resource/apply"
+	"github.com/hashicorp/consul/testrpc"
+)
+
+func TestResourceReadInvalidArgs(t *testing.T) {
+	t.Parallel()
+
+	type tc struct {
+		args         []string
+		expectedCode int
+		expectedErr  error
+	}
+
+	cases := map[string]tc{
+		"nil args": {
+			args:         nil,
+			expectedCode: 1,
+			expectedErr:  errors.New("Incorrect argument format: Must specify two arguments: resource type and resource name"),
+		},
+		"empty args": {
+			args:         []string{},
+			expectedCode: 1,
+			expectedErr:  errors.New("Incorrect argument format: Must specify two arguments: resource type and resource name"),
+		},
+		"missing file path": {
+			args:         []string{"-f"},
+			expectedCode: 1,
+			expectedErr:  errors.New("Failed to parse args: flag needs an argument: -f"),
+		},
+		"file not found": {
+			args:         []string{"-f=../testdata/test.hcl"},
+			expectedCode: 1,
+			expectedErr:  errors.New("Failed to load data: Failed to read file: open ../testdata/test.hcl: no such file or directory"),
+		},
+		"provide type and name": {
+			args:         []string{"a.b.c"},
+			expectedCode: 1,
+			expectedErr:  errors.New("Incorrect argument format: Must specify two arguments: resource type and resource name"),
+		},
+		"provide type and name with -f": {
+			args:         []string{"a.b.c", "name", "-f", "test.hcl"},
+			expectedCode: 1,
+			expectedErr:  errors.New("Incorrect argument format: File argument is not needed when resource information is provided with the command"),
+		},
+		"provide type and name with -f and other flags": {
+			args:         []string{"a.b.c", "name", "-f", "test.hcl", "-namespace", "default"},
+			expectedCode: 1,
+			expectedErr:  errors.New("Incorrect argument format: File argument is not needed when resource information is provided with the command"),
+		},
+		"does not provide resource name after type": {
+			args:         []string{"a.b.c", "-namespace", "default"},
+			expectedCode: 1,
+			expectedErr:  errors.New("Incorrect argument format: Must provide resource name right after type"),
+		},
+		"invalid resource type format": {
+			args:         []string{"a.", "name", "-namespace", "default"},
+			expectedCode: 1,
+			expectedErr:  errors.New("Incorrect argument format: Must provide resource type argument with either in group.verion.kind format or its shorthand name"),
+		},
+	}
+
+	for desc, tc := range cases {
+		t.Run(desc, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			c := New(ui)
+
+			code := c.Run(tc.args)
+
+			require.Equal(t, tc.expectedCode, code)
+			require.Contains(t, ui.ErrorWriter.String(), tc.expectedErr.Error())
+		})
+	}
+}
+
+func createResource(t *testing.T, a *agent.TestAgent) {
+	applyUi := cli.NewMockUi()
+	applyCmd := apply.New(applyUi)
+
+	args := []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-token=root",
+	}
+
+	args = append(args, []string{"-f=../testdata/demo.hcl"}...)
+
+	code := applyCmd.Run(args)
+	require.Equal(t, 0, code)
+	require.Empty(t, applyUi.ErrorWriter.String())
+}
+
+func TestResourceRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	defaultCmdArgs := []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-token=root",
+	}
+
+	createResource(t, a)
+	cases := []struct {
+		name         string
+		args         []string
+		expectedCode int
+		errMsg       string
+	}{
+		{
+			name:         "read resource in hcl format",
+			args:         []string{"-f=../testdata/demo.hcl"},
+			expectedCode: 0,
+			errMsg:       "",
+		},
+		{
+			name:         "read resource in command line format",
+			args:         []string{"demo.v2.Artist", "korn", "-partition=default", "-namespace=default", "-peer=local"},
+			expectedCode: 0,
+			errMsg:       "",
+		},
+		{
+			name:         "read resource that doesn't exist",
+			args:         []string{"demo.v2.Artist", "fake-korn", "-partition=default", "-namespace=default", "-peer=local"},
+			expectedCode: 1,
+			errMsg:       "Error reading resource demo.v2.Artist/fake-korn: Unexpected response code: 404 (rpc error: code = NotFound desc = resource not found)\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			c := New(ui)
+			cliArgs := append(tc.args, defaultCmdArgs...)
+			code := c.Run(cliArgs)
+			require.Equal(t, tc.errMsg, ui.ErrorWriter.String())
+			require.Equal(t, tc.expectedCode, code)
+		})
+	}
+}

--- a/command/resource/read-grpc/read_test.go
+++ b/command/resource/read-grpc/read_test.go
@@ -144,7 +144,7 @@ func TestResourceRead(t *testing.T) {
 			name:         "read resource that doesn't exist",
 			args:         []string{"demo.v2.Artist", "fake-korn", "-partition=default", "-namespace=default", "-peer=local"},
 			expectedCode: 1,
-			errMsg:       "Error reading resource group:\"demo\" group_version:\"v2\" kind:\"Artist\"/fake-korn: error reading resource: rpc error: code = NotFound desc = resource not found\n",
+			errMsg:       "error reading resource: rpc error: code = NotFound desc = resource not found\n",
 		},
 	}
 
@@ -154,7 +154,7 @@ func TestResourceRead(t *testing.T) {
 			c := New(ui)
 			cliArgs := append(tc.args, defaultCmdArgs...)
 			code := c.Run(cliArgs)
-			require.Equal(t, tc.errMsg, ui.ErrorWriter.String())
+			require.Contains(t, ui.ErrorWriter.String(), tc.errMsg)
 			require.Equal(t, tc.expectedCode, code)
 		})
 	}

--- a/command/resource/read-grpc/read_test.go
+++ b/command/resource/read-grpc/read_test.go
@@ -144,7 +144,7 @@ func TestResourceRead(t *testing.T) {
 			name:         "read resource that doesn't exist",
 			args:         []string{"demo.v2.Artist", "fake-korn", "-partition=default", "-namespace=default", "-peer=local"},
 			expectedCode: 1,
-			errMsg:       "Error reading resource group:\"demo\" group_version:\"v2\" kind:\"Artist\"/fake-korn: error reading resource: rpc error: code = NotFound desc = resource not found\n",
+			errMsg:       "Error reading resource group:\"demo\"  group_version:\"v2\"  kind:\"Artist\"/fake-korn: error reading resource: rpc error: code = NotFound desc = resource not found\n",
 		},
 	}
 

--- a/command/resource/read-grpc/read_test.go
+++ b/command/resource/read-grpc/read_test.go
@@ -144,7 +144,7 @@ func TestResourceRead(t *testing.T) {
 			name:         "read resource that doesn't exist",
 			args:         []string{"demo.v2.Artist", "fake-korn", "-partition=default", "-namespace=default", "-peer=local"},
 			expectedCode: 1,
-			errMsg:       "Error reading resource group:\"demo\"  group_version:\"v2\"  kind:\"Artist\"/fake-korn: error reading resource: rpc error: code = NotFound desc = resource not found\n",
+			errMsg:       "Error reading resource group:\"demo\" group_version:\"v2\" kind:\"Artist\"/fake-korn: error reading resource: rpc error: code = NotFound desc = resource not found\n",
 		},
 	}
 

--- a/command/resource/resource-grpc.go
+++ b/command/resource/resource-grpc.go
@@ -63,7 +63,7 @@ func (resource *ResourceGRPC) Read(resourceType *pbresource.Type, resourceTenanc
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("error writing resource: %+v", err)
+		return nil, fmt.Errorf("error reading resource: %+v", err)
 	}
 
 	return readRsp.Resource, err


### PR DESCRIPTION
### Description

[This](https://hashicorp.atlassian.net/browse/NET-5649) is the background for this ticket.

In this PR, we enable the read command for grpc cli. The read command needs four flags to pass the information to consul:
- namespace
- partion
- peer
- stale

The user could also choose to use the `hcl`  file to retrieve the target resource information.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
