### PR TITLE
docs: fix partition target in samenessgroups

### DIFF
--- a/website/content/docs/k8s/connect/cluster-peering/usage/create-sameness-groups.mdx
+++ b/website/content/docs/k8s/connect/cluster-peering/usage/create-sameness-groups.mdx
@@ -125,7 +125,7 @@ spec:
   members:                                   
     - partition: partition-1
     - peer: dc1-partition-1
-    - peer: dc2-partition-2
+    - peer: dc1-partition-2
 ```
 
 </CodeBlockConfig>


### PR DESCRIPTION
### Description

A simple fix for a typo. The yaml file is targeted at `dc2` and should point to the local `partition-1`; as well as the remote `partition-1` and `partition-2` from `dc1`.

### Testing & Reproduction steps
None

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
