### PR TITLE
ci: Use Consul Go version for Vault int tests

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -160,6 +160,7 @@ jobs:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
     needs:
       - setup
+      - get-go-version
       - dev-build
     permissions:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
@@ -179,8 +180,9 @@ jobs:
 
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          # Do not explicitly set Go version here, as it should depend on what Vault declares.
-          go-version-file: 'go.mod'
+          # We use the current Consul Go version here since Vault is installed as a binary
+          # and tests are run from the Consul repo.
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
 
       - name: Install Vault
         run: |


### PR DESCRIPTION
Unlike the Nomad tests (where Nomad is compiled from source and provides the tests), Vault is installed as a binary, and local Consul tests are run.

Fixes incorrect version change introduced in #20058.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
