### PR TITLE
Unconditionally add Access-Control-Expose-Headers HTTP header

### DIFF
--- a/.changelog/20220.txt
+++ b/.changelog/20220.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cloud: unconditionally add Access-Control-Expose-Headers HTTP header
+```

--- a/agent/hcp/bootstrap/bootstrap.go
+++ b/agent/hcp/bootstrap/bootstrap.go
@@ -126,7 +126,7 @@ func AddAclPolicyAccessControlHeader(baseLoader ConfigLoader) ConfigLoader {
 			rc.HTTPResponseHeaders[accessControlHeaderName] = prevValue + "," + accessControlHeaderValue
 		}
 
-		return res, err
+		return res, nil
 	}
 }
 

--- a/agent/hcp/bootstrap/bootstrap.go
+++ b/agent/hcp/bootstrap/bootstrap.go
@@ -106,6 +106,30 @@ func LoadConfig(ctx context.Context, client hcpclient.Client, dataDir string, lo
 	return newLoader, nil
 }
 
+func AddAclPolicyAccessControlHeader(baseLoader ConfigLoader) ConfigLoader {
+	return func(source config.Source) (config.LoadResult, error) {
+		res, err := baseLoader(source)
+		if err != nil {
+			return res, err
+		}
+
+		rc := res.RuntimeConfig
+
+		// HTTP response headers are modified for the HCP UI to work.
+		if rc.HTTPResponseHeaders == nil {
+			rc.HTTPResponseHeaders = make(map[string]string)
+		}
+		prevValue, ok := rc.HTTPResponseHeaders[accessControlHeaderName]
+		if !ok {
+			rc.HTTPResponseHeaders[accessControlHeaderName] = accessControlHeaderValue
+		} else {
+			rc.HTTPResponseHeaders[accessControlHeaderName] = prevValue + "," + accessControlHeaderValue
+		}
+
+		return res, err
+	}
+}
+
 // bootstrapConfigLoader is a ConfigLoader for passing bootstrap JSON config received from HCP
 // to the config.builder. ConfigLoaders are functions used to build an agent's RuntimeConfig
 // from various sources like files and flags. This config is contained in the config.LoadResult.
@@ -166,17 +190,6 @@ const (
 // handled by the config.builder.
 func finalizeRuntimeConfig(rc *config.RuntimeConfig, cfg *RawBootstrapConfig) {
 	rc.Cloud.ManagementToken = cfg.ManagementToken
-
-	// HTTP response headers are modified for the HCP UI to work.
-	if rc.HTTPResponseHeaders == nil {
-		rc.HTTPResponseHeaders = make(map[string]string)
-	}
-	prevValue, ok := rc.HTTPResponseHeaders[accessControlHeaderName]
-	if !ok {
-		rc.HTTPResponseHeaders[accessControlHeaderName] = accessControlHeaderValue
-	} else {
-		rc.HTTPResponseHeaders[accessControlHeaderName] = prevValue + "," + accessControlHeaderValue
-	}
 }
 
 // fetchBootstrapConfig will fetch boostrap configuration from remote servers and persist it to disk.

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -183,6 +183,11 @@ func (c *cmd) run(args []string) int {
 		}
 	}
 
+	// We unconditionally add an Access Control header to our config in order to allow the HCP UI to work.
+	// We do this unconditionally because the cluster can be linked to HCP at any time (not just at startup) and this
+	// is simpler than selectively reloading parts of config at runtime.
+	loader = hcpbootstrap.AddAclPolicyAccessControlHeader(loader)
+
 	bd, err := agent.NewBaseDeps(loader, logGate, nil)
 	if err != nil {
 		ui.Error(err.Error())


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
This adds the following header to _all_ Consul HTTP responses:
```
Access-Control-Expose-Headers: x-consul-default-acl-policy
```

The reasoning for this is in [this RFC](https://docs.google.com/document/d/185Kj_pDcuOmmVOzIPZYsCLIIOFB_26bg9kWD7i8qgkQ/edit#heading=h.5gihsi8y54bu), but in summary, we need this header in order to support the HCP UI. Previously, we added this at startup conditionally if the cluster was being linked to HCP. With the changes in the RFC, we are allowing Consul to be linked to HCP at any time and adding this header unconditionally at startup is the simplest solution as it doesn't require us to reload configuration at runtime.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
#### Manual test
##### Before
```
➜ http localhost:8500/v1/catalog/services
HTTP/1.1 200 OK
Content-Length: 2
Content-Type: application/json
Date: Tue, 16 Jan 2024 17:08:27 GMT
Vary: Accept-Encoding
X-Consul-Default-Acl-Policy: deny
X-Consul-Effective-Consistency: leader
X-Consul-Index: 19
X-Consul-Knownleader: true
X-Consul-Lastcontact: 0
X-Consul-Query-Backend: blocking-query

{}
```

##### After
```
➜  http localhost:8500/v1/catalog/services
HTTP/1.1 200 OK
Access-Control-Expose-Headers: x-consul-default-acl-policy
Content-Length: 2
Content-Type: application/json
Date: Tue, 16 Jan 2024 18:29:13 GMT
Vary: Accept-Encoding
X-Consul-Default-Acl-Policy: deny
X-Consul-Effective-Consistency: leader
X-Consul-Index: 18
X-Consul-Knownleader: true
X-Consul-Lastcontact: 0
X-Consul-Query-Backend: blocking-query

{}
```

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->
Jira: https://hashicorp.atlassian.net/browse/CC-7045
RFC: https://docs.google.com/document/d/185Kj_pDcuOmmVOzIPZYsCLIIOFB_26bg9kWD7i8qgkQ/edit#heading=h.5gihsi8y54bu

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
