### PR TITLE
check error in TestDNSCycleRecursorCheckAllFail before asserting response to stop panic in CI.

### DIFF
--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -320,7 +320,8 @@ func TestDNSCycleRecursorCheckAllFail(t *testing.T) {
 			m.SetQuestion("google.com.", dns.TypeA)
 			// Agent request
 			client := new(dns.Client)
-			in, _, _ := client.Exchange(m, agent.DNSAddr())
+			in, _, err := client.Exchange(m, agent.DNSAddr())
+			require.NoError(t, err)
 			// Verify if we hit SERVFAIL from Consul
 			require.Equal(t, dns.RcodeServerFailure, in.Rcode)
 		})


### PR DESCRIPTION
there is likely a flake in here as well, but this panic causes other tests not to run and stops gotestum from re-running tests with `rerun aborted because previous run had a suspected panic and some test may not have run.`. This PR is just meant to stabilize the panic and hopefully fixing the flake will be easier with an error message.


the original panic error is below when the test tries to check `in.Rcode` but has not checked for an error first:
```
2024-01-17T04:19:11.7723556Z === [31mFAIL[0m: agent TestDNSCycleRecursorCheckAllFail (6.18s)
2024-01-17T04:19:11.7724191Z panic: runtime error: invalid memory address or nil pointer dereference [recovered]
2024-01-17T04:19:11.7724772Z 	panic: runtime error: invalid memory address or nil pointer dereference
2024-01-17T04:19:11.7725299Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x330d5bd]
2024-01-17T04:19:11.7725310Z 
2024-01-17T04:19:11.7725551Z goroutine 46254152 [running]:
2024-01-17T04:19:11.7725870Z testing.tRunner.func1.2({0x3977c20, 0x7b98970})
2024-01-17T04:19:11.7726726Z 	/home/runner/actions-runner/_work/_tool/go/1.21.6/x64/src/testing/testing.go:1545 +0x238
2024-01-17T04:19:11.7726952Z testing.tRunner.func1()
2024-01-17T04:19:11.7727805Z 	/home/runner/actions-runner/_work/_tool/go/1.21.6/x64/src/testing/testing.go:1548 +0x397
2024-01-17T04:19:11.7728030Z panic({0x3977c20?, 0x7b98970?})
2024-01-17T04:19:11.7728853Z 	/home/runner/actions-runner/_work/_tool/go/1.21.6/x64/src/runtime/panic.go:914 +0x21f
2024-01-17T04:19:11.7729561Z github.com/hashicorp/consul/agent.TestDNSCycleRecursorCheckAllFail.func1(0x21043ad?)
2024-01-17T04:19:11.7730559Z 	/home/runner/actions-runner/_work/consul-enterprise/consul-enterprise/agent/dns_test.go:324 +0x23d
2024-01-17T04:19:11.7730844Z testing.tRunner(0xc0b4e66b60, 0xc0bc9ac7e0)
2024-01-17T04:19:11.7731675Z 	/home/runner/actions-runner/_work/_tool/go/1.21.6/x64/src/testing/testing.go:1595 +0xff
2024-01-17T04:19:11.7732006Z created by testing.(*T).Run in goroutine 7722171
2024-01-17T04:19:11.7732861Z 	/home/runner/actions-runner/_work/_tool/go/1.21.6/x64/src/testing/testing.go:1648 +0x3ad
```

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
