### PR TITLE
Migrate the Endpoints controller to use the controller cache

### DIFF
--- a/acl/MockAuthorizer.go
+++ b/acl/MockAuthorizer.go
@@ -225,7 +225,7 @@ func (m *MockAuthorizer) ServiceReadAll(ctx *AuthorizerContext) EnforcementDecis
 }
 
 func (m *MockAuthorizer) ServiceReadPrefix(prefix string, ctx *AuthorizerContext) EnforcementDecision {
-	ret := m.Called(ctx)
+	ret := m.Called(prefix, ctx)
 	return ret.Get(0).(EnforcementDecision)
 }
 

--- a/internal/catalog/exports.go
+++ b/internal/catalog/exports.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/consul/internal/catalog/internal/types"
 	"github.com/hashicorp/consul/internal/controller"
 	"github.com/hashicorp/consul/internal/resource"
-	"github.com/hashicorp/consul/internal/resource/mappers/selectiontracker"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
@@ -63,8 +62,7 @@ type ControllerDependencies = controllers.Dependencies
 
 func DefaultControllerDependencies() ControllerDependencies {
 	return ControllerDependencies{
-		EndpointsWorkloadMapper: selectiontracker.New(),
-		FailoverMapper:          failovermapper.New(),
+		FailoverMapper: failovermapper.New(),
 	}
 }
 

--- a/internal/catalog/internal/controllers/register.go
+++ b/internal/catalog/internal/controllers/register.go
@@ -12,13 +12,12 @@ import (
 )
 
 type Dependencies struct {
-	EndpointsWorkloadMapper endpoints.WorkloadMapper
-	FailoverMapper          failover.FailoverMapper
+	FailoverMapper failover.FailoverMapper
 }
 
 func Register(mgr *controller.Manager, deps Dependencies) {
 	mgr.Register(nodehealth.NodeHealthController())
 	mgr.Register(workloadhealth.WorkloadHealthController())
-	mgr.Register(endpoints.ServiceEndpointsController(deps.EndpointsWorkloadMapper))
+	mgr.Register(endpoints.ServiceEndpointsController())
 	mgr.Register(failover.FailoverPolicyController(deps.FailoverMapper))
 }

--- a/internal/catalog/workloadselector/acls.go
+++ b/internal/catalog/workloadselector/acls.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package workloadselector
+
+import (
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+func aclReadHookResourceWithWorkloadSelector(authorizer acl.Authorizer, authzContext *acl.AuthorizerContext, id *pbresource.ID, _ *pbresource.Resource) error {
+	return authorizer.ToAllowAuthorizer().ServiceReadAllowed(id.GetName(), authzContext)
+}
+
+func aclWriteHookResourceWithWorkloadSelector[T WorkloadSelecting](authorizer acl.Authorizer, authzContext *acl.AuthorizerContext, r *resource.DecodedResource[T]) error {
+	// First check service:write on the name.
+	err := authorizer.ToAllowAuthorizer().ServiceWriteAllowed(r.GetId().GetName(), authzContext)
+	if err != nil {
+		return err
+	}
+
+	// Then also check whether we're allowed to select a service.
+	for _, name := range r.Data.GetWorkloads().GetNames() {
+		err = authorizer.ToAllowAuthorizer().ServiceReadAllowed(name, authzContext)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, prefix := range r.Data.GetWorkloads().GetPrefixes() {
+		err = authorizer.ToAllowAuthorizer().ServiceReadPrefixAllowed(prefix, authzContext)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ACLHooks[T WorkloadSelecting]() *resource.ACLHooks {
+	return &resource.ACLHooks{
+		Read:  aclReadHookResourceWithWorkloadSelector,
+		Write: resource.DecodeAndAuthorizeWrite(aclWriteHookResourceWithWorkloadSelector[T]),
+		List:  resource.NoOpACLListHook,
+	}
+}

--- a/internal/catalog/workloadselector/acls_test.go
+++ b/internal/catalog/workloadselector/acls_test.go
@@ -1,0 +1,120 @@
+package workloadselector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/resourcetest"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+func TestACLHooks(t *testing.T) {
+	suite.Run(t, new(aclHookSuite))
+}
+
+type aclHookSuite struct {
+	suite.Suite
+
+	hooks *resource.ACLHooks
+	authz *acl.MockAuthorizer
+	ctx   *acl.AuthorizerContext
+	res   *pbresource.Resource
+}
+
+func (suite *aclHookSuite) SetupTest() {
+	suite.authz = new(acl.MockAuthorizer)
+
+	suite.authz.On("ToAllowAuthorizer").Return(acl.AllowAuthorizer{Authorizer: suite.authz, AccessorID: "862270e5-7d7b-4583-98bc-4d14810cc158"})
+
+	suite.ctx = &acl.AuthorizerContext{}
+	acl.DefaultEnterpriseMeta().FillAuthzContext(suite.ctx)
+
+	suite.hooks = ACLHooks[*pbcatalog.Service]()
+
+	suite.res = resourcetest.Resource(pbcatalog.ServiceType, "foo").
+		WithData(suite.T(), &pbcatalog.Service{
+			Workloads: &pbcatalog.WorkloadSelector{
+				Prefixes: []string{"api-"},
+				Names:    []string{"bar"},
+			},
+		}).
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+}
+
+func (suite *aclHookSuite) TeardownTest() {
+	suite.authz.AssertExpectations(suite.T())
+}
+
+func (suite *aclHookSuite) TestReadHook_Allowed() {
+	suite.authz.On("ServiceRead", "foo", suite.ctx).
+		Return(acl.Allow).
+		Once()
+
+	require.NoError(suite.T(), suite.hooks.Read(suite.authz, suite.ctx, suite.res.Id, nil))
+}
+
+func (suite *aclHookSuite) TestReadHook_Denied() {
+	suite.authz.On("ServiceRead", "foo", suite.ctx).
+		Return(acl.Deny).
+		Once()
+
+	require.Error(suite.T(), suite.hooks.Read(suite.authz, suite.ctx, suite.res.Id, nil))
+}
+
+func (suite *aclHookSuite) TestWriteHook_ServiceWriteDenied() {
+	suite.authz.On("ServiceWrite", "foo", suite.ctx).
+		Return(acl.Deny).
+		Once()
+
+	require.Error(suite.T(), suite.hooks.Write(suite.authz, suite.ctx, suite.res))
+}
+
+func (suite *aclHookSuite) TestWriteHook_ServiceReadNameDenied() {
+	suite.authz.On("ServiceWrite", "foo", suite.ctx).
+		Return(acl.Allow).
+		Once()
+
+	suite.authz.On("ServiceRead", "bar", suite.ctx).
+		Return(acl.Deny).
+		Once()
+
+	require.Error(suite.T(), suite.hooks.Write(suite.authz, suite.ctx, suite.res))
+}
+
+func (suite *aclHookSuite) TestWriteHook_ServiceReadPrefixDenied() {
+	suite.authz.On("ServiceWrite", "foo", suite.ctx).
+		Return(acl.Allow).
+		Once()
+
+	suite.authz.On("ServiceRead", "bar", suite.ctx).
+		Return(acl.Allow).
+		Once()
+
+	suite.authz.On("ServiceReadPrefix", "api-", suite.ctx).
+		Return(acl.Deny).
+		Once()
+
+	require.Error(suite.T(), suite.hooks.Write(suite.authz, suite.ctx, suite.res))
+}
+
+func (suite *aclHookSuite) TestWriteHook_Allowed() {
+	suite.authz.On("ServiceWrite", "foo", suite.ctx).
+		Return(acl.Allow).
+		Once()
+
+	suite.authz.On("ServiceRead", "bar", suite.ctx).
+		Return(acl.Allow).
+		Once()
+
+	suite.authz.On("ServiceReadPrefix", "api-", suite.ctx).
+		Return(acl.Allow).
+		Once()
+
+	require.NoError(suite.T(), suite.hooks.Write(suite.authz, suite.ctx, suite.res))
+}

--- a/internal/catalog/workloadselector/index.go
+++ b/internal/catalog/workloadselector/index.go
@@ -1,0 +1,72 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package workloadselector
+
+import (
+	"github.com/hashicorp/consul/internal/controller/cache/index"
+	"github.com/hashicorp/consul/internal/controller/cache/indexers"
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+const (
+	IndexName = "selected-workloads"
+)
+
+func Index[T WorkloadSelecting](name string) *index.Index {
+	return indexers.DecodedMultiIndexer[T](
+		name,
+		index.SingleValueFromOneOrTwoArgs[resource.ReferenceOrID, index.IndexQueryOptions](fromArgs),
+		fromResource[T],
+	)
+}
+
+func fromArgs(r resource.ReferenceOrID, opts index.IndexQueryOptions) ([]byte, error) {
+	workloadRef := &pbresource.Reference{
+		Type:    pbcatalog.WorkloadType,
+		Tenancy: r.GetTenancy(),
+		Name:    r.GetName(),
+	}
+
+	if opts.Prefix {
+		return index.PrefixIndexFromRefOrID(workloadRef), nil
+	} else {
+		return index.IndexFromRefOrID(workloadRef), nil
+	}
+}
+
+func fromResource[T WorkloadSelecting](res *resource.DecodedResource[T]) (bool, [][]byte, error) {
+	sel := res.Data.GetWorkloads()
+	if sel == nil || (len(sel.Prefixes) == 0 && len(sel.Names) == 0) {
+		return false, nil, nil
+	}
+
+	var indexes [][]byte
+
+	for _, name := range sel.Names {
+		ref := &pbresource.Reference{
+			Type:    pbcatalog.WorkloadType,
+			Tenancy: res.Id.Tenancy,
+			Name:    name,
+		}
+
+		indexes = append(indexes, index.IndexFromRefOrID(ref))
+	}
+
+	for _, name := range sel.Prefixes {
+		ref := &pbresource.Reference{
+			Type:    pbcatalog.WorkloadType,
+			Tenancy: res.Id.Tenancy,
+			Name:    name,
+		}
+
+		b := index.IndexFromRefOrID(ref)
+
+		// need to remove the path separator to be compatible with prefix matching
+		indexes = append(indexes, b[:len(b)-1])
+	}
+
+	return true, indexes, nil
+}

--- a/internal/catalog/workloadselector/index_test.go
+++ b/internal/catalog/workloadselector/index_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package workloadselector
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/internal/controller/cache"
+	"github.com/hashicorp/consul/internal/controller/cache/index"
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/resourcetest"
+	rtest "github.com/hashicorp/consul/internal/resource/resourcetest"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/hashicorp/consul/proto/private/prototest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceWorkloadIndexer(t *testing.T) {
+	c := cache.New()
+	i := Index[*pbcatalog.Service]("selected-workloads")
+	require.NoError(t, c.AddIndex(pbcatalog.ServiceType, i))
+
+	foo := rtest.Resource(pbcatalog.ServiceType, "foo").
+		WithData(t, &pbcatalog.Service{
+			Workloads: &pbcatalog.WorkloadSelector{
+				Names: []string{
+					"api-2",
+				},
+				Prefixes: []string{
+					"api-1",
+				},
+			},
+		}).
+		WithTenancy(&pbresource.Tenancy{
+			Partition: "default",
+			Namespace: "default",
+			PeerName:  "local",
+		}).
+		Build()
+
+	require.NoError(t, c.Insert(foo))
+
+	bar := rtest.Resource(pbcatalog.ServiceType, "bar").
+		WithData(t, &pbcatalog.Service{
+			Workloads: &pbcatalog.WorkloadSelector{
+				Names: []string{
+					"api-3",
+				},
+				Prefixes: []string{
+					"api-2",
+				},
+			},
+		}).
+		WithTenancy(&pbresource.Tenancy{
+			Partition: "default",
+			Namespace: "default",
+			PeerName:  "local",
+		}).
+		Build()
+
+	require.NoError(t, c.Insert(bar))
+
+	api123 := rtest.Resource(pbcatalog.WorkloadType, "api-123").
+		WithTenancy(&pbresource.Tenancy{
+			Partition: "default",
+			Namespace: "default",
+			PeerName:  "local",
+		}).
+		Reference("")
+
+	api2 := rtest.Resource(pbcatalog.WorkloadType, "api-2").
+		WithTenancy(&pbresource.Tenancy{
+			Partition: "default",
+			Namespace: "default",
+			PeerName:  "local",
+		}).
+		Reference("")
+
+	resources, err := c.Parents(pbcatalog.ServiceType, i.Name(), api123)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	prototest.AssertDeepEqual(t, foo, resources[0])
+
+	resources, err = c.Parents(pbcatalog.ServiceType, i.Name(), api2)
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	prototest.AssertElementsMatch(t, []*pbresource.Resource{foo, bar}, resources)
+
+	refPrefix := &pbresource.Reference{
+		Type: pbcatalog.WorkloadType,
+		Tenancy: &pbresource.Tenancy{
+			Partition: "default",
+			Namespace: "default",
+		},
+	}
+	resources, err = c.List(pbcatalog.ServiceType, i.Name(), refPrefix, index.IndexQueryOptions{Prefix: true})
+	require.NoError(t, err)
+	// because foo and bar both have 2 index values they will appear in the output twice
+	require.Len(t, resources, 4)
+	prototest.AssertElementsMatch(t, []*pbresource.Resource{foo, bar, foo, bar}, resources)
+}
+
+func TestServiceWorkloadIndexer_FromResource_Errors(t *testing.T) {
+	t.Run("nil-selector", func(t *testing.T) {
+		res := resourcetest.Resource(pbcatalog.ServiceType, "foo").
+			WithData(t, &pbcatalog.Service{}).
+			WithTenancy(resource.DefaultNamespacedTenancy()).
+			Build()
+
+		decoded, err := resource.Decode[*pbcatalog.Service](res)
+
+		indexed, vals, err := fromResource(decoded)
+		require.False(t, indexed)
+		require.Nil(t, vals)
+		require.NoError(t, err)
+	})
+
+	t.Run("no-selections", func(t *testing.T) {
+		res := resourcetest.Resource(pbcatalog.ServiceType, "foo").
+			WithData(t, &pbcatalog.Service{
+				Workloads: &pbcatalog.WorkloadSelector{},
+			}).
+			WithTenancy(resource.DefaultNamespacedTenancy()).
+			Build()
+
+		decoded, err := resource.Decode[*pbcatalog.Service](res)
+
+		indexed, vals, err := fromResource(decoded)
+		require.False(t, indexed)
+		require.Nil(t, vals)
+		require.NoError(t, err)
+	})
+}

--- a/internal/catalog/workloadselector/integ_test.go
+++ b/internal/catalog/workloadselector/integ_test.go
@@ -1,0 +1,134 @@
+package workloadselector_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/consul/internal/catalog/workloadselector"
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/controller/cache"
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/resourcetest"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
+	"github.com/hashicorp/consul/proto/private/prototest"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkloadSelectorCacheIntegration(t *testing.T) {
+	c := cache.New()
+	i := workloadselector.Index[*pbcatalog.Service]("selected-workloads")
+	c.AddType(pbcatalog.WorkloadType)
+	c.AddIndex(pbcatalog.ServiceType, i)
+
+	rt := controller.Runtime{
+		Cache:  c,
+		Logger: testutil.Logger(t),
+	}
+
+	svcFoo := resourcetest.Resource(pbcatalog.ServiceType, "foo").
+		WithData(t, &pbcatalog.Service{
+			Workloads: &pbcatalog.WorkloadSelector{
+				Names:    []string{"foo"},
+				Prefixes: []string{"api-", "other-"},
+			},
+		}).
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	svcBar := resourcetest.Resource(pbcatalog.ServiceType, "bar").
+		WithData(t, &pbcatalog.Service{
+			Workloads: &pbcatalog.WorkloadSelector{
+				Names:    []string{"bar"},
+				Prefixes: []string{"api-1", "something-else-"},
+			},
+		}).
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	workloadBar := resourcetest.Resource(pbcatalog.WorkloadType, "bar").
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	workloadAPIFoo := resourcetest.Resource(pbcatalog.WorkloadType, "api-foo").
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	workloadAPI12 := resourcetest.Resource(pbcatalog.WorkloadType, "api-1").
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	workloadFoo := resourcetest.Resource(pbcatalog.WorkloadType, "foo").
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	workloadSomethingElse12 := resourcetest.Resource(pbcatalog.WorkloadType, "something-else-12").
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	// prime the cache with all of our services and workloads
+	require.NoError(t, c.Insert(svcFoo))
+	require.NoError(t, c.Insert(svcBar))
+	require.NoError(t, c.Insert(workloadAPIFoo))
+	require.NoError(t, c.Insert(workloadAPI12))
+	require.NoError(t, c.Insert(workloadFoo))
+	require.NoError(t, c.Insert(workloadSomethingElse12))
+
+	// check that mapping a selecting resource to the list of currently selected workloads works as expected
+	reqs, err := workloadselector.MapSelectorToWorkloads[*pbcatalog.Service](context.Background(), rt, svcFoo)
+	require.NoError(t, err)
+	// in particular workloadSomethingElse12 should not show up here
+	expected := []controller.Request{
+		{ID: workloadFoo.Id},
+		{ID: workloadAPI12.Id},
+		{ID: workloadAPIFoo.Id},
+	}
+	prototest.AssertElementsMatch(t, expected, reqs)
+
+	reqs, err = workloadselector.MapSelectorToWorkloads[*pbcatalog.Service](context.Background(), rt, svcBar)
+	require.NoError(t, err)
+	// in particular workloadFoo and workloadAPIFoo should not show up here
+	expected = []controller.Request{
+		{ID: workloadSomethingElse12.Id},
+		{ID: workloadAPI12.Id},
+		{ID: workloadBar.Id},
+	}
+	prototest.AssertElementsMatch(t, expected, reqs)
+
+	// create the mapper to verify that finding services that select workloads functions correctly
+	mapper := workloadselector.MapWorkloadsToSelectors(pbcatalog.ServiceType, i.Name())
+
+	// check that workloadAPIFoo only returns a request for serviceFoo
+	reqs, err = mapper(context.Background(), rt, workloadAPIFoo)
+	require.NoError(t, err)
+	expected = []controller.Request{
+		{ID: svcFoo.Id},
+	}
+	prototest.AssertElementsMatch(t, expected, reqs)
+
+	// check that workloadAPI12 returns both services
+	reqs, err = mapper(context.Background(), rt, workloadAPI12)
+	require.NoError(t, err)
+	expected = []controller.Request{
+		{ID: svcFoo.Id},
+		{ID: svcBar.Id},
+	}
+	prototest.AssertElementsMatch(t, expected, reqs)
+
+	// check that workloadSomethingElse12 returns only svcBar
+	reqs, err = mapper(context.Background(), rt, workloadSomethingElse12)
+	require.NoError(t, err)
+	expected = []controller.Request{
+		{ID: svcBar.Id},
+	}
+	prototest.AssertElementsMatch(t, expected, reqs)
+
+	// check that workloadFoo returns only svcFoo
+	reqs, err = mapper(context.Background(), rt, workloadFoo)
+	require.NoError(t, err)
+	expected = []controller.Request{
+		{ID: svcFoo.Id},
+	}
+	prototest.AssertElementsMatch(t, expected, reqs)
+
+}

--- a/internal/catalog/workloadselector/mapper.go
+++ b/internal/catalog/workloadselector/mapper.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package workloadselector
+
+import (
+	"context"
+
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/controller/cache/index"
+	"github.com/hashicorp/consul/internal/controller/dependency"
+	"github.com/hashicorp/consul/internal/resource"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+// MapSelectorToWorkloads will use the "id" index on watched Workload type to find all current
+// workloads selected by the resource.
+func MapSelectorToWorkloads[T WorkloadSelecting](_ context.Context, rt controller.Runtime, r *pbresource.Resource) ([]controller.Request, error) {
+	res, err := resource.Decode[T](r)
+	if err != nil {
+		return nil, err
+	}
+
+	sel := res.Data.GetWorkloads()
+	var reqs []controller.Request
+
+	// Generate requests for all Workloads specified by an exact name
+	for _, name := range sel.GetNames() {
+		reqs = append(reqs, controller.Request{
+			ID: &pbresource.ID{
+				Type:    pbcatalog.WorkloadType,
+				Name:    name,
+				Tenancy: r.Id.Tenancy,
+			},
+		})
+	}
+
+	// Generate requests for workloads that would match the given prefix.
+	for _, prefix := range sel.GetPrefixes() {
+		iter, err := rt.Cache.ListIterator(pbcatalog.WorkloadType, "id", &pbresource.ID{
+			Type:    pbcatalog.WorkloadType,
+			Name:    prefix,
+			Tenancy: r.Id.Tenancy,
+		}, index.IndexQueryOptions{Prefix: true})
+
+		if err != nil {
+			return nil, err
+		}
+
+		for res := iter.Next(); res != nil; res = iter.Next() {
+			reqs = append(reqs, controller.Request{
+				ID: res.Id,
+			})
+		}
+	}
+
+	return reqs, nil
+}
+
+// MapWorkloadsToSelectors returns a DependencyMapper that will use the specified index to map a workload
+// to resources that select it.
+//
+// This mapper can only be used on watches for the Workload type and works in conjunction with the Index
+// created by this package.
+func MapWorkloadsToSelectors(indexType *pbresource.Type, indexName string) controller.DependencyMapper {
+	return dependency.CacheParentsMapper(indexType, indexName)
+}

--- a/internal/catalog/workloadselector/mapper_test.go
+++ b/internal/catalog/workloadselector/mapper_test.go
@@ -1,0 +1,169 @@
+package workloadselector
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/controller/cache/cachemock"
+	"github.com/hashicorp/consul/internal/controller/cache/index"
+	"github.com/hashicorp/consul/internal/controller/cache/index/indexmock"
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/internal/resource/resourcetest"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/hashicorp/consul/proto/private/prototest"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+var injectedError = errors.New("injected error")
+
+func TestMapSelectorToWorkloads(t *testing.T) {
+	cache := cachemock.NewReadOnlyCache(t)
+
+	rt := controller.Runtime{
+		Cache: cache,
+	}
+
+	mres := indexmock.NewResourceIterator(t)
+
+	svc := resourcetest.Resource(pbcatalog.ServiceType, "api").
+		WithData(t, &pbcatalog.Service{
+			Workloads: &pbcatalog.WorkloadSelector{
+				Prefixes: []string{"api-"},
+				Names:    []string{"foo"},
+			},
+		}).
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	api1 := resourcetest.Resource(pbcatalog.WorkloadType, "api-1").
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	api2 := resourcetest.Resource(pbcatalog.WorkloadType, "api-2").
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	cache.EXPECT().
+		ListIterator(pbcatalog.WorkloadType, "id", &pbresource.ID{
+			Type:    pbcatalog.WorkloadType,
+			Name:    "api-",
+			Tenancy: resource.DefaultNamespacedTenancy(),
+		}, index.IndexQueryOptions{Prefix: true}).
+		Return(mres, nil).
+		Once()
+
+	mres.EXPECT().Next().Return(api1).Once()
+	mres.EXPECT().Next().Return(api2).Once()
+	mres.EXPECT().Next().Return(nil).Once()
+
+	expected := []controller.Request{
+		{
+			ID: resourcetest.Resource(pbcatalog.WorkloadType, "foo").
+				WithTenancy(resource.DefaultNamespacedTenancy()).
+				ID(),
+		},
+		{ID: api1.Id},
+		{ID: api2.Id},
+	}
+
+	reqs, err := MapSelectorToWorkloads[*pbcatalog.Service](context.Background(), rt, svc)
+	require.NoError(t, err)
+	prototest.AssertElementsMatch(t, expected, reqs)
+}
+
+func TestMapSelectorToWorkloads_DecodeError(t *testing.T) {
+	res := resourcetest.Resource(pbcatalog.ServiceType, "foo").
+		WithData(t, &pbcatalog.DNSPolicy{}).
+		Build()
+
+	reqs, err := MapSelectorToWorkloads[*pbcatalog.Service](context.Background(), controller.Runtime{}, res)
+	require.Nil(t, reqs)
+	require.Error(t, err)
+	require.ErrorAs(t, err, &resource.ErrDataParse{})
+}
+
+func TestMapSelectorToWorkloads_CacheError(t *testing.T) {
+	cache := cachemock.NewReadOnlyCache(t)
+
+	rt := controller.Runtime{
+		Cache: cache,
+	}
+
+	svc := resourcetest.Resource(pbcatalog.ServiceType, "api").
+		WithData(t, &pbcatalog.Service{
+			Workloads: &pbcatalog.WorkloadSelector{
+				Prefixes: []string{"api-"},
+			},
+		}).
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	cache.EXPECT().
+		ListIterator(pbcatalog.WorkloadType, "id", &pbresource.ID{
+			Type:    pbcatalog.WorkloadType,
+			Name:    "api-",
+			Tenancy: resource.DefaultNamespacedTenancy(),
+		}, index.IndexQueryOptions{Prefix: true}).
+		Return(nil, injectedError).
+		Once()
+
+	reqs, err := MapSelectorToWorkloads[*pbcatalog.Service](context.Background(), rt, svc)
+	require.ErrorIs(t, err, injectedError)
+	require.Nil(t, reqs)
+}
+
+func TestMapWorkloadsToSelectors(t *testing.T) {
+	cache := cachemock.NewReadOnlyCache(t)
+	rt := controller.Runtime{
+		Cache:  cache,
+		Logger: hclog.NewNullLogger(),
+	}
+
+	dm := MapWorkloadsToSelectors(pbcatalog.ServiceType, "selected-workloads")
+
+	workload := resourcetest.Resource(pbcatalog.WorkloadType, "api-123").
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	svc1 := resourcetest.Resource(pbcatalog.ServiceType, "foo").
+		WithData(t, &pbcatalog.Service{
+			Workloads: &pbcatalog.WorkloadSelector{
+				Prefixes: []string{"api-"},
+			},
+		}).
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	svc2 := resourcetest.Resource(pbcatalog.ServiceType, "bar").
+		WithData(t, &pbcatalog.Service{
+			Workloads: &pbcatalog.WorkloadSelector{
+				Prefixes: []string{"api-"},
+			},
+		}).
+		WithTenancy(resource.DefaultNamespacedTenancy()).
+		Build()
+
+	mres := indexmock.NewResourceIterator(t)
+
+	cache.EXPECT().
+		ParentsIterator(pbcatalog.ServiceType, "selected-workloads", workload.Id).
+		Return(mres, nil).
+		Once()
+
+	mres.EXPECT().Next().Return(svc1).Once()
+	mres.EXPECT().Next().Return(svc2).Once()
+	mres.EXPECT().Next().Return(nil).Once()
+
+	reqs, err := dm(context.Background(), rt, workload)
+	require.NoError(t, err)
+	expected := []controller.Request{
+		{ID: svc1.Id},
+		{ID: svc2.Id},
+	}
+	prototest.AssertElementsMatch(t, expected, reqs)
+
+}

--- a/internal/catalog/workloadselector/selecting.go
+++ b/internal/catalog/workloadselector/selecting.go
@@ -1,0 +1,16 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package workloadselector
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
+)
+
+// WorkloadSelecting denotes a resource type that uses workload selectors.
+type WorkloadSelecting interface {
+	proto.Message
+	GetWorkloads() *pbcatalog.WorkloadSelector
+}

--- a/internal/controller/cache/index/convenience.go
+++ b/internal/controller/cache/index/convenience.go
@@ -11,6 +11,10 @@ import (
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
+type IndexQueryOptions struct {
+	Prefix bool
+}
+
 func IndexFromID(id *pbresource.ID, includeUid bool) []byte {
 	var b Builder
 	b.Raw(IndexFromType(id.Type))
@@ -85,6 +89,14 @@ var ReferenceOrIDFromArgs = SingleValueFromArgs[resource.ReferenceOrID](func(r r
 
 var PrefixReferenceOrIDFromArgs = SingleValueFromArgs[resource.ReferenceOrID](func(r resource.ReferenceOrID) ([]byte, error) {
 	return PrefixIndexFromRefOrID(r), nil
+})
+
+var MaybePrefixReferenceOrIDFromArgs = SingleValueFromOneOrTwoArgs[resource.ReferenceOrID, IndexQueryOptions](func(r resource.ReferenceOrID, opts IndexQueryOptions) ([]byte, error) {
+	if opts.Prefix {
+		return PrefixIndexFromRefOrID(r), nil
+	} else {
+		return IndexFromRefOrID(r), nil
+	}
 })
 
 func SingleValueFromArgs[T any](indexer func(value T) ([]byte, error)) func(args ...any) ([]byte, error) {

--- a/internal/controller/cache/indexers/id_indexer.go
+++ b/internal/controller/cache/indexers/id_indexer.go
@@ -38,7 +38,7 @@ type idOrRefIndexer struct {
 
 // FromArgs constructs a radix tree key from an ID for lookup.
 func (i idOrRefIndexer) FromArgs(args ...any) ([]byte, error) {
-	return index.ReferenceOrIDFromArgs(args...)
+	return index.MaybePrefixReferenceOrIDFromArgs(args...)
 }
 
 // FromObject constructs a radix tree key from a Resource at write-time, or an


### PR DESCRIPTION
### Description

https://github.com/hashicorp/consul/pull/19767 and https://github.com/hashicorp/consul/pull/19942 have laid the groundwork for better resource relationship management within controllers.

This PR updates the endpoints controller to take advantage of the controller cache. This also contains a second commit for a common workload selection indexer/mapper which can be reused across other controllers which select workloads.

### Testing & Reproduction steps

* New unit tests for the workloadselector package
* Existing controller tests still pass
