### PR TITLE
Handle NamespaceTrafficPermissions when reconciling TrafficPermissions

### DIFF
--- a/internal/auth/internal/controllers/trafficpermissions/controller.go
+++ b/internal/auth/internal/controllers/trafficpermissions/controller.go
@@ -5,6 +5,7 @@ package trafficpermissions
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -92,9 +93,10 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 	}
 
 	// Part 2: Recompute a CTP from TP create / modify / delete, or create a new CTP from existing TPs:
-	latestTrafficPermissions, err := computeNewTrafficPermissions(ctx, rt, r.mapper, ctpID, oldResource)
+	latestTrafficPermissions, err := computeNewTrafficPermissions(ctx, rt, r.mapper, ctpID)
 	if err != nil {
 		rt.Logger.Error("error calculating computed permissions", "error", err)
+		writeFailedStatus(ctx, rt, oldResource, err.Error())
 		return err
 	}
 
@@ -106,7 +108,7 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 	newCTPData, err := anypb.New(latestTrafficPermissions)
 	if err != nil {
 		rt.Logger.Error("error marshalling latest traffic permissions", "error", err)
-		writeFailedStatus(ctx, rt, oldResource, nil, err.Error())
+		writeFailedStatus(ctx, rt, oldResource, err.Error())
 		return err
 	}
 	rt.Logger.Trace("writing computed traffic permissions")
@@ -119,7 +121,7 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 	})
 	if err != nil || rsp.Resource == nil {
 		rt.Logger.Error("error writing new computed traffic permissions", "error", err)
-		writeFailedStatus(ctx, rt, oldResource, nil, err.Error())
+		writeFailedStatus(ctx, rt, oldResource, err.Error())
 		return err
 	} else {
 		rt.Logger.Trace("new computed traffic permissions were successfully written")
@@ -138,14 +140,14 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 	return err
 }
 
-func writeFailedStatus(ctx context.Context, rt controller.Runtime, ctp *pbresource.Resource, tp *pbresource.ID, errDetail string) error {
+func writeFailedStatus(ctx context.Context, rt controller.Runtime, ctp *pbresource.Resource, errDetail string) {
 	if ctp == nil {
-		return nil
+		return
 	}
 	newStatus := &pbresource.Status{
 		ObservedGeneration: ctp.Generation,
 		Conditions: []*pbresource.Condition{
-			ConditionFailedToCompute(ctp.Id.Name, tp.Name, errDetail),
+			ConditionFailedToCompute(ctp.Id.Name, errDetail),
 		},
 	}
 	_, err := rt.Client.WriteStatus(ctx, &pbresource.WriteStatusRequest{
@@ -153,11 +155,19 @@ func writeFailedStatus(ctx context.Context, rt controller.Runtime, ctp *pbresour
 		Key:    StatusKey,
 		Status: newStatus,
 	})
-	return err
+	if err != nil {
+		rt.Logger.Error("error writing failed status", "error", err)
+	}
 }
 
 // computeNewTrafficPermissions will use all associated Traffic Permissions to create new ComputedTrafficPermissions data
-func computeNewTrafficPermissions(ctx context.Context, rt controller.Runtime, wm TrafficPermissionsMapper, ctpID *pbresource.ID, ctp *pbresource.Resource) (*pbauth.ComputedTrafficPermissions, error) {
+func computeNewTrafficPermissions(ctx context.Context, rt controller.Runtime, wm TrafficPermissionsMapper, ctpID *pbresource.ID) (*pbauth.ComputedTrafficPermissions, error) {
+	// Get all enterprise TPs, if applicable
+	allow, deny, err := getEnterpriseTrafficPermissions(ctx, rt, ctpID)
+	if err != nil {
+		return nil, err
+	}
+
 	// Part 1: Get all TPs that apply to workload identity
 	// Get already associated WorkloadIdentities/CTPs for reconcile requests:
 	trackedTPs := wm.GetTrafficPermissionsForCTP(ctpID)
@@ -166,14 +176,15 @@ func computeNewTrafficPermissions(ctx context.Context, rt controller.Runtime, wm
 	} else {
 		rt.Logger.Trace("found no tracked traffic permissions for CTP")
 	}
-	ap := make([]*pbauth.Permission, 0)
-	dp := make([]*pbauth.Permission, 0)
-	isDefault := true
+
+	// isDefault means no known traffic permissions were applied
+	isDefault := len(allow) == 0 && len(deny) == 0
+
 	for _, t := range trackedTPs {
 		rsp, err := resource.GetDecodedResource[*pbauth.TrafficPermissions](ctx, rt.Client, resource.IDFromReference(t))
 		if err != nil {
+			err = fmt.Errorf("could not fetch traffic permission %q: %w", resource.IDFromReference(t), err)
 			rt.Logger.Error("error reading traffic permissions resource for computation", "error", err)
-			writeFailedStatus(ctx, rt, ctp, resource.IDFromReference(t), err.Error())
 			return nil, err
 		}
 		if rsp == nil {
@@ -183,14 +194,14 @@ func computeNewTrafficPermissions(ctx context.Context, rt controller.Runtime, wm
 		}
 		isDefault = false
 		if rsp.Data.Action == pbauth.Action_ACTION_ALLOW {
-			ap = append(ap, rsp.Data.Permissions...)
+			allow = append(allow, rsp.Data.Permissions...)
 		} else {
-			dp = append(dp, rsp.Data.Permissions...)
+			deny = append(deny, rsp.Data.Permissions...)
 		}
 	}
 	return &pbauth.ComputedTrafficPermissions{
-		AllowPermissions: ap,
-		DenyPermissions:  dp,
+		AllowPermissions: allow,
+		DenyPermissions:  deny,
 		IsDefault:        isDefault,
 	}, nil
 }

--- a/internal/auth/internal/controllers/trafficpermissions/controller_ce.go
+++ b/internal/auth/internal/controllers/trafficpermissions/controller_ce.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !consulent
+
+package trafficpermissions
+
+import (
+	"context"
+
+	"github.com/hashicorp/consul/internal/controller"
+	pbauth "github.com/hashicorp/consul/proto-public/pbauth/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+// getEnterpriseTrafficPermissions is a stub for enterprise traffic permissions.
+// We return empty allow and deny slices.
+func getEnterpriseTrafficPermissions(
+	_ context.Context,
+	_ controller.Runtime,
+	_ *pbresource.ID,
+) (allow []*pbauth.Permission, deny []*pbauth.Permission, err error) {
+	allow = make([]*pbauth.Permission, 0)
+	deny = make([]*pbauth.Permission, 0)
+	return allow, deny, nil
+}

--- a/internal/auth/internal/controllers/trafficpermissions/status.go
+++ b/internal/auth/internal/controllers/trafficpermissions/status.go
@@ -30,11 +30,8 @@ func ConditionComputed(workloadIdentity string, isDefault bool) *pbresource.Cond
 	}
 }
 
-func ConditionFailedToCompute(workloadIdentity string, trafficPermissions string, errDetail string) *pbresource.Condition {
+func ConditionFailedToCompute(workloadIdentity string, errDetail string) *pbresource.Condition {
 	message := fmt.Sprintf(ConditionPermissionsFailedMsg, workloadIdentity)
-	if len(trafficPermissions) > 0 {
-		message = message + fmt.Sprintf(", traffic permission %s cannot be computed", trafficPermissions)
-	}
 	if len(errDetail) > 0 {
 		message = message + fmt.Sprintf(", error details: %s", errDetail)
 	}

--- a/internal/auth/internal/types/types.go
+++ b/internal/auth/internal/types/types.go
@@ -11,4 +11,6 @@ func Register(r resource.Registry) {
 	RegisterWorkloadIdentity(r)
 	RegisterTrafficPermissions(r)
 	RegisterComputedTrafficPermission(r)
+
+	RegisterEnterpriseTypes(r)
 }

--- a/internal/auth/internal/types/types_ce.go
+++ b/internal/auth/internal/types/types_ce.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !consulent
+
+package types
+
+import "github.com/hashicorp/consul/internal/resource"
+
+func RegisterEnterpriseTypes(_ resource.Registry) {}


### PR DESCRIPTION
### Description

Registers the NamespaceTrafficPermissions type and adds logic to the Computed Traffic Permissions controller to handle NTP in the reconcile loop.

### Testing & Reproduction steps

Added testcases for new type
Added NamespaceTrafficPermissions to existing reconcile test
Added test ensuring that tenancy gets applied correctly to workload identities