### PR TITLE
security: disable Vault secret scans due to false positives

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -17,7 +17,19 @@ container {
 	alpine_secdb = true
 
 	secrets {
-		all = true
+		matchers = {
+			// Use default list, minus Vault (`hashicorp`), which has experienced false positives.
+			// See https://github.com/hashicorp/security-scanner/blob/v0.0.2/pkg/scanner/secrets.go#L130C2-L130C2
+			known = [
+				// "hashicorp",
+				"aws",
+				"google",
+				"slack",
+				"github",
+				"azure",
+				"npm",
+			]
+		}
 	}
 
 	# Triage items that are _safe_ to ignore here. Note that this list should be
@@ -41,6 +53,16 @@ binary {
 	# (yarn.lock) in the Consul binary. This is something we may investigate in the future.
 	
 	secrets {
-		all = true
+		// Use most of default list, minus Vault (`hashicorp`), which has experienced false positives.
+		// See https://github.com/hashicorp/security-scanner/blob/v0.0.2/pkg/scanner/secrets.go#L130C2-L130C2
+		known = [
+			// "hashicorp",
+			"aws",
+			"google",
+			"slack",
+			"github",
+			"azure",
+			"npm",
+		]
 	}
 }


### PR DESCRIPTION
This was recently shown to have issues with false positives that blocked a preview release build, so disabling for now.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [ ] not a security concern
