### PR TITLE
Use null route cluster for default router when no matches on v2 mesh gateway

### DIFF
--- a/internal/mesh/internal/controllers/gatewayproxy/builder/builder_test.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/builder/builder_test.go
@@ -197,7 +197,7 @@ func (suite *proxyStateTemplateBuilderSuite) TestProxyStateTemplateBuilder_Build
 			"without address ports": suite.workloadWithOutAddressPorts,
 		} {
 			testutil.RunStep(suite.T(), name, func(t *testing.T) {
-				builder := NewProxyStateTemplateBuilder(workload, suite.exportedServicesPeerData, logger, f, dc, trustDomain)
+				builder := NewProxyStateTemplateBuilder(workload, suite.exportedServicesPeerData.Data.Services, logger, f, dc, trustDomain)
 				expectedProxyStateTemplate := &pbmesh.ProxyStateTemplate{
 					ProxyState: &pbmesh.ProxyState{
 						Identity: &pbresource.Reference{
@@ -223,7 +223,7 @@ func (suite *proxyStateTemplateBuilderSuite) TestProxyStateTemplateBuilder_Build
 										L4: &pbproxystate.L4Destination{
 											Destination: &pbproxystate.L4Destination_Cluster{
 												Cluster: &pbproxystate.DestinationCluster{
-													Name: "",
+													Name: xdscommon.BlackHoleClusterName,
 												},
 											},
 											StatPrefix: "prefix",
@@ -267,6 +267,17 @@ func (suite *proxyStateTemplateBuilderSuite) TestProxyStateTemplateBuilder_Build
 							},
 						},
 						Clusters: map[string]*pbproxystate.Cluster{
+							xdscommon.BlackHoleClusterName: {
+								Name:     xdscommon.BlackHoleClusterName,
+								Protocol: pbproxystate.Protocol_PROTOCOL_TCP,
+								Group: &pbproxystate.Cluster_EndpointGroup{
+									EndpointGroup: &pbproxystate.EndpointGroup{
+										Group: &pbproxystate.EndpointGroup_Static{
+											Static: &pbproxystate.StaticEndpointGroup{},
+										},
+									},
+								},
+							},
 							fmt.Sprintf("mesh.%s", connect.PeeredServiceSNI("api-1", tenancy.Namespace, tenancy.Partition, "api-1", "trustDomain")): {
 								Name: fmt.Sprintf("mesh.%s", connect.PeeredServiceSNI("api-1", tenancy.Namespace, tenancy.Partition, "api-1", "trustDomain")),
 								Group: &pbproxystate.Cluster_EndpointGroup{

--- a/internal/mesh/internal/controllers/gatewayproxy/controller.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/controller.go
@@ -119,15 +119,14 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 		Type: pbmulticluster.ComputedExportedServicesType,
 	}
 
-	exportedServices, err := dataFetcher.FetchExportedServices(ctx, exportedServicesID)
-	if err != nil || exportedServices == nil {
-		if err != nil {
-			rt.Logger.Error("error reading the associated exported services", "error", err)
-		}
-
-		if exportedServices == nil {
-			rt.Logger.Error("exported services was nil")
-		}
+	var exportedServices []*pbmulticluster.ComputedExportedService
+	dec, err := dataFetcher.FetchExportedServices(ctx, exportedServicesID)
+	if err != nil {
+		rt.Logger.Error("error reading the associated exported services", "error", err)
+	} else if dec == nil {
+		rt.Logger.Error("exported services was nil")
+	} else {
+		exportedServices = dec.Data.Services
 	}
 
 	trustDomain, err := r.getTrustDomain()


### PR DESCRIPTION
### Description
Mesh gateways won't start up successfully today if there are no exported services. This seems to be due to the fact that the only router on the listener in this case points to a non-existent cluster named `""`.

When this default router points to a valid cluster, the mesh gateway starts up correctly even when no services are exported. I used the "null route cluster" concept from the sidecar proxy builder for this target cluster.

### Testing & Reproduction steps
Install w/ v2 resource APIs and mesh gateways enabled. The mesh gateway pods should come up healthy before creating any `ExportedServices` resources in k8s.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
