### PR TITLE
security: fix syntax for release scan config

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -17,8 +17,8 @@ container {
 	alpine_secdb = true
 
 	secrets {
-		matchers = {
-			// Use default list, minus Vault (`hashicorp`), which has experienced false positives.
+		matchers {
+			// Use most of default list, minus Vault (`hashicorp`), which has experienced false positives.
 			// See https://github.com/hashicorp/security-scanner/blob/v0.0.2/pkg/scanner/secrets.go#L130C2-L130C2
 			known = [
 				// "hashicorp",
@@ -53,16 +53,18 @@ binary {
 	# (yarn.lock) in the Consul binary. This is something we may investigate in the future.
 	
 	secrets {
-		// Use most of default list, minus Vault (`hashicorp`), which has experienced false positives.
-		// See https://github.com/hashicorp/security-scanner/blob/v0.0.2/pkg/scanner/secrets.go#L130C2-L130C2
-		known = [
-			// "hashicorp",
-			"aws",
-			"google",
-			"slack",
-			"github",
-			"azure",
-			"npm",
-		]
+		matchers {
+			// Use most of default list, minus Vault (`hashicorp`), which has experienced false positives.
+			// See https://github.com/hashicorp/security-scanner/blob/v0.0.2/pkg/scanner/secrets.go#L130C2-L130C2
+			known = [
+				// "hashicorp",
+				"aws",
+				"google",
+				"slack",
+				"github",
+				"azure",
+				"npm",
+			]
+		}
 	}
 }


### PR DESCRIPTION
Correct syntax errors introduced in #20264.

### Description

I forgot that nothing would lint the file, which would have caught this in CI. This should fix release scans and retain the intended impact of the first change.

### Testing & Reproduction steps

Tested locally:
```shell
❯ SECURITY_SCANNER_CONFIG_FILE=.release/security-scan.hcl scan binary ~/Downloads/consul_1.15.9-dev+ent_darwin_arm64/consul
✓ Scanned file:{path:"/Users/michael.zalimeni/Downloads/consul_1.15.9-dev+ent_darwin_arm64/consul"} in 10.3s - no results found

❯ SECURITY_SCANNER_CONFIG_FILE=.release/security-scan.hcl scan container hashicorp/consul:1.17
✓ Scanned docker:{owner:"hashicorp" name:"consul"} tag:"1.17" localDaemon:true in 50.8s - no results found
```

Previously would produce a syntax error:
```
failed to decode scan config contents, unable to gracefully handle: scan.hcl:58,3-8: Unsupported argument; An argument named "known" is not expected here.
```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [ ] not a security concern
