### PR TITLE
ci: sync point release branches in addition to .x

### DIFF
--- a/.github/workflows/ce-merge-trigger.yml
+++ b/.github/workflows/ce-merge-trigger.yml
@@ -5,7 +5,7 @@ on:
       - closed
     branches:
       - main
-      - 'release/*.*.x'
+      - release/**
 
 jobs:
   trigger-ce-merge:


### PR DESCRIPTION
This replicates the pattern used in `main` and `release/1.17.x`.

https://github.com/hashicorp/consul/blob/main/.github/workflows/ce-merge-trigger.yml

@jm96441n LMK if you'd like me to backport this to the point-release branch as well.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
