### PR TITLE
Backport of security: disable Vault secret scans due to false positives into release/1.15.9

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -18,8 +18,8 @@ container {
 	alpine_secdb = true
 
 	secrets {
-		matchers = {
-			// Use default list, minus Vault (`hashicorp`), which has experienced false positives.
+		matchers {
+			// Use most of default list, minus Vault (`hashicorp`), which has experienced false positives.
 			// See https://github.com/hashicorp/security-scanner/blob/v0.0.2/pkg/scanner/secrets.go#L130C2-L130C2
 			known = [
 				// "hashicorp",
@@ -54,16 +54,18 @@ binary {
 	# (yarn.lock) in the Consul binary. This is something we may investigate in the future.
 
 	secrets {
-		// Use most of default list, minus Vault (`hashicorp`), which has experienced false positives.
-		// See https://github.com/hashicorp/security-scanner/blob/v0.0.2/pkg/scanner/secrets.go#L130C2-L130C2
-		known = [
-			// "hashicorp",
-			"aws",
-			"google",
-			"slack",
-			"github",
-			"azure",
-			"npm",
-		]
+		matchers {
+			// Use most of default list, minus Vault (`hashicorp`), which has experienced false positives.
+			// See https://github.com/hashicorp/security-scanner/blob/v0.0.2/pkg/scanner/secrets.go#L130C2-L130C2
+			known = [
+				// "hashicorp",
+				"aws",
+				"google",
+				"slack",
+				"github",
+				"azure",
+				"npm",
+			]
+		}
 	}
 }

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -18,7 +18,19 @@ container {
 	alpine_secdb = true
 
 	secrets {
-		all = true
+		matchers = {
+			// Use default list, minus Vault (`hashicorp`), which has experienced false positives.
+			// See https://github.com/hashicorp/security-scanner/blob/v0.0.2/pkg/scanner/secrets.go#L130C2-L130C2
+			known = [
+				// "hashicorp",
+				"aws",
+				"google",
+				"slack",
+				"github",
+				"azure",
+				"npm",
+			]
+		}
 	}
 
 	# Triage items that are _safe_ to ignore here. Note that this list should be
@@ -42,6 +54,16 @@ binary {
 	# (yarn.lock) in the Consul binary. This is something we may investigate in the future.
 
 	secrets {
-		all = true
+		// Use most of default list, minus Vault (`hashicorp`), which has experienced false positives.
+		// See https://github.com/hashicorp/security-scanner/blob/v0.0.2/pkg/scanner/secrets.go#L130C2-L130C2
+		known = [
+			// "hashicorp",
+			"aws",
+			"google",
+			"slack",
+			"github",
+			"azure",
+			"npm",
+		]
 	}
 }


### PR DESCRIPTION
Backport of https://github.com/hashicorp/consul/pull/20264 and subsequent fix https://github.com/hashicorp/consul/pull/20279

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
