### PR TITLE
resource: retry non-CAS deletes automatically

### DIFF
--- a/agent/grpc-external/services/resource/server.go
+++ b/agent/grpc-external/services/resource/server.go
@@ -5,7 +5,9 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -19,6 +21,7 @@ import (
 	"github.com/hashicorp/consul/acl/resolver"
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/storage"
+	"github.com/hashicorp/consul/lib/retry"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
@@ -295,6 +298,41 @@ func isTenancyMarkedForDeletion(reg *resource.Registration, tenancyBridge Tenanc
 
 	// Cluster scope has no tenancy so always return false
 	return false, nil
+}
+
+// retryCAS retries the given operation with exponential backoff if the user
+// didn't provide a version. This is intended to hide failures when the user
+// isn't intentionally performing a CAS operation (all writes are, by design,
+// CAS operations at the storage backend layer).
+func (s *Server) retryCAS(ctx context.Context, vsn string, cas func() error) error {
+	if vsn != "" {
+		return cas()
+	}
+
+	const maxAttempts = 5
+
+	// These parameters are fairly arbitrary, so if you find better ones then go
+	// ahead and swap them out! In general, we want to wait long enough to smooth
+	// over small amounts of storage replication lag, but not so long that we make
+	// matters worse by holding onto load.
+	backoff := &retry.Waiter{
+		MinWait: 50 * time.Millisecond,
+		MaxWait: 1 * time.Second,
+		Jitter:  retry.NewJitter(50),
+		Factor:  75 * time.Millisecond,
+	}
+
+	var err error
+	for i := 1; i <= maxAttempts; i++ {
+		if err = cas(); !errors.Is(err, storage.ErrCASFailure) {
+			break
+		}
+		if backoff.Wait(ctx) != nil {
+			break
+		}
+		s.Logger.Trace("retrying failed CAS operation", "failure_count", i)
+	}
+	return err
 }
 
 func clone[T proto.Message](v T) T { return proto.Clone(v).(T) }

--- a/agent/grpc-external/services/resource/write.go
+++ b/agent/grpc-external/services/resource/write.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"time"
 
 	"github.com/oklog/ulid/v2"
 	"golang.org/x/exp/maps"
@@ -18,7 +17,6 @@ import (
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/storage"
-	"github.com/hashicorp/consul/lib/retry"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
@@ -251,41 +249,6 @@ func (s *Server) Write(ctx context.Context, req *pbresource.WriteRequest) (*pbre
 		return nil, status.Errorf(codes.Internal, "failed to write resource: %v", err.Error())
 	}
 	return &pbresource.WriteResponse{Resource: result}, nil
-}
-
-// retryCAS retries the given operation with exponential backoff if the user
-// didn't provide a version. This is intended to hide failures when the user
-// isn't intentionally performing a CAS operation (all writes are, by design,
-// CAS operations at the storage backend layer).
-func (s *Server) retryCAS(ctx context.Context, vsn string, cas func() error) error {
-	if vsn != "" {
-		return cas()
-	}
-
-	const maxAttempts = 5
-
-	// These parameters are fairly arbitrary, so if you find better ones then go
-	// ahead and swap them out! In general, we want to wait long enough to smooth
-	// over small amounts of storage replication lag, but not so long that we make
-	// matters worse by holding onto load.
-	backoff := &retry.Waiter{
-		MinWait: 50 * time.Millisecond,
-		MaxWait: 1 * time.Second,
-		Jitter:  retry.NewJitter(50),
-		Factor:  75 * time.Millisecond,
-	}
-
-	var err error
-	for i := 1; i <= maxAttempts; i++ {
-		if err = cas(); !errors.Is(err, storage.ErrCASFailure) {
-			break
-		}
-		if backoff.Wait(ctx) != nil {
-			break
-		}
-		s.Logger.Trace("retrying failed CAS operation", "failure_count", i)
-	}
-	return err
 }
 
 func (s *Server) ensureWriteRequestValid(req *pbresource.WriteRequest) (*resource.Registration, error) {

--- a/agent/grpc-external/services/resource/write_status_test.go
+++ b/agent/grpc-external/services/resource/write_status_test.go
@@ -518,8 +518,8 @@ func TestWriteStatus_NonCASUpdate_Retry(t *testing.T) {
 	backend := &blockOnceBackend{
 		Backend: server.Backend,
 
-		readCh:  make(chan struct{}),
-		blockCh: make(chan struct{}),
+		readCompletedCh: make(chan struct{}),
+		blockCh:         make(chan struct{}),
 	}
 	server.Backend = backend
 
@@ -534,7 +534,7 @@ func TestWriteStatus_NonCASUpdate_Retry(t *testing.T) {
 
 	// Wait for the read, to ensure the Write in the goroutine above has read the
 	// current version of the resource.
-	<-backend.readCh
+	<-backend.readCompletedCh
 
 	// Update the resource.
 	_, err = client.Write(testContext(t), &pbresource.WriteRequest{Resource: modifyArtist(t, res)})


### PR DESCRIPTION
### Description

CE version of merged ENT PR: https://github.com/hashicorp/consul-enterprise/pull/8366

NET-6719

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
