### PR TITLE
Fix CICD docker image rate limits.

### DIFF
--- a/test/integration/consul-container/libs/cluster/container.go
+++ b/test/integration/consul-container/libs/cluster/container.go
@@ -608,7 +608,7 @@ func startContainer(ctx context.Context, req testcontainers.ContainerRequest) (t
 	})
 }
 
-const pauseImage = "registry.k8s.io/pause:3.3"
+const pauseImage = "hashiderek/pause"
 
 type containerOpts struct {
 	configFile        string

--- a/testing/deployer/sprawl/internal/tfgen/gen.go
+++ b/testing/deployer/sprawl/internal/tfgen/gen.go
@@ -251,7 +251,7 @@ func (g *Generator) Generate(step Step) error {
 		addVolume(c.TLSVolumeName)
 	}
 
-	addImage("pause", "registry.k8s.io/pause:3.3")
+	addImage("pause", "hashiderek/pause")
 
 	if step.StartServers() {
 		for _, c := range g.topology.SortedClusters() {


### PR DESCRIPTION
The docker image used in CICD was referencing `registry.k8s.io/pause:3.3`, which appears to no longer function correctly (either due to rate limiting or not being available to pull). This commit swaps over to a Hashicorp mirrored image that shouldn't have rate limits or disappearing images.