### PR TITLE
[CC-7063] Fetch HCP agent bootstrap config in Link reconciler

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -993,6 +993,7 @@ func (s *Server) registerControllers(deps Deps, proxyUpdater ProxyUpdater) error
 		ResourceApisEnabled:    s.useV2Resources,
 		HCPAllowV2ResourceApis: s.hcpAllowV2Resources,
 		CloudConfig:            deps.HCP.Config,
+		DataDir:                deps.HCP.DataDir,
 	})
 
 	// When not enabled, the v1 tenancy bridge is used by default.

--- a/agent/hcp/bootstrap/bootstrap.go
+++ b/agent/hcp/bootstrap/bootstrap.go
@@ -73,6 +73,10 @@ func FetchBootstrapConfig(ctx context.Context, client hcpclient.Client, dataDir 
 
 		cfg, err := fetchBootstrapConfig(reqCtx, client, dataDir)
 		if err != nil {
+			if errors.Is(err, hcpclient.ErrUnauthorized) || errors.Is(err, hcpclient.ErrForbidden) {
+				// Don't retry on terminal errors
+				return nil, err
+			}
 			ui.Error(fmt.Sprintf("Error: failed to fetch bootstrap config from HCP, will retry in %s: %s",
 				w.NextWait().Round(time.Second), err))
 			if err := w.Wait(ctx); err != nil {

--- a/agent/hcp/bootstrap/bootstrap.go
+++ b/agent/hcp/bootstrap/bootstrap.go
@@ -465,7 +465,7 @@ func LoadManagementToken(ctx context.Context, logger hclog.Logger, client hcpcli
 	token, err := loadManagementToken(hcpCfgDir)
 
 	if err != nil {
-		logger.Debug("fetching configuration from HCP")
+		logger.Debug("failed to load management token from local disk, fetching configuration from HCP", "error", err)
 		var err error
 		cfg, err := fetchBootstrapConfig(ctx, client, dataDir)
 		if err != nil {

--- a/agent/hcp/bootstrap/bootstrap.go
+++ b/agent/hcp/bootstrap/bootstrap.go
@@ -1,10 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-// Package bootstrap handles bootstrapping an agent's config from HCP. It must be a
-// separate package from other HCP components because it has a dependency on
-// agent/config while other components need to be imported and run within the
-// server process in agent/consul and that would create a dependency cycle.
+// Package bootstrap handles bootstrapping an agent's config from HCP.
 package bootstrap
 
 import (
@@ -21,7 +18,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/connect"
 	hcpclient "github.com/hashicorp/consul/agent/hcp/client"
 	"github.com/hashicorp/consul/lib"
@@ -40,8 +36,6 @@ const (
 	successFileName = "successful-bootstrap"
 )
 
-type ConfigLoader func(source config.Source) (config.LoadResult, error)
-
 // UI is a shim to allow the agent command to pass in it's mitchelh/cli.UI so we
 // can output useful messages to the user during bootstrapping. For example if
 // we have to retry several times to bootstrap we don't want the agent to just
@@ -59,137 +53,6 @@ type UI interface {
 type RawBootstrapConfig struct {
 	ConfigJSON      string
 	ManagementToken string
-}
-
-// LoadConfig will attempt to load previously-fetched config from disk and fall back to
-// fetch from HCP servers if the local data is incomplete.
-// It must be passed a (CLI) UI implementation so it can deliver progress
-// updates to the user, for example if it is waiting to retry for a long period.
-func LoadConfig(ctx context.Context, client hcpclient.Client, dataDir string, loader ConfigLoader, ui UI) (ConfigLoader, error) {
-	ui.Output("Loading configuration from HCP")
-
-	// See if we have existing config on disk
-	//
-	// OPTIMIZE: We could probably be more intelligent about config loading.
-	// The currently implemented approach is:
-	// 1. Attempt to load data from disk
-	// 2. If that fails or the data is incomplete, block indefinitely fetching remote config.
-	//
-	// What if instead we had the following flow:
-	// 1. Attempt to fetch config from HCP.
-	// 2. If that fails, fall back to data on disk from last fetch.
-	// 3. If that fails, go into blocking loop to fetch remote config.
-	//
-	// This should allow us to more gracefully transition cases like when
-	// an existing cluster is linked, but then wants to receive TLS materials
-	// at a later time. Currently, if we observe the existing-cluster marker we
-	// don't attempt to fetch any additional configuration from HCP.
-
-	cfg, ok := loadPersistedBootstrapConfig(dataDir, ui)
-	if !ok {
-		ui.Info("Fetching configuration from HCP servers")
-
-		var err error
-		cfg, err = fetchBootstrapConfig(ctx, client, dataDir, ui)
-		if err != nil {
-			return nil, fmt.Errorf("failed to bootstrap from HCP: %w", err)
-		}
-		ui.Info("Configuration fetched from HCP and saved on local disk")
-
-	} else {
-		ui.Info("Loaded HCP configuration from local disk")
-
-	}
-
-	// Create a new loader func to return
-	newLoader := bootstrapConfigLoader(loader, cfg)
-	return newLoader, nil
-}
-
-func AddAclPolicyAccessControlHeader(baseLoader ConfigLoader) ConfigLoader {
-	return func(source config.Source) (config.LoadResult, error) {
-		res, err := baseLoader(source)
-		if err != nil {
-			return res, err
-		}
-
-		rc := res.RuntimeConfig
-
-		// HTTP response headers are modified for the HCP UI to work.
-		if rc.HTTPResponseHeaders == nil {
-			rc.HTTPResponseHeaders = make(map[string]string)
-		}
-		prevValue, ok := rc.HTTPResponseHeaders[accessControlHeaderName]
-		if !ok {
-			rc.HTTPResponseHeaders[accessControlHeaderName] = accessControlHeaderValue
-		} else {
-			rc.HTTPResponseHeaders[accessControlHeaderName] = prevValue + "," + accessControlHeaderValue
-		}
-
-		return res, nil
-	}
-}
-
-// bootstrapConfigLoader is a ConfigLoader for passing bootstrap JSON config received from HCP
-// to the config.builder. ConfigLoaders are functions used to build an agent's RuntimeConfig
-// from various sources like files and flags. This config is contained in the config.LoadResult.
-//
-// The flow to include bootstrap config from HCP as a loader's data source is as follows:
-//
-//  1. A base ConfigLoader function (baseLoader) is created on agent start, and it sets the input
-//     source argument as the DefaultConfig.
-//
-//  2. When a server agent can be configured by HCP that baseLoader is wrapped in this bootstrapConfigLoader.
-//
-//  3. The bootstrapConfigLoader calls that base loader with the bootstrap JSON config as the
-//     default source. This data will be merged with other valid sources in the config.builder.
-//
-//  4. The result of the call to baseLoader() below contains the resulting RuntimeConfig, and we do some
-//     additional modifications to attach data that doesn't get populated during the build in the config pkg.
-//
-// Note that since the ConfigJSON is stored as the baseLoader's DefaultConfig, its data is the first
-// to be merged by the config.builder and could be overwritten by user-provided values in config files or
-// CLI flags. However, values set to RuntimeConfig after the baseLoader call are final.
-func bootstrapConfigLoader(baseLoader ConfigLoader, cfg *RawBootstrapConfig) ConfigLoader {
-	return func(source config.Source) (config.LoadResult, error) {
-		// Don't allow any further attempts to provide a DefaultSource. This should
-		// only ever be needed later in client agent AutoConfig code but that should
-		// be mutually exclusive from this bootstrapping mechanism since this is
-		// only for servers. If we ever try to change that, this clear failure
-		// should alert future developers that the assumptions are changing rather
-		// than quietly not applying the config they expect!
-		if source != nil {
-			return config.LoadResult{},
-				fmt.Errorf("non-nil config source provided to a loader after HCP bootstrap already provided a DefaultSource")
-		}
-
-		// Otherwise, just call to the loader we were passed with our own additional
-		// JSON as the source.
-		//
-		// OPTIMIZE: We could check/log whether any fields set by the remote config were overwritten by a user-provided flag.
-		res, err := baseLoader(config.FileSource{
-			Name:   "HCP Bootstrap",
-			Format: "json",
-			Data:   cfg.ConfigJSON,
-		})
-		if err != nil {
-			return res, fmt.Errorf("failed to load HCP Bootstrap config: %w", err)
-		}
-
-		finalizeRuntimeConfig(res.RuntimeConfig, cfg)
-		return res, nil
-	}
-}
-
-const (
-	accessControlHeaderName  = "Access-Control-Expose-Headers"
-	accessControlHeaderValue = "x-consul-default-acl-policy"
-)
-
-// finalizeRuntimeConfig will set additional HCP-specific values that are not
-// handled by the config.builder.
-func finalizeRuntimeConfig(rc *config.RuntimeConfig, cfg *RawBootstrapConfig) {
-	rc.Cloud.ManagementToken = cfg.ManagementToken
 }
 
 // fetchBootstrapConfig will fetch boostrap configuration from remote servers and persist it to disk.
@@ -440,21 +303,6 @@ func loadBootstrapConfigJSON(dataDir string) (string, error) {
 	}
 	if err != nil {
 		return "", fmt.Errorf("failed to check for bootstrap config: %w", err)
-	}
-
-	// Attempt to load persisted config to check for errors and basic validity.
-	// Errors here will raise issues like referencing unsupported config fields.
-	_, err = config.Load(config.LoadOpts{
-		ConfigFiles: []string{filename},
-		HCL: []string{
-			"server = true",
-			`bind_addr = "127.0.0.1"`,
-			fmt.Sprintf("data_dir = %q", dataDir),
-		},
-		ConfigFormat: "json",
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to parse local bootstrap config: %w", err)
 	}
 
 	jsonBs, err := os.ReadFile(filename)

--- a/agent/hcp/bootstrap/bootstrap_test.go
+++ b/agent/hcp/bootstrap/bootstrap_test.go
@@ -4,340 +4,16 @@
 package bootstrap
 
 import (
-	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"fmt"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/hashicorp/consul/agent/config"
-	"github.com/hashicorp/consul/agent/hcp"
-	hcpclient "github.com/hashicorp/consul/agent/hcp/client"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
 )
-
-func TestBootstrapConfigLoader(t *testing.T) {
-	baseLoader := func(source config.Source) (config.LoadResult, error) {
-		return config.Load(config.LoadOpts{
-			DefaultConfig: source,
-			HCL: []string{
-				`server = true`,
-				`bind_addr = "127.0.0.1"`,
-				`data_dir = "/tmp/consul-data"`,
-			},
-		})
-	}
-
-	bootstrapLoader := func(source config.Source) (config.LoadResult, error) {
-		return bootstrapConfigLoader(baseLoader, &RawBootstrapConfig{
-			ConfigJSON:      `{"bootstrap_expect": 8}`,
-			ManagementToken: "test-token",
-		})(source)
-	}
-
-	result, err := bootstrapLoader(nil)
-	require.NoError(t, err)
-
-	// bootstrap_expect and management token are injected from bootstrap config received from HCP.
-	require.Equal(t, 8, result.RuntimeConfig.BootstrapExpect)
-	require.Equal(t, "test-token", result.RuntimeConfig.Cloud.ManagementToken)
-}
-
-func Test_finalizeRuntimeConfig(t *testing.T) {
-	type testCase struct {
-		rc       *config.RuntimeConfig
-		cfg      *RawBootstrapConfig
-		verifyFn func(t *testing.T, rc *config.RuntimeConfig)
-	}
-	run := func(t *testing.T, tc testCase) {
-		finalizeRuntimeConfig(tc.rc, tc.cfg)
-		tc.verifyFn(t, tc.rc)
-	}
-
-	tt := map[string]testCase{
-		"set management token": {
-			rc: &config.RuntimeConfig{},
-			cfg: &RawBootstrapConfig{
-				ManagementToken: "test-token",
-			},
-			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
-				require.Equal(t, "test-token", rc.Cloud.ManagementToken)
-			},
-		},
-	}
-
-	for name, tc := range tt {
-		t.Run(name, func(t *testing.T) {
-			run(t, tc)
-		})
-	}
-}
-
-func Test_AddAclPolicyAccessControlHeader(t *testing.T) {
-	type testCase struct {
-		rc         *config.RuntimeConfig
-		cfg        *RawBootstrapConfig
-		baseLoader ConfigLoader
-		verifyFn   func(t *testing.T, rc *config.RuntimeConfig)
-	}
-	run := func(t *testing.T, tc testCase) {
-		loader := AddAclPolicyAccessControlHeader(tc.baseLoader)
-		result, err := loader(nil)
-		require.NoError(t, err)
-		tc.verifyFn(t, result.RuntimeConfig)
-	}
-
-	tt := map[string]testCase{
-		"append to header if present": {
-			baseLoader: func(source config.Source) (config.LoadResult, error) {
-				return config.Load(config.LoadOpts{
-					DefaultConfig: config.DefaultSource(),
-					HCL: []string{
-						`server = true`,
-						`bind_addr = "127.0.0.1"`,
-						`data_dir = "/tmp/consul-data"`,
-						fmt.Sprintf(`http_config = { response_headers = { %s = "test" } }`, accessControlHeaderName),
-					},
-				})
-			},
-			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
-				require.Equal(t, "test,x-consul-default-acl-policy", rc.HTTPResponseHeaders[accessControlHeaderName])
-			},
-		},
-		"set header if not present": {
-			baseLoader: func(source config.Source) (config.LoadResult, error) {
-				return config.Load(config.LoadOpts{
-					DefaultConfig: config.DefaultSource(),
-					HCL: []string{
-						`server = true`,
-						`bind_addr = "127.0.0.1"`,
-						`data_dir = "/tmp/consul-data"`,
-					},
-				})
-			},
-			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
-				require.Equal(t, "x-consul-default-acl-policy", rc.HTTPResponseHeaders[accessControlHeaderName])
-			},
-		},
-	}
-
-	for name, tc := range tt {
-		t.Run(name, func(t *testing.T) {
-			run(t, tc)
-		})
-	}
-}
-
-func boolPtr(value bool) *bool {
-	return &value
-}
-
-func TestLoadConfig_Persistence(t *testing.T) {
-	type testCase struct {
-		// resourceID is the HCP resource ID. If set, a server is considered to be cloud-enabled.
-		resourceID string
-
-		// devMode indicates whether the loader should not have a data directory.
-		devMode bool
-
-		// verifyFn issues case-specific assertions.
-		verifyFn func(t *testing.T, rc *config.RuntimeConfig)
-	}
-
-	run := func(t *testing.T, tc testCase) {
-		dir, err := os.MkdirTemp(os.TempDir(), "bootstrap-test-")
-		require.NoError(t, err)
-		t.Cleanup(func() { os.RemoveAll(dir) })
-
-		s := hcp.NewMockHCPServer()
-		s.AddEndpoint(TestEndpoint())
-
-		// Use an HTTPS server since that's what the HCP SDK expects for auth.
-		srv := httptest.NewTLSServer(s)
-		defer srv.Close()
-
-		caCert, err := x509.ParseCertificate(srv.TLS.Certificates[0].Certificate[0])
-		require.NoError(t, err)
-
-		pool := x509.NewCertPool()
-		pool.AddCert(caCert)
-		clientTLS := &tls.Config{RootCAs: pool}
-
-		baseOpts := config.LoadOpts{
-			HCL: []string{
-				`server = true`,
-				`bind_addr = "127.0.0.1"`,
-				fmt.Sprintf(`http_config = { response_headers = { %s = "Content-Encoding" } }`, accessControlHeaderName),
-				fmt.Sprintf(`cloud { client_id="test" client_secret="test" hostname=%q auth_url=%q resource_id=%q }`,
-					srv.Listener.Addr().String(), srv.URL, tc.resourceID),
-			},
-		}
-		if tc.devMode {
-			baseOpts.DevMode = boolPtr(true)
-		} else {
-			baseOpts.HCL = append(baseOpts.HCL, fmt.Sprintf(`data_dir = %q`, dir))
-		}
-
-		baseLoader := func(source config.Source) (config.LoadResult, error) {
-			baseOpts.DefaultConfig = source
-			return config.Load(baseOpts)
-		}
-
-		ui := cli.NewMockUi()
-
-		// Load initial config to check whether bootstrapping from HCP is enabled.
-		initial, err := baseLoader(nil)
-		require.NoError(t, err)
-
-		// Override the client TLS config so that the test server can be trusted.
-		initial.RuntimeConfig.Cloud.WithTLSConfig(clientTLS)
-		client, err := hcpclient.NewClient(initial.RuntimeConfig.Cloud)
-		require.NoError(t, err)
-
-		loader, err := LoadConfig(context.Background(), client, initial.RuntimeConfig.DataDir, baseLoader, ui)
-		require.NoError(t, err)
-
-		// Load the agent config with the potentially wrapped loader.
-		fromRemote, err := loader(nil)
-		require.NoError(t, err)
-
-		// HCP-enabled cases should fetch from HCP on the first run of LoadConfig.
-		require.Contains(t, ui.OutputWriter.String(), "Fetching configuration from HCP")
-
-		// Run case-specific verification.
-		tc.verifyFn(t, fromRemote.RuntimeConfig)
-
-		require.Empty(t, fromRemote.RuntimeConfig.ACLInitialManagementToken,
-			"initial_management token should have been sanitized")
-
-		if tc.devMode {
-			// Re-running the bootstrap func below isn't relevant to dev mode
-			// since they don't have a data directory to load data from.
-			return
-		}
-
-		// Run LoadConfig again to exercise the logic of loading config from disk.
-		loader, err = LoadConfig(context.Background(), client, initial.RuntimeConfig.DataDir, baseLoader, ui)
-		require.NoError(t, err)
-
-		fromDisk, err := loader(nil)
-		require.NoError(t, err)
-
-		// HCP-enabled cases should fetch from disk on the second run.
-		require.Contains(t, ui.OutputWriter.String(), "Loaded HCP configuration from local disk")
-
-		// Config loaded from disk should be the same as the one that was initially fetched from the HCP servers.
-		require.Equal(t, fromRemote.RuntimeConfig, fromDisk.RuntimeConfig)
-	}
-
-	tt := map[string]testCase{
-		"dev mode": {
-			devMode: true,
-
-			resourceID: "organization/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
-				"project/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
-				"consul.cluster/new-cluster-id",
-
-			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
-				require.Empty(t, rc.DataDir)
-
-				// Dev mode should have persisted certs since they can't be inlined.
-				require.NotEmpty(t, rc.TLS.HTTPS.CertFile)
-				require.NotEmpty(t, rc.TLS.HTTPS.KeyFile)
-				require.NotEmpty(t, rc.TLS.HTTPS.CAFile)
-
-				// Find the temporary directory they got stored in.
-				dir := filepath.Dir(rc.TLS.HTTPS.CertFile)
-
-				// Ensure we only stored the TLS materials.
-				entries, err := os.ReadDir(dir)
-				require.NoError(t, err)
-				require.Len(t, entries, 3)
-
-				haveFiles := make([]string, 3)
-				for i, entry := range entries {
-					haveFiles[i] = entry.Name()
-				}
-
-				wantFiles := []string{caFileName, certFileName, keyFileName}
-				require.ElementsMatch(t, wantFiles, haveFiles)
-			},
-		},
-		"new cluster": {
-			resourceID: "organization/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
-				"project/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
-				"consul.cluster/new-cluster-id",
-
-			// New clusters should have received and persisted the whole suite of config.
-			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
-				dir := filepath.Join(rc.DataDir, subDir)
-
-				entries, err := os.ReadDir(dir)
-				require.NoError(t, err)
-				require.Len(t, entries, 6)
-
-				files := []string{
-					filepath.Join(dir, configFileName),
-					filepath.Join(dir, caFileName),
-					filepath.Join(dir, certFileName),
-					filepath.Join(dir, keyFileName),
-					filepath.Join(dir, tokenFileName),
-					filepath.Join(dir, successFileName),
-				}
-				for _, name := range files {
-					_, err := os.Stat(name)
-					require.NoError(t, err)
-				}
-
-				require.Equal(t, filepath.Join(dir, certFileName), rc.TLS.HTTPS.CertFile)
-				require.Equal(t, filepath.Join(dir, keyFileName), rc.TLS.HTTPS.KeyFile)
-				require.Equal(t, filepath.Join(dir, caFileName), rc.TLS.HTTPS.CAFile)
-
-				cert, key, caCerts, err := loadCerts(dir)
-				require.NoError(t, err)
-
-				require.NoError(t, validateTLSCerts(cert, key, caCerts))
-			},
-		},
-		"existing cluster": {
-			resourceID: "organization/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
-				"project/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
-				"consul.cluster/" + TestExistingClusterID,
-
-			// Existing clusters should have only received and persisted the management token.
-			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
-				dir := filepath.Join(rc.DataDir, subDir)
-
-				entries, err := os.ReadDir(dir)
-				require.NoError(t, err)
-				require.Len(t, entries, 3)
-
-				files := []string{
-					filepath.Join(dir, tokenFileName),
-					filepath.Join(dir, successFileName),
-					filepath.Join(dir, configFileName),
-				}
-				for _, name := range files {
-					_, err := os.Stat(name)
-					require.NoError(t, err)
-				}
-			},
-		},
-	}
-
-	for name, tc := range tt {
-		t.Run(name, func(t *testing.T) {
-			run(t, tc)
-		})
-	}
-}
 
 func Test_loadPersistedBootstrapConfig(t *testing.T) {
 	type expect struct {
@@ -356,7 +32,7 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { os.RemoveAll(dataDir) })
 
-		dir := filepath.Join(dataDir, subDir)
+		dir := filepath.Join(dataDir, SubDir)
 
 		// Do some common setup as if we received config from HCP and persisted it to disk.
 		require.NoError(t, lib.EnsurePath(dir, true))
@@ -387,7 +63,7 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 		}
 
 		ui := cli.NewMockUi()
-		cfg, loaded := loadPersistedBootstrapConfig(dataDir, ui)
+		cfg, loaded := LoadPersistedBootstrapConfig(dataDir, ui)
 		require.Equal(t, tc.expect.loaded, loaded, ui.ErrorWriter.String())
 		if loaded {
 			require.Equal(t, token, cfg.ManagementToken)
@@ -444,7 +120,7 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 		"new cluster some files": {
 			mutateFn: func(t *testing.T, dir string) {
 				// Remove one of the required files
-				require.NoError(t, os.Remove(filepath.Join(dir, certFileName)))
+				require.NoError(t, os.Remove(filepath.Join(dir, CertFileName)))
 			},
 			expect: expect{
 				loaded:  false,
@@ -464,7 +140,7 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 		},
 		"new cluster invalid cert": {
 			mutateFn: func(t *testing.T, dir string) {
-				name := filepath.Join(dir, certFileName)
+				name := filepath.Join(dir, CertFileName)
 				require.NoError(t, os.WriteFile(name, []byte("not-a-cert"), 0600))
 			},
 			expect: expect{
@@ -474,7 +150,7 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 		},
 		"new cluster invalid CA": {
 			mutateFn: func(t *testing.T, dir string) {
-				name := filepath.Join(dir, caFileName)
+				name := filepath.Join(dir, CAFileName)
 				require.NoError(t, os.WriteFile(name, []byte("not-a-ca-cert"), 0600))
 			},
 			expect: expect{
@@ -482,20 +158,10 @@ func Test_loadPersistedBootstrapConfig(t *testing.T) {
 				warning: "invalid CA certificate",
 			},
 		},
-		"new cluster invalid config flag": {
-			mutateFn: func(t *testing.T, dir string) {
-				name := filepath.Join(dir, configFileName)
-				require.NoError(t, os.WriteFile(name, []byte(`{"not_a_consul_agent_config_field" = "zap"}`), 0600))
-			},
-			expect: expect{
-				loaded:  false,
-				warning: "failed to parse local bootstrap config",
-			},
-		},
 		"existing cluster invalid token": {
 			existingCluster: true,
 			mutateFn: func(t *testing.T, dir string) {
-				name := filepath.Join(dir, tokenFileName)
+				name := filepath.Join(dir, TokenFileName)
 				require.NoError(t, os.WriteFile(name, []byte("not-a-uuid"), 0600))
 			},
 			expect: expect{

--- a/agent/hcp/bootstrap/config-loader/loader.go
+++ b/agent/hcp/bootstrap/config-loader/loader.go
@@ -1,0 +1,167 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package loader handles loading the bootstrap agent config  fetched from HCP into
+// the agent's config. It must be a separate package from other HCP components
+// because it has a dependency on agent/config while other components need to be
+// imported and run within the server process in agent/consul and that would create
+// a dependency cycle.
+package loader
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/consul/agent/config"
+)
+
+type ConfigLoader func(source config.Source) (config.LoadResult, error)
+
+// LoadConfig will attempt to load previously-fetched config from disk and fall back to
+// fetch from HCP servers if the local data is incomplete.
+// It must be passed a (CLI) UI implementation so it can deliver progress
+// updates to the user, for example if it is waiting to retry for a long period.
+func LoadConfig(ctx context.Context, client hcpclient.Client, dataDir string, loader ConfigLoader, ui UI) (ConfigLoader, error) {
+	ui.Output("Loading configuration from HCP")
+
+	// See if we have existing config on disk
+	//
+	// OPTIMIZE: We could probably be more intelligent about config loading.
+	// The currently implemented approach is:
+	// 1. Attempt to load data from disk
+	// 2. If that fails or the data is incomplete, block indefinitely fetching remote config.
+	//
+	// What if instead we had the following flow:
+	// 1. Attempt to fetch config from HCP.
+	// 2. If that fails, fall back to data on disk from last fetch.
+	// 3. If that fails, go into blocking loop to fetch remote config.
+	//
+	// This should allow us to more gracefully transition cases like when
+	// an existing cluster is linked, but then wants to receive TLS materials
+	// at a later time. Currently, if we observe the existing-cluster marker we
+	// don't attempt to fetch any additional configuration from HCP.
+
+	cfg, ok := loadPersistedBootstrapConfig(dataDir, ui)
+	if !ok {
+		ui.Info("Fetching configuration from HCP servers")
+
+		var err error
+		cfg, err = fetchBootstrapConfig(ctx, client, dataDir, ui)
+		if err != nil {
+			return nil, fmt.Errorf("failed to bootstrap from HCP: %w", err)
+		}
+		ui.Info("Configuration fetched from HCP and saved on local disk")
+
+	} else {
+		ui.Info("Loaded HCP configuration from local disk")
+
+	}
+
+	// Create a new loader func to return
+	newLoader := bootstrapConfigLoader(loader, cfg)
+	return newLoader, nil
+}
+
+func AddAclPolicyAccessControlHeader(baseLoader ConfigLoader) ConfigLoader {
+	return func(source config.Source) (config.LoadResult, error) {
+		res, err := baseLoader(source)
+		if err != nil {
+			return res, err
+		}
+
+		rc := res.RuntimeConfig
+
+		// HTTP response headers are modified for the HCP UI to work.
+		if rc.HTTPResponseHeaders == nil {
+			rc.HTTPResponseHeaders = make(map[string]string)
+		}
+		prevValue, ok := rc.HTTPResponseHeaders[accessControlHeaderName]
+		if !ok {
+			rc.HTTPResponseHeaders[accessControlHeaderName] = accessControlHeaderValue
+		} else {
+			rc.HTTPResponseHeaders[accessControlHeaderName] = prevValue + "," + accessControlHeaderValue
+		}
+
+		return res, nil
+	}
+}
+
+// bootstrapConfigLoader is a ConfigLoader for passing bootstrap JSON config received from HCP
+// to the config.builder. ConfigLoaders are functions used to build an agent's RuntimeConfig
+// from various sources like files and flags. This config is contained in the config.LoadResult.
+//
+// The flow to include bootstrap config from HCP as a loader's data source is as follows:
+//
+//  1. A base ConfigLoader function (baseLoader) is created on agent start, and it sets the input
+//     source argument as the DefaultConfig.
+//
+//  2. When a server agent can be configured by HCP that baseLoader is wrapped in this bootstrapConfigLoader.
+//
+//  3. The bootstrapConfigLoader calls that base loader with the bootstrap JSON config as the
+//     default source. This data will be merged with other valid sources in the config.builder.
+//
+//  4. The result of the call to baseLoader() below contains the resulting RuntimeConfig, and we do some
+//     additional modifications to attach data that doesn't get populated during the build in the config pkg.
+//
+// Note that since the ConfigJSON is stored as the baseLoader's DefaultConfig, its data is the first
+// to be merged by the config.builder and could be overwritten by user-provided values in config files or
+// CLI flags. However, values set to RuntimeConfig after the baseLoader call are final.
+func bootstrapConfigLoader(baseLoader ConfigLoader, cfg *RawBootstrapConfig) ConfigLoader {
+	return func(source config.Source) (config.LoadResult, error) {
+		// Don't allow any further attempts to provide a DefaultSource. This should
+		// only ever be needed later in client agent AutoConfig code but that should
+		// be mutually exclusive from this bootstrapping mechanism since this is
+		// only for servers. If we ever try to change that, this clear failure
+		// should alert future developers that the assumptions are changing rather
+		// than quietly not applying the config they expect!
+		if source != nil {
+			return config.LoadResult{},
+				fmt.Errorf("non-nil config source provided to a loader after HCP bootstrap already provided a DefaultSource")
+		}
+
+		// Otherwise, just call to the loader we were passed with our own additional
+		// JSON as the source.
+		//
+		// OPTIMIZE: We could check/log whether any fields set by the remote config were overwritten by a user-provided flag.
+		res, err := baseLoader(config.FileSource{
+			Name:   "HCP Bootstrap",
+			Format: "json",
+			Data:   cfg.ConfigJSON,
+		})
+		if err != nil {
+			return res, fmt.Errorf("failed to load HCP Bootstrap config: %w", err)
+		}
+
+		finalizeRuntimeConfig(res.RuntimeConfig, cfg)
+		return res, nil
+	}
+}
+
+const (
+	accessControlHeaderName  = "Access-Control-Expose-Headers"
+	accessControlHeaderValue = "x-consul-default-acl-policy"
+)
+
+// finalizeRuntimeConfig will set additional HCP-specific values that are not
+// handled by the config.builder.
+func finalizeRuntimeConfig(rc *config.RuntimeConfig, cfg *RawBootstrapConfig) {
+	rc.Cloud.ManagementToken = cfg.ManagementToken
+}
+
+func validatePersistedConfig(dataDir string, filename string) error {
+	// Attempt to load persisted config to check for errors and basic validity.
+	// Errors here will raise issues like referencing unsupported config fields.
+	_, err := config.Load(config.LoadOpts{
+		ConfigFiles: []string{filename},
+		HCL: []string{
+			"server = true",
+			`bind_addr = "127.0.0.1"`,
+			fmt.Sprintf("data_dir = %q", dataDir),
+		},
+		ConfigFormat: "json",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to parse local bootstrap config: %w", err)
+	}
+	return nil
+}

--- a/agent/hcp/bootstrap/config-loader/loader_test.go
+++ b/agent/hcp/bootstrap/config-loader/loader_test.go
@@ -1,0 +1,389 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package loader
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/consul/agent/config"
+	"github.com/hashicorp/consul/agent/hcp"
+	"github.com/hashicorp/consul/agent/hcp/bootstrap"
+	hcpclient "github.com/hashicorp/consul/agent/hcp/client"
+	"github.com/hashicorp/consul/lib"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBootstrapConfigLoader(t *testing.T) {
+	baseLoader := func(source config.Source) (config.LoadResult, error) {
+		return config.Load(config.LoadOpts{
+			DefaultConfig: source,
+			HCL: []string{
+				`server = true`,
+				`bind_addr = "127.0.0.1"`,
+				`data_dir = "/tmp/consul-data"`,
+			},
+		})
+	}
+
+	bootstrapLoader := func(source config.Source) (config.LoadResult, error) {
+		return bootstrapConfigLoader(baseLoader, &bootstrap.RawBootstrapConfig{
+			ConfigJSON:      `{"bootstrap_expect": 8}`,
+			ManagementToken: "test-token",
+		})(source)
+	}
+
+	result, err := bootstrapLoader(nil)
+	require.NoError(t, err)
+
+	// bootstrap_expect and management token are injected from bootstrap config received from HCP.
+	require.Equal(t, 8, result.RuntimeConfig.BootstrapExpect)
+	require.Equal(t, "test-token", result.RuntimeConfig.Cloud.ManagementToken)
+}
+
+func Test_finalizeRuntimeConfig(t *testing.T) {
+	type testCase struct {
+		rc       *config.RuntimeConfig
+		cfg      *bootstrap.RawBootstrapConfig
+		verifyFn func(t *testing.T, rc *config.RuntimeConfig)
+	}
+	run := func(t *testing.T, tc testCase) {
+		finalizeRuntimeConfig(tc.rc, tc.cfg)
+		tc.verifyFn(t, tc.rc)
+	}
+
+	tt := map[string]testCase{
+		"set management token": {
+			rc: &config.RuntimeConfig{},
+			cfg: &bootstrap.RawBootstrapConfig{
+				ManagementToken: "test-token",
+			},
+			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
+				require.Equal(t, "test-token", rc.Cloud.ManagementToken)
+			},
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func Test_AddAclPolicyAccessControlHeader(t *testing.T) {
+	type testCase struct {
+		baseLoader ConfigLoader
+		verifyFn   func(t *testing.T, rc *config.RuntimeConfig)
+	}
+	run := func(t *testing.T, tc testCase) {
+		loader := AddAclPolicyAccessControlHeader(tc.baseLoader)
+		result, err := loader(nil)
+		require.NoError(t, err)
+		tc.verifyFn(t, result.RuntimeConfig)
+	}
+
+	tt := map[string]testCase{
+		"append to header if present": {
+			baseLoader: func(source config.Source) (config.LoadResult, error) {
+				return config.Load(config.LoadOpts{
+					DefaultConfig: config.DefaultSource(),
+					HCL: []string{
+						`server = true`,
+						`bind_addr = "127.0.0.1"`,
+						`data_dir = "/tmp/consul-data"`,
+						fmt.Sprintf(`http_config = { response_headers = { %s = "test" } }`, accessControlHeaderName),
+					},
+				})
+			},
+			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
+				require.Equal(t, "test,x-consul-default-acl-policy", rc.HTTPResponseHeaders[accessControlHeaderName])
+			},
+		},
+		"set header if not present": {
+			baseLoader: func(source config.Source) (config.LoadResult, error) {
+				return config.Load(config.LoadOpts{
+					DefaultConfig: config.DefaultSource(),
+					HCL: []string{
+						`server = true`,
+						`bind_addr = "127.0.0.1"`,
+						`data_dir = "/tmp/consul-data"`,
+					},
+				})
+			},
+			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
+				require.Equal(t, "x-consul-default-acl-policy", rc.HTTPResponseHeaders[accessControlHeaderName])
+			},
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func TestLoadConfig_Persistence(t *testing.T) {
+	type testCase struct {
+		// resourceID is the HCP resource ID. If set, a server is considered to be cloud-enabled.
+		resourceID string
+
+		// devMode indicates whether the loader should not have a data directory.
+		devMode bool
+
+		// verifyFn issues case-specific assertions.
+		verifyFn func(t *testing.T, rc *config.RuntimeConfig)
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		dir, err := os.MkdirTemp(os.TempDir(), "bootstrap-test-")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+
+		s := hcp.NewMockHCPServer()
+		s.AddEndpoint(bootstrap.TestEndpoint())
+
+		// Use an HTTPS server since that's what the HCP SDK expects for auth.
+		srv := httptest.NewTLSServer(s)
+		defer srv.Close()
+
+		caCert, err := x509.ParseCertificate(srv.TLS.Certificates[0].Certificate[0])
+		require.NoError(t, err)
+
+		pool := x509.NewCertPool()
+		pool.AddCert(caCert)
+		clientTLS := &tls.Config{RootCAs: pool}
+
+		baseOpts := config.LoadOpts{
+			HCL: []string{
+				`server = true`,
+				`bind_addr = "127.0.0.1"`,
+				fmt.Sprintf(`http_config = { response_headers = { %s = "Content-Encoding" } }`, accessControlHeaderName),
+				fmt.Sprintf(`cloud { client_id="test" client_secret="test" hostname=%q auth_url=%q resource_id=%q }`,
+					srv.Listener.Addr().String(), srv.URL, tc.resourceID),
+			},
+		}
+		if tc.devMode {
+			baseOpts.DevMode = boolPtr(true)
+		} else {
+			baseOpts.HCL = append(baseOpts.HCL, fmt.Sprintf(`data_dir = %q`, dir))
+		}
+
+		baseLoader := func(source config.Source) (config.LoadResult, error) {
+			baseOpts.DefaultConfig = source
+			return config.Load(baseOpts)
+		}
+
+		ui := cli.NewMockUi()
+
+		// Load initial config to check whether bootstrapping from HCP is enabled.
+		initial, err := baseLoader(nil)
+		require.NoError(t, err)
+
+		// Override the client TLS config so that the test server can be trusted.
+		initial.RuntimeConfig.Cloud.WithTLSConfig(clientTLS)
+		client, err := hcpclient.NewClient(initial.RuntimeConfig.Cloud)
+		require.NoError(t, err)
+
+		loader, err := LoadConfig(context.Background(), client, initial.RuntimeConfig.DataDir, baseLoader, ui)
+		require.NoError(t, err)
+
+		// Load the agent config with the potentially wrapped loader.
+		fromRemote, err := loader(nil)
+		require.NoError(t, err)
+
+		// HCP-enabled cases should fetch from HCP on the first run of LoadConfig.
+		require.Contains(t, ui.OutputWriter.String(), "Fetching configuration from HCP")
+
+		// Run case-specific verification.
+		tc.verifyFn(t, fromRemote.RuntimeConfig)
+
+		require.Empty(t, fromRemote.RuntimeConfig.ACLInitialManagementToken,
+			"initial_management token should have been sanitized")
+
+		if tc.devMode {
+			// Re-running the bootstrap func below isn't relevant to dev mode
+			// since they don't have a data directory to load data from.
+			return
+		}
+
+		// Run LoadConfig again to exercise the logic of loading config from disk.
+		loader, err = LoadConfig(context.Background(), client, initial.RuntimeConfig.DataDir, baseLoader, ui)
+		require.NoError(t, err)
+
+		fromDisk, err := loader(nil)
+		require.NoError(t, err)
+
+		// HCP-enabled cases should fetch from disk on the second run.
+		require.Contains(t, ui.OutputWriter.String(), "Loaded HCP configuration from local disk")
+
+		// Config loaded from disk should be the same as the one that was initially fetched from the HCP servers.
+		require.Equal(t, fromRemote.RuntimeConfig, fromDisk.RuntimeConfig)
+	}
+
+	tt := map[string]testCase{
+		"dev mode": {
+			devMode: true,
+
+			resourceID: "organization/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
+				"project/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
+				"consul.cluster/new-cluster-id",
+
+			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
+				require.Empty(t, rc.DataDir)
+
+				// Dev mode should have persisted certs since they can't be inlined.
+				require.NotEmpty(t, rc.TLS.HTTPS.CertFile)
+				require.NotEmpty(t, rc.TLS.HTTPS.KeyFile)
+				require.NotEmpty(t, rc.TLS.HTTPS.CAFile)
+
+				// Find the temporary directory they got stored in.
+				dir := filepath.Dir(rc.TLS.HTTPS.CertFile)
+
+				// Ensure we only stored the TLS materials.
+				entries, err := os.ReadDir(dir)
+				require.NoError(t, err)
+				require.Len(t, entries, 3)
+
+				haveFiles := make([]string, 3)
+				for i, entry := range entries {
+					haveFiles[i] = entry.Name()
+				}
+
+				wantFiles := []string{bootstrap.CAFileName, bootstrap.CertFileName, bootstrap.KeyFileName}
+				require.ElementsMatch(t, wantFiles, haveFiles)
+			},
+		},
+		"new cluster": {
+			resourceID: "organization/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
+				"project/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
+				"consul.cluster/new-cluster-id",
+
+			// New clusters should have received and persisted the whole suite of config.
+			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
+				dir := filepath.Join(rc.DataDir, bootstrap.SubDir)
+
+				entries, err := os.ReadDir(dir)
+				require.NoError(t, err)
+				require.Len(t, entries, 6)
+
+				files := []string{
+					filepath.Join(dir, bootstrap.ConfigFileName),
+					filepath.Join(dir, bootstrap.CAFileName),
+					filepath.Join(dir, bootstrap.CertFileName),
+					filepath.Join(dir, bootstrap.KeyFileName),
+					filepath.Join(dir, bootstrap.TokenFileName),
+					filepath.Join(dir, bootstrap.SuccessFileName),
+				}
+				for _, name := range files {
+					_, err := os.Stat(name)
+					require.NoError(t, err)
+				}
+
+				require.Equal(t, filepath.Join(dir, bootstrap.CertFileName), rc.TLS.HTTPS.CertFile)
+				require.Equal(t, filepath.Join(dir, bootstrap.KeyFileName), rc.TLS.HTTPS.KeyFile)
+				require.Equal(t, filepath.Join(dir, bootstrap.CAFileName), rc.TLS.HTTPS.CAFile)
+
+				cert, key, caCerts, err := bootstrap.LoadCerts(dir)
+				require.NoError(t, err)
+
+				require.NoError(t, bootstrap.ValidateTLSCerts(cert, key, caCerts))
+			},
+		},
+		"existing cluster": {
+			resourceID: "organization/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
+				"project/0b9de9a3-8403-4ca6-aba8-fca752f42100/" +
+				"consul.cluster/" + bootstrap.TestExistingClusterID,
+
+			// Existing clusters should have only received and persisted the management token.
+			verifyFn: func(t *testing.T, rc *config.RuntimeConfig) {
+				dir := filepath.Join(rc.DataDir, bootstrap.SubDir)
+
+				entries, err := os.ReadDir(dir)
+				require.NoError(t, err)
+				require.Len(t, entries, 3)
+
+				files := []string{
+					filepath.Join(dir, bootstrap.TokenFileName),
+					filepath.Join(dir, bootstrap.SuccessFileName),
+					filepath.Join(dir, bootstrap.ConfigFileName),
+				}
+				for _, name := range files {
+					_, err := os.Stat(name)
+					require.NoError(t, err)
+				}
+			},
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestValidatePersistedConfig(t *testing.T) {
+	type testCase struct {
+		configContents string
+		expectErr      string
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		dataDir, err := os.MkdirTemp(os.TempDir(), "load-bootstrap-test-")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dataDir) })
+
+		dir := filepath.Join(dataDir, bootstrap.SubDir)
+		require.NoError(t, lib.EnsurePath(dir, true))
+
+		if tc.configContents != "" {
+			name := filepath.Join(dir, bootstrap.ConfigFileName)
+			require.NoError(t, os.WriteFile(name, []byte(tc.configContents), 0600))
+		}
+
+		err = validatePersistedConfig(dataDir)
+		if tc.expectErr != "" {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectErr)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+
+	tt := map[string]testCase{
+		"valid": {
+			configContents: `{"bootstrap_expect": 1, "cloud": {"resource_id": "id"}}`,
+		},
+		"invalid config key": {
+			configContents: `{"not_a_consul_agent_config_field": "zap"}`,
+			expectErr:      "invalid config key not_a_consul_agent_config_field",
+		},
+		"invalid format": {
+			configContents: `{"not_json" = "invalid"}`,
+			expectErr:      "invalid character '=' after object key",
+		},
+		"missing configuration file": {
+			expectErr: "no such file or directory",
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}

--- a/agent/hcp/client/client.go
+++ b/agent/hcp/client/client.go
@@ -5,12 +5,16 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"golang.org/x/oauth2"
 
 	hcptelemetry "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-telemetry-gateway/preview/2023-04-14/client/consul_telemetry_service"
 	hcpgnm "github.com/hashicorp/hcp-sdk-go/clients/cloud-global-network-manager-service/preview/2022-02-15/client/global_network_manager_service"
@@ -124,9 +128,8 @@ func (c *hcpClient) FetchBootstrap(ctx context.Context) (*BootstrapConfig, error
 
 	resp, err := c.gnm.AgentBootstrapConfig(params, nil)
 	if err != nil {
-		return nil, err
+		return nil, decodeError(err)
 	}
-
 	return bootstrapConfigFromHCP(resp.Payload), nil
 }
 
@@ -327,7 +330,7 @@ func (c *hcpClient) GetCluster(ctx context.Context) (*Cluster, error) {
 
 	resp, err := c.gnm.GetCluster(params, nil)
 	if err != nil {
-		return nil, err
+		return nil, decodeError(err)
 	}
 
 	return clusterFromHCP(resp.Payload), nil
@@ -339,4 +342,30 @@ func clusterFromHCP(payload *gnmmod.HashicorpCloudGlobalNetworkManager20220215Ge
 		AccessLevel:  payload.Cluster.ConsulAccessLevel,
 		HCPPortalURL: payload.Cluster.HcpPortalURL,
 	}
+}
+
+func decodeError(err error) error {
+	// Determine the code from the type of error
+	var code int
+	switch e := err.(type) {
+	case *url.Error:
+		oauthErr, ok := errors.Unwrap(e.Err).(*oauth2.RetrieveError)
+		if ok {
+			code = oauthErr.Response.StatusCode
+		}
+	case *hcpgnm.AgentBootstrapConfigDefault:
+		code = e.Code()
+	case *hcpgnm.GetClusterDefault:
+		code = e.Code()
+	}
+
+	// Return specific error for codes if relevant
+	switch code {
+	case http.StatusUnauthorized:
+		return ErrUnauthorized
+	case http.StatusForbidden:
+		return ErrForbidden
+	}
+
+	return err
 }

--- a/agent/hcp/client/errors.go
+++ b/agent/hcp/client/errors.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package client
+
+import "errors"
+
+var (
+	ErrUnauthorized = errors.New("unauthorized")
+	ErrForbidden    = errors.New("forbidden")
+)

--- a/agent/hcp/deps.go
+++ b/agent/hcp/deps.go
@@ -23,9 +23,10 @@ type Deps struct {
 	Provider          scada.Provider
 	Sink              metrics.MetricSink
 	TelemetryProvider *hcpProviderImpl
+	DataDir           string
 }
 
-func NewDeps(cfg config.CloudConfig, logger hclog.Logger) (Deps, error) {
+func NewDeps(cfg config.CloudConfig, logger hclog.Logger, dataDir string) (Deps, error) {
 	ctx := context.Background()
 	ctx = hclog.WithContext(ctx, logger)
 
@@ -59,6 +60,7 @@ func NewDeps(cfg config.CloudConfig, logger hclog.Logger) (Deps, error) {
 		Provider:          provider,
 		Sink:              sink,
 		TelemetryProvider: metricsProvider,
+		DataDir:           dataDir,
 	}, nil
 }
 

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -141,12 +141,16 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer, providedLogger hcl
 		// This values is set late within newNodeIDFromConfig above
 		cfg.Cloud.NodeID = cfg.NodeID
 
-		d.HCP, err = hcp.NewDeps(cfg.Cloud, d.Logger.Named("hcp"))
+		d.HCP, err = hcp.NewDeps(cfg.Cloud, d.Logger.Named("hcp"), cfg.DataDir)
 		if err != nil {
 			return d, err
 		}
 		if d.HCP.Sink != nil {
 			extraSinks = append(extraSinks, d.HCP.Sink)
+		}
+	} else {
+		d.HCP = hcp.Deps{
+			DataDir: cfg.DataDir,
 		}
 	}
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/config"
-	hcpbootstrap "github.com/hashicorp/consul/agent/hcp/bootstrap"
+	hcpbootstrap "github.com/hashicorp/consul/agent/hcp/bootstrap/config-loader"
 	hcpclient "github.com/hashicorp/consul/agent/hcp/client"
 	"github.com/hashicorp/consul/command/cli"
 	"github.com/hashicorp/consul/command/flags"

--- a/internal/hcp/internal/controllers/link/controller.go
+++ b/internal/hcp/internal/controllers/link/controller.go
@@ -9,9 +9,9 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	gnmmod "github.com/hashicorp/hcp-sdk-go/clients/cloud-global-network-manager-service/preview/2022-02-15/models"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	hcpclient "github.com/hashicorp/consul/agent/hcp/client"
 	"github.com/hashicorp/consul/agent/hcp/config"
@@ -42,7 +42,13 @@ var DefaultHCPClientFn HCPClientFn = func(link *pbhcp.Link) (hcpclient.Client, e
 	return hcpClient, nil
 }
 
-func LinkController(resourceApisEnabled bool, hcpAllowV2ResourceApis bool, hcpClientFn HCPClientFn, cfg config.CloudConfig) *controller.Controller {
+func LinkController(
+	resourceApisEnabled bool,
+	hcpAllowV2ResourceApis bool,
+	hcpClientFn HCPClientFn,
+	cfg config.CloudConfig,
+	dataDir string,
+) *controller.Controller {
 	return controller.NewController("link", pbhcp.LinkType).
 		WithInitializer(&linkInitializer{
 			cloudConfig: cfg,
@@ -51,6 +57,7 @@ func LinkController(resourceApisEnabled bool, hcpAllowV2ResourceApis bool, hcpCl
 			resourceApisEnabled:    resourceApisEnabled,
 			hcpAllowV2ResourceApis: hcpAllowV2ResourceApis,
 			hcpClientFn:            hcpClientFn,
+			dataDir:                dataDir,
 		})
 }
 
@@ -58,6 +65,7 @@ type linkReconciler struct {
 	resourceApisEnabled    bool
 	hcpAllowV2ResourceApis bool
 	hcpClientFn            HCPClientFn
+	dataDir                string
 }
 
 func (r *linkReconciler) writeStatusIfNotEqual(ctx context.Context, rt controller.Runtime, res *pbresource.Resource, status *pbresource.Status) error {

--- a/internal/hcp/internal/controllers/link/controller_test.go
+++ b/internal/hcp/internal/controllers/link/controller_test.go
@@ -103,7 +103,7 @@ func (suite *controllerSuite) TestController_Ok() {
 	linkData := &pbhcp.Link{
 		ClientId:     "abc",
 		ClientSecret: "abc",
-		ResourceId:   "abc",
+		ResourceId:   types.GenerateTestResourceID(suite.T()),
 	}
 
 	link := rtest.Resource(pbhcp.LinkType, "global").
@@ -134,7 +134,7 @@ func (suite *controllerSuite) TestController_Initialize() {
 	cloudCfg := config.CloudConfig{
 		ClientID:     "client-id-abc",
 		ClientSecret: "client-secret-abc",
-		ResourceID:   "resource-id-abc",
+		ResourceID:   types.GenerateTestResourceID(suite.T()),
 	}
 
 	dataDir := testutil.TempDir(suite.T(), "test-link-controller")
@@ -189,7 +189,7 @@ func (suite *controllerSuite) TestControllerResourceApisEnabled_LinkDisabled() {
 	linkData := &pbhcp.Link{
 		ClientId:     "abc",
 		ClientSecret: "abc",
-		ResourceId:   "abc",
+		ResourceId:   types.GenerateTestResourceID(suite.T()),
 	}
 	link := rtest.Resource(pbhcp.LinkType, "global").
 		WithData(suite.T(), linkData).
@@ -231,7 +231,7 @@ func (suite *controllerSuite) TestControllerResourceApisEnabledWithOverride_Link
 	linkData := &pbhcp.Link{
 		ClientId:     "abc",
 		ClientSecret: "abc",
-		ResourceId:   "abc",
+		ResourceId:   types.GenerateTestResourceID(suite.T()),
 	}
 	link := rtest.Resource(pbhcp.LinkType, "global").
 		WithData(suite.T(), linkData).
@@ -263,7 +263,7 @@ func (suite *controllerSuite) TestController_GetClusterError() {
 	linkData := &pbhcp.Link{
 		ClientId:     "abc",
 		ClientSecret: "abc",
-		ResourceId:   "abc",
+		ResourceId:   types.GenerateTestResourceID(suite.T()),
 	}
 	link := rtest.Resource(pbhcp.LinkType, "global").
 		WithData(suite.T(), linkData).

--- a/internal/hcp/internal/controllers/link/status.go
+++ b/internal/hcp/internal/controllers/link/status.go
@@ -94,5 +94,11 @@ func linkingFailed(ctx context.Context, rt controller.Runtime, res *pbresource.R
 		Conditions:         []*pbresource.Condition{condition},
 	}
 
-	return writeStatusIfNotEqual(ctx, rt, res, newStatus)
+	writeErr := writeStatusIfNotEqual(ctx, rt, res, newStatus)
+	if writeErr != nil {
+		rt.Logger.Error("error writing status", "error", writeErr)
+		return writeErr
+	}
+
+	return nil
 }

--- a/internal/hcp/internal/controllers/link/status.go
+++ b/internal/hcp/internal/controllers/link/status.go
@@ -4,8 +4,13 @@
 package link
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
+	"github.com/hashicorp/consul/agent/hcp/client"
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
@@ -16,10 +21,14 @@ const (
 	LinkedReason                         = "SUCCESS"
 	FailedReason                         = "FAILED"
 	DisabledReasonV2ResourcesUnsupported = "DISABLED_V2_RESOURCES_UNSUPPORTED"
+	UnauthorizedReason                   = "UNAUTHORIZED"
+	ForbiddenReason                      = "FORBIDDEN"
 
 	LinkedMessageFormat                = "Successfully linked to cluster '%s'"
-	FailedMessage                      = "Failed to link to HCP"
+	FailedMessage                      = "Failed to link to HCP due to unexpected error"
 	DisabledResourceAPIsEnabledMessage = "Link is disabled because resource-apis are enabled"
+	UnauthorizedMessage                = "Access denied, check client_id and client_secret"
+	ForbiddenMessage                   = "Access denied, check the resource_id"
 )
 
 var (
@@ -35,6 +44,18 @@ var (
 		Reason:  FailedReason,
 		Message: FailedMessage,
 	}
+	ConditionUnauthorized = &pbresource.Condition{
+		Type:    StatusLinked,
+		State:   pbresource.Condition_STATE_FALSE,
+		Reason:  UnauthorizedReason,
+		Message: UnauthorizedMessage,
+	}
+	ConditionForbidden = &pbresource.Condition{
+		Type:    StatusLinked,
+		State:   pbresource.Condition_STATE_FALSE,
+		Reason:  ForbiddenReason,
+		Message: ForbiddenMessage,
+	}
 )
 
 func ConditionLinked(resourceId string) *pbresource.Condition {
@@ -44,4 +65,34 @@ func ConditionLinked(resourceId string) *pbresource.Condition {
 		Reason:  LinkedReason,
 		Message: fmt.Sprintf(LinkedMessageFormat, resourceId),
 	}
+}
+
+func writeStatusIfNotEqual(ctx context.Context, rt controller.Runtime, res *pbresource.Resource, status *pbresource.Status) error {
+	if resource.EqualStatus(res.Status[StatusKey], status, false) {
+		return nil
+	}
+	_, err := rt.Client.WriteStatus(ctx, &pbresource.WriteStatusRequest{
+		Id:     res.Id,
+		Key:    StatusKey,
+		Status: status,
+	})
+	return err
+}
+
+func linkingFailed(ctx context.Context, rt controller.Runtime, res *pbresource.Resource, err error) error {
+	var condition *pbresource.Condition
+	switch {
+	case errors.Is(err, client.ErrUnauthorized):
+		condition = ConditionUnauthorized
+	case errors.Is(err, client.ErrForbidden):
+		condition = ConditionForbidden
+	default:
+		condition = ConditionFailed
+	}
+	newStatus := &pbresource.Status{
+		ObservedGeneration: res.Generation,
+		Conditions:         []*pbresource.Condition{condition},
+	}
+
+	return writeStatusIfNotEqual(ctx, rt, res, newStatus)
 }

--- a/internal/hcp/internal/controllers/register.go
+++ b/internal/hcp/internal/controllers/register.go
@@ -4,7 +4,6 @@
 package controllers
 
 import (
-	hcpclient "github.com/hashicorp/consul/agent/hcp/client"
 	"github.com/hashicorp/consul/agent/hcp/config"
 	"github.com/hashicorp/consul/internal/controller"
 	"github.com/hashicorp/consul/internal/hcp/internal/controllers/link"
@@ -14,7 +13,7 @@ type Dependencies struct {
 	CloudConfig            config.CloudConfig
 	ResourceApisEnabled    bool
 	HCPAllowV2ResourceApis bool
-	HCPClient              hcpclient.Client
+	DataDir                string
 }
 
 func Register(mgr *controller.Manager, deps Dependencies) {
@@ -23,5 +22,6 @@ func Register(mgr *controller.Manager, deps Dependencies) {
 		deps.HCPAllowV2ResourceApis,
 		link.DefaultHCPClientFn,
 		deps.CloudConfig,
+		deps.DataDir,
 	))
 }

--- a/internal/hcp/internal/types/link.go
+++ b/internal/hcp/internal/types/link.go
@@ -5,15 +5,11 @@ package types
 
 import (
 	"errors"
-	"fmt"
-	"testing"
 
 	"github.com/hashicorp/consul/internal/resource"
 	pbhcp "github.com/hashicorp/consul/proto-public/pbhcp/v2"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-uuid"
 	hcpresource "github.com/hashicorp/hcp-sdk-go/resource"
-	"github.com/stretchr/testify/require"
 )
 
 type DecodedLink = resource.DecodedResource[*pbhcp.Link]
@@ -80,17 +76,4 @@ func validateLink(res *DecodedLink) error {
 	}
 
 	return err
-}
-
-func GenerateTestResourceID(t *testing.T) string {
-	t.Helper()
-
-	orgID, err := uuid.GenerateUUID()
-	require.NoError(t, err)
-
-	projectID, err := uuid.GenerateUUID()
-	require.NoError(t, err)
-
-	template := "organization/%s/project/%s/hashicorp.consul.global-network-manager.cluster/test-cluster"
-	return fmt.Sprintf(template, orgID, projectID)
 }

--- a/internal/hcp/internal/types/link.go
+++ b/internal/hcp/internal/types/link.go
@@ -5,10 +5,15 @@ package types
 
 import (
 	"errors"
+	"fmt"
+	"testing"
 
 	"github.com/hashicorp/consul/internal/resource"
 	pbhcp "github.com/hashicorp/consul/proto-public/pbhcp/v2"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	hcpresource "github.com/hashicorp/hcp-sdk-go/resource"
+	"github.com/stretchr/testify/require"
 )
 
 type DecodedLink = resource.DecodedResource[*pbhcp.Link]
@@ -20,7 +25,8 @@ const (
 )
 
 var (
-	linkConfigurationNameError = errors.New("only a single Link resource is allowed and it must be named global")
+	errLinkConfigurationName = errors.New("only a single Link resource is allowed and it must be named global")
+	errInvalidHCPResourceID  = errors.New("could not parse, invalid format")
 )
 
 func RegisterLink(r resource.Registry) {
@@ -40,7 +46,7 @@ func validateLink(res *DecodedLink) error {
 	if res.Id.Name != LinkName {
 		err = multierror.Append(err, resource.ErrInvalidField{
 			Name:    "name",
-			Wrapped: linkConfigurationNameError,
+			Wrapped: errLinkConfigurationName,
 		})
 	}
 
@@ -63,7 +69,28 @@ func validateLink(res *DecodedLink) error {
 			Name:    "resource_id",
 			Wrapped: resource.ErrMissing,
 		})
+	} else {
+		_, parseErr := hcpresource.FromString(res.Data.ResourceId)
+		if parseErr != nil {
+			err = multierror.Append(err, resource.ErrInvalidField{
+				Name:    "resource_id",
+				Wrapped: errInvalidHCPResourceID,
+			})
+		}
 	}
 
 	return err
+}
+
+func GenerateTestResourceID(t *testing.T) string {
+	t.Helper()
+
+	orgID, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+
+	projectID, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+
+	template := "organization/%s/project/%s/hashicorp.consul.global-network-manager.cluster/test-cluster"
+	return fmt.Sprintf(template, orgID, projectID)
 }

--- a/internal/hcp/internal/types/link_test.go
+++ b/internal/hcp/internal/types/link_test.go
@@ -35,7 +35,7 @@ func TestValidateLink_Ok(t *testing.T) {
 	data := &pbhcp.Link{
 		ClientId:     "abc",
 		ClientSecret: "abc",
-		ResourceId:   "abc",
+		ResourceId:   GenerateTestResourceID(t),
 	}
 
 	res := createCloudLinkResource(t, data)
@@ -60,7 +60,7 @@ func TestValidateLink_InvalidName(t *testing.T) {
 	data := &pbhcp.Link{
 		ClientId:     "abc",
 		ClientSecret: "abc",
-		ResourceId:   "abc",
+		ResourceId:   GenerateTestResourceID(t),
 	}
 
 	res := createCloudLinkResource(t, data)
@@ -70,7 +70,7 @@ func TestValidateLink_InvalidName(t *testing.T) {
 
 	expected := resource.ErrInvalidField{
 		Name:    "name",
-		Wrapped: linkConfigurationNameError,
+		Wrapped: errLinkConfigurationName,
 	}
 
 	var actual resource.ErrInvalidField
@@ -82,7 +82,7 @@ func TestValidateLink_MissingClientId(t *testing.T) {
 	data := &pbhcp.Link{
 		ClientId:     "",
 		ClientSecret: "abc",
-		ResourceId:   "abc",
+		ResourceId:   GenerateTestResourceID(t),
 	}
 
 	res := createCloudLinkResource(t, data)
@@ -103,7 +103,7 @@ func TestValidateLink_MissingClientSecret(t *testing.T) {
 	data := &pbhcp.Link{
 		ClientId:     "abc",
 		ClientSecret: "",
-		ResourceId:   "abc",
+		ResourceId:   GenerateTestResourceID(t),
 	}
 
 	res := createCloudLinkResource(t, data)
@@ -141,6 +141,27 @@ func TestValidateLink_MissingResourceId(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+func TestValidateLink_InvalidResourceId(t *testing.T) {
+	data := &pbhcp.Link{
+		ClientId:     "abc",
+		ClientSecret: "abc",
+		ResourceId:   "abc",
+	}
+
+	res := createCloudLinkResource(t, data)
+
+	err := ValidateLink(res)
+
+	expected := resource.ErrInvalidField{
+		Name:    "resource_id",
+		Wrapped: errInvalidHCPResourceID,
+	}
+
+	var actual resource.ErrInvalidField
+	require.ErrorAs(t, err, &actual)
+	require.Equal(t, expected, actual)
+}
+
 // Currently, we have no specific ACLs configured so the default `operator` permissions are required
 func TestLinkACLs(t *testing.T) {
 	registry := resource.NewRegistry()
@@ -149,7 +170,7 @@ func TestLinkACLs(t *testing.T) {
 	data := &pbhcp.Link{
 		ClientId:     "abc",
 		ClientSecret: "abc",
-		ResourceId:   "abc",
+		ResourceId:   GenerateTestResourceID(t),
 	}
 	link := createCloudLinkResource(t, data)
 

--- a/internal/hcp/internal/types/testing.go
+++ b/internal/hcp/internal/types/testing.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func GenerateTestResourceID(t *testing.T) string {
+	orgID, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+
+	projectID, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+
+	template := "organization/%s/project/%s/hashicorp.consul.global-network-manager.cluster/test-cluster"
+	return fmt.Sprintf(template, orgID, projectID)
+}


### PR DESCRIPTION
### Description
This PR updates the link reconciler to get the value of the management token from HCP by fetching the agent bootstrap configuration. This reuses a lot of the existing logic for fetching the agent bootstrap config, specifically the code that first checks if the relevant files already exist locally on disk.

This PR is best viewed commit-by-commit. The main changes are:

- Moves the config loader code into a separate package to avoid cyclical dependencies
- Adds support for loading just the management token rather than also checking for the server configuration, as the server config is not needed by the link resource.
- Passes the data directory as a dependency to the link controller so that it can check if the management token file exists in the data directory or not.
- Calls the load management token (which will in turn call fetch bootstrap config) in the link reconciler
- Handle unauthorized and forbidden errors so that the link status can give a descriptive error and so fetch bootstrap actually does stop on terminal errors
- Validates the resource ID format as part of the link request to return a more descriptive error 


### Testing & Reproduction steps
Read-write scenario:
1. Create a link with HCP credentials to a read-write cluster.
2. Check that the `hcp-config` directory was created in the data-dir and populated as expected.
3. Inspect the logs for the relevant messages.
4. Send another PUT request to the link using the same values to start another reconcile.
5. Inspect the logs to see that the token was loaded locally and not fetched from HCP.

```
$ ls data-dir/
checkpoint-signature	node-id			raft			serf			server_metadata.json
```

```
$ curl \
--request PUT \
--header "Content-Type: application/json" \
--location "http://127.0.0.1:8500/api/hcp/v2/link/global" \
--data '{
  "data": {
    "resource_id": "<redacted>",
    "client_id": "<redacted>",
    "client_secret": "<redacted>"
  }
}'
```
```
$ ls data-dir/
checkpoint-signature	hcp-config		node-id			raft			serf			server_metadata.json

$ ls data-dir/hcp-config/
hcp-management-token	server-config.json	successful-bootstrap
```

```
2024-01-22T10:18:23.347-0600 [DEBUG] agent.server.controller-runtime: fetching configuration from HCP: controller=consul.io/hcp/link managed_type=hcp.v2.Link resource-id="uid:\"01HMRZEF0Q5F5DXZQHVASZ3JD3\" name:\"global\" type:{group:\"hcp\" group_version:\"v2\" kind:\"Link\"} tenancy:{peer_name:\"local\"}"
2024-01-22T10:18:23.424-0600 [DEBUG] agent.server.controller-runtime: configuration fetched from HCP and saved on local disk: controller=consul.io/hcp/link managed_type=hcp.v2.Link resource-id="uid:\"01HMRZEF0Q5F5DXZQHVASZ3JD3\" name:\"global\" type:{group:\"hcp\" group_version:\"v2\" kind:\"Link\"} tenancy:{peer_name:\"local\"}"
```

```
2024-01-22T10:18:23.704-0600 [TRACE] agent.server.controller-runtime: loaded HCP configuration from local disk: controller=consul.io/hcp/link managed_type=hcp.v2.Link resource-id="uid:\"01HMRZEF0Q5F5DXZQHVASZ3JD3\" name:\"global\" type:{group:\"hcp\" group_version:\"v2\" kind:\"Link\"} tenancy:{peer_name:\"local\"}"
```

Read-only scenario:
1. Create a link with HCP credentials to a read-only cluster.
2. Check that the `hcp-config` directory was NOT created.

```
$ curl \
--request PUT \
--header "Content-Type: application/json" \
--location "http://127.0.0.1:8500/api/hcp/v2/link/global" \
--data '{
  "data": {
    "resource_id": "<redacted>",
    "client_id": "<redacted>",
    "client_secret": "<redacted>"
  }
}'
```
```
$ ls data-dir/
checkpoint-signature	node-id			raft			serf			server_metadata.json
```

```
$ curl http://127.0.0.1:8500/api/hcp/v2/link/global 
{
  "data": {
    "accessLevel": "ACCESS_LEVEL_GLOBAL_READ_ONLY",
…
  },
…  },
  "status": {
    "consul.io/hcp/link": {
      "conditions": [
        {
          "message": "Successfully linked to cluster '<redacted>'",
          "reason": "SUCCESS",
          "state": "STATE_TRUE",
          "type": "linked"
        }
      ],
      "observedGeneration": "01HMRZQ5443F2Z312V1GE3WB7Q",
      "updatedAt": "2024-01-22T16:23:07.978814Z"
    }
  },
  "version": "37"
}
```

### Links
- https://hashicorp.atlassian.net/browse/CC-7063

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
