### PR TITLE
[CC-7044] Start HCP manager as part of link creation

### DIFF
--- a/.changelog/20312.txt
+++ b/.changelog/20312.txt
@@ -1,0 +1,6 @@
+```release-note:feature
+cloud: Adds new API/CLI to initiate and manage link cluster to HCP Consul Central
+```
+```release-note:breaking-change
+telemetry: Adds fix to always default to prefixing gauge-type metrics with the hostname of the Consul agent, even if only the default metric sinks are enabled.
+```

--- a/.changelog/20312.txt
+++ b/.changelog/20312.txt
@@ -1,6 +1,6 @@
 ```release-note:feature
-cloud: Adds new API/CLI to initiate and manage link cluster to HCP Consul Central
+cloud: Adds new API/CLI to initiate and manage linking a Consul cluster to HCP Consul Central
 ```
 ```release-note:breaking-change
-telemetry: Adds fix to always default to prefixing gauge-type metrics with the hostname of the Consul agent, even if only the default metric sinks are enabled.
+telemetry: Adds fix to always use the value of `telemetry.disable_hostname` when determining whether to prefix gauge-type metrics with the hostname of the Consul agent. Previously, if only the default metric sink was enabled, this configuration was ignored and always treated as `true`, even though its default value is `false`.
 ```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1295,7 +1295,7 @@ func (a *Agent) listenHTTP() ([]apiServer, error) {
 	}
 
 	httpAddrs := a.config.HTTPAddrs
-	if a.config.IsCloudEnabled() {
+	if a.scadaProvider != nil {
 		httpAddrs = append(httpAddrs, scada.CAPCoreAPI)
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/hashicorp/serf/serf"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
@@ -6338,12 +6337,8 @@ func TestAgent_scadaProvider(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, l.Close())
 
-	pvd.EXPECT().UpdateMeta(mock.Anything).Once()
-	pvd.EXPECT().Start().Return(nil).Once()
 	pvd.EXPECT().Listen(scada.CAPCoreAPI.Capability()).Return(l, nil).Once()
 	pvd.EXPECT().Stop().Return(nil).Once()
-	pvd.EXPECT().SessionStatus().Return("test")
-	pvd.EXPECT().UpdateHCPConfig(mock.Anything).Return(nil).Once()
 	a := TestAgent{
 		OverrideDeps: func(deps *BaseDeps) {
 			deps.HCP.Provider = pvd

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1112,8 +1112,8 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		LocalProxyConfigResyncInterval:    30 * time.Second,
 	}
 
-	// host metrics are enabled by default if consul is configured with HashiCorp Cloud Platform integration
-	rt.Telemetry.EnableHostMetrics = boolValWithDefault(c.Telemetry.EnableHostMetrics, rt.IsCloudEnabled())
+	// host metrics are enabled by default to support HashiCorp Cloud Platform integration
+	rt.Telemetry.EnableHostMetrics = boolValWithDefault(c.Telemetry.EnableHostMetrics, true)
 
 	rt.TLS, err = b.buildTLSConfig(rt, c.TLS)
 	if err != nil {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -601,7 +601,9 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 		SCADAProvider:     flat.HCP.Provider,
 		TelemetryProvider: flat.HCP.TelemetryProvider,
 		ManagementTokenUpserterFn: func(name, secretId string) error {
-			if s.config.ACLsEnabled && s.IsLeader() {
+			// Check the state of the server before attempting to upsert the token. Otherwise,
+			// the upsert will fail and log errors that do not require action from the user.
+			if s.config.ACLsEnabled && s.IsLeader() && s.InPrimaryDatacenter() {
 				// Idea for improvement: Upsert a token with a well-known accessorId here instead
 				// of a randomly generated one. This would prevent any possible insertion collision between
 				// this and the insertion that happens during the ACL initialization process (initializeACLs function)

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -993,6 +993,7 @@ func (s *Server) registerControllers(deps Deps, proxyUpdater ProxyUpdater) error
 		HCPAllowV2ResourceApis: s.hcpAllowV2Resources,
 		CloudConfig:            deps.HCP.Config,
 		DataDir:                deps.HCP.DataDir,
+		HCPManager:             s.hcpManager,
 	})
 
 	// When not enabled, the v1 tenancy bridge is used by default.

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -596,7 +596,6 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 
 	s.hcpManager = hcp.NewManager(hcp.ManagerConfig{
 		CloudConfig:       s.config.Cloud,
-		Client:            flat.HCP.Client,
 		StatusFn:          s.hcpServerStatus(flat),
 		Logger:            logger.Named("hcp_manager"),
 		SCADAProvider:     flat.HCP.Provider,
@@ -954,6 +953,7 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 	go s.updateMetrics()
 
 	// Now we are setup, configure the HCP manager
+	s.hcpManager.UpdateConfig(flat.HCP.Client, s.config.Cloud)
 	err = s.hcpManager.Start(&lib.StopChannelContext{StopCh: shutdownCh})
 	if err != nil {
 		logger.Error("error starting HCP manager, some HashiCorp Cloud Platform functionality has been disabled",

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -954,13 +954,11 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 	go s.updateMetrics()
 
 	// Now we are setup, configure the HCP manager
-	go func() {
-		err := s.hcpManager.Run(&lib.StopChannelContext{StopCh: shutdownCh})
-		if err != nil {
-			logger.Error("error starting HCP manager, some HashiCorp Cloud Platform functionality has been disabled",
-				"error", err)
-		}
-	}()
+	err = s.hcpManager.Start(&lib.StopChannelContext{StopCh: shutdownCh})
+	if err != nil {
+		logger.Error("error starting HCP manager, some HashiCorp Cloud Platform functionality has been disabled",
+			"error", err)
+	}
 
 	err = s.runEnterpriseRateLimiterConfigEntryController()
 	if err != nil {

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -2095,30 +2095,6 @@ func TestServer_Peering_LeadershipCheck(t *testing.T) {
 	require.NotEqual(t, s2.config.RPCAddr.String(), peeringLeaderAddr)
 }
 
-func TestServer_hcpManager(t *testing.T) {
-	_, conf1 := testServerConfig(t)
-	conf1.BootstrapExpect = 1
-	conf1.RPCAdvertise = &net.TCPAddr{IP: []byte{127, 0, 0, 2}, Port: conf1.RPCAddr.Port}
-	hcp1 := hcpclient.NewMockClient(t)
-	hcp1.EXPECT().PushServerStatus(mock.Anything, mock.MatchedBy(func(status *hcpclient.ServerStatus) bool {
-		return status.ID == string(conf1.NodeID)
-	})).Run(func(ctx context.Context, status *hcpclient.ServerStatus) {
-		require.Equal(t, status.LanAddress, "127.0.0.2")
-	}).Call.Return(nil)
-
-	deps1 := newDefaultDeps(t, conf1)
-	deps1.HCP.Client = hcp1
-	s1, err := newServerWithDeps(t, conf1, deps1)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer s1.Shutdown()
-	require.NotNil(t, s1.hcpManager)
-	waitForLeaderEstablishment(t, s1)
-	hcp1.AssertExpectations(t)
-
-}
-
 func TestServer_addServerTLSInfo(t *testing.T) {
 	testCases := map[string]struct {
 		errMsg            string

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -39,6 +39,7 @@ import (
 	external "github.com/hashicorp/consul/agent/grpc-external"
 	grpcmiddleware "github.com/hashicorp/consul/agent/grpc-middleware"
 	hcpclient "github.com/hashicorp/consul/agent/hcp/client"
+	hcpconfig "github.com/hashicorp/consul/agent/hcp/config"
 	"github.com/hashicorp/consul/agent/leafcert"
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/rpc/middleware"
@@ -2093,6 +2094,51 @@ func TestServer_Peering_LeadershipCheck(t *testing.T) {
 	require.Equal(t, s1.config.RPCAddr.String(), peeringLeaderAddr)
 	// test corollary by transitivity to future-proof against any setup bugs
 	require.NotEqual(t, s2.config.RPCAddr.String(), peeringLeaderAddr)
+}
+
+func TestServer_hcpManager(t *testing.T) {
+	_, conf1 := testServerConfig(t)
+
+	// Configure the server for the StatusFn
+	conf1.BootstrapExpect = 1
+	conf1.RPCAdvertise = &net.TCPAddr{IP: []byte{127, 0, 0, 2}, Port: conf1.RPCAddr.Port}
+	hcp1 := hcpclient.NewMockClient(t)
+	hcp1.EXPECT().PushServerStatus(mock.Anything, mock.MatchedBy(func(status *hcpclient.ServerStatus) bool {
+		return status.ID == string(conf1.NodeID)
+	})).Run(func(ctx context.Context, status *hcpclient.ServerStatus) {
+		require.Equal(t, status.LanAddress, "127.0.0.2")
+	}).Call.Return(nil)
+
+	// Configure the server for the ManagementTokenUpserterFn
+	conf1.ACLsEnabled = true
+
+	deps1 := newDefaultDeps(t, conf1)
+	s1, err := newServerWithDeps(t, conf1, deps1)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer s1.Shutdown()
+	require.NotNil(t, s1.hcpManager)
+	waitForLeaderEstablishment(t, s1)
+
+	// Update the HCP manager and start it
+	token, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	s1.hcpManager.UpdateConfig(hcp1, hcpconfig.CloudConfig{
+		ManagementToken: token,
+	})
+	err = s1.hcpManager.Start(context.Background())
+	require.NoError(t, err)
+
+	// Validate that the server status pushed as expected
+	hcp1.AssertExpectations(t)
+
+	// Validate that the HCP token has been created as expected
+	retry.Run(t, func(r *retry.R) {
+		_, createdToken, err := s1.fsm.State().ACLTokenGetBySecret(nil, token, nil)
+		require.NoError(r, err)
+		require.NotNil(r, createdToken)
+	})
 }
 
 func TestServer_addServerTLSInfo(t *testing.T) {

--- a/agent/hcp/config/config.go
+++ b/agent/hcp/config/config.go
@@ -71,3 +71,50 @@ func (c *CloudConfig) HCPConfig(opts ...hcpcfg.HCPConfigOption) (hcpcfg.HCPConfi
 func (c *CloudConfig) IsConfigured() bool {
 	return c.ResourceID != "" && c.ClientID != "" && c.ClientSecret != ""
 }
+
+// Merge returns a cloud configuration that is the combined the values of
+// two configurations.
+func Merge(o CloudConfig, n CloudConfig) CloudConfig {
+	c := o
+	if n.ResourceID != "" {
+		c.ResourceID = n.ResourceID
+	}
+
+	if n.ClientID != "" {
+		c.ClientID = n.ClientID
+	}
+
+	if n.ClientSecret != "" {
+		c.ClientSecret = n.ClientSecret
+	}
+
+	if n.Hostname != "" {
+		c.Hostname = n.Hostname
+	}
+
+	if n.AuthURL != "" {
+		c.AuthURL = n.AuthURL
+	}
+
+	if n.ScadaAddress != "" {
+		c.ScadaAddress = n.ScadaAddress
+	}
+
+	if n.ManagementToken != "" {
+		c.ManagementToken = n.ManagementToken
+	}
+
+	if n.TLSConfig != nil {
+		c.TLSConfig = n.TLSConfig
+	}
+
+	if n.NodeID != "" {
+		c.NodeID = n.NodeID
+	}
+
+	if n.NodeName != "" {
+		c.NodeName = n.NodeName
+	}
+
+	return c
+}

--- a/agent/hcp/config/config_test.go
+++ b/agent/hcp/config/config_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMerge(t *testing.T) {
+	oldCfg := CloudConfig{
+		ResourceID:      "old-resource-id",
+		ClientID:        "old-client-id",
+		ClientSecret:    "old-client-secret",
+		Hostname:        "old-hostname",
+		AuthURL:         "old-auth-url",
+		ScadaAddress:    "old-scada-address",
+		ManagementToken: "old-token",
+		TLSConfig: &tls.Config{
+			ServerName: "old-server-name",
+		},
+		NodeID:   "old-node-id",
+		NodeName: "old-node-name",
+	}
+
+	newCfg := CloudConfig{
+		ResourceID:      "new-resource-id",
+		ClientID:        "new-client-id",
+		ClientSecret:    "new-client-secret",
+		Hostname:        "new-hostname",
+		AuthURL:         "new-auth-url",
+		ScadaAddress:    "new-scada-address",
+		ManagementToken: "new-token",
+		TLSConfig: &tls.Config{
+			ServerName: "new-server-name",
+		},
+		NodeID:   "new-node-id",
+		NodeName: "new-node-name",
+	}
+
+	for name, tc := range map[string]struct {
+		newCfg      CloudConfig
+		expectedCfg CloudConfig
+	}{
+		"Empty": {
+			newCfg:      CloudConfig{},
+			expectedCfg: oldCfg,
+		},
+		"All": {
+			newCfg:      newCfg,
+			expectedCfg: newCfg,
+		},
+		"Partial": {
+			newCfg: CloudConfig{
+				ResourceID:      newCfg.ResourceID,
+				ClientID:        newCfg.ClientID,
+				ClientSecret:    newCfg.ClientSecret,
+				ManagementToken: newCfg.ManagementToken,
+			},
+			expectedCfg: CloudConfig{
+				ResourceID:      newCfg.ResourceID,
+				ClientID:        newCfg.ClientID,
+				ClientSecret:    newCfg.ClientSecret,
+				ManagementToken: newCfg.ManagementToken,
+				Hostname:        oldCfg.Hostname,
+				AuthURL:         oldCfg.AuthURL,
+				ScadaAddress:    oldCfg.ScadaAddress,
+				TLSConfig:       oldCfg.TLSConfig,
+				NodeID:          oldCfg.NodeID,
+				NodeName:        oldCfg.NodeName,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			merged := Merge(oldCfg, tc.newCfg)
+			require.Equal(t, tc.expectedCfg, merged)
+		})
+	}
+}

--- a/agent/hcp/deps.go
+++ b/agent/hcp/deps.go
@@ -20,7 +20,7 @@ import (
 type Deps struct {
 	Config            config.CloudConfig
 	Provider          scada.Provider
-	Sink              metrics.MetricSink
+	Sink              metrics.ShutdownSink
 	TelemetryProvider *hcpProviderImpl
 	DataDir           string
 }
@@ -63,7 +63,7 @@ func sink(
 	ctx context.Context,
 	metricsClient telemetry.MetricsClient,
 	cfgProvider *hcpProviderImpl,
-) (metrics.MetricSink, error) {
+) (metrics.ShutdownSink, error) {
 	logger := hclog.FromContext(ctx)
 
 	reader := telemetry.NewOTELReader(metricsClient, cfgProvider)

--- a/agent/hcp/deps.go
+++ b/agent/hcp/deps.go
@@ -19,7 +19,6 @@ import (
 // Deps contains the interfaces that the rest of Consul core depends on for HCP integration.
 type Deps struct {
 	Config            config.CloudConfig
-	Client            client.Client
 	Provider          scada.Provider
 	Sink              metrics.MetricSink
 	TelemetryProvider *hcpProviderImpl
@@ -29,15 +28,6 @@ type Deps struct {
 func NewDeps(cfg config.CloudConfig, logger hclog.Logger, dataDir string) (Deps, error) {
 	ctx := context.Background()
 	ctx = hclog.WithContext(ctx, logger)
-
-	var hcpClient client.Client
-	if cfg.ResourceID != "" {
-		var err error
-		hcpClient, err = client.NewClient(cfg)
-		if err != nil {
-			return Deps{}, fmt.Errorf("failed to init client: %w", err)
-		}
-	}
 
 	provider, err := scada.New(logger.Named("scada"))
 	if err != nil {
@@ -60,7 +50,6 @@ func NewDeps(cfg config.CloudConfig, logger hclog.Logger, dataDir string) (Deps,
 
 	return Deps{
 		Config:            cfg,
-		Client:            hcpClient,
 		Provider:          provider,
 		Sink:              sink,
 		TelemetryProvider: metricsProvider,

--- a/agent/hcp/deps.go
+++ b/agent/hcp/deps.go
@@ -30,9 +30,13 @@ func NewDeps(cfg config.CloudConfig, logger hclog.Logger, dataDir string) (Deps,
 	ctx := context.Background()
 	ctx = hclog.WithContext(ctx, logger)
 
-	hcpClient, err := client.NewClient(cfg)
-	if err != nil {
-		return Deps{}, fmt.Errorf("failed to init client: %w", err)
+	var hcpClient client.Client
+	if cfg.ResourceID != "" {
+		var err error
+		hcpClient, err = client.NewClient(cfg)
+		if err != nil {
+			return Deps{}, fmt.Errorf("failed to init client: %w", err)
+		}
 	}
 
 	provider, err := scada.New(logger.Named("scada"))

--- a/agent/hcp/manager.go
+++ b/agent/hcp/manager.go
@@ -88,11 +88,11 @@ func NewManager(cfg ManagerConfig) *Manager {
 // manager has been previously started, it will not start again.
 func (m *Manager) Start(ctx context.Context) error {
 	// Check if the manager has already started
-	if m.isRunning() {
+	changed := m.setRunning(true)
+	if !changed {
 		m.logger.Trace("HCP manager already started")
 		return nil
 	}
-	m.setRunning(true)
 
 	var err error
 	m.logger.Info("HCP manager starting")
@@ -287,8 +287,17 @@ func (m *Manager) isRunning() bool {
 	return m.running
 }
 
-func (m *Manager) setRunning(s bool) {
+// setRunning sets the running status of the manager to the given value. If the
+// given value is the same as the current running status, it returns false. If
+// current status is updated to the given status, it returns true.
+func (m *Manager) setRunning(r bool) bool {
 	m.runLock.Lock()
 	defer m.runLock.Unlock()
-	m.running = s
+
+	if m.running == r {
+		return false
+	}
+
+	m.running = r
+	return true
 }

--- a/agent/hcp/manager_test.go
+++ b/agent/hcp/manager_test.go
@@ -58,11 +58,9 @@ func TestManager_Start(t *testing.T) {
 		mockTelemetryCfg, nil).Maybe()
 
 	mgr := NewManager(ManagerConfig{
-		Client:                    client,
 		Logger:                    hclog.New(&hclog.LoggerOptions{Output: io.Discard}),
 		StatusFn:                  statusF,
 		ManagementTokenUpserterFn: upsertManagementTokenF,
-		CloudConfig:               cloudCfg,
 		SCADAProvider:             scadaM,
 		TelemetryProvider:         telemetryProvider,
 	})
@@ -70,6 +68,7 @@ func TestManager_Start(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
+	mgr.UpdateConfig(client, cloudCfg)
 	mgr.Start(ctx)
 	select {
 	case <-updateCh:

--- a/agent/hcp/manager_test.go
+++ b/agent/hcp/manager_test.go
@@ -76,13 +76,18 @@ func TestManager_Start(t *testing.T) {
 		require.Fail(t, "manager did not send update in expected time")
 	}
 
+	select {
+	case <-upsertManagementTokenCalled:
+	case <-time.After(time.Second):
+		require.Fail(t, "manager did not upsert management token in expected time")
+	}
+
 	// Make sure after manager has stopped no more statuses are pushed.
 	cancel()
 	client.AssertExpectations(t)
 	require.Equal(t, client, telemetryProvider.hcpClient)
 	require.NotNil(t, telemetryProvider.GetHeader())
 	require.NotNil(t, telemetryProvider.GetHTTPClient())
-	require.NotEmpty(t, upsertManagementTokenCalled, "upsert management token function not called")
 }
 
 func TestManager_StartMultipleTimes(t *testing.T) {

--- a/agent/hcp/telemetry/otel_sink.go
+++ b/agent/hcp/telemetry/otel_sink.go
@@ -136,6 +136,10 @@ func NewOTELSink(ctx context.Context, opts *OTELSinkOpts) (*OTELSink, error) {
 	}, nil
 }
 
+func (o *OTELSink) Shutdown() {
+	o.meterProvider.Shutdown(context.TODO())
+}
+
 // SetGauge emits a Consul gauge metric.
 func (o *OTELSink) SetGauge(key []string, val float32) {
 	o.SetGaugeWithLabels(key, val, nil)

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -137,21 +137,15 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer, providedLogger hcl
 	cfg.Telemetry.PrometheusOpts.SummaryDefinitions = summaries
 
 	var extraSinks []metrics.MetricSink
-	if cfg.IsCloudEnabled() {
-		// This values is set late within newNodeIDFromConfig above
-		cfg.Cloud.NodeID = cfg.NodeID
+	// This values is set late within newNodeIDFromConfig above
+	cfg.Cloud.NodeID = cfg.NodeID
 
-		d.HCP, err = hcp.NewDeps(cfg.Cloud, d.Logger.Named("hcp"), cfg.DataDir)
-		if err != nil {
-			return d, err
-		}
-		if d.HCP.Sink != nil {
-			extraSinks = append(extraSinks, d.HCP.Sink)
-		}
-	} else {
-		d.HCP = hcp.Deps{
-			DataDir: cfg.DataDir,
-		}
+	d.HCP, err = hcp.NewDeps(cfg.Cloud, d.Logger.Named("hcp"), cfg.DataDir)
+	if err != nil {
+		return d, err
+	}
+	if d.HCP.Sink != nil {
+		extraSinks = append(extraSinks, d.HCP.Sink)
 	}
 
 	d.MetricsConfig, err = lib.InitTelemetry(cfg.Telemetry, d.Logger, extraSinks...)

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -271,6 +271,9 @@ func (bd BaseDeps) Close() {
 	bd.AutoConfig.Stop()
 	bd.LeafCertManager.Stop()
 	bd.MetricsConfig.Cancel()
+	if bd.HCP.Sink != nil {
+		bd.HCP.Sink.Shutdown()
+	}
 
 	for _, fn := range []func(){bd.deregisterBalancer, bd.deregisterResolver, bd.stopHostCollector} {
 		if fn != nil {

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -58,8 +58,13 @@ func TestAPI_AgentMetrics(t *testing.T) {
 		if err != nil {
 			r.Fatalf("err: %v", err)
 		}
+		hostname, err := os.Hostname()
+		if err != nil {
+			r.Fatalf("error determining hostname: %v", err)
+		}
+		metricName := fmt.Sprintf("consul.%s.runtime.alloc_bytes", hostname)
 		for _, g := range metrics.Gauges {
-			if g.Name == "consul.runtime.alloc_bytes" {
+			if g.Name == metricName {
 				return
 			}
 		}

--- a/internal/hcp/internal/controllers/link/controller.go
+++ b/internal/hcp/internal/controllers/link/controller.go
@@ -28,14 +28,10 @@ import (
 // This function type should be passed to a LinkController in order to tell it how to make a client from
 // a Link. For normal use, DefaultHCPClientFn should be used, but tests can substitute in a function that creates a
 // mock client.
-type HCPClientFn func(link *pbhcp.Link) (hcpclient.Client, error)
+type HCPClientFn func(config.CloudConfig) (hcpclient.Client, error)
 
-var DefaultHCPClientFn HCPClientFn = func(link *pbhcp.Link) (hcpclient.Client, error) {
-	hcpClient, err := hcpclient.NewClient(config.CloudConfig{
-		ResourceID:   link.ResourceId,
-		ClientID:     link.ClientId,
-		ClientSecret: link.ClientSecret,
-	})
+var DefaultHCPClientFn HCPClientFn = func(cfg config.CloudConfig) (hcpclient.Client, error) {
+	hcpClient, err := hcpclient.NewClient(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -51,6 +47,7 @@ func LinkController(
 	hcpManager *hcp.Manager,
 ) *controller.Controller {
 	return controller.NewController("link", pbhcp.LinkType).
+		WithPlacement(controller.PlacementEachServer).
 		WithInitializer(&linkInitializer{
 			cloudConfig: cfg,
 		}).
@@ -135,7 +132,14 @@ func (r *linkReconciler) Reconcile(ctx context.Context, rt controller.Runtime, r
 		return writeStatusIfNotEqual(ctx, rt, res, newStatus)
 	}
 
-	hcpClient, err := r.hcpClientFn(&link)
+	existingCfg := r.hcpManager.GetCloudConfig()
+	newCfg := config.CloudConfig{
+		ResourceID:   link.ResourceId,
+		ClientID:     link.ClientId,
+		ClientSecret: link.ClientSecret,
+	}
+	cfg := config.Merge(existingCfg, newCfg)
+	hcpClient, err := r.hcpClientFn(cfg)
 	if err != nil {
 		rt.Logger.Error("error creating HCP client", "error", err)
 		return err
@@ -163,7 +167,7 @@ func (r *linkReconciler) Reconcile(ctx context.Context, rt controller.Runtime, r
 		}
 		_, err = rt.Client.Write(ctx, &pbresource.WriteRequest{Resource: &pbresource.Resource{
 			Id: &pbresource.ID{
-				Name: "global",
+				Name: types.LinkName,
 				Type: pbhcp.LinkType,
 			},
 			Metadata: res.Metadata,
@@ -177,13 +181,25 @@ func (r *linkReconciler) Reconcile(ctx context.Context, rt controller.Runtime, r
 
 	// Load the management token if access is not set to read-only. Read-only clusters
 	// will not have a management token provided by HCP.
+	var token string
 	if accessLevel != pbhcp.AccessLevel_ACCESS_LEVEL_GLOBAL_READ_ONLY {
-		_, err = bootstrap.LoadManagementToken(ctx, rt.Logger, hcpClient, r.dataDir)
+		token, err = bootstrap.LoadManagementToken(ctx, rt.Logger, hcpClient, r.dataDir)
 		if err != nil {
 			linkingFailed(ctx, rt, res, err)
 			return err
 		}
-		// TODO: Update the HCP manager with the loaded management token as part of CC-7044
+	}
+
+	// Update the HCP manager configuration with the link values
+	cfg.ManagementToken = token
+	r.hcpManager.UpdateConfig(hcpClient, cfg)
+
+	// Start the manager
+	err = r.hcpManager.Start(ctx)
+	if err != nil {
+		rt.Logger.Error("error starting HCP manager", "error", err)
+		linkingFailed(ctx, rt, res, err)
+		return err
 	}
 
 	newStatus = &pbresource.Status{

--- a/internal/hcp/internal/controllers/link/controller.go
+++ b/internal/hcp/internal/controllers/link/controller.go
@@ -47,6 +47,11 @@ func LinkController(
 	hcpManager *hcp.Manager,
 ) *controller.Controller {
 	return controller.NewController("link", pbhcp.LinkType).
+		// Placement is configured to each server so that the HCP manager is started
+		// on each server. We plan to implement an alternative strategy to starting
+		// the HCP manager so that the controller placement will eventually only be
+		// on the leader.
+		// https://hashicorp.atlassian.net/browse/CC-7364
 		WithPlacement(controller.PlacementEachServer).
 		WithInitializer(&linkInitializer{
 			cloudConfig: cfg,

--- a/internal/hcp/internal/controllers/link/controller.go
+++ b/internal/hcp/internal/controllers/link/controller.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/hashicorp/consul/agent/hcp"
 	"github.com/hashicorp/consul/agent/hcp/bootstrap"
 	hcpclient "github.com/hashicorp/consul/agent/hcp/client"
 	"github.com/hashicorp/consul/agent/hcp/config"
@@ -47,6 +48,7 @@ func LinkController(
 	hcpClientFn HCPClientFn,
 	cfg config.CloudConfig,
 	dataDir string,
+	hcpManager *hcp.Manager,
 ) *controller.Controller {
 	return controller.NewController("link", pbhcp.LinkType).
 		WithInitializer(&linkInitializer{
@@ -57,6 +59,7 @@ func LinkController(
 			hcpAllowV2ResourceApis: hcpAllowV2ResourceApis,
 			hcpClientFn:            hcpClientFn,
 			dataDir:                dataDir,
+			hcpManager:             hcpManager,
 		})
 }
 
@@ -65,6 +68,7 @@ type linkReconciler struct {
 	hcpAllowV2ResourceApis bool
 	hcpClientFn            HCPClientFn
 	dataDir                string
+	hcpManager             *hcp.Manager
 }
 
 func hcpAccessLevelToConsul(level *gnmmod.HashicorpCloudGlobalNetworkManager20220215ClusterConsulAccessLevel) pbhcp.AccessLevel {

--- a/internal/hcp/internal/controllers/link/controller.go
+++ b/internal/hcp/internal/controllers/link/controller.go
@@ -132,6 +132,10 @@ func (r *linkReconciler) Reconcile(ctx context.Context, rt controller.Runtime, r
 		return writeStatusIfNotEqual(ctx, rt, res, newStatus)
 	}
 
+	// Merge the link data with the existing cloud config so that we only overwrite the
+	// fields that are provided by the link. This ensures that:
+	// 1. The HCP configuration (i.e., how to connect to HCP) is preserved
+	// 2. The Consul agent's node ID and node name are preserved
 	existingCfg := r.hcpManager.GetCloudConfig()
 	newCfg := config.CloudConfig{
 		ResourceID:   link.ResourceId,

--- a/internal/hcp/internal/controllers/register.go
+++ b/internal/hcp/internal/controllers/register.go
@@ -4,6 +4,7 @@
 package controllers
 
 import (
+	"github.com/hashicorp/consul/agent/hcp"
 	"github.com/hashicorp/consul/agent/hcp/config"
 	"github.com/hashicorp/consul/internal/controller"
 	"github.com/hashicorp/consul/internal/hcp/internal/controllers/link"
@@ -14,6 +15,7 @@ type Dependencies struct {
 	ResourceApisEnabled    bool
 	HCPAllowV2ResourceApis bool
 	DataDir                string
+	HCPManager             *hcp.Manager
 }
 
 func Register(mgr *controller.Manager, deps Dependencies) {
@@ -23,5 +25,6 @@ func Register(mgr *controller.Manager, deps Dependencies) {
 		link.DefaultHCPClientFn,
 		deps.CloudConfig,
 		deps.DataDir,
+		deps.HCPManager,
 	))
 }

--- a/internal/hcp/internal/types/link_test.go
+++ b/internal/hcp/internal/types/link_test.go
@@ -182,15 +182,15 @@ func TestLinkACLs(t *testing.T) {
 			WriteOK: rtest.DENY,
 			ListOK:  rtest.DENY,
 		},
-		"link test read": {
-			Rules:   `operator = "read"`,
+		"link test read and list": {
+			Rules:   `{"operator": "read"}`,
 			Res:     link,
 			ReadOK:  rtest.ALLOW,
 			WriteOK: rtest.DENY,
 			ListOK:  rtest.ALLOW,
 		},
 		"link test write": {
-			Rules:   `operator = "write"`,
+			Rules:   `{"operator": "write", "acl": "write"}`,
 			Res:     link,
 			ReadOK:  rtest.ALLOW,
 			WriteOK: rtest.ALLOW,

--- a/lib/telemetry.go
+++ b/lib/telemetry.go
@@ -360,13 +360,9 @@ func configureSinks(cfg TelemetryConfig, memSink metrics.MetricSink, extraSinks 
 		}
 	}
 
-	if len(sinks) > 0 {
-		sinks = append(sinks, memSink)
-		metrics.NewGlobal(metricsConf, sinks)
-	} else {
-		metricsConf.EnableHostname = false
-		metrics.NewGlobal(metricsConf, memSink)
-	}
+	sinks = append(sinks, memSink)
+	metrics.NewGlobal(metricsConf, sinks)
+
 	return sinks, errors
 }
 


### PR DESCRIPTION
### Description
Depends on https://github.com/hashicorp/consul/pull/20306

This PR starts the HCP manger when an HCP link resource is created instead of when Consul is started. This allows the linking process to be initiated via the HCP link API.

These changes are best viewed commit-by-commit. A summary of the changes are:

- Check explicitly for ACL policies since the HCP manger will create a token, so `acl:write` is also now required in addition to `operator:write`
- Change the HCP manager’s Run method to a Start method, keep track of if its running, and only allow to start once
- Always initialize the required HCP components (i.e., SCADA provider, HCP metrics sink) when Consul starts
- Pass the HCP manager as a dependency to the link controller 
- When a link is created, update the HCP manager with the HCP configs and start it

This PR also introduces a breaking change, though that change actually fixes Consul's behavior to match what we have documented. The [agent telemetry docs](https://developer.hashicorp.com/consul/docs/agent/telemetry) and the [agent configuration docs](https://developer.hashicorp.com/consul/docs/agent/config/config-files#telemetry-disable_hostname) for `telemetry.disable_hostname` both state that by default, the hostname of the Consul agent should prefix gauge-type metrics. However, before this PR, if there were no additional metrics sinks enabled, the hostname prefixing was disabled. Now that we're always enabling the HCP metrics sink, we will now always prefix the gauge-metrics by default.

### Testing & Reproduction steps

Linking via API:
1. Start Consul without a `cloud` configuration
2. Make a PUT request to create a link resource
3. Inspect logs to see that HCP manager has started
4. Check in HCP portal that all features are working as expected (server info and services syncing, observability, global workflows, etc.)
5. Make a GET request to the link and check the status is successful

Other variations tested:
- Linking via configuration rather than the API 
- Bootstrapping via configuration

### Links
- https://hashicorp.atlassian.net/browse/CC-7044

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
