### PR TITLE
docs: Update k8s/connect/create-sameness-groups

### DIFF
--- a/website/content/docs/k8s/connect/cluster-peering/usage/create-sameness-groups.mdx
+++ b/website/content/docs/k8s/connect/cluster-peering/usage/create-sameness-groups.mdx
@@ -146,7 +146,7 @@ The following example demonstrates how to format three different `ExportedServic
 apiVersion: consul.hashicorp.com/v1alpha1
 Kind: ExportedServices
 metadata:
-  name: product-group-export
+  name: partition-1
 spec:
   services:
     - name: api
@@ -163,7 +163,7 @@ spec:
 apiVersion: consul.hashicorp.com/v1alpha1
 Kind: ExportedServices
 metadata:
-  name: product-group-export
+  name: partition-2
 spec:
   services:
     - name: api
@@ -180,7 +180,7 @@ spec:
 apiVersion: consul.hashicorp.com/v1alpha1
 Kind: ExportedServices
 metadata:
-  name: product-group-export
+  name: partition-1
 spec:
   services:
     - name: api


### PR DESCRIPTION
### Description

A small change to the export group name reflecting the local partition being exported from as defined in the [Exported Services Configuration docs](/consul/docs/connect/config-entries/exported-services#configuration).

### Testing & Reproduction steps

None

### Links

https://developer.hashicorp.com/consul/docs/connect/config-entries/exported-services#configuration

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
