### PR TITLE
feat(v2dns): add partial support for SOA records

### DIFF
--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -12,10 +12,38 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
+var (
+	ErrNoData       = fmt.Errorf("no data")
+	ErrECSNotGlobal = fmt.Errorf("ECS response is not global")
+)
+
+// ECSNotGlobalError may be used to wrap an error or nil, to indicate that the
+// EDNS client subnet source scope is not global.
+// TODO (v2-dns): prepared queries errors are wrapped by this
+type ECSNotGlobalError struct {
+	error
+}
+
+func (e ECSNotGlobalError) Error() string {
+	if e.error == nil {
+		return ""
+	}
+	return e.error.Error()
+}
+
+func (e ECSNotGlobalError) Is(other error) bool {
+	return other == ErrECSNotGlobal
+}
+
+func (e ECSNotGlobalError) Unwrap() error {
+	return e.error
+}
+
 // Query is used to request a name-based Service Discovery lookup.
 type Query struct {
 	QueryType    QueryType
 	QueryPayload QueryPayload
+	Limit        int
 }
 
 // QueryType is used to filter service endpoints.

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -285,6 +285,7 @@ func TestDNSCycleRecursorCheck(t *testing.T) {
 					A:   []byte{0xAC, 0x15, 0x2D, 0x43}, // 172 , 21, 45, 67
 				},
 			}
+			require.NotNil(t, in)
 			require.Equal(t, wantAnswer, in.Answer)
 		})
 	}
@@ -323,6 +324,7 @@ func TestDNSCycleRecursorCheckAllFail(t *testing.T) {
 			in, _, err := client.Exchange(m, agent.DNSAddr())
 			require.NoError(t, err)
 			// Verify if we hit SERVFAIL from Consul
+			require.NotNil(t, in)
 			require.Equal(t, dns.RcodeServerFailure, in.Rcode)
 		})
 	}


### PR DESCRIPTION
### Description

This PR adds partial support for SOA records. SOA records are return in these cases:
* When an SOA query type is used. Nameservers are also provided in this case.
* When there is a valid query name but no data to return.

The necessary code paths for this record type are implemented, but not the fetching of nameservers, which will come in a subsequent PR.

### Testing & Reproduction steps
* Unit tests are added with mock QueryProcessors
* V1 DNS tests - there weren't any to enable here. They all involve hitting the catalog in one way or another.

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] appropriate backport labels added
* [X] not a security concern