### PR TITLE
Add finalizer to link resource

### DIFF
--- a/internal/hcp/internal/controllers/link/controller.go
+++ b/internal/hcp/internal/controllers/link/controller.go
@@ -108,8 +108,7 @@ func (r *linkReconciler) Reconcile(ctx context.Context, rt controller.Runtime, r
 		return err
 	}
 
-	err = addFinalizer(ctx, rt, res)
-	if err != nil {
+	if err = addFinalizer(ctx, rt, res); err != nil {
 		rt.Logger.Error("error adding finalizer to link resource", "error", err)
 		return err
 	}

--- a/internal/hcp/internal/controllers/link/controller.go
+++ b/internal/hcp/internal/controllers/link/controller.go
@@ -114,8 +114,7 @@ func (r *linkReconciler) Reconcile(ctx context.Context, rt controller.Runtime, r
 	}
 
 	if resource.IsMarkedForDeletion(res) {
-		err := cleanup(ctx, rt, res, r.dataDir)
-		if err != nil {
+		if err = cleanup(ctx, rt, res, r.dataDir); err != nil {
 			rt.Logger.Error("error cleaning up link resource", "error", err)
 			return err
 		}

--- a/internal/hcp/internal/controllers/link/finalizer.go
+++ b/internal/hcp/internal/controllers/link/finalizer.go
@@ -1,0 +1,74 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package link
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/consul/agent/hcp/bootstrap"
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/resource"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+func cleanup(ctx context.Context, rt controller.Runtime, res *pbresource.Resource, dataDir string) error {
+	rt.Logger.Trace("cleaning up link resource")
+	if dataDir != "" {
+		hcpConfigDir := filepath.Join(dataDir, bootstrap.SubDir)
+		rt.Logger.Debug("deleting hcp-config dir", "dir", hcpConfigDir)
+		err := os.RemoveAll(hcpConfigDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := ensureDeleted(ctx, rt, res)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addFinalizer(ctx context.Context, rt controller.Runtime, res *pbresource.Resource) error {
+	// The statusKey doubles as the finalizer name for the link resource
+	if resource.HasFinalizer(res, StatusKey) {
+		rt.Logger.Trace("already has finalizer")
+		return nil
+	}
+
+	// Finalizer hasn't been written, so add it.
+	resource.AddFinalizer(res, StatusKey)
+	_, err := rt.Client.Write(ctx, &pbresource.WriteRequest{Resource: res})
+	if err != nil {
+		return err
+	}
+	rt.Logger.Trace("added finalizer")
+	return err
+}
+
+// ensureDeleted makes sure a link is finally deleted
+func ensureDeleted(ctx context.Context, rt controller.Runtime, res *pbresource.Resource) error {
+	// Remove finalizer if present
+	if resource.HasFinalizer(res, StatusKey) {
+		resource.RemoveFinalizer(res, StatusKey)
+		_, err := rt.Client.Write(ctx, &pbresource.WriteRequest{Resource: res})
+		if err != nil {
+			return err
+		}
+		rt.Logger.Trace("removed finalizer")
+	}
+
+	// Finally, delete the link
+	_, err := rt.Client.Delete(ctx, &pbresource.DeleteRequest{Id: res.Id})
+	if err != nil {
+		return err
+	}
+
+	// Success
+	rt.Logger.Trace("finally deleted")
+	return nil
+}


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
This adds a `Finalizer` to the Link controller. For now, this just handles deleting the `hcp-config` directory.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
In addition to automated unit tests, I performed the following manual test.

1. Run consul like so:
```
go run . agent -dev --log-level trace --data-dir /tmp/consul-test
```
2. Verify that `hcp-config` directory is created
```
➜  consul git:(nickcellino/CC-7338/add-link-finalizer) ls /tmp/consul-test
checkpoint-signature hcp-config           node-id              serf
➜  consul git:(nickcellino/CC-7338/add-link-finalizer) ls /tmp/consul-test/hcp-config
hcp-management-token server-config.json   successful-bootstrap
➜  consul git:(nickcellino/CC-7338/add-link-finalizer)
```

3. Create a Link:
```shell-session
➜  consul git:(nickcellino/CC-7338/add-link-finalizer) http PUT localhost:8500/api/hcp/v2/link/global data[resourceId]=$RESOURCE_ID data[clientSecret]=$CLIENT_SECRET data[clientId]=$CLIENT_ID X-Consul-Token:$CONSUL_HTTP_TOKEN
HTTP/1.1 200 OK
Content-Length: 617
Content-Type: text/plain; charset=utf-8
Date: Tue, 23 Jan 2024 21:27:06 GMT

{
    "data": {
        "clientId": "...",
        "clientSecret": "...",
        "resourceId": "organization/d95434ef-1f14-4b17-b23e-1eb608bb9fda/project/e263159f-b9ea-468e-8dc5-ee3d23403fe2/hashicorp.consul.global-network-manager.cluster/my-cluster"
    },
    "generation": "01HMW3GFRA65WXEG75PEQ4734K",
    "id": {
        "name": "global",
        "tenancy": {
            "peerName": "local"
        },
        "type": {
            "group": "hcp",
            "groupVersion": "v2",
            "kind": "Link"
        },
        "uid": "01HMW3GFRA65WXEG75PDFC5YQP"
    },
    "version": "29"
}
```

Verify from logs that finalizer has been added ✅ :
```
2024-01-23T16:27:06.763-0500 [TRACE] agent.server.controller-runtime: added finalizer: controller=consul.io/hcp/link managed_type=hcp.v2.Link resource-id="uid:\"01HMW3GFRA65WXEG75PDFC5YQP\" name:\"global\" type:{group:\"hcp\" group_version:\"v2\" kind:\"Link\"} tenancy:{peer_name:\"local\"}"
```
4. Delete the Link:
```shell-session
➜  consul git:(nickcellino/CC-7338/add-link-finalizer) http DELETE localhost:8500/api/hcp/v2/link/global
HTTP/1.1 204 No Content
Date: Tue, 23 Jan 2024 21:32:45 GMT
```

Verify from logs that cleanup has been called ✅ :
```
2024-01-23T16:32:45.578-0500 [TRACE] agent.server.controller-runtime: cleaning up link resource: controller=consul.io/hcp/link managed_type=hcp.v2.Link resource-id="uid:\"01HMW3GFRA65WXEG75PDFC5YQP\" name:\"global\" type:{group:\"hcp\" group_version:\"v2\" kind:\"Link\"} tenancy:{peer_name:\"local\"}"
2024-01-23T16:32:45.578-0500 [DEBUG] agent.server.controller-runtime: deleting hcp-config dir: controller=consul.io/hcp/link managed_type=hcp.v2.Link resource-id="uid:\"01HMW3GFRA65WXEG75PDFC5YQP\" name:\"global\" type:{group:\"hcp\" group_version:\"v2\" kind:\"Link\"} tenancy:{peer_name:\"local\"}" dir=/tmp/consul-test/hcp-config
2024-01-23T16:32:45.579-0500 [TRACE] agent.server.controller-runtime: removed finalizer: controller=consul.io/hcp/link managed_type=hcp.v2.Link resource-id="uid:\"01HMW3GFRA65WXEG75PDFC5YQP\" name:\"global\" type:{group:\"hcp\" group_version:\"v2\" kind:\"Link\"} tenancy:{peer_name:\"local\"}"
2024-01-23T16:32:45.579-0500 [TRACE] agent.server.controller-runtime: finally deleted: controller=consul.io/hcp/link managed_type=hcp.v2.Link resource-id="uid:\"01HMW3GFRA65WXEG75PDFC5YQP\" name:\"global\" type:{group:\"hcp\" group_version:\"v2\" kind:\"Link\"} tenancy:{peer_name:\"local\"}"
```
5. Verify that `hcp-config` directory no longer exists ✅
```
➜  consul git:(nickcellino/CC-7338/add-link-finalizer) ls /tmp/consul-test
checkpoint-signature node-id              serf
```

6. Verify that Link no longer exists:
```
➜  consul git:(nickcellino/CC-7338/add-link-finalizer) http GET localhost:8500/api/hcp/v2/link/global
HTTP/1.1 404 Not Found
Content-Length: 52
Content-Type: text/plain; charset=utf-8
Date: Tue, 23 Jan 2024 21:34:14 GMT

rpc error: code = NotFound desc = resource not found
```

### Links
https://hashicorp.atlassian.net/browse/CC-7338

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
