### PR TITLE
Update Vault/Nomad versions.

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -86,7 +86,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        nomad-version: ['v1.6.2', 'v1.5.9', 'v1.4.13']
+        nomad-version: ['v1.7.3', 'v1.6.6', 'v1.5.13']
     steps:
       - name: Checkout Nomad
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -167,7 +167,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        vault-version: ["1.15.0", "1.14.4", "1.13.8", "1.12.11"]
+        vault-version: ["1.15.4", "1.14.8", "1.13.12"]
     env:
       VAULT_BINARY_VERSION: ${{ matrix.vault-version }}
     steps:


### PR DESCRIPTION


Update Vault/Nomad versions to ensure we're testing all the latest versions .

### Description

Test Nomad's latest supported nomad-version: ['v1.7.3', 'v1.6.6', 'v1.5.13']
https://github.com/hashicorp/nomad/blob/v1.7.3/CHANGELOG.md

Test Vault's latest supported vault-version: ["1.15.4", "1.14.8", "1.13.12"]
Grabbed the latest from the changelog- (https://github.com/hashicorp/vault/commit/b5e9f3f32ca55a11b0722858f352a4e70d22be60)

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
