### PR TITLE
Exported services CLI and docs

### DIFF
--- a/command/exportedservices/exported_services.go
+++ b/command/exportedservices/exported_services.go
@@ -1,0 +1,83 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package exportedservices
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/mitchellh/cli"
+)
+
+func New(ui cli.Ui) *cmd {
+	c := &cmd{UI: ui}
+	c.init()
+	return c
+}
+
+type cmd struct {
+	UI    cli.Ui
+	flags *flag.FlagSet
+	http  *flags.HTTPFlags
+	help  string
+}
+
+func (c *cmd) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.http = &flags.HTTPFlags{}
+	flags.Merge(c.flags, c.http.ClientFlags())
+	flags.Merge(c.flags, c.http.ServerFlags())
+	flags.Merge(c.flags, c.http.PartitionFlag())
+	c.help = flags.Usage(help, c.flags)
+}
+
+func (c *cmd) Run(args []string) int {
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	client, err := c.http.APIClient()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error connect to Consul agent: %s", err))
+		return 1
+	}
+
+	exportedServices, _, err := client.ExportedServices(nil)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading exported services: %v", err))
+		return 1
+	}
+
+	b, err := json.MarshalIndent(exportedServices, "", "    ")
+	if err != nil {
+		c.UI.Error("Failed to encode output data")
+		return 1
+	}
+
+	c.UI.Info(string(b))
+	return 0
+}
+
+func (c *cmd) Synopsis() string {
+	return synopsis
+}
+
+func (c *cmd) Help() string {
+	return flags.Usage(c.help, nil)
+}
+
+const (
+	synopsis = "Lists exported services"
+	help     = `
+Usage: consul exported-services [options]
+
+  Lists all the exported services and their consumers. Wildcards and sameness groups are expanded.
+
+  Example:
+
+    $ consul exported-services
+`
+)

--- a/command/exportedservices/exported_services_test.go
+++ b/command/exportedservices/exported_services_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package exportedservices
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/api"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportedServices_noTabs(t *testing.T) {
+	t.Parallel()
+
+	require.NotContains(t, New(cli.NewMockUi()).Help(), "\t")
+}
+
+func TestExportedServices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	set, _, err := client.ConfigEntries().Set(&api.ExportedServicesConfigEntry{
+		Name: "default",
+		Services: []api.ExportedService{
+			{
+				Name: "web",
+				Consumers: []api.ServiceConsumer{
+					{
+						Peer: "east",
+					},
+					{
+						Peer: "west",
+					},
+				},
+			},
+			{
+				Name: "db",
+				Consumers: []api.ServiceConsumer{
+					{
+						Peer: "east",
+					},
+					{
+						Peer: "west",
+					},
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.True(t, set)
+
+	args := []string{
+		"-http-addr=" + a.HTTPAddr(),
+	}
+
+	code := c.Run(args)
+	require.Equal(t, 0, code)
+
+	var resp []api.ResolvedExportedService
+
+	err = json.Unmarshal(ui.OutputWriter.Bytes(), &resp)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(resp))
+	require.Equal(t, "db", resp[0].Service)
+	require.Equal(t, "web", resp[1].Service)
+	require.Equal(t, []string{"east", "west"}, resp[0].Consumers.Peers)
+}

--- a/command/registry.go
+++ b/command/registry.go
@@ -69,6 +69,7 @@ import (
 	"github.com/hashicorp/consul/command/debug"
 	"github.com/hashicorp/consul/command/event"
 	"github.com/hashicorp/consul/command/exec"
+	exportedservices "github.com/hashicorp/consul/command/exportedservices"
 	"github.com/hashicorp/consul/command/forceleave"
 	"github.com/hashicorp/consul/command/info"
 	"github.com/hashicorp/consul/command/intention"
@@ -212,6 +213,7 @@ func RegisteredCommands(ui cli.Ui) map[string]mcli.CommandFactory {
 		entry{"debug", func(ui cli.Ui) (cli.Command, error) { return debug.New(ui), nil }},
 		entry{"event", func(ui cli.Ui) (cli.Command, error) { return event.New(ui), nil }},
 		entry{"exec", func(ui cli.Ui) (cli.Command, error) { return exec.New(ui, MakeShutdownCh()), nil }},
+		entry{"exported-services", func(ui cli.Ui) (cli.Command, error) { return exportedservices.New(ui), nil }},
 		entry{"force-leave", func(ui cli.Ui) (cli.Command, error) { return forceleave.New(ui), nil }},
 		entry{"info", func(ui cli.Ui) (cli.Command, error) { return info.New(ui), nil }},
 		entry{"intention", func(ui cli.Ui) (cli.Command, error) { return intention.New(), nil }},

--- a/website/content/api-docs/exported-services.mdx
+++ b/website/content/api-docs/exported-services.mdx
@@ -1,0 +1,146 @@
+---
+layout: api
+page_title: Exported Services - HTTP API
+description: The /exported-services endpoint is used to list all the exported services  
+  along with their consumers.
+---
+
+# Exported Services HTTP Endpoint
+
+-> **1.17.3+:** The exported services API is available in Consul versions 1.17.3 and newer.
+
+The `/exported-services` endpoint returns the list of exported services and their consumers.
+
+This will fetch all of the services that were exported using an
+[`exported-services` configuration entry](/consul/docs/connect/config-entries/exported-services).
+Sameness groups and wildcards in the configuration entry are expanded in the response.
+
+## List Exported Services
+
+If overrides are needed they are passed as the JSON-encoded request body and
+the `POST` method must be used, otherwise `GET` is sufficient.
+
+| Method             | Path                 | Produces           |
+| ------------------ | -------------------- | ------------------ |
+| `GET`              | `/exported-services` | `application/json` |
+
+
+The table below shows this endpoint's support for
+[blocking queries](/consul/api-docs/features/blocking),
+[consistency modes](/consul/api-docs/features/consistency),
+[agent caching](/consul/api-docs/features/caching), and
+[required ACLs](/consul/api-docs/api-structure#authentication).
+
+| Blocking Queries | Consistency Modes | Agent Caching   | ACL Required                   |
+| ---------------- | ----------------- | --------------- | ------------------------------ |
+| `YES`            | `none`            | `none`          | `mesh:read` or `operator:read` |
+
+
+### Query Parameters
+
+- `partition` `(string: "")` <EnterpriseAlert inline /> - Specifies the partition from which the 
+  services are exported. If not specified will default to `default`.
+
+
+### Sample Request
+
+```shell-session
+$ curl --header "X-Consul-Token: 0137db51-5895-4c25-b6cd-d9ed992f4a52" \
+   http://127.0.0.1:8500/v1/exported-services
+```
+
+### Sample Response
+
+<Tabs>
+
+<Tab heading="CE">
+
+```json
+[
+    {
+        "Service": "frontend",
+        "Consumers": {
+            "Peers": [
+                "east",
+                "west",
+            ]
+        }
+    },
+    {
+        "Service": "db",
+        "Consumers": {
+            "Peers": [
+                "east",
+            ]
+        }
+    },
+    {
+        "Service": "web",
+        "Consumers": {
+            "Peers": [
+                "east",
+                "west"
+            ]
+        }
+    }
+]
+```
+
+</Tab>
+
+<Tab heading="Enterprise">
+
+```json
+[
+    {
+        "Service": "frontend",
+        "Partition": "default",
+        "Namespace": "default",
+        "Consumers": {
+            "Peers": [
+                "east",
+                "west"
+            ],
+            "Partitions": [
+                "part1"
+            ]
+        }
+    },
+    {
+        "Service": "frontend",
+        "Partition": "default",
+        "Namespace": "ns",
+        "Consumers": {
+            "Peers": [
+                "east",
+            ]
+        }
+    },
+    {
+        "Service": "web",
+        "Partition": "default",
+        "Namespace": "default",
+        "Consumers": {
+            "Peers": [
+                "west"
+            ],
+            "Partitions": [
+                "part1"
+            ]
+        }
+    },
+    {
+        "Service": "db",
+        "Partition": "default",
+        "Namespace": "default",
+        "Consumers": {
+            "Partitions": [
+                "part1"
+            ]
+        }
+    }
+]
+```
+
+</Tab>
+</Tabs>

--- a/website/content/commands/exported-services.mdx
+++ b/website/content/commands/exported-services.mdx
@@ -1,0 +1,37 @@
+---
+layout: commands
+page_title: 'Commands: Exported Services'
+description: >-
+  The `exported-services` command lists all the exported services along 
+  with their consumers. Wildcards and sameness groups are expanded.
+---
+
+# Consul Exported Services
+
+Command: `consul exported-services`
+
+Corresponding HTTP API Endpoint: [\[GET\] /v1/exported-services](/consul/api-docs/exported-services)
+
+The `exported-services` command displays all of the services that were exported 
+using an [`exported-services` configuration entry](/consul/docs/connect/config-entries/exported-services).
+Sameness groups and wildcards in the configuration entry are expanded in the response.
+
+
+The table below shows this command's [required ACLs](/consul/api-docs/api-structure#authentication).
+
+| ACL Required                   |
+| ------------------------------ |
+| `mesh:read` or `operator:read` |
+
+## Usage
+
+Usage: `consul exported-services [options]`
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -132,6 +132,10 @@
     "path": "event"
   },
   {
+    "title": "Exported Services",
+    "path": "exported-services"
+  },
+  {
     "title": "Health",
     "path": "health"
   },

--- a/website/data/commands-nav-data.json
+++ b/website/data/commands-nav-data.json
@@ -282,6 +282,10 @@
     "path": "exec"
   },
   {
+    "title": "exported-services",
+    "path": "exported-services"
+  },
+  {
     "title": "force-leave",
     "path": "force-leave"
   },


### PR DESCRIPTION
### Description

This PR adds a new cli command to list exported services

command: `consul exported-services`

The PR also adds the API docs for the exported services API. 

### Testing & Reproduction steps
- Tests added
- Manual testing

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
