### PR TITLE
docs: Fix example service registration for built-in proxy

### DIFF
--- a/ui/packages/consul-ui/mock-api/v1/agent/services
+++ b/ui/packages/consul-ui/mock-api/v1/agent/services
@@ -12,14 +12,16 @@
     "ModifyIndex": 0,
     "ProxyDestination": "",
     "Connect": {
-      "Proxy": {
-        "ExecMode": "daemon",
-        "Command": [
-          "/bin/consul",
-          "connect",
-          "proxy"
-        ],
-        "Config": null
+      "SidecarService": {
+        "Proxy": {
+          "ExecMode": "daemon",
+          "Command": [
+            "/bin/consul",
+            "connect",
+            "proxy"
+          ],
+          "Config": null
+        }
       }
     }
   },

--- a/website/content/docs/connect/proxies/built-in.mdx
+++ b/website/content/docs/connect/proxies/built-in.mdx
@@ -24,23 +24,25 @@ for the built-in proxy.
   "service": {
     "name": "example-service",
     "connect": {
-      "proxy": {
-        "config": {
-          "bind_address": "0.0.0.0",
-          "bind_port": 20000,
-          "local_service_address": "127.0.0.1:1234",
-          "local_connect_timeout_ms": 1000,
-          "handshake_timeout_ms": 10000,
-          "upstreams": []
-        },
-        "upstreams": [
-          {
-            "destination_name": "example-upstream",
-            "config": {
-              "connect_timeout_ms": 1000
+      "sidecar_service": {
+        "proxy": {
+          "config": {
+            "bind_address": "0.0.0.0",
+            "bind_port": 20000,
+            "local_service_address": "127.0.0.1:1234",
+            "local_connect_timeout_ms": 1000,
+            "handshake_timeout_ms": 10000,
+            "upstreams": []
+          },
+          "upstreams": [
+            {
+              "destination_name": "example-upstream",
+              "config": {
+                "connect_timeout_ms": 1000
+              }
             }
-          }
-        ]
+          ]
+        }
       }
     }
   }


### PR DESCRIPTION
### Description

Fix the sample service registration for the built-in proxy by adding the missing `sidecar_service` block.


### PR Checklist

* [X] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
