### PR TITLE
Change logging of registered v2 resource endpoints to add /api prefix

### DIFF
--- a/.changelog/20352.txt
+++ b/.changelog/20352.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+logging: add /api prefix to v2 resource endpoint logs
+```

--- a/agent/http.go
+++ b/agent/http.go
@@ -260,9 +260,11 @@ func (s *HTTPHandlers) handler() http.Handler {
 	handlePProf("/debug/pprof/symbol", pprof.Symbol)
 	handlePProf("/debug/pprof/trace", pprof.Trace)
 
-	mux.Handle("/api/",
-		http.StripPrefix("/api",
+	resourceAPIPrefix := "/api"
+	mux.Handle(resourceAPIPrefix+"/",
+		http.StripPrefix(resourceAPIPrefix,
 			resourcehttp.NewHandler(
+				resourceAPIPrefix,
 				s.agent.delegate.ResourceServiceClient(),
 				s.agent.baseDeps.Registry,
 				s.parseToken,

--- a/internal/resource/http/http.go
+++ b/internal/resource/http/http.go
@@ -28,7 +28,14 @@ const (
 	HeaderConsistencyMode = "x-consul-consistency-mode"
 )
 
+// NewHandler creates a new HTTP handler for the resource service.
+// httpPathPrefix is the prefix to be used for all HTTP endpoints. Should start with "/" and
+// end without a trailing "/".
+// client is the gRPC client to be used to communicate with the resource service.
+// registry is the resource registry to be used to determine the resource types.
+// parseToken is a function that will be called to parse the Consul token from the request.
 func NewHandler(
+	httpPathPrefix string,
 	client pbresource.ResourceServiceClient,
 	registry resource.Registry,
 	parseToken func(req *http.Request, token *string),
@@ -38,10 +45,10 @@ func NewHandler(
 		// List Endpoint
 		base := strings.ToLower(fmt.Sprintf("/%s/%s/%s", t.Type.Group, t.Type.GroupVersion, t.Type.Kind))
 		mux.Handle(base, http.StripPrefix(base, &listHandler{t, client, parseToken, logger}))
+		logger.Info("Registered resource endpoint", "endpoint", fmt.Sprintf("%s%s", httpPathPrefix, base))
 
 		// Individual Resource Endpoints
 		prefix := strings.ToLower(fmt.Sprintf("%s/", base))
-		logger.Info("Registered resource endpoint", "endpoint", prefix)
 		mux.Handle(prefix, http.StripPrefix(prefix, &resourceHandler{t, client, parseToken, logger}))
 	}
 

--- a/internal/resource/http/http_test.go
+++ b/internal/resource/http/http_test.go
@@ -139,7 +139,7 @@ func TestResourceWriteHandler(t *testing.T) {
 		WithACLResolver(aclResolver).
 		WithRegisterFns(demo.RegisterTypes)
 	client := builder.Run(t)
-	handler := NewHandler(client, builder.Registry(), parseToken, hclog.NewNullLogger())
+	handler := NewHandler("/api", client, builder.Registry(), parseToken, hclog.NewNullLogger())
 
 	t.Run("should be blocked if the token is not authorized", func(t *testing.T) {
 		rsp := httptest.NewRecorder()
@@ -369,7 +369,7 @@ func TestResourceReadHandler(t *testing.T) {
 		WithRegisterFns(demo.RegisterTypes).
 		WithACLResolver(aclResolver)
 	client := builder.Run(t)
-	handler := NewHandler(client, builder.Registry(), parseToken, hclog.NewNullLogger())
+	handler := NewHandler("/api", client, builder.Registry(), parseToken, hclog.NewNullLogger())
 
 	createdResource := createResource(t, handler, nil)
 
@@ -422,7 +422,7 @@ func TestResourceDeleteHandler(t *testing.T) {
 		WithRegisterFns(demo.RegisterTypes).
 		WithACLResolver(aclResolver)
 	client := builder.Run(t)
-	handler := NewHandler(client, builder.Registry(), parseToken, hclog.NewNullLogger())
+	handler := NewHandler("/api", client, builder.Registry(), parseToken, hclog.NewNullLogger())
 
 	t.Run("should surface PermissionDenied error from resource service", func(t *testing.T) {
 		createResource(t, handler, nil)
@@ -498,7 +498,7 @@ func TestResourceListHandler(t *testing.T) {
 		WithRegisterFns(demo.RegisterTypes).
 		WithACLResolver(aclResolver)
 	client := builder.Run(t)
-	handler := NewHandler(client, builder.Registry(), parseToken, hclog.NewNullLogger())
+	handler := NewHandler("/api", client, builder.Registry(), parseToken, hclog.NewNullLogger())
 
 	t.Run("should return MethodNotAllowed", func(t *testing.T) {
 		rsp := httptest.NewRecorder()


### PR DESCRIPTION
Previous:

    agent.http: Registered resource endpoint: endpoint=/demo/v1/executive

New:

    agent.http: Registered resource endpoint: endpoint=/api/demo/v1/executive

This reduces confusion when attempting to call the APIs after looking at the logs.

### PR Checklist

* [x] updated test coverage
* [x] appropriate backport labels added
* [x] not a security concern
