### PR TITLE
NET-5398: Update UI server to include if v2 is enabled

### DIFF
--- a/.changelog/20353.txt
+++ b/.changelog/20353.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: adds V2CatalogEnabled to config that is passed to the ui
+```

--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -31,6 +31,14 @@ func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}
 		uiCfg["metrics_provider_options"] = json.RawMessage(cfg.UIConfig.MetricsProviderOptionsJSON)
 	}
 
+	v2CatalogEnabled := false
+	for _, experiment := range cfg.Experiments {
+		if experiment == "resource-apis" {
+			v2CatalogEnabled = true
+			break
+		}
+	}
+
 	d := map[string]interface{}{
 		"ContentPath":       cfg.UIConfig.ContentPath,
 		"ACLsEnabled":       cfg.ACLsEnabled,
@@ -39,6 +47,7 @@ func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}
 		"LocalDatacenter":   cfg.Datacenter,
 		"PrimaryDatacenter": cfg.PrimaryDatacenter,
 		"PeeringEnabled":    cfg.PeeringEnabled,
+		"V2CatalogEnabled":  v2CatalogEnabled,
 	}
 
 	// Also inject additional provider scripts if needed, otherwise strip the

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -51,7 +51,8 @@ func TestUIServerIndex(t *testing.T) {
 					"metrics_provider": "",
 					"metrics_proxy_enabled": false,
 					"dashboard_url_templates": null
-				}
+				},
+				"V2CatalogEnabled": false
 			}`,
 		},
 		{
@@ -90,7 +91,8 @@ func TestUIServerIndex(t *testing.T) {
 					},
 					"metrics_proxy_enabled": false,
 					"dashboard_url_templates": null
-				}
+				},
+				"V2CatalogEnabled": false
 			}`,
 		},
 		{
@@ -111,7 +113,8 @@ func TestUIServerIndex(t *testing.T) {
 					"metrics_provider": "",
 					"metrics_proxy_enabled": false,
 					"dashboard_url_templates": null
-				}
+				},
+				"V2CatalogEnabled": false
 			}`,
 		},
 		{
@@ -132,7 +135,30 @@ func TestUIServerIndex(t *testing.T) {
 					"metrics_provider": "",
 					"metrics_proxy_enabled": false,
 					"dashboard_url_templates": null
-				}
+				},
+				"V2CatalogEnabled": false
+			}`,
+		},
+		{
+			name:         "v2 catalog enabled",
+			cfg:          basicUIEnabledConfig(withV2CatalogEnabled()),
+			path:         "/",
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"<!-- CONSUL_VERSION:"},
+			wantUICfgJSON: `{
+				"ACLsEnabled": false,
+				"HCPEnabled": false,
+				"LocalDatacenter": "dc1",
+				"PrimaryDatacenter": "dc1",
+				"ContentPath": "/ui/",
+				"PeeringEnabled": true,
+				"UIConfig": {
+					"hcp_enabled": false,
+					"metrics_provider": "",
+					"metrics_proxy_enabled": false,
+					"dashboard_url_templates": null
+				},
+				"V2CatalogEnabled": true 
 			}`,
 		},
 		{
@@ -155,7 +181,8 @@ func TestUIServerIndex(t *testing.T) {
 					"metrics_provider": "",
 					"metrics_proxy_enabled": false,
 					"dashboard_url_templates": null
-				}
+				},
+				"V2CatalogEnabled": false
 			}`,
 		},
 		{
@@ -187,7 +214,8 @@ func TestUIServerIndex(t *testing.T) {
 					"metrics_provider": "bar",
 					"metrics_proxy_enabled": false,
 					"dashboard_url_templates": null
-				}
+				},
+				"V2CatalogEnabled": false
 			}`,
 		},
 		{
@@ -317,6 +345,12 @@ func withMetricsProviderOptions(jsonStr string) cfgFunc {
 func withHCPEnabled() cfgFunc {
 	return func(cfg *config.RuntimeConfig) {
 		cfg.UIConfig.HCPEnabled = true
+	}
+}
+
+func withV2CatalogEnabled() cfgFunc {
+	return func(cfg *config.RuntimeConfig) {
+		cfg.Experiments = append(cfg.Experiments, "resource-apis")
 	}
 }
 
@@ -466,6 +500,7 @@ func TestHandler_ServeHTTP_TransformIsEvaluatedOnEachRequest(t *testing.T) {
 			"metrics_proxy_enabled": false,
 			"dashboard_url_templates": null
 		},
+		"V2CatalogEnabled": false,
 		"apple": "seeds"
 	}`
 		require.JSONEq(t, expected, extractUIConfig(t, rec.Body.String()))
@@ -492,6 +527,7 @@ func TestHandler_ServeHTTP_TransformIsEvaluatedOnEachRequest(t *testing.T) {
 				"metrics_proxy_enabled": false,
 				"dashboard_url_templates": null
 			},
+			"V2CatalogEnabled": false,
 			"apple": "plant"
 		}`
 		require.JSONEq(t, expected, extractUIConfig(t, rec.Body.String()))

--- a/ui/packages/consul-ui/app/utils/get-environment.js
+++ b/ui/packages/consul-ui/app/utils/get-environment.js
@@ -197,6 +197,10 @@ export default function (config = {}, win = window, doc = document) {
             // reserve 1 for traffic that we can't manage
             return 5;
         }
+      case 'CONSUL_V2_CATALOG_ENABLED':
+        return operatorConfig.V2CatalogEnabled === 'undefined'
+          ? false
+          : operatorConfig.V2CatalogEnabled;
     }
   };
   const ui = function (key) {
@@ -243,6 +247,9 @@ export default function (config = {}, win = window, doc = document) {
               break;
             case 'TokenSecretID':
               prev['CONSUL_HTTP_TOKEN'] = value;
+              break;
+            case 'CONSUL_V2_CATALOG_ENABLE':
+              prev['CONSUL_V2_CATALOG_ENALBED'] = JSON.parse(value);
               break;
             default:
               prev[key] = value;
@@ -295,6 +302,7 @@ export default function (config = {}, win = window, doc = document) {
       case 'CONSUL_METRICS_PROXY_ENABLE':
       case 'CONSUL_SERVICE_DASHBOARD_URL':
       case 'CONSUL_BASE_UI_URL':
+      case 'CONSUL_V2_CATALOG_ENABLED':
       case 'CONSUL_HTTP_PROTOCOL':
       case 'CONSUL_HTTP_MAX_CONNECTIONS': {
         // We allow the operator to set these ones via various methods

--- a/ui/packages/consul-ui/app/utils/get-environment.js
+++ b/ui/packages/consul-ui/app/utils/get-environment.js
@@ -249,7 +249,7 @@ export default function (config = {}, win = window, doc = document) {
               prev['CONSUL_HTTP_TOKEN'] = value;
               break;
             case 'CONSUL_V2_CATALOG_ENABLE':
-              prev['CONSUL_V2_CATALOG_ENALBED'] = JSON.parse(value);
+              prev['CONSUL_V2_CATALOG_ENABLED'] = JSON.parse(value);
               break;
             default:
               prev[key] = value;

--- a/ui/packages/consul-ui/config/environment.js
+++ b/ui/packages/consul-ui/config/environment.js
@@ -94,6 +94,7 @@ module.exports = function (environment, $ = process.env) {
       LocalDatacenter: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
       PrimaryDatacenter: env('CONSUL_DATACENTER_PRIMARY', 'dc1'),
       APIPrefix: env('CONSUL_API_PREFIX', ''),
+      V2CatalogEnabled: false,
     },
 
     // Static variables used in multiple places throughout the UI
@@ -122,6 +123,7 @@ module.exports = function (environment, $ = process.env) {
           LocalDatacenter: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
           PrimaryDatacenter: env('CONSUL_DATACENTER_PRIMARY', 'dc1'),
           APIPrefix: env('CONSUL_API_PREFIX', ''),
+          V2CatalogEnabled: env('CONSUL_V2_CATALOG_ENABLED', false),
         },
 
         '@hashicorp/ember-cli-api-double': {
@@ -176,6 +178,7 @@ module.exports = function (environment, $ = process.env) {
           LocalDatacenter: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
           PrimaryDatacenter: env('CONSUL_DATACENTER_PRIMARY', 'dc1'),
           APIPrefix: env('CONSUL_API_PREFIX', ''),
+          V2CatalogEnabled: env('CONSUL_V2_CATALOG_ENABLED', false),
         },
 
         '@hashicorp/ember-cli-api-double': {

--- a/ui/packages/consul-ui/lib/startup/templates/body.html.js
+++ b/ui/packages/consul-ui/lib/startup/templates/body.html.js
@@ -115,7 +115,7 @@ ${
     'CONSUL_HCP_ENABLE': {
       name: 'consul-hcp',
       default: ${config.operatorConfig.HCPEnabled}
-    }
+    },
   }
 );
 </script>

--- a/ui/packages/consul-ui/node-tests/config/environment.js
+++ b/ui/packages/consul-ui/node-tests/config/environment.js
@@ -31,6 +31,7 @@ test('config has the correct environment settings', function (t) {
         LocalDatacenter: 'dc1',
         PrimaryDatacenter: 'dc1',
         APIPrefix: '',
+        V2CatalogEnabled: false,
       },
     },
     {
@@ -49,6 +50,7 @@ test('config has the correct environment settings', function (t) {
         LocalDatacenter: 'dc1',
         PrimaryDatacenter: 'dc1',
         APIPrefix: '',
+        V2CatalogEnabled: false,
       },
     },
     {
@@ -67,6 +69,7 @@ test('config has the correct environment settings', function (t) {
         LocalDatacenter: 'dc1',
         PrimaryDatacenter: 'dc1',
         APIPrefix: '',
+        V2CatalogEnabled: false,
       },
     },
     {
@@ -82,6 +85,7 @@ test('config has the correct environment settings', function (t) {
         LocalDatacenter: 'dc1',
         PrimaryDatacenter: 'dc1',
         APIPrefix: '',
+        V2CatalogEnabled: false,
       },
     },
   ].forEach(function (item) {


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
For [NET-5398](https://hashicorp.atlassian.net/browse/NET-5398) we need to not render the rest of the ui app if v2 catalog is enabled and show a message as to why it's disabled and link out to help resources. Right now this would require another network request on app boot and we would have to wait until that resolves before rendering the rest of the app. 

I saw that experiments is a part of the runtime config so I figured we could add a `V2CatalogEnabled` property to the config that we pass to the UI app. With this, we can immediately check if V2 is enabled and render the help page, or immediately proceed with normal app operations if it's not enabled.

Enabled:
<img width="1489" alt="Screenshot 2024-01-25 at 2 47 00 PM" src="https://github.com/hashicorp/consul/assets/5448834/b7174df0-8568-45e5-a139-4e2288814e78">

Disabled:
<img width="1489" alt="Screenshot 2024-01-25 at 3 56 46 PM" src="https://github.com/hashicorp/consul/assets/5448834/695e74db-e816-47af-936d-6cab879912a4">


### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
I've tested this by building the ui and the consul and then running it with and without the resources-api experiment enabled. Reference the linked issues below for more instructions.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->
[NET-5398](https://hashicorp.atlassian.net/browse/NET-5398)
[Running Consul with v2 enabled](https://hashicorp.atlassian.net/browse/CC-6956)
[Original slack question about how to determine v2 is enabled](https://hashicorp.slack.com/archives/C0253EQ5B40/p1697572777999039)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern


[NET-5398]: https://hashicorp.atlassian.net/browse/NET-5398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NET-5398]: https://hashicorp.atlassian.net/browse/NET-5398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ