### PR TITLE
add support for more envoy versions for LTS

### DIFF
--- a/.github/workflows/nightly-test-integrations-1.15.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.15.x.yml
@@ -73,10 +73,10 @@ jobs:
         env:
           # this is further going to multiplied in envoy-integration tests by the 
           # other dimensions in the matrix.  Currently TOTAL_RUNNERS would be
-          # multiplied by 8 based on these values:
-          # envoy-version: ["1.22.11", "1.23.12", "1.24.12", "1.25.11"]
+          # 14 based on these values:
+          # envoy-version: ["1.22.11", "1.23.12", "1.24.12", "1.25.11", "1.26.6", "1.27.2", "1.28.0"]
           # xds-target: ["server", "client"]
-          TOTAL_RUNNERS: 4 
+          TOTAL_RUNNERS: 7
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
         run: |
           NUM_RUNNERS=$TOTAL_RUNNERS
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        envoy-version: ["1.22.11", "1.23.12", "1.24.12", "1.25.11"]
+        envoy-version: ["1.22.11", "1.23.12", "1.24.12", "1.25.11", "1.26.6", "1.27.2", "1.28.0"]
         xds-target: ["server", "client"]
         test-cases: ${{ fromJSON(needs.generate-envoy-job-matrices.outputs.envoy-matrix) }}
     env:


### PR DESCRIPTION
### Description

LTS releases will support a widening number of envoy versions and we need to run integration tests against them. To be specific, 1.15.x is going to be the next LTS release.

### Testing & Reproduction steps

Ran CI against my branch and reverted it.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
