### PR TITLE
[NET-5075] Implement mesh gateway mode for explicit destinations

### DIFF
--- a/internal/mesh/internal/controllers/sidecarproxy/controller.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/controller.go
@@ -200,7 +200,7 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 		BuildLocalApp(workloadDataWithInheritedPorts, ctp)
 
 	// Get all destinationsData.
-	destinationsData, err := dataFetcher.FetchComputedExplicitDestinationsData(ctx, req.ID)
+	destinationsData, err := dataFetcher.FetchComputedExplicitDestinationsData(ctx, req.ID, proxyCfg.GetData())
 	if err != nil {
 		rt.Logger.Error("error fetching explicit destinations for this proxy", "error", err)
 		return err

--- a/internal/mesh/internal/types/proxy_configuration.go
+++ b/internal/mesh/internal/types/proxy_configuration.go
@@ -100,13 +100,6 @@ func validateDynamicProxyConfiguration(cfg *pbmesh.DynamicConfig) error {
 		})
 	}
 
-	if cfg.GetMeshGatewayMode() != pbmesh.MeshGatewayMode_MESH_GATEWAY_MODE_UNSPECIFIED {
-		err = multierror.Append(err, resource.ErrInvalidField{
-			Name:    "mesh_gateway_mode",
-			Wrapped: resource.ErrUnsupported,
-		})
-	}
-
 	if cfg.GetAccessLogs() != nil {
 		err = multierror.Append(err, resource.ErrInvalidField{
 			Name:    "access_logs",

--- a/internal/mesh/internal/types/proxy_configuration_test.go
+++ b/internal/mesh/internal/types/proxy_configuration_test.go
@@ -130,7 +130,6 @@ func TestValidateProxyConfiguration_AllFieldsInvalid(t *testing.T) {
 		DynamicConfig: &pbmesh.DynamicConfig{
 			// Set unsupported fields.
 			MutualTlsMode:           pbmesh.MutualTLSMode_MUTUAL_TLS_MODE_PERMISSIVE,
-			MeshGatewayMode:         pbmesh.MeshGatewayMode_MESH_GATEWAY_MODE_LOCAL,
 			AccessLogs:              &pbmesh.AccessLogsConfig{},
 			PublicListenerJson:      "listener-json",
 			ListenerTracingJson:     "tracing-json",
@@ -167,7 +166,6 @@ func TestValidateProxyConfiguration_AllFieldsInvalid(t *testing.T) {
 	var dynamicCfgErr error
 	unsupportedFields := []string{
 		"mutual_tls_mode",
-		"mesh_gateway_mode",
 		"access_logs",
 		"public_listener_json",
 		"listener_tracing_json",
@@ -246,7 +244,7 @@ func TestValidateProxyConfiguration_AllFieldsValid(t *testing.T) {
 
 		DynamicConfig: &pbmesh.DynamicConfig{
 			MutualTlsMode:   pbmesh.MutualTLSMode_MUTUAL_TLS_MODE_DEFAULT,
-			MeshGatewayMode: pbmesh.MeshGatewayMode_MESH_GATEWAY_MODE_UNSPECIFIED,
+			MeshGatewayMode: pbmesh.MeshGatewayMode_MESH_GATEWAY_MODE_LOCAL,
 
 			TransparentProxy: &pbmesh.TransparentProxy{
 				DialedDirectly:       false,


### PR DESCRIPTION
### Description
When a destination resides in a different partition from the source and mesh gateway mode is set to local or remote, the mesh gateway's service endpoints should be used for the destination cluster instead of the destination's own endpoints.

The results in outgoing requests targeting the appropriate mesh gateway (either local or remote) but sending along the same SNI + ALPN that was previously used. The mesh gateway will then forward the request to the appropriate place based on the SNI+ALPN combination.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
