### PR TITLE
support capital letters in AclBinding

### DIFF
--- a/acl/validation.go
+++ b/acl/validation.go
@@ -16,8 +16,8 @@ const (
 )
 
 var (
-	validServiceIdentityName = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-_]*[a-z0-9])?$`)
-	validNodeIdentityName    = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-_]*[a-z0-9])?$`)
+	validServiceIdentityName = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9\-_]*[A-Za-z0-9])?$`)
+	validNodeIdentityName    = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9\-_]*[A-Za-z0-9])?$`)
 	validPolicyName          = regexp.MustCompile(`^[A-Za-z0-9\-_]+\/?[A-Za-z0-9\-_]*$`)
 	validRoleName            = regexp.MustCompile(`^[A-Za-z0-9\-_]{1,256}$`)
 	validAuthMethodName      = regexp.MustCompile(`^[A-Za-z0-9\-_]{1,128}$`)

--- a/agent/consul/auth/binder.go
+++ b/agent/consul/auth/binder.go
@@ -213,7 +213,7 @@ func IsValidBindingRule(bindType, bindName string, bindVars *structs.ACLTemplate
 // computeBindName interprets given HIL bindName with any given variables in projectedVars.
 // validate (if not nil) will be called on the interpreted string.
 func computeBindName(bindName string, projectedVars map[string]string, validate func(string) bool) (string, error) {
-	computed, err := template.InterpolateHIL(bindName, projectedVars, true)
+	computed, err := template.InterpolateHIL(bindName, projectedVars, false)
 	if err != nil {
 		return "", fmt.Errorf("error interpreting template: %w", err)
 	}


### PR DESCRIPTION
### Description
Updates AclBindings to support service names that contain capital letters. See https://github.com/hashicorp/consul/issues/20373 for more details.

![image](https://github.com/hashicorp/consul/assets/17842707/ef081924-d897-4d0b-ad7b-0743b33ca640)

closes https://github.com/hashicorp/consul/issues/20373

### Testing & Reproduction steps
Follow [this very well written doc](https://developer.hashicorp.com/nomad/tutorials/integrate-consul/consul-acl#consul-acl) and change the httpd service name in the last step to 'Httpd'

### Links

### PR Checklist

* [X] updated test coverage
* [X] external facing docs updated
* [ ] appropriate backport labels added
* [X] not a security concern
