### PR TITLE
Disable CICD Envoy check

### DIFF
--- a/.github/workflows/verify-envoy-version.yml
+++ b/.github/workflows/verify-envoy-version.yml
@@ -12,7 +12,8 @@ on:
   push:
     branches:
       - main
-      - release/**
+      # Disabled due to 1.15 having a much longer list of Envoy versions it supports with its LTS lifecycle.
+      #- release/**
 
 jobs:
   verify-envoy-version:


### PR DESCRIPTION
The current version of this script does not work well with the LTS release having a much longer list of supported Envoy versions than the other branches. Later on, we should tweak this to have the expected behavior, but for now, it is being disabled so that the CICD pipeline can complete successfully and publish images.