### PR TITLE
NET-6653 Enabling container logs when initConsulServers fails and ret…

### DIFF
--- a/testing/deployer/sprawl/boot.go
+++ b/testing/deployer/sprawl/boot.go
@@ -313,6 +313,9 @@ func (s *Sprawl) initConsulServers() error {
 
 func (s *Sprawl) createFirstTime() error {
 	if err := s.initConsulServers(); err != nil {
+		if err := s.CaptureLogs(context.Background()); err != nil {
+			s.logger.Warn("container logs capture encountered failures", "error", err)
+		}
 		return fmt.Errorf("initConsulServers: %w", err)
 	}
 


### PR DESCRIPTION
…urn an error (container logs during launch() failure)

On branch NET-6653
	modified:   testing/deployer/sprawl/boot.go

### Description


As per discussions with R.B and Hui, we have decided to  capture logs whenever initConsulServers() fails.

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
