### PR TITLE
docs: Fix indention of wal object in agent config

### DIFF
--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -1700,7 +1700,7 @@ subsystem that provides Consul's service mesh capabilities.
     because Consul must scan the database to find free space
     within the file.
 
-  - - `wal` ((#raft_logstore_wal)) - Object that configures the `wal` backend.
+  - `wal` ((#raft_logstore_wal)) - Object that configures the `wal` backend.
     Refer to [Experimental WAL LogStore backend](/consul/docs/agent/wal-logstore)
     for more information.
 


### PR DESCRIPTION
### Description

In agent config doc, wal and boldb should be in the same level. Remove the extra `-`

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
