### PR TITLE
Resolve Consul DNS in OpenShift

### DIFF
--- a/.changelog/20439.txt
+++ b/.changelog/20439.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docs: Consul DNS Forwarding configuration for OpenShift update for [Resolve Consul DNS Requests in Kubernetes](https://developer.hashicorp.com/consul/docs/k8s/dns)
+```

--- a/website/content/docs/k8s/dns.mdx
+++ b/website/content/docs/k8s/dns.mdx
@@ -136,6 +136,10 @@ in full cluster rebuilds.
 
 ## OpenShift DNS Operator
 
+<Note>
+OpenShift CLI `oc` is utilized below complete the following steps. You can find more details on how to install OpenShift CLI from [Getting started with OpenShift CLI](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html).
+</Note>
+
 You can use DNS forwarding to override the default forwarding configuration in the `/etc/resolv.conf` file by specifying
 the `consul-dns` service for the `consul` subdomain (zone).
 

--- a/website/content/docs/k8s/dns.mdx
+++ b/website/content/docs/k8s/dns.mdx
@@ -134,6 +134,68 @@ in full cluster rebuilds.
 
 -> **Note:** If using a different zone than `.consul`, change the key accordingly.
 
+## OpenShift DNS Operator
+
+You can use DNS forwarding to override the default forwarding configuration in the `/etc/resolv.conf` file by specifying
+the `consul-dns` service for the `consul` subdomain (zone).
+
+Find `consul-dns` service clusterIP:
+
+```shell-session
+$ oc get svc consul-dns --namespace consul --output jsonpath='{.spec.clusterIP}'
+172.30.186.254
+```
+
+Edit the `default` DNS Operator:
+
+```shell-session
+$ oc edit edit dns.operator/default
+```
+
+Append the following `servers` section entry to the `spec` section of the DNS Operator configuration:
+
+```yaml
+spec:
+  servers:
+  - name: consul-server
+    zones:
+    - consul
+    forwardPlugin:
+      policy: Random
+      upstreams:
+      - 172.30.186.254 # Set to clusterIP of consul-dns service
+```
+
+Save the configuration changes and verify the `dns-default` configmap has been updated:
+
+```shell-session
+$ oc get configmap/dns-default -n openshift-dns -o yaml
+```
+
+Example output with updated `consul` forwarding zone:
+
+```yaml
+...
+data:
+  Corefile: |
+    # consul-server
+    consul:5353 {
+        prometheus 127.0.0.1:9153
+        forward . 172.30.186.254 {
+            policy random
+        }
+        errors
+        log . {
+            class error
+        }
+        bufsize 1232
+        cache 900 {
+            denial 9984 30
+        }
+    }
+...
+```
+
 ## Verifying DNS Works
 
 To verify DNS works, run a simple job to query DNS. Save the following

--- a/website/content/docs/k8s/dns.mdx
+++ b/website/content/docs/k8s/dns.mdx
@@ -136,9 +136,7 @@ in full cluster rebuilds.
 
 ## OpenShift DNS Operator
 
-<Note>
-OpenShift CLI `oc` is utilized below complete the following steps. You can find more details on how to install OpenShift CLI from [Getting started with OpenShift CLI](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html).
-</Note>
+-> **Note:** OpenShift CLI `oc` is utilized below complete the following steps. You can find more details on how to install OpenShift CLI from [Getting started with OpenShift CLI](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html).
 
 You can use DNS forwarding to override the default forwarding configuration in the `/etc/resolv.conf` file by specifying
 the `consul-dns` service for the `consul` subdomain (zone).


### PR DESCRIPTION
This updates our Consul DNS forwarding documentation to include methods for updating the DNS Operator on OpenShift clusters to include Consul's DNS service.

### Description

Our documentation titled **Resolve Consul DNS Requests in Kubernetes** has long been missing steps to update Kubernetes on OpenShift's DNS Operator to include the Consul DNS Forwarder. This PR aims to close that gap.

### Testing & Reproduction steps

* Deploy Consul on OpenShift, and ensure the following overrides are set to enable `consul-dns` service:

```yaml
dns:
  enabled: true
  enabledRedirection: true
  type: ClusterIP
```

* Find `consul-dns` service clusterIP: `oc get svc consul-dns --namespace consul --output jsonpath='{.spec.clusterIP}'`
* Edit the DNS Operator Configuration (as outlined in the OpenShift [Documentation](https://docs.openshift.com/container-platform/4.14/networking/dns-operator.html#nw-dns-forward_dns-operator)): 
  * Edit DNS Operator: `oc edit edit dns.operator/default`
* Add `consul-dns` clusterIP as upstream server for the `consul` zone and save configuration changes: 

```yaml
spec:
  servers:
  - name: consul-server
    zones:
    - consul
    forwardPlugin:
      policy: Random
      upstreams:
      - 172.30.186.254 # Set to clusterIP of consul-dns service
```

* Verify DNS Operator applied the changes: `oc get configmap/dns-default -n openshift-dns -o yaml`

```yaml
...
data:
  Corefile: |
    # consul-server
    consul:5353 {
        prometheus 127.0.0.1:9153
        forward . 172.30.186.254 {
            policy random
        }
        errors
        log . {
            class error
        }
        bufsize 1232
        cache 900 {
            denial 9984 30
        }
    }
...
```

* From terminal of pod deployed to the Consul service mesh, verify DNS name resolution with Consul domain:

```shell-session
$ nslookup consul.service.consul
Server:         172.30.0.10
Address:        172.30.0.10:53


Name:   consul.service.consul
Address: 10.129.2.21
Name:   consul.service.consul
Address: 10.130.2.18
Name:   consul.service.consul
Address: 10.128.2.19

$ nslookup backend.virtual.consul.ns.consul
Server:         172.30.0.10
Address:         172.30.0.10:53

Name:   backend.virtual.consul.ns.consul
Address: 240.0.0.5

Name:   backend.virtual.consul.ns.consul
Address: 240.0.0.5
```


### Links

[OpenShift DNS Operator: Using DNS Forwarding](https://docs.openshift.com/container-platform/4.14/networking/dns-operator.html#nw-dns-forward_dns-operator)

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
