### PR TITLE
missing prefix /

### DIFF
--- a/agent/grpc-external/server.go
+++ b/agent/grpc-external/server.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/consul/tlsutil"
 )
 
-const FORWARD_SERVICE_NAME_PREFIX = "hashicorp.consul."
+const FORWARD_SERVICE_NAME_PREFIX = "/hashicorp.consul."
 
 var (
 	metricsLabels = []metrics.Label{{

--- a/command/resource/client/client.go
+++ b/command/resource/client/client.go
@@ -160,7 +160,7 @@ func dial(c *GRPCConfig) (*grpc.ClientConn, error) {
 func checkCertificates(c *GRPCConfig) error {
 	if c.GRPCTLS {
 		certFileEmpty := c.CertFile == ""
-		keyFileEmpty := c.CertFile == ""
+		keyFileEmpty := c.KeyFile == ""
 
 		// both files need to be empty or both files need to be provided
 		if certFileEmpty != keyFileEmpty {

--- a/command/resource/client/grpc-flags.go
+++ b/command/resource/client/grpc-flags.go
@@ -52,7 +52,7 @@ func (f *GRPCFlags) ClientFlags() *flag.FlagSet {
 			"127.0.0.1:8502. If you intend to communicate in TLS mode, you have to either "+
 			"include https:// schema in the address, use grpc-tls flag or set environment variable "+
 			"CONSUL_GRPC_TLS = true, otherwise it uses plaintext mode")
-	fs.Var(&f.caFile, "grpc-tls",
+	fs.Var(&f.grpcTLS, "grpc-tls",
 		"Set to true if you aim to communicate in TLS mode in the GRPC call.")
 	fs.Var(&f.certFile, "client-cert",
 		"Path to a client cert file to use for TLS when 'verify_incoming' is enabled. This "+

--- a/test/integration/consul-container/libs/cluster/agent.go
+++ b/test/integration/consul-container/libs/cluster/agent.go
@@ -29,6 +29,7 @@ type Agent interface {
 	GetAgentName() string
 	GetPartition() string
 	GetPod() testcontainers.Container
+	GetConsulContainer() testcontainers.Container
 	Logs(context.Context) (io.ReadCloser, error)
 	ClaimAdminPort() (int, error)
 	GetConfig() Config

--- a/test/integration/consul-container/libs/cluster/container.go
+++ b/test/integration/consul-container/libs/cluster/container.go
@@ -77,6 +77,10 @@ func (c *consulContainerNode) GetPod() testcontainers.Container {
 	return c.pod
 }
 
+func (c *consulContainerNode) GetConsulContainer() testcontainers.Container {
+	return c.container
+}
+
 func (c *consulContainerNode) Logs(context context.Context) (io.ReadCloser, error) {
 	return c.container.Logs(context)
 }

--- a/test/integration/consul-container/test/resource/grpc_forwarding_test.go
+++ b/test/integration/consul-container/test/resource/grpc_forwarding_test.go
@@ -126,15 +126,8 @@ func setupClusterAndClient(t *testing.T, aclEnabled bool) (*libcluster.Cluster, 
 		ApplyDefaultProxySettings: false,
 	}
 	cluster, _, _ := libtopology.NewCluster(t, clusterConfig)
-	var clientAgent libcluster.Agent
-	for _, a := range cluster.Agents {
-		if !a.IsServer() {
-			clientAgent = a
-			break
-		}
-	}
 
-	return cluster, clientAgent
+	return cluster, cluster.Clients()[0]
 }
 
 func terminate(t *testing.T, cluster *libcluster.Cluster) {

--- a/test/integration/consul-container/test/resource/grpc_forwarding_test.go
+++ b/test/integration/consul-container/test/resource/grpc_forwarding_test.go
@@ -22,11 +22,10 @@ const (
 
 func TestClientForwardToServer(t *testing.T) {
 	type operation struct {
-		action         func(*testing.T, libcluster.Agent, string) (int, string)
-		includeToken   bool
-		expectedCode   int
-		expectedMsg    string
-		expectedErrMsg string
+		action       func(*testing.T, libcluster.Agent, string) (int, string)
+		includeToken bool
+		expectedCode int
+		expectedMsg  string
 	}
 	type testCase struct {
 		description string
@@ -36,34 +35,31 @@ func TestClientForwardToServer(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			description: "The read request should be routed to consul server agent",
+			description: "The apply request should be forwarded to consul server agent",
 			operations: []operation{
 				{
-					action:         applyResource,
-					includeToken:   false,
-					expectedCode:   0,
-					expectedMsg:    "demo.v2.Artist 'korn' created.",
-					expectedErrMsg: "",
+					action:       applyResource,
+					includeToken: false,
+					expectedCode: 0,
+					expectedMsg:  "demo.v2.Artist 'korn' created.",
 				},
 			},
 			aclEnabled: false,
 		},
 		{
-			description: "The read request should be denied if missing token when ACL is enabled",
+			description: "The apply request should be denied if missing token when ACL is enabled",
 			operations: []operation{
 				{
-					action:         applyResource,
-					includeToken:   false,
-					expectedCode:   1,
-					expectedMsg:    "",
-					expectedErrMsg: "failed getting authorizer: ACL not found",
+					action:       applyResource,
+					includeToken: false,
+					expectedCode: 1,
+					expectedMsg:  "failed getting authorizer: ACL not found",
 				},
 				{
-					action:         applyResource,
-					includeToken:   true,
-					expectedCode:   0,
-					expectedMsg:    "demo.v2.Artist 'korn' created.",
-					expectedErrMsg: "",
+					action:       applyResource,
+					includeToken: true,
+					expectedCode: 0,
+					expectedMsg:  "demo.v2.Artist 'korn' created.",
 				},
 			},
 			aclEnabled: true,
@@ -87,11 +83,7 @@ func TestClientForwardToServer(t *testing.T) {
 				}
 				code, res := op.action(t, clientAgent, token)
 				require.Equal(t, op.expectedCode, code)
-				if code == 0 {
-					require.Contains(t, res, op.expectedMsg)
-				} else {
-					require.Contains(t, res, op.expectedErrMsg)
-				}
+				require.Contains(t, res, op.expectedMsg)
 			}
 		})
 	}

--- a/test/integration/consul-container/test/resource/grpc_forwarding_test.go
+++ b/test/integration/consul-container/test/resource/grpc_forwarding_test.go
@@ -55,6 +55,12 @@ func TestClientForwardToServer(t *testing.T) {
 					expectedCode: 1,
 					expectedMsg:  "failed getting authorizer: ACL not found",
 				},
+			},
+			aclEnabled: true,
+		},
+		{
+			description: "The apply request should be allowed if providing token when ACL is enabled",
+			operations: []operation{
 				{
 					action:       applyResource,
 					includeToken: true,

--- a/test/integration/consul-container/test/resource/resource_test.go
+++ b/test/integration/consul-container/test/resource/resource_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	libcluster "github.com/hashicorp/consul/test/integration/consul-container/libs/cluster"
+	libtopology "github.com/hashicorp/consul/test/integration/consul-container/libs/topology"
+)
+
+const (
+	RESOURCE_FILE_PATH_ON_HOST      = "../../../../../command/resource/testdata/demo.hcl"
+	RESOURCE_FILE_PATH_ON_CONTAINER = "/consul/data/demo.hcl"
+)
+
+func TestClientForwardToServer(t *testing.T) {
+	type operation struct {
+		action         func(*testing.T, libcluster.Agent, string) (int, string)
+		includeToken   bool
+		expectedCode   int
+		expectedMsg    string
+		expectedErrMsg string
+	}
+	type testCase struct {
+		description string
+		operations  []operation
+		aclEnabled  bool
+	}
+
+	testCases := []testCase{
+		{
+			description: "The read request should be routed to consul server agent",
+			operations: []operation{
+				{
+					action:         applyResource,
+					includeToken:   false,
+					expectedCode:   0,
+					expectedMsg:    "demo.v2.Artist 'korn' created.",
+					expectedErrMsg: "",
+				},
+			},
+			aclEnabled: false,
+		},
+		{
+			description: "The read request should be denied if missing token when ACL is enabled",
+			operations: []operation{
+				{
+					action:         applyResource,
+					includeToken:   false,
+					expectedCode:   1,
+					expectedMsg:    "",
+					expectedErrMsg: "failed getting authorizer: ACL not found",
+				},
+				{
+					action:         applyResource,
+					includeToken:   true,
+					expectedCode:   0,
+					expectedMsg:    "demo.v2.Artist 'korn' created.",
+					expectedErrMsg: "",
+				},
+			},
+			aclEnabled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			var clientAgent libcluster.Agent
+			cluster, clientAgent := setupClusterAndClient(t, tc.aclEnabled)
+			defer terminate(t, cluster)
+
+			// perform actions and validate returned messages
+			for _, op := range tc.operations {
+				token := ""
+				if op.includeToken {
+					token = cluster.TokenBootstrap
+				}
+				code, res := op.action(t, clientAgent, token)
+				require.Equal(t, op.expectedCode, code)
+				if code == 0 {
+					require.Contains(t, res, op.expectedMsg)
+				} else {
+					require.Contains(t, res, op.expectedErrMsg)
+				}
+			}
+		})
+	}
+}
+
+func applyResource(t *testing.T, clientAgent libcluster.Agent, token string) (int, string) {
+	ctx := context.Background()
+	c := clientAgent.GetConsulContainer()
+	err := c.CopyFileToContainer(ctx, RESOURCE_FILE_PATH_ON_HOST, RESOURCE_FILE_PATH_ON_CONTAINER, 700)
+	require.NoError(t, err)
+	args := []string{"/bin/consul", "resource", "apply", fmt.Sprintf("-f=%s", RESOURCE_FILE_PATH_ON_CONTAINER)}
+	if token != "" {
+		args = append(args, fmt.Sprintf("-token=%s", token))
+	}
+	code, reader, err := c.Exec(ctx, args)
+	require.NoError(t, err)
+	buf, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	return code, string(buf)
+}
+
+// passing two cmd args to set up the cluster
+func setupClusterAndClient(t *testing.T, aclEnabled bool) (*libcluster.Cluster, libcluster.Agent) {
+	clusterConfig := &libtopology.ClusterConfig{
+		NumServers:  1,
+		NumClients:  1,
+		LogConsumer: &libtopology.TestLogConsumer{},
+		BuildOpts: &libcluster.BuildOptions{
+			Datacenter:             "dc1",
+			InjectAutoEncryption:   true,
+			InjectGossipEncryption: true,
+			ACLEnabled:             aclEnabled,
+		},
+		ApplyDefaultProxySettings: false,
+	}
+	cluster, _, _ := libtopology.NewCluster(t, clusterConfig)
+	var clientAgent libcluster.Agent
+	for _, a := range cluster.Agents {
+		if !a.IsServer() {
+			clientAgent = a
+			break
+		}
+	}
+
+	return cluster, clientAgent
+}
+
+func terminate(t *testing.T, cluster *libcluster.Cluster) {
+	err := cluster.Terminate()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### Description

This PR fix the allow forward policy. We should only allow the client agent to forward services that starts with `/hashicorp.consul.` but we missed the prefix `/` in the code base.

We also fix some typos in the code base.

The integration tests ensure that the forwarding policy actually works.

### PR Checklist

* [x] updated test coverage
* [ ] ~external facing docs updated~
* [x] appropriate backport labels added
* [x] not a security concern
