### PR TITLE
Update cache section for certain API calls

### DIFF
--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -402,7 +402,7 @@ Refer to the [formatting specification](https://golang.org/pkg/time/#ParseDurati
 
   </CodeTabs>
 
-- `cache` configuration for client agents. The configurable values are the following:
+- `cache` configuration for client agents. If '?cached' is not appended in an API call using [streaming backend](https://developer.hashicorp.com/consul/api-docs/features/blocking#streaming-backend) and index is specified, this configuration will be bypassed. The configurable values are the following:
 
   - `entry_fetch_max_burst` The size of the token bucket used to recharge the rate-limit per
     cache entry. The default value is 2 and means that when cache has not been updated

--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -402,7 +402,7 @@ Refer to the [formatting specification](https://golang.org/pkg/time/#ParseDurati
 
   </CodeTabs>
 
-- `cache` configuration for client agents. If '?cached' is not appended in an API call using [streaming backend](https://developer.hashicorp.com/consul/api-docs/features/blocking#streaming-backend) and index is specified, this configuration will be bypassed. The configurable values are the following:
+- `cache` configuration for client agents. When an `?index` query parameter is specified but '?cached' is not appended in a [streaming backend call](/consul/api-docs/features/blocking#streaming-backend), Consul bypasses these configuration values. The configurable values are the following:
 
   - `entry_fetch_max_burst` The size of the token bucket used to recharge the rate-limit per
     cache entry. The default value is 2 and means that when cache has not been updated


### PR DESCRIPTION
Providing more detail to the [cache section](https://developer.hashicorp.com/consul/docs/agent/config/config-files#cache) to address behavior of API calls using streaming backend. This will help users understand that when '?index' is used and '?cached' is not, caching to servers will be [bypassed](https://github.com/hashicorp/consul/blob/543c6a30af784a39fea5f7893b785ff1ba6d4d2e/agent/cache/cache.go#L406), causing [entry_fetch_max_burst](https://developer.hashicorp.com/consul/docs/agent/config/config-files#entry_fetch_max_burst) and [entry_fetch_rate](https://developer.hashicorp.com/consul/docs/agent/config/config-files#entry_fetch_rate) to not be used in this scenario.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
