### PR TITLE
DNS V2 - Revise discovery result to have service and node name and address fields.

### DIFF
--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -79,11 +79,11 @@ type QueryTenancy struct {
 // QueryPayload represents all information needed by the data backend
 // to decide which records to include.
 type QueryPayload struct {
-	Name       string
-	PortName   string       // v1 - this could optionally be "connect" or "ingress"; v2 - this is the service port name
-	Tag        string       // deprecated: use for V1 only
-	RemoteAddr net.Addr     // deprecated: used for prepared queries
-	Tenancy    QueryTenancy // tenancy includes any additional labels specified before the domain
+	Name     string
+	PortName string       // v1 - this could optionally be "connect" or "ingress"; v2 - this is the service port name
+	Tag      string       // deprecated: use for V1 only
+	SourceIP net.IP       // deprecated: used for prepared queries
+	Tenancy  QueryTenancy // tenancy includes any additional labels specified before the domain
 
 	// v2 fields only
 	EnableFailover bool

--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -104,17 +104,21 @@ const (
 // It is the responsibility of the DNS encoder to know what to do with
 // each Result, based on the query type.
 type Result struct {
-	Address    string            // A/AAAA/CNAME records - could be used in the Extra section. CNAME is required to handle hostname addresses in workloads & nodes.
+	Service    *Location         // The name and address of the service.
+	Node       *Location         // The name and address of the node.
 	Weight     uint32            // SRV queries
 	PortName   string            // Used to generate a fgdn when a specifc port was queried
 	PortNumber uint32            // SRV queries
 	Metadata   map[string]string // Used to collect metadata into TXT Records
 	Type       ResultType        // Used to reconstruct the fqdn name of the resource
 
-	// Used in SRV & PTR queries to point at an A/AAAA Record.
-	Target string
-
 	Tenancy ResultTenancy
+}
+
+// Location is used to represent a service, node, or workload.
+type Location struct {
+	Name    string
+	Address string
 }
 
 // ResultTenancy is used to reconstruct the fqdn name of the resource.

--- a/agent/discovery/discovery_test.go
+++ b/agent/discovery/discovery_test.go
@@ -26,9 +26,9 @@ var (
 	}
 
 	testResult = &Result{
-		Address: "1.2.3.4",
+		Node:    &Location{Address: "1.2.3.4"},
 		Type:    ResultTypeNode, // This isn't correct for some test cases, but we are only asserting the right data fetcher functions are called
-		Target:  "foo",
+		Service: &Location{Name: "foo"},
 	}
 )
 

--- a/agent/discovery/query_fetcher_v1_test.go
+++ b/agent/discovery/query_fetcher_v1_test.go
@@ -51,8 +51,11 @@ func Test_FetchVirtualIP(t *testing.T) {
 				Token: "test-token",
 			},
 			expectedResult: &Result{
-				Address: "192.168.10.10",
-				Type:    ResultTypeVirtual,
+				Service: &Location{
+					Name:    "db",
+					Address: "192.168.10.10",
+				},
+				Type: ResultTypeVirtual,
 			},
 			expectedErr: nil,
 		},
@@ -97,7 +100,7 @@ func Test_FetchVirtualIP(t *testing.T) {
 					if tc.expectedErr == nil {
 						// set the out parameter to ensure that it is used to formulate the result.Address
 						reply := args.Get(3).(*string)
-						*reply = tc.expectedResult.Address
+						*reply = tc.expectedResult.Service.Address
 					}
 				})
 			// TODO (v2-dns): mock these properly
@@ -131,210 +134,62 @@ func Test_FetchEndpoints(t *testing.T) {
 		DNSUseCache:    true,
 		DNSCacheMaxAge: 100,
 	}
-	tests := []struct {
-		name                   string
-		queryPayload           *QueryPayload
-		context                Context
-		rpcFuncForServiceNodes func(ctx context.Context, req structs.ServiceSpecificRequest) (structs.IndexedCheckServiceNodes, cache.ResultMeta, error)
-		expectedResults        []*Result
-		expectedErr            error
-	}{
+	ctx := Context{
+		Token: "test-token",
+	}
+	expectedResults := []*Result{
 		{
-			name: "when service address is IPv4, result type is service, address is service address and target is service name",
-			queryPayload: &QueryPayload{
-				Name: "service-name",
-				Tenancy: QueryTenancy{
-					Namespace: defaultTestNamespace,
-					Partition: defaultTestPartition,
-				},
+			Node: &Location{
+				Name:    "node-name",
+				Address: "node-address",
 			},
-			rpcFuncForServiceNodes: func(ctx context.Context, req structs.ServiceSpecificRequest) (structs.IndexedCheckServiceNodes, cache.ResultMeta, error) {
-				return structs.IndexedCheckServiceNodes{
-					Nodes: []structs.CheckServiceNode{
-						{
-							Node: &structs.Node{
-								Address:   "node-address",
-								Node:      "node-name",
-								Partition: defaultTestPartition,
-							},
-							Service: &structs.NodeService{
-								Address:        "127.0.0.1",
-								Service:        "service-name",
-								EnterpriseMeta: acl.NewEnterpriseMetaWithPartition(defaultTestPartition, defaultTestNamespace),
-							},
-						},
-					},
-				}, cache.ResultMeta{}, nil
+			Service: &Location{
+				Name:    "service-name",
+				Address: "service-address",
 			},
-			context: Context{
-				Token: "test-token",
-			},
-			expectedResults: []*Result{
-				{
-					Address: "127.0.0.1",
-					Target:  "service-name",
-					Type:    ResultTypeService,
-					Weight:  1,
-					Tenancy: ResultTenancy{
-						Namespace: defaultTestNamespace,
-						Partition: defaultTestPartition,
-					},
-				},
-			},
-			expectedErr: nil,
-		},
-		{
-			name: "when service address is IPv6, result type is service, address is service address and target is service name",
-			queryPayload: &QueryPayload{
-				Name: "service-name",
-				Tenancy: QueryTenancy{
-					Namespace: defaultTestNamespace,
-					Partition: defaultTestPartition,
-				},
-			},
-			rpcFuncForServiceNodes: func(ctx context.Context, req structs.ServiceSpecificRequest) (structs.IndexedCheckServiceNodes, cache.ResultMeta, error) {
-				return structs.IndexedCheckServiceNodes{
-					Nodes: []structs.CheckServiceNode{
-						{
-							Node: &structs.Node{
-								Address:   "node-address",
-								Node:      "node-name",
-								Partition: defaultTestPartition,
-							},
-							Service: &structs.NodeService{
-								Address:        "2001:db8:1:2:cafe::1337",
-								Service:        "service-name",
-								EnterpriseMeta: acl.NewEnterpriseMetaWithPartition(defaultTestPartition, defaultTestNamespace),
-							},
-						},
-					},
-				}, cache.ResultMeta{}, nil
-			},
-			context: Context{
-				Token: "test-token",
-			},
-			expectedResults: []*Result{
-				{
-					Address: "2001:db8:1:2:cafe::1337",
-					Target:  "service-name",
-					Type:    ResultTypeService,
-					Weight:  1,
-					Tenancy: ResultTenancy{
-						Namespace: defaultTestNamespace,
-						Partition: defaultTestPartition,
-					},
-				},
-			},
-			expectedErr: nil,
-		},
-		{
-			name: "when service address is not IP but is not empty, result type is node, address is node address, and target is service address",
-			queryPayload: &QueryPayload{
-				Name: "service-name",
-				Tenancy: QueryTenancy{
-					Namespace: defaultTestNamespace,
-					Partition: defaultTestPartition,
-				},
-			},
-			rpcFuncForServiceNodes: func(ctx context.Context, req structs.ServiceSpecificRequest) (structs.IndexedCheckServiceNodes, cache.ResultMeta, error) {
-				return structs.IndexedCheckServiceNodes{
-					Nodes: []structs.CheckServiceNode{
-						{
-							Node: &structs.Node{
-								Address:   "node-address",
-								Node:      "node-name",
-								Partition: defaultTestPartition,
-							},
-							Service: &structs.NodeService{
-								Address:        "foo",
-								Service:        "service-name",
-								EnterpriseMeta: acl.NewEnterpriseMetaWithPartition(defaultTestPartition, defaultTestNamespace),
-							},
-						},
-					},
-				}, cache.ResultMeta{}, nil
-			},
-			context: Context{
-				Token: "test-token",
-			},
-			expectedResults: []*Result{
-				{
-					Address: "node-address",
-					Target:  "foo",
-					Type:    ResultTypeNode,
-					Weight:  1,
-					Tenancy: ResultTenancy{
-						Namespace: defaultTestNamespace,
-						Partition: defaultTestPartition,
-					},
-				},
-			},
-			expectedErr: nil,
-		},
-		{
-			name: "when service address is empty, result type is node, address is node address, and target is node name",
-			queryPayload: &QueryPayload{
-				Name: "service-name",
-				Tenancy: QueryTenancy{
-					Namespace: defaultTestNamespace,
-					Partition: defaultTestPartition,
-				},
-			},
-			rpcFuncForServiceNodes: func(ctx context.Context, req structs.ServiceSpecificRequest) (structs.IndexedCheckServiceNodes, cache.ResultMeta, error) {
-				return structs.IndexedCheckServiceNodes{
-					Nodes: []structs.CheckServiceNode{
-						{
-							Node: &structs.Node{
-								Address:   "node-address",
-								Node:      "node-name",
-								Partition: defaultTestPartition,
-							},
-							Service: &structs.NodeService{
-								Address:        "",
-								Service:        "service-name",
-								EnterpriseMeta: acl.NewEnterpriseMetaWithPartition(defaultTestPartition, defaultTestNamespace),
-							},
-						},
-					},
-				}, cache.ResultMeta{}, nil
-			},
-			context: Context{
-				Token: "test-token",
-			},
-			expectedResults: []*Result{
-				{
-					Address: "node-address",
-					Target:  "node-name",
-					Type:    ResultTypeNode,
-					Weight:  1,
-					Tenancy: ResultTenancy{
-						Namespace: defaultTestNamespace,
-						Partition: defaultTestPartition,
-					},
-				},
-			},
-			expectedErr: nil,
+			Type:   ResultTypeService,
+			Weight: 1,
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			logger := testutil.Logger(t)
-			mockRPC := cachetype.NewMockRPC(t)
-			// TODO (v2-dns): mock these properly
-			translateServicePortFunc := func(dc string, port int, taggedAddresses map[string]structs.ServiceAddress) int { return 0 }
-			rpcFuncForSamenessGroup := func(ctx context.Context, req *structs.ConfigEntryQuery) (structs.SamenessGroupConfigEntry, cache.ResultMeta, error) {
-				return structs.SamenessGroupConfigEntry{}, cache.ResultMeta{}, nil
-			}
-			getFromCacheFunc := func(ctx context.Context, t string, r cache.Request) (interface{}, cache.ResultMeta, error) {
-				return nil, cache.ResultMeta{}, nil
-			}
-
-			df := NewV1DataFetcher(rc, acl.DefaultEnterpriseMeta(), getFromCacheFunc, mockRPC.RPC, tc.rpcFuncForServiceNodes, rpcFuncForSamenessGroup, translateServicePortFunc, logger)
-
-			results, err := df.FetchEndpoints(tc.context, tc.queryPayload, LookupTypeService)
-			require.Equal(t, tc.expectedErr, err)
-			require.Equal(t, tc.expectedResults, results)
-		})
+	logger := testutil.Logger(t)
+	mockRPC := cachetype.NewMockRPC(t)
+	// TODO (v2-dns): mock these properly
+	translateServicePortFunc := func(dc string, port int, taggedAddresses map[string]structs.ServiceAddress) int { return 0 }
+	rpcFuncForSamenessGroup := func(ctx context.Context, req *structs.ConfigEntryQuery) (structs.SamenessGroupConfigEntry, cache.ResultMeta, error) {
+		return structs.SamenessGroupConfigEntry{}, cache.ResultMeta{}, nil
 	}
+	getFromCacheFunc := func(ctx context.Context, t string, r cache.Request) (interface{}, cache.ResultMeta, error) {
+		return nil, cache.ResultMeta{}, nil
+	}
+	rpcFuncForServiceNodes := func(ctx context.Context, req structs.ServiceSpecificRequest) (structs.IndexedCheckServiceNodes, cache.ResultMeta, error) {
+		return structs.IndexedCheckServiceNodes{
+			Nodes: []structs.CheckServiceNode{
+				{
+					Node: &structs.Node{
+						Address: "node-address",
+						Node:    "node-name",
+					},
+					Service: &structs.NodeService{
+						Address: "service-address",
+						Service: "service-name",
+					},
+				},
+			},
+		}, cache.ResultMeta{}, nil
+	}
+	queryPayload := &QueryPayload{
+		Name: "service-name",
+		Tenancy: QueryTenancy{
+			Peer:      "test-peer",
+			Namespace: defaultTestNamespace,
+			Partition: defaultTestPartition,
+		},
+	}
+
+	df := NewV1DataFetcher(rc, acl.DefaultEnterpriseMeta(), getFromCacheFunc, mockRPC.RPC, rpcFuncForServiceNodes, rpcFuncForSamenessGroup, translateServicePortFunc, logger)
+
+	results, err := df.FetchEndpoints(ctx, queryPayload, LookupTypeService)
+	require.NoError(t, err)
+	require.Equal(t, expectedResults, results)
 }

--- a/agent/discovery/query_fetcher_v2.go
+++ b/agent/discovery/query_fetcher_v2.go
@@ -124,13 +124,15 @@ func (f *V2DataFetcher) FetchWorkload(reqContext Context, req *QueryPayload) (*R
 
 	tenancy := response.GetResource().GetId().GetTenancy()
 	result := &Result{
-		Address: address,
-		Type:    ResultTypeWorkload,
+		Node: &Location{
+			Address: address,
+			Name:    response.GetResource().GetId().GetName(),
+		},
+		Type: ResultTypeWorkload,
 		Tenancy: ResultTenancy{
 			Namespace: tenancy.GetNamespace(),
 			Partition: tenancy.GetPartition(),
 		},
-		Target: response.GetResource().GetId().GetName(),
 	}
 
 	if req.PortName == "" {

--- a/agent/discovery/query_fetcher_v2.go
+++ b/agent/discovery/query_fetcher_v2.go
@@ -171,7 +171,7 @@ func (f *V2DataFetcher) ValidateRequest(_ Context, req *QueryPayload) error {
 	if req.Tag != "" {
 		return ErrNotSupported
 	}
-	if req.RemoteAddr != nil {
+	if req.SourceIP != nil {
 		return ErrNotSupported
 	}
 	return nil

--- a/agent/discovery/query_fetcher_v2_test.go
+++ b/agent/discovery/query_fetcher_v2_test.go
@@ -58,13 +58,12 @@ func Test_FetchWorkload(t *testing.T) {
 					})
 			},
 			expectedResult: &Result{
-				Address: "1.2.3.4",
-				Type:    ResultTypeWorkload,
+				Node: &Location{Name: "foo-1234", Address: "1.2.3.4"},
+				Type: ResultTypeWorkload,
 				Tenancy: ResultTenancy{
 					Namespace: resource.DefaultNamespaceName,
 					Partition: resource.DefaultPartitionName,
 				},
-				Target: "foo-1234",
 			},
 			expectedErr: nil,
 		},
@@ -130,7 +129,7 @@ func Test_FetchWorkload(t *testing.T) {
 					})
 			},
 			expectedResult: &Result{
-				Address:    "1.2.3.4",
+				Node:       &Location{Name: "foo-1234", Address: "1.2.3.4"},
 				Type:       ResultTypeWorkload,
 				PortName:   "api",
 				PortNumber: 5678,
@@ -138,7 +137,6 @@ func Test_FetchWorkload(t *testing.T) {
 					Namespace: resource.DefaultNamespaceName,
 					Partition: resource.DefaultPartitionName,
 				},
-				Target: "foo-1234",
 			},
 			expectedErr: nil,
 		},
@@ -189,13 +187,12 @@ func Test_FetchWorkload(t *testing.T) {
 					})
 			},
 			expectedResult: &Result{
-				Address: "1.2.3.4",
-				Type:    ResultTypeWorkload,
+				Node: &Location{Name: "foo-1234", Address: "1.2.3.4"},
+				Type: ResultTypeWorkload,
 				Tenancy: ResultTenancy{
 					Namespace: "test-namespace",
 					Partition: "test-partition",
 				},
-				Target: "foo-1234",
 			},
 			expectedErr: nil,
 		},

--- a/agent/dns/router_ce.go
+++ b/agent/dns/router_ce.go
@@ -12,26 +12,27 @@ import (
 )
 
 // canonicalNameForResult returns the canonical name for a discovery result.
-func canonicalNameForResult(result *discovery.Result, domain string) string {
-	switch result.Type {
+func canonicalNameForResult(resultType discovery.ResultType, target, domain string,
+	tenancy discovery.ResultTenancy, portName string) string {
+	switch resultType {
 	case discovery.ResultTypeService:
-		return fmt.Sprintf("%s.%s.%s.%s", result.Target, "service", result.Tenancy.Datacenter, domain)
+		return fmt.Sprintf("%s.%s.%s.%s", target, "service", tenancy.Datacenter, domain)
 	case discovery.ResultTypeNode:
-		if result.Tenancy.PeerName != "" {
+		if tenancy.PeerName != "" {
 			// We must return a more-specific DNS name for peering so
 			// that there is no ambiguity with lookups.
 			return fmt.Sprintf("%s.node.%s.peer.%s",
-				result.Target,
-				result.Tenancy.PeerName,
+				target,
+				tenancy.PeerName,
 				domain)
 		}
 		// Return a simpler format for non-peering nodes.
-		return fmt.Sprintf("%s.node.%s.%s", result.Target, result.Tenancy.Datacenter, domain)
+		return fmt.Sprintf("%s.node.%s.%s", target, tenancy.Datacenter, domain)
 	case discovery.ResultTypeWorkload:
-		if result.PortName != "" {
-			return fmt.Sprintf("%s.port.%s.workload.%s", result.PortName, result.Target, domain)
+		if portName != "" {
+			return fmt.Sprintf("%s.port.%s.workload.%s", portName, target, domain)
 		}
-		return fmt.Sprintf("%s.workload.%s", result.Target, domain)
+		return fmt.Sprintf("%s.workload.%s", target, domain)
 	}
 	return ""
 }

--- a/agent/dns/router_ce_test.go
+++ b/agent/dns/router_ce_test.go
@@ -37,9 +37,9 @@ func getAdditionalTestCases(t *testing.T) []HandleTestCase {
 			configureDataFetcher: func(fetcher discovery.CatalogDataFetcher) {
 				results := []*discovery.Result{
 					{
-						Address: "1.2.3.4",
+						Node:    &discovery.Location{Name: "foonode", Address: "1.2.3.4"},
 						Type:    discovery.ResultTypeNode,
-						Target:  "foo",
+						Service: &discovery.Location{Name: "foo", Address: "foo"},
 						Tenancy: discovery.ResultTenancy{
 							Datacenter: "dc2",
 							PeerName:   "peer1",
@@ -100,9 +100,9 @@ func getAdditionalTestCases(t *testing.T) []HandleTestCase {
 			configureDataFetcher: func(fetcher discovery.CatalogDataFetcher) {
 				results := []*discovery.Result{
 					{
-						Address: "1.2.3.4",
+						Node:    &discovery.Location{Name: "foonode", Address: "1.2.3.4"},
+						Service: &discovery.Location{Name: "foo", Address: "foo"},
 						Type:    discovery.ResultTypeService,
-						Target:  "foo",
 						Tenancy: discovery.ResultTenancy{
 							Datacenter: "dc2",
 						},

--- a/agent/dns/router_query_test.go
+++ b/agent/dns/router_query_test.go
@@ -206,7 +206,7 @@ func Test_buildQueryFromDNSMessage(t *testing.T) {
 			if context == nil {
 				context = &Context{}
 			}
-			query, err := buildQueryFromDNSMessage(tc.request, *context, "consul.", ".")
+			query, err := buildQueryFromDNSMessage(tc.request, *context, "consul.", ".", nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedQuery, query)
 		})

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -598,14 +598,13 @@ func TestDNS_ServiceLookup(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
 func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
 	t.Parallel()
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		node_name = "my.test-node"
@@ -1679,7 +1678,7 @@ func TestDNS_AltDomain_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): this requires WAN translation work to be implemented
 func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1896,7 +1895,6 @@ func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
 func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1920,7 +1918,7 @@ func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 	}
 	for _, tst := range tests {
 		t.Run(fmt.Sprintf("A lookup %v", tst.name), func(t *testing.T) {
-			for name, experimentsHCL := range getVersionHCL(false) {
+			for name, experimentsHCL := range getVersionHCL(true) {
 				t.Run(name, func(t *testing.T) {
 					a := NewTestAgent(t, fmt.Sprintf("%s %s", tst.config, experimentsHCL))
 					defer a.Shutdown()
@@ -2168,14 +2166,13 @@ func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
 func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
 	t.Parallel()
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 	"testing"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 )
 
-// TODO (v2-dns): requires PTR implementation
 func TestDNS_ServiceReverseLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -77,7 +77,6 @@ func TestDNS_ServiceReverseLookup(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): requires PTR implementation
 func TestDNS_ServiceReverseLookup_IPV6(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -134,7 +133,6 @@ func TestDNS_ServiceReverseLookup_IPV6(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): requires PTR implementation
 func TestDNS_ServiceReverseLookup_CustomDomain(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -193,7 +191,6 @@ func TestDNS_ServiceReverseLookup_CustomDomain(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): requires PTR implementation
 func TestDNS_ServiceReverseLookupNodeAddress(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -379,6 +376,7 @@ func TestDNS_ServiceLookupPreferNoCNAME(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): requires additional recursion work
 func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -453,10 +451,20 @@ func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
 			in, _, err := c.Exchange(m, a.DNSAddr())
 			require.NoError(t, err)
 
-			// expect a CNAME and an A RR
+			// expect two A RRs
 			require.Len(t, in.Answer, 2)
 			require.IsType(t, &dns.A{}, in.Answer[0])
+			require.Equal(t, "db.service.consul.", in.Answer[0].Header().Name)
+			isOneOfTheseIPs := func(ip net.IP) bool {
+				if ip.Equal(net.ParseIP("198.18.0.1")) || ip.Equal(net.ParseIP("198.18.0.3")) {
+					return true
+				}
+				return false
+			}
+			require.True(t, isOneOfTheseIPs(in.Answer[0].(*dns.A).A))
 			require.IsType(t, &dns.A{}, in.Answer[1])
+			require.Equal(t, "db.service.consul.", in.Answer[1].Header().Name)
+			require.True(t, isOneOfTheseIPs(in.Answer[1].(*dns.A).A))
 		})
 	}
 }
@@ -590,8 +598,7 @@ func TestDNS_ServiceLookup(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this is formulating the correct response
-// but failing with an I/O timeout on the dns client Exchange() call
+// TODO (v2-dns): this requires a prepared query
 func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -999,7 +1006,7 @@ func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
 	}
 
 	t.Parallel()
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		node_name = "test-node"
@@ -2413,6 +2420,7 @@ func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): this requires implementing health filtering
 func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2577,6 +2585,7 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): this requires implementing health filtering
 func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2698,6 +2707,7 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): this requires implementing health filtering
 func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")


### PR DESCRIPTION
### Description
This changes the discovery result to pass back the name and address of both service and Node.  previously we had target and address as two string fields.  The dns logic needs access to more data in order to process the dns results from the discovery results.

### Testing & Reproduction steps
- Tests enabled for v2 dns in `agent/dns_service_lookup_test.go`, `agent/dns_node_lookup_test.go`, and `agent/dns_test.go`

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
