### PR TITLE
NET-7488 - dns v2 add support for prepared queries in catalog v1 data model

### DIFF
--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -79,11 +79,11 @@ type QueryTenancy struct {
 // QueryPayload represents all information needed by the data backend
 // to decide which records to include.
 type QueryPayload struct {
-	Name       string
-	PortName   string       // v1 - this could optionally be "connect" or "ingress"; v2 - this is the service port name
-	Tag        string       // deprecated: use for V1 only
-	RemoteAddr net.Addr     // deprecated: used for prepared queries
-	Tenancy    QueryTenancy // tenancy includes any additional labels specified before the domain
+	Name     string
+	PortName string       // v1 - this could optionally be "connect" or "ingress"; v2 - this is the service port name
+	Tag      string       // deprecated: use for V1 only
+	SourceIP net.IP       // deprecated: used for prepared queries
+	Tenancy  QueryTenancy // tenancy includes any additional labels specified before the domain
 
 	// v2 fields only
 	EnableFailover bool

--- a/agent/discovery/query_fetcher_v2.go
+++ b/agent/discovery/query_fetcher_v2.go
@@ -171,7 +171,7 @@ func (f *V2DataFetcher) ValidateRequest(_ Context, req *QueryPayload) error {
 	if req.Tag != "" {
 		return ErrNotSupported
 	}
-	if req.RemoteAddr != nil {
+	if req.SourceIP != nil {
 		return ErrNotSupported
 	}
 	return nil

--- a/agent/dns/router_query_test.go
+++ b/agent/dns/router_query_test.go
@@ -206,7 +206,7 @@ func Test_buildQueryFromDNSMessage(t *testing.T) {
 			if context == nil {
 				context = &Context{}
 			}
-			query, err := buildQueryFromDNSMessage(tc.request, *context, "consul.", ".")
+			query, err := buildQueryFromDNSMessage(tc.request, *context, "consul.", ".", nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedQuery, query)
 		})

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -598,14 +598,13 @@ func TestDNS_ServiceLookup(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
 func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
 	t.Parallel()
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		node_name = "my.test-node"
@@ -1679,7 +1678,7 @@ func TestDNS_AltDomain_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): this requires WAN translation work to be implemented
 func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1896,7 +1895,6 @@ func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
 func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1920,7 +1918,7 @@ func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 	}
 	for _, tst := range tests {
 		t.Run(fmt.Sprintf("A lookup %v", tst.name), func(t *testing.T) {
-			for name, experimentsHCL := range getVersionHCL(false) {
+			for name, experimentsHCL := range getVersionHCL(true) {
 				t.Run(name, func(t *testing.T) {
 					a := NewTestAgent(t, fmt.Sprintf("%s %s", tst.config, experimentsHCL))
 					defer a.Shutdown()
@@ -2168,14 +2166,13 @@ func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
 func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
 	t.Parallel()
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()


### PR DESCRIPTION
### Description
This is part of the DNS re-write that includes Catalog V2 support.

This PR completes the round-trip for `query.` queries against catalog v1 from dns v2.   

Out of Scope:
- TTL for Prepared Queries.  This will be addressed in NET-7613 which is ready for dev.

### Testing & Reproduction steps
- Tests enabled for v2 dns in `agent/dns_service_lookup_test.go`

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
