### PR TITLE
Fixes the help text for Config Entry delete

### DIFF
--- a/command/config/delete/config_delete.go
+++ b/command/config/delete/config_delete.go
@@ -166,7 +166,7 @@ func (c *cmd) Help() string {
 const (
 	synopsis = "Delete a centralized config entry"
 	help     = `
-Usage: consul config delete [options] ([-kind <config kind> -name <config name>] | [-f FILENAME])
+Usage: consul config delete [options] ([-kind <config kind> -name <config name>] | [-filename FILENAME])
 
   Deletes the configuration entry specified by the kind and name.
 


### PR DESCRIPTION
### Description

The config entry delete commands help text shows the short form of the actual arg `-filename`, that doesn't exist.

```
❯ consul config delete --help
Usage: consul config delete [options] ([-kind <config kind> -name <config name>] | [-f FILENAME])

  Deletes the configuration entry specified by the kind and name.

  Example:

    $ consul config delete -kind service-defaults -name web
    $ consul config delete -filename service-defaults-web.hcl
```

### Testing & Reproduction steps

Built a custom binary and tested it.
```
❯ ./consul version
Consul v1.19.0-dev
Build Date 1970-01-01T00:00:01Z
Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)

❯ ./consul config delete -help
Usage: consul config delete [options] ([-kind <config kind> -name <config name>] | [-filename FILENAME])

  Deletes the configuration entry specified by the kind and name.

  Example:

    $ consul config delete -kind service-defaults -name web
    $ consul config delete -filename service-defaults-web.hcl
```

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
