### PR TITLE
NET-7630 - Fix TXT record creation on node queries

### DIFF
--- a/agent/dns/router.go
+++ b/agent/dns/router.go
@@ -864,19 +864,16 @@ func (r *Router) getAnswerExtraAndNs(result *discovery.Result, req *dns.Msg, req
 		answer = append(answer, a...)
 		extra = append(extra, e...)
 
-		if cfg.NodeMetaTXT {
-			name := serviceAddress.FQDN()
-			if !serviceAddress.IsInternalFQDN(r.domain) && !serviceAddress.IsExternalFQDN(r.domain) {
-				name = canonicalNameForResult(discovery.ResultTypeNode, result.Node.Name, domain, result.Tenancy, result.PortName)
-			}
-			extra = append(extra, makeTXTRecord(name, result, ttl)...)
-		}
 	default:
 		a, e := r.getAnswerExtrasForAddressAndTarget(nodeAddress, serviceAddress, req, reqCtx,
 			result, ttl, remoteAddress, cfg, domain, maxRecursionLevel)
 		answer = append(answer, a...)
 		extra = append(extra, e...)
 	}
+
+	a, e := getAnswerAndExtraTXT(req, cfg, qName, result, ttl, domain)
+	answer = append(answer, a...)
+	extra = append(extra, e...)
 	return
 }
 
@@ -946,7 +943,46 @@ func (r *Router) getAnswerExtrasForAddressAndTarget(nodeAddress *dnsAddress, ser
 		answer = append(answer, a...)
 		extra = append(extra, e...)
 	}
+
 	return
+}
+
+// getAnswerAndExtraTXT determines whether a TXT needs to be create and then
+// returns the TXT record in the answer or extra depending on the question type.
+func getAnswerAndExtraTXT(req *dns.Msg, cfg *RouterDynamicConfig, qName string,
+	result *discovery.Result, ttl uint32, domain string) (answer []dns.RR, extra []dns.RR) {
+	recordHeaderName := qName
+	serviceAddress := newDNSAddress("")
+	if result.Service != nil {
+		serviceAddress = newDNSAddress(result.Service.Address)
+	}
+	if result.Type != discovery.ResultTypeNode &&
+		result.Type != discovery.ResultTypeVirtual &&
+		!serviceAddress.IsInternalFQDN(domain) &&
+		!serviceAddress.IsExternalFQDN(domain) {
+		recordHeaderName = canonicalNameForResult(discovery.ResultTypeNode, result.Node.Name,
+			domain, result.Tenancy, result.PortName)
+	}
+	qType := req.Question[0].Qtype
+	generateMeta := false
+	metaInAnswer := false
+	if qType == dns.TypeANY || qType == dns.TypeTXT {
+		generateMeta = true
+		metaInAnswer = true
+	} else if cfg.NodeMetaTXT {
+		generateMeta = true
+	}
+
+	// Do not generate txt records if we don't have to: https://github.com/hashicorp/consul/pull/5272
+	if generateMeta {
+		meta := makeTXTRecord(recordHeaderName, result, ttl)
+		if metaInAnswer {
+			answer = append(answer, meta...)
+		} else {
+			extra = append(extra, meta...)
+		}
+	}
+	return answer, extra
 }
 
 // getAnswerExtrasForIP creates the dns answer and extra from IP dnsAddress pairs.

--- a/agent/dns/router_query.go
+++ b/agent/dns/router_query.go
@@ -45,9 +45,13 @@ func buildQueryFromDNSMessage(req *dns.Msg, reqCtx Context, domain, altDomain st
 
 // getQueryNameAndTagFromParts returns the query name and tag from the query parts that are taken from the original dns question.
 func getQueryNameAndTagFromParts(queryType discovery.QueryType, queryParts []string) (string, string) {
+	n := len(queryParts)
+	if n == 0 {
+		return "", ""
+	}
+
 	switch queryType {
 	case discovery.QueryTypeService:
-		n := len(queryParts)
 		// Support RFC 2782 style syntax
 		if n == 2 && strings.HasPrefix(queryParts[1], "_") && strings.HasPrefix(queryParts[0], "_") {
 			// Grab the tag since we make nuke it if it's tcp
@@ -62,9 +66,9 @@ func getQueryNameAndTagFromParts(queryType discovery.QueryType, queryParts []str
 			// _name._tag.service.consul
 			return name, tag
 		}
-		return queryParts[len(queryParts)-1], ""
+		return queryParts[n-1], ""
 	}
-	return queryParts[len(queryParts)-1], ""
+	return queryParts[n-1], ""
 }
 
 // getQueryTenancy returns a discovery.QueryTenancy from a DNS message.

--- a/agent/dns_node_lookup_test.go
+++ b/agent/dns_node_lookup_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 )
 
+// TODO (v2-dns): Failing on "lookup a non-existing node, we should receive a SOA"
+// it is coming back empty.
 func TestDNS_NodeLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -116,12 +118,12 @@ func TestDNS_NodeLookup(t *testing.T) {
 	}
 }
 
-func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
+func TestDNS_NodeLookup_CaseInsensitive(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -155,6 +157,8 @@ func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): NET-7632 - Fix node lookup when question name has a period in it.
+// Answer is coming back empty
 func TestDNS_NodeLookup_PeriodName(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -207,7 +211,7 @@ func TestDNS_NodeLookup_AAAA(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -252,6 +256,11 @@ func TestDNS_NodeLookup_AAAA(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): NET-7631 - Implement external CNAME references
+// Failing on answer assertion.  some CNAMEs are not getting created
+// and the record type on the AAAA record is incorrect.
+// External services do not appear to be working properly here
+// and in the service lookup tests.
 func TestDNS_NodeLookup_CNAME(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -324,7 +333,7 @@ func TestDNS_NodeLookup_TXT(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -378,7 +387,7 @@ func TestDNS_NodeLookup_TXT_DontSuppress(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false } `+experimentsHCL)
 			defer a.Shutdown()
@@ -432,7 +441,7 @@ func TestDNS_NodeLookup_ANY(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -481,7 +490,7 @@ func TestDNS_NodeLookup_ANY_DontSuppressTXT(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false } `+experimentsHCL)
 			defer a.Shutdown()
@@ -530,7 +539,7 @@ func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false } `+experimentsHCL)
 			defer a.Shutdown()
@@ -569,6 +578,9 @@ func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): NET-7631 - Implement external CNAME references
+// Failing on "Should have the CNAME record + a few A records" comment
+// External services do not appear to be working properly here either.
 func TestDNS_NodeLookup_TTL(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -370,7 +370,6 @@ func TestDNS_ServiceLookupPreferNoCNAME(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): requires additional recursion work
 func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -462,7 +461,7 @@ func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): NET-7640 - NS Record not populate on some invalid service / prepared query lookups.
 func TestDNS_ServiceLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -654,6 +653,7 @@ func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): NET-7659 - Fix Ingress and Connect Service Lookups
 func TestDNS_ConnectServiceLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -705,6 +705,7 @@ func TestDNS_ConnectServiceLookup(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): NET-7659 - Fix Ingress and Connect Service Lookups
 func TestDNS_IngressServiceLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1118,7 +1119,7 @@ func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): NET-7636 - Implement target having encoded IP address
 func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1219,7 +1220,7 @@ func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): NET-7636 - Implement target having encoded IP address
 func TestDNS_AltDomain_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1327,7 +1328,7 @@ func TestDNS_AltDomain_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): NET-7631 - Implement external CNAME references
 func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1448,7 +1449,7 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): NET-7636 - Implement target having encoded IP address
 func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1549,7 +1550,7 @@ func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): NET-7636 - Implement target having encoded IP address
 func TestDNS_AltDomain_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1657,7 +1658,7 @@ func TestDNS_AltDomain_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires WAN translation work to be implemented
+// TODO (v2-dns):  NET-7634 - Implement WAN translation
 func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1873,7 +1874,7 @@ func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 	}
 }
 
-func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
+func TestDNS_ServiceLookup_CaseInsensitive(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
@@ -1974,7 +1975,7 @@ func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this returns a response where the answer is an SOA record
+// TODO (v2-dns): NET-7632 - Fix node and prepared query lookups when question name has a period in it
 func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2054,7 +2055,7 @@ func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this returns a response where the answer is an SOA record
+// TODO (v2-dns): NET-7632 - Fix node and prepared query lookups when question name has a period in it.
 func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2251,7 +2252,7 @@ func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): NET-7641 - Service lookups not properly de-duping SRV records
 func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2390,7 +2391,7 @@ func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires implementing health filtering
+// TODO (v2-dns): NET-7637 - implementing health filtering
 func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2554,7 +2555,7 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires implementing health filtering
+// TODO (v2-dns): NET-7637 - implementing health filtering
 func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2675,7 +2676,7 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires implementing health filtering
+// TODO (v2-dns): NET-7637 - implementing health filtering
 func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2826,7 +2827,7 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): NET-7635 - Fix dns: overflowing header size in tests
 func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2925,7 +2926,7 @@ func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): NET-7635 - Fix dns: overflowing header size in tests
 func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -3002,7 +3003,7 @@ func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
+// TODO (v2-dns): NET-7638 - Implemented truncated response
 func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -3295,6 +3296,7 @@ func checkDNSService(
 	}
 }
 
+// TODO (v2-dns): NET-7633 - implement answer limits.
 func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -3375,6 +3377,7 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): NET-7633 - implement answer limits.
 func TestDNS_ServiceLookup_AnswerLimits(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -3446,7 +3449,6 @@ func TestDNS_ServiceLookup_AnswerLimits(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
 func TestDNS_ServiceLookup_CNAME(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -3460,7 +3462,7 @@ func TestDNS_ServiceLookup_CNAME(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
@@ -3551,7 +3553,6 @@ func TestDNS_ServiceLookup_CNAME(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): this requires a prepared query
 func TestDNS_ServiceLookup_ServiceAddress_CNAME(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -3565,7 +3566,7 @@ func TestDNS_ServiceLookup_ServiceAddress_CNAME(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
@@ -3968,7 +3969,7 @@ func TestDNS_ServiceLookup_FilterACL(t *testing.T) {
 				}
 			`
 
-			for name, experimentsHCL := range getVersionHCL(false) {
+			for name, experimentsHCL := range getVersionHCL(true) {
 				t.Run(name, func(t *testing.T) {
 					a := NewTestAgent(t, hcl+experimentsHCL)
 					defer a.Shutdown()

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -128,7 +128,7 @@ func getVersionHCL(enableV2 bool) map[string]string {
 }
 
 // Copied to agent/dns/recursor_test.go
-func TestRecursorAddr(t *testing.T) {
+func TestNDS_RecursorAddr(t *testing.T) {
 	addr, err := recursorAddr("8.8.8.8")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -153,7 +153,7 @@ func TestRecursorAddr(t *testing.T) {
 	}
 }
 
-func TestEncodeKVasRFC1464(t *testing.T) {
+func TestDNS_EncodeKVasRFC1464(t *testing.T) {
 	// Test cases are from rfc1464
 	type rfc1464Test struct {
 		key, value, internalForm, externalForm string
@@ -187,7 +187,7 @@ func TestDNS_Over_TCP(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -244,7 +244,7 @@ func TestDNS_EmptyAltDomain(t *testing.T) {
 	}
 }
 
-func TestDNSCycleRecursorCheck(t *testing.T) {
+func TestDNS_CycleRecursorCheck(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
@@ -286,7 +286,7 @@ func TestDNSCycleRecursorCheck(t *testing.T) {
 		})
 	}
 }
-func TestDNSCycleRecursorCheckAllFail(t *testing.T) {
+func TestDNS_CycleRecursorCheckAllFail(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
@@ -325,6 +325,7 @@ func TestDNSCycleRecursorCheckAllFail(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7643 - Implement EDNS0 records when queried
 func TestDNS_EDNS0(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -372,6 +373,7 @@ func TestDNS_EDNS0(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7643 - Implement EDNS0 records when queried
 func TestDNS_EDNS0_ECS(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -613,6 +615,7 @@ func TestDNS_ReverseLookup_IPV6(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7640 - NS Record not populate on some invalid service / prepared query lookups
 func TestDNS_SOA_Settings(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -812,6 +815,9 @@ func TestDNS_InifiniteRecursion(t *testing.T) {
 	}
 }
 
+// TODO: NET-7640 - NS Record not populate on some invalid service / prepared query lookups
+// this is actually an I/O timeout so it might not be the same root cause listed in NET-7640
+// but going to cover investigating it there.
 func TestDNS_NSRecords(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -854,6 +860,7 @@ func TestDNS_NSRecords(t *testing.T) {
 	}
 }
 
+// TODO: NET-7640 - NS Record not populate on some invalid service / prepared query lookups
 func TestDNS_AltDomain_NSRecords(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -909,6 +916,7 @@ func TestDNS_AltDomain_NSRecords(t *testing.T) {
 	}
 }
 
+// TODO: NET-7640 - NS Record not populate on some invalid service / prepared query lookups
 func TestDNS_NSRecords_IPV6(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -952,6 +960,7 @@ func TestDNS_NSRecords_IPV6(t *testing.T) {
 	}
 }
 
+// TODO: NET-7640 - NS Record not populate on some invalid service / prepared query lookups
 func TestDNS_AltDomain_NSRecords_IPV6(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1007,6 +1016,7 @@ func TestDNS_AltDomain_NSRecords_IPV6(t *testing.T) {
 	}
 }
 
+// TODO NET-7644 - Implement service and prepared query lookup for tagged addresses
 func TestDNS_Lookup_TaggedIPAddresses(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1597,7 +1607,8 @@ func TestDNS_RecursorTimeout(t *testing.T) {
 	}
 }
 
-func TestBinarySearch(t *testing.T) {
+// TODO(v2-dns): NET-7646 - account for this functionality since there is
+func TestDNS_BinarySearch(t *testing.T) {
 	msgSrc := new(dns.Msg)
 	msgSrc.Compress = true
 	msgSrc.SetQuestion("redis.service.consul.", dns.TypeSRV)
@@ -1637,6 +1648,7 @@ func TestBinarySearch(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7635 - Fix dns: overflowing header size or IO timeouts
 func TestDNS_TCP_and_UDP_Truncate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1969,6 +1981,7 @@ func TestDNS_NonExistentDC_Server(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7647 - Fix non-existent dc tests
 // TestDNS_NonExistentDC_RPC verifies NXDOMAIN is returned when
 // Consul server agent is queried over RPC by a non-server agent
 // for a service in a non-existent domain
@@ -2013,6 +2026,7 @@ func TestDNS_NonExistentDC_RPC(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7647 - Fix non-existent dc tests
 func TestDNS_NonExistingLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2049,6 +2063,7 @@ func TestDNS_NonExistingLookup(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7647 - Fix non-existent dc tests
 func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2195,7 +2210,7 @@ func TestDNS_AltDomains_Service(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		alt_domain = "test-domain."
@@ -2288,6 +2303,7 @@ func TestDNS_AltDomains_Service(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7640 - NS or SOA Records not populate on some invalid service / prepared query lookups
 func TestDNS_AltDomains_SOA(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2348,7 +2364,7 @@ func TestDNS_AltDomains_Overlap(t *testing.T) {
 	// this tests the domain matching logic in DNSServer when encountering more
 	// than one potential match (i.e. ambiguous match)
 	// it should select the longer matching domain when dispatching
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		node_name = "test-node"
@@ -2398,7 +2414,7 @@ func TestDNS_AltDomain_DCName_Overlap(t *testing.T) {
 
 	// this tests the DC name overlap with the consul domain/alt-domain
 	// we should get response when DC suffix is a prefix of consul alt-domain
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		datacenter = "dc-test"
@@ -2438,7 +2454,7 @@ func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		dns_config {
@@ -2489,6 +2505,7 @@ func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 	}
 }
 
+// TODO (v2-dns): NET-7640 - NS or SOA Records not populate on some invalid service / prepared query lookups
 func TestDNS_InvalidQueries(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2537,6 +2554,7 @@ func TestDNS_InvalidQueries(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7648 - Prepared Query - inject agent source and dc to RPC
 func TestDNS_PreparedQuery_AgentSource(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2577,6 +2595,7 @@ func TestDNS_PreparedQuery_AgentSource(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7648 - Prepared Query - inject agent source and dc to RPC
 func TestDNS_EDNS_Truncate_AgentSource(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2626,7 +2645,7 @@ func TestDNS_EDNS_Truncate_AgentSource(t *testing.T) {
 }
 
 func TestDNS_trimUDPResponse_NoTrim(t *testing.T) {
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 
 			req := &dns.Msg{}
@@ -2688,7 +2707,7 @@ func TestDNS_trimUDPResponse_NoTrim(t *testing.T) {
 }
 
 func TestDNS_trimUDPResponse_TrimLimit(t *testing.T) {
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			cfg := loadRuntimeConfig(t, `node_name = "test" data_dir = "a" bind_addr = "127.0.0.1" node_name = "dummy" `+experimentsHCL)
 
@@ -2731,7 +2750,7 @@ func TestDNS_trimUDPResponse_TrimLimit(t *testing.T) {
 }
 
 func TestDNS_trimUDPResponse_TrimLimitWithNS(t *testing.T) {
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			cfg := loadRuntimeConfig(t, `node_name = "test" data_dir = "a" bind_addr = "127.0.0.1" node_name = "dummy" `+experimentsHCL)
 
@@ -2782,7 +2801,7 @@ func TestDNS_trimUDPResponse_TrimLimitWithNS(t *testing.T) {
 }
 
 func TestDNS_trimTCPResponse_TrimLimitWithNS(t *testing.T) {
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			cfg := loadRuntimeConfig(t, `node_name = "test" data_dir = "a" bind_addr = "127.0.0.1" node_name = "dummy" `+experimentsHCL)
 
@@ -2842,7 +2861,7 @@ func loadRuntimeConfig(t *testing.T, hcl string) *config.RuntimeConfig {
 }
 
 func TestDNS_trimUDPResponse_TrimSize(t *testing.T) {
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			cfg := loadRuntimeConfig(t, `node_name = "test" data_dir = "a" bind_addr = "127.0.0.1" node_name = "dummy" `+experimentsHCL)
 
@@ -2898,7 +2917,7 @@ func TestDNS_trimUDPResponse_TrimSize(t *testing.T) {
 }
 
 func TestDNS_trimUDPResponse_TrimSizeEDNS(t *testing.T) {
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 
 			cfg := loadRuntimeConfig(t, `node_name = "test" data_dir = "a" bind_addr = "127.0.0.1" node_name = "dummy" `+experimentsHCL)
@@ -2981,7 +3000,7 @@ func TestDNS_trimUDPResponse_TrimSizeEDNS(t *testing.T) {
 }
 
 func TestDNS_trimUDPResponse_TrimSizeMaxSize(t *testing.T) {
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 
 			cfg := loadRuntimeConfig(t, `node_name = "test" data_dir = "a" bind_addr = "127.0.0.1" node_name = "dummy" `+experimentsHCL)
@@ -3032,6 +3051,7 @@ func TestDNS_trimUDPResponse_TrimSizeMaxSize(t *testing.T) {
 	}
 }
 
+// TODO(v2-dns): NET-7649 - Implement sync extra
 func TestDNS_syncExtra(t *testing.T) {
 	resp := &dns.Msg{
 		Answer: []dns.RR{
@@ -3256,7 +3276,7 @@ func TestDNS_syncExtra(t *testing.T) {
 }
 
 func TestDNS_Compression_trimUDPResponse(t *testing.T) {
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 
 			cfg := loadRuntimeConfig(t, `data_dir = "a" bind_addr = "127.0.0.1" node_name = "dummy" `+experimentsHCL)
@@ -3283,7 +3303,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 
 			a := NewTestAgent(t, experimentsHCL)
@@ -3611,7 +3631,7 @@ func TestDNS_ReloadConfig_DuringQuery(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -3677,7 +3697,7 @@ func TestDNS_ReloadConfig_DuringQuery(t *testing.T) {
 	}
 }
 
-func TestECSNotGlobalError(t *testing.T) {
+func TestDNS_ECSNotGlobalError(t *testing.T) {
 	t.Run("wrap nil", func(t *testing.T) {
 		e := ecsNotGlobalError{}
 		require.True(t, errors.Is(e, errECSNotGlobal))
@@ -3709,7 +3729,7 @@ func perfectlyRandomChoices(size int, frac float64) []bool {
 	return out
 }
 
-func TestPerfectlyRandomChoices(t *testing.T) {
+func TestDNS_PerfectlyRandomChoices(t *testing.T) {
 	count := func(got []bool) int {
 		var x int
 		for _, v := range got {
@@ -3771,7 +3791,7 @@ type testCaseParseLocality struct {
 	expectedOK          bool
 }
 
-func Test_ParseLocality(t *testing.T) {
+func TestDNS_ParseLocality(t *testing.T) {
 	testCases := getTestCasesParseLocality()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -3789,7 +3809,7 @@ func Test_ParseLocality(t *testing.T) {
 
 }
 
-func Test_EffectiveDatacenter(t *testing.T) {
+func TestDNS_EffectiveDatacenter(t *testing.T) {
 	type testCase struct {
 		name          string
 		queryLocality queryLocality


### PR DESCRIPTION
### Description

- TXT records were not working on node lookups.
- audited the failing tests in the service and node lookups file and created sub tasks for them related to the theme of what needed to be implemented.


### Testing & Reproduction steps
CI

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
