### PR TITLE
Caching performance improvements

### DIFF
--- a/internal/catalog/internal/controllers/endpoints/controller.go
+++ b/internal/catalog/internal/controllers/endpoints/controller.go
@@ -40,7 +40,7 @@ func ServiceEndpointsController() *controller.Controller {
 			// ServiceEndpoints are name-aligned with the Service type
 			dependency.ReplaceType(pbcatalog.ServiceEndpointsType),
 			// This cache index keeps track of the relationship between WorkloadSelectors (and the workload names and prefixes
-			// they include) and Services. This allows us to efficiently find all services and service endpoints that are
+			// they include) and Services. This allows us to efficiently find all services and service endpoints that
 			// are affected by the change to a workload.
 			workloadselector.Index[*pbcatalog.Service](selectedWorkloadsIndexName)).
 		WithWatch(pbcatalog.WorkloadType,

--- a/internal/controller/cache/cache.go
+++ b/internal/controller/cache/cache.go
@@ -76,6 +76,8 @@ type cache struct {
 	queries map[string]Query
 }
 
+var _ Cache = (*cache)(nil)
+
 func New() Cache {
 	return newCache()
 }
@@ -90,12 +92,13 @@ func newCache() *cache {
 func (c *cache) ensureTypeCached(it *pbresource.Type) *kindIndices {
 	ut := unversionedType{Group: it.Group, Kind: it.Kind}
 
-	_, ok := c.kinds[ut]
+	r, ok := c.kinds[ut]
 	if !ok {
-		c.kinds[ut] = newKindIndices()
+		r = newKindIndices()
+		c.kinds[ut] = r
 	}
 
-	return c.kinds[ut]
+	return r
 }
 
 func (c *cache) AddType(it *pbresource.Type) {

--- a/internal/controller/cache/cache_bench_test.go
+++ b/internal/controller/cache/cache_bench_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/hashicorp/go-uuid"
 
 	"github.com/hashicorp/consul/internal/controller/cache/index"
+	"github.com/hashicorp/consul/internal/controller/cache/indexers"
+	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
@@ -124,22 +126,462 @@ func Benchmark_cache_AddQuery(b *testing.B) {
 }
 
 // From ReadOnlyCache interface
-func Benchmark_cache_Get(b *testing.B) {}
+func Benchmark_cache_Get_CacheHit(b *testing.B) {
+	c := New()
 
-func Benchmark_cache_List(b *testing.B) {}
+	typeCount := 1000
 
-func Benchmark_cache_ListIterator(b *testing.B) {}
+	// generate types and add indices
+	newTypes := make([]*pbresource.Type, 0, typeCount)
+	newIndices := make([]*index.Index, 0, typeCount)
+	resources := make([]*pbresource.Resource, 0, b.N)
+	for i := 0; i < typeCount; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
 
-func Benchmark_cache_Parents(b *testing.B) {}
+		newType := &pbresource.Type{
+			Group:        u,
+			GroupVersion: u,
+			Kind:         u,
+		}
+		newTypes = append(newTypes, newType)
+		newIndices = append(newIndices, getTestIndexer())
 
-func Benchmark_cache_ParentsIterator(b *testing.B) {}
+		if err = c.AddIndex(newTypes[i], newIndices[i]); err != nil {
+			b.Error(err)
+		}
+	}
 
-func Benchmark_cache_Query(b *testing.B) {}
+	for i := 0; i < b.N; i++ {
+		resourceType := newTypes[i%len(newTypes)]
+
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+		item := &pbresource.Resource{
+			Id: &pbresource.ID{
+				Uid:  u,
+				Name: u,
+				Type: resourceType,
+			},
+		}
+		resources = append(resources, item)
+		// Insert the item into the cache ahead of time
+		if err = c.Insert(item); err != nil {
+			b.Error(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := c.Get(resources[i].Id.Type, "uuid", resources[i].Id.Name)
+		if err != nil {
+			b.Error(err)
+		}
+		if res == nil {
+			b.Logf("unexpected cache miss")
+		}
+	}
+	resultCache = c
+}
+
+func Benchmark_cache_Get_CacheMiss(b *testing.B) {
+	c := New()
+
+	typeCount := 1000
+
+	// generate types and add indices
+	newTypes := make([]*pbresource.Type, 0, typeCount)
+	newIndices := make([]*index.Index, 0, typeCount)
+	resources := make([]*pbresource.Resource, 0, b.N)
+	for i := 0; i < typeCount; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+
+		newType := &pbresource.Type{
+			Group:        u,
+			GroupVersion: u,
+			Kind:         u,
+		}
+		newTypes = append(newTypes, newType)
+		newIndices = append(newIndices, getTestIndexer())
+
+		if err = c.AddIndex(newTypes[i], newIndices[i]); err != nil {
+			b.Error(err)
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		resourceType := newTypes[i%len(newTypes)]
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+		item := &pbresource.Resource{
+			Id: &pbresource.ID{
+				Uid:  u,
+				Name: u,
+				Type: resourceType,
+			},
+		}
+		resources = append(resources, item)
+		// Don't add the item to the cache since we want all misses
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := c.Get(resources[i].Id.Type, "uuid", resources[i].Id.Name)
+		if err != nil {
+			b.Error(err)
+		}
+		if res != nil {
+			b.Logf("unexpected cache hit")
+		}
+	}
+	resultCache = c
+}
+
+func Benchmark_cache_List(b *testing.B) {
+	c := New()
+
+	// reduce the number of types, so we have a higher number of resources per type
+	typeCount := 5
+
+	// generate types and add indices
+	newTypes := make([]*pbresource.Type, 0, typeCount)
+	newIndices := make([]*index.Index, 0, typeCount)
+	resources := make([]*pbresource.Resource, 0, b.N)
+	for i := 0; i < typeCount; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+
+		newType := &pbresource.Type{
+			Group:        u,
+			GroupVersion: u,
+			Kind:         u,
+		}
+		newTypes = append(newTypes, newType)
+		newIndices = append(newIndices, getTestIndexer())
+
+		if err = c.AddIndex(newTypes[i], newIndices[i]); err != nil {
+			b.Error(err)
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		resourceType := newTypes[i%len(newTypes)]
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+		item := &pbresource.Resource{
+			Id: &pbresource.ID{
+				Uid:  u,
+				Name: u,
+				Type: resourceType,
+			},
+		}
+		resources = append(resources, item)
+		// Insert the item into the cache ahead of time
+		if err = c.Insert(item); err != nil {
+			b.Error(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := c.List(resources[i].Id.Type, "uuid", resources[i].Id.Name)
+		if err != nil {
+			b.Error(err)
+		}
+		if len(res) <= 0 {
+			b.Error("unexpected empty iterator")
+		}
+	}
+	resultCache = c
+}
+
+func Benchmark_cache_ListIterator(b *testing.B) {
+	c := New()
+
+	// reduce the number of types, so we have a higher number of resources per type
+	typeCount := 5
+
+	// generate types and add indices
+	newTypes := make([]*pbresource.Type, 0, typeCount)
+	newIndices := make([]*index.Index, 0, typeCount)
+	resources := make([]*pbresource.Resource, 0, b.N)
+	for i := 0; i < typeCount; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+
+		newType := &pbresource.Type{
+			Group:        u,
+			GroupVersion: u,
+			Kind:         u,
+		}
+		newTypes = append(newTypes, newType)
+		newIndices = append(newIndices, getTestIndexer())
+
+		if err = c.AddIndex(newTypes[i], newIndices[i]); err != nil {
+			b.Error(err)
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		resourceType := newTypes[i%len(newTypes)]
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+		item := &pbresource.Resource{
+			Id: &pbresource.ID{
+				Uid:  u,
+				Name: u,
+				Type: resourceType,
+			},
+		}
+		resources = append(resources, item)
+		// Insert the item into the cache ahead of time
+		if err = c.Insert(item); err != nil {
+			b.Error(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := c.ListIterator(resources[i].Id.Type, "uuid", resources[i].Id.Name)
+		if err != nil {
+			b.Error(err)
+		}
+		if res == nil {
+			b.Error("unexpected nil iterator")
+		}
+	}
+	resultCache = c
+}
+
+func Benchmark_cache_Parents(b *testing.B) {
+	// TODO (@johnlanda)
+}
+
+func Benchmark_cache_ParentsIterator(b *testing.B) {
+  // TODO (@johnlanda)
+}
+
+func Benchmark_cache_Query(b *testing.B) {
+	c := New()
+
+	names := make([]string, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+
+		names = append(names, u)
+	}
+
+	queryFunc := func(c ReadOnlyCache, args ...any) (ResourceIterator, error) {
+		return nil, nil
+	}
+
+	for i := 0; i < b.N; i++ {
+		err := c.AddQuery(names[i], queryFunc)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := c.Query(names[i])
+		if err != nil {
+			b.Error(err)
+		}
+	}
+	resultCache = c
+}
 
 // From WriteCache interface
-func Benchmark_cache_Insert(b *testing.B) {}
+func Benchmark_cache_Insert_New(b *testing.B) {
+	c := New()
 
-func Benchmark_cache_Delete(b *testing.B) {}
+	typeCount := 1000
+
+	// generate types and add indices
+	newTypes := make([]*pbresource.Type, 0, typeCount)
+	newIndices := make([]*index.Index, 0, typeCount)
+	resources := make([]*pbresource.Resource, 0, b.N)
+	for i := 0; i < typeCount; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+
+		newType := &pbresource.Type{
+			Group:        u,
+			GroupVersion: u,
+			Kind:         u,
+		}
+		newTypes = append(newTypes, newType)
+
+		newIndex := index.New(u, testSingleIndexer{})
+		newIndices = append(newIndices, newIndex)
+
+		if err = c.AddIndex(newTypes[i], newIndices[i]); err != nil {
+			b.Error(err)
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		resourceType := newTypes[i%len(newTypes)]
+		// pull the uuid out of the type
+		u := resourceType.GroupVersion
+		item := &pbresource.Resource{
+			Id: &pbresource.ID{
+				Uid:  u,
+				Name: u,
+				Type: resourceType,
+			},
+		}
+		resources = append(resources, item)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := c.Insert(resources[i])
+		if err != nil {
+			b.Error(err)
+		}
+	}
+	resultCache = c
+}
+
+func Benchmark_cache_Insert_Existing(b *testing.B) {
+	c := New()
+
+	typeCount := 1000
+
+	// generate types and add indices
+	newTypes := make([]*pbresource.Type, 0, typeCount)
+	newIndices := make([]*index.Index, 0, typeCount)
+	resources := make([]*pbresource.Resource, 0, b.N)
+	for i := 0; i < typeCount; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+
+		newType := &pbresource.Type{
+			Group:        u,
+			GroupVersion: u,
+			Kind:         u,
+		}
+		newTypes = append(newTypes, newType)
+
+		newIndex := index.New(u, testSingleIndexer{})
+		newIndices = append(newIndices, newIndex)
+
+		if err = c.AddIndex(newTypes[i], newIndices[i]); err != nil {
+			b.Error(err)
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		resourceType := newTypes[i%len(newTypes)]
+		// pull the uuid out of the type
+		u := resourceType.GroupVersion
+		item := &pbresource.Resource{
+			Id: &pbresource.ID{
+				Uid:  u,
+				Name: u,
+				Type: resourceType,
+			},
+		}
+		resources = append(resources, item)
+		// Insert the item into the cache ahead of time
+		if err := c.Insert(item); err != nil {
+			b.Error(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := c.Insert(resources[i])
+		if err != nil {
+			b.Error(err)
+		}
+	}
+	resultCache = c
+}
+
+func Benchmark_cache_Delete(b *testing.B) {
+	c := New()
+
+	typeCount := 1000
+
+	// generate types and add indices
+	newTypes := make([]*pbresource.Type, 0, typeCount)
+	newIndices := make([]*index.Index, 0, typeCount)
+	resources := make([]*pbresource.Resource, 0, b.N)
+	for i := 0; i < typeCount; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+
+		newType := &pbresource.Type{
+			Group:        u,
+			GroupVersion: u,
+			Kind:         u,
+		}
+		newTypes = append(newTypes, newType)
+
+		newIndex := index.New(u, testSingleIndexer{})
+		newIndices = append(newIndices, newIndex)
+
+		if err = c.AddIndex(newTypes[i], newIndices[i]); err != nil {
+			b.Error(err)
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		resourceType := newTypes[i%len(newTypes)]
+		// pull the uuid out of the type
+		u := resourceType.GroupVersion
+		item := &pbresource.Resource{
+			Id: &pbresource.ID{
+				Uid:  u,
+				Name: u,
+				Type: resourceType,
+			},
+		}
+		resources = append(resources, item)
+		// Insert the item into the cache ahead of time
+		if err := c.Insert(item); err != nil {
+			b.Error(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := c.Delete(resources[i])
+		if err != nil {
+			b.Error(err)
+		}
+	}
+	resultCache = c
+}
 
 type testSingleIndexer struct{}
 
@@ -149,4 +591,15 @@ func (testSingleIndexer) FromArgs(args ...any) ([]byte, error) {
 
 func (testSingleIndexer) FromResource(*pbresource.Resource) (bool, []byte, error) {
 	return false, nil, nil
+}
+
+func getTestIndexer() *index.Index {
+	return indexers.DecodedSingleIndexer(
+		"uuid",
+		index.SingleValueFromArgs(func(value string) ([]byte, error) {
+			return []byte(value), nil
+		}),
+		func(r *resource.DecodedResource[*pbresource.Resource]) (bool, []byte, error) {
+			return true, []byte(r.Id.Name), nil
+		})
 }

--- a/internal/controller/cache/cache_bench_test.go
+++ b/internal/controller/cache/cache_bench_test.go
@@ -1,0 +1,152 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+
+	"github.com/hashicorp/consul/internal/controller/cache/index"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+var resultCache Cache
+
+// From Cache interface
+func Benchmark_cache_AddType_New(b *testing.B) {
+	c := New()
+
+	// Always add a new type since if existing then it is just a map access
+	newTypes := make([]*pbresource.Type, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+
+		newType := &pbresource.Type{
+			Group:        u,
+			GroupVersion: u,
+			Kind:         u,
+		}
+		newTypes = append(newTypes, newType)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.AddType(newTypes[i])
+	}
+	// store result as package level variable to ensure not removed by compiler
+	resultCache = c
+}
+
+func Benchmark_cache_AddType_Existing(b *testing.B) {
+	c := New()
+
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		b.Error(err)
+	}
+
+	newType := &pbresource.Type{
+		Group:        u,
+		GroupVersion: u,
+		Kind:         u,
+	}
+
+	c.AddType(newType)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.AddType(newType)
+	}
+	// store result as package level variable to ensure not removed by compiler
+	resultCache = c
+}
+
+func Benchmark_cache_AddIndex(b *testing.B) {
+	c := New()
+
+	newTypes := make([]*pbresource.Type, 0, b.N)
+	newIndices := make([]*index.Index, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+
+		newType := &pbresource.Type{
+			Group:        u,
+			GroupVersion: u,
+			Kind:         u,
+		}
+		newTypes = append(newTypes, newType)
+
+		newIndex := index.New(u, testSingleIndexer{})
+		newIndices = append(newIndices, newIndex)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := c.AddIndex(newTypes[i], newIndices[i])
+		if err != nil {
+			b.Error(err)
+		}
+	}
+	resultCache = c
+}
+
+func Benchmark_cache_AddQuery(b *testing.B) {
+	c := New()
+
+	names := make([]string, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		u, err := uuid.GenerateUUID()
+		if err != nil {
+			b.Error(err)
+		}
+
+		names = append(names, u)
+	}
+
+	queryFunc := func(c ReadOnlyCache, args ...any) (ResourceIterator, error) {
+		return nil, nil
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := c.AddQuery(names[i], queryFunc)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+
+	resultCache = c
+}
+
+// From ReadOnlyCache interface
+func Benchmark_cache_Get(b *testing.B) {}
+
+func Benchmark_cache_List(b *testing.B) {}
+
+func Benchmark_cache_ListIterator(b *testing.B) {}
+
+func Benchmark_cache_Parents(b *testing.B) {}
+
+func Benchmark_cache_ParentsIterator(b *testing.B) {}
+
+func Benchmark_cache_Query(b *testing.B) {}
+
+// From WriteCache interface
+func Benchmark_cache_Insert(b *testing.B) {}
+
+func Benchmark_cache_Delete(b *testing.B) {}
+
+type testSingleIndexer struct{}
+
+func (testSingleIndexer) FromArgs(args ...any) ([]byte, error) {
+	return index.ReferenceOrIDFromArgs(args)
+}
+
+func (testSingleIndexer) FromResource(*pbresource.Resource) (bool, []byte, error) {
+	return false, nil, nil
+}

--- a/internal/controller/cache/kind.go
+++ b/internal/controller/cache/kind.go
@@ -14,16 +14,16 @@ import (
 const IDIndex = "id"
 
 type kindIndices struct {
-	mu sync.RWMutex
+	indices map[string]*index.Index
 
 	it unversionedType
 
-	indices map[string]*index.Index
+	mu sync.RWMutex
 }
 
 func newKindIndices() *kindIndices {
 	kind := &kindIndices{
-		indices: make(map[string]*index.Index),
+		indices: make(map[string]*index.Index, 1),
 	}
 
 	// add the id index


### PR DESCRIPTION
### Description

Caching performance improvements and benchmarks

* 50% improvement for `cache.AddType` on existing types
* 10% improvement for `cache.AddType` for new types
* 10% improvement for `cache.AddIndex`
* 50% reduction of size of `kindIndices`

old:
```
go test -bench Benchmark_cache_AddIndex -run ^$ -count 5 ./internal/controller/cache
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/consul/internal/controller/cache
Benchmark_cache_AddIndex-12      1600906               732.0 ns/op
Benchmark_cache_AddIndex-12      1622610               778.1 ns/op
Benchmark_cache_AddIndex-12      1922361               856.4 ns/op
Benchmark_cache_AddIndex-12      1581726               737.5 ns/op
Benchmark_cache_AddIndex-12      1658888               809.6 ns/op
PASS
ok      github.com/hashicorp/consul/internal/controller/cache   29.278s

go test -bench Benchmark_cache_AddType -run ^$ -count 5 -benchmem ./internal/controller/cache
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/consul/internal/controller/cache
Benchmark_cache_AddType_New-12           1757521               773.1 ns/op           790 B/op          9 allocs/op
Benchmark_cache_AddType_New-12           1915255               743.8 ns/op           772 B/op          9 allocs/op
Benchmark_cache_AddType_New-12           1684995               844.1 ns/op           800 B/op          9 allocs/op
Benchmark_cache_AddType_New-12           1840144               741.4 ns/op           780 B/op          9 allocs/op
Benchmark_cache_AddType_New-12           1781332               789.1 ns/op           787 B/op          9 allocs/op
Benchmark_cache_AddType_Existing-12     34208458                35.75 ns/op            0 B/op          0 allocs/op
Benchmark_cache_AddType_Existing-12     34524012                35.45 ns/op            0 B/op          0 allocs/op
Benchmark_cache_AddType_Existing-12     34367828                35.03 ns/op            0 B/op          0 allocs/op
Benchmark_cache_AddType_Existing-12     34876370                36.42 ns/op            0 B/op          0 allocs/op
Benchmark_cache_AddType_Existing-12     34563870                34.63 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/hashicorp/consul/internal/controller/cache   31.074s
```

new:
```
go test -bench Benchmark_cache_AddIndex -run ^$ -count 5 ./internal/controller/cache
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/consul/internal/controller/cache
Benchmark_cache_AddIndex-12      2092167               702.0 ns/op
Benchmark_cache_AddIndex-12      1912968               708.4 ns/op
Benchmark_cache_AddIndex-12      1838739               738.5 ns/op
Benchmark_cache_AddIndex-12      1727347               757.3 ns/op
Benchmark_cache_AddIndex-12      1931530               703.1 ns/op
PASS
ok      github.com/hashicorp/consul/internal/controller/cache   27.553s

go test -bench Benchmark_cache_AddType -run ^$ -count 5 -benchmem ./internal/controller/cache
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/consul/internal/controller/cache
Benchmark_cache_AddType_New-12           1810838               685.5 ns/op           783 B/op          9 allocs/op
Benchmark_cache_AddType_New-12           1774274               759.1 ns/op           788 B/op          9 allocs/op
Benchmark_cache_AddType_New-12           2014064               692.9 ns/op           762 B/op          9 allocs/op
Benchmark_cache_AddType_New-12           1886276               708.6 ns/op           775 B/op          9 allocs/op
Benchmark_cache_AddType_New-12           1704679               816.6 ns/op           797 B/op          9 allocs/op
Benchmark_cache_AddType_Existing-12     65070776                18.18 ns/op            0 B/op          0 allocs/op
Benchmark_cache_AddType_Existing-12     65581833                18.23 ns/op            0 B/op          0 allocs/op
Benchmark_cache_AddType_Existing-12     65527668                18.07 ns/op            0 B/op          0 allocs/op
Benchmark_cache_AddType_Existing-12     67483812                18.10 ns/op            0 B/op          0 allocs/op
Benchmark_cache_AddType_Existing-12     65270455                18.20 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/hashicorp/consul/internal/controller/cache   30.591s
```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
