### PR TITLE
Decouple xds capacity controller and raft-autopilot

### DIFF
--- a/.changelog/20511.txt
+++ b/.changelog/20511.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Remove code coupling where the xDS capacity controller could negatively affect raft autopilot performance.
+```


### PR DESCRIPTION
This prevents a potential bug where raft-autopilot could deadlock while attempting to execute `AutopilotDelegate.NotifyState()` on an xdscapacity controller that has stopped / delayed consuming messages.

The following line of logic appears that it could be a potential problem:

1. The call to `countProxies()` can wait for up to 1 minute before retrying to load info. It also never resets its counter, which means a significant wait is more likely. https://github.com/hashicorp/consul/blob/v1.17.2/agent/consul/xdscapacity/capacity.go#L194

2. `countProxies()` shares a loop with the consumption from the `serverCh` that has counts published to it. https://github.com/hashicorp/consul/blob/v1.17.2/agent/consul/xdscapacity/capacity.go#L93-L97

3. The `serverCh` channel is published to by the `SetServerCount()` function. https://github.com/hashicorp/consul/blob/v1.17.2/agent/consul/xdscapacity/capacity.go#L113

4. The autopilot state delegate calls `SetServerCount()` on every change. https://github.com/hashicorp/consul/blob/main/agent/consul/autopilot.go#L68

5. Autopilot acquires an exclusive lock and waits for the delegate to finish execution. https://github.com/hashicorp/raft-autopilot/blob/v0.1.6/state.go#L390-L393