### PR TITLE
Fix logging when we fail to export metrics to hcp

### DIFF
--- a/.changelog/20514.txt
+++ b/.changelog/20514.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+hcp: fix error logs when failing to push metrics
+```

--- a/agent/hcp/deps.go
+++ b/agent/hcp/deps.go
@@ -68,7 +68,7 @@ func newSink(
 	logger := hclog.FromContext(ctx)
 
 	// Set the global OTEL error handler. Without this, on any failure to publish metrics in
-	// otelExporter.Export, the error is logger to stderr without the formatting or group
+	// otelExporter.Export, the default OTEL handler logs to stderr without the formatting or group
 	// that hclog provides. Here we override that global error handler once so logs are
 	// in the standard format and include "hcp" in the group name like:
 	// 2024-02-06T22:35:19.072Z [ERROR] agent.hcp: failed to export metrics: failed to export metrics: code 404: 404 page not found

--- a/agent/hcp/deps_test.go
+++ b/agent/hcp/deps_test.go
@@ -21,7 +21,7 @@ func TestSink(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	s, err := sink(ctx, mockMetricsClient{}, &hcpProviderImpl{})
+	s, err := newSink(ctx, mockMetricsClient{}, &hcpProviderImpl{})
 
 	require.NotNil(t, s)
 	require.NoError(t, err)


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

Testing 1.18.x I noticed some stderr log lines w/o the normal hclog formatting:

```
2024-02-06T22:35:18.972Z [ERROR] agent.envoy: Error receiving new DeltaDiscoveryRequest; closing request channel: error="rpc error: code = Canceled desc = context canceled"
2024-02-06T22:35:19.072Z [ERROR] agent.envoy: Error receiving new DeltaDiscoveryRequest; closing request channel: error="rpc error: code = Canceled desc = context canceled"
2024/02/06 22:35:31 failed to export metrics: failed to export metrics: code 404: 404 page not found
2024/02/06 22:44:31 failed to export metrics: failed to export metrics: code 404: 404 page not found
```

Here in OTEL there's a `GlobalHandler` that defaults to logging to stderr: https://github.com/open-telemetry/opentelemetry-go/blob/main/internal/global/handler.go#L96

The OTEL PeriodicReader calls that here whenever `otelExporter.Export` fails: https://github.com/open-telemetry/opentelemetry-go/blob/e3eb3f7538e790a853c3ce210cf48123ddd5ca20/sdk/metric/periodic_reader.go#L181

This change here is to override the default global error handler with one that logs to the hclog.Logger instead

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
