### PR TITLE
Register the multicluster types for the catalogtest integration tests

### DIFF
--- a/internal/catalog/catalogtest/run_test.go
+++ b/internal/catalog/catalogtest/run_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/consul/internal/catalog"
 	"github.com/hashicorp/consul/internal/controller/controllertest"
+	"github.com/hashicorp/consul/internal/multicluster"
 	"github.com/hashicorp/consul/internal/resource/reaper"
 	rtest "github.com/hashicorp/consul/internal/resource/resourcetest"
 	"github.com/hashicorp/consul/proto-public/pbresource"
@@ -21,7 +22,7 @@ func runInMemResourceServiceAndControllers(t *testing.T) pbresource.ResourceServ
 	t.Helper()
 
 	return controllertest.NewControllerTestBuilder().
-		WithResourceRegisterFns(catalog.RegisterTypes).
+		WithResourceRegisterFns(catalog.RegisterTypes, multicluster.RegisterTypes).
 		WithControllerRegisterFns(
 			reaper.RegisterControllers,
 			catalog.RegisterControllers,


### PR DESCRIPTION
### Description

In Consul Enterprise the failover controller depends on the multicluster types so they need to be registered here to prevent a panic.

### Testing & Reproduction steps

N/A - the change doesn't affect Consul CE and already has been made in Consul Enterprise. This is just synchronizing the files.
