### PR TITLE
V1 Compat Exported Services Controller Optimizations

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1043,10 +1043,11 @@ func (s *Server) registerControllers(deps Deps, proxyUpdater ProxyUpdater) error
 		})
 
 		auth.RegisterControllers(s.controllerManager, auth.DefaultControllerDependencies())
+		multicluster.RegisterControllers(s.controllerManager)
+	} else {
+		shim := NewExportedServicesShim(s)
+		multicluster.RegisterCompatControllers(s.controllerManager, multicluster.DefaultCompatControllerDependencies(shim))
 	}
-
-	shim := NewExportedServicesShim(s)
-	multicluster.RegisterControllers(s.controllerManager, multicluster.DefaultControllerDependencies(shim))
 
 	reaper.RegisterControllers(s.controllerManager)
 

--- a/internal/multicluster/exports.go
+++ b/internal/multicluster/exports.go
@@ -26,16 +26,26 @@ func RegisterTypes(r resource.Registry) {
 }
 
 type ControllerDependencies = controllers.Dependencies
+type CompatControllerDependencies = controllers.CompatDependencies
 
-func DefaultControllerDependencies(ac v1compat.AggregatedConfig) ControllerDependencies {
+func DefaultControllerDependencies() ControllerDependencies {
 	return ControllerDependencies{
 		ExportedServicesSamenessGroupsExpander: exportedServicesSamenessGroupExpander.New(),
-		ConfigEntryExports:                     ac,
+	}
+}
+
+func DefaultCompatControllerDependencies(ac v1compat.AggregatedConfig) CompatControllerDependencies {
+	return CompatControllerDependencies{
+		ConfigEntryExports: ac,
 	}
 }
 
 // RegisterControllers registers controllers for the multicluster types with
 // the given controller Manager.
-func RegisterControllers(mgr *controller.Manager, deps ControllerDependencies) {
-	controllers.Register(mgr, deps)
+func RegisterControllers(mgr *controller.Manager) {
+	controllers.Register(mgr, DefaultControllerDependencies())
+}
+
+func RegisterCompatControllers(mgr *controller.Manager, deps CompatControllerDependencies) {
+	controllers.RegisterCompat(mgr, deps)
 }

--- a/internal/multicluster/internal/controllers/register.go
+++ b/internal/multicluster/internal/controllers/register.go
@@ -11,10 +11,16 @@ import (
 
 type Dependencies struct {
 	ExportedServicesSamenessGroupsExpander exportedservices.ExportedServicesSamenessGroupExpander
-	ConfigEntryExports                     v1compat.AggregatedConfig
+}
+
+type CompatDependencies struct {
+	ConfigEntryExports v1compat.AggregatedConfig
 }
 
 func Register(mgr *controller.Manager, deps Dependencies) {
 	mgr.Register(exportedservices.Controller(deps.ExportedServicesSamenessGroupsExpander))
+}
+
+func RegisterCompat(mgr *controller.Manager, deps CompatDependencies) {
 	mgr.Register(v1compat.Controller(deps.ConfigEntryExports))
 }

--- a/internal/multicluster/internal/controllers/v1compat/controller.go
+++ b/internal/multicluster/internal/controllers/v1compat/controller.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/controller/cache"
+	"github.com/hashicorp/consul/internal/controller/cache/index"
 	"github.com/hashicorp/consul/internal/multicluster/internal/types"
 	"github.com/hashicorp/consul/internal/resource"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
@@ -105,30 +107,48 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 		EnterpriseMeta: *entMeta,
 	}
 
-	partitionExports, err := resource.ListDecodedResource[*pbmulticluster.PartitionExportedServices](ctx, rt.Client, &pbresource.ListRequest{
-		Type:    pbmulticluster.PartitionExportedServicesType,
-		Tenancy: req.ID.Tenancy,
-	})
+	partitionExports, err := cache.ListDecoded[*pbmulticluster.PartitionExportedServices](
+		rt.Cache,
+		pbmulticluster.PartitionExportedServicesType,
+		"id",
+		&pbresource.ID{
+			Type:    pbmulticluster.PartitionExportedServicesType,
+			Tenancy: req.ID.Tenancy,
+		},
+		index.IndexQueryOptions{Prefix: true},
+	)
 
 	if err != nil {
 		rt.Logger.Error("error retrieving partition exported services", "error", err)
 		return err
 	}
 
-	namespaceExports, err := resource.ListDecodedResource[*pbmulticluster.NamespaceExportedServices](ctx, rt.Client, &pbresource.ListRequest{
-		Type:    pbmulticluster.NamespaceExportedServicesType,
-		Tenancy: req.ID.Tenancy,
-	})
+	namespaceExports, err := cache.ListDecoded[*pbmulticluster.NamespaceExportedServices](
+		rt.Cache,
+		pbmulticluster.NamespaceExportedServicesType,
+		"id",
+		&pbresource.ID{
+			Type:    pbmulticluster.NamespaceExportedServicesType,
+			Tenancy: req.ID.Tenancy,
+		},
+		index.IndexQueryOptions{Prefix: true},
+	)
 
 	if err != nil {
 		rt.Logger.Error("error retrieving namespace exported service", "error", err)
 		return err
 	}
 
-	serviceExports, err := resource.ListDecodedResource[*pbmulticluster.ExportedServices](ctx, rt.Client, &pbresource.ListRequest{
-		Type:    pbmulticluster.ExportedServicesType,
-		Tenancy: req.ID.Tenancy,
-	})
+	serviceExports, err := cache.ListDecoded[*pbmulticluster.ExportedServices](
+		rt.Cache,
+		pbmulticluster.ExportedServicesType,
+		"id",
+		&pbresource.ID{
+			Type:    pbmulticluster.ExportedServicesType,
+			Tenancy: req.ID.Tenancy,
+		},
+		index.IndexQueryOptions{Prefix: true},
+	)
 
 	if err != nil {
 		rt.Logger.Error("error retrieving exported services", "error", err)


### PR DESCRIPTION
### Description

* Don't start the v2 exported services controller in v1 mode.
* Use the controller cache.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
