### PR TITLE
Fix: avoid redundant logs on failures to export metrics

### DIFF
--- a/agent/auto-config/auto_config_test.go
+++ b/agent/auto-config/auto_config_test.go
@@ -850,7 +850,7 @@ func startedAutoConfig(t *testing.T, autoEncrypt bool) testAutoConfig {
 		originalToken: originalToken,
 		initialRoots:  indexedRoots,
 		initialCert:   cert,
-		extraCerts:    extraCerts,
+		extraCerts:    exrts,
 		stop:          cancel,
 	}
 }

--- a/agent/auto-config/auto_config_test.go
+++ b/agent/auto-config/auto_config_test.go
@@ -850,7 +850,7 @@ func startedAutoConfig(t *testing.T, autoEncrypt bool) testAutoConfig {
 		originalToken: originalToken,
 		initialRoots:  indexedRoots,
 		initialCert:   cert,
-		extraCerts:    exrts,
+		extraCerts:    extraCerts,
 		stop:          cancel,
 	}
 }

--- a/agent/hcp/client/http_client.go
+++ b/agent/hcp/client/http_client.go
@@ -28,7 +28,7 @@ const (
 )
 
 // NewHTTPClient configures the retryable HTTP client.
-func NewHTTPClient(tlsCfg *tls.Config, source oauth2.TokenSource, logger hclog.Logger) *retryablehttp.Client {
+func NewHTTPClient(tlsCfg *tls.Config, source oauth2.TokenSource) *retryablehttp.Client {
 	tlsTransport := cleanhttp.DefaultPooledTransport()
 	tlsTransport.TLSClientConfig = tlsCfg
 
@@ -43,8 +43,9 @@ func NewHTTPClient(tlsCfg *tls.Config, source oauth2.TokenSource, logger hclog.L
 	}
 
 	retryClient := &retryablehttp.Client{
-		HTTPClient:   client,
-		Logger:       logger,
+		HTTPClient: client,
+		// We already log failed requests elsewhere, we pass a null logger here to avoid redundant logs.
+		Logger:       hclog.NewNullLogger(),
 		RetryWaitMin: defaultRetryWaitMin,
 		RetryWaitMax: defaultRetryWaitMax,
 		RetryMax:     defaultRetryMax,

--- a/agent/hcp/client/http_client_test.go
+++ b/agent/hcp/client/http_client_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/agent/hcp/config"
-	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +17,7 @@ func TestNewHTTPClient(t *testing.T) {
 	mockHCPCfg, err := mockCfg.HCPConfig()
 	require.NoError(t, err)
 
-	client := NewHTTPClient(mockHCPCfg.APITLSConfig(), mockHCPCfg, hclog.NewNullLogger())
+	client := NewHTTPClient(mockHCPCfg.APITLSConfig(), mockHCPCfg)
 	require.NotNil(t, client)
 
 	var req *http.Request

--- a/agent/hcp/telemetry_provider.go
+++ b/agent/hcp/telemetry_provider.go
@@ -300,10 +300,7 @@ func (h *hcpProviderImpl) updateHTTPConfig(cfg config.CloudConfigurer) error {
 	if err != nil {
 		return fmt.Errorf("failed to configure telemetry HTTP client: %v", err)
 	}
-	h.httpCfg.client = client.NewHTTPClient(
-		hcpCfg.APITLSConfig(),
-		hcpCfg,
-		h.logger.Named("hcp_telemetry_client"))
+	h.httpCfg.client = client.NewHTTPClient(hcpCfg.APITLSConfig(), hcpCfg)
 
 	return nil
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

I'm seeing redundant log lines on failures to push metrics to HCP:

> 2024-02-07T14:22:37.358Z [ERROR] agent.hcp.hcp_telemetry_client: request failed: error="Post \"[https://consul-telemetry.hcp.dev/otlp/v1/metrics\\](https://consul-telemetry.hcp.dev/otlp/v1/metrics%5C%5C)": http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error" method=POST url=https://consul-telemetry.hcp.dev/otlp/v1/metrics

> 2024/02/07 14:22:37 failed to export metrics: failed to post metrics: POST https://consul-telemetry.hcp.dev/otlp/v1/metrics giving up after 1 attempt(s): Post "https://consul-telemetry.hcp.dev/otlp/v1/metrics": http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error

We log in two places:
- here in the go-retryablehttp client: https://github.com/hashicorp/go-retryablehttp/blob/4165cf8897205a879a06b20d1ed0a2a76fbb6a17/client.go#L669
- here in the metrics exporter: https://github.com/hashicorp/consul/blob/47c5c8b7a1c9bbcbbb8aa367f99f0c2a6980c4d3/agent/hcp/client/metrics_client.go#L75

The fix here is to pass a NullLogger to the http client so:
- we do not get redundant log lines on errors
- we get the log lines with the name/group that we use elsewhere. After the other logging change this will be the `hcp.telemetry` group logs: https://github.com/hashicorp/consul/pull/20514

An alternative approach is to combine this PR with the other logging-related PR: https://github.com/hashicorp/consul/pull/20514. And:
- set the otel global logger to a no-op logger that does nothing
- also disable logging in the go-retryablehttp client (NullLogger as in this PR)
- _only_ log in `ExportMetrics`

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
