### PR TITLE
[CC-7434] Skip collecting data directory metrics in dev mode

### DIFF
--- a/lib/hoststats/collector.go
+++ b/lib/hoststats/collector.go
@@ -87,7 +87,7 @@ func (c *Collector) collect() {
 	// Determine up-time
 	uptime, err := host.Uptime()
 	if err != nil {
-		c.logger.Error("failed to collect uptime stats", "error", err)
+		c.logger.Debug("failed to collect uptime stats", "error", err)
 		uptime = 0
 	}
 	hs.Uptime = uptime
@@ -95,7 +95,7 @@ func (c *Collector) collect() {
 	// Collect memory stats
 	mstats, err := c.collectMemoryStats()
 	if err != nil {
-		c.logger.Error("failed to collect memory stats", "error", err)
+		c.logger.Debug("failed to collect memory stats", "error", err)
 		mstats = &MemoryStats{}
 	}
 	hs.Memory = mstats
@@ -103,7 +103,7 @@ func (c *Collector) collect() {
 	// Collect cpu stats
 	cpus, err := c.collectCPUStats()
 	if err != nil {
-		c.logger.Error("failed to collect cpu stats", "error", err)
+		c.logger.Debug("failed to collect cpu stats", "error", err)
 		cpus = []*CPUStats{}
 	}
 	hs.CPU = cpus
@@ -112,7 +112,7 @@ func (c *Collector) collect() {
 	if c.dataDir != "" {
 		diskStats, err := c.collectDiskStats(c.dataDir)
 		if err != nil {
-			c.logger.Error("failed to collect dataDir disk stats", "error", err)
+			c.logger.Debug("failed to collect dataDir disk stats", "error", err)
 		}
 		hs.DataDirStats = diskStats
 	}

--- a/lib/hoststats/collector.go
+++ b/lib/hoststats/collector.go
@@ -109,11 +109,13 @@ func (c *Collector) collect() {
 	hs.CPU = cpus
 
 	// Collect disk stats
-	diskStats, err := c.collectDiskStats(c.dataDir)
-	if err != nil {
-		c.logger.Error("failed to collect dataDir disk stats", "error", err)
+	if c.dataDir != "" {
+		diskStats, err := c.collectDiskStats(c.dataDir)
+		if err != nil {
+			c.logger.Error("failed to collect dataDir disk stats", "error", err)
+		}
+		hs.DataDirStats = diskStats
 	}
-	hs.DataDirStats = diskStats
 
 	// Update the collected status object.
 	c.hostStatsLock.Lock()

--- a/lib/hoststats/collector_test.go
+++ b/lib/hoststats/collector_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package hoststats
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+// TestCollector_collect validates that metrics for host resource usage
+// are collected as expected.
+func TestCollector_collect(t *testing.T) {
+	testcases := map[string]struct {
+		skipDataDir bool
+	}{
+		"WithDataDirectory": {},
+		"NoDataDirectory": {
+			skipDataDir: true,
+		},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			dataDir := ""
+			if !tc.skipDataDir {
+				dataDir = testutil.TempDir(t, "consul-config")
+			}
+
+			collector := initCollector(hclog.NewNullLogger(), dataDir)
+			collector.collect()
+
+			hs := collector.hostStats
+			require.NotNil(t, hs)
+			require.Greater(t, hs.Uptime, uint64(0))
+			require.NotNil(t, hs.Memory)
+			require.NotNil(t, hs.CPU)
+			if !tc.skipDataDir {
+				require.NotNil(t, hs.DataDirStats)
+			} else {
+				require.Nil(t, hs.DataDirStats)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
Fixes an issue where in dev mode, the data directory is not set, so this metrics collection would always fail and logs errors.

```
2024-02-07T14:15:06.466-0600 [ERROR] agent.host_stats: failed to collect dataDir disk stats: error="failed to collect disk usage stats: no such file or directory"
2024-02-07T14:15:16.468-0600 [ERROR] agent.host_stats: failed to collect dataDir disk stats: error="failed to collect disk usage stats: no such file or directory"
2024-02-07T14:15:26.468-0600 [ERROR] agent.host_stats: failed to collect dataDir disk stats: error="failed to collect disk usage stats: no such file or directory"
```


### Testing & Reproduction steps
Checked that metrics were skipped in dev mode:
1. Started consul in dev mode (`consul agent -dev`)
2. Inspected the logs to ensure this error was no longer outputted

Checked that metrics were collected otherwise:
1. Started Consul in server mode and not dev mode (`consul agent -server`)
2. Fetched the agent metrics (`/v1/agent/metrics`) and checked that there were data directory metrics:

```
...
        {
            "Name": "consul.mkam-host.host.disk.available",
            "Value": 135710160000,
            "Labels": {
                "path": ".mkam/data-dir"
            }
        },
        {
            "Name": "consul.mkam-host.host.disk.inodes_percent",
            "Value": 0.44313493,
            "Labels": {
                "path": ".mkam/data-dir"
            }
        },
...
```

### Links
https://hashicorp.atlassian.net/browse/CC-7434

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
