### PR TITLE
[NET-7450] Fix listenerToProtocol function for input

### DIFF
--- a/internal/mesh/internal/controllers/apigateways/controller.go
+++ b/internal/mesh/internal/controllers/apigateways/controller.go
@@ -5,6 +5,8 @@ package apigateways
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/hashicorp/consul/internal/controller"
 	"github.com/hashicorp/consul/internal/mesh/internal/controllers/apigateways/fetcher"
@@ -67,6 +69,7 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 
 	serviceData, err := anypb.New(service)
 	if err != nil {
+		rt.Logger.Trace("error creating the serviceData", "apigatewayID", req.ID, "error", err)
 		return err
 	}
 
@@ -81,14 +84,16 @@ func (r *reconciler) Reconcile(ctx context.Context, rt controller.Runtime, req c
 	})
 
 	if err != nil {
+		rt.Logger.Trace("error writing the service", "apigatewayID", req.ID, "error", err)
 		return err
 	}
 
+	rt.Logger.Trace("successfully reconciled APIGateway", "apigatewayID", req.ID)
 	return nil
 }
 
 func listenerProtocolToCatalogProtocol(listenerProtocol string) pbcatalog.Protocol {
-	switch listenerProtocol {
+	switch strings.ToLower(listenerProtocol) {
 	case "http":
 		return pbcatalog.Protocol_PROTOCOL_HTTP
 	case "tcp":
@@ -96,6 +101,6 @@ func listenerProtocolToCatalogProtocol(listenerProtocol string) pbcatalog.Protoc
 	case "grpc":
 		return pbcatalog.Protocol_PROTOCOL_GRPC
 	default:
-		panic("this is a programmer error, the only available protocols are tcp/http/grpc")
+		panic(fmt.Sprintf("this is a programmer error, the only available protocols are tcp/http/grpc. You provided: %q", listenerProtocol))
 	}
 }

--- a/internal/mesh/internal/controllers/apigateways/controller_test.go
+++ b/internal/mesh/internal/controllers/apigateways/controller_test.go
@@ -81,6 +81,11 @@ func (suite *apigatewayControllerSuite) TestReconciler_Reconcile() {
 						TargetPort:  "tcp-listener",
 						Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
 					},
+					{
+						VirtualPort: 8081,
+						TargetPort:  "tcp-upper",
+						Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
+					},
 				},
 			}
 			req := controller.Request{ID: id}
@@ -139,6 +144,11 @@ func (suite *apigatewayControllerSuite) setupSuiteWithTenancy(tenancy *pbresourc
 					Name:     "tcp-listener",
 					Port:     8080,
 					Protocol: "tcp",
+				},
+				{
+					Name:     "tcp-upper",
+					Port:     8081,
+					Protocol: "TCP",
 				},
 			},
 		}).


### PR DESCRIPTION
### Description

Makes the listenerToProtocol function more forgiving of different cased input (in the case that input is `TCP` for example).

### Testing & Reproduction steps


### Links


### PR Checklist

* [X] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
