### PR TITLE
chor: remove temporary CONSUL_HCP_LINK_ENABLED env flag

### DIFF
--- a/ui/packages/consul-ui/app/services/hcp-link-status.js
+++ b/ui/packages/consul-ui/app/services/hcp-link-status.js
@@ -9,14 +9,12 @@ import { tracked } from '@glimmer/tracking';
 const LOCAL_STORAGE_KEY = 'consul:hideHcpLinkBanner';
 
 export default class HcpLinkStatus extends Service {
-  @service('env') env;
   @service abilities;
   @tracked
   userDismissedBanner = false;
 
   get shouldDisplayBanner() {
-    const hcpLinkEnabled = this.env.var('CONSUL_HCP_LINK_ENABLED');
-    return !this.userDismissedBanner && this.hasPermissionToLink && hcpLinkEnabled;
+    return !this.userDismissedBanner && this.hasPermissionToLink;
   }
 
   get hasPermissionToLink() {

--- a/ui/packages/consul-ui/tests/acceptance/link-to-hcp-test.js
+++ b/ui/packages/consul-ui/tests/acceptance/link-to-hcp-test.js
@@ -6,7 +6,6 @@
 import { module, test } from 'qunit';
 import { click, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { EnvStub } from 'consul-ui/services/env';
 
 const bannerSelector = '[data-test-link-to-hcp-banner]';
 const linkToHcpSelector = '[data-test-link-to-hcp]';
@@ -16,14 +15,6 @@ module('Acceptance | link to hcp', function (hooks) {
   hooks.beforeEach(function () {
     // clear local storage so we don't have any settings
     window.localStorage.clear();
-    this.owner.register(
-      'service:env',
-      class Stub extends EnvStub {
-        stubEnv = {
-          CONSUL_HCP_LINK_ENABLED: true,
-        };
-      }
-    );
   });
 
   test('the banner and nav item are initially displayed on services page', async function (assert) {
@@ -43,18 +34,5 @@ module('Acceptance | link to hcp', function (hooks) {
     assert.dom(bannerSelector).doesNotExist('Banner is still gone after refresh');
     // link to HCP nav item still there
     assert.dom(linkToHcpSelector).isVisible('Link to HCP nav item is visible by default');
-  });
-
-  test('the banner is not displayed if the env var is not set', async function (assert) {
-    this.owner.register(
-      'service:env',
-      class Stub extends EnvStub {
-        stubEnv = {};
-      }
-    );
-    // default route is services page so we're good here
-    await visit('/');
-    // Expect the banner to be visible by default
-    assert.dom(bannerSelector).doesNotExist('Banner is not here');
   });
 });

--- a/ui/packages/consul-ui/tests/integration/components/link-to-hcp-banner-test.js
+++ b/ui/packages/consul-ui/tests/integration/components/link-to-hcp-banner-test.js
@@ -27,14 +27,6 @@ module('Integration | Component | link-to-hcp-banner', function (hooks) {
 
   hooks.beforeEach(function () {
     this.owner.register('service:hcp-link-status', HcpLinkStatusStub);
-    this.owner.register(
-      'service:env',
-      class Stub extends EnvStub {
-        stubEnv = {
-          CONSUL_HCP_LINK_ENABLED: true,
-        };
-      }
-    );
   });
 
   test('it renders banner when hcp-link-status says it should', async function (assert) {


### PR DESCRIPTION
### Description

Remove temporary `CONSUL_HCP_LINK_ENABLED` env flag.
PR it was added: https://github.com/hashicorp/consul/pull/20392
<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps
1. go to consul 
2. go to Service list - link to HCP banner is visible
3. set CONSUL_HCP_LINK_ENABLED to true and then to false (from cookies or with running locally Scenario('CONSUL_HCP_LINK_ENABLED=true')) - banner is still there for any value
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
