### PR TITLE
docs: document behaviour of tls.https.verify_outgoing

### DIFF
--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -2153,7 +2153,8 @@ specially crafted certificate signed by the CA can be used to gain full access t
       will not make use of TLS for outgoing connections. This applies to clients
       and servers as both will make outgoing connections. This setting does not
       apply to the gRPC interface as Consul makes no outgoing connections on this
-      interface.
+      interface. If set to true for the HTTPS interface, this will apply to [watches](/consul/docs/dynamic-app-config/watches)
+      because internally watches are implemented by making HTTPS requests to the local agent.
 
   - `grpc` ((#tls_grpc)) Provides settings for the gRPC/xDS interface. To enable
     the gRPC interface you must define a port via [`ports.grpc_tls`](#grpc_tls_port).

--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -2153,8 +2153,7 @@ specially crafted certificate signed by the CA can be used to gain full access t
       will not make use of TLS for outgoing connections. This applies to clients
       and servers as both will make outgoing connections. This setting does not
       apply to the gRPC interface as Consul makes no outgoing connections on this
-      interface. If set to true for the HTTPS interface, this will apply to [watches](/consul/docs/dynamic-app-config/watches)
-      because internally watches are implemented by making HTTPS requests to the local agent.
+      interface. When set to true for the HTTPS interface, this parameter applies to [watches](/consul/docs/dynamic-app-config/watches), which operate by making HTTPS requests to the local agent.
 
   - `grpc` ((#tls_grpc)) Provides settings for the gRPC/xDS interface. To enable
     the gRPC interface you must define a port via [`ports.grpc_tls`](#grpc_tls_port).


### PR DESCRIPTION
At first it's not clear what verify_outgoing would do for the https listener as it seems like Consul agent's don't make https requests. Upon further investigation, it's clear that Consul agents do make https requests in the following scenarios:
- to implement watches
- to perform checks

In the first scenario, this setting is used here:
https://github.com/hashicorp/consul/blob/a1c8d4dd19caad13edf2d86441d1b7f9bbdc9c34/agent/config/runtime.go#L1725

In the second scenario, it's actually the internal_rpc setting that is used:
https://github.com/hashicorp/consul/blob/a1c8d4dd19caad13edf2d86441d1b7f9bbdc9c34/tlsutil/config.go#L903
