### PR TITLE
NET-7637 / NET-7659/NET-7636/NET-7647/NET-7648/NET-7646/NET-7649/NET-7645 - Multiple DNS v2 fixes

### DIFF
--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	ErrECSNotGlobal = fmt.Errorf("ECS response is not global")
-	ErrNoData       = fmt.Errorf("no data")
-	ErrNotFound     = fmt.Errorf("not found")
-	ErrNotSupported = fmt.Errorf("not supported")
+	ErrECSNotGlobal       = fmt.Errorf("ECS response is not global")
+	ErrNoData             = fmt.Errorf("no data")
+	ErrNotFound           = fmt.Errorf("not found")
+	ErrNotSupported       = fmt.Errorf("not supported")
+	ErrNoPathToDatacenter = fmt.Errorf("no path to datacenter")
 )
 
 // ECSNotGlobalError may be used to wrap an error or nil, to indicate that the

--- a/agent/discovery/query_fetcher_v1_ce.go
+++ b/agent/discovery/query_fetcher_v1_ce.go
@@ -29,10 +29,10 @@ func queryTenancyToEntMeta(_ QueryTenancy) acl.EnterpriseMeta {
 }
 
 // fetchServiceFromSamenessGroup fetches a service from a sameness group.
-func (f *V1DataFetcher) fetchServiceFromSamenessGroup(ctx Context, req *QueryPayload, cfg *v1DataFetcherDynamicConfig) ([]*Result, error) {
+func (f *V1DataFetcher) fetchServiceFromSamenessGroup(ctx Context, req *QueryPayload, cfg *v1DataFetcherDynamicConfig, lookupType LookupType) ([]*Result, error) {
 	f.logger.Debug(fmt.Sprintf("fetchServiceFromSamenessGroup - req: %+v", req))
 	if req.Tenancy.SamenessGroup == "" {
 		return nil, errors.New("sameness groups must be provided for service lookups")
 	}
-	return f.fetchServiceBasedOnTenancy(ctx, req, cfg)
+	return f.fetchServiceBasedOnTenancy(ctx, req, cfg, lookupType)
 }

--- a/agent/dns/router_query.go
+++ b/agent/dns/router_query.go
@@ -94,6 +94,7 @@ func getQueryTenancy(reqCtx Context, queryType discovery.QueryType, querySuffixe
 			Namespace:     labels.Namespace,
 			Partition:     labels.Partition,
 			SamenessGroup: labels.SamenessGroup,
+			Datacenter:    reqCtx.DefaultDatacenter,
 		}, nil
 	}
 
@@ -108,8 +109,19 @@ func getQueryTenancy(reqCtx Context, queryType discovery.QueryType, querySuffixe
 		Namespace:  labels.Namespace,
 		Partition:  labels.Partition,
 		Peer:       labels.Peer,
-		Datacenter: labels.Datacenter,
+		Datacenter: getEffectiveDatacenter(labels, reqCtx.DefaultDatacenter),
 	}, nil
+}
+
+// getEffectiveDatacenter returns the effective datacenter from the parsed labels.
+func getEffectiveDatacenter(labels *parsedLabels, defaultDC string) string {
+	switch {
+	case labels.Datacenter != "":
+		return labels.Datacenter
+	case labels.PeerOrDatacenter != "" && labels.Peer != labels.PeerOrDatacenter:
+		return labels.PeerOrDatacenter
+	}
+	return defaultDC
 }
 
 // getQueryTypePartsAndSuffixesFromDNSMessage returns the query type, the parts, and suffixes of the query name.

--- a/agent/dns/router_query_test.go
+++ b/agent/dns/router_query_test.go
@@ -159,15 +159,20 @@ func Test_buildQueryFromDNSMessage(t *testing.T) {
 					},
 				},
 			},
+			requestContext: &Context{
+				DefaultDatacenter: "default-dc",
+				DefaultPartition:  "default-partition",
+			},
 			expectedQuery: &discovery.Query{
 				QueryType: discovery.QueryTypeWorkload,
 				QueryPayload: discovery.QueryPayload{
 					Name:     "foo",
 					PortName: "api",
 					Tenancy: discovery.QueryTenancy{
-						Namespace: "banana",
-						Partition: "orange",
-						Peer:      "apple",
+						Namespace:  "banana",
+						Partition:  "orange",
+						Peer:       "apple",
+						Datacenter: "default-dc",
 					},
 				},
 			},
@@ -186,6 +191,10 @@ func Test_buildQueryFromDNSMessage(t *testing.T) {
 					},
 				},
 			},
+			requestContext: &Context{
+				DefaultDatacenter: "default-dc",
+				DefaultPartition:  "default-partition",
+			},
 			expectedQuery: &discovery.Query{
 				QueryType: discovery.QueryTypeService,
 				QueryPayload: discovery.QueryPayload{
@@ -194,6 +203,7 @@ func Test_buildQueryFromDNSMessage(t *testing.T) {
 						Namespace:     "banana",
 						Partition:     "orange",
 						SamenessGroup: "apple",
+						Datacenter:    "default-dc",
 					},
 				},
 			},

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -652,13 +652,12 @@ func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7659 - Fix Ingress and Connect Service Lookups
 func TestDNS_ConnectServiceLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -704,13 +703,12 @@ func TestDNS_ConnectServiceLookup(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7659 - Fix Ingress and Connect Service Lookups
 func TestDNS_IngressServiceLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -1118,13 +1116,12 @@ func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7636 - Implement target having encoded IP address
 func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -1219,13 +1216,12 @@ func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7636 - Implement target having encoded IP address
 func TestDNS_AltDomain_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		alt_domain = "test-domain"
@@ -1448,13 +1444,12 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7636 - Implement target having encoded IP address
 func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -1549,13 +1544,12 @@ func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7636 - Implement target having encoded IP address
 func TestDNS_AltDomain_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		alt_domain = "test-domain"
@@ -2389,13 +2383,12 @@ func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7637 - implementing health filtering
 func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -2553,13 +2546,12 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7637 - implementing health filtering
 func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -2674,13 +2666,12 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7637 - implementing health filtering
 func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		dns_config {
@@ -2999,13 +2990,12 @@ func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7638 - Implemented truncated response
 func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		dns_config {
@@ -3211,7 +3201,7 @@ func checkDNSService(
 	expectedResultsCount int,
 	udpSize uint16,
 ) {
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		node_name = "test-node"


### PR DESCRIPTION
### Description

NET-7637 - Implement Health filtering.  Fixes tests:

- TestDNS_ServiceLookup_FilterCritical
- TestDNS_ServiceLookup_OnlyFailing
- TestDNS_ServiceLookup_OnlyPassing

NET-7659 - Fix Ingress and Connect Service Lookups. Fixes tests:
- TestDNS_IngressServiceLookup
- TestDNS_ConnectServiceLookup

NET-7636 - Implement target having encoded IP address. fixes tests:
- TestDNS_ServiceLookup_ServiceAddressIPV6
- TestDNS_ServiceLookup_ServiceAddress_A
- TestDNS_AltDomain_ServiceLookup_ServiceAddressIPV6
- TestDNS_AltDomain_ServiceLookup_ServiceAddress_A

NET-7647 - supporting non-existent lookups and datacenters. fixes tests:
- TestDNS_NonExistentDC_Server
- TestDNS_NonExistentDC_RPC
- TestDNS_NonExistingLookup
- TestDNS_NonExistingLookupEmptyAorAAAA

NET-7648/NET-7646/NET-7649 - Prepared Query - inject agent source and dc to RPC. Fixes tests:
- TestDNS_PreparedQuery_AgentSource
- TestDNS_EDNS_Truncate_AgentSource

NET-7645 - Allow prepared queries with periods in the name
- TestDNS_PreparedQueryNearIP
- TestDNS_PreparedQueryNearIPEDNS
- TestDNS_ServiceLookup_PreparedQueryNamePeriod

Also 
- added tests for syncExtra and dnsBinaryTruncate in order to resolve NET-7646 and NET-7648.
- enabled `TestDNS_ServiceLookup_LargeResponses` now works (probably from work prior to this PR) so just going to include turning it on in here and it will resolve NET-7638.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* ~~[ ] external facing docs updated~~
* [x] appropriate backport labels added
* [x] not a security concern
