### PR TITLE
feat(v2dns): prepared query ttls

### DIFF
--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -107,11 +107,11 @@ const (
 type Result struct {
 	Service    *Location         // The name and address of the service.
 	Node       *Location         // The name and address of the node.
-	Weight     uint32            // SRV queries
 	PortName   string            // Used to generate a fgdn when a specifc port was queried
 	PortNumber uint32            // SRV queries
 	Metadata   map[string]string // Used to collect metadata into TXT Records
 	Type       ResultType        // Used to reconstruct the fqdn name of the resource
+	DNS        DNSConfig         // Used for DNS-specific configuration for this result
 
 	Tenancy ResultTenancy
 }
@@ -120,6 +120,11 @@ type Result struct {
 type Location struct {
 	Name    string
 	Address string
+}
+
+type DNSConfig struct {
+	TTL    *uint32 // deprecated: use for V1 prepared queries only
+	Weight uint32  // SRV queries
 }
 
 // ResultTenancy is used to reconstruct the fqdn name of the resource.

--- a/agent/discovery/query_fetcher_v1_test.go
+++ b/agent/discovery/query_fetcher_v1_test.go
@@ -147,8 +147,10 @@ func Test_FetchEndpoints(t *testing.T) {
 				Name:    "service-name",
 				Address: "service-address",
 			},
-			Type:   ResultTypeService,
-			Weight: 1,
+			Type: ResultTypeService,
+			DNS: DNSConfig{
+				Weight: 1,
+			},
 		},
 	}
 

--- a/agent/discovery/query_fetcher_v2.go
+++ b/agent/discovery/query_fetcher_v2.go
@@ -116,7 +116,9 @@ func (f *V2DataFetcher) FetchEndpoints(reqContext Context, req *QueryPayload, lo
 				Namespace: resourceObj.GetId().GetTenancy().GetNamespace(),
 				Partition: resourceObj.GetId().GetTenancy().GetPartition(),
 			},
-			Weight: weight,
+			DNS: DNSConfig{
+				Weight: weight,
+			},
 		}
 		results = append(results, result)
 	}

--- a/agent/discovery/query_fetcher_v2_test.go
+++ b/agent/discovery/query_fetcher_v2_test.go
@@ -261,7 +261,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 			},
 		},
@@ -360,7 +362,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 2,
+					DNS: DNSConfig{
+						Weight: 2,
+					},
 				},
 				{
 					Node: &Location{Name: "consul-2", Address: "2.3.4.5"},
@@ -369,7 +373,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 3,
+					DNS: DNSConfig{
+						Weight: 3,
+					},
 				},
 			},
 		},
@@ -408,7 +414,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 2,
+					DNS: DNSConfig{
+						Weight: 2,
+					},
 				},
 			},
 		},
@@ -452,7 +460,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 				{
 					Node: &Location{Name: "consul-2", Address: "10.0.0.2"},
@@ -461,7 +471,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 				{
 					Node: &Location{Name: "consul-3", Address: "10.0.0.3"},
@@ -470,7 +482,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 				{
 					Node: &Location{Name: "consul-4", Address: "10.0.0.4"},
@@ -479,7 +493,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 				{
 					Node: &Location{Name: "consul-5", Address: "10.0.0.5"},
@@ -488,7 +504,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 				{
 					Node: &Location{Name: "consul-6", Address: "10.0.0.6"},
@@ -497,7 +515,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 				{
 					Node: &Location{Name: "consul-7", Address: "10.0.0.7"},
@@ -506,7 +526,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 				{
 					Node: &Location{Name: "consul-8", Address: "10.0.0.8"},
@@ -515,7 +537,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 				{
 					Node: &Location{Name: "consul-9", Address: "10.0.0.9"},
@@ -524,7 +548,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 				{
 					Node: &Location{Name: "consul-10", Address: "10.0.0.10"},
@@ -533,7 +559,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 			},
 			verifyShuffle: true,
@@ -572,7 +600,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: resource.DefaultNamespaceName,
 						Partition: resource.DefaultPartitionName,
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 			},
 		},
@@ -613,7 +643,9 @@ func Test_V2FetchEndpoints(t *testing.T) {
 						Namespace: "test-namespace",
 						Partition: "test-partition",
 					},
-					Weight: 1,
+					DNS: DNSConfig{
+						Weight: 1,
+					},
 				},
 			},
 		},

--- a/agent/dns/router_test.go
+++ b/agent/dns/router_test.go
@@ -1791,6 +1791,165 @@ func Test_HandleRequest(t *testing.T) {
 				},
 			},
 		},
+		// V1 Prepared Queries
+		{
+			name: "v1 prepared query w/ TTL override, ANY query, returns A record",
+			request: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Opcode: dns.OpcodeQuery,
+				},
+				Question: []dns.Question{
+					{
+						Name:   "foo.query.consul.",
+						Qtype:  dns.TypeA,
+						Qclass: dns.ClassINET,
+					},
+				},
+			},
+			agentConfig: &config.RuntimeConfig{
+				DNSDomain:  "consul",
+				DNSNodeTTL: 123 * time.Second,
+				DNSSOA: config.RuntimeSOAConfig{
+					Refresh: 1,
+					Retry:   2,
+					Expire:  3,
+					Minttl:  4,
+				},
+				DNSUDPAnswerLimit: maxUDPAnswerLimit,
+				// We shouldn't use this if we have the override defined
+				DNSServiceTTL: map[string]time.Duration{
+					"foo": 1 * time.Second,
+				},
+			},
+			configureDataFetcher: func(fetcher discovery.CatalogDataFetcher) {
+				fetcher.(*discovery.MockCatalogDataFetcher).
+					On("FetchPreparedQuery", mock.Anything, mock.Anything).
+					Return([]*discovery.Result{
+						{
+							Service: &discovery.Location{Name: "foo", Address: "1.2.3.4"},
+							Node:    &discovery.Location{Name: "bar", Address: "1.2.3.4"},
+							Type:    discovery.ResultTypeService,
+							Tenancy: discovery.ResultTenancy{
+								Datacenter: "dc1",
+							},
+							DNS: discovery.DNSConfig{
+								TTL:    getUint32Ptr(3),
+								Weight: 1,
+							},
+						},
+					}, nil).
+					Run(func(args mock.Arguments) {
+						req := args.Get(1).(*discovery.QueryPayload)
+						require.Equal(t, "foo", req.Name)
+					})
+			},
+			validateAndNormalizeExpected: true,
+			response: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Opcode:        dns.OpcodeQuery,
+					Response:      true,
+					Authoritative: true,
+				},
+				Compress: true,
+				Question: []dns.Question{
+					{
+						Name:   "foo.query.consul.",
+						Qtype:  dns.TypeA,
+						Qclass: dns.ClassINET,
+					},
+				},
+				Answer: []dns.RR{
+					&dns.A{
+						Hdr: dns.RR_Header{
+							Name:   "foo.query.consul.",
+							Rrtype: dns.TypeA,
+							Class:  dns.ClassINET,
+							Ttl:    3,
+						},
+						A: net.ParseIP("1.2.3.4"),
+					},
+				},
+			},
+		},
+		{
+			name: "v1 prepared query w/ matching service TTL, ANY query, returns A record",
+			request: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Opcode: dns.OpcodeQuery,
+				},
+				Question: []dns.Question{
+					{
+						Name:   "foo.query.consul.",
+						Qtype:  dns.TypeA,
+						Qclass: dns.ClassINET,
+					},
+				},
+			},
+			agentConfig: &config.RuntimeConfig{
+				DNSDomain:  "consul",
+				DNSNodeTTL: 123 * time.Second,
+				DNSSOA: config.RuntimeSOAConfig{
+					Refresh: 1,
+					Retry:   2,
+					Expire:  3,
+					Minttl:  4,
+				},
+				DNSUDPAnswerLimit: maxUDPAnswerLimit,
+				// Results should use this as the TTL
+				DNSServiceTTL: map[string]time.Duration{
+					"foo": 1 * time.Second,
+				},
+			},
+			configureDataFetcher: func(fetcher discovery.CatalogDataFetcher) {
+				fetcher.(*discovery.MockCatalogDataFetcher).
+					On("FetchPreparedQuery", mock.Anything, mock.Anything).
+					Return([]*discovery.Result{
+						{
+							Service: &discovery.Location{Name: "foo", Address: "1.2.3.4"},
+							Node:    &discovery.Location{Name: "bar", Address: "1.2.3.4"},
+							Type:    discovery.ResultTypeService,
+							Tenancy: discovery.ResultTenancy{
+								Datacenter: "dc1",
+							},
+							DNS: discovery.DNSConfig{
+								// Intentionally no TTL here.
+								Weight: 1,
+							},
+						},
+					}, nil).
+					Run(func(args mock.Arguments) {
+						req := args.Get(1).(*discovery.QueryPayload)
+						require.Equal(t, "foo", req.Name)
+					})
+			},
+			validateAndNormalizeExpected: true,
+			response: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Opcode:        dns.OpcodeQuery,
+					Response:      true,
+					Authoritative: true,
+				},
+				Compress: true,
+				Question: []dns.Question{
+					{
+						Name:   "foo.query.consul.",
+						Qtype:  dns.TypeA,
+						Qclass: dns.ClassINET,
+					},
+				},
+				Answer: []dns.RR{
+					&dns.A{
+						Hdr: dns.RR_Header{
+							Name:   "foo.query.consul.",
+							Rrtype: dns.TypeA,
+							Class:  dns.ClassINET,
+							Ttl:    1,
+						},
+						A: net.ParseIP("1.2.3.4"),
+					},
+				},
+			},
+		},
 	}
 
 	testCases = append(testCases, getAdditionalTestCases(t)...)
@@ -2173,4 +2332,9 @@ func TestDNS_syncExtra(t *testing.T) {
 	if !reflect.DeepEqual(resp, expected) {
 		t.Fatalf("Bad %#v vs. %#v", *resp, *expected)
 	}
+}
+
+// getUint32Ptr return the pointer of an uint32 literal
+func getUint32Ptr(i uint32) *uint32 {
+	return &i
 }


### PR DESCRIPTION
### Description
This adds support for Prepared Query TTLs in the V2 DNS server in two ways:
* If returned as part of the prepared query result, that TTL will be threaded back to the router as an override
* If there is no override, prepared queries should look at service TTLs.

### Testing & Reproduction steps
* I updated the existing V1 tests to prove this is the correct behavior, since there was no existing coverage.
* New router tests look at both cases. With both an override and service TTL, and with only a matching service TTL.

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] appropriate backport labels added
* [X] not a security concern
