### PR TITLE
feat(v2dns): catalog v2 service query support

### DIFF
--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -105,13 +105,16 @@ const (
 // It is the responsibility of the DNS encoder to know what to do with
 // each Result, based on the query type.
 type Result struct {
-	Service    *Location         // The name and address of the service.
-	Node       *Location         // The name and address of the node.
-	PortName   string            // Used to generate a fgdn when a specifc port was queried
-	PortNumber uint32            // SRV queries
-	Metadata   map[string]string // Used to collect metadata into TXT Records
-	Type       ResultType        // Used to reconstruct the fqdn name of the resource
-	DNS        DNSConfig         // Used for DNS-specific configuration for this result
+	Service  *Location         // The name and address of the service.
+	Node     *Location         // The name and address of the node.
+	Weight   uint32            // SRV queries
+	Metadata map[string]string // Used to collect metadata into TXT Records
+	Type     ResultType        // Used to reconstruct the fqdn name of the resource
+	DNS      DNSConfig         // Used for DNS-specific configuration for this result
+
+	// Ports include anything the node/service/workload implements. These are filtered if requested by the client.
+	// They are used in to generate the FQDN and SRV port numbers in V2 Catalog responses.
+	Ports []Port
 
 	Tenancy ResultTenancy
 }
@@ -125,6 +128,11 @@ type Location struct {
 type DNSConfig struct {
 	TTL    *uint32 // deprecated: use for V1 prepared queries only
 	Weight uint32  // SRV queries
+}
+
+type Port struct {
+	Name   string
+	Number uint32
 }
 
 // ResultTenancy is used to reconstruct the fqdn name of the resource.

--- a/agent/discovery/query_fetcher_v1.go
+++ b/agent/discovery/query_fetcher_v1.go
@@ -422,8 +422,10 @@ func (f *V1DataFetcher) buildResultsFromServiceNodes(nodes []structs.CheckServic
 				TTL:    ttlOverride,
 				Weight: uint32(findWeight(n)),
 			},
-			PortNumber: uint32(f.translateServicePortFunc(n.Node.Datacenter, n.Service.Port, n.Service.TaggedAddresses)),
-			Metadata:   n.Node.Meta,
+			Ports: []Port{
+				{Number: uint32(f.translateServicePortFunc(n.Node.Datacenter, n.Service.Port, n.Service.TaggedAddresses))},
+			},
+			Metadata: n.Node.Meta,
 			Tenancy: ResultTenancy{
 				Namespace:  n.Service.NamespaceOrEmpty(),
 				Partition:  n.Service.PartitionOrEmpty(),

--- a/agent/discovery/query_fetcher_v1_test.go
+++ b/agent/discovery/query_fetcher_v1_test.go
@@ -151,6 +151,11 @@ func Test_FetchEndpoints(t *testing.T) {
 			DNS: DNSConfig{
 				Weight: 1,
 			},
+			Ports: []Port{
+				{
+					Number: 0,
+				},
+			},
 		},
 	}
 

--- a/agent/discovery/query_fetcher_v2.go
+++ b/agent/discovery/query_fetcher_v2.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -73,10 +74,12 @@ func (f *V2DataFetcher) FetchEndpoints(reqContext Context, req *QueryPayload, lo
 	configCtx := f.dynamicConfig.Load().(*v2DataFetcherDynamicConfig)
 
 	serviceEndpoints := pbcatalog.ServiceEndpoints{}
-	resourceObj, err := f.fetchResource(reqContext, *req, pbcatalog.ServiceEndpointsType, &serviceEndpoints)
+	serviceEndpointsResource, err := f.fetchResource(reqContext, *req, pbcatalog.ServiceEndpointsType, &serviceEndpoints)
 	if err != nil {
 		return nil, err
 	}
+
+	f.logger.Trace("shuffling endpoints", "name", req.Name, "endpoints", len(serviceEndpoints.Endpoints))
 
 	// Shuffle the endpoints slice
 	shuffleFunc := func(i, j int) {
@@ -91,10 +94,15 @@ func (f *V2DataFetcher) FetchEndpoints(reqContext Context, req *QueryPayload, lo
 	}
 
 	results := make([]*Result, 0, limit)
-	for idx := 0; idx < limit; idx++ {
-		endpoint := serviceEndpoints.Endpoints[idx]
+	for _, endpoint := range serviceEndpoints.Endpoints[:limit] {
 
-		// TODO (v2-dns): filter based on the port name requested
+		// First we check the endpoint first to make sure that the requested port is matched from the service.
+		// We error here because we expect all endpoints to have the same ports as the service.
+		ports := getResultPorts(req, endpoint.Ports) //assuming the logic changed in getResultPorts
+		if len(ports) == 0 {
+			f.logger.Debug("could not find matching port in endpoint", "name", req.Name, "port", req.PortName)
+			return nil, ErrNotFound
+		}
 
 		address, err := f.addressFromWorkloadAddresses(endpoint.Addresses, req.Name)
 		if err != nil {
@@ -103,6 +111,7 @@ func (f *V2DataFetcher) FetchEndpoints(reqContext Context, req *QueryPayload, lo
 
 		weight, ok := getEndpointWeight(endpoint, configCtx)
 		if !ok {
+			f.logger.Debug("endpoint filtered out because of health status", "name", req.Name, "endpoint", endpoint.GetTargetRef().GetName())
 			continue
 		}
 
@@ -111,14 +120,15 @@ func (f *V2DataFetcher) FetchEndpoints(reqContext Context, req *QueryPayload, lo
 				Address: address,
 				Name:    endpoint.GetTargetRef().GetName(),
 			},
-			Type: ResultTypeWorkload, // TODO (v2-dns): I'm not really sure if it's better to have SERVICE OR WORKLOAD here
+			Type: ResultTypeWorkload,
 			Tenancy: ResultTenancy{
-				Namespace: resourceObj.GetId().GetTenancy().GetNamespace(),
-				Partition: resourceObj.GetId().GetTenancy().GetPartition(),
+				Namespace: serviceEndpointsResource.GetId().GetTenancy().GetNamespace(),
+				Partition: serviceEndpointsResource.GetId().GetTenancy().GetPartition(),
 			},
 			DNS: DNSConfig{
 				Weight: weight,
 			},
+			Ports: ports,
 		}
 		results = append(results, result)
 	}
@@ -145,6 +155,14 @@ func (f *V2DataFetcher) FetchWorkload(reqContext Context, req *QueryPayload) (*R
 		return nil, err
 	}
 
+	// First we check the endpoint first to make sure that the requested port is matched from the service.
+	// We error here because we expect all endpoints to have the same ports as the service.
+	ports := getResultPorts(req, workload.Ports) //assuming the logic changed in getResultPorts
+	if ports == nil || len(ports) == 0 {
+		f.logger.Debug("could not find matching port in endpoint", "name", req.Name, "port", req.PortName)
+		return nil, ErrNotFound
+	}
+
 	address, err := f.addressFromWorkloadAddresses(workload.Addresses, req.Name)
 	if err != nil {
 		return nil, err
@@ -161,24 +179,10 @@ func (f *V2DataFetcher) FetchWorkload(reqContext Context, req *QueryPayload) (*R
 			Namespace: tenancy.GetNamespace(),
 			Partition: tenancy.GetPartition(),
 		},
+		Ports: ports,
 	}
 
-	if req.PortName == "" {
-		return result, nil
-	}
-
-	// If a port is specified, make sure the workload implements that port name.
-	for name, port := range workload.Ports {
-		if name == req.PortName {
-			result.PortName = req.PortName
-			result.PortNumber = port.Port
-			return result, nil
-		}
-	}
-
-	f.logger.Debug("could not find matching port for workload", "name", req.Name, "port", req.PortName)
-	// Return an ErrNotFound, which is equivalent to NXDOMAIN
-	return nil, ErrNotFound
+	return result, nil
 }
 
 // FetchPreparedQuery is used to fetch a prepared query from the V2 catalog.
@@ -283,6 +287,46 @@ func getEndpointWeight(endpoint *pbcatalog.Endpoint, configCtx *v2DataFetcherDyn
 		weight = 1
 	}
 	return weight, true
+}
+
+// getResultPorts conditionally returns ports from a map based on a query. The results are sorted by name.
+func getResultPorts(req *QueryPayload, workloadPorts map[string]*pbcatalog.WorkloadPort) []Port {
+	if len(workloadPorts) == 0 {
+		return nil
+	}
+
+	var ports []Port
+	if req.PortName != "" {
+		// Make sure the workload implements that port name.
+		if _, ok := workloadPorts[req.PortName]; !ok {
+			return nil
+		}
+		// In the case that the query asked for a specific port, we only return that port.
+		ports = []Port{
+			{
+				Name:   req.PortName,
+				Number: workloadPorts[req.PortName].Port,
+			},
+		}
+	} else {
+		// If the client didn't specify a particular port, return all the workload ports.
+		for name, port := range workloadPorts {
+			ports = append(ports, Port{
+				Name:   name,
+				Number: port.Port,
+			})
+		}
+		// Stable Sort
+		slices.SortStableFunc(ports, func(i, j Port) int {
+			if i.Name < j.Name {
+				return -1
+			} else if i.Name > j.Name {
+				return 1
+			}
+			return 0
+		})
+	}
+	return ports
 }
 
 // queryTenancyToResourceTenancy converts a QueryTenancy to a pbresource.Tenancy.

--- a/agent/dns/router_ce.go
+++ b/agent/dns/router_ce.go
@@ -36,8 +36,3 @@ func canonicalNameForResult(resultType discovery.ResultType, target, domain stri
 	}
 	return ""
 }
-
-// getDefaultPartitionName returns the default partition name.
-func getDefaultPartitionName() string {
-	return ""
-}


### PR DESCRIPTION
### Description

This PR completes service queries against the V2 Catalog using the refactored DNS server. Multi-port services and A/AAAA/SRV queries with port names are now supported.

### Testing & Reproduction steps
* unit tests updated as noted
* integration tests coming in a future PR
* manual testing
I used some of the workload, healthstatus, and service resources [in this scenario](https://github.com/DanStough/consul-scenarios/tree/main/local/v2-resource-api) to configure a test agent. Then I ran some of the following commands:

#### A/AAAA Query
```bash
❯ dig @127.0.0.1 -p 8600 royco-waystar.service.consul

; <<>> DiG 9.18.21 <<>> @127.0.0.1 -p 8600 royco-waystar.service.consul
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 15083
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;royco-waystar.service.consul.  IN      A

;; ANSWER SECTION:
royco-waystar.service.consul. 0 IN      A       10.0.0.1
```

#### SRV Query
```bash
❯ dig @127.0.0.1 -p 8600 royco-waystar.service.consul SRV

; <<>> DiG 9.18.21 <<>> @127.0.0.1 -p 8600 royco-waystar.service.consul SRV
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 285
;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 2
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;royco-waystar.service.consul.  IN      SRV

;; ANSWER SECTION:
royco-waystar.service.consul. 0 IN      SRV     1 1 20000 mesh.port.royco-waystar-75675f5897-11111.workload.consul.
royco-waystar.service.consul. 0 IN      SRV     1 1 80 public.port.royco-waystar-75675f5897-11111.workload.consul.

;; ADDITIONAL SECTION:
mesh.port.royco-waystar-75675f5897-11111.workload.consul. 0 IN A 10.0.0.1
public.port.royco-waystar-75675f5897-11111.workload.consul. 0 IN A 10.0.0.1
```

#### SRV Query + Port Name
```bash
❯ dig @127.0.0.1 -p 8600 mesh.port.royco-waystar.service.consul SRV

; <<>> DiG 9.18.21 <<>> @127.0.0.1 -p 8600 mesh.port.royco-waystar.service.consul SRV
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 50324
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;mesh.port.royco-waystar.service.consul.        IN SRV

;; ANSWER SECTION:
mesh.port.royco-waystar.service.consul. 0 IN SRV 1 1 20000 mesh.port.royco-waystar-75675f5897-11111.workload.consul.

;; ADDITIONAL SECTION:
mesh.port.royco-waystar-75675f5897-11111.workload.consul. 0 IN A 10.0.0.1
```

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] appropriate backport labels added
* [X] not a security concern
