### PR TITLE
feat(v2dns): enable peering queries

### DIFF
--- a/agent/discovery/query_fetcher_v1.go
+++ b/agent/discovery/query_fetcher_v1.go
@@ -99,6 +99,11 @@ func (f *V1DataFetcher) LoadConfig(config *config.RuntimeConfig) {
 
 // FetchNodes fetches A/AAAA/CNAME
 func (f *V1DataFetcher) FetchNodes(ctx Context, req *QueryPayload) ([]*Result, error) {
+	if req.Tenancy.Namespace != "" && req.Tenancy.Namespace != acl.DefaultNamespaceName {
+		// Nodes are not namespaced, so this is a name error
+		return nil, ErrNotFound
+	}
+
 	cfg := f.dynamicConfig.Load().(*v1DataFetcherDynamicConfig)
 	// Make an RPC request
 	args := &structs.NodeSpecificRequest{
@@ -430,6 +435,7 @@ func (f *V1DataFetcher) buildResultsFromServiceNodes(nodes []structs.CheckServic
 				Namespace:  n.Service.NamespaceOrEmpty(),
 				Partition:  n.Service.PartitionOrEmpty(),
 				Datacenter: n.Node.Datacenter,
+				PeerName:   req.Tenancy.Peer,
 			},
 		})
 	}

--- a/agent/discovery/query_fetcher_v1_test.go
+++ b/agent/discovery/query_fetcher_v1_test.go
@@ -156,6 +156,9 @@ func Test_FetchEndpoints(t *testing.T) {
 					Number: 0,
 				},
 			},
+			Tenancy: ResultTenancy{
+				PeerName: "test-peer",
+			},
 		},
 	}
 

--- a/agent/discovery/query_fetcher_v2.go
+++ b/agent/discovery/query_fetcher_v2.go
@@ -62,7 +62,9 @@ func (f *V2DataFetcher) LoadConfig(config *config.RuntimeConfig) {
 
 // FetchNodes fetches A/AAAA/CNAME
 func (f *V2DataFetcher) FetchNodes(ctx Context, req *QueryPayload) ([]*Result, error) {
-	return nil, nil
+	// TODO (v2-dns): NET-6623 - Implement FetchNodes
+	// Make sure that we validate that namespace is not provided here
+	return nil, fmt.Errorf("not implemented")
 }
 
 // FetchEndpoints fetches records for A/AAAA/CNAME or SRV requests for services
@@ -137,13 +139,15 @@ func (f *V2DataFetcher) FetchEndpoints(reqContext Context, req *QueryPayload, lo
 
 // FetchVirtualIP fetches A/AAAA records for virtual IPs
 func (f *V2DataFetcher) FetchVirtualIP(ctx Context, req *QueryPayload) (*Result, error) {
-	return nil, nil
+	// TODO (v2-dns): NET-6624 - Implement FetchVirtualIP
+	return nil, fmt.Errorf("not implemented")
 }
 
 // FetchRecordsByIp is used for PTR requests to look up a service/node from an IP.
-// TODO (v2-dns): Validate non-nil IP
 func (f *V2DataFetcher) FetchRecordsByIp(ctx Context, ip net.IP) ([]*Result, error) {
-	return nil, nil
+	// TODO (v2-dns): NET-6795 - Implement FetchRecordsByIp
+	// Validate non-nil IP
+	return nil, fmt.Errorf("not implemented")
 }
 
 // FetchWorkload is used to fetch a single workload from the V2 catalog.

--- a/agent/dns_ce_test.go
+++ b/agent/dns_ce_test.go
@@ -17,13 +17,12 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 )
 
-// TODO(v2-dns): NET-7910 - Fix ENT and CE variants of DNS v1 compatibility tests
 func TestDNS_CE_PeeredServices(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := StartTestAgent(t, TestAgent{HCL: ``, Overrides: `peering = { test_allow_peer_registrations = true } ` + experimentsHCL})
 			defer a.Shutdown()


### PR DESCRIPTION
### Description
This completes peering and sameness group queries for v2 DNS. All of the tests in `dns_ce.go` and `dns_ent.go` are either enabled or deemed unsupported in v2 DNS 

### Testing & Reproduction steps
* Running the agent tests `dns*.go`

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] appropriate backport labels added
* [X] not a security concern
