### PR TITLE
NET-7644/NET-7634 - Implement query lookup for tagged addresses on nodes and services including WAN translation.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1140,11 +1140,13 @@ func (a *Agent) listenAndServeV2DNS() error {
 
 	// create server
 	cfg := dns.Config{
-		AgentConfig: a.config,
-		EntMeta:     *a.AgentEnterpriseMeta(),
-		Logger:      a.logger,
-		Processor:   processor,
-		TokenFunc:   a.getTokenFunc(),
+		AgentConfig:                 a.config,
+		EntMeta:                     *a.AgentEnterpriseMeta(),
+		Logger:                      a.logger,
+		Processor:                   processor,
+		TokenFunc:                   a.getTokenFunc(),
+		TranslateAddressFunc:        a.TranslateAddress,
+		TranslateServiceAddressFunc: a.TranslateServiceAddress,
 	}
 
 	for _, addr := range a.config.DNSAddrs {

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -13,6 +13,7 @@ import (
 
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/internal/dnsutil"
 )
 
 var CatalogCounters = []prometheus.CounterDefinition{
@@ -257,7 +258,7 @@ RETRY_ONCE:
 	}
 	out.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
 
-	s.agent.TranslateAddresses(args.Datacenter, out.Nodes, TranslateAddressAcceptAny)
+	s.agent.TranslateAddresses(args.Datacenter, out.Nodes, dnsutil.TranslateAddressAcceptAny)
 
 	// Use empty list instead of nil
 	if out.Nodes == nil {
@@ -403,7 +404,7 @@ func (s *HTTPHandlers) catalogServiceNodes(resp http.ResponseWriter, req *http.R
 	}
 
 	out.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
-	s.agent.TranslateAddresses(args.Datacenter, out.ServiceNodes, TranslateAddressAcceptAny)
+	s.agent.TranslateAddresses(args.Datacenter, out.ServiceNodes, dnsutil.TranslateAddressAcceptAny)
 
 	// Use empty list instead of nil
 	if out.ServiceNodes == nil {
@@ -457,7 +458,7 @@ RETRY_ONCE:
 	}
 	out.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
 	if out.NodeServices != nil {
-		s.agent.TranslateAddresses(args.Datacenter, out.NodeServices, TranslateAddressAcceptAny)
+		s.agent.TranslateAddresses(args.Datacenter, out.NodeServices, dnsutil.TranslateAddressAcceptAny)
 	}
 
 	// TODO: The NodeServices object in IndexedNodeServices is a pointer to
@@ -521,7 +522,7 @@ RETRY_ONCE:
 		goto RETRY_ONCE
 	}
 	out.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
-	s.agent.TranslateAddresses(args.Datacenter, &out.NodeServices, TranslateAddressAcceptAny)
+	s.agent.TranslateAddresses(args.Datacenter, &out.NodeServices, dnsutil.TranslateAddressAcceptAny)
 
 	// Use empty list instead of nil
 	for _, s := range out.NodeServices.Services {

--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -119,10 +119,18 @@ type Result struct {
 	Tenancy ResultTenancy
 }
 
-// Location is used to represent a service, node, or workload.
-type Location struct {
+// TaggedAddress is used to represent a tagged address.
+type TaggedAddress struct {
 	Name    string
 	Address string
+	Port    Port
+}
+
+// Location is used to represent a service, node, or workload.
+type Location struct {
+	Name            string
+	Address         string
+	TaggedAddresses map[string]*TaggedAddress // Used to collect tagged addresses into A/AAAA Records
 }
 
 type DNSConfig struct {

--- a/agent/discovery/query_fetcher_v1_test.go
+++ b/agent/discovery/query_fetcher_v1_test.go
@@ -140,12 +140,14 @@ func Test_FetchEndpoints(t *testing.T) {
 	expectedResults := []*Result{
 		{
 			Node: &Location{
-				Name:    "node-name",
-				Address: "node-address",
+				Name:            "node-name",
+				Address:         "node-address",
+				TaggedAddresses: map[string]*TaggedAddress{},
 			},
 			Service: &Location{
-				Name:    "service-name",
-				Address: "service-address",
+				Name:            "service-name",
+				Address:         "service-address",
+				TaggedAddresses: map[string]*TaggedAddress{},
 			},
 			Type: ResultTypeService,
 			DNS: DNSConfig{

--- a/agent/dns/router_query.go
+++ b/agent/dns/router_query.go
@@ -70,6 +70,24 @@ func getQueryNameAndTagFromParts(queryType discovery.QueryType, queryParts []str
 			return name, tag
 		}
 		return queryParts[n-1], ""
+	case discovery.QueryTypePreparedQuery:
+		name := ""
+
+		// If the first and last DNS query parts begin with _, this is an RFC 2782 style SRV lookup.
+		// This allows for prepared query names to include "." (for backwards compatibility).
+		// Otherwise, this is a standard prepared query lookup.
+		if n >= 2 && strings.HasPrefix(queryParts[0], "_") && strings.HasPrefix(queryParts[n-1], "_") {
+			// The last DNS query part is the protocol field (ignored).
+			// All prior parts are the prepared query name or ID.
+			name = strings.Join(queryParts[:n-1], ".")
+
+			// Strip leading underscore
+			name = name[1:]
+		} else {
+			// Allow a "." in the query name, just join all the parts.
+			name = strings.Join(queryParts, ".")
+		}
+		return name, ""
 	}
 	return queryParts[n-1], ""
 }

--- a/agent/dns/router_service_question_test.go
+++ b/agent/dns/router_service_question_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package dns
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/agent/discovery"
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_HandleRequest_ServiceQuestions(t *testing.T) {
+	testCases := []HandleTestCase{
+		// Service Lookup
+		{
+			name: "When no data is return from a query, send SOA",
+			request: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Opcode: dns.OpcodeQuery,
+				},
+				Question: []dns.Question{
+					{
+						Name:   "foo.service.consul.",
+						Qtype:  dns.TypeA,
+						Qclass: dns.ClassINET,
+					},
+				},
+			},
+			configureDataFetcher: func(fetcher discovery.CatalogDataFetcher) {
+				fetcher.(*discovery.MockCatalogDataFetcher).
+					On("FetchEndpoints", mock.Anything, mock.Anything, mock.Anything).
+					Return(nil, discovery.ErrNoData).
+					Run(func(args mock.Arguments) {
+						req := args.Get(1).(*discovery.QueryPayload)
+						reqType := args.Get(2).(discovery.LookupType)
+
+						require.Equal(t, discovery.LookupTypeService, reqType)
+						require.Equal(t, "foo", req.Name)
+					})
+			},
+			validateAndNormalizeExpected: true,
+			response: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Opcode:        dns.OpcodeQuery,
+					Response:      true,
+					Authoritative: true,
+					Rcode:         dns.RcodeSuccess,
+				},
+				Compress: true,
+				Question: []dns.Question{
+					{
+						Name:   "foo.service.consul.",
+						Qtype:  dns.TypeA,
+						Qclass: dns.ClassINET,
+					},
+				},
+				Ns: []dns.RR{
+					&dns.SOA{
+						Hdr: dns.RR_Header{
+							Name:   "consul.",
+							Rrtype: dns.TypeSOA,
+							Class:  dns.ClassINET,
+							Ttl:    4,
+						},
+						Ns:      "ns.consul.",
+						Serial:  uint32(time.Now().Unix()),
+						Mbox:    "hostmaster.consul.",
+						Refresh: 1,
+						Expire:  3,
+						Retry:   2,
+						Minttl:  4,
+					},
+				},
+			},
+		},
+		{
+			// TestDNS_ExternalServiceToConsulCNAMELookup
+			name: "req type: service / question type: SRV / CNAME required: no",
+			request: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Opcode: dns.OpcodeQuery,
+				},
+				Question: []dns.Question{
+					{
+						Name:  "alias.service.consul.",
+						Qtype: dns.TypeSRV,
+					},
+				},
+			},
+			configureDataFetcher: func(fetcher discovery.CatalogDataFetcher) {
+				fetcher.(*discovery.MockCatalogDataFetcher).
+					On("FetchEndpoints", mock.Anything,
+						&discovery.QueryPayload{
+							Name:    "alias",
+							Tenancy: discovery.QueryTenancy{},
+						}, discovery.LookupTypeService).
+					Return([]*discovery.Result{
+						{
+							Type:    discovery.ResultTypeVirtual,
+							Service: &discovery.Location{Name: "alias", Address: "web.service.consul"},
+							Node:    &discovery.Location{Name: "web", Address: "web.service.consul"},
+						},
+					},
+						nil).On("FetchEndpoints", mock.Anything,
+					&discovery.QueryPayload{
+						Name:    "web",
+						Tenancy: discovery.QueryTenancy{},
+					}, discovery.LookupTypeService).
+					Return([]*discovery.Result{
+						{
+							Type:    discovery.ResultTypeNode,
+							Service: &discovery.Location{Name: "web", Address: "webnode"},
+							Node:    &discovery.Location{Name: "webnode", Address: "127.0.0.2"},
+						},
+					}, nil).On("ValidateRequest", mock.Anything,
+					mock.Anything).Return(nil).On("NormalizeRequest", mock.Anything)
+			},
+			response: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Response:      true,
+					Authoritative: true,
+				},
+				Compress: true,
+				Question: []dns.Question{
+					{
+						Name:  "alias.service.consul.",
+						Qtype: dns.TypeSRV,
+					},
+				},
+				Answer: []dns.RR{
+					&dns.SRV{
+						Hdr: dns.RR_Header{
+							Name:   "alias.service.consul.",
+							Rrtype: dns.TypeSRV,
+							Class:  dns.ClassINET,
+							Ttl:    123,
+						},
+						Target:   "web.service.consul.",
+						Priority: 1,
+					},
+				},
+				Extra: []dns.RR{
+					&dns.A{
+						Hdr: dns.RR_Header{
+							Name:   "web.service.consul.",
+							Rrtype: dns.TypeA,
+							Class:  dns.ClassINET,
+							Ttl:    123,
+						},
+						A: net.ParseIP("127.0.0.2"),
+					},
+				},
+			},
+		},
+	}
+
+	testCases = append(testCases, getAdditionalTestCases(t)...)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runHandleTestCases(t, tc)
+		})
+	}
+}

--- a/agent/dns/server.go
+++ b/agent/dns/server.go
@@ -5,6 +5,8 @@ package dns
 
 import (
 	"fmt"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/internal/dnsutil"
 	"net"
 
 	"github.com/miekg/dns"
@@ -36,11 +38,13 @@ type Server struct {
 
 // Config represent all the DNS configuration required to construct a DNS server.
 type Config struct {
-	AgentConfig *config.RuntimeConfig
-	EntMeta     acl.EnterpriseMeta
-	Logger      hclog.Logger
-	Processor   DiscoveryQueryProcessor
-	TokenFunc   func() string
+	AgentConfig                 *config.RuntimeConfig
+	EntMeta                     acl.EnterpriseMeta
+	Logger                      hclog.Logger
+	Processor                   DiscoveryQueryProcessor
+	TokenFunc                   func() string
+	TranslateAddressFunc        func(dc string, addr string, taggedAddresses map[string]string, accept dnsutil.TranslateAddressAccept) string
+	TranslateServiceAddressFunc func(dc string, address string, taggedAddresses map[string]structs.ServiceAddress, accept dnsutil.TranslateAddressAccept) string
 }
 
 // NewServer creates a new DNS server.

--- a/agent/dns_node_lookup_test.go
+++ b/agent/dns_node_lookup_test.go
@@ -14,14 +14,12 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 )
 
-// TODO (v2-dns): Failing on "lookup a non-existing node, we should receive a SOA"
-// it is coming back empty.
 func TestDNS_NodeLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -1338,7 +1338,6 @@ func TestDNS_AltDomain_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7632 - Fix node and prepared query lookups when question name has a period in it
 func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -1352,7 +1351,7 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, `
 		               recursors = ["`+recursor.Addr+`"]
@@ -1666,13 +1665,12 @@ func TestDNS_AltDomain_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns):  NET-7634 - Implement WAN translation
 func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a1 := NewTestAgent(t, `
 		datacenter = "dc1"
@@ -2063,13 +2061,12 @@ func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7632 - Fix node and prepared query lookups when question name has a period in it.
 func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -3297,7 +3294,6 @@ func checkDNSService(
 	}
 }
 
-// TODO (v2-dns): NET-7633 - implement answer limits.
 func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -1008,13 +1008,12 @@ func TestDNS_AltDomain_NSRecords_IPV6(t *testing.T) {
 	}
 }
 
-// TODO NET-7644 - Implement service and prepared query lookup for tagged addresses
 func TestDNS_Lookup_TaggedIPAddresses(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -1222,7 +1221,7 @@ func TestDNS_PreparedQueryNearIPEDNS(t *testing.T) {
 		{"foo3", "198.18.0.3", lib.GenerateCoordinate(30 * time.Millisecond)},
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -1356,7 +1355,7 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 		{"foo3", "198.18.0.3", lib.GenerateCoordinate(30 * time.Millisecond)},
 	}
 
-	for name, experimentsHCL := range getVersionHCL(false) {
+	for name, experimentsHCL := range getVersionHCL(true) {
 		t.Run(name, func(t *testing.T) {
 			a := NewTestAgent(t, experimentsHCL)
 			defer a.Shutdown()
@@ -2149,25 +2148,27 @@ func TestDNS_NonExistentLookupEmptyAorAAAA(t *testing.T) {
 				"webv4.query.consul.",
 			}
 			for _, question := range questions {
-				m := new(dns.Msg)
-				m.SetQuestion(question, dns.TypeAAAA)
+				t.Run(question, func(t *testing.T) {
+					m := new(dns.Msg)
+					m.SetQuestion(question, dns.TypeAAAA)
 
-				c := new(dns.Client)
-				in, _, err := c.Exchange(m, a.DNSAddr())
-				if err != nil {
-					t.Fatalf("err: %v", err)
-				}
+					c := new(dns.Client)
+					in, _, err := c.Exchange(m, a.DNSAddr())
+					if err != nil {
+						t.Fatalf("err: %v", err)
+					}
 
-				require.Len(t, in.Ns, 1)
-				soaRec, ok := in.Ns[0].(*dns.SOA)
-				if !ok {
-					t.Fatalf("Bad: %#v", in.Ns[0])
-				}
-				if soaRec.Hdr.Ttl != 0 {
-					t.Fatalf("Bad: %#v", in.Ns[0])
-				}
+					require.Len(t, in.Ns, 1)
+					soaRec, ok := in.Ns[0].(*dns.SOA)
+					if !ok {
+						t.Fatalf("Bad: %#v", in.Ns[0])
+					}
+					if soaRec.Hdr.Ttl != 0 {
+						t.Fatalf("Bad: %#v", in.Ns[0])
+					}
 
-				require.Equal(t, dns.RcodeSuccess, in.Rcode)
+					require.Equal(t, dns.RcodeSuccess, in.Rcode)
+				})
 			}
 
 			// Check for ipv4 records on ipv6-only service directly and via the
@@ -2177,30 +2178,32 @@ func TestDNS_NonExistentLookupEmptyAorAAAA(t *testing.T) {
 				"webv6.query.consul.",
 			}
 			for _, question := range questions {
-				m := new(dns.Msg)
-				m.SetQuestion(question, dns.TypeA)
+				t.Run(question, func(t *testing.T) {
+					m := new(dns.Msg)
+					m.SetQuestion(question, dns.TypeA)
 
-				c := new(dns.Client)
-				in, _, err := c.Exchange(m, a.DNSAddr())
-				if err != nil {
-					t.Fatalf("err: %v", err)
-				}
+					c := new(dns.Client)
+					in, _, err := c.Exchange(m, a.DNSAddr())
+					if err != nil {
+						t.Fatalf("err: %v", err)
+					}
 
-				if len(in.Ns) != 1 {
-					t.Fatalf("Bad: %#v", in)
-				}
+					if len(in.Ns) != 1 {
+						t.Fatalf("Bad: %#v", in)
+					}
 
-				soaRec, ok := in.Ns[0].(*dns.SOA)
-				if !ok {
-					t.Fatalf("Bad: %#v", in.Ns[0])
-				}
-				if soaRec.Hdr.Ttl != 0 {
-					t.Fatalf("Bad: %#v", in.Ns[0])
-				}
+					soaRec, ok := in.Ns[0].(*dns.SOA)
+					if !ok {
+						t.Fatalf("Bad: %#v", in.Ns[0])
+					}
+					if soaRec.Hdr.Ttl != 0 {
+						t.Fatalf("Bad: %#v", in.Ns[0])
+					}
 
-				if in.Rcode != dns.RcodeSuccess {
-					t.Fatalf("Bad: %#v", in)
-				}
+					if in.Rcode != dns.RcodeSuccess {
+						t.Fatalf("Bad: %#v", in)
+					}
+				})
 			}
 		})
 	}

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/internal/dnsutil"
 )
 
 const (
@@ -243,7 +244,7 @@ func (s *HTTPHandlers) healthServiceNodes(resp http.ResponseWriter, req *http.Re
 	}
 
 	// Translate addresses after filtering so we don't waste effort.
-	s.agent.TranslateAddresses(args.Datacenter, out.Nodes, TranslateAddressAcceptAny)
+	s.agent.TranslateAddresses(args.Datacenter, out.Nodes, dnsutil.TranslateAddressAcceptAny)
 
 	// Use empty list instead of nil
 	if out.Nodes == nil {

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -11,6 +11,7 @@ import (
 
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/internal/dnsutil"
 )
 
 // preparedQueryCreateResponse is used to wrap the query ID.
@@ -162,7 +163,7 @@ func (s *HTTPHandlers) preparedQueryExecute(id string, resp http.ResponseWriter,
 	// a query can fail over to a different DC than where the execute request
 	// was sent to. That's why we use the reply's DC and not the one from
 	// the args.
-	s.agent.TranslateAddresses(reply.Datacenter, reply.Nodes, TranslateAddressAcceptAny)
+	s.agent.TranslateAddresses(reply.Datacenter, reply.Nodes, dnsutil.TranslateAddressAcceptAny)
 
 	// Use empty list instead of nil.
 	if reply.Nodes == nil {

--- a/internal/dnsutil/dns.go
+++ b/internal/dnsutil/dns.go
@@ -13,6 +13,8 @@ import (
 	"github.com/miekg/dns"
 )
 
+type TranslateAddressAccept int
+
 // MaxLabelLength is the maximum length for a name that can be used in DNS.
 const (
 	MaxLabelLength = 63
@@ -20,6 +22,12 @@ const (
 	arpaLabel     = "arpa"
 	arpaIPV4Label = "in-addr"
 	arpaIPV6Label = "ip6"
+
+	TranslateAddressAcceptDomain TranslateAddressAccept = 1 << iota
+	TranslateAddressAcceptIPv4
+	TranslateAddressAcceptIPv6
+
+	TranslateAddressAcceptAny TranslateAddressAccept = ^0
 )
 
 // InvalidNameRe is a regex that matches characters which can not be included in


### PR DESCRIPTION
### Description
Fixes tests:
- TestDNS_Lookup_TaggedIPAddresses (passing). part of NET-7644.
- TestDNS_ServiceLookup_WanTranslation (not passing). part of NET-7634.

## Notes 
- this logic requires addtional data from the database in the TaggedAddresses collection on nodes and services, as well as it also requires whether you are asking for IPV6, IPV4 or ANY,
- since it requires data from the database, there needs to be a change to DiscoveryResult.  
  - Right now it is just  TaggedAddresses on the Discovery Result level. 
  - Also, the Tagged Address on the service has address and PortNumber, so I hacked around with moving PortName and PortNumber to the Location struct and then making Tagged Addresses a `map[string]*Location` on the discovery result.
  - This is still a WIP and it looks like both Node and Service will need tagged addresses, so we will consider moving TaggedAddresses into `DiscoveryResult.Node` and `DiscoveryResult.Service`.  
- On the translation end of things, rather than copying all of the address translation code, I opted to ust inject the function from the agent as we did with various rpc functions.
  - Since the return type is in the agent package, I had to move the TranslateAccept enum in `internal/dnsutil/dns.go` to avoid import cycles.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* ~~[ ] external facing docs updated~~
* [x] appropriate backport labels added
* [x] not a security concern
