### PR TITLE
NET-7783: Fix sameness group expansion to 0 sources error CE

### DIFF
--- a/internal/auth/internal/controllers/trafficpermissions/builder.go
+++ b/internal/auth/internal/controllers/trafficpermissions/builder.go
@@ -41,7 +41,7 @@ func newTrafficPermissionsBuilder(expander expander.SamenessGroupExpander, sgMap
 
 // track will use all associated XTrafficPermissions to create new ComputedTrafficPermissions samenessGroupsForTrafficPermission
 func track[S types.XTrafficPermissions](tpb *trafficPermissionsBuilder, xtp *resource.DecodedResource[S]) {
-	missingSamenessGroups := tpb.sgExpander.Expand(xtp.Data, tpb.sgMap)
+	permissions, missingSamenessGroups := tpb.sgExpander.Expand(xtp.Data, tpb.sgMap)
 
 	if len(missingSamenessGroups) > 0 {
 		tpb.missing[resource.NewReferenceKey(xtp.Id)] = missingSamenessGroupReferences{
@@ -53,9 +53,9 @@ func track[S types.XTrafficPermissions](tpb *trafficPermissionsBuilder, xtp *res
 	tpb.isDefault = false
 
 	if xtp.Data.GetAction() == pbauth.Action_ACTION_ALLOW {
-		tpb.allowedPermissions = append(tpb.allowedPermissions, xtp.Data.GetPermissions()...)
+		tpb.allowedPermissions = append(tpb.allowedPermissions, permissions...)
 	} else {
-		tpb.denyPermissions = append(tpb.denyPermissions, xtp.Data.GetPermissions()...)
+		tpb.denyPermissions = append(tpb.denyPermissions, permissions...)
 	}
 }
 

--- a/internal/auth/internal/controllers/trafficpermissions/expander/expander_ce/expander_ce.go
+++ b/internal/auth/internal/controllers/trafficpermissions/expander/expander_ce/expander_ce.go
@@ -23,10 +23,9 @@ func New() *SamenessGroupExpander {
 	return &SamenessGroupExpander{}
 }
 
-func (sgE *SamenessGroupExpander) Expand(_ types.XTrafficPermissions,
-	_ map[string][]*pbmulticluster.SamenessGroupMember) []string {
-	// no-op for CE
-	return nil
+func (sgE *SamenessGroupExpander) Expand(xtp types.XTrafficPermissions,
+	_ map[string][]*pbmulticluster.SamenessGroupMember) ([]*pbauth.Permission, []string) {
+	return xtp.GetPermissions(), nil
 }
 
 func (sgE *SamenessGroupExpander) List(_ context.Context, _ controller.Runtime,

--- a/internal/auth/internal/controllers/trafficpermissions/expander/interface.go
+++ b/internal/auth/internal/controllers/trafficpermissions/expander/interface.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/hashicorp/consul/internal/auth/internal/types"
 	"github.com/hashicorp/consul/internal/controller"
+
+	pbauth "github.com/hashicorp/consul/proto-public/pbauth/v2beta1"
 	pbmulticluster "github.com/hashicorp/consul/proto-public/pbmulticluster/v2beta1"
 )
 
 // SamenessGroupExpander is used to expand sameness group for a ComputedTrafficPermission resource
 type SamenessGroupExpander interface {
-	Expand(types.XTrafficPermissions, map[string][]*pbmulticluster.SamenessGroupMember) []string
+	Expand(types.XTrafficPermissions, map[string][]*pbmulticluster.SamenessGroupMember) ([]*pbauth.Permission, []string)
 	List(context.Context, controller.Runtime, controller.Request) (map[string][]*pbmulticluster.SamenessGroupMember, error)
 }


### PR DESCRIPTION
### Description

This PR is CE port of Enterprise changes which fixes the bug:
When a valid traffic permissions has only missing sameness group in the source, then the samenss group expansion results in `ComputedTrafficPermission` having permission with 0 sources. This results in a validation error as it not expected to have 0 source in permission. 

Fix:
While expanding we only add those permissions which are valid( > 0 sources). 
The expansion approach is slightly changed to return the permissions instead of modifying the passed traffic permission.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
