### PR TITLE
chor: adds informative error message when acls disabled and read-only…

### DIFF
--- a/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
+++ b/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
@@ -10,6 +10,12 @@
       Link to HCP Consul Central
     </M.Header>
     <M.Body>
+      {{#if (not (can "read acls"))}}
+        <Hds::Alert class="link-to-hcp-modal__no-acls-alert" @type="inline" @color="critical" data-test-link-to-hcp-modal-no-acls-alert as |A|>
+          <A.Title>ACLs are disabled on this cluster.</A.Title>
+          <A.Description>The cluster can only be linked with read/write access.</A.Description>
+        </Hds::Alert>
+      {{/if}}
       <Hds::Form::Radio::Group data-test-link-to-hcp-modal-access-level-options @layout="vertical" @name="accessMode" as
                                |G|>
         <G.Legend>Select cluster access mode before linking</G.Legend>

--- a/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
+++ b/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
@@ -33,8 +33,11 @@
             with the “builtin/global-read-only” policy in the next step.
           </F.HelperText>
         </G.Radio::Field>
+        {{#if (and this.isReadOnlyAccessLevelSelected (not (can "read acls")))}}
+          <G.Error data-test-link-to-hcp-modal-access-level-options-error>ACLs are disabled on this cluster and are required for read-only access.</G.Error>
+        {{/if}}
       </Hds::Form::Radio::Group>
-      {{#if (and this.isReadOnlyAccessLevelSelected (can "create tokens"))}}
+      {{#if (and this.isReadOnlyAccessLevelSelected (can "read acls") (can "create tokens"))}}
         <div class="link-to-hcp-modal__generate-token">
           {{#if  globalReadonlyPolicy.data}}
             <p class="hds-typography-display-100 hds-font-weight-medium font-family-sans-display">

--- a/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.scss
+++ b/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.scss
@@ -4,6 +4,9 @@
  */
 
 .link-to-hcp-modal {
+  &__no-acls-alert {
+    margin-bottom: 16px;
+  }
   &__generate-token {
     display: flex;
     flex-direction: column;

--- a/ui/packages/consul-ui/tests/integration/components/link-to-hcp-modal-test.js
+++ b/ui/packages/consul-ui/tests/integration/components/link-to-hcp-modal-test.js
@@ -14,6 +14,7 @@ import { BlockingEventSource as RealEventSource } from 'consul-ui/utils/dom/even
 import { ACCESS_LEVEL } from 'consul-ui/components/link-to-hcp-modal';
 
 const modalSelector = '[data-test-link-to-hcp-modal]';
+const modalNoACLsAlertSelector = '[data-test-link-to-hcp-modal-no-acls-alert]';
 const modalOptionReadOnlySelector = '#accessMode-readonly';
 const modalOptionReadOnlyErrorSelector = '[data-test-link-to-hcp-modal-access-level-options-error]';
 const modalGenerateTokenCardSelector = '[data-test-link-to-hcp-modal-generate-token-card]';
@@ -89,6 +90,8 @@ module('Integration | Component | link-to-hcp-modal', function (hooks) {
                                      @partition="-" />`);
 
     assert.dom(modalSelector).exists({ count: 1 });
+    assert.dom(`${modalSelector} ${modalNoACLsAlertSelector}`).doesNotExist();
+
     // select read-only
     await click(`${modalSelector} ${modalOptionReadOnlySelector}`);
 
@@ -185,6 +188,7 @@ module('Integration | Component | link-to-hcp-modal', function (hooks) {
                                      @partition="-" />`);
 
     assert.dom(modalSelector).exists({ count: 1 });
+    assert.dom(`${modalSelector} ${modalNoACLsAlertSelector}`).doesNotExist();
     // select read-only
     await click(`${modalSelector} ${modalOptionReadOnlySelector}`);
 
@@ -211,6 +215,7 @@ module('Integration | Component | link-to-hcp-modal', function (hooks) {
                                      @partition="-" />`);
 
     assert.dom(modalSelector).exists({ count: 1 });
+    assert.dom(`${modalSelector} ${modalNoACLsAlertSelector}`).isVisible();
     // select read-only
     await click(`${modalSelector} ${modalOptionReadOnlySelector}`);
 

--- a/ui/packages/consul-ui/tests/integration/components/link-to-hcp-modal-test.js
+++ b/ui/packages/consul-ui/tests/integration/components/link-to-hcp-modal-test.js
@@ -15,6 +15,7 @@ import { ACCESS_LEVEL } from 'consul-ui/components/link-to-hcp-modal';
 
 const modalSelector = '[data-test-link-to-hcp-modal]';
 const modalOptionReadOnlySelector = '#accessMode-readonly';
+const modalOptionReadOnlyErrorSelector = '[data-test-link-to-hcp-modal-access-level-options-error]';
 const modalGenerateTokenCardSelector = '[data-test-link-to-hcp-modal-generate-token-card]';
 const modalGenerateTokenCardValueSelector =
   '[data-test-link-to-hcp-modal-generate-token-card-value]';
@@ -58,6 +59,9 @@ module('Integration | Component | link-to-hcp-modal', function (hooks) {
       class Stub extends Service {
         can(permission) {
           if (permission === 'create tokens') {
+            return true;
+          }
+          if (permission === 'read acls') {
             return true;
           }
         }
@@ -188,5 +192,31 @@ module('Integration | Component | link-to-hcp-modal', function (hooks) {
     assert.dom(`${modalSelector} ${modalGenerateTokenButtonSelector}`).doesNotExist();
     // Missed policy alert is visible
     assert.dom(`${modalSelector} ${modalGenerateTokenMissedPolicyAlertSelector}`).isVisible();
+  });
+
+  test('it shows an error wher read-only selected and acls are disabled', async function (assert) {
+    this.owner.register(
+      'service:abilities',
+      class Stub extends Service {
+        can(permission) {
+          if (permission === 'read acls') {
+            return false;
+          }
+        }
+      }
+    );
+
+    await render(hbs`<LinkToHcpModal @dc="dc-1"
+                                     @nspace="default"
+                                     @partition="-" />`);
+
+    assert.dom(modalSelector).exists({ count: 1 });
+    // select read-only
+    await click(`${modalSelector} ${modalOptionReadOnlySelector}`);
+
+    // when read-only selected and no policy, it doesn't show the generate token button
+    assert.dom(`${modalSelector} ${modalGenerateTokenButtonSelector}`).doesNotExist();
+    // No acls enabled error is presented
+    assert.dom(`${modalSelector} ${modalOptionReadOnlyErrorSelector}`).isVisible();
   });
 });


### PR DESCRIPTION
… selected

### Description
- Add modal critical alert when acls are disabled
- Add error message when acls are disabled and read-only selected

https://github.com/hashicorp/consul/assets/10027860/a185cf1f-67f8-4d08-ab0a-15d43308a675


<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps
1. go to Consul
2. set cookies: CONSUL_ACLS_ENABLE to 0 
3. Check the link to hcp modal and verify if the critical alert and an error message on selecting read-only are shown 
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links
https://hashicorp.atlassian.net/browse/CC-7447
<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
