### PR TITLE
Fix #20594 : Feature - 'consul tls cert renew' command

### DIFF
--- a/.changelog/20604.txt
+++ b/.changelog/20604.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: Adds new command `tls cert renew` to renew existing tls certificate using same private key.
+```

--- a/command/registry.go
+++ b/command/registry.go
@@ -133,6 +133,7 @@ import (
 	tlscacreate "github.com/hashicorp/consul/command/tls/ca/create"
 	tlscert "github.com/hashicorp/consul/command/tls/cert"
 	tlscertcreate "github.com/hashicorp/consul/command/tls/cert/create"
+	tlscertrenew "github.com/hashicorp/consul/command/tls/cert/renew"
 	"github.com/hashicorp/consul/command/troubleshoot"
 	troubleshootports "github.com/hashicorp/consul/command/troubleshoot/ports"
 	troubleshootproxy "github.com/hashicorp/consul/command/troubleshoot/proxy"
@@ -275,6 +276,7 @@ func RegisteredCommands(ui cli.Ui) map[string]mcli.CommandFactory {
 		entry{"tls ca create", func(ui cli.Ui) (cli.Command, error) { return tlscacreate.New(ui), nil }},
 		entry{"tls cert", func(ui cli.Ui) (cli.Command, error) { return tlscert.New(), nil }},
 		entry{"tls cert create", func(ui cli.Ui) (cli.Command, error) { return tlscertcreate.New(ui), nil }},
+		entry{"tls cert renew", func(ui cli.Ui) (cli.Command, error) { return tlscertrenew.New(ui), nil }},
 		entry{"troubleshoot", func(ui cli.Ui) (cli.Command, error) { return troubleshoot.New(), nil }},
 		entry{"troubleshoot proxy", func(ui cli.Ui) (cli.Command, error) { return troubleshootproxy.New(ui), nil }},
 		entry{"troubleshoot upstreams", func(ui cli.Ui) (cli.Command, error) { return troubleshootupstreams.New(ui), nil }},

--- a/command/tls/cert/renew/tls_cert_renew.go
+++ b/command/tls/cert/renew/tls_cert_renew.go
@@ -1,0 +1,237 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package create
+
+import (
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/hashicorp/consul/command/tls"
+	"github.com/hashicorp/consul/lib/file"
+	"github.com/hashicorp/consul/tlsutil"
+	"github.com/mitchellh/cli"
+)
+
+func New(ui cli.Ui) *cmd {
+	c := &cmd{UI: ui}
+	c.init()
+	return c
+}
+
+type cmd struct {
+	UI          cli.Ui
+	flags       *flag.FlagSet
+	ca          string
+	key         string
+	server      bool
+	client      bool
+	cli         bool
+	dc          string
+	days        int
+	domain      string
+	help        string
+	node        string
+	dnsnames    flags.AppendSliceValue
+	ipaddresses flags.AppendSliceValue
+	prefix      string
+}
+
+func (c *cmd) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.StringVar(&c.ca, "ca", "#DOMAIN#-agent-ca.pem", "Provide path to the ca. Defaults to #DOMAIN#-agent-ca.pem.")
+	c.flags.StringVar(&c.key, "key", "#DOMAIN#-agent-ca-key.pem", "Provide path to the key. Defaults to #DOMAIN#-agent-ca-key.pem.")
+	c.flags.BoolVar(&c.server, "server", false, "Generate server certificate.")
+	c.flags.BoolVar(&c.client, "client", false, "Generate client certificate.")
+	c.flags.StringVar(&c.node, "node", "", "When generating a server cert and this is set an additional dns name is included of the form <node>.server.<datacenter>.<domain>.")
+	c.flags.BoolVar(&c.cli, "cli", false, "Generate cli certificate.")
+	c.flags.IntVar(&c.days, "days", 365, "Provide number of days the certificate is valid for from now on. Defaults to 1 year.")
+	c.flags.StringVar(&c.dc, "dc", "dc1", "Provide the datacenter. Matters only for -server certificates. Defaults to dc1.")
+	c.flags.StringVar(&c.domain, "domain", "consul", "Provide the domain. Matters only for -server certificates.")
+	c.flags.Var(&c.dnsnames, "additional-dnsname", "Provide an additional dnsname for Subject Alternative Names. "+
+		"localhost is always included. This flag may be provided multiple times.")
+	c.flags.Var(&c.ipaddresses, "additional-ipaddress", "Provide an additional ipaddress for Subject Alternative Names. "+
+		"127.0.0.1 is always included. This flag may be provided multiple times.")
+	c.help = flags.Usage(help, c.flags)
+}
+
+func (c *cmd) Run(args []string) int {
+	if err := c.flags.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		c.UI.Error(fmt.Sprintf("Failed to parse args: %v", err))
+		return 1
+	}
+	if c.ca == "" {
+		c.UI.Error("Please provide the ca")
+		return 1
+	}
+	if c.key == "" {
+		c.UI.Error("Please provide the key")
+		return 1
+	}
+
+	if !((c.server && !c.client && !c.cli) ||
+		(!c.server && c.client && !c.cli) ||
+		(!c.server && !c.client && c.cli)) {
+		c.UI.Error("Please provide either -server, -client, or -cli")
+		return 1
+	}
+
+	if c.node != "" && !c.server {
+		c.UI.Error("-node requires -server")
+		return 1
+	}
+
+	var DNSNames []string
+	var IPAddresses []net.IP
+	var extKeyUsage []x509.ExtKeyUsage
+	var name, prefix string
+
+	for _, d := range c.dnsnames {
+		if len(d) > 0 {
+			DNSNames = append(DNSNames, strings.TrimSpace(d))
+		}
+	}
+
+	for _, i := range c.ipaddresses {
+		if len(i) > 0 {
+			IPAddresses = append(IPAddresses, net.ParseIP(strings.TrimSpace(i)))
+		}
+	}
+
+	if c.server {
+		name = fmt.Sprintf("server.%s.%s", c.dc, c.domain)
+
+		if c.node != "" {
+			nodeName := fmt.Sprintf("%s.server.%s.%s", c.node, c.dc, c.domain)
+			DNSNames = append(DNSNames, nodeName)
+		}
+		DNSNames = append(DNSNames, name)
+		DNSNames = append(DNSNames, "localhost")
+
+		IPAddresses = append(IPAddresses, net.ParseIP("127.0.0.1"))
+		extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+		prefix = fmt.Sprintf("%s-server-%s", c.dc, c.domain)
+
+	} else if c.client {
+		name = fmt.Sprintf("client.%s.%s", c.dc, c.domain)
+		DNSNames = append(DNSNames, []string{name, "localhost"}...)
+		IPAddresses = append(IPAddresses, net.ParseIP("127.0.0.1"))
+		extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+		prefix = fmt.Sprintf("%s-client-%s", c.dc, c.domain)
+	} else if c.cli {
+		name = fmt.Sprintf("cli.%s.%s", c.dc, c.domain)
+		DNSNames = []string{name, "localhost"}
+		prefix = fmt.Sprintf("%s-cli-%s", c.dc, c.domain)
+	} else {
+		c.UI.Error("Neither client, cli nor server - should not happen")
+		return 1
+	}
+
+	var pkFileName, certFileName string
+	max := 10000
+	for i := 0; i <= max; i++ {
+		tmpCert := fmt.Sprintf("%s-%d.pem", prefix, i)
+		tmpPk := fmt.Sprintf("%s-%d-key.pem", prefix, i)
+		if tls.FileDoesNotExist(tmpCert) && tls.FileDoesNotExist(tmpPk) {
+			certFileName = tmpCert
+			pkFileName = tmpPk
+			break
+		}
+		if i == max {
+			c.UI.Error("Could not find a filename that doesn't already exist")
+			return 1
+		}
+	}
+
+	caFile := strings.Replace(c.ca, "#DOMAIN#", c.domain, 1)
+	keyFile := strings.Replace(c.key, "#DOMAIN#", c.domain, 1)
+	cert, err := os.ReadFile(caFile)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading CA: %s", err))
+		return 1
+	}
+	key, err := os.ReadFile(keyFile)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading CA key: %s", err))
+		return 1
+	}
+
+	if c.server {
+		c.UI.Info(
+			`==> WARNING: Server Certificates grants authority to become a
+    server and access all state in the cluster including root keys
+    and all ACL tokens. Do not distribute them to production hosts
+    that are not server nodes. Store them as securely as CA keys.`)
+	}
+	c.UI.Info("==> Using " + caFile + " and " + keyFile)
+
+	signer, err := tlsutil.ParseSigner(string(key))
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	pub, priv, err := tlsutil.RenewCert(tlsutil.CertOpts{
+		Signer: signer, CA: string(cert), Name: name, Days: c.days,
+		DNSNames: DNSNames, IPAddresses: IPAddresses, ExtKeyUsage: extKeyUsage,
+	})
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if err = tlsutil.Verify(string(cert), pub, name); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if err := file.WriteAtomicWithPerms(certFileName, []byte(pub), 0755, 0666); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+	c.UI.Output("==> Saved " + certFileName)
+
+	if err := file.WriteAtomicWithPerms(pkFileName, []byte(priv), 0755, 0600); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+	c.UI.Output("==> Saved " + pkFileName)
+
+	return 0
+}
+
+func (c *cmd) Synopsis() string {
+	return synopsis
+}
+
+func (c *cmd) Help() string {
+	return c.help
+}
+
+const synopsis = "Renew a existing certificate"
+const help = `
+Usage: consul tls cert renew [options]
+
+  Renew existing certificate
+
+  $ consul tls cert renew -server
+  ==> WARNING: Server Certificates grants authority to become a
+      server and access all state in the cluster including root keys
+      and all ACL tokens. Do not distribute them to production hosts
+      that are not server nodes. Store them as securely as CA keys.
+  ==> Using consul-agent-ca.pem and consul-agent-ca-key.pem
+  ==> Saved dc1-server-consul-0.pem
+  ==> Saved dc1-server-consul-0-key.pem
+  $ consul tls cert create -client
+  ==> Using consul-agent-ca.pem and consul-agent-ca-key.pem
+  ==> Saved dc1-client-consul-0.pem
+  ==> Saved dc1-client-consul-0-key.pem
+`

--- a/command/tls/cert/renew/tls_cert_renew.go
+++ b/command/tls/cert/renew/tls_cert_renew.go
@@ -212,16 +212,11 @@ Usage: consul tls cert renew [options]
 
   Renew existing certificate
 
-  $ consul tls cert renew -server
+  $ consul tls cert renew -existingcert=dc1-server-consul-0.pem -existingkey=dc1-server-consul-0-key.pem
   ==> WARNING: Server Certificates grants authority to become a
       server and access all state in the cluster including root keys
       and all ACL tokens. Do not distribute them to production hosts
       that are not server nodes. Store them as securely as CA keys.
   ==> Using consul-agent-ca.pem and consul-agent-ca-key.pem
-  ==> Saved dc1-server-consul-0.pem
-  ==> Saved dc1-server-consul-0-key.pem
-  $ consul tls cert create -client
-  ==> Using consul-agent-ca.pem and consul-agent-ca-key.pem
-  ==> Saved dc1-client-consul-0.pem
-  ==> Saved dc1-client-consul-0-key.pem
+  ==> Saved dc1-server-consul-1.pem
 `

--- a/command/tls/cert/renew/tls_cert_renew.go
+++ b/command/tls/cert/renew/tls_cert_renew.go
@@ -49,7 +49,7 @@ func (c *cmd) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
 	c.flags.StringVar(&c.ca, "ca", "#DOMAIN#-agent-ca.pem", "Provide path to the ca. Defaults to #DOMAIN#-agent-ca.pem.")
 	c.flags.StringVar(&c.key, "key", "#DOMAIN#-agent-ca-key.pem", "Provide path to the key. Defaults to #DOMAIN#-agent-ca-key.pem.")
-	c.flags.StringVar(&c.existingkey, "key", "#DOMAIN#-agent-#-key.pem", "Provide path to the existing key. Defaults to #DOMAIN#-agent-#-key.pem.")
+	c.flags.StringVar(&c.existingkey, "existingkey", "", "Provide path to the existing key like #DOMAIN#-agent-#-key.pem.")
 	c.flags.BoolVar(&c.server, "server", false, "Generate server certificate.")
 	c.flags.BoolVar(&c.client, "client", false, "Generate client certificate.")
 	c.flags.StringVar(&c.node, "node", "", "When generating a server cert and this is set an additional dns name is included of the form <node>.server.<datacenter>.<domain>.")
@@ -80,10 +80,6 @@ func (c *cmd) Run(args []string) int {
 		c.UI.Error("Please provide the key")
 		return 1
 	}
-	if c.existingkey == "" {
-		c.UI.Error("Please provide the existingkey")
-		return 1
-	}
 
 	if !((c.server && !c.client && !c.cli) ||
 		(!c.server && c.client && !c.cli) ||
@@ -94,6 +90,11 @@ func (c *cmd) Run(args []string) int {
 
 	if c.node != "" && !c.server {
 		c.UI.Error("-node requires -server")
+		return 1
+	}
+
+	if c.existingkey == "" {
+		c.UI.Error("Please provide the existingkey like #DOMAIN#-agent-#-key.pem.")
 		return 1
 	}
 

--- a/command/tls/cert/renew/tls_cert_renew_test.go
+++ b/command/tls/cert/renew/tls_cert_renew_test.go
@@ -1,0 +1,326 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package renew
+
+import (
+	"crypto"
+	"crypto/x509"
+	"io/fs"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/sdk/testutil"
+
+	caCreate "github.com/hashicorp/consul/command/tls/ca/create"
+	certCreate "github.com/hashicorp/consul/command/tls/cert/create"
+)
+
+func TestValidateCommand_noTabs(t *testing.T) {
+	t.Parallel()
+	if strings.ContainsRune(New(nil).Help(), '\t') {
+		t.Fatal("help has tabs")
+	}
+}
+
+func TestTlsCertRenewCommand_InvalidArgs(t *testing.T) {
+	t.Parallel()
+
+	type testcase struct {
+		args      []string
+		expectErr string
+	}
+
+	cases := map[string]testcase{
+		"no args (ca/key inferred)": {[]string{},
+			"Please provide either -server, -client, or -cli"},
+		"no ca": {[]string{"-ca", "", "-key", ""},
+			"Please provide the ca"},
+		"no key": {[]string{"-ca", "foo.pem", "-key", ""},
+			"Please provide the key"},
+		"no existingkey": {[]string{"-server", "-existingkey", ""},
+			"Please provide the existingkey like #DOMAIN#-agent-#-key.pem."},
+
+		"server+client+cli": {[]string{"-server", "-client", "-cli"},
+			"Please provide either -server, -client, or -cli"},
+		"server+client": {[]string{"-server", "-client"},
+			"Please provide either -server, -client, or -cli"},
+		"server+cli": {[]string{"-server", "-cli"},
+			"Please provide either -server, -client, or -cli"},
+		"client+cli": {[]string{"-client", "-cli"},
+			"Please provide either -server, -client, or -cli"},
+
+		"client+node": {[]string{"-client", "-node", "foo"},
+			"-node requires -server"},
+		"cli+node": {[]string{"-cli", "-node", "foo"},
+			"-node requires -server"},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ui := cli.NewMockUi()
+			cmd := New(ui)
+			require.NotEqual(t, 0, cmd.Run(tc.args))
+			got := ui.ErrorWriter.String()
+			if tc.expectErr == "" {
+				require.NotEmpty(t, got) // don't care
+			} else {
+				require.Contains(t, got, tc.expectErr)
+			}
+		})
+	}
+}
+
+func TestTlsCertRenewCommand_fileCreate(t *testing.T) {
+	testDir := testutil.TempDir(t, "tls")
+
+	defer switchToTempDir(t, testDir)()
+
+	// Setup CA keys
+	createCA(t, "consul")
+	createCA(t, "nomad")
+
+	type testcase struct {
+		name            string
+		typ             string
+		args            []string
+		certPath        string
+		keyPath         string
+		existingkeyPath string
+		expectCN        string
+		expectDNS       []string
+		expectIP        []net.IP
+	}
+
+	// The following subtests must run serially.
+	cases := []testcase{
+		{"server0",
+			"server",
+			[]string{"-server"},
+			"dc1-server-consul-0.pem",
+			"dc1-server-consul-0-key.pem",
+			"server.dc1.consul",
+			[]string{
+				"server.dc1.consul",
+				"localhost",
+			},
+			[]net.IP{{127, 0, 0, 1}},
+		},
+		{"server1-with-node",
+			"server",
+			[]string{"-server", "-node", "mysrv"},
+			"dc1-server-consul-1.pem",
+			"dc1-server-consul-1-key.pem",
+			"server.dc1.consul",
+			[]string{
+				"mysrv.server.dc1.consul",
+				"server.dc1.consul",
+				"localhost",
+			},
+			[]net.IP{{127, 0, 0, 1}},
+		},
+		{"server0-dc2-altdomain",
+			"server",
+			[]string{"-server", "-dc", "dc2", "-domain", "nomad"},
+			"dc2-server-nomad-0.pem",
+			"dc2-server-nomad-0-key.pem",
+			"server.dc2.nomad",
+			[]string{
+				"server.dc2.nomad",
+				"localhost",
+			},
+			[]net.IP{{127, 0, 0, 1}},
+		},
+		{"client0",
+			"client",
+			[]string{"-client"},
+			"dc1-client-consul-0.pem",
+			"dc1-client-consul-0-key.pem",
+			"client.dc1.consul",
+			[]string{
+				"client.dc1.consul",
+				"localhost",
+			},
+			[]net.IP{{127, 0, 0, 1}},
+		},
+		{"client1",
+			"client",
+			[]string{"-client"},
+			"dc1-client-consul-1.pem",
+			"dc1-client-consul-1-key.pem",
+			"client.dc1.consul",
+			[]string{
+				"client.dc1.consul",
+				"localhost",
+			},
+			[]net.IP{{127, 0, 0, 1}},
+		},
+		{"client0-dc2-altdomain",
+			"client",
+			[]string{"-client", "-dc", "dc2", "-domain", "nomad"},
+			"dc2-client-nomad-0.pem",
+			"dc2-client-nomad-0-key.pem",
+			"client.dc2.nomad",
+			[]string{
+				"client.dc2.nomad",
+				"localhost",
+			},
+			[]net.IP{{127, 0, 0, 1}},
+		},
+		{"cli0",
+			"cli",
+			[]string{"-cli"},
+			"dc1-cli-consul-0.pem",
+			"dc1-cli-consul-0-key.pem",
+			"cli.dc1.consul",
+			[]string{
+				"cli.dc1.consul",
+				"localhost",
+			},
+			nil,
+		},
+		{"cli1",
+			"cli",
+			[]string{"-cli"},
+			"dc1-cli-consul-1.pem",
+			"dc1-cli-consul-1-key.pem",
+			"cli.dc1.consul",
+			[]string{
+				"cli.dc1.consul",
+				"localhost",
+			},
+			nil,
+		},
+		{"cli0-dc2-altdomain",
+			"cli",
+			[]string{"-cli", "-dc", "dc2", "-domain", "nomad"},
+			"dc2-cli-nomad-0.pem",
+			"dc2-cli-nomad-0-key.pem",
+			"cli.dc2.nomad",
+			[]string{
+				"cli.dc2.nomad",
+				"localhost",
+			},
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		require.True(t, t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			cmd := New(ui)
+			require.Equal(t, 0, cmd.Run(tc.args))
+			require.Equal(t, "", ui.ErrorWriter.String())
+
+			cert, _ := expectFiles(t, tc.certPath, tc.keyPath)
+			require.Equal(t, tc.expectCN, cert.Subject.CommonName)
+			require.True(t, cert.BasicConstraintsValid)
+			require.Equal(t, x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment, cert.KeyUsage)
+			switch tc.typ {
+			case "server":
+				require.Equal(t,
+					[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+					cert.ExtKeyUsage)
+			case "client":
+				require.Equal(t,
+					[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+					cert.ExtKeyUsage)
+			case "cli":
+				require.Len(t, cert.ExtKeyUsage, 0)
+			}
+			require.False(t, cert.IsCA)
+			require.Equal(t, tc.expectDNS, cert.DNSNames)
+			require.Equal(t, tc.expectIP, cert.IPAddresses)
+		}))
+	}
+}
+
+func expectFiles(t *testing.T, certPath, keyPath string) (*x509.Certificate, crypto.Signer) {
+	t.Helper()
+
+	require.FileExists(t, certPath)
+	require.FileExists(t, keyPath)
+
+	fi, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatal("should not happen", err)
+	}
+	if want, have := fs.FileMode(0600), fi.Mode().Perm(); want != have {
+		t.Fatalf("private key file %s: permissions: want: %o; have: %o", keyPath, want, have)
+	}
+
+	certData, err := os.ReadFile(certPath)
+	require.NoError(t, err)
+	keyData, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+
+	cert, err := connect.ParseCert(string(certData))
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+
+	signer, err := connect.ParseSigner(string(keyData))
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+
+	return cert, signer
+}
+
+func createCA(t *testing.T, domain string) {
+	t.Helper()
+
+	ui := cli.NewMockUi()
+	caCmd := caCreate.New(ui)
+
+	args := []string{
+		"-domain=" + domain,
+	}
+
+	require.Equal(t, 0, caCmd.Run(args))
+	require.Equal(t, "", ui.ErrorWriter.String())
+
+	require.FileExists(t, "consul-agent-ca.pem")
+}
+
+func createCert(t *testing.T, domain string) {
+	t.Helper()
+
+	ui := cli.NewMockUi()
+	caCmd := certCreate.New(ui)
+
+	args := []string{
+		"-server",
+	}
+
+	require.Equal(t, 0, caCmd.Run(args))
+	require.Equal(t, "", ui.ErrorWriter.String())
+
+	require.FileExists(t, "consul-agent-ca.pem")
+}
+
+// switchToTempDir is meant to be used in a defer statement like:
+//
+//	defer switchToTempDir(t, testDir)()
+//
+// This exploits the fact that the body of a defer is evaluated
+// EXCEPT for the final function call invocation inline with the code
+// where it is found. Only the final evaluation happens in the defer
+// at a later time. In this case it means we switch to the temp
+// directory immediately and defer switching back in one line of test
+// code.
+func switchToTempDir(t *testing.T, testDir string) func() {
+	previousDirectory, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(testDir))
+	return func() {
+		os.Chdir(previousDirectory)
+	}
+}

--- a/tlsutil/generate.go
+++ b/tlsutil/generate.go
@@ -209,7 +209,7 @@ func RenewCert(opts CertOpts, existingkey []byte) (string, error) {
 	}
 
 	keyBlock, _ := pem.Decode(existingkey)
-	existingPrivateKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	existingPrivateKey, err := x509.ParseECPrivateKey(keyBlock.Bytes)
 	if err != nil {
 		return "", fmt.Errorf("error parsing existing private key: %w", err)
 	}


### PR DESCRIPTION
### Description

Add new cli cmd to be able to renew existing TLS Server Certificate -
`consul tls cert renew`

fixes #20594 

The approach used to renew existing TLS certificate - 
1. New Public Key (cert file) is created with same  (existing) input private key.
2. The same CA used to generate initial cert is used to sign. CA file path to be  input.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

1. Create CA with cmd `consul tls ca create`
3. Create Cert with cmd `consul tls cert create -server`
4. Renew Certificate created in step 2 with same private key created in step 2 - with new cmd - `consul tls cert renew -server -existingkey=<key file created in step2>`
5. Replace cert file created in step 2 with new (renewed) cert file created in step3. 
6. This will avert having to distribute a new trust chain to all clients and avoid a service disruption to clients. 

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
