### PR TITLE
feat(v2dns): add v2 style query metrics

### DIFF
--- a/agent/discovery/query_fetcher_v1.go
+++ b/agent/discovery/query_fetcher_v1.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/prometheus"
 
 	"github.com/hashicorp/go-hclog"
 
@@ -28,6 +29,15 @@ const (
 	// Increment a counter when requests staler than this are served
 	staleCounterThreshold = 5 * time.Second
 )
+
+// DNSCounters pre-registers the staleness metric.
+// This value is used by both the V1 and V2 DNS (V1 Catalog-only) servers.
+var DNSCounters = []prometheus.CounterDefinition{
+	{
+		Name: []string{"dns", "stale_queries"},
+		Help: "Increments when an agent serves a query within the allowed stale threshold.",
+	},
+}
 
 // v1DataFetcherDynamicConfig is used to store the dynamic configuration of the V1 data fetcher.
 type v1DataFetcherDynamicConfig struct {

--- a/agent/dns/router_test.go
+++ b/agent/dns/router_test.go
@@ -6,11 +6,12 @@ package dns
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/consul/internal/dnsutil"
 	"net"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/internal/dnsutil"
 
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/mock"
@@ -2743,7 +2744,15 @@ func runHandleTestCases(t *testing.T, tc HandleTestCase) {
 	if ctx == nil {
 		ctx = &Context{}
 	}
-	actual := router.HandleRequest(tc.request, *ctx, tc.remoteAddress)
+
+	var remoteAddress net.Addr
+	if tc.remoteAddress != nil {
+		remoteAddress = tc.remoteAddress
+	} else {
+		remoteAddress = &net.UDPAddr{}
+	}
+
+	actual := router.HandleRequest(tc.request, *ctx, remoteAddress)
 	require.Equal(t, tc.response, actual)
 }
 

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/consul/agent/consul/stream"
 	"github.com/hashicorp/consul/agent/consul/usagemetrics"
 	"github.com/hashicorp/consul/agent/consul/xdscapacity"
+	"github.com/hashicorp/consul/agent/discovery"
 	"github.com/hashicorp/consul/agent/grpc-external/limiter"
 	grpcInt "github.com/hashicorp/consul/agent/grpc-internal"
 	"github.com/hashicorp/consul/agent/grpc-internal/balancer"
@@ -434,6 +435,7 @@ func getPrometheusDefs(cfg *config.RuntimeConfig, isServer bool) ([]prometheus.G
 		consul.CatalogCounters,
 		consul.ClientCounters,
 		consul.RPCCounters,
+		discovery.DNSCounters,
 		grpcWare.StatsCounters,
 		local.StateCounters,
 		xds.StatsCounters,


### PR DESCRIPTION
### Description
This PR adds metrics for the V2 DNS server per the RFC. The two V1 metrics are consolidated into "query" with a request type label. There are also some bugfixes to pre-register the staleness metric.

The new metric for queries is added to V1 so there is a migration path.

### Testing & Reproduction steps
None really.

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~ - This will happen in a separate PR
* [X] appropriate backport labels added
* [X] not a security concern
