### PR TITLE
Add samenessgroup registration for enterprise

### DIFF
--- a/internal/auth/internal/controllers/trafficpermissions/controller_test.go
+++ b/internal/auth/internal/controllers/trafficpermissions/controller_test.go
@@ -722,7 +722,7 @@ func TestController_OrphanedTrafficPermissions(t *testing.T) {
 	client := rtest.NewClient(
 		controllertest.NewControllerTestBuilder().
 			WithTenancies(resourcetest.TestTenancies()...).
-			WithResourceRegisterFns(types.Register).
+			WithResourceRegisterFns(types.Register, multicluster.RegisterTypes).
 			WithControllerRegisterFns(func(mgr *controller.Manager) {
 				mgr.Register(Controller(trafficpermissionsmapper.New(), expander.GetSamenessGroupExpander()))
 			}).


### PR DESCRIPTION
### Description

Fixes missed enterprise type registration in https://github.com/hashicorp/consul/pull/20593

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
