### PR TITLE
docs: developer docs for resource finalizers

### DIFF
--- a/docs/v2-architecture/controller-architecture/guide.md
+++ b/docs/v2-architecture/controller-architecture/guide.md
@@ -530,15 +530,15 @@ Example flow in a controller's `Reconcile` method
 const finalizer = "consul.io/bar-finalizer"
 
 func (barReconciler) Reconcile(ctx context.Context, rt controller.Runtime, req controller.Request) error {
-    ...
-    // Check if resource is marked for deletion. If yes, perform cleanup, remove finalizer, and Write the resource
+	...
+	// Check if resource is marked for deletion. If yes, perform cleanup, remove finalizer, and Write the resource
 	if resource.IsMarkedForDeletion(res) {
-        // Perform some cleanup...
+		// Perform some cleanup...
 		return EnsureFinalizerRemoved(ctx, rt, res, finalizer)
 	}
 
-    // Check if resource has finalizer. If not, add it and Write the resource
-	if err = EnsureHasFinalizer(ctx, rt, res, finalizer); err != nil {
+	// Check if resource has finalizer. If not, add it and Write the resource
+	if err := EnsureHasFinalizer(ctx, rt, res, finalizer); err != nil {
 		return err
 	}
 }

--- a/docs/v2-architecture/controller-architecture/guide.md
+++ b/docs/v2-architecture/controller-architecture/guide.md
@@ -525,6 +525,25 @@ func RemoveFinalizer(res *pbresource.Resource, finalizer string) { ... }
 func GetFinalizers(res *pbresource.Resource) mapset.Set[string] { ... }
 ```
 
+Example flow in a controller's `Reconcile` method
+```Go
+const finalizer = "consul.io/bar-finalizer"
+
+func (barReconciler) Reconcile(ctx context.Context, rt controller.Runtime, req controller.Request) error {
+    ...
+    // Check if resource is marked for deletion. If yes, perform cleanup, remove finalizer, and Write the resource
+	if resource.IsMarkedForDeletion(res) {
+        // Perform some cleanup...
+		return EnsureFinalizerRemoved(ctx, rt, res, finalizer)
+	}
+
+    // Check if resource has finalizer. If not, add it and Write the resource
+	if err = EnsureHasFinalizer(ctx, rt, res, finalizer); err != nil {
+		return err
+	}
+}
+```
+
 ## Ownership & Cascading Deletion
 
 The resource service implements a lightweight `1:N` ownership model where, on


### PR DESCRIPTION
### Description

Docs for finalizers. See https://hashicorp.atlassian.net/browse/NET-6959.

### Reviewers
- tagging @mkam and @NickCellino as primaries since you folks are the only ones that have tried to use finalizers
- @loshz for core team coverage

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
