### PR TITLE
fix(v2dns): add node ttl to workloads, comment cleanup, and changelog

### DIFF
--- a/.changelog/20643.txt
+++ b/.changelog/20643.txt
@@ -1,0 +1,7 @@
+```release-note:feature
+dns: adds experimental support for a refactored DNS server that is v1 and v2 Catalog compatible. 
+Use `v2dns` in the `experiments` agent config to enable. 
+It will automatically be enabled when using the `resource-apis` (Catalog v2) experiment.
+The new DNS implementation will be the default in Consul 1.19.
+See the [Consul 1.18.x Release Notes](https://developer.hashicorp.com/consul/docs/release-notes/consul/v1_18_x) for deprecated DNS features.
+```

--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -20,7 +20,6 @@ var (
 
 // ECSNotGlobalError may be used to wrap an error or nil, to indicate that the
 // EDNS client subnet source scope is not global.
-// TODO (v2-dns): prepared queries errors are wrapped by this
 type ECSNotGlobalError struct {
 	error
 }

--- a/agent/discovery/query_fetcher_v1.go
+++ b/agent/discovery/query_fetcher_v1.go
@@ -58,7 +58,6 @@ type v1DataFetcherDynamicConfig struct {
 
 // V1DataFetcher is used to fetch data from the V1 catalog.
 type V1DataFetcher struct {
-	// TODO(v2-dns): store this in the config.
 	defaultEnterpriseMeta acl.EnterpriseMeta
 	dynamicConfig         atomic.Value
 	logger                hclog.Logger
@@ -275,7 +274,7 @@ func (f *V1DataFetcher) FetchRecordsByIp(reqCtx Context, ip net.IP) ([]*Result, 
 	}
 
 	// nothing found locally, recurse
-	// TODO: (v2-dns) implement recursion
+	// TODO: (v2-dns) implement recursion (NET-7883)
 	//d.handleRecurse(resp, req)
 
 	return nil, fmt.Errorf("unhandled error in FetchRecordsByIp")

--- a/agent/discovery/query_fetcher_v1_test.go
+++ b/agent/discovery/query_fetcher_v1_test.go
@@ -103,7 +103,6 @@ func Test_FetchVirtualIP(t *testing.T) {
 						*reply = tc.expectedResult.Service.Address
 					}
 				})
-			// TODO (v2-dns): mock these properly
 			translateServicePortFunc := func(dc string, port int, taggedAddresses map[string]structs.ServiceAddress) int { return 0 }
 			rpcFuncForServiceNodes := func(ctx context.Context, req structs.ServiceSpecificRequest) (structs.IndexedCheckServiceNodes, cache.ResultMeta, error) {
 				return structs.IndexedCheckServiceNodes{}, cache.ResultMeta{}, nil
@@ -166,7 +165,6 @@ func Test_FetchEndpoints(t *testing.T) {
 
 	logger := testutil.Logger(t)
 	mockRPC := cachetype.NewMockRPC(t)
-	// TODO (v2-dns): mock these properly
 	translateServicePortFunc := func(dc string, port int, taggedAddresses map[string]structs.ServiceAddress) int { return 0 }
 	rpcFuncForSamenessGroup := func(ctx context.Context, req *structs.ConfigEntryQuery) (structs.SamenessGroupConfigEntry, cache.ResultMeta, error) {
 		return structs.SamenessGroupConfigEntry{}, cache.ResultMeta{}, nil

--- a/agent/dns/parser_test.go
+++ b/agent/dns/parser_test.go
@@ -1,6 +1,0 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: BUSL-1.1
-
-package dns
-
-// TODO (v2-dns): parser tests

--- a/agent/dns/router_test.go
+++ b/agent/dns/router_test.go
@@ -1874,6 +1874,7 @@ func Test_HandleRequest(t *testing.T) {
 							Name:   "api.port.foo.workload.consul.",
 							Rrtype: dns.TypeA,
 							Class:  dns.ClassINET,
+							Ttl:    123,
 						},
 						A: net.ParseIP("1.2.3.4"),
 					},
@@ -1932,6 +1933,7 @@ func Test_HandleRequest(t *testing.T) {
 							Name:   "foo.workload.consul.",
 							Rrtype: dns.TypeA,
 							Class:  dns.ClassINET,
+							Ttl:    123,
 						},
 						A: net.ParseIP("1.2.3.4"),
 					},
@@ -1994,6 +1996,7 @@ func Test_HandleRequest(t *testing.T) {
 							Name:   "foo.workload.bar.ns.baz.ap.dc3.dc.consul.",
 							Rrtype: dns.TypeA,
 							Class:  dns.ClassINET,
+							Ttl:    123,
 						},
 						A: net.ParseIP("1.2.3.4"),
 					},
@@ -2058,6 +2061,7 @@ func Test_HandleRequest(t *testing.T) {
 							Name:   "api.port.foo.workload.consul.",
 							Rrtype: dns.TypeCNAME,
 							Class:  dns.ClassINET,
+							Ttl:    123,
 						},
 						Target: "foo.example.com.",
 					},
@@ -2165,6 +2169,7 @@ func Test_HandleRequest(t *testing.T) {
 							Name:   "api.port.foo.workload.consul.",
 							Rrtype: dns.TypeCNAME,
 							Class:  dns.ClassINET,
+							Ttl:    123,
 						},
 						Target: "foo.example.com.",
 					},
@@ -2173,6 +2178,7 @@ func Test_HandleRequest(t *testing.T) {
 							Name:   "foo.example.com.",
 							Rrtype: dns.TypeA,
 							Class:  dns.ClassINET,
+							Ttl:    123,
 						},
 						A: net.ParseIP("1.2.3.4"),
 					},
@@ -2280,15 +2286,17 @@ func Test_HandleRequest(t *testing.T) {
 							Name:   "api.port.foo.workload.consul.",
 							Rrtype: dns.TypeCNAME,
 							Class:  dns.ClassINET,
+							Ttl:    123,
 						},
 						Target: "foo.example.com.",
 					},
-					// TODO (v2-dns): this next record is wrong per the RFC
+					// TODO (v2-dns): this next record is wrong per the RFC-1034 mentioned in the comment above (NET-8060)
 					&dns.A{
 						Hdr: dns.RR_Header{
 							Name:   "foo.example.com.",
 							Rrtype: dns.TypeCNAME,
 							Class:  dns.ClassINET,
+							Ttl:    123,
 						},
 						A: net.ParseIP("1.2.3.4"),
 					},
@@ -2383,7 +2391,7 @@ func Test_HandleRequest(t *testing.T) {
 				Answer: []dns.RR{
 					&dns.A{
 						Hdr: dns.RR_Header{
-							Name:   "foo.service.consul.", // TODO (v2-dns): verify this shouldn't include tenancy for workloads
+							Name:   "foo.service.consul.",
 							Rrtype: dns.TypeA,
 							Class:  dns.ClassINET,
 							Ttl:    uint32(123),
@@ -2882,7 +2890,7 @@ func Test_HandleRequest(t *testing.T) {
 						},
 						A: net.ParseIP("1.2.3.4"),
 					},
-					// TODO (v2-dns): This needs to be de-dupped
+					// TODO (v2-dns): This needs to be de-duplicated (NET-8064)
 					&dns.A{
 						Hdr: dns.RR_Header{
 							Name:   "foo-1.example.com.",

--- a/agent/dns/server_test.go
+++ b/agent/dns/server_test.go
@@ -1,6 +1,0 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: BUSL-1.1
-
-package dns
-
-// TODO (v2-dns): add at least one test to listen and serve with a dummy router.

--- a/agent/dns_node_lookup_test.go
+++ b/agent/dns_node_lookup_test.go
@@ -155,8 +155,7 @@ func TestDNS_NodeLookup_CaseInsensitive(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7632 - Fix node lookup when question name has a period in it.
-// Answer is coming back empty
+// V2 DNS does not support node names with a period. This will be deprecated.
 func TestDNS_NodeLookup_PeriodName(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -1981,7 +1981,7 @@ func TestDNS_ServiceLookup_CaseInsensitive(t *testing.T) {
 	}
 }
 
-// TODO (v2-dns): NET-7632 - Fix node and prepared query lookups when question name has a period in it
+// V2 DNS: we have deprecated support for service tags w/ periods
 func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -3623,7 +3623,7 @@ func TestDNS_V1ConfigReload(t *testing.T) {
 
 }
 
-// TODO (v2-dns) add a test for checking the V2 DNS Server reloads the config
+// TODO (v2-dns) add a test for checking the V2 DNS Server reloads the config (NET-8056)
 
 func TestDNS_ReloadConfig_DuringQuery(t *testing.T) {
 	if testing.Short() {

--- a/agent/grpc-external/services/dns/server_v2.go
+++ b/agent/grpc-external/services/dns/server_v2.go
@@ -72,7 +72,7 @@ func (s *ServerV2) Query(ctx context.Context, req *pbdns.QueryRequest) (*pbdns.Q
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failure decoding dns request: %s", err.Error()))
 	}
 
-	// TODO (v2-dns): parse token and other context metadata from the grpc request/metadata
+	// TODO (v2-dns): parse token and other context metadata from the grpc request/metadata (NET-7885)
 	reqCtx := agentdns.Context{
 		Token: s.TokenFunc(),
 	}


### PR DESCRIPTION
### Description
This PR started out as comment cleanup but ended up including some functional changes, including eliminating some unused fields and adding the Node TTLs to Workloads (which was discussed previously with Keeler). 

The changelog for V2 DNS is also included here.

### Testing & Reproduction steps
* CI


### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] appropriate backport labels added
* [X] not a security concern