### PR TITLE
chor: change cluster name param to have datacenter.name as default value

### DIFF
--- a/ui/packages/consul-ui/app/components/hcp-nav-item/index.js
+++ b/ui/packages/consul-ui/app/components/hcp-nav-item/index.js
@@ -52,7 +52,6 @@ export default class HcpLinkItemComponent extends Component {
 
   @action
   onLinkToConsulCentral() {
-    this.hcpLinkModal.setResourceId(this.args.linkData?.resourceId);
     this.hcpLinkModal.show();
   }
 }

--- a/ui/packages/consul-ui/app/components/link-to-hcp-banner/index.js
+++ b/ui/packages/consul-ui/app/components/link-to-hcp-banner/index.js
@@ -22,7 +22,6 @@ export default class LinkToHcpBannerComponent extends Component {
   }
   @action
   onClusterLink() {
-    this.hcpLinkModal.setResourceId(this.args.linkData?.resourceId);
     this.hcpLinkModal.show();
   }
 }

--- a/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
+++ b/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
@@ -101,7 +101,7 @@
         />
         <Hds::Button type="button" @text="Cancel" @color="secondary"
                      data-test-link-to-hcp-modal-cancel-button
-          {{on "click" (fn this.deactivateModal)}}
+          {{on "click" F.close}}
         />
       </Hds::ButtonSet>
     </M.Footer>

--- a/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
+++ b/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
@@ -45,7 +45,7 @@
       </Hds::Form::Radio::Group>
       {{#if (and this.isReadOnlyAccessLevelSelected (can "read acls") (can "create tokens"))}}
         <div class="link-to-hcp-modal__generate-token">
-          {{#if  globalReadonlyPolicy.data}}
+          {{#if  (and globalReadonlyPolicy globalReadonlyPolicy.data)}}
             <p class="hds-typography-display-100 hds-font-weight-medium font-family-sans-display">
               Generate a read-only ACL token now (preferred) or copy an existing token’s secret ID
             </p>
@@ -101,7 +101,7 @@
         />
         <Hds::Button type="button" @text="Cancel" @color="secondary"
                      data-test-link-to-hcp-modal-cancel-button
-          {{on "click" F.close}}
+          {{on "click" (fn this.deactivateModal)}}
         />
       </Hds::ButtonSet>
     </M.Footer>

--- a/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
+++ b/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
@@ -97,7 +97,7 @@
                      @icon="external-link"
                      @iconPosition="trailing"
                      data-test-link-to-hcp-modal-next-button
-                     @href={{hcp-authentication-link this.hcpLinkModal.resourceId this.accessLevel}}
+                     @href={{hcp-authentication-link @dc this.accessLevel}}
         />
         <Hds::Button type="button" @text="Cancel" @color="secondary"
                      data-test-link-to-hcp-modal-cancel-button

--- a/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.js
+++ b/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.js
@@ -27,6 +27,12 @@ export default class LinkToHcpModalComponent extends Component {
   isGeneratingToken = false;
   AccessLevel = ACCESS_LEVEL;
 
+  constructor(args, owner) {
+    super(...arguments);
+    // it is needed for .lookup to not flakey in tests
+    this.hideModal = this.hcpLinkModal.hide.bind(this.hcpLinkModal);
+  }
+
   get isReadOnlyAccessLevelSelected() {
     return this.accessLevel === this.AccessLevel.GLOBALREADONLY;
   }
@@ -34,10 +40,6 @@ export default class LinkToHcpModalComponent extends Component {
   get isTokenGenerated() {
     return this.token && this.token.length > 0;
   }
-
-  deactivateModal = () => {
-    this.hcpLinkModal.hide();
-  };
 
   onGenerateTokenClicked = (policy) => {
     this.isGeneratingToken = true;
@@ -54,11 +56,11 @@ export default class LinkToHcpModalComponent extends Component {
   };
 
   @action
-  onCancel() {
-    this.deactivateModal();
-  }
-  @action
   onAccessModeChanged({ target }) {
     this.accessLevel = target.value;
+  }
+  @action
+  deactivateModal() {
+    this.hideModal();
   }
 }

--- a/ui/packages/consul-ui/app/helpers/hcp-authentication-link.js
+++ b/ui/packages/consul-ui/app/helpers/hcp-authentication-link.js
@@ -18,17 +18,12 @@ export const HCP_PREFIX =
   'https://portal.cloud.hashicorp.com/services/consul/clusters/self-managed/link-existing';
 export default class hcpAuthenticationLink extends Helper {
   @service('env') env;
-  compute([resourceId, accessMode], hash) {
+  compute([datacenterName, accessMode]) {
     let url = new URL(HCP_PREFIX);
     const clusterVersion = this.env.var('CONSUL_VERSION');
 
-    // if resourceId is empty, we still might want the user to get to the HCP sign-in page
-    if (resourceId) {
-      // Array looks like: ["organization", organizationId, "project", projectId, "hashicorp.consul.global-network-manager.cluster", "Cluster Id"]
-      const [, , , , , clusterName] = resourceId.split('/');
-      if (clusterName) {
-        url.searchParams.append('cluster_name', clusterName);
-      }
+    if (datacenterName) {
+      url.searchParams.append('cluster_name', datacenterName);
     }
 
     if (clusterVersion) {

--- a/ui/packages/consul-ui/app/helpers/hcp-authentication-link.js
+++ b/ui/packages/consul-ui/app/helpers/hcp-authentication-link.js
@@ -7,10 +7,6 @@ import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
 /**
- * A resourceId Looks like:
- * organization/b4432207-bb9c-438e-a160-b98923efa979/project/4b09958c-fa91-43ab-8029-eb28d8cee9d4/hashicorp.consul.global-network-manager.cluster/test-from-api
- * organization/${organizationId}/project/${projectId}/hashicorp.consul.global-network-manager.cluster/${clusterName}
- *
  * A HCP URL looks like:
  * https://portal.cloud.hashicorp.com/services/consul/clusters/self-managed/link-existing?cluster_name=test-from-api&cluster_version=1.18.0&cluster_access_mode=CONSUL_ACCESS_LEVEL_GLOBAL_READ_WRITE&redirect_url=localhost:8500/services
  */

--- a/ui/packages/consul-ui/app/services/hcp-link-modal.js
+++ b/ui/packages/consul-ui/app/services/hcp-link-modal.js
@@ -8,7 +8,6 @@ import { tracked } from '@glimmer/tracking';
 
 export default class HcpLinkModalService extends Service {
   @tracked isModalVisible = false;
-  @tracked resourceId = null;
 
   show(hcpLinkData) {
     this.isModalVisible = true;
@@ -16,8 +15,5 @@ export default class HcpLinkModalService extends Service {
 
   hide() {
     this.isModalVisible = false;
-  }
-  setResourceId(resourceId) {
-    this.resourceId = resourceId;
   }
 }

--- a/ui/packages/consul-ui/app/services/hcp-link-modal.js
+++ b/ui/packages/consul-ui/app/services/hcp-link-modal.js
@@ -9,7 +9,7 @@ import { tracked } from '@glimmer/tracking';
 export default class HcpLinkModalService extends Service {
   @tracked isModalVisible = false;
 
-  show(hcpLinkData) {
+  show() {
     this.isModalVisible = true;
   }
 

--- a/ui/packages/consul-ui/tests/acceptance/link-to-hcp-test.js
+++ b/ui/packages/consul-ui/tests/acceptance/link-to-hcp-test.js
@@ -60,8 +60,5 @@ module('Acceptance | link to hcp', function (hooks) {
 
     // link to HCP modal appears
     assert.dom(linkToHcpModalSelector).isVisible('Link to HCP modal is visible');
-
-    // Click on the cancel button
-    await click(`${linkToHcpModalSelector} ${linkToHcpModalCancelButtonSelector}`);
   });
 });

--- a/ui/packages/consul-ui/tests/acceptance/link-to-hcp-test.js
+++ b/ui/packages/consul-ui/tests/acceptance/link-to-hcp-test.js
@@ -60,5 +60,8 @@ module('Acceptance | link to hcp', function (hooks) {
 
     // link to HCP modal appears
     assert.dom(linkToHcpModalSelector).isVisible('Link to HCP modal is visible');
+
+    // Click on the cancel button
+    await click(`${linkToHcpModalSelector} ${linkToHcpModalCancelButtonSelector}`);
   });
 });

--- a/ui/packages/consul-ui/tests/acceptance/link-to-hcp-test.js
+++ b/ui/packages/consul-ui/tests/acceptance/link-to-hcp-test.js
@@ -6,7 +6,6 @@
 import { module, test } from 'qunit';
 import { click, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import HcpLinkModalService from 'consul-ui/services/hcp-link-modal';
 
 const bannerSelector = '[data-test-link-to-hcp-banner]';
 const linkToHcpSelector = '[data-test-link-to-hcp]';
@@ -15,20 +14,10 @@ const linkToHcpModalSelector = '[data-test-link-to-hcp-modal]';
 const linkToHcpModalCancelButtonSelector = '[data-test-link-to-hcp-modal-cancel-button]';
 module('Acceptance | link to hcp', function (hooks) {
   setupApplicationTest(hooks);
-  const correctResourceId =
-    'organization/b4432207-bb9c-438e-a160-b98923efa979/project/4b09958c-fa91-43ab-8029-eb28d8cee9d4/hashicorp.consul.global-network-manager.cluster/test-from-api';
 
   hooks.beforeEach(function () {
     // clear local storage so we don't have any settings
     window.localStorage.clear();
-    this.owner.register(
-      'service:hcp-link-modal',
-      class extends HcpLinkModalService {
-        setResourceId(resourceId) {
-          super.setResourceId(correctResourceId);
-        }
-      }
-    );
   });
 
   test('the banner and nav item are initially displayed on services page', async function (assert) {

--- a/ui/packages/consul-ui/tests/integration/components/link-to-hcp-modal-test.js
+++ b/ui/packages/consul-ui/tests/integration/components/link-to-hcp-modal-test.js
@@ -27,8 +27,6 @@ const modalGenerateTokenMissedPolicyAlertSelector =
   '[data-test-link-to-hcp-modal-missed-policy-alert]';
 const modalNextButtonSelector = '[data-test-link-to-hcp-modal-next-button]';
 const modalCancelButtonSelector = '[data-test-link-to-hcp-modal-cancel-button]';
-const resourceId =
-  'organization/b4432207-bb9c-438e-a160-b98923efa979/project/4b09958c-fa91-43ab-8029-eb28d8cee9d4/hashicorp.consul.global-network-manager.cluster/test-from-api';
 
 module('Integration | Component | link-to-hcp-modal', function (hooks) {
   let originalClipboardWriteText;
@@ -71,7 +69,6 @@ module('Integration | Component | link-to-hcp-modal', function (hooks) {
     this.owner.register(
       'service:hcp-link-modal',
       class Stub extends Service {
-        resourceId = resourceId;
         hide = hideModal;
       }
     );

--- a/ui/packages/consul-ui/tests/integration/helpers/hcp-authentication-link-test.js
+++ b/ui/packages/consul-ui/tests/integration/helpers/hcp-authentication-link-test.js
@@ -10,12 +10,9 @@ import { setupRenderingTest } from 'ember-qunit';
 import { HCP_PREFIX } from 'consul-ui/helpers/hcp-authentication-link';
 import { EnvStub } from 'consul-ui/services/env';
 
-// organization/b4432207-bb9c-438e-a160-b98923efa979/project/4b09958c-fa91-43ab-8029-eb28d8cee9d4/hashicorp.consul.global-network-manager.cluster/test-from-api
 const clusterName = 'hello';
 const clusterVersion = '1.18.0';
 const accessMode = 'CONSUL_ACCESS_LEVEL_GLOBAL_READ_WRITE';
-const projectId = '4b09958c-fa91-43ab-8029-eb28d8cee9d4';
-const realResourceId = `organization/b4432207-bb9c-438e-a160-b98923efa979/project/${projectId}/hashicorp.consul.global-network-manager.cluster/${clusterName}`;
 module('Integration | Helper | hcp-authentication-link', function (hooks) {
   setupRenderingTest(hooks);
   hooks.beforeEach(function () {
@@ -29,9 +26,9 @@ module('Integration | Helper | hcp-authentication-link', function (hooks) {
     );
   });
   test('it makes a URL out of a real resourceId', async function (assert) {
-    this.resourceId = realResourceId;
+    this.dcName = clusterName;
 
-    await render(hbs`{{hcp-authentication-link resourceId}}`);
+    await render(hbs`{{hcp-authentication-link dcName}}`);
 
     assert.equal(
       this.element.textContent.trim(),
@@ -39,38 +36,21 @@ module('Integration | Helper | hcp-authentication-link', function (hooks) {
     );
   });
 
-  test('it returns correct link with invalid resourceId', async function (assert) {
-    this.resourceId = 'invalid';
+  test('it returns correct link without dc name', async function (assert) {
+    this.dcName = null;
 
-    await render(hbs`{{hcp-authentication-link resourceId}}`);
-    assert.equal(
-      this.element.textContent.trim(),
-      `${HCP_PREFIX}?cluster_version=${clusterVersion}`
-    );
-
-    // not enough items in id
-    this.resourceId =
-      '`organization/b4432207-bb9c-438e-a160-b98923efa979/project/${projectId}/hashicorp.consul.global-network-manager.cluster`';
-    await render(hbs`{{hcp-authentication-link resourceId}}`);
-    assert.equal(
-      this.element.textContent.trim(),
-      `${HCP_PREFIX}?cluster_version=${clusterVersion}`
-    );
-
-    // value is null
-    this.resourceId = null;
-    await render(hbs`{{hcp-authentication-link resourceId}}`);
+    await render(hbs`{{hcp-authentication-link dcName}}`);
     assert.equal(
       this.element.textContent.trim(),
       `${HCP_PREFIX}?cluster_version=${clusterVersion}`
     );
   });
 
-  test('it makes a URL out of a real resourceId and accessLevel, if passed', async function (assert) {
-    this.resourceId = realResourceId;
+  test('it makes a URL out of a dc name and accessLevel, if passed', async function (assert) {
+    this.dcName = clusterName;
     this.accessMode = accessMode;
 
-    await render(hbs`{{hcp-authentication-link resourceId accessMode}}`);
+    await render(hbs`{{hcp-authentication-link dcName accessMode}}`);
 
     assert.equal(
       this.element.textContent.trim(),


### PR DESCRIPTION
### Description
rethink on default value for cluster name on linking. 
With the pr it is set to datacenter name

<!-- Please describe why you're making this change, in plain English. -->
Attention to link ⬇️ 
<img width="1260" alt="image" src="https://github.com/hashicorp/consul/assets/10027860/113438fe-71f6-407c-8289-00a075c5c664">

### Testing & Reproduction steps
1. fo to consul 
2. check the link to hcp modal and click/hover the Next button
3. see the cluster_name param in the link bellow/in a new tab when redirected
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
