### PR TITLE
Add api-gateway builder with basic required endpoint/cluster generation

### DIFF
--- a/internal/mesh/internal/controllers/gatewayproxy/builder/api_gateway_builder.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/builder/api_gateway_builder.go
@@ -1,0 +1,99 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package builder
+
+import (
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul/internal/mesh/internal/controllers/gatewayproxy/fetcher"
+	"github.com/hashicorp/consul/internal/mesh/internal/proxytarget"
+	"github.com/hashicorp/consul/internal/mesh/internal/types"
+	pbauth "github.com/hashicorp/consul/proto-public/pbauth/v2beta1"
+	meshv2beta1 "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbmesh/v2beta1/pbproxystate"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+)
+
+type apiGWProxyStateTemplateBuilder struct {
+	workload    *types.DecodedWorkload
+	dataFetcher *fetcher.Fetcher
+	dc          string
+	computed    *meshv2beta1.ComputedGatewayConfiguration
+	logger      hclog.Logger
+	trustDomain string
+}
+
+func NewAPIGWProxyStateTemplateBuilder(workload *types.DecodedWorkload, configuration *meshv2beta1.ComputedGatewayConfiguration, logger hclog.Logger, dataFetcher *fetcher.Fetcher, dc, trustDomain string) *apiGWProxyStateTemplateBuilder {
+	return &apiGWProxyStateTemplateBuilder{
+		workload:    workload,
+		dataFetcher: dataFetcher,
+		computed:    configuration,
+		dc:          dc,
+		logger:      logger,
+		trustDomain: trustDomain,
+	}
+}
+
+func (b *apiGWProxyStateTemplateBuilder) identity() *pbresource.Reference {
+	return &pbresource.Reference{
+		Name:    b.workload.Data.Identity,
+		Tenancy: b.workload.Id.Tenancy,
+		Type:    pbauth.WorkloadIdentityType,
+	}
+}
+
+func (b *apiGWProxyStateTemplateBuilder) defaultDC(dc string) string {
+	if dc != b.dc {
+		panic("cross datacenter service discovery clusters are not supported in v2")
+	}
+	return dc
+}
+
+func (b *apiGWProxyStateTemplateBuilder) clustersAndEndpoints() (map[string]*pbproxystate.Cluster, map[string]*pbproxystate.EndpointRef) {
+	clusters := map[string]*pbproxystate.Cluster{}
+	endpoints := map[string]*pbproxystate.EndpointRef{}
+
+	for _, listener := range b.computed.ListenerConfigs {
+		for _, config := range listener.HostnameConfigs {
+			listenerClusters, listenerEndpoints := proxytarget.ClustersAndEndpoints(config.Routes, b.trustDomain, b.identity().Name, b.defaultDC)
+			for name, cluster := range listenerClusters {
+				clusters[name] = cluster
+			}
+			for name, endpoint := range listenerEndpoints {
+				endpoints[name] = endpoint
+			}
+		}
+	}
+
+	return clusters, endpoints
+}
+
+func (b *apiGWProxyStateTemplateBuilder) listenersAndRoutes() ([]*pbproxystate.Listener, map[string]*pbproxystate.Route) {
+	listeners := []*pbproxystate.Listener{}
+	routes := map[string]*pbproxystate.Route{}
+
+	return listeners, routes
+}
+
+func (b *apiGWProxyStateTemplateBuilder) certificates() map[string]*pbproxystate.LeafCertificate {
+	return make(map[string]*pbproxystate.LeafCertificate)
+}
+
+func (b *apiGWProxyStateTemplateBuilder) Build() *meshv2beta1.ProxyStateTemplate {
+	clusters, endpoints := b.clustersAndEndpoints()
+	listeners, routes := b.listenersAndRoutes()
+
+	return &meshv2beta1.ProxyStateTemplate{
+		ProxyState: &meshv2beta1.ProxyState{
+			Identity:         b.identity(),
+			Listeners:        listeners,
+			Clusters:         clusters,
+			Routes:           routes,
+			LeafCertificates: b.certificates(),
+		},
+		RequiredEndpoints:        endpoints,
+		RequiredLeafCertificates: make(map[string]*pbproxystate.LeafCertificateRef),
+		RequiredTrustBundles:     make(map[string]*pbproxystate.TrustBundleRef),
+	}
+}

--- a/internal/mesh/internal/controllers/gatewayproxy/builder/api_gateway_builder_test.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/builder/api_gateway_builder_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package builder
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
+
+	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
+	"github.com/hashicorp/consul/internal/catalog"
+	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/mesh/internal/controllers/gatewayproxy/fetcher"
+	"github.com/hashicorp/consul/internal/mesh/internal/types"
+	"github.com/hashicorp/consul/internal/multicluster"
+	"github.com/hashicorp/consul/internal/resource/resourcetest"
+	"github.com/hashicorp/consul/internal/testing/golden"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
+	meshv2beta1 "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbmesh/v2beta1/pbproxystate"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/hashicorp/consul/proto/private/prototest"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}
+
+func protoToJSON(t *testing.T, pb proto.Message) string {
+	return prototest.ProtoToJSON(t, pb)
+}
+
+type apiGatewayStateTemplateBuilderSuite struct {
+	suite.Suite
+
+	ctx            context.Context
+	client         pbresource.ResourceServiceClient
+	resourceClient *resourcetest.Client
+	rt             controller.Runtime
+
+	workload              *types.DecodedWorkload
+	computedConfiguration *meshv2beta1.ComputedGatewayConfiguration
+
+	tenancies []*pbresource.Tenancy
+}
+
+func (suite *apiGatewayStateTemplateBuilderSuite) SetupTest() {
+	suite.ctx = testutil.TestContext(suite.T())
+	suite.tenancies = resourcetest.TestTenancies()
+	suite.client = svctest.NewResourceServiceBuilder().
+		WithRegisterFns(types.Register, catalog.RegisterTypes, multicluster.RegisterTypes).
+		WithTenancies(suite.tenancies...).
+		Run(suite.T())
+	suite.resourceClient = resourcetest.NewClient(suite.client)
+	suite.rt = controller.Runtime{
+		Client: suite.client,
+		Logger: testutil.Logger(suite.T()),
+	}
+}
+
+func (suite *apiGatewayStateTemplateBuilderSuite) setupWithTenancy(tenancy *pbresource.Tenancy) {
+	suite.workload = &types.DecodedWorkload{
+		Data: &pbcatalog.Workload{
+			Identity: "test",
+			Addresses: []*pbcatalog.WorkloadAddress{
+				{
+					Host:     "127.0.0.1",
+					External: false,
+				},
+			},
+			Ports: map[string]*pbcatalog.WorkloadPort{
+				"tcp": {
+					Port:     23,
+					Protocol: pbcatalog.Protocol_PROTOCOL_TCP,
+				},
+			},
+		},
+		Resource: &pbresource.Resource{
+			Id: &pbresource.ID{
+				Name:    "test",
+				Tenancy: tenancy,
+			},
+		},
+	}
+
+	suite.computedConfiguration = &pbmesh.ComputedGatewayConfiguration{
+		ListenerConfigs: map[string]*pbmesh.ComputedGatewayListener{
+			"tcp": &pbmesh.ComputedGatewayListener{
+				HostnameConfigs: map[string]*pbmesh.ComputedHostnameRoutes{
+					"*": &pbmesh.ComputedHostnameRoutes{
+						Routes: &pbmesh.ComputedPortRoutes{
+							Config: &pbmesh.ComputedPortRoutes_Tcp{
+								Tcp: &pbmesh.ComputedTCPRoute{
+									Rules: []*pbmesh.ComputedTCPRouteRule{
+										{BackendRefs: []*pbmesh.ComputedTCPBackendRef{
+											{BackendTarget: "backend-v1", Weight: 3},
+											{BackendTarget: "backend-v2", Weight: 1},
+										}},
+									},
+								},
+							},
+							ParentRef: &pbmesh.ParentReference{
+								Ref: &pbresource.Reference{
+									Type:    pbmesh.APIGatewayType,
+									Tenancy: tenancy,
+									Name:    "test",
+								},
+							},
+							Protocol: pbcatalog.Protocol_PROTOCOL_TCP,
+							Targets: map[string]*pbmesh.BackendTargetDetails{
+								"backend-v1": &pbmesh.BackendTargetDetails{
+									Type:              pbmesh.BackendTargetDetailsType_BACKEND_TARGET_DETAILS_TYPE_DIRECT,
+									DestinationConfig: &pbmesh.DestinationConfig{},
+									ServiceEndpointsRef: &pbproxystate.EndpointRef{
+										Id: &pbresource.ID{
+											Name:    "backend-v1",
+											Type:    pbcatalog.ServiceEndpointsType,
+											Tenancy: tenancy,
+										},
+										RoutePort: "target",
+										MeshPort:  "mesh",
+									},
+									BackendRef: &pbmesh.BackendReference{
+										Ref: &pbresource.Reference{
+											Tenancy: tenancy,
+											Name:    "backend-v1",
+										},
+										Port:       "target",
+										Datacenter: "dc1",
+									},
+								},
+								"backend-v2": &pbmesh.BackendTargetDetails{
+									Type:              pbmesh.BackendTargetDetailsType_BACKEND_TARGET_DETAILS_TYPE_DIRECT,
+									DestinationConfig: &pbmesh.DestinationConfig{},
+									ServiceEndpointsRef: &pbproxystate.EndpointRef{
+										Id: &pbresource.ID{
+											Name:    "backend-v2",
+											Type:    pbcatalog.ServiceEndpointsType,
+											Tenancy: tenancy,
+										},
+										RoutePort: "target",
+										MeshPort:  "mesh",
+									},
+									BackendRef: &pbmesh.BackendReference{
+										Ref: &pbresource.Reference{
+											Tenancy: tenancy,
+											Name:    "backend-v2",
+										},
+										Port:       "target",
+										Datacenter: "dc1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (suite *apiGatewayStateTemplateBuilderSuite) TestProxyStateTemplateBuilder_BuildForPeeredExportedServices() {
+	suite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
+		t := suite.T()
+
+		logger := testutil.Logger(t)
+		builder := NewAPIGWProxyStateTemplateBuilder(suite.workload, suite.computedConfiguration, logger, fetcher.New(suite.client), "dc1", "domain")
+
+		actual := protoToJSON(t, builder.Build())
+		expected := golden.Get(t, actual, "api-"+tenancy.Partition+"-"+tenancy.Namespace+".golden")
+		require.JSONEq(t, expected, actual)
+	})
+}
+
+func TestAPIGatewayStateTemplateBuilder(t *testing.T) {
+	suite.Run(t, new(apiGatewayStateTemplateBuilderSuite))
+}
+
+func (suite *apiGatewayStateTemplateBuilderSuite) appendTenancyInfo(tenancy *pbresource.Tenancy) string {
+	return fmt.Sprintf("%s_Namespace_%s_Partition", tenancy.Namespace, tenancy.Partition)
+}
+
+func (suite *apiGatewayStateTemplateBuilderSuite) runTestCaseWithTenancies(t func(*pbresource.Tenancy)) {
+	for _, tenancy := range suite.tenancies {
+		suite.Run(suite.appendTenancyInfo(tenancy), func() {
+			suite.setupWithTenancy(tenancy)
+			t(tenancy)
+		})
+	}
+}

--- a/internal/mesh/internal/controllers/gatewayproxy/builder/testdata/api-default-default.golden
+++ b/internal/mesh/internal/controllers/gatewayproxy/builder/testdata/api-default-default.golden
@@ -1,0 +1,100 @@
+{
+  "proxyState": {
+    "clusters": {
+      "target.backend-v1.default.dc1.internal.domain": {
+        "altStatName": "target.backend-v1.default.dc1.internal.domain",
+        "endpointGroup": {
+          "dynamic": {
+            "config": {
+              "disablePanicThreshold": true
+            },
+            "outboundTls": {
+              "alpnProtocols": [
+                "consul~target"
+              ],
+              "outboundMesh": {
+                "identityKey": "test",
+                "sni": "backend-v1.default.dc1.internal.domain",
+                "validationContext": {
+                  "trustBundlePeerNameKey": "local"
+                }
+              }
+            }
+          }
+        },
+        "name": "target.backend-v1.default.dc1.internal.domain",
+        "protocol": "PROTOCOL_TCP"
+      },
+      "target.backend-v2.default.dc1.internal.domain": {
+        "altStatName": "target.backend-v2.default.dc1.internal.domain",
+        "endpointGroup": {
+          "dynamic": {
+            "config": {
+              "disablePanicThreshold": true
+            },
+            "outboundTls": {
+              "alpnProtocols": [
+                "consul~target"
+              ],
+              "outboundMesh": {
+                "identityKey": "test",
+                "sni": "backend-v2.default.dc1.internal.domain",
+                "validationContext": {
+                  "trustBundlePeerNameKey": "local"
+                }
+              }
+            }
+          }
+        },
+        "name": "target.backend-v2.default.dc1.internal.domain",
+        "protocol": "PROTOCOL_TCP"
+      }
+    },
+    "identity": {
+      "name": "test",
+      "tenancy": {
+        "namespace": "default",
+        "partition": "default"
+      },
+      "type": {
+        "group": "auth",
+        "groupVersion": "v2beta1",
+        "kind": "WorkloadIdentity"
+      }
+    }
+  },
+  "requiredEndpoints": {
+    "target.backend-v1.default.dc1.internal.domain": {
+      "id": {
+        "name": "backend-v1",
+        "tenancy": {
+          "namespace": "default",
+          "partition": "default"
+        },
+        "type": {
+          "group": "catalog",
+          "groupVersion": "v2beta1",
+          "kind": "ServiceEndpoints"
+        }
+      },
+      "meshPort": "mesh",
+      "routePort": "target"
+    },
+    "target.backend-v2.default.dc1.internal.domain": {
+      "id": {
+        "name": "backend-v2",
+        "tenancy": {
+          "namespace": "default",
+          "partition": "default"
+        },
+        "type": {
+          "group": "catalog",
+          "groupVersion": "v2beta1",
+          "kind": "ServiceEndpoints"
+        }
+      },
+      "meshPort": "mesh",
+      "routePort": "target"
+    }
+  }
+}

--- a/internal/mesh/internal/proxytarget/alpn.go
+++ b/internal/mesh/internal/proxytarget/alpn.go
@@ -1,0 +1,7 @@
+package proxytarget
+
+import "fmt"
+
+func GetAlpnProtocolFromPortName(portName string) string {
+	return fmt.Sprintf("consul~%s", portName)
+}

--- a/internal/mesh/internal/proxytarget/clusters.go
+++ b/internal/mesh/internal/proxytarget/clusters.go
@@ -1,0 +1,269 @@
+package proxytarget
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/envoyextensions/xdscommon"
+	"github.com/hashicorp/consul/internal/mesh/internal/types"
+	"github.com/hashicorp/consul/internal/resource"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbmesh/v2beta1/pbproxystate"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+const (
+	nullRouteClusterName = "null_route_cluster"
+)
+
+func nullRouteCluster() *pbproxystate.Cluster {
+	return &pbproxystate.Cluster{
+		Name: nullRouteClusterName,
+		Group: &pbproxystate.Cluster_EndpointGroup{
+			EndpointGroup: &pbproxystate.EndpointGroup{
+				Group: &pbproxystate.EndpointGroup_Static{
+					Static: &pbproxystate.StaticEndpointGroup{
+						Config: &pbproxystate.StaticEndpointGroupConfig{
+							ConnectTimeout: durationpb.New(10 * time.Second),
+						},
+					},
+				},
+			},
+		},
+		Protocol: pbproxystate.Protocol_PROTOCOL_TCP,
+	}
+}
+
+func ClusterSNI(serviceRef *pbresource.Reference, datacenter, trustDomain string) string {
+	return connect.ServiceSNI(serviceRef.Name,
+		"",
+		serviceRef.Tenancy.Namespace,
+		serviceRef.Tenancy.Partition,
+		datacenter,
+		trustDomain)
+}
+
+func newClusterEndpointGroup(
+	clusterName string,
+	sni string,
+	portName string,
+	trustDomain string,
+	identityKey string,
+	destinationIdentities []*pbresource.Reference,
+	connectTimeout *durationpb.Duration,
+	loadBalancer *pbmesh.LoadBalancer,
+) *pbproxystate.EndpointGroup {
+	var spiffeIDs []string
+	for _, identity := range destinationIdentities {
+		spiffeIDs = append(spiffeIDs, connect.SpiffeIDFromIdentityRef(trustDomain, identity))
+	}
+
+	// TODO(v2): DestinationPolicy: circuit breakers, outlier detection
+
+	// TODO(v2): if http2/grpc then set http2protocol options
+
+	degConfig := &pbproxystate.DynamicEndpointGroupConfig{
+		DisablePanicThreshold: true,
+		ConnectTimeout:        connectTimeout,
+	}
+
+	if loadBalancer != nil {
+		// enumcover:pbmesh.LoadBalancerPolicy
+		switch loadBalancer.Policy {
+		case pbmesh.LoadBalancerPolicy_LOAD_BALANCER_POLICY_RANDOM:
+			degConfig.LbPolicy = &pbproxystate.DynamicEndpointGroupConfig_Random{}
+
+		case pbmesh.LoadBalancerPolicy_LOAD_BALANCER_POLICY_ROUND_ROBIN:
+			degConfig.LbPolicy = &pbproxystate.DynamicEndpointGroupConfig_RoundRobin{}
+
+		case pbmesh.LoadBalancerPolicy_LOAD_BALANCER_POLICY_LEAST_REQUEST:
+			var choiceCount uint32
+			cfg, ok := loadBalancer.Config.(*pbmesh.LoadBalancer_LeastRequestConfig)
+			if ok {
+				choiceCount = cfg.LeastRequestConfig.GetChoiceCount()
+			}
+			degConfig.LbPolicy = &pbproxystate.DynamicEndpointGroupConfig_LeastRequest{
+				LeastRequest: &pbproxystate.LBPolicyLeastRequest{
+					ChoiceCount: wrapperspb.UInt32(choiceCount),
+				},
+			}
+
+		case pbmesh.LoadBalancerPolicy_LOAD_BALANCER_POLICY_MAGLEV:
+			degConfig.LbPolicy = &pbproxystate.DynamicEndpointGroupConfig_Maglev{}
+
+		case pbmesh.LoadBalancerPolicy_LOAD_BALANCER_POLICY_RING_HASH:
+			policy := &pbproxystate.DynamicEndpointGroupConfig_RingHash{}
+
+			cfg, ok := loadBalancer.Config.(*pbmesh.LoadBalancer_RingHashConfig)
+			if ok {
+				policy.RingHash = &pbproxystate.LBPolicyRingHash{
+					MinimumRingSize: wrapperspb.UInt64(cfg.RingHashConfig.MinimumRingSize),
+					MaximumRingSize: wrapperspb.UInt64(cfg.RingHashConfig.MaximumRingSize),
+				}
+			}
+
+			degConfig.LbPolicy = policy
+
+		case pbmesh.LoadBalancerPolicy_LOAD_BALANCER_POLICY_UNSPECIFIED:
+			// fallthrough to default
+		default:
+			// do nothing
+		}
+	}
+
+	return &pbproxystate.EndpointGroup{
+		Name: clusterName,
+		Group: &pbproxystate.EndpointGroup_Dynamic{
+			Dynamic: &pbproxystate.DynamicEndpointGroup{
+				Config: degConfig,
+				OutboundTls: &pbproxystate.TransportSocket{
+					ConnectionTls: &pbproxystate.TransportSocket_OutboundMesh{
+						OutboundMesh: &pbproxystate.OutboundMeshMTLS{
+							IdentityKey: identityKey,
+							ValidationContext: &pbproxystate.MeshOutboundValidationContext{
+								SpiffeIds:              spiffeIDs,
+								TrustBundlePeerNameKey: resource.DefaultPeerName,
+							},
+							Sni: sni,
+						},
+					},
+					AlpnProtocols: []string{GetAlpnProtocolFromPortName(portName)},
+				},
+			},
+		},
+	}
+}
+
+func ClustersAndEndpoints(routes *pbmesh.ComputedPortRoutes, trustDomain, identityKey string, defaultDC func(dc string) string) (map[string]*pbproxystate.Cluster, map[string]*pbproxystate.EndpointRef) {
+	clusters := map[string]*pbproxystate.Cluster{}
+	endpoints := map[string]*pbproxystate.EndpointRef{}
+
+	targets := routes.Targets
+	effectiveProtocol := routes.Protocol
+
+	switch routeConfig := routes.Config.(type) {
+	case *pbmesh.ComputedPortRoutes_Http:
+		for _, rule := range routeConfig.Http.Rules {
+			for _, backendRef := range rule.BackendRefs {
+				if backendRef.BackendTarget == types.NullRouteBackend {
+					clusters[nullRouteClusterName] = nullRouteCluster()
+				}
+			}
+		}
+	case *pbmesh.ComputedPortRoutes_Grpc:
+		for _, rule := range routeConfig.Grpc.Rules {
+			for _, backendRef := range rule.BackendRefs {
+				if backendRef.BackendTarget == types.NullRouteBackend {
+					clusters[nullRouteClusterName] = nullRouteCluster()
+				}
+			}
+		}
+	case *pbmesh.ComputedPortRoutes_Tcp:
+		for _, rule := range routeConfig.Tcp.Rules {
+			for _, backendRef := range rule.BackendRefs {
+				if backendRef.BackendTarget == types.NullRouteBackend {
+					clusters[nullRouteClusterName] = nullRouteCluster()
+				}
+			}
+		}
+	default:
+		return clusters, endpoints
+	}
+
+	for _, details := range targets {
+		// NOTE: we only emit clusters for DIRECT targets here.
+		if details.Type != pbmesh.BackendTargetDetailsType_BACKEND_TARGET_DETAILS_TYPE_DIRECT {
+			continue
+		}
+
+		connectTimeout := details.DestinationConfig.ConnectTimeout
+		loadBalancer := details.DestinationConfig.LoadBalancer
+
+		// NOTE: we collect both DIRECT and INDIRECT target information here.
+		portName := details.BackendRef.Port
+		sni := ClusterSNI(
+			details.BackendRef.Ref,
+			defaultDC(details.BackendRef.Datacenter),
+			trustDomain,
+		)
+		clusterName := fmt.Sprintf("%s.%s", portName, sni)
+
+		egName := ""
+		if details.FailoverConfig != nil {
+			egName = fmt.Sprintf("%s%d~%s", xdscommon.FailoverClusterNamePrefix, 0, clusterName)
+		}
+		egBase := newClusterEndpointGroup(egName, sni, portName, trustDomain, identityKey, details.IdentityRefs, connectTimeout, loadBalancer)
+
+		var endpointGroups []*pbproxystate.EndpointGroup
+
+		// Original target is the first (or only) target.
+		endpointGroups = append(endpointGroups, egBase)
+		endpoints[clusterName] = details.ServiceEndpointsRef
+
+		if details.FailoverConfig != nil {
+			failover := details.FailoverConfig
+			// TODO(v2): handle other forms of failover (regions/locality/etc)
+
+			for i, dest := range failover.Destinations {
+				if dest.BackendTarget == types.NullRouteBackend {
+					continue // not possible
+				}
+				destDetails, ok := targets[dest.BackendTarget]
+				if !ok {
+					continue // not possible
+				}
+
+				destConnectTimeout := destDetails.DestinationConfig.ConnectTimeout
+				destLoadBalancer := destDetails.DestinationConfig.LoadBalancer
+
+				destPortName := destDetails.BackendRef.Port
+
+				destSNI := ClusterSNI(
+					destDetails.BackendRef.Ref,
+					defaultDC(destDetails.BackendRef.Datacenter),
+					trustDomain,
+				)
+
+				// index 0 was already given to non-fail original
+				failoverGroupIndex := i + 1
+				destClusterName := fmt.Sprintf("%s%d~%s", xdscommon.FailoverClusterNamePrefix, failoverGroupIndex, clusterName)
+
+				egDest := newClusterEndpointGroup(destClusterName, destSNI, destPortName, trustDomain, identityKey, destDetails.IdentityRefs, destConnectTimeout, destLoadBalancer)
+
+				endpointGroups = append(endpointGroups, egDest)
+				endpoints[destClusterName] = destDetails.ServiceEndpointsRef
+			}
+		}
+
+		cluster := &pbproxystate.Cluster{
+			Name:        clusterName,
+			AltStatName: clusterName,
+			Protocol:    pbproxystate.Protocol(effectiveProtocol),
+		}
+		switch len(endpointGroups) {
+		case 0:
+			panic("no endpoint groups provided")
+		case 1:
+			cluster.Group = &pbproxystate.Cluster_EndpointGroup{
+				EndpointGroup: endpointGroups[0],
+			}
+		default:
+			cluster.Group = &pbproxystate.Cluster_FailoverGroup{
+				FailoverGroup: &pbproxystate.FailoverGroup{
+					EndpointGroups: endpointGroups,
+					Config: &pbproxystate.FailoverGroupConfig{
+						UseAltStatName: true,
+						ConnectTimeout: connectTimeout,
+					},
+				},
+			}
+		}
+
+		clusters[cluster.Name] = cluster
+	}
+
+	return clusters, endpoints
+}


### PR DESCRIPTION
### Description

This adds endpoint/cluster generation for the `ProxyStateTemplate` builder for API Gateways. It also does a slight pass on extracting the endpoint/cluster targeting code from our E/W route implementation since the cluster/endpoint construction should be identical.

Keeping it as a draft until #20645 lands, since it leverages the protobuf definitions introduced there.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
