### PR TITLE
test: update the RunWithTenancies function to properly attribute test failures to subtests

### DIFF
--- a/docs/v2-architecture/controller-architecture/testing.md
+++ b/docs/v2-architecture/controller-architecture/testing.md
@@ -36,7 +36,7 @@ import (
 )
 
 func TestReconcile(t *testing.T) {
-	rtest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	rtest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		suite.Run(t, &reconcileSuite{tenancy: tenancy})
 	})
 }

--- a/internal/mesh/internal/controllers/explicitdestinations/controller_test.go
+++ b/internal/mesh/internal/controllers/explicitdestinations/controller_test.go
@@ -63,7 +63,7 @@ type controllerTestSuite struct {
 
 func TestFindDuplicates(t *testing.T) {
 	// Create some conflicting destinations.
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		dest1 := &pbmesh.Destinations{
 			Workloads: &pbcatalog.WorkloadSelector{
 				Names: []string{"foo"},
@@ -187,7 +187,7 @@ func TestFindDuplicates(t *testing.T) {
 		require.Contains(t, duplicates, resource.NewReferenceKey(dest3Res.Id))
 		require.Contains(t, duplicates, resource.NewReferenceKey(dest4Res.Id))
 		require.NotContains(t, duplicates, resource.NewReferenceKey(nonConflictingDestRes.Id))
-	}, t)
+	})
 }
 
 func (suite *controllerTestSuite) SetupTest() {

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destination_multiport_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destination_multiport_test.go
@@ -30,7 +30,7 @@ func TestBuildMultiportImplicitDestinations(t *testing.T) {
 		datacenter  = "dc1"
 	)
 
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		// TODO(rb/v2): add a fetchertest package to construct implicit upstreams
 		// correctly from inputs. the following is far too manual and error prone
 		// to be an accurate representation of what implicit upstreams look like.
@@ -262,5 +262,5 @@ func TestBuildMultiportImplicitDestinations(t *testing.T) {
 				require.Equal(t, protoToJSON(t, expected), protoToJSON(t, proxyTmpl))
 			})
 		}
-	}, t)
+	})
 }

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/destinations_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/destinations_test.go
@@ -56,7 +56,7 @@ func TestBuildExplicitDestinations(t *testing.T) {
 	types.Register(registry)
 	catalog.RegisterTypes(registry)
 
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		api1Service := resourcetest.Resource(pbcatalog.ServiceType, "api-1").
 			WithTenancy(tenancy).
 			WithData(t, serviceData).
@@ -444,12 +444,12 @@ func TestBuildExplicitDestinations(t *testing.T) {
 				require.JSONEq(t, expected, actual)
 			})
 		}
-	}, t)
+	})
 
 }
 
 func TestBuildImplicitDestinations(t *testing.T) {
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		api1Service := resourcetest.Resource(pbcatalog.ServiceType, "api-1").
 			WithTenancy(tenancy).
 			WithData(t, serviceData).
@@ -572,5 +572,5 @@ func TestBuildImplicitDestinations(t *testing.T) {
 				require.JSONEq(t, expected, actual)
 			})
 		}
-	}, t)
+	})
 }

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/expose_paths_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/expose_paths_test.go
@@ -4,21 +4,21 @@
 package builder
 
 import (
-	"github.com/hashicorp/consul/internal/resource/resourcetest"
-	"github.com/hashicorp/consul/proto-public/pbresource"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 // This file contains tests only for error and edge cases cases. The happy case is tested in local_app_test.go
 
 func TestBuildExposePaths_NilChecks(t *testing.T) {
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		testutil.RunStep(t, "proxy cfg is nil", func(t *testing.T) {
 			b := New(testProxyStateTemplateID(tenancy), testIdentityRef(tenancy), "foo.consul", "dc1", true, nil)
 			require.NotPanics(t, func() {
@@ -41,11 +41,11 @@ func TestBuildExposePaths_NilChecks(t *testing.T) {
 				b.buildExposePaths(nil)
 			})
 		})
-	}, t)
+	})
 }
 
 func TestBuildExposePaths_NoExternalMeshWorkloadAddress(t *testing.T) {
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		workload := &pbcatalog.Workload{
 			Addresses: []*pbcatalog.WorkloadAddress{
 				{Host: "1.1.1.1", External: true},
@@ -73,11 +73,11 @@ func TestBuildExposePaths_NoExternalMeshWorkloadAddress(t *testing.T) {
 		b := New(testProxyStateTemplateID(tenancy), testIdentityRef(tenancy), "foo.consul", "dc1", true, proxycfg)
 		b.buildExposePaths(workload)
 		require.Empty(t, b.proxyStateTemplate.ProxyState.Listeners)
-	}, t)
+	})
 }
 
 func TestBuildExposePaths_InvalidProtocol(t *testing.T) {
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		workload := &pbcatalog.Workload{
 			Addresses: []*pbcatalog.WorkloadAddress{
 				{Host: "1.1.1.1"},
@@ -107,5 +107,5 @@ func TestBuildExposePaths_InvalidProtocol(t *testing.T) {
 		require.PanicsWithValue(t, "unsupported expose paths protocol", func() {
 			b.buildExposePaths(workload)
 		})
-	}, t)
+	})
 }

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/local_app_multiport_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/local_app_multiport_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestBuildLocalApp_Multiport(t *testing.T) {
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		cases := map[string]struct {
 			workload *pbcatalog.Workload
 		}{
@@ -169,5 +169,5 @@ func TestBuildLocalApp_Multiport(t *testing.T) {
 				require.Equal(t, protoToJSON(t, expected), protoToJSON(t, proxyTmpl))
 			})
 		}
-	}, t)
+	})
 }

--- a/internal/mesh/internal/controllers/sidecarproxy/builder/local_app_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/builder/local_app_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/protobuf/types/known/durationpb"
-
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	"github.com/hashicorp/consul/internal/testing/golden"
@@ -24,7 +23,7 @@ import (
 )
 
 func TestBuildLocalApp(t *testing.T) {
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		cases := map[string]struct {
 			workload     *pbcatalog.Workload
 			ctp          *pbauth.ComputedTrafficPermissions
@@ -127,11 +126,11 @@ func TestBuildLocalApp(t *testing.T) {
 				require.Equal(t, protoToJSON(t, expected), protoToJSON(t, proxyTmpl))
 			})
 		}
-	}, t)
+	})
 }
 
 func TestBuildLocalApp_WithProxyConfiguration(t *testing.T) {
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		cases := map[string]struct {
 			workload *pbcatalog.Workload
 			proxyCfg *pbmesh.ComputedProxyConfiguration
@@ -245,11 +244,11 @@ func TestBuildLocalApp_WithProxyConfiguration(t *testing.T) {
 				require.Equal(t, protoToJSON(t, expected), protoToJSON(t, proxyTmpl))
 			})
 		}
-	}, t)
+	})
 }
 
 func TestBuildTrafficPermissions(t *testing.T) {
-	resourcetest.RunWithTenancies(func(tenancy *pbresource.Tenancy) {
+	resourcetest.RunWithTenancies(t, func(t *testing.T, tenancy *pbresource.Tenancy) {
 		testTrustDomain := "test.consul"
 
 		cases := map[string]struct {
@@ -1104,7 +1103,7 @@ func TestBuildTrafficPermissions(t *testing.T) {
 				}
 			})
 		}
-	}, t)
+	})
 }
 
 func testProxyStateTemplateID(tenancy *pbresource.Tenancy) *pbresource.ID {

--- a/internal/resource/resourcetest/tenancy.go
+++ b/internal/resource/resourcetest/tenancy.go
@@ -81,10 +81,10 @@ func AppendTenancyInfo(name string, tenancy *pbresource.Tenancy) string {
 	return fmt.Sprintf("%s_%s_Namespace_%s_Partition", name, tenancy.Namespace, tenancy.Partition)
 }
 
-func RunWithTenancies(testFunc func(tenancy *pbresource.Tenancy), t *testing.T) {
+func RunWithTenancies(t *testing.T, testFunc func(t *testing.T, tenancy *pbresource.Tenancy)) {
 	for _, tenancy := range TestTenancies() {
 		t.Run(AppendTenancyInfo(t.Name(), tenancy), func(t *testing.T) {
-			testFunc(tenancy)
+			testFunc(t, tenancy)
 		})
 	}
 }


### PR DESCRIPTION
### Description

The signature of `resourcetest.RunWithTenancies` did not permit properly attributing subtest failures to the enclosing subtests. This PR adjusts the signature to allow that attribution.
