### PR TITLE
Add listener generation code for TCP routes on API Gateways

### DIFF
--- a/internal/mesh/internal/controllers/gatewayproxy/builder/api_gateway_builder.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/builder/api_gateway_builder.go
@@ -4,12 +4,18 @@
 package builder
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/hashicorp/go-hclog"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/hashicorp/consul/internal/mesh/internal/controllers/gatewayproxy/fetcher"
 	"github.com/hashicorp/consul/internal/mesh/internal/proxytarget"
 	"github.com/hashicorp/consul/internal/mesh/internal/types"
 	pbauth "github.com/hashicorp/consul/proto-public/pbauth/v2beta1"
+	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	meshv2beta1 "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbmesh/v2beta1/pbproxystate"
 	"github.com/hashicorp/consul/proto-public/pbresource"
@@ -51,7 +57,24 @@ func (b *apiGWProxyStateTemplateBuilder) defaultDC(dc string) string {
 }
 
 func (b *apiGWProxyStateTemplateBuilder) clustersAndEndpoints() (map[string]*pbproxystate.Cluster, map[string]*pbproxystate.EndpointRef) {
-	clusters := map[string]*pbproxystate.Cluster{}
+	// we always add the null route cluster since we target it by default
+	clusters := map[string]*pbproxystate.Cluster{
+		nullRouteClusterName: &pbproxystate.Cluster{
+			Name: nullRouteClusterName,
+			Group: &pbproxystate.Cluster_EndpointGroup{
+				EndpointGroup: &pbproxystate.EndpointGroup{
+					Group: &pbproxystate.EndpointGroup_Static{
+						Static: &pbproxystate.StaticEndpointGroup{
+							Config: &pbproxystate.StaticEndpointGroupConfig{
+								ConnectTimeout: durationpb.New(10 * time.Second),
+							},
+						},
+					},
+				},
+			},
+			Protocol: pbproxystate.Protocol_PROTOCOL_TCP,
+		},
+	}
 	endpoints := map[string]*pbproxystate.EndpointRef{}
 
 	for _, listener := range b.computed.ListenerConfigs {
@@ -69,9 +92,228 @@ func (b *apiGWProxyStateTemplateBuilder) clustersAndEndpoints() (map[string]*pbp
 	return clusters, endpoints
 }
 
+func makeInboundListener(
+	name string,
+	port uint32,
+	tls *pbproxystate.TLSParameters,
+	certificate *pbresource.Reference,
+	workload *pbcatalog.Workload,
+) *pbproxystate.Listener {
+	listener := &pbproxystate.Listener{
+		Name:      name,
+		Direction: pbproxystate.Direction_DIRECTION_INBOUND,
+		DefaultRouter: &pbproxystate.Router{
+			Destination: &pbproxystate.Router_L4{
+				L4: &pbproxystate.L4Destination{
+					Destination: &pbproxystate.L4Destination_Cluster{
+						Cluster: &pbproxystate.DestinationCluster{
+							Name: nullRouteClusterName,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if tls != nil {
+		listener.DefaultRouter.InboundTls = &pbproxystate.TransportSocket{
+			TlsParameters: tls,
+			ConnectionTls: &pbproxystate.TransportSocket_InboundNonMesh{
+				InboundNonMesh: &pbproxystate.InboundNonMeshTLS{
+					Identity: &pbproxystate.InboundNonMeshTLS_LeafKey{
+						LeafKey: certificate.String(),
+					},
+				},
+			},
+		}
+	}
+
+	addresses := workload.GetAddresses()
+
+	// If there are more than one address, use the first one in the list.
+	var address string
+	if len(addresses) > 0 {
+		address = addresses[0].Host
+	}
+
+	listener.BindAddress = &pbproxystate.Listener_HostPort{
+		HostPort: &pbproxystate.HostPortAddress{
+			Host: address,
+			Port: port,
+		},
+	}
+
+	// Add TLS inspection capability to be able to parse ALPN and/or SNI information from inbound connections.
+	listener.Capabilities = append(listener.Capabilities, pbproxystate.Capability_CAPABILITY_L4_TLS_INSPECTION)
+
+	return listener
+}
+
+func makeL4RouterForDirect(
+	tls *pbproxystate.TLSParameters,
+	certificate *pbresource.Reference,
+	clusterName,
+	hostname string,
+) *pbproxystate.Router {
+	// For explicit destinations, we have no filter chain match, and filters
+	// are based on port protocol.
+	router := &pbproxystate.Router{
+		Match: &pbproxystate.Match{
+			ServerNames: []string{hostname},
+		},
+	}
+
+	if tls != nil {
+		router.InboundTls = &pbproxystate.TransportSocket{
+			TlsParameters: tls,
+			ConnectionTls: &pbproxystate.TransportSocket_InboundNonMesh{
+				InboundNonMesh: &pbproxystate.InboundNonMeshTLS{
+					Identity: &pbproxystate.InboundNonMeshTLS_LeafKey{
+						LeafKey: certificate.String(),
+					},
+				},
+			},
+		}
+	}
+
+	statPrefix := fmt.Sprintf("upstream.%s", clusterName)
+
+	router.Destination = &pbproxystate.Router_L4{
+		L4: &pbproxystate.L4Destination{
+			Destination: &pbproxystate.L4Destination_Cluster{
+				Cluster: &pbproxystate.DestinationCluster{
+					Name: clusterName,
+				},
+			},
+			StatPrefix: statPrefix,
+		},
+	}
+
+	return router
+}
+
+func makeL4RouterForSplit(
+	tls *pbproxystate.TLSParameters,
+	certificate *pbresource.Reference,
+	clusters []*pbproxystate.L4WeightedDestinationCluster,
+	hostname string,
+) *pbproxystate.Router {
+	// For explicit destinations, we have no filter chain match, and filters
+	// are based on port protocol.
+	router := &pbproxystate.Router{
+		Match: &pbproxystate.Match{
+			ServerNames: []string{hostname},
+		},
+	}
+
+	if tls != nil {
+		router.InboundTls = &pbproxystate.TransportSocket{
+			TlsParameters: tls,
+			ConnectionTls: &pbproxystate.TransportSocket_InboundNonMesh{
+				InboundNonMesh: &pbproxystate.InboundNonMeshTLS{
+					Identity: &pbproxystate.InboundNonMeshTLS_LeafKey{
+						LeafKey: certificate.String(),
+					},
+				},
+			},
+		}
+	}
+
+	statPrefix := "upstream."
+
+	router.Destination = &pbproxystate.Router_L4{
+		L4: &pbproxystate.L4Destination{
+			Destination: &pbproxystate.L4Destination_WeightedClusters{
+				WeightedClusters: &pbproxystate.L4WeightedClusterGroup{
+					Clusters: clusters,
+				},
+			},
+			StatPrefix: statPrefix,
+		},
+	}
+
+	return router
+}
+
+func (b *apiGWProxyStateTemplateBuilder) routerForHostname(
+	tls *pbproxystate.TLSParameters,
+	certificate *pbresource.Reference,
+	hostname string,
+	routes *meshv2beta1.ComputedPortRoutes,
+) *pbproxystate.Router {
+	var (
+		targets = routes.Targets
+	)
+
+	switch config := routes.Config.(type) {
+	case *meshv2beta1.ComputedPortRoutes_Tcp:
+		route := config.Tcp
+
+		if len(route.Rules) != 1 {
+			panic("not possible due to validation and computation")
+		}
+
+		// When not using RDS we must generate a cluster name to attach to
+		// the filter chain. With RDS, cluster names get attached to the
+		// dynamic routes instead.
+
+		routeRule := route.Rules[0]
+
+		switch len(routeRule.BackendRefs) {
+		case 0:
+			panic("not possible to have a tcp route rule with no backend refs")
+		case 1:
+			tcpBackendRef := routeRule.BackendRefs[0]
+			backend := targets[tcpBackendRef.BackendTarget]
+
+			clusterName := proxytarget.ClusterSNI(
+				backend.BackendRef.Ref,
+				b.defaultDC(backend.BackendRef.Datacenter),
+				b.trustDomain,
+			)
+
+			return makeL4RouterForDirect(tls, certificate, clusterName, hostname)
+		default:
+			clusters := make([]*pbproxystate.L4WeightedDestinationCluster, 0, len(routeRule.BackendRefs))
+			for _, tcpBackendRef := range routeRule.BackendRefs {
+				backend := targets[tcpBackendRef.BackendTarget]
+
+				clusterName := proxytarget.ClusterSNI(
+					backend.BackendRef.Ref,
+					b.defaultDC(backend.BackendRef.Datacenter),
+					b.trustDomain,
+				)
+
+				clusters = append(clusters, &pbproxystate.L4WeightedDestinationCluster{
+					Name:   clusterName,
+					Weight: wrapperspb.UInt32(tcpBackendRef.Weight),
+				})
+			}
+
+			return makeL4RouterForSplit(tls, certificate, clusters, hostname)
+		}
+	default:
+		return nil
+	}
+}
+
 func (b *apiGWProxyStateTemplateBuilder) listenersAndRoutes() ([]*pbproxystate.Listener, map[string]*pbproxystate.Route) {
 	listeners := []*pbproxystate.Listener{}
 	routes := map[string]*pbproxystate.Route{}
+
+	for listenerName, listenerConfig := range b.computed.ListenerConfigs {
+		listener := makeInboundListener(listenerName, listenerConfig.Port, listenerConfig.TlsParameters, listenerConfig.Certificate, b.workload.Data)
+		for hostname, computedHostname := range listenerConfig.HostnameConfigs {
+			computedRoute := computedHostname.Routes
+
+			router := b.routerForHostname(listenerConfig.TlsParameters, computedHostname.Certificate, hostname, computedRoute)
+
+			if router != nil {
+				listener.Routers = append(listener.Routers, router)
+			}
+		}
+		listeners = append(listeners, listener)
+	}
 
 	return listeners, routes
 }

--- a/internal/mesh/internal/controllers/gatewayproxy/builder/api_gateway_builder_test.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/builder/api_gateway_builder_test.go
@@ -96,6 +96,7 @@ func (suite *apiGatewayStateTemplateBuilderSuite) setupWithTenancy(tenancy *pbre
 	suite.computedConfiguration = &pbmesh.ComputedGatewayConfiguration{
 		ListenerConfigs: map[string]*pbmesh.ComputedGatewayListener{
 			"tcp": &pbmesh.ComputedGatewayListener{
+				Port: 23,
 				HostnameConfigs: map[string]*pbmesh.ComputedHostnameRoutes{
 					"*": &pbmesh.ComputedHostnameRoutes{
 						Routes: &pbmesh.ComputedPortRoutes{

--- a/internal/mesh/internal/controllers/gatewayproxy/builder/testdata/api-default-default.golden
+++ b/internal/mesh/internal/controllers/gatewayproxy/builder/testdata/api-default-default.golden
@@ -1,6 +1,17 @@
 {
   "proxyState": {
     "clusters": {
+      "null_route_cluster": {
+        "endpointGroup": {
+          "static": {
+            "config": {
+              "connectTimeout": "10s"
+            }
+          }
+        },
+        "name": "null_route_cluster",
+        "protocol": "PROTOCOL_TCP"
+      },
       "target.backend-v1.default.dc1.internal.domain": {
         "altStatName": "target.backend-v1.default.dc1.internal.domain",
         "endpointGroup": {
@@ -61,7 +72,51 @@
         "groupVersion": "v2beta1",
         "kind": "WorkloadIdentity"
       }
-    }
+    },
+    "listeners": [
+      {
+        "capabilities": [
+          "CAPABILITY_L4_TLS_INSPECTION"
+        ],
+        "defaultRouter": {
+          "l4": {
+            "cluster": {
+              "name": "null_route_cluster"
+            }
+          }
+        },
+        "direction": "DIRECTION_INBOUND",
+        "hostPort": {
+          "host": "127.0.0.1",
+          "port": 23
+        },
+        "name": "tcp",
+        "routers": [
+          {
+            "l4": {
+              "statPrefix": "upstream.",
+              "weightedClusters": {
+                "clusters": [
+                  {
+                    "name": "backend-v1.default.dc1.internal.domain",
+                    "weight": 3
+                  },
+                  {
+                    "name": "backend-v2.default.dc1.internal.domain",
+                    "weight": 1
+                  }
+                ]
+              }
+            },
+            "match": {
+              "serverNames": [
+                "*"
+              ]
+            }
+          }
+        ]
+      }
+    ]
   },
   "requiredEndpoints": {
     "target.backend-v1.default.dc1.internal.domain": {


### PR DESCRIPTION
### Description

Much of this code is adapted from the `sidecarproxy` builder, but adjusted for the introduced `ComputedGatewayConfiguration`. Since we're starting with TCP routes, listeners target their clusters directly without any sort of additional RDS, so routes are not currently output in the golden file.

Leaving in Draft until  #20645 and #20647 merge.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
