### PR TITLE
update the link to documents from hcp link modal

### DIFF
--- a/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
+++ b/ui/packages/consul-ui/app/components/link-to-hcp-modal/index.hbs
@@ -20,7 +20,7 @@
                                |G|>
         <G.Legend>Select cluster access mode before linking</G.Legend>
         <G.HelperText>Control the level of access that HCP Consul Central has to your linked cluster.
-          <Hds::Link::Inline @href="https://developer.hashicorp.com/consul/docs/security/acl" @isHrefExternal={{true}}
+          <Hds::Link::Inline @href="https://developer.hashicorp.com/hcp/docs/consul/concepts/cluster-permissions" @isHrefExternal={{true}}
                              @color="secondary">Learn more
           </Hds::Link::Inline>
         </G.HelperText>


### PR DESCRIPTION
### Description

After bug bash findings: 
Update the docs link from https://developer.hashicorp.com/consul/docs/security/acl
Should link to: https://developer.hashicorp.com/hcp/docs/consul/concepts/cluster-permissions

<img width="1082" alt="image" src="https://github.com/hashicorp/consul/assets/10027860/8c17456d-969a-4a3a-84f4-31d0a2258a0e">

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
