### PR TITLE
[CE ]Backport of fix(v2dns): allow secondary datacenters

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -878,7 +878,6 @@ func (a *Agent) Start(ctx context.Context) error {
 
 	// start DNS servers
 	if a.baseDeps.UseV2DNS() {
-		a.logger.Warn("DNS v2 is under construction")
 		if err := a.listenAndServeV2DNS(); err != nil {
 			return err
 		}

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -632,8 +632,7 @@ func TestBuilder_CheckExperimentsInSecondaryDatacenters(t *testing.T) {
 			expectErr: true,
 		},
 		"secondary server v2dns": {
-			hcl:       secondary + `experiments = ["v2dns"]`,
-			expectErr: true,
+			hcl: secondary + `experiments = ["v2dns"]`,
 		},
 		"secondary server v2tenancy": {
 			hcl:       secondary + `experiments = ["v2tenancy"]`,

--- a/agent/consul/options.go
+++ b/agent/consul/options.go
@@ -50,8 +50,10 @@ type Deps struct {
 	EnterpriseDeps
 }
 
-// UseV2DNS returns true if "v2-dns" is present in the Experiments
-// array of the agent config. It is assumed if the v2 resource APIs are enabled.
+// UseV2DNS returns true if "v2dns" is present in the Experiments
+// array of the agent config. V2 DNS refers to the refactored implementation of Consul's DNS server.
+// It can handle either the v1 or v2 Catalog APIs.
+// It is enabled automatically if the v2 resource APIs are enabled.
 func (d Deps) UseV2DNS() bool {
 	if stringslice.Contains(d.Experiments, V2DNSExperimentName) || d.UseV2Resources() {
 		return true

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -143,7 +143,7 @@ const (
 // Likely these will all be short lived exclusions.
 func IsExperimentAllowedOnSecondaries(name string) bool {
 	switch name {
-	case CatalogResourceExperimentName, V2DNSExperimentName, V2TenancyExperimentName:
+	case CatalogResourceExperimentName, V2TenancyExperimentName:
 		return false
 	default:
 		return true

--- a/agent/dns/router.go
+++ b/agent/dns/router.go
@@ -984,7 +984,6 @@ func (r *Router) getAnswerExtraAndNs(result *discovery.Result, port discovery.Po
 		answer = append(answer, makeNSRecord(domain, fqdn, ttl))
 		extra = append(extra, extraRecord)
 	case qType == dns.TypeSOA:
-		// to be returned in the result.
 		fqdn := canonicalNameForResult(result.Type, result.Node.Name, domain, result.Tenancy, port.Name)
 		extraRecord := makeIPBasedRecord(fqdn, nodeAddress, ttl)
 

--- a/agent/dns_catalogv2_test.go
+++ b/agent/dns_catalogv2_test.go
@@ -261,7 +261,8 @@ func TestDNS_CatalogV2_Basic(t *testing.T) {
 				require.Equal(t, 9, len(in.Answer), "answer count did not match expected\n\n%s", in.String())
 				require.Equal(t, 9, len(in.Extra), "extra answer count did not match expected\n\n%s", in.String())
 			} else {
-				// Expect 1 result per port, per workload, up to the default limit of 3. In practice the results are truncated at 2.
+				// Expect 1 result per port, per workload, up to the default limit of 3. In practice the results are truncated
+				// at 2 because of the record byte size.
 				require.Equal(t, 2, len(in.Answer), "answer count did not match expected\n\n%s", in.String())
 				require.Equal(t, 2, len(in.Extra), "extra answer count did not match expected\n\n%s", in.String())
 			}


### PR DESCRIPTION
### Description
Release backport of #20657

I noticed that we added code to invalidate certain experiments on secondary datacenters. We want to allow V2 DNS on secondary centers if we ever want to delete the old implementation.

### Testing & Reproduction steps
* Unit tests updates

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] appropriate backport labels added
* [X] not a security concern