### PR TITLE
Set replication metric to 0 when losing leadership

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -771,6 +771,12 @@ func (s *Server) runACLReplicator(
 
 		index, exit, err := replicateFunc(ctx, logger, lastRemoteIndex)
 		if exit {
+			metrics.SetGauge([]string{"leader", "replication", metricName, "status"},
+				0,
+			)
+			metrics.SetGauge([]string{"leader", "replication", metricName, "index"},
+				0,
+			)
 			return nil
 		}
 

--- a/agent/consul/replication.go
+++ b/agent/consul/replication.go
@@ -153,6 +153,12 @@ func (r *Replicator) Run(ctx context.Context) error {
 		// Perform a single round of replication
 		index, exit, err := r.delegate.Replicate(ctx, atomic.LoadUint64(&r.lastRemoteIndex), r.logger)
 		if exit {
+			metrics.SetGauge([]string{"leader", "replication", r.delegate.MetricName(), "status"},
+				0,
+			)
+			metrics.SetGauge([]string{"leader", "replication", r.delegate.MetricName(), "index"},
+				0,
+			)
 			return nil
 		}
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/11377#issuecomment-966107284

When the leader changes the replication metrics on the old leader (now follower) keeps reporting 1. This PR fixes that issue.


