### PR TITLE
Manual backport of [NET-6741] make: Add target for updating dependencies across all modules into release/1.15.x

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -242,18 +242,13 @@ cov: other-consul dev-build
 
 test: other-consul dev-build lint test-internal
 
-go-mod-tidy:
-	@echo "--> Running go mod tidy"
-	@cd sdk && go mod tidy
-	@cd api && go mod tidy
-	@go mod tidy
-	@cd test/integration/consul-container && go mod tidy
-	@cd test/integration/connect/envoy/test-sds-server && go mod tidy
-	@cd proto-public && go mod tidy
-	@cd internal/tools/proto-gen-rpc-glue && go mod tidy
-	@cd internal/tools/proto-gen-rpc-glue/e2e && go mod tidy
-	@cd internal/tools/proto-gen-rpc-glue/e2e/consul && go mod tidy
-	@cd internal/tools/protoc-gen-consul-rate-limit && go mod tidy
+.PHONY: go-mod-tidy
+go-mod-tidy: $(foreach mod,$(GO_MODULES),go-mod-tidy/$(mod))
+
+.PHONY: mod-tidy/%
+go-mod-tidy/%:
+	@echo "--> Running go mod tidy ($*)"
+	@cd $* && go mod tidy
 
 .PHONY: go-mod-get
 go-mod-get: $(foreach mod,$(GO_MODULES),go-mod-get/$(mod)) ## Run go get and go mod tidy in every module for the given dependency

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,8 @@
 
 SHELL = bash
 
+GO_MODULES := $(shell find . -name go.mod -exec dirname {} \; | grep -v "proto-gen-rpc-glue/e2e" | sort)
+
 ###
 # These version variables can either be a valid string for "go install <module>@<version>"
 # or the string @DEV to imply use what is currently installed locally.
@@ -10,6 +12,7 @@ SHELL = bash
 GOLANGCI_LINT_VERSION='v1.55.2'
 MOCKERY_VERSION='v2.20.0'
 BUF_VERSION='v1.4.0'
+
 PROTOC_GEN_GO_GRPC_VERSION="v1.2.0"
 MOG_VERSION='v0.4.0'
 PROTOC_GO_INJECT_TAG_VERSION='v1.3.0'
@@ -252,6 +255,18 @@ go-mod-tidy:
 	@cd internal/tools/proto-gen-rpc-glue/e2e/consul && go mod tidy
 	@cd internal/tools/protoc-gen-consul-rate-limit && go mod tidy
 
+.PHONY: go-mod-get
+go-mod-get: $(foreach mod,$(GO_MODULES),go-mod-get/$(mod)) ## Run go get and go mod tidy in every module for the given dependency
+
+.PHONY: go-mod-get/%
+go-mod-get/%:
+ifndef DEP_VERSION
+	$(error DEP_VERSION is undefined: set this to <dependency>@<version>, e.g. github.com/hashicorp/go-hclog@v1.5.0)
+endif
+	@echo "--> Running go get ${DEP_VERSION} ($*)"
+	@cd $* && go get $(DEP_VERSION)
+	@echo "--> Running go mod tidy ($*)"
+	@cd $* && go mod tidy
 
 test-internal:
 	@echo "--> Running go test"


### PR DESCRIPTION
Backport of https://github.com/hashicorp/consul/pull/19785 which also includes updates to Go modules list / Make target from https://github.com/hashicorp/consul/pull/17462 (landed on `main` during 1.16).

Asking for a quick extra review bc @rboyer 's  original `go-mod-tidy` introduction [noted](https://github.com/hashicorp/consul/pull/7179/commits/ce3b557e8359221723373e6d8172334dafab463e) "the correct order" and I wanted to make sure this wasn't sneakily risky in 1.15.

### Testing & Reproduction steps

Tested locally as in original PR, same results.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

<details>
<summary> Overview of commits </summary>

  - 6f0e24cda79b6c395b7424a0389e97afbb36a712 

</details>