### PR TITLE
[CE] feat(v2dns): enable v2 dns as default

### DIFF
--- a/.changelog/20715.txt
+++ b/.changelog/20715.txt
@@ -1,0 +1,6 @@
+```release-note:feature
+dns: queries now default to a refactored DNS server that is v1 and v2 Catalog compatible. 
+Use `v1dns` in the `experiments` agent config to disable. 
+The legacy server will be removed in a future release of Consul.
+See the [Consul 1.19.x Release Notes](https://developer.hashicorp.com/consul/docs/release-notes/consul/v1_19_x) for removed DNS features.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -878,13 +878,12 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	// start DNS servers
-	if a.baseDeps.UseV2DNS() {
-		a.logger.Warn("DNS v2 is under construction")
-		if err := a.listenAndServeV2DNS(); err != nil {
+	if a.baseDeps.UseV1DNS() {
+		if err := a.listenAndServeV1DNS(); err != nil {
 			return err
 		}
 	} else {
-		if err := a.listenAndServeV1DNS(); err != nil {
+		if err := a.listenAndServeV2DNS(); err != nil {
 			return err
 		}
 	}

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -618,8 +618,8 @@ func TestBuilder_CheckExperimentsInSecondaryDatacenters(t *testing.T) {
 		"primary server v2catalog": {
 			hcl: primary + `experiments = ["resource-apis"]`,
 		},
-		"primary server v2dns": {
-			hcl: primary + `experiments = ["v2dns"]`,
+		"primary server v1dns": {
+			hcl: primary + `experiments = ["v1dns"]`,
 		},
 		"primary server v2tenancy": {
 			hcl: primary + `experiments = ["v2tenancy"]`,
@@ -631,9 +631,8 @@ func TestBuilder_CheckExperimentsInSecondaryDatacenters(t *testing.T) {
 			hcl:       secondary + `experiments = ["resource-apis"]`,
 			expectErr: true,
 		},
-		"secondary server v2dns": {
-			hcl:       secondary + `experiments = ["v2dns"]`,
-			expectErr: true,
+		"secondary server v1dns": {
+			hcl: secondary + `experiments = ["v1dns"]`,
 		},
 		"secondary server v2tenancy": {
 			hcl:       secondary + `experiments = ["v2tenancy"]`,

--- a/agent/consul/options.go
+++ b/agent/consul/options.go
@@ -50,10 +50,10 @@ type Deps struct {
 	EnterpriseDeps
 }
 
-// UseV2DNS returns true if "v2-dns" is present in the Experiments
-// array of the agent config. It is assumed if the v2 resource APIs are enabled.
-func (d Deps) UseV2DNS() bool {
-	if stringslice.Contains(d.Experiments, V2DNSExperimentName) || d.UseV2Resources() {
+// UseV1DNS returns true if "v1dns" is present in the Experiments
+// array of the agent config. It is ignored if the v2 resource APIs are enabled.
+func (d Deps) UseV1DNS() bool {
+	if stringslice.Contains(d.Experiments, V1DNSExperimentName) && !d.UseV2Resources() {
 		return true
 	}
 	return false

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -132,7 +132,7 @@ const (
 
 	LeaderTransferMinVersion      = "1.6.0"
 	CatalogResourceExperimentName = "resource-apis"
-	V2DNSExperimentName           = "v2dns"
+	V1DNSExperimentName           = "v1dns"
 	V2TenancyExperimentName       = "v2tenancy"
 	HCPAllowV2ResourceAPIs        = "hcp-v2-resource-apis"
 )
@@ -143,7 +143,7 @@ const (
 // Likely these will all be short lived exclusions.
 func IsExperimentAllowedOnSecondaries(name string) bool {
 	switch name {
-	case CatalogResourceExperimentName, V2DNSExperimentName, V2TenancyExperimentName:
+	case CatalogResourceExperimentName, V2TenancyExperimentName:
 		return false
 	default:
 		return true

--- a/agent/dns_catalogv2_test.go
+++ b/agent/dns_catalogv2_test.go
@@ -261,7 +261,8 @@ func TestDNS_CatalogV2_Basic(t *testing.T) {
 				require.Equal(t, 9, len(in.Answer), "answer count did not match expected\n\n%s", in.String())
 				require.Equal(t, 9, len(in.Extra), "extra answer count did not match expected\n\n%s", in.String())
 			} else {
-				// Expect 1 result per port, per workload, up to the default limit of 3. In practice the results are truncated at 2.
+				// Expect 1 result per port, per workload, up to the default limit of 3. In practice the results are truncated
+				// at 2 because of the record byte size.
 				require.Equal(t, 2, len(in.Answer), "answer count did not match expected\n\n%s", in.String())
 				require.Equal(t, 2, len(in.Extra), "extra answer count did not match expected\n\n%s", in.String())
 			}

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -121,11 +121,11 @@ func dnsTXT(src string, txt []string) *dns.TXT {
 
 func getVersionHCL(enableV2 bool) map[string]string {
 	versions := map[string]string{
-		"DNS: v1 / Catalog: v1": "",
+		"DNS: v1 / Catalog: v1": "experiments=[\"v1dns\"]",
 	}
 
 	if enableV2 {
-		versions["DNS: v2 / Catalog: v1"] = `experiments=["v2dns"]`
+		versions["DNS: v2 / Catalog: v1"] = ""
 	}
 	return versions
 }
@@ -3338,6 +3338,7 @@ func TestDNS_V1ConfigReload(t *testing.T) {
 				min_ttl = 4
 			}
 		}
+		experiments = ["v1dns"]
 	`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")


### PR DESCRIPTION
### Description
This PR default enables the V2 DNS server implementation for Consul 1.19. The experiment flag is changed to `v1dns` to be able to revert to the old implementation until there is more feedback on V2. 

**Notes:**
1. I noticed that RB added a gate to prevent these flags on secondary servers, but we definitely should allow this.
2. This is only for 1.19. I will create a separate PR against 1.18 to re-enable secondary servers using V2 DNS

### Testing & Reproduction steps
* Existing `agent` tests are updated to run against both implementations.
* Any integration tests should now run against the new implementation.

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] appropriate backport labels added
* [X] not a security concern
