### PR TITLE
Hardcode links to CCM to be false 

### DIFF
--- a/.changelog/20474.txt
+++ b/.changelog/20474.txt
@@ -1,3 +1,0 @@
-```release-note:breaking-change
-ui: Adds a "Link to HCP Consul Central" modal with integration to side-nav and link to HCP banner. There will be an option to disable the Link to HCP banner from the UI in a follow-up release.
-```

--- a/ui/packages/consul-ui/app/components/hcp-nav-item/index.js
+++ b/ui/packages/consul-ui/app/components/hcp-nav-item/index.js
@@ -41,7 +41,8 @@ export default class HcpLinkItemComponent extends Component {
       return false;
     }
 
-    return true;
+    // With the death of Consul Central, we don't want to display the link nav item
+    return false;
   }
 
   get shouldShowBackToHcpItem() {

--- a/ui/packages/consul-ui/app/services/hcp-link-status.js
+++ b/ui/packages/consul-ui/app/services/hcp-link-status.js
@@ -14,7 +14,8 @@ export default class HcpLinkStatus extends Service {
   userDismissedBanner = false;
 
   get shouldDisplayBanner() {
-    return !this.userDismissedBanner && this.hasPermissionToLink;
+    // With the death of Consul Central, we don't want to display the link nav item
+    return false;
   }
 
   get hasPermissionToLink() {

--- a/ui/packages/consul-ui/tests/acceptance/link-to-hcp-test.js
+++ b/ui/packages/consul-ui/tests/acceptance/link-to-hcp-test.js
@@ -12,7 +12,7 @@ const linkToHcpSelector = '[data-test-link-to-hcp]';
 const linkToHcpBannerButtonSelector = '[data-test-link-to-hcp-banner-button]';
 const linkToHcpModalSelector = '[data-test-link-to-hcp-modal]';
 const linkToHcpModalCancelButtonSelector = '[data-test-link-to-hcp-modal-cancel-button]';
-module('Acceptance | link to hcp', function (hooks) {
+module.skip('Acceptance | link to hcp', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {

--- a/ui/packages/consul-ui/tests/integration/components/hcp-nav-item-test.js
+++ b/ui/packages/consul-ui/tests/integration/components/hcp-nav-item-test.js
@@ -86,7 +86,7 @@ module('Integration | Component | hcp nav item', function (hooks) {
     });
   });
 
-  module('when rendered in self managed mode', function (hooks) {
+  module.skip('when rendered in self managed mode', function (hooks) {
     hooks.beforeEach(function () {
       this.owner.register(
         'service:env',


### PR DESCRIPTION
### Description
This PR just hardcodes all of the CTAS to never display - so we can ensure the 1.18 release does not display them!
We will pull all this code out in a follow up PR

### Testing & Reproduction steps
Load the UI - see that there's no CTAs to Consul Cental

### Screenshots
![image](https://github.com/hashicorp/consul/assets/4359781/619900f7-1b34-43f3-a4a7-2391d2d39a6f)


### References
![image](https://github.com/hashicorp/consul/assets/4359781/8b9fd533-453f-4cee-988f-9b0255919e74)
