### PR TITLE
docs: update Helm docs for consul-k8s 1.4.0

### DIFF
--- a/website/content/docs/k8s/helm.mdx
+++ b/website/content/docs/k8s/helm.mdx
@@ -134,7 +134,7 @@ Use these links to navigate to a particular top-level stanza.
 
     - `vault` ((#v-global-secretsbackend-vault))
 
-      - `vaultNamespace` ((#v-global-secretsbackend-vault-vaultnamespace)) (`string: ""`) - Vault namespace (optional). This sets the Vault namespace for the `vault.hashicorp.com/namespace` 
+      - `vaultNamespace` ((#v-global-secretsbackend-vault-vaultnamespace)) (`string: ""`) - Vault namespace (optional). This sets the Vault namespace for the `vault.hashicorp.com/namespace`
         agent annotation and [Vault Connect CA namespace](/consul/docs/connect/ca/vault#namespace).
         To override one of these values individually, see `agentAnnotations` and `connectCA.additionalConfig`.
 
@@ -423,7 +423,7 @@ Use these links to navigate to a particular top-level stanza.
 
       - `secretKey` ((#v-global-acls-replicationtoken-secretkey)) (`string: null`) - The key within the Kubernetes or Vault secret that holds the replication token.
 
-    - `resources` ((#v-global-acls-resources)) (`map`) - The resource requests (CPU, memory, etc.) for the server-acl-init and server-acl-init-cleanup pods. 
+    - `resources` ((#v-global-acls-resources)) (`map`) - The resource requests (CPU, memory, etc.) for the server-acl-init and server-acl-init-cleanup pods.
       This should be a YAML map corresponding to a Kubernetes
       [`ResourceRequirements``](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core)
       object.
@@ -501,7 +501,7 @@ Use these links to navigate to a particular top-level stanza.
     - `enabled` ((#v-global-federation-enabled)) (`boolean: false`) - If enabled, this datacenter will be federation-capable. Only federation
       via mesh gateways is supported.
       Mesh gateways and servers will be configured to allow federation.
-      Requires `global.tls.enabled`, `connectInject.enabled`, and one of 
+      Requires `global.tls.enabled`, `connectInject.enabled`, and one of
       `meshGateway.enabled` or `externalServers.enabled` to be true.
       Requires Consul 1.8+.
 
@@ -525,7 +525,7 @@ Use these links to navigate to a particular top-level stanza.
       from the one used by the Consul Service Mesh.
       Please refer to the [Kubernetes Auth Method documentation](/consul/docs/security/acl/auth-methods/kubernetes).
 
-      If `externalServers.enabled` is set to true, `global.federation.k8sAuthMethodHost` and 
+      If `externalServers.enabled` is set to true, `global.federation.k8sAuthMethodHost` and
       `externalServers.k8sAuthMethodHost` should be set to the same value.
 
       You can retrieve this value from your `kubeconfig` by running:
@@ -546,6 +546,12 @@ Use these links to navigate to a particular top-level stanza.
     - `enableAgentMetrics` ((#v-global-metrics-enableagentmetrics)) (`boolean: false`) - Configures consul agent metrics. Only applicable if
       `global.metrics.enabled` is true.
 
+    - `disableAgentHostName` ((#v-global-metrics-disableagenthostname)) (`boolean: false`) - Set to true to stop prepending the machine's hostname to gauge-type metrics. Default is false.
+      Only applicable if `global.metrics.enabled` and `global.metrics.enableAgentMetrics` is true.
+
+    - `enableHostMetrics` ((#v-global-metrics-enablehostmetrics)) (`boolean: false`) - Configures consul agent underlying host metrics. Only applicable if
+      Only applicable if `global.metrics.enabled` and `global.metrics.enableAgentMetrics` is true.
+
     - `agentMetricsRetentionTime` ((#v-global-metrics-agentmetricsretentiontime)) (`string: 1m`) - Configures the retention time for metrics in Consul clients and
       servers. This must be greater than 0 for Consul clients and servers
       to expose any metrics at all.
@@ -557,6 +563,120 @@ Use these links to navigate to a particular top-level stanza.
 
     - `enableTelemetryCollector` ((#v-global-metrics-enabletelemetrycollector)) (`boolean: false`) - Configures the Helm chart’s components to forward envoy metrics for the Consul service mesh to the
       consul-telemetry-collector. This includes gateway metrics and sidecar metrics.
+
+    - `prefixFilter` ((#v-global-metrics-prefixfilter)) - This configures the list of filter rules to apply for allowing/blocking
+      metrics by prefix in the following format:
+
+      A leading "+" will enable any metrics with the given prefix, and a leading "-" will block them.
+      If there is overlap between two rules, the more specific rule will take precedence.
+      Blocking will take priority if the same prefix is listed multiple times.
+
+      - allowList:
+
+      - `allowList` ((#v-global-metrics-prefixfilter-allowlist)) (`array<string>: []`)
+
+      - `blockList` ((#v-global-metrics-prefixfilter-blocklist)) (`array<string>: []`)
+
+    - `datadog` ((#v-global-metrics-datadog)) - Configures consul integration configurations for datadog on kubernetes.
+      Only applicable if `global.metrics.enabled` and `global.metrics.enableAgentMetrics` is true.
+
+      - `enabled` ((#v-global-metrics-datadog-enabled)) (`boolean: false`) - Enables datadog [Consul Autodiscovery Integration](https://docs.datadoghq.com/integrations/consul/?tab=containerized#metric-collection)
+        by configuring the required `ad.datadoghq.com/consul.checks` annotation. The following _Consul_ agent metrics/health statuses
+        are monitored by Datadog unless monitoring via OpenMetrics (Prometheus) or DogStatsD:
+          - Serf events and member flaps
+          - The Raft protocol
+          - DNS performance
+          - API Endpoints scraped:
+            - `/v1/agent/metrics?format=prometheus`
+            - `/v1/agent/self`
+            - `/v1/status/leader`
+            - `/v1/status/peers`
+            - `/v1/catalog/services`
+            - `/v1/health/service`
+            - `/v1/health/state/any`
+            - `/v1/coordinate/datacenters`
+            - `/v1/coordinate/nodes`
+
+        Setting either `global.metrics.datadog.otlp.enabled=true` or `global.metrics.datadog.dogstatsd.enabled=true` disables the above checks
+        in lieu of metrics data collection via DogStatsD or by a customer OpenMetrics (Prometheus) collection endpoint.
+
+        ~> **Note:** If you have a [dogstatsd_mapper_profile](https://docs.datadoghq.com/integrations/consul/?tab=host#dogstatsd) configured for Consul
+        residing on either your Datadog NodeAgent or ClusterAgent the default Consul agent metrics/health status checks will fail. If you do not desire
+        to utilize DogStatsD metrics emission from Consul, remove this configuration file, and restart your Datadog agent to permit the checks to run.
+
+      - `openMetricsPrometheus` ((#v-global-metrics-datadog-openmetricsprometheus)) - Configures Kubernetes Prometheus/OpenMetrics auto-discovery annotations for use with Datadog.
+        This configuration is less common and more for advanced usage with custom metrics monitoring
+        configurations. See https://docs.datadoghq.com/containers/kubernetes/prometheus/?tab=kubernetesadv2 for more details
+        surround further configuration.
+
+        - `enabled` ((#v-global-metrics-datadog-openmetricsprometheus-enabled)) (`boolean: false`)
+
+      - `otlp` ((#v-global-metrics-datadog-otlp))
+
+        - `enabled` ((#v-global-metrics-datadog-otlp-enabled)) (`boolean: false`) - Enables forwarding of Consul's Telemetry Collector OTLP metrics for
+          ingestion by Datadog Agent.
+
+        - `protocol` ((#v-global-metrics-datadog-otlp-protocol)) (`string: "http"`) - Protocol used for DataDog Endpoint OTLP ingestion.
+
+          Valid protocol options are one of either:
+
+            - "http": will forward to DataDog HTTP OTLP Node Agent Endpoint default - "0.0.0.0:4318"
+            - "grpc": will forward to DataDog gRPC OTLP Node Agent Endpoint default - "0.0.0.0:4317"
+
+      - `dogstatsd` ((#v-global-metrics-datadog-dogstatsd)) - Configuration settings for DogStatsD metrics aggregation service
+        that is bundled with the Datadog Agent.
+        DogStatsD implements the StatsD protocol and adds a few Datadog-specific extensions:
+        - Histogram metric type
+        - Service checks
+        - Events
+        - Tagging
+
+        - `enabled` ((#v-global-metrics-datadog-dogstatsd-enabled)) (`boolean: false`)
+
+        - `socketTransportType` ((#v-global-metrics-datadog-dogstatsd-sockettransporttype)) (`string: "UDS"`) - Sets the socket transport type for dogstatsd:
+           - "UDS" (Unix Domain Socket): prefixes `unix://` to URL and appends path to socket (i.e., "unix:///var/run/datadog/dsd.socket")
+             If set, this will create the required [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) mount for
+             managing [DogStatsD with Unix Domain Socket on Kubernetes](https://docs.datadoghq.com/developers/dogstatsd/unix_socket/?tab=kubernetes).
+             The volume is mounted using the `DirectoryOrCreate` type, thereby setting `0755` permissions with the same kubelet group ownership.
+
+           Applies the following `volumes` and `volumeMounts` to the consul-server stateful set consul containers:
+
+          ```yaml
+          volumes:
+            - name: dsdsocket
+              hostPath:
+                path: /var/run/datadog
+                type: DirectoryOrCreate
+          volumeMounts:
+            - name: dsdsocket
+              mountPath: /var/run/datadog
+              readOnly: true
+          ```
+           - "UDP" (User Datagram Protocol): assigns address to use `hostname/IP:Port` formatted URL for UDP transport to hostIP based
+              dogstatsd sink (i.e., 127.0.0.1:8125). HostIP of Datadog agent must be reachable and known to Consul server emitting metrics.
+
+        - `dogstatsdAddr` ((#v-global-metrics-datadog-dogstatsd-dogstatsdaddr)) (`string: "/var/run/datadog/dsd.socket"`) - Sets URL path for dogstatsd:
+
+          Can be either a path to unix domain socket or an IP Address or Hostname that's reachable from the
+          consul-server service, server containers. When using "UDS" the path will be appended. When using "UDP"
+          the path will be prepended to the specified `dogstatsdPort`.
+
+        - `dogstatsdPort` ((#v-global-metrics-datadog-dogstatsd-dogstatsdport)) (`integer: 0`) - Configures IP based dogstatsd designated port that will be appended to "UDP" based transport socket IP/Hostname URL.
+
+          If using a kubernetes service based address (i.e., datadog.default.svc.cluster.local), set this to 0 to
+          mitigate appending a port value to the dogstatsd address field. Resultant address would be "datadog.default.svc.cluster.local" with
+          default port setting, while appending a non-zero port would result in "172.10.23.6:8125" with a dogstatsdAddr value
+          of "172.10.23.6".
+
+        - `dogstatsdTags` ((#v-global-metrics-datadog-dogstatsd-dogstatsdtags)) (`array<string>: ["source:consul","consul_service:consul-server"]`) - Configures datadog [autodiscovery](https://docs.datadoghq.com/containers/kubernetes/log/?tab=operator#autodiscovery)
+          style [log integration](https://docs.datadoghq.com/integrations/consul/?tab=containerized#log-collection)
+          configuration for Consul.
+
+          The default settings should handle most Consul Kubernetes deployment schemes. The resultant annotation
+          will reside on the consul-server statefulset as autodiscovery annotations.
+          (i.e., ad.datadoghq.com/consul.logs: ["source:consul","consul_service:consul-server", ""])
+
+      - `namespace` ((#v-global-metrics-datadog-namespace)) (`string: "default"`) - Namespace
 
   - `imageConsulDataplane` ((#v-global-imageconsuldataplane)) (`string: hashicorp/consul-dataplane:<latest supported version>`) - The name (and tag) of the consul-dataplane Docker image used for the
     connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
@@ -570,49 +690,53 @@ Use these links to navigate to a particular top-level stanza.
   - `consulAPITimeout` ((#v-global-consulapitimeout)) (`string: 5s`) - The time in seconds that the consul API client will wait for a response from
     the API before cancelling the request.
 
-  - `cloud` ((#v-global-cloud)) - Enables installing an HCP Consul self-managed cluster.
+  - `cloud` ((#v-global-cloud)) - Enables installing an HCP Consul Central self-managed cluster.
     Requires Consul v1.14+.
 
-    - `enabled` ((#v-global-cloud-enabled)) (`boolean: false`) - If true, the Helm chart will enable the installation of an HCP Consul
-      self-managed cluster.
+    - `enabled` ((#v-global-cloud-enabled)) (`boolean: false`) - If true, the Helm chart will link a [self-managed cluster to HCP](/hcp/docs/consul/self-managed).
+      This can either be used to [configure a new cluster](/hcp/docs/consul/self-managed/new)
+      or [link an existing one](/hcp/docs/consul/self-managed/existing).
 
-    - `resourceId` ((#v-global-cloud-resourceid)) - The name of the Kubernetes secret that holds the HCP resource id.
+      Note: this setting should not be enabled for [HashiCorp-managed clusters](/hcp/docs/consul/hcp-managed).
+      It is strictly for linking self-managed clusters.
+
+    - `resourceId` ((#v-global-cloud-resourceid)) - The resource id of the HCP Consul Central cluster to link to. Eg:
+      organization/27109cd4-a309-4bf3-9986-e1d071914b18/project/fcef6c24-259d-4510-bb8d-1d812e120e34/hashicorp.consul.global-network-manager.cluster/consul-cluster
       This is required when global.cloud.enabled is true.
 
       - `secretName` ((#v-global-cloud-resourceid-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the resource id.
 
       - `secretKey` ((#v-global-cloud-resourceid-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the resource id.
 
-    - `clientId` ((#v-global-cloud-clientid)) - The name of the Kubernetes secret that holds the HCP cloud client id.
+    - `clientId` ((#v-global-cloud-clientid)) - The client id portion of a [service principal](/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to link the cluster
+      in global.cloud.resourceId to HCP Consul Central.
       This is required when global.cloud.enabled is true.
 
       - `secretName` ((#v-global-cloud-clientid-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the client id.
 
       - `secretKey` ((#v-global-cloud-clientid-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the client id.
 
-    - `clientSecret` ((#v-global-cloud-clientsecret)) - The name of the Kubernetes secret that holds the HCP cloud client secret.
+    - `clientSecret` ((#v-global-cloud-clientsecret)) - The client secret portion of a [service principal](/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to link the cluster
+      in global.cloud.resourceId to HCP Consul Central.
       This is required when global.cloud.enabled is true.
 
       - `secretName` ((#v-global-cloud-clientsecret-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the client secret.
 
       - `secretKey` ((#v-global-cloud-clientsecret-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the client secret.
 
-    - `apiHost` ((#v-global-cloud-apihost)) - The name of the Kubernetes secret that holds the HCP cloud client id.
-      This is optional when global.cloud.enabled is true.
+    - `apiHost` ((#v-global-cloud-apihost)) - The hostname of HCP's API. This setting is used for internal testing and validation.
 
       - `secretName` ((#v-global-cloud-apihost-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the api hostname.
 
       - `secretKey` ((#v-global-cloud-apihost-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the api hostname.
 
-    - `authUrl` ((#v-global-cloud-authurl)) - The name of the Kubernetes secret that holds the HCP cloud authorization url.
-      This is optional when global.cloud.enabled is true.
+    - `authUrl` ((#v-global-cloud-authurl)) - The URL of HCP's auth API. This setting is used for internal testing and validation.
 
       - `secretName` ((#v-global-cloud-authurl-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the authorization url.
 
       - `secretKey` ((#v-global-cloud-authurl-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the authorization url.
 
-    - `scadaAddress` ((#v-global-cloud-scadaaddress)) - The name of the Kubernetes secret that holds the HCP cloud scada address.
-      This is optional when global.cloud.enabled is true.
+    - `scadaAddress` ((#v-global-cloud-scadaaddress)) - The address of HCP's scada service. This setting is used for internal testing and validation.
 
       - `secretName` ((#v-global-cloud-scadaaddress-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the scada address.
 
@@ -649,6 +773,14 @@ Use these links to navigate to a particular top-level stanza.
       upgrade could risk breaking your Consul cluster.
       If this flag is set, Consul components will use the
       V2 resources APIs for all operations.
+    * `v2tenancy`:
+      _**Danger**_! This feature is under active development. It is not
+      recommended for production use. Setting this flag during an
+      upgrade could risk breaking your Consul cluster.
+      If this flag is set, Consul V2 resources (catalog, mesh, auth, etc)
+      will use V2 implementations for tenancy (partitions and namesapces)
+      instead of bridging to the existing V1 implementations. The
+      `resource-apis` feature flag must also be set.
 
     Example:
 
@@ -761,7 +893,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `persistentVolumeClaimRetentionPolicy` ((#v-server-persistentvolumeclaimretentionpolicy)) (`map`) - The [Persistent Volume Claim (PVC) retention policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
     controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
-    WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted, 
+    WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted,
     and WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down.
 
     Example:
@@ -777,6 +909,10 @@ Use these links to navigate to a particular top-level stanza.
     setting will only enable usage of the feature. Consul will automatically initialize
     a new CA and set of certificates. Additional service mesh settings can be configured
     by setting the `server.extraConfig` value or by applying [configuration entries](/consul/docs/connect/config-entries).
+
+  - `enableAgentDebug` ((#v-server-enableagentdebug)) (`boolean: false`) - When set to true, enables Consul to report additional debugging information, including runtime profiling (pprof) data.
+    This setting is only required for clusters without ACL enabled. Sets `enable_debug` in server agent config to `true`.
+    If you change this setting, you must restart the agent for the change to take effect. Default is false.
 
   - `serviceAccount` ((#v-server-serviceaccount))
 
@@ -838,8 +974,14 @@ Use these links to navigate to a particular top-level stanza.
       cluster. If enabled, it only registers the budget so long as
       the server cluster is enabled. To disable, set to `false`.
 
-    - `maxUnavailable` ((#v-server-disruptionbudget-maxunavailable)) (`integer: null`) - The maximum number of unavailable pods. By default, this will be
-      automatically computed based on the `server.replicas` value to be `(n/2)-1`.
+    - `maxUnavailable` ((#v-server-disruptionbudget-maxunavailable)) (`integer: null`) - The maximum number of unavailable pods. In most cases you should not change this as it is automatically set to
+      the correct number when left as null. This setting has been kept to not break backwards compatibility.
+
+      By default, this is set to 1 internally in the chart. When server pods are stopped gracefully, they leave the Raft
+      consensus pool. When running an odd number of servers, one server leaving the pool does not change the quorum
+      size, and so fault tolerance is not affected. However, if more than one server were to leave the pool, the quorum
+      size would change. That's why this is set to 1 internally and should not be changed in most cases.
+
       If you need to set this to `0`, you will need to add a
       --set 'server.disruptionBudget.maxUnavailable=0'` flag to the helm chart installation
       command because of a limitation in the Helm templating language.
@@ -1053,7 +1195,7 @@ Use these links to navigate to a particular top-level stanza.
         ...
       ```
 
-  - `auditLogs` ((#v-server-auditlogs)) - <EnterpriseAlert inline /> Added in Consul 1.8, the audit object allow users to enable auditing 
+  - `auditLogs` ((#v-server-auditlogs)) - <EnterpriseAlert inline /> Added in Consul 1.8, the audit object allow users to enable auditing
     and configure a sink and filters for their audit logs. Please refer to
     [audit logs](/consul/docs/enterprise/audit-logging) documentation
     for further information.
@@ -1061,7 +1203,7 @@ Use these links to navigate to a particular top-level stanza.
     - `enabled` ((#v-server-auditlogs-enabled)) (`boolean: false`) - Controls whether Consul logs out each time a user performs an operation.
       global.acls.manageSystemACLs must be enabled to use this feature.
 
-    - `sinks` ((#v-server-auditlogs-sinks)) (`array<map>`) - A single entry of the sink object provides configuration for the destination to which Consul 
+    - `sinks` ((#v-server-auditlogs-sinks)) (`array<map>`) - A single entry of the sink object provides configuration for the destination to which Consul
       will log auditing events.
 
       Example:
@@ -1076,7 +1218,7 @@ Use these links to navigate to a particular top-level stanza.
           rotate_duration: 24h
           rotate_max_files: 15
           rotate_bytes: 25165824
-          
+
       ```
 
       The sink object supports the following keys:
@@ -1152,13 +1294,13 @@ Use these links to navigate to a particular top-level stanza.
     Note: If enabling clients, `client.join` must also be set to the hosts that should be
     used to join the cluster. In most cases, the `client.join` values
     should be the same, however, they may be different if you
-    wish to use separate hosts for the HTTPS connections.
+    wish to use separate hosts for the HTTPS connections. `tlsServerName` is required if TLS is enabled and 'hosts' is not a DNS name.
 
   - `httpsPort` ((#v-externalservers-httpsport)) (`integer: 8501`) - The HTTPS port of the Consul servers.
 
   - `grpcPort` ((#v-externalservers-grpcport)) (`integer: 8502`) - The GRPC port of the Consul servers.
 
-  - `tlsServerName` ((#v-externalservers-tlsservername)) (`string: null`) - The server name to use as the SNI host header when connecting with HTTPS.
+  - `tlsServerName` ((#v-externalservers-tlsservername)) (`string: null`) - The server name to use as the SNI host header when connecting with HTTPS. This name also appears as the hostname in the server certificate's subject field.
 
   - `useSystemRoots` ((#v-externalservers-usesystemroots)) (`boolean: false`) - If true, consul-k8s-control-plane components will ignore the CA set in
     `global.tls.caCert` when making HTTPS calls to Consul servers and
@@ -1173,7 +1315,7 @@ Use these links to navigate to a particular top-level stanza.
     This address must be reachable from the Consul servers.
     Please refer to the [Kubernetes Auth Method documentation](/consul/docs/security/acl/auth-methods/kubernetes).
 
-    If `global.federation.enabled` is set to true, `global.federation.k8sAuthMethodHost` and 
+    If `global.federation.enabled` is set to true, `global.federation.k8sAuthMethodHost` and
     `externalServers.k8sAuthMethodHost` should be set to the same value.
 
     You could retrieve this value from your `kubeconfig` by running:
@@ -1793,7 +1935,7 @@ Use these links to navigate to a particular top-level stanza.
       These CRDs can clash with existing Gateway API CRDs if they are already installed in your cluster.
       If this setting is false, you will need to install the Gateway API CRDs manually.
 
-    - `manageNonStandardCRDs` ((#v-connectinject-apigateway-managenonstandardcrds)) (`boolean: false`) - Enables Consul on Kubernets to manage only the non-standard CRDs used for Gateway API. If manageExternalCRDs is true 
+    - `manageNonStandardCRDs` ((#v-connectinject-apigateway-managenonstandardcrds)) (`boolean: false`) - Enables Consul on Kubernets to manage only the non-standard CRDs used for Gateway API. If manageExternalCRDs is true
       then all CRDs will be installed; otherwise, if manageNonStandardCRDs is true then only TCPRoute, GatewayClassConfig and MeshService
       will be installed.
 
@@ -2174,18 +2316,21 @@ Use these links to navigate to a particular top-level stanza.
       - `consul.hashicorp.com/sidecar-proxy-lifecycle-graceful-port`
       - `consul.hashicorp.com/sidecar-proxy-lifecycle-graceful-shutdown-path`
 
-        - `defaultEnabled` ((#v-connectinject-sidecarproxy-lifecycle-defaultenabled)) (`boolean: true`)
+      - `defaultEnabled` ((#v-connectinject-sidecarproxy-lifecycle-defaultenabled)) (`boolean: true`)
 
-        - `defaultEnableShutdownDrainListeners` ((#v-connectinject-sidecarproxy-lifecycle-defaultenableshutdowndrainlisteners)) (`boolean: true`)
+      - `defaultEnableShutdownDrainListeners` ((#v-connectinject-sidecarproxy-lifecycle-defaultenableshutdowndrainlisteners)) (`boolean: true`)
 
-        - `defaultShutdownGracePeriodSeconds` ((#v-connectinject-sidecarproxy-lifecycle-defaultshutdowngraceperiodseconds)) (`integer: 30`)
+      - `defaultShutdownGracePeriodSeconds` ((#v-connectinject-sidecarproxy-lifecycle-defaultshutdowngraceperiodseconds)) (`integer: 30`)
 
-        - `defaultGracefulPort` ((#v-connectinject-sidecarproxy-lifecycle-defaultgracefulport)) (`integer: 20600`)
+      - `defaultGracefulPort` ((#v-connectinject-sidecarproxy-lifecycle-defaultgracefulport)) (`integer: 20600`)
 
-        - `defaultGracefulShutdownPath` ((#v-connectinject-sidecarproxy-lifecycle-defaultgracefulshutdownpath)) (`string: /graceful_shutdown`)
+      - `defaultGracefulShutdownPath` ((#v-connectinject-sidecarproxy-lifecycle-defaultgracefulshutdownpath)) (`string: /graceful_shutdown`)
 
-    - `defaultStartupFailureSeconds` ((#v-connectinject-sidecarproxy-defaultstartupfailureseconds)) (`integer: 0`) - Enables a startup probe that polls the Envoy sidecar health every second. When a container fails health checks consecutively for this period of time during startup, K8s restarts the container according to its [`restartPolicy`](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy). A value of `0` disables the probe.
-    - `defaultLivenessFailureSeconds` ((#v-connectinject-sidecarproxy-defaultlivenessfailureseconds)) (`integer: 0`) - Enables a liveness probe that polls the Envoy sidecar health every second. When a container fails health checks  for this period of time, K8s restarts the container according to its [`restartPolicy`](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy). A value of `0` disables the probe.
+    - `defaultStartupFailureSeconds` ((#v-connectinject-sidecarproxy-defaultstartupfailureseconds)) (`integer: 0`) - Configures how long the k8s startup probe will wait before the proxy is considered to be unhealthy and the container is restarted.
+      A value of zero disables the probe.
+
+    - `defaultLivenessFailureSeconds` ((#v-connectinject-sidecarproxy-defaultlivenessfailureseconds)) (`integer: 0`) - Configures how long the k8s liveness probe will wait before the proxy is considered to be unhealthy and the container is restarted.
+      A value of zero disables the probe.
 
   - `initContainer` ((#v-connectinject-initcontainer)) (`map`) - The resource settings for the Connect injected init container. If null, the resources
     won't be set for the initContainer. The defaults are optimized for developer instances of
@@ -2493,8 +2638,8 @@ Use these links to navigate to a particular top-level stanza.
 
   - `gateways` ((#v-ingressgateways-gateways)) (`array<map>`) - Gateways is a list of gateway objects. The only required field for
     each is `name`, though they can also contain any of the fields in
-    `defaults`. You must provide a unique name for each ingress gateway. These names 
-    must be unique across different namespaces. 
+    `defaults`. You must provide a unique name for each ingress gateway. These names
+    must be unique across different namespaces.
     Values defined here override the defaults, except in the case of annotations where both will be applied.
 
     - `name` ((#v-ingressgateways-gateways-name)) (`string: ingress-gateway`)
@@ -2788,7 +2933,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `service` ((#v-telemetrycollector-service))
 
-    - `annotations` ((#v-telemetrycollector-service-annotations)) (`string: null`) - This value defines additional annotations for the server service account. This should be formatted as a multi-line
+    - `annotations` ((#v-telemetrycollector-service-annotations)) (`string: null`) - This value defines additional annotations for the telemetry-collector's service account. This should be formatted as a multi-line
       string.
 
       ```yaml
@@ -2810,17 +2955,37 @@ Use these links to navigate to a particular top-level stanza.
 
   - `cloud` ((#v-telemetrycollector-cloud))
 
-    - `clientId` ((#v-telemetrycollector-cloud-clientid))
+    - `resourceId` ((#v-telemetrycollector-cloud-resourceid)) - The resource id of the HCP Consul Central cluster to push metrics for. Eg:
+      `organization/27109cd4-a309-4bf3-9986-e1d071914b18/project/fcef6c24-259d-4510-bb8d-1d812e120e34/hashicorp.consul.global-network-manager.cluster/consul-cluster`
 
-      - `secretName` ((#v-telemetrycollector-cloud-clientid-secretname)) (`string: null`)
+      This is used for HCP Consul Central-linked or managed clusters where global.cloud.resourceId is unset. For example, when using externalServers
+      with HCP Consul-managed clusters or HCP Consul Central-linked clusters in a different admin partition.
 
-      - `secretKey` ((#v-telemetrycollector-cloud-clientid-secretkey)) (`string: null`)
+      If global.cloud.resourceId is set, this should either be unset (defaulting to global.cloud.resourceId) or be the same as global.cloud.resourceId.
 
-    - `clientSecret` ((#v-telemetrycollector-cloud-clientsecret))
+      - `secretName` ((#v-telemetrycollector-cloud-resourceid-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the resource id.
 
-      - `secretName` ((#v-telemetrycollector-cloud-clientsecret-secretname)) (`string: null`)
+      - `secretKey` ((#v-telemetrycollector-cloud-resourceid-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the resource id.
 
-      - `secretKey` ((#v-telemetrycollector-cloud-clientsecret-secretkey)) (`string: null`)
+    - `clientId` ((#v-telemetrycollector-cloud-clientid)) - The client id portion of a [service principal](/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to push metrics to HCP
+
+      This is set in two scenarios:
+        - the service principal in global.cloud is unset
+        - the HCP UI provides a service principal with more narrowly scoped permissions that the service principal used in global.cloud
+
+      - `secretName` ((#v-telemetrycollector-cloud-clientid-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the client id.
+
+      - `secretKey` ((#v-telemetrycollector-cloud-clientid-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the client id.
+
+    - `clientSecret` ((#v-telemetrycollector-cloud-clientsecret)) - The client secret portion of a [service principal](/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to push metrics to HCP.
+
+      This is set in two scenarios:
+        - the service principal in global.cloud is unset
+        - the HCP UI provides a service principal with more narrowly scoped permissions that the service principal used in global.cloud
+
+      - `secretName` ((#v-telemetrycollector-cloud-clientsecret-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the client secret.
+
+      - `secretKey` ((#v-telemetrycollector-cloud-clientsecret-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the client secret.
 
   - `initContainer` ((#v-telemetrycollector-initcontainer))
 
@@ -2830,7 +2995,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `priorityClassName` ((#v-telemetrycollector-priorityclassname)) (`string: ""`) - Optional priorityClassName.
 
-  - `extraEnvironmentVars` ((#v-telemetrycollector-extraenvironmentvars)) (`map`) - A list of extra environment variables to set within the stateful set.
+  - `extraEnvironmentVars` ((#v-telemetrycollector-extraenvironmentvars)) (`map`) - A list of extra environment variables to set within the deployment.
     These could be used to include proxy settings required for cloud auto-join
     feature, in case kubernetes cluster is behind egress http proxies. Additionally,
     it could be used to configure custom consul parameters.


### PR DESCRIPTION
### Description

This PR is the regeneration of the Helm docs with updated values from `consul-k8s` 1.4.0, released today.

### Testing & Reproduction steps

Visual inspection

### Links

Generated from the 1.4.0 `values.yaml` [here](https://github.com/hashicorp/consul-k8s/blob/release/1.4.0/charts/consul/values.yaml)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
