### PR TITLE
docs: Update OpenShift compat matrix

### DIFF
--- a/website/content/docs/k8s/compatibility.mdx
+++ b/website/content/docs/k8s/compatibility.mdx
@@ -29,7 +29,7 @@ apply to both Consul Enterprise and Consul community edition (CE).
 
 | Consul version | Compatible `consul-k8s` versions | Compatible Kubernetes versions | Compatible OpenShift versions          |
 | -------------- | -------------------------------- | -------------------------------| -------------------------------------- |
-| 1.18.x CE      | 1.4.x                            | 1.26.x - 1.29.x                | 4.12.x - 4.15.x (4.16.x not available) |
+| 1.18.x CE      | 1.4.x                            | 1.26.x - 1.29.x                | 4.13.x - 4.15.x (4.16.x not available) |
 | 1.17.x         | 1.3.x                            | 1.25.x - 1.28.x                | 4.12.x - 4.15.x                        |
 | 1.16.x         | 1.2.x                            | 1.24.x - 1.27.x                | 4.11.x - 4.14.x                        |
 
@@ -42,7 +42,7 @@ until the LTS release reaches its end of maintenance.
 
 | Consul version | Compatible `consul-k8s` versions | Compatible Kubernetes versions | Compatible OpenShift versions          |
 | -------------- | -------------------------------- | -------------------------------| -------------------------------------- |
-| 1.18.x Ent     | 1.4.x                            | 1.26.x - 1.29.x                | 4.12.x - 4.15.x (4.16.x not available) |
+| 1.18.x Ent     | 1.4.x                            | 1.26.x - 1.29.x                | 4.13.x - 4.15.x (4.16.x not available) |
 | 1.15.x Ent     | 1.1.x                            | 1.23.x - 1.28.x                | 4.10.x - 4.15.x                        |
 
 ### Version-specific upgrade requirements


### PR DESCRIPTION
### Description

K8s 1.26.x is actually built-in to OpenShift 4.13.x so we need to change the version of OpenShift for Consul K8s 1.4.x we support. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
