### PR TITLE
Fix typo in ingress-gateway docs

### DIFF
--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -576,7 +576,7 @@ Specifies a list of cipher suites that gateway listeners support when negotiatin
 - Default: None
 - Data type: List of string values. Refer to the [Consul repository](https://github.com/hashicorp/consul/blob/v1.11.2/types/tls.go#L154-L169) for a list of supported ciphers.
 
-### `TSL.SDS`
+### `TLS.SDS`
 
 Specifies parameters for loading the TLS certificates from an external SDS service. Refer to [Serve custom TLS certificates from an external service](/consul/docs/connect/gateways/ingress-gateway/tls-external-service) for additional information.
 


### PR DESCRIPTION
### Description
Fix typo in ingress gateway docs header. This typo was breaking links that appear earlier in the document since they targeted an element ID with the correct spelling.

### Testing & Reproduction steps
Visual inspection

### Links
[Here is the section header containing the typo](https://developer.hashicorp.com/consul/docs/connect/config-entries/ingress-gateway#tsl-sds)
### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
