### PR TITLE
Add API gateway to index of configuration entries

### DIFF
--- a/website/content/docs/connect/config-entries/index.mdx
+++ b/website/content/docs/connect/config-entries/index.mdx
@@ -11,6 +11,8 @@ Configuration entries can be used to configure the behavior of Consul service me
 
 The following configuration entries are supported:
 
+- [API Gateway](/consul/docs/connect/config-entries/api-gateway) - defines the configuration for an API gateway
+
 - [Ingress Gateway](/consul/docs/connect/config-entries/ingress-gateway) - defines the
   configuration for an ingress gateway
 


### PR DESCRIPTION
### Description
Adds the API gateway configuration entry -- introduced as beta in Consul 1.15 and GA in Consul 1.16 -- to the list of configuration entries.

I've only backported to 1.17 and 1.18 as the page linked to did not exist in its current location prior to that.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links
[Modified page including API gateway config entry](https://consul-9kub2rqr6-hashicorp.vercel.app/consul/docs/connect/config-entries)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
