### PR TITLE
golangci-lint: enable testifylint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,15 +4,16 @@
 linters:
   disable-all: true
   enable:
-    - gofmt
-    - govet
-    - unconvert
-    - staticcheck
-    - ineffassign
-    - unparam
-    - forbidigo
-    - gomodguard
     - depguard
+    - forbidigo
+    - gofmt
+    - gomodguard
+    - govet
+    - ineffassign
+    - staticcheck
+    - testifylint
+    - unconvert
+    - unparam
 
 issues:
   # Disable the default exclude list so that all excludes are explicitly
@@ -106,6 +107,22 @@ linters-settings:
           desc: "only use forked copy in github.com/hashicorp/consul-net-rpc/net/rpc"
         - pkg: github.com/golang/protobuf
           desc: "only use google.golang.org/protobuf"
+  testifylint:
+    disable:
+      - error-is-as
+      - float-compare
+      - go-require
+      - require-error
+    enable:
+      - bool-compare
+      - compares
+      - empty
+      - error-nil
+      - expected-actual
+      - len
+      - suite-dont-use-pkg
+      - suite-extra-assert-call
+      - suite-thelper
 
 run:
   timeout: 10m

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -264,10 +264,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, policyInput.Description, policy.Description)
 			require.Equal(t, policyInput.Rules, policy.Rules)
 			require.Equal(t, policyInput.Datacenters, policy.Datacenters)
-			require.True(t, policy.CreateIndex > 0)
+			require.Greater(t, policy.CreateIndex, 0)
 			require.Equal(t, policy.CreateIndex, policy.ModifyIndex)
 			require.NotNil(t, policy.Hash)
-			require.NotEqual(t, policy.Hash, []byte{})
+			require.NotEqual(t, []byte{}, policy.Hash)
 
 			idMap["policy-test"] = policy.ID
 			policyMap[policy.ID] = policy
@@ -294,10 +294,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, policyInput.Description, policy.Description)
 			require.Equal(t, policyInput.Rules, policy.Rules)
 			require.Equal(t, policyInput.Datacenters, policy.Datacenters)
-			require.True(t, policy.CreateIndex > 0)
+			require.Greater(t, policy.CreateIndex, 0)
 			require.Equal(t, policy.CreateIndex, policy.ModifyIndex)
 			require.NotNil(t, policy.Hash)
-			require.NotEqual(t, policy.Hash, []byte{})
+			require.NotEqual(t, []byte{}, policy.Hash)
 
 			idMap["policy-minimal"] = policy.ID
 			policyMap[policy.ID] = policy
@@ -324,10 +324,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, policyInput.Description, policy.Description)
 			require.Equal(t, policyInput.Rules, policy.Rules)
 			require.Equal(t, policyInput.Datacenters, policy.Datacenters)
-			require.True(t, policy.CreateIndex > 0)
+			require.Greater(t, policy.CreateIndex, 0)
 			require.Equal(t, policy.CreateIndex, policy.ModifyIndex)
 			require.NotNil(t, policy.Hash)
-			require.NotEqual(t, policy.Hash, []byte{})
+			require.NotEqual(t, []byte{}, policy.Hash)
 
 			idMap["policy-read-all-nodes"] = policy.ID
 			policyMap[policy.ID] = policy
@@ -382,10 +382,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, policyInput.Description, policy.Description)
 			require.Equal(t, policyInput.Rules, policy.Rules)
 			require.Equal(t, policyInput.Datacenters, policy.Datacenters)
-			require.True(t, policy.CreateIndex > 0)
-			require.True(t, policy.CreateIndex < policy.ModifyIndex)
+			require.Greater(t, policy.CreateIndex, 0)
+			require.Less(t, policy.CreateIndex, policy.ModifyIndex)
 			require.NotNil(t, policy.Hash)
-			require.NotEqual(t, policy.Hash, []byte{})
+			require.NotEqual(t, []byte{}, policy.Hash)
 
 			idMap["policy-read-all-nodes"] = policy.ID
 			policyMap[policy.ID] = policy
@@ -522,10 +522,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, roleInput.Description, role.Description)
 			require.Equal(t, roleInput.Policies, role.Policies)
 			require.Equal(t, roleInput.NodeIdentities, role.NodeIdentities)
-			require.True(t, role.CreateIndex > 0)
+			require.Greater(t, role.CreateIndex, 0)
 			require.Equal(t, role.CreateIndex, role.ModifyIndex)
 			require.NotNil(t, role.Hash)
-			require.NotEqual(t, role.Hash, []byte{})
+			require.NotEqual(t, []byte{}, role.Hash)
 
 			idMap["role-test"] = role.ID
 			roleMap[role.ID] = role
@@ -555,10 +555,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, roleInput.Name, role.Name)
 			require.Equal(t, roleInput.Description, role.Description)
 			require.Equal(t, roleInput.ServiceIdentities, role.ServiceIdentities)
-			require.True(t, role.CreateIndex > 0)
+			require.Greater(t, role.CreateIndex, 0)
 			require.Equal(t, role.CreateIndex, role.ModifyIndex)
 			require.NotNil(t, role.Hash)
-			require.NotEqual(t, role.Hash, []byte{})
+			require.NotEqual(t, []byte{}, role.Hash)
 
 			idMap["role-service-id-web"] = role.ID
 			roleMap[role.ID] = role
@@ -626,10 +626,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, roleInput.Policies, role.Policies)
 			require.Equal(t, roleInput.ServiceIdentities, role.ServiceIdentities)
 			require.Equal(t, roleInput.NodeIdentities, role.NodeIdentities)
-			require.True(t, role.CreateIndex > 0)
-			require.True(t, role.CreateIndex < role.ModifyIndex)
+			require.Greater(t, role.CreateIndex, 0)
+			require.Less(t, role.CreateIndex, role.ModifyIndex)
 			require.NotNil(t, role.Hash)
-			require.NotEqual(t, role.Hash, []byte{})
+			require.NotEqual(t, []byte{}, role.Hash)
 
 			idMap["role-test"] = role.ID
 			roleMap[role.ID] = role
@@ -757,10 +757,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, tokenInput.Description, token.Description)
 			require.Equal(t, tokenInput.Policies, token.Policies)
 			require.Equal(t, tokenInput.NodeIdentities, token.NodeIdentities)
-			require.True(t, token.CreateIndex > 0)
+			require.Greater(t, token.CreateIndex, 0)
 			require.Equal(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
-			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, []byte{}, token.Hash)
 
 			idMap["token-test"] = token.AccessorID
 			tokenMap[token.AccessorID] = token
@@ -795,10 +795,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Len(t, token.SecretID, 36)
 			require.Equal(t, tokenInput.Description, token.Description)
 			require.Equal(t, tokenInput.Policies, token.Policies)
-			require.True(t, token.CreateIndex > 0)
+			require.Greater(t, token.CreateIndex, 0)
 			require.Equal(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
-			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, []byte{}, token.Hash)
 
 			idMap["token-local"] = token.AccessorID
 			tokenMap[token.AccessorID] = token
@@ -857,10 +857,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.NotEqual(t, baseToken.SecretID, token.SecretID)
 			require.Equal(t, tokenInput.Description, token.Description)
 			require.Equal(t, baseToken.Policies, token.Policies)
-			require.True(t, token.CreateIndex > 0)
+			require.Greater(t, token.CreateIndex, 0)
 			require.Equal(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
-			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, []byte{}, token.Hash)
 
 			idMap["token-cloned"] = token.AccessorID
 			tokenMap[token.AccessorID] = token
@@ -899,10 +899,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, tokenInput.Description, token.Description)
 			require.Equal(t, tokenInput.Policies, token.Policies)
 			require.Equal(t, tokenInput.NodeIdentities, token.NodeIdentities)
-			require.True(t, token.CreateIndex > 0)
-			require.True(t, token.CreateIndex < token.ModifyIndex)
+			require.Greater(t, token.CreateIndex, 0)
+			require.Less(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
-			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, []byte{}, token.Hash)
 			require.NotEqual(t, token.Hash, originalToken.Hash)
 
 			tokenMap[token.AccessorID] = token
@@ -941,10 +941,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, tokenInput.Description, token.Description)
 			require.Equal(t, tokenInput.Policies, token.Policies)
 			require.Equal(t, tokenInput.NodeIdentities, token.NodeIdentities)
-			require.True(t, token.CreateIndex > 0)
-			require.True(t, token.CreateIndex < token.ModifyIndex)
+			require.Greater(t, token.CreateIndex, 0)
+			require.Less(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
-			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, []byte{}, token.Hash)
 			require.NotEqual(t, token.Hash, originalToken.Hash)
 
 			tokenMap[token.AccessorID] = token
@@ -1067,10 +1067,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Len(t, token.SecretID, 36)
 			require.Equal(t, tokenInput.Description, token.Description)
 			require.Equal(t, tokenInput.Policies, token.Policies)
-			require.True(t, token.CreateIndex > 0)
+			require.Greater(t, token.CreateIndex, 0)
 			require.Equal(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
-			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, []byte{}, token.Hash)
 
 			idMap["token-test"] = token.AccessorID
 			tokenMap[token.AccessorID] = token
@@ -1106,10 +1106,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Len(t, token.AccessorID, 36)
 			require.Equal(t, tokenInput.Description, token.Description)
 			require.Equal(t, tokenInput.Policies, token.Policies)
-			require.True(t, token.CreateIndex > 0)
+			require.Greater(t, token.CreateIndex, 0)
 			require.Equal(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
-			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, []byte{}, token.Hash)
 
 			idMap["token-test"] = token.AccessorID
 			tokenMap[token.AccessorID] = token
@@ -1146,10 +1146,10 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, tokenInput.AccessorID, token.AccessorID)
 			require.Equal(t, tokenInput.Description, token.Description)
 			require.Equal(t, tokenInput.Policies, token.Policies)
-			require.True(t, token.CreateIndex > 0)
+			require.Greater(t, token.CreateIndex, 0)
 			require.Equal(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
-			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, []byte{}, token.Hash)
 
 			idMap["token-test"] = token.AccessorID
 			tokenMap[token.AccessorID] = token
@@ -1534,7 +1534,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			require.Equal(t, methodInput.Type, method.Type)
 			require.Equal(t, methodInput.Description, method.Description)
 			require.Equal(t, methodInput.Config, method.Config)
-			require.True(t, method.CreateIndex > 0)
+			require.Greater(t, method.CreateIndex, 0)
 			require.Equal(t, method.CreateIndex, method.ModifyIndex)
 
 			methodMap[method.Name] = method
@@ -1565,7 +1565,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			require.Equal(t, methodInput.Type, method.Type)
 			require.Equal(t, methodInput.Description, method.Description)
 			require.Equal(t, methodInput.Config, method.Config)
-			require.True(t, method.CreateIndex > 0)
+			require.Greater(t, method.CreateIndex, 0)
 			require.Equal(t, method.CreateIndex, method.ModifyIndex)
 
 			methodMap[method.Name] = method
@@ -1632,8 +1632,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			require.Equal(t, methodInput.Type, method.Type)
 			require.Equal(t, methodInput.Description, method.Description)
 			require.Equal(t, methodInput.Config, method.Config)
-			require.True(t, method.CreateIndex > 0)
-			require.True(t, method.CreateIndex < method.ModifyIndex)
+			require.Greater(t, method.CreateIndex, 0)
+			require.Less(t, method.CreateIndex, method.ModifyIndex)
 
 			methodMap[method.Name] = method
 		})
@@ -1730,7 +1730,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			require.Equal(t, ruleInput.Selector, rule.Selector)
 			require.Equal(t, ruleInput.BindType, rule.BindType)
 			require.Equal(t, ruleInput.BindName, rule.BindName)
-			require.True(t, rule.CreateIndex > 0)
+			require.Greater(t, rule.CreateIndex, 0)
 			require.Equal(t, rule.CreateIndex, rule.ModifyIndex)
 
 			idMap["rule-test"] = rule.ID
@@ -1762,7 +1762,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			require.Equal(t, ruleInput.Selector, rule.Selector)
 			require.Equal(t, ruleInput.BindType, rule.BindType)
 			require.Equal(t, ruleInput.BindName, rule.BindName)
-			require.True(t, rule.CreateIndex > 0)
+			require.Greater(t, rule.CreateIndex, 0)
 			require.Equal(t, rule.CreateIndex, rule.ModifyIndex)
 
 			idMap["rule-other"] = rule.ID
@@ -1819,8 +1819,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			require.Equal(t, ruleInput.Selector, rule.Selector)
 			require.Equal(t, ruleInput.BindType, rule.BindType)
 			require.Equal(t, ruleInput.BindName, rule.BindName)
-			require.True(t, rule.CreateIndex > 0)
-			require.True(t, rule.CreateIndex < rule.ModifyIndex)
+			require.Greater(t, rule.CreateIndex, 0)
+			require.Less(t, rule.CreateIndex, rule.ModifyIndex)
 
 			idMap["rule-test"] = rule.ID
 			ruleMap[rule.ID] = rule
@@ -1935,15 +1935,15 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			require.Len(t, token.SecretID, 36)
 			require.Equal(t, `token created via login: {"foo":"bar"}`, token.Description)
 			require.True(t, token.Local)
-			require.Len(t, token.Policies, 0)
-			require.Len(t, token.Roles, 0)
+			require.Empty(t, token.Policies)
+			require.Empty(t, token.Roles)
 			require.Len(t, token.ServiceIdentities, 1)
 			require.Equal(t, "demo1", token.ServiceIdentities[0].ServiceName)
-			require.Len(t, token.ServiceIdentities[0].Datacenters, 0)
-			require.True(t, token.CreateIndex > 0)
+			require.Empty(t, token.ServiceIdentities[0].Datacenters)
+			require.Greater(t, token.CreateIndex, 0)
 			require.Equal(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
-			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, []byte{}, token.Hash)
 
 			idMap["token-test-1"] = token.AccessorID
 			tokenMap[token.AccessorID] = token
@@ -1969,15 +1969,15 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			require.Len(t, token.SecretID, 36)
 			require.Equal(t, `token created via login: {"blah":"woot"}`, token.Description)
 			require.True(t, token.Local)
-			require.Len(t, token.Policies, 0)
-			require.Len(t, token.Roles, 0)
+			require.Empty(t, token.Policies)
+			require.Empty(t, token.Roles)
 			require.Len(t, token.ServiceIdentities, 1)
 			require.Equal(t, "demo2", token.ServiceIdentities[0].ServiceName)
-			require.Len(t, token.ServiceIdentities[0].Datacenters, 0)
-			require.True(t, token.CreateIndex > 0)
+			require.Empty(t, token.ServiceIdentities[0].Datacenters)
+			require.Greater(t, token.CreateIndex, 0)
 			require.Equal(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
-			require.NotEqual(t, token.Hash, []byte{})
+			require.NotEqual(t, []byte{}, token.Hash)
 
 			idMap["token-test-2"] = token.AccessorID
 			tokenMap[token.AccessorID] = token
@@ -1991,7 +1991,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			require.NoError(t, err)
 			tokens, ok := raw.(structs.ACLTokenListStubs)
 			require.True(t, ok)
-			require.Len(t, tokens, 0)
+			require.Empty(t, tokens)
 		})
 
 		t.Run("List Tokens by (correct) Method", func(t *testing.T) {
@@ -2184,10 +2184,10 @@ func TestACLEndpoint_LoginLogout_jwt(t *testing.T) {
 				require.Equal(t, method.Name, token.AuthMethod)
 				require.Equal(t, `token created via login`, token.Description)
 				require.True(t, token.Local)
-				require.Len(t, token.Roles, 0)
+				require.Empty(t, token.Roles)
 				require.Len(t, token.ServiceIdentities, 1)
 				svcid := token.ServiceIdentities[0]
-				require.Len(t, svcid.Datacenters, 0)
+				require.Empty(t, svcid.Datacenters)
 				require.Equal(t, "test--jeff2--engineering", svcid.ServiceName)
 
 				// and delete it

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -455,7 +455,7 @@ func TestACL_filterMembers(t *testing.T) {
 
 	var members []serf.Member
 	require.NoError(t, a.filterMembers(nodeROSecret, &members))
-	require.Len(t, members, 0)
+	require.Empty(t, members)
 
 	members = []serf.Member{
 		{Name: "Node 1"},
@@ -464,8 +464,8 @@ func TestACL_filterMembers(t *testing.T) {
 	}
 	require.NoError(t, a.filterMembers(nodeROSecret, &members))
 	require.Len(t, members, 2)
-	require.Equal(t, members[0].Name, "Node 1")
-	require.Equal(t, members[1].Name, "Node 2")
+	require.Equal(t, "Node 1", members[0].Name)
+	require.Equal(t, "Node 2", members[1].Name)
 }
 
 func TestACL_filterServicesWithAuthorizer(t *testing.T) {

--- a/agent/agent_ce_test.go
+++ b/agent/agent_ce_test.go
@@ -26,7 +26,7 @@ func TestAgent_consulConfig_Reporting(t *testing.T) {
 	`
 	a := NewTestAgent(t, hcl)
 	defer a.Shutdown()
-	require.Equal(t, false, a.consulConfig().Reporting.License.Enabled)
+	require.False(t, a.consulConfig().Reporting.License.Enabled)
 }
 
 func TestAgent_consulConfig_Reporting_Default(t *testing.T) {
@@ -41,5 +41,5 @@ func TestAgent_consulConfig_Reporting_Default(t *testing.T) {
 	`
 	a := NewTestAgent(t, hcl)
 	defer a.Shutdown()
-	require.Equal(t, false, a.consulConfig().Reporting.License.Enabled)
+	require.False(t, a.consulConfig().Reporting.License.Enabled)
 }

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -432,7 +432,7 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 		if len(val) != 0 {
 			t.Fatalf("bad: %v", val)
 		}
-		require.Len(t, val, 0)
+		require.Empty(t, val)
 		require.Empty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 
@@ -775,7 +775,7 @@ func TestAgent_Service(t *testing.T) {
 				require.Equal(t, tt.wantCode, resp.Code, "body: %s", resp.Body.String())
 			}
 			if tt.wantWait != 0 {
-				assert.True(t, elapsed >= tt.wantWait, "should have waited at least %s, "+
+				assert.GreaterOrEqual(t, elapsed, tt.wantWait, "should have waited at least %s, "+
 					"took %s", tt.wantWait, elapsed)
 			}
 
@@ -1428,7 +1428,7 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 			t.Fatalf("Err: %v", err)
 		}
 
-		require.Len(t, val, 0)
+		require.Empty(t, val)
 		require.Empty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 
@@ -2107,7 +2107,7 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 		if err := dec.Decode(&val); err != nil {
 			t.Fatalf("Err: %v", err)
 		}
-		require.Len(t, val, 0)
+		require.Empty(t, val)
 		require.Empty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 
@@ -3589,7 +3589,7 @@ func testAgent_RegisterService_ReRegister(t *testing.T, extraHCL string) {
 	require.Equal(t, http.StatusOK, resp.Code)
 
 	checks := a.State.Checks(structs.DefaultEnterpriseMetaInDefaultPartition())
-	require.Equal(t, 3, len(checks))
+	require.Len(t, checks, 3)
 
 	checkIDs := []string{}
 	for id := range checks {
@@ -6960,7 +6960,7 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 	requireLeafValidUnderCA(t, issued, ca1)
 
 	// Verify blocking index
-	assert.True(t, issued.ModifyIndex > 0)
+	assert.Greater(t, issued.ModifyIndex, 0)
 	assert.Equal(t, fmt.Sprintf("%d", issued.ModifyIndex),
 		resp.Header().Get("X-Consul-Index"))
 
@@ -7109,7 +7109,7 @@ func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
 	requireLeafValidUnderCA(t, issued, ca1)
 
 	// Verify blocking index
-	assert.True(t, issued.ModifyIndex > 0)
+	assert.Greater(t, issued.ModifyIndex, 0)
 	assert.Equal(t, fmt.Sprintf("%d", issued.ModifyIndex),
 		resp.Header().Get("X-Consul-Index"))
 
@@ -7344,7 +7344,7 @@ func TestAgentConnectCALeafCert_Vault_doesNotChurnLeafCertsAtIdle(t *testing.T) 
 	requireLeafValidUnderCA(t, issued, ca1)
 
 	// Verify blocking index
-	assert.True(t, issued.ModifyIndex > 0)
+	assert.Greater(t, issued.ModifyIndex, 0)
 	assert.Equal(t, fmt.Sprintf("%d", issued.ModifyIndex),
 		resp.Header().Get("X-Consul-Index"))
 
@@ -7480,7 +7480,7 @@ func TestAgentConnectCALeafCert_secondaryDC_good(t *testing.T) {
 	requireLeafValidUnderCA(t, issued, dc1_ca1)
 
 	// Verify blocking index
-	assert.True(t, issued.ModifyIndex > 0)
+	assert.Greater(t, issued.ModifyIndex, 0)
 	assert.Equal(t, fmt.Sprintf("%d", issued.ModifyIndex),
 		resp.Header().Get("X-Consul-Index"))
 
@@ -7728,7 +7728,7 @@ func TestAgentConnectAuthorize_allow(t *testing.T) {
 		req.Intention.DestinationName = target
 		req.Intention.Action = structs.IntentionActionAllow
 
-		require.Nil(t, a.RPC(context.Background(), "Intention.Apply", &req, &ixnId))
+		require.NoError(t, a.RPC(context.Background(), "Intention.Apply", &req, &ixnId))
 	}
 
 	args := &structs.ConnectAuthorizeRequest{
@@ -7778,7 +7778,7 @@ func TestAgentConnectAuthorize_allow(t *testing.T) {
 		req.Intention.DestinationName = target
 		req.Intention.Action = structs.IntentionActionDeny
 
-		require.Nil(t, a.RPC(context.Background(), "Intention.Apply", &req, &ixnId))
+		require.NoError(t, a.RPC(context.Background(), "Intention.Apply", &req, &ixnId))
 	}
 
 	// Short sleep lets the cache background refresh happen
@@ -7831,7 +7831,7 @@ func TestAgentConnectAuthorize_deny(t *testing.T) {
 		req.Intention.Action = structs.IntentionActionDeny
 
 		var reply string
-		assert.Nil(t, a.RPC(context.Background(), "Intention.Apply", &req, &reply))
+		require.NoError(t, a.RPC(context.Background(), "Intention.Apply", &req, &reply))
 	}
 
 	args := &structs.ConnectAuthorizeRequest{
@@ -7949,7 +7949,7 @@ func TestAgentConnectAuthorize_denyWildcard(t *testing.T) {
 		req.Intention.Action = structs.IntentionActionAllow
 
 		var reply string
-		assert.Nil(t, a.RPC(context.Background(), "Intention.Apply", &req, &reply))
+		require.NoError(t, a.RPC(context.Background(), "Intention.Apply", &req, &reply))
 	}
 
 	// Web should be allowed
@@ -8145,7 +8145,7 @@ func TestAgent_Host(t *testing.T) {
 	resp := httptest.NewRecorder()
 	// TODO: AgentHost should write to response so that we can test using ServeHTTP()
 	respRaw, err := a.srv.AgentHost(resp, req)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.NotNil(t, respRaw)
 
@@ -8184,7 +8184,7 @@ func TestAgent_HostBadACL(t *testing.T) {
 	resp := httptest.NewRecorder()
 	// TODO: AgentHost should write to response so that we can test using ServeHTTP()
 	_, err := a.srv.AgentHost(resp, req)
-	assert.EqualError(t, err, "ACL not found")
+	require.EqualError(t, err, "ACL not found")
 	assert.Equal(t, http.StatusOK, resp.Code)
 }
 
@@ -8206,7 +8206,7 @@ func TestAgent_Version(t *testing.T) {
 	// req.Header.Add("X-Consul-Token", "initial-management")
 	resp := httptest.NewRecorder()
 	respRaw, err := a.srv.AgentVersion(resp, req)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.NotNil(t, respRaw)
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -788,7 +788,7 @@ func test_createAlias(t *testing.T, agent *TestAgent, chk *structs.CheckType, ex
 		chk.CheckID = types.CheckID(fmt.Sprintf("check-%d", serviceNum))
 	}
 	err := agent.addServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceLocal)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return func(r *retry.R) {
 		t.Helper()
 		found := false
@@ -833,9 +833,9 @@ func TestAgent_CheckAliasRPC(t *testing.T) {
 	unlockIndexOnNode := func() {
 		// We ensure to not block and update Agent's index
 		srv.Tags = []string{fmt.Sprintf("tag-%s", time.Now())}
-		assert.NoError(t, a.waitForUp())
+		require.NoError(t, a.waitForUp())
 		err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceLocal)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	shutdownAgent := func() {
 		// This is to be sure Alias Checks on remote won't be blocked during 1 min
@@ -848,9 +848,9 @@ func TestAgent_CheckAliasRPC(t *testing.T) {
 	defer shutdownAgent()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
-	assert.NoError(t, a.waitForUp())
+	require.NoError(t, a.waitForUp())
 	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceLocal)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	retry.Run(t, func(r *retry.R) {
 		r.Helper()
@@ -860,7 +860,7 @@ func TestAgent_CheckAliasRPC(t *testing.T) {
 		args.AllowStale = true
 		var out structs.IndexedNodeServices
 		err := a.RPC(context.Background(), "Catalog.NodeServices", &args, &out)
-		assert.NoError(r, err)
+		require.NoError(r, err)
 		foundService := false
 		lookup := structs.NewServiceID("svcid1", structs.WildcardEnterpriseMetaInDefaultPartition())
 		for _, srv := range out.NodeServices.Services {
@@ -1151,7 +1151,7 @@ func TestAddServiceIPv4TaggedDefault(t *testing.T) {
 	}
 
 	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
 	require.NotNil(t, ns)
@@ -1184,7 +1184,7 @@ func TestAddServiceIPv6TaggedDefault(t *testing.T) {
 	}
 
 	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
 	require.NotNil(t, ns)
@@ -1223,7 +1223,7 @@ func TestAddServiceIPv4TaggedSet(t *testing.T) {
 	}
 
 	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
 	require.NotNil(t, ns)
@@ -1262,7 +1262,7 @@ func TestAddServiceIPv6TaggedSet(t *testing.T) {
 	}
 
 	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
 	require.NotNil(t, ns)
@@ -3432,7 +3432,7 @@ func TestAgent_Service_Reap(t *testing.T) {
 
 	// Make sure it's there and there's no critical check yet.
 	requireServiceExists(t, a, "redis")
-	require.Len(t, a.State.CriticalCheckStates(structs.WildcardEnterpriseMetaInDefaultPartition()), 0, "should not have critical checks")
+	require.Empty(t, a.State.CriticalCheckStates(structs.WildcardEnterpriseMetaInDefaultPartition()), "should not have critical checks")
 
 	// Wait for the check TTL to fail but before the check is reaped.
 	time.Sleep(100 * time.Millisecond)
@@ -3444,7 +3444,7 @@ func TestAgent_Service_Reap(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	requireServiceExists(t, a, "redis")
-	require.Len(t, a.State.CriticalCheckStates(structs.WildcardEnterpriseMetaInDefaultPartition()), 0, "should not have critical checks")
+	require.Empty(t, a.State.CriticalCheckStates(structs.WildcardEnterpriseMetaInDefaultPartition()), "should not have critical checks")
 
 	// Wait for the check TTL to fail again.
 	time.Sleep(100 * time.Millisecond)
@@ -3454,7 +3454,7 @@ func TestAgent_Service_Reap(t *testing.T) {
 	// Wait for the reap.
 	time.Sleep(400 * time.Millisecond)
 	requireServiceMissing(t, a, "redis")
-	require.Len(t, a.State.CriticalCheckStates(structs.WildcardEnterpriseMetaInDefaultPartition()), 0, "should not have critical checks")
+	require.Empty(t, a.State.CriticalCheckStates(structs.WildcardEnterpriseMetaInDefaultPartition()), "should not have critical checks")
 }
 
 func TestAgent_Service_NoReap(t *testing.T) {
@@ -3489,7 +3489,7 @@ func TestAgent_Service_NoReap(t *testing.T) {
 
 	// Make sure it's there and there's no critical check yet.
 	requireServiceExists(t, a, "redis")
-	require.Len(t, a.State.CriticalCheckStates(structs.WildcardEnterpriseMetaInDefaultPartition()), 0)
+	require.Empty(t, a.State.CriticalCheckStates(structs.WildcardEnterpriseMetaInDefaultPartition()))
 
 	// Wait for the check TTL to fail.
 	time.Sleep(200 * time.Millisecond)
@@ -4067,7 +4067,7 @@ func TestAgent_SecurityChecks(t *testing.T) {
 	data := make([]byte, 0, 8192)
 	buf := &syncBuffer{b: bytes.NewBuffer(data)}
 	a.LogOutput = buf
-	assert.NoError(t, a.Start(t))
+	require.NoError(t, a.Start(t))
 	assert.Contains(t, buf.String(), "using enable-script-checks without ACLs and without allow_write_http_from is DANGEROUS")
 }
 
@@ -4160,7 +4160,7 @@ func testAgent_ReloadConfigAndKeepChecksStatus(t *testing.T, extraHCL string) {
 
 	// Make sure check is passing before we reload.
 	gotChecks := a.State.Checks(nil)
-	require.Equal(t, 1, len(gotChecks), "Should have a check registered, but had %#v", gotChecks)
+	require.Len(t, gotChecks, 1, "Should have a check registered, but had %#v", gotChecks)
 	for id, check := range gotChecks {
 		require.Equal(t, "passing", check.Status, "check %q is wrong", id)
 	}
@@ -4294,7 +4294,7 @@ func TestAgent_ReloadConfig_EnableDebug(t *testing.T) {
 		},
 	)
 	require.NoError(t, a.reloadConfigInternal(c))
-	require.Equal(t, true, a.enableDebug.Load())
+	require.True(t, a.enableDebug.Load())
 
 	c = TestConfig(
 		testutil.Logger(t),
@@ -4305,7 +4305,7 @@ func TestAgent_ReloadConfig_EnableDebug(t *testing.T) {
 		},
 	)
 	require.NoError(t, a.reloadConfigInternal(c))
-	require.Equal(t, false, a.enableDebug.Load())
+	require.False(t, a.enableDebug.Load())
 }
 
 func TestAgent_consulConfig_AutoEncryptAllowTLS(t *testing.T) {
@@ -4692,12 +4692,12 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 
 	retry.Run(t, func(r *retry.R) {
 		chks := a.ServiceHTTPBasedChecks(structs.NewServiceID("web", nil))
-		require.Equal(r, chks[0].ProxyHTTP, "http://localhost:21500/mypath?query")
+		require.Equal(r, "http://localhost:21500/mypath?query", chks[0].ProxyHTTP)
 	})
 
 	retry.Run(t, func(r *retry.R) {
 		hc := a.State.Check(structs.NewCheckID("http", nil))
-		require.Equal(r, hc.ExposedPort, 21500)
+		require.Equal(r, 21500, hc.ExposedPort)
 	})
 
 	retry.Run(t, func(r *retry.R) {
@@ -4705,12 +4705,12 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 
 		// GRPC check will be at a later index than HTTP check because of the fetching order in ServiceHTTPBasedChecks.
 		// Note that this relies on listener ports auto-incrementing in a.listenerPortLocked.
-		require.Equal(r, chks[1].ProxyGRPC, "localhost:21501/myservice")
+		require.Equal(r, "localhost:21501/myservice", chks[1].ProxyGRPC)
 	})
 
 	retry.Run(t, func(r *retry.R) {
 		hc := a.State.Check(structs.NewCheckID("grpc", nil))
-		require.Equal(r, hc.ExposedPort, 21501)
+		require.Equal(r, 21501, hc.ExposedPort)
 	})
 
 	// Re-register a proxy and disable exposing HTTP checks.
@@ -4744,7 +4744,7 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 
 	retry.Run(t, func(r *retry.R) {
 		hc := a.State.Check(structs.NewCheckID("http", nil))
-		require.Equal(r, hc.ExposedPort, 0)
+		require.Equal(r, 0, hc.ExposedPort)
 	})
 
 	retry.Run(t, func(r *retry.R) {
@@ -4756,7 +4756,7 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 
 	retry.Run(t, func(r *retry.R) {
 		hc := a.State.Check(structs.NewCheckID("grpc", nil))
-		require.Equal(r, hc.ExposedPort, 0)
+		require.Equal(r, 0, hc.ExposedPort)
 	})
 }
 
@@ -4845,24 +4845,24 @@ func TestAgent_RerouteNewHTTPChecks(t *testing.T) {
 
 	retry.Run(t, func(r *retry.R) {
 		chks := a.ServiceHTTPBasedChecks(structs.NewServiceID("web", nil))
-		require.Equal(r, chks[0].ProxyHTTP, "http://localhost:21500/mypath?query")
+		require.Equal(r, "http://localhost:21500/mypath?query", chks[0].ProxyHTTP)
 	})
 
 	retry.Run(t, func(r *retry.R) {
 		hc := a.State.Check(structs.NewCheckID("http", nil))
-		require.Equal(r, hc.ExposedPort, 21500)
+		require.Equal(r, 21500, hc.ExposedPort)
 	})
 
 	retry.Run(t, func(r *retry.R) {
 		chks := a.ServiceHTTPBasedChecks(structs.NewServiceID("web", nil))
 
 		// GRPC check will be at a later index than HTTP check because of the fetching order in ServiceHTTPBasedChecks.
-		require.Equal(r, chks[1].ProxyGRPC, "localhost:21501/myservice")
+		require.Equal(r, "localhost:21501/myservice", chks[1].ProxyGRPC)
 	})
 
 	retry.Run(t, func(r *retry.R) {
 		hc := a.State.Check(structs.NewCheckID("grpc", nil))
-		require.Equal(r, hc.ExposedPort, 21501)
+		require.Equal(r, 21501, hc.ExposedPort)
 	})
 }
 

--- a/agent/cache-types/catalog_datacenters_test.go
+++ b/agent/cache-types/catalog_datacenters_test.go
@@ -59,24 +59,24 @@ func TestCatalogDatacenters(t *testing.T) {
 	// Fetch first time
 	result, err := typ.Fetch(cache.FetchOptions{}, &structs.DatacentersRequest{})
 	require.NoError(t, err)
-	require.Equal(t, result, cache.FetchResult{
+	require.Equal(t, cache.FetchResult{
 		Value: resp,
 		Index: 1,
-	})
+	}, result)
 
 	result2, err := typ.Fetch(cache.FetchOptions{LastResult: &result}, &structs.DatacentersRequest{QueryOptions: structs.QueryOptions{MustRevalidate: true}})
 	require.NoError(t, err)
-	require.Equal(t, result2, cache.FetchResult{
+	require.Equal(t, cache.FetchResult{
 		Value: resp2,
 		Index: 2,
-	})
+	}, result2)
 
 	result3, err := typ.Fetch(cache.FetchOptions{LastResult: &result2}, &structs.DatacentersRequest{QueryOptions: structs.QueryOptions{MustRevalidate: true}})
 	require.NoError(t, err)
-	require.Equal(t, result3, cache.FetchResult{
+	require.Equal(t, cache.FetchResult{
 		Value: resp3,
 		Index: 3,
-	})
+	}, result3)
 
 	// make sure it was called the right number of times
 	rpc.AssertExpectations(t)

--- a/agent/cache-types/connect_ca_root_test.go
+++ b/agent/cache-types/connect_ca_root_test.go
@@ -38,7 +38,7 @@ func TestConnectCARoot(t *testing.T) {
 		MinIndex: 24,
 		Timeout:  1 * time.Second,
 	}, &structs.DCSpecificRequest{Datacenter: "dc1"})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, cache.FetchResult{
 		Value: resp,
 		Index: 48,
@@ -53,7 +53,7 @@ func TestConnectCARoot_badReqType(t *testing.T) {
 	// Fetch
 	_, err := typ.Fetch(cache.FetchOptions{}, cache.TestRequest(
 		t, cache.RequestInfo{Key: "foo", MinIndex: 64}))
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "wrong type")
 
 }

--- a/agent/cache/watch_test.go
+++ b/agent/cache/watch_test.go
@@ -74,7 +74,7 @@ func TestCacheNotify(t *testing.T) {
 	})
 
 	// There should be no more updates delivered yet
-	require.Len(t, ch, 0)
+	require.Empty(t, ch)
 
 	// Trigger blocking query to return a "change"
 	close(trigger[0])
@@ -125,7 +125,7 @@ func TestCacheNotify(t *testing.T) {
 	// it's only a sanity check, if we somehow _do_ get the change delivered later
 	// than 10ms the next value assertion will fail anyway.
 	time.Sleep(10 * time.Millisecond)
-	require.Len(t, ch, 0)
+	require.Empty(t, ch)
 
 	// Trigger final update
 	close(trigger[3])
@@ -204,7 +204,7 @@ func TestCacheNotifyPolling(t *testing.T) {
 	})
 
 	// There should be no more updates delivered yet
-	require.Len(t, ch, 0)
+	require.Empty(t, ch)
 
 	// make sure the updates do not come too quickly
 	select {
@@ -218,18 +218,18 @@ func TestCacheNotifyPolling(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		require.Fail(t, "Didn't receive the notification")
 	case result := <-ch:
-		require.Equal(t, result.Result, 12)
-		require.Equal(t, result.CorrelationID, "test")
-		require.Equal(t, result.Meta.Hit, false)
-		require.Equal(t, result.Meta.Index, uint64(1))
+		require.Equal(t, 12, result.Result)
+		require.Equal(t, "test", result.CorrelationID)
+		require.False(t, result.Meta.Hit)
+		require.Equal(t, uint64(1), result.Meta.Index)
 		// pretty conservative check it should be even newer because without a second
 		// notifier each value returned will have been executed just then and not served
 		// from the cache.
-		require.True(t, result.Meta.Age < 50*time.Millisecond)
+		require.Less(t, result.Meta.Age, 50*time.Millisecond)
 		require.NoError(t, result.Err)
 	}
 
-	require.Len(t, ch, 0)
+	require.Empty(t, ch)
 
 	// Register a second observer using same chan and request. Note that this is
 	// testing a few things implicitly:
@@ -247,7 +247,7 @@ func TestCacheNotifyPolling(t *testing.T) {
 		Err:           nil,
 	})
 
-	require.Len(t, ch, 0)
+	require.Empty(t, ch)
 
 	// wait for the next batch of responses
 	events := make([]UpdateEvent, 0)
@@ -263,18 +263,18 @@ func TestCacheNotifyPolling(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, events[0].Result, 42)
-	require.Equal(t, events[0].Meta.Hit && events[1].Meta.Hit, false)
-	require.Equal(t, events[0].Meta.Index, uint64(1))
-	require.True(t, events[0].Meta.Age < 50*time.Millisecond)
+	require.Equal(t, 42, events[0].Result)
+	require.False(t, events[0].Meta.Hit && events[1].Meta.Hit)
+	require.Equal(t, uint64(1), events[0].Meta.Index)
+	require.Less(t, events[0].Meta.Age, 50*time.Millisecond)
 	require.NoError(t, events[0].Err)
-	require.Equal(t, events[1].Result, 42)
+	require.Equal(t, 42, events[1].Result)
 	// Sometimes this would be a hit and others not. It all depends on when the various getWithIndex calls got fired.
 	// If both are done concurrently then it will not be a cache hit but the request gets single flighted and both
 	// get notified at the same time.
 	// require.Equal(t,events[1].Meta.Hit, true)
-	require.Equal(t, events[1].Meta.Index, uint64(1))
-	require.True(t, events[1].Meta.Age < 100*time.Millisecond)
+	require.Equal(t, uint64(1), events[1].Meta.Index)
+	require.Less(t, events[1].Meta.Age, 100*time.Millisecond)
 	require.NoError(t, events[1].Err)
 }
 
@@ -335,11 +335,11 @@ OUT:
 		}
 	}
 	// Must be fewer than 10 failures in that time
-	require.True(t, numErrors < 10, fmt.Sprintf("numErrors: %d", numErrors))
+	require.Less(t, numErrors, 10, fmt.Sprintf("numErrors: %d", numErrors))
 
 	// Check the number of RPCs as a sanity check too
 	actual := atomic.LoadUint32(&retries)
-	require.True(t, actual < 10, fmt.Sprintf("actual: %d", actual))
+	require.Less(t, actual, 10, fmt.Sprintf("actual: %d", actual))
 }
 
 // Test that a refresh performs a backoff.
@@ -401,11 +401,11 @@ OUT:
 		}
 	}
 	// Must be fewer than 10 failures in that time
-	require.True(t, numErrors < 10, fmt.Sprintf("numErrors: %d", numErrors))
+	require.Less(t, numErrors, 10, fmt.Sprintf("numErrors: %d", numErrors))
 
 	// Check the number of RPCs as a sanity check too
 	actual := atomic.LoadUint32(&retries)
-	require.True(t, actual < 10, fmt.Sprintf("actual: %d", actual))
+	require.Less(t, actual, 10, fmt.Sprintf("actual: %d", actual))
 }
 
 func Test_isEqual(t *testing.T) {

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -317,7 +317,7 @@ func TestCatalogNodes_Filter(t *testing.T) {
 
 	v, ok := nodes[0].Meta["somekey"]
 	require.True(t, ok)
-	require.Equal(t, v, "somevalue")
+	require.Equal(t, "somevalue", v)
 }
 
 func TestCatalogNodes_WanTranslation(t *testing.T) {
@@ -1068,9 +1068,9 @@ func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
 	require.True(t, ok, "obj1 is not a structs.ServiceNodes")
 	require.Len(t, nodes1, 1)
 	node1 := nodes1[0]
-	require.Equal(t, node1.Address, "127.0.0.2")
-	require.Equal(t, node1.ServiceAddress, "1.2.3.4")
-	require.Equal(t, node1.ServicePort, 80)
+	require.Equal(t, "127.0.0.2", node1.Address)
+	require.Equal(t, "1.2.3.4", node1.ServiceAddress)
+	require.Equal(t, 80, node1.ServicePort)
 
 	// Query DC2 from DC2.
 	resp2 := httptest.NewRecorder()
@@ -1083,9 +1083,9 @@ func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
 	require.True(t, ok, "obj2 is not a structs.ServiceNodes")
 	require.Len(t, nodes2, 1)
 	node2 := nodes2[0]
-	require.Equal(t, node2.Address, "127.0.0.1")
-	require.Equal(t, node2.ServiceAddress, "127.0.0.1")
-	require.Equal(t, node2.ServicePort, 8080)
+	require.Equal(t, "127.0.0.1", node2.Address)
+	require.Equal(t, "127.0.0.1", node2.ServiceAddress)
+	require.Equal(t, 8080, node2.ServicePort)
 }
 
 func TestCatalogServiceNodes_DistanceSort(t *testing.T) {
@@ -1197,13 +1197,13 @@ func TestCatalogServiceNodes_ConnectProxy(t *testing.T) {
 	// Register
 	args := structs.TestRegisterRequestProxy(t)
 	var out struct{}
-	assert.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+	require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
 
 	req, _ := http.NewRequest("GET", fmt.Sprintf(
 		"/v1/catalog/service/%s", args.Service.Service), nil)
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.CatalogServiceNodes(resp, req)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assertIndex(t, resp)
 
 	nodes := obj.(structs.ServiceNodes)
@@ -1297,7 +1297,7 @@ func validateMergeCentralConfigResponse(t *testing.T, v *structs.ServiceNode,
 	// validate service defaults are resolved in the merged service config
 	// expected number of upstreams = (number of upstreams defined in the register request proxy config +
 	//	1 centrally configured default from service defaults)
-	require.Equal(t, len(registerServiceReq.Service.Proxy.Upstreams)+1, len(v.ServiceProxy.Upstreams))
+	require.Len(t, v.ServiceProxy.Upstreams, len(registerServiceReq.Service.Proxy.Upstreams)+1)
 	for _, up := range v.ServiceProxy.Upstreams {
 		if up.DestinationType != "" && up.DestinationType != structs.UpstreamDestTypeService {
 			continue
@@ -1472,13 +1472,13 @@ func TestCatalogConnectServiceNodes_good(t *testing.T) {
 	args := structs.TestRegisterRequestProxy(t)
 	args.Service.Address = "127.0.0.55"
 	var out struct{}
-	assert.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+	require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
 
 	req, _ := http.NewRequest("GET", fmt.Sprintf(
 		"/v1/catalog/connect/%s", args.Service.Proxy.DestinationServiceName), nil)
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.CatalogConnectServiceNodes(resp, req)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assertIndex(t, resp)
 
 	nodes := obj.(structs.ServiceNodes)
@@ -1793,13 +1793,13 @@ func TestCatalogNodeServices_ConnectProxy(t *testing.T) {
 	// Register
 	args := structs.TestRegisterRequestProxy(t)
 	var out struct{}
-	assert.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+	require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
 
 	req, _ := http.NewRequest("GET", fmt.Sprintf(
 		"/v1/catalog/node/%s", args.Node), nil)
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.CatalogNodeServices(resp, req)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assertIndex(t, resp)
 
 	ns := obj.(*structs.NodeServices)
@@ -1875,7 +1875,7 @@ func TestCatalogNodeServices_WanTranslation(t *testing.T) {
 	service1, ok := obj1.(*structs.NodeServices)
 	require.True(t, ok, "obj1 is not a *structs.NodeServices")
 	require.NotNil(t, service1.Node)
-	require.Equal(t, service1.Node.Address, "127.0.0.2")
+	require.Equal(t, "127.0.0.2", service1.Node.Address)
 	require.Len(t, service1.Services, 1)
 	ns1, ok := service1.Services["http_wan_translation_test"]
 	require.True(t, ok, "Missing service http_wan_translation_test")
@@ -1892,12 +1892,12 @@ func TestCatalogNodeServices_WanTranslation(t *testing.T) {
 	service2 := obj2.(*structs.NodeServices)
 	require.True(t, ok, "obj2 is not a *structs.NodeServices")
 	require.NotNil(t, service2.Node)
-	require.Equal(t, service2.Node.Address, "127.0.0.1")
+	require.Equal(t, "127.0.0.1", service2.Node.Address)
 	require.Len(t, service2.Services, 1)
 	ns2, ok := service2.Services["http_wan_translation_test"]
 	require.True(t, ok, "Missing service http_wan_translation_test")
-	require.Equal(t, ns2.Address, "127.0.0.1")
-	require.Equal(t, ns2.Port, 8080)
+	require.Equal(t, "127.0.0.1", ns2.Address)
+	require.Equal(t, 8080, ns2.Port)
 }
 
 func TestCatalog_GatewayServices_Terminating(t *testing.T) {
@@ -1920,7 +1920,7 @@ func TestCatalog_GatewayServices_Terminating(t *testing.T) {
 		ServiceID: args.Service.Service,
 	}
 	var out struct{}
-	assert.NoError(t, a.RPC(context.Background(), "Catalog.Register", &args, &out))
+	require.NoError(t, a.RPC(context.Background(), "Catalog.Register", &args, &out))
 
 	// Associate the gateway and api/redis services
 	entryArgs := &structs.ConfigEntryRequest{
@@ -1949,13 +1949,13 @@ func TestCatalog_GatewayServices_Terminating(t *testing.T) {
 		},
 	}
 	var entryResp bool
-	assert.NoError(t, a.RPC(context.Background(), "ConfigEntry.Apply", &entryArgs, &entryResp))
+	require.NoError(t, a.RPC(context.Background(), "ConfigEntry.Apply", &entryArgs, &entryResp))
 
 	retry.Run(t, func(r *retry.R) {
 		req, _ := http.NewRequest("GET", "/v1/catalog/gateway-services/terminating", nil)
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.CatalogGatewayServices(resp, req)
-		assert.NoError(r, err)
+		require.NoError(r, err)
 
 		header := resp.Header().Get("X-Consul-Index")
 		if header == "" || header == "0" {

--- a/agent/config/builder_ce_test.go
+++ b/agent/config/builder_ce_test.go
@@ -140,7 +140,7 @@ func TestValidateEnterpriseConfigKeys(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			errs := validateEnterpriseConfigKeys(&tcase.config)
 			if len(tcase.badKeys) == 0 {
-				require.Len(t, errs, 0)
+				require.Empty(t, errs)
 				return
 			}
 

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -195,12 +195,12 @@ func TestBuilder_unixPermissionsVal(t *testing.T) {
 	require.NoError(t, b.err)
 	_ = b.unixPermissionsVal("local_bind_socket_mode", &goodmode)
 	require.NoError(t, b.err)
-	require.Len(t, b.Warnings, 0)
+	require.Empty(t, b.Warnings)
 
 	_ = b.unixPermissionsVal("local_bind_socket_mode", &badmode)
-	require.NotNil(t, b.err)
+	require.Error(t, b.err)
 	require.Contains(t, b.err.Error(), "local_bind_socket_mode: invalid mode")
-	require.Len(t, b.Warnings, 0)
+	require.Empty(t, b.Warnings)
 }
 
 func patchLoadOptsShims(opts *LoadOpts) {
@@ -360,7 +360,7 @@ func TestBuilder_ServiceVal_with_Check(t *testing.T) {
 		},
 	})
 	require.NoError(t, b.err)
-	require.Equal(t, 1, len(svc.Checks))
+	require.Len(t, svc.Checks, 1)
 	require.Equal(t, "localhost:53", svc.Checks[0].UDP)
 }
 

--- a/agent/config/deprecated_test.go
+++ b/agent/config/deprecated_test.go
@@ -85,7 +85,7 @@ raft_boltdb {
 	// defaults makes this test difficult to read. So as a workaround, compare
 	// specific values.
 	rt := result.RuntimeConfig
-	require.Equal(t, true, rt.ACLsEnabled)
+	require.True(t, rt.ACLsEnabled)
 	require.Equal(t, "dcone", rt.PrimaryDatacenter)
 	require.Equal(t, "token1", rt.ACLTokens.ACLAgentToken)
 	require.Equal(t, "token2", rt.ACLTokens.ACLDefaultToken)
@@ -93,7 +93,7 @@ raft_boltdb {
 	require.Equal(t, "deny", rt.ACLResolverSettings.ACLDefaultPolicy)
 	require.Equal(t, "async-cache", rt.ACLResolverSettings.ACLDownPolicy)
 	require.Equal(t, 3*time.Hour, rt.ACLResolverSettings.ACLTokenTTL)
-	require.Equal(t, true, rt.ACLEnableKeyListPolicy)
+	require.True(t, rt.ACLEnableKeyListPolicy)
 
 	for _, l := range []tlsutil.ProtocolConfig{rt.TLS.InternalRPC, rt.TLS.GRPC, rt.TLS.HTTPS} {
 		require.Equal(t, "some-ca-file", l.CAFile)
@@ -136,7 +136,7 @@ enable_acl_replication = true
 	// defaults makes this test difficult to read. So as a workaround, compare
 	// specific values.
 	rt := result.RuntimeConfig
-	require.Equal(t, true, rt.ACLTokenReplication)
+	require.True(t, rt.ACLTokenReplication)
 }
 
 func TestLoad_DeprecatedConfig_ACLMasterTokens(t *testing.T) {

--- a/agent/config/runtime_ce_test.go
+++ b/agent/config/runtime_ce_test.go
@@ -112,8 +112,8 @@ func TestLoad_ReportingConfig(t *testing.T) {
 		patchLoadOptsShims(&opts)
 		result, err := Load(opts)
 		require.NoError(t, err)
-		require.Len(t, result.Warnings, 0)
-		require.Equal(t, false, result.RuntimeConfig.Reporting.License.Enabled)
+		require.Empty(t, result.Warnings)
+		require.False(t, result.RuntimeConfig.Reporting.License.Enabled)
 	})
 
 	t.Run("load from HCL defaults to false", func(t *testing.T) {
@@ -136,8 +136,8 @@ func TestLoad_ReportingConfig(t *testing.T) {
 		patchLoadOptsShims(&opts)
 		result, err := Load(opts)
 		require.NoError(t, err)
-		require.Len(t, result.Warnings, 0)
-		require.Equal(t, false, result.RuntimeConfig.Reporting.License.Enabled)
+		require.Empty(t, result.Warnings)
+		require.False(t, result.RuntimeConfig.Reporting.License.Enabled)
 	})
 
 	t.Run("with value set returns warning and defaults to false", func(t *testing.T) {
@@ -164,6 +164,6 @@ func TestLoad_ReportingConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result.Warnings, 1)
 		require.Contains(t, result.Warnings[0], "\"reporting.license.enabled\" is a Consul Enterprise configuration and will have no effect")
-		require.Equal(t, false, result.RuntimeConfig.Reporting.License.Enabled)
+		require.False(t, result.RuntimeConfig.Reporting.License.Enabled)
 	})
 }

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -6174,7 +6174,7 @@ func (tc testCase) run(format string, dataDir string) func(t *testing.T) {
 		fs := flag.NewFlagSet("", flag.ContinueOnError)
 		AddFlags(fs, &opts)
 		require.NoError(t, fs.Parse(tc.args))
-		require.Len(t, fs.Args(), 0)
+		require.Empty(t, fs.Args())
 
 		for i, data := range tc.source(format) {
 			opts.sources = append(opts.sources, FileSource{
@@ -7448,7 +7448,7 @@ func TestRuntime_APIConfigHTTPS(t *testing.T) {
 	require.Equal(t, "", cfg.TLSConfig.CertFile)
 	require.Equal(t, "", cfg.TLSConfig.KeyFile)
 	require.Equal(t, rt.Datacenter, cfg.Datacenter)
-	require.Equal(t, true, cfg.TLSConfig.InsecureSkipVerify)
+	require.True(t, cfg.TLSConfig.InsecureSkipVerify)
 
 	rt.TLS.HTTPS.VerifyOutgoing = true
 	cfg, err = rt.APIConfig(true)
@@ -7460,7 +7460,7 @@ func TestRuntime_APIConfigHTTPS(t *testing.T) {
 	require.Equal(t, rt.TLS.HTTPS.CertFile, cfg.TLSConfig.CertFile)
 	require.Equal(t, rt.TLS.HTTPS.KeyFile, cfg.TLSConfig.KeyFile)
 	require.Equal(t, rt.Datacenter, cfg.Datacenter)
-	require.Equal(t, false, cfg.TLSConfig.InsecureSkipVerify)
+	require.False(t, cfg.TLSConfig.InsecureSkipVerify)
 }
 
 func TestRuntime_APIConfigHTTP(t *testing.T) {

--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -99,7 +99,7 @@ func TestConfig_Get(t *testing.T) {
 		value := obj.(structs.ConfigEntry)
 		require.Equal(t, structs.ServiceDefaults, value.GetKind())
 		entry := value.(*structs.ServiceConfigEntry)
-		require.Equal(t, entry.Name, "foo")
+		require.Equal(t, "foo", entry.Name)
 	})
 	t.Run("list both service entries", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/config/service-defaults", nil)
@@ -109,8 +109,8 @@ func TestConfig_Get(t *testing.T) {
 
 		value := obj.([]structs.ConfigEntry)
 		require.Len(t, value, 2)
-		require.Equal(t, value[0].(*structs.ServiceConfigEntry).Name, "bar")
-		require.Equal(t, value[1].(*structs.ServiceConfigEntry).Name, "foo")
+		require.Equal(t, "bar", value[0].(*structs.ServiceConfigEntry).Name)
+		require.Equal(t, "foo", value[1].(*structs.ServiceConfigEntry).Name)
 	})
 	t.Run("get global proxy config", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/config/proxy-defaults/global", nil)
@@ -119,7 +119,7 @@ func TestConfig_Get(t *testing.T) {
 		require.NoError(t, err)
 
 		value := obj.(structs.ConfigEntry)
-		require.Equal(t, value.GetKind(), structs.ProxyDefaults)
+		require.Equal(t, structs.ProxyDefaults, value.GetKind())
 		entry := value.(*structs.ProxyConfigEntry)
 		require.Equal(t, structs.ProxyConfigGlobal, entry.Name)
 		require.Contains(t, entry.Config, "foo")
@@ -129,7 +129,7 @@ func TestConfig_Get(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/config/", nil)
 		resp := httptest.NewRecorder()
 		_, err := a.srv.Config(resp, req)
-		require.Error(t, errors.New("Must provide either a kind or both kind and name"), err)
+		require.ErrorIs(t, errors.New("Must provide either a kind or both kind and name"), err)
 	})
 	t.Run("get the single mesh config", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/config/mesh/mesh", nil)
@@ -215,7 +215,7 @@ func TestConfig_Delete(t *testing.T) {
 		require.Equal(t, structs.ServiceDefaults, out.Kind)
 		require.Len(t, out.Entries, 1)
 		entry := out.Entries[0].(*structs.ServiceConfigEntry)
-		require.Equal(t, entry.Name, "foo")
+		require.Equal(t, "foo", entry.Name)
 	}
 }
 
@@ -337,7 +337,7 @@ func TestConfig_Apply(t *testing.T) {
 		require.NoError(t, a.RPC(context.Background(), "ConfigEntry.Get", &args, &out))
 		require.NotNil(t, out.Entry)
 		entry := out.Entry.(*structs.ServiceConfigEntry)
-		require.Equal(t, entry.Name, "foo")
+		require.Equal(t, "foo", entry.Name)
 	}
 }
 
@@ -723,7 +723,7 @@ func TestConfig_Apply_Decoding(t *testing.T) {
 			require.NoError(t, a.RPC(context.Background(), "ConfigEntry.Get", &args, &out))
 			require.NotNil(t, out.Entry)
 			entry := out.Entry.(*structs.ServiceConfigEntry)
-			require.Equal(t, entry.Name, "foo")
+			require.Equal(t, "foo", entry.Name)
 		}
 	})
 }

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -194,7 +194,7 @@ func TestConsulCAProvider_SignLeaf(t *testing.T) {
 
 				// Ensure the cert is valid now and expires within the correct limit.
 				now := time.Now()
-				require.True(t, parsed.NotAfter.Sub(now) < time.Hour)
+				require.Less(t, parsed.NotAfter.Sub(now), time.Hour)
 				require.True(t, parsed.NotBefore.Before(now))
 			}
 
@@ -219,7 +219,7 @@ func TestConsulCAProvider_SignLeaf(t *testing.T) {
 				requireNotEncoded(t, parsed.AuthorityKeyId)
 
 				// Ensure the cert is valid now and expires within the correct limit.
-				require.True(t, time.Until(parsed.NotAfter) < 3*24*time.Hour)
+				require.Less(t, time.Until(parsed.NotAfter), 3*24*time.Hour)
 				require.True(t, parsed.NotBefore.Before(time.Now()))
 			}
 
@@ -248,7 +248,7 @@ func TestConsulCAProvider_SignLeaf(t *testing.T) {
 
 				// Ensure the cert is valid now and expires within the correct limit.
 				now := time.Now()
-				require.True(t, parsed.NotAfter.Sub(now) < time.Hour)
+				require.Less(t, parsed.NotAfter.Sub(now), time.Hour)
 				require.True(t, parsed.NotBefore.Before(now))
 			}
 		})

--- a/agent/connect/ca/provider_vault_auth_test.go
+++ b/agent/connect/ca/provider_vault_auth_test.go
@@ -772,7 +772,7 @@ func TestVaultCAProvider_AliCloudAuthClient(t *testing.T) {
 
 				queries := requrl.Query()
 				require.Subset(t, queries, c.expQry, "query missing fields")
-				require.Equal(t, requrl.Hostname(), "sts.test-region.aliyuncs.com")
+				require.Equal(t, "sts.test-region.aliyuncs.com", requrl.Hostname())
 			}
 		})
 	}

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -586,7 +586,7 @@ func TestVaultCAProvider_SignLeaf(t *testing.T) {
 
 			// Ensure the cert is valid now and expires within the correct limit.
 			now := time.Now()
-			require.True(t, parsed.NotAfter.Sub(now) < time.Hour)
+			require.Less(t, parsed.NotAfter.Sub(now), time.Hour)
 			require.True(t, parsed.NotBefore.Before(now))
 
 			// Make sure we can validate the cert as expected.
@@ -612,7 +612,7 @@ func TestVaultCAProvider_SignLeaf(t *testing.T) {
 			require.NotEqual(t, firstSerial, parsed.SerialNumber.Uint64())
 
 			// Ensure the cert is valid now and expires within the correct limit.
-			require.True(t, time.Until(parsed.NotAfter) < time.Hour)
+			require.Less(t, time.Until(parsed.NotAfter), time.Hour)
 			require.True(t, parsed.NotBefore.Before(time.Now()))
 
 			// Make sure we can validate the cert as expected.

--- a/agent/connect/testing_ca_test.go
+++ b/agent/connect/testing_ca_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,16 +68,16 @@ func testCAAndLeaf_xc(t *testing.T, keyType string, keyBits int) {
 
 	// Create a temporary directory for storing the certs
 	td, err := os.MkdirTemp("", "consul")
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(td)
 
 	// Write the cert
 	xcbundle := []byte(ca1.RootCert)
 	xcbundle = append(xcbundle, '\n')
 	xcbundle = append(xcbundle, []byte(ca2.SigningCert)...)
-	assert.Nil(t, os.WriteFile(filepath.Join(td, "ca.pem"), xcbundle, 0644))
-	assert.Nil(t, os.WriteFile(filepath.Join(td, "leaf1.pem"), []byte(leaf1), 0644))
-	assert.Nil(t, os.WriteFile(filepath.Join(td, "leaf2.pem"), []byte(leaf2), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(td, "ca.pem"), xcbundle, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(td, "leaf1.pem"), []byte(leaf1), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(td, "leaf2.pem"), []byte(leaf2), 0644))
 
 	// OpenSSL verify the cross-signed leaf (leaf2)
 	{
@@ -87,7 +86,7 @@ func testCAAndLeaf_xc(t *testing.T, keyType string, keyBits int) {
 		cmd.Dir = td
 		output, err := cmd.Output()
 		t.Log(string(output))
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	// OpenSSL verify the old leaf (leaf1)
@@ -97,7 +96,7 @@ func testCAAndLeaf_xc(t *testing.T, keyType string, keyBits int) {
 		cmd.Dir = td
 		output, err := cmd.Output()
 		t.Log(string(output))
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	}
 }
 

--- a/agent/connect/uri_signing_test.go
+++ b/agent/connect/uri_signing_test.go
@@ -14,7 +14,7 @@ import (
 func TestSpiffeIDSigningForCluster(t *testing.T) {
 	// For now it should just append .consul to the ID.
 	id := SpiffeIDSigningForCluster(TestClusterID)
-	assert.Equal(t, id.URI().String(), "spiffe://"+TestClusterID+".consul")
+	assert.Equal(t, "spiffe://"+TestClusterID+".consul", id.URI().String())
 }
 
 // fakeCertURI is a CertURI implementation that our implementation doesn't know

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -59,7 +59,7 @@ func TestConnectCARoots_list(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/v1/connect/ca/roots", nil)
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.ConnectCARoots(resp, req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	value := obj.(structs.IndexedCARoots)
 	assert.Equal(t, value.ActiveRootID, ca2.ID)
@@ -288,7 +288,7 @@ func TestConnectCARoots_PEMEncoding(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, obj, "Endpoint returned an object for serialization when it should have returned nil and written to the responses")
 	resp := recorder.Result()
-	require.Equal(t, resp.Header.Get("Content-Type"), "application/pem-certificate-chain")
+	require.Equal(t, "application/pem-certificate-chain", resp.Header.Get("Content-Type"))
 
 	data, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -50,9 +50,9 @@ func TestACLEndpoint_BootstrapTokens(t *testing.T) {
 	// level checks on the ACL since we don't have control over the UUID or
 	// Raft indexes at this level.
 	require.NoError(t, msgpackrpc.CallWithCodec(codec, "ACL.BootstrapTokens", &arg, &out))
-	require.Equal(t, 36, len(out.AccessorID))
+	require.Len(t, out.AccessorID, 36)
 	require.True(t, strings.HasPrefix(out.Description, "Bootstrap Token"))
-	require.True(t, out.CreateIndex > 0)
+	require.Greater(t, out.CreateIndex, 0)
 	require.Equal(t, out.CreateIndex, out.ModifyIndex)
 
 	// Finally, make sure that another attempt is rejected.
@@ -69,10 +69,10 @@ func TestACLEndpoint_BootstrapTokens(t *testing.T) {
 	oldID := out.AccessorID
 	// Finally, make sure that another attempt is rejected.
 	require.NoError(t, msgpackrpc.CallWithCodec(codec, "ACL.BootstrapTokens", &arg, &out))
-	require.Equal(t, 36, len(out.AccessorID))
+	require.Len(t, out.AccessorID, 36)
 	require.NotEqual(t, oldID, out.AccessorID)
 	require.True(t, strings.HasPrefix(out.Description, "Bootstrap Token"))
-	require.True(t, out.CreateIndex > 0)
+	require.Greater(t, out.CreateIndex, 0)
 	require.Equal(t, out.CreateIndex, out.ModifyIndex)
 }
 
@@ -96,9 +96,9 @@ func TestACLEndpoint_ProvidedBootstrapTokens(t *testing.T) {
 	var out structs.ACLToken
 	require.NoError(t, msgpackrpc.CallWithCodec(codec, "ACL.BootstrapTokens", &arg, &out))
 	require.Equal(t, out.SecretID, arg.BootstrapSecret)
-	require.Equal(t, 36, len(out.AccessorID))
+	require.Len(t, out.AccessorID, 36)
 	require.True(t, strings.HasPrefix(out.Description, "Bootstrap Token"))
-	require.True(t, out.CreateIndex > 0)
+	require.Greater(t, out.CreateIndex, 0)
 	require.Equal(t, out.CreateIndex, out.ModifyIndex)
 }
 
@@ -595,7 +595,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 
 		require.NotNil(t, token)
 		require.NotNil(t, token.AccessorID)
-		require.Equal(t, token.Description, "foobar")
+		require.Equal(t, "foobar", token.Description)
 		require.Equal(t, token.AccessorID, resp.AccessorID)
 		require.Len(t, token.NodeIdentities, 1)
 		require.Equal(t, "foo", token.NodeIdentities[0].NodeName)
@@ -639,7 +639,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 
 		require.NotNil(t, token)
 		require.NotNil(t, token.AccessorID)
-		require.Equal(t, token.Description, "new-description")
+		require.Equal(t, "new-description", token.Description)
 		require.Equal(t, token.AccessorID, resp.AccessorID)
 		require.Empty(t, token.NodeIdentities)
 	})
@@ -684,10 +684,10 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 
 		require.NotNil(t, token)
 		require.NotNil(t, token.AccessorID)
-		require.Equal(t, token.Description, "foobar")
+		require.Equal(t, "foobar", token.Description)
 		require.Equal(t, token.AccessorID, resp.AccessorID)
 
-		require.Len(t, token.Policies, 0)
+		require.Empty(t, token.Policies)
 	})
 
 	t.Run("Create it using Roles linked by id and name", func(t *testing.T) {
@@ -730,10 +730,10 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 
 		require.NotNil(t, token)
 		require.NotNil(t, token.AccessorID)
-		require.Equal(t, token.Description, "foobar")
+		require.Equal(t, "foobar", token.Description)
 		require.Equal(t, token.AccessorID, resp.AccessorID)
 
-		require.Len(t, token.Roles, 0)
+		require.Empty(t, token.Roles)
 	})
 
 	t.Run("Create it with AuthMethod set outside of login", func(t *testing.T) {
@@ -841,7 +841,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 		token := tokenResp.Token
 
 		require.NotNil(t, token)
-		require.Len(t, token.Roles, 0)
+		require.Empty(t, token.Roles)
 		require.Equal(t, "updated token", token.Description)
 		require.True(t, token.Local)
 		require.Equal(t, methodToken.SecretID, token.SecretID)
@@ -886,7 +886,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 		resp := structs.ACLToken{}
 
 		err := a.TokenSet(&req, &resp)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 
 	for _, test := range []struct {
@@ -942,7 +942,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 				require.NotNil(t, token)
 				require.ElementsMatch(t, req.ACLToken.ServiceIdentities, token.ServiceIdentities)
 			} else {
-				require.NotNil(t, err)
+				require.Error(t, err)
 			}
 		})
 	}
@@ -1060,7 +1060,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 			if test.errString != "" {
 				testutil.RequireErrorContains(t, err, test.errString)
 			} else {
-				require.NotNil(t, err)
+				require.Error(t, err)
 			}
 		})
 
@@ -1082,7 +1082,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 			if test.errString != "" {
 				testutil.RequireErrorContains(t, err, test.errStringTTL)
 			} else {
-				require.NotNil(t, err)
+				require.Error(t, err)
 			}
 		})
 	}
@@ -1132,7 +1132,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 
 		require.NotNil(t, token)
 		require.NotNil(t, token.AccessorID)
-		require.Equal(t, token.Description, "foobar")
+		require.Equal(t, "foobar", token.Description)
 		require.Equal(t, token.AccessorID, resp.AccessorID)
 		requireTimeEquals(t, &expectExpTime, resp.ExpirationTime)
 
@@ -1165,7 +1165,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 
 		require.NotNil(t, token)
 		require.NotNil(t, token.AccessorID)
-		require.Equal(t, token.Description, "foobar")
+		require.Equal(t, "foobar", token.Description)
 		require.Equal(t, token.AccessorID, resp.AccessorID)
 		requireTimeEquals(t, &expTime, resp.ExpirationTime)
 
@@ -1215,7 +1215,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 
 		require.NotNil(t, token)
 		require.NotNil(t, token.AccessorID)
-		require.Equal(t, token.Description, "new-description-1")
+		require.Equal(t, "new-description-1", token.Description)
 		require.Equal(t, token.AccessorID, resp.AccessorID)
 		requireTimeEquals(t, &expTime, resp.ExpirationTime)
 	})
@@ -1243,7 +1243,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 
 		require.NotNil(t, token)
 		require.NotNil(t, token.AccessorID)
-		require.Equal(t, token.Description, "new-description-2")
+		require.Equal(t, "new-description-2", token.Description)
 		require.Equal(t, token.AccessorID, resp.AccessorID)
 		requireTimeEquals(t, &expTime, resp.ExpirationTime)
 	})
@@ -1391,7 +1391,7 @@ func TestACLEndpoint_TokenSet_CustomID(t *testing.T) {
 		require.NotNil(t, token)
 		require.Equal(t, req.ACLToken.AccessorID, token.AccessorID)
 		require.Equal(t, req.ACLToken.SecretID, token.SecretID)
-		require.Equal(t, token.Description, "foobar")
+		require.Equal(t, "foobar", token.Description)
 	})
 
 	// Reserved AccessorID
@@ -1632,7 +1632,7 @@ func TestACLEndpoint_TokenSet_anon(t *testing.T) {
 
 	tokenResp, err := retrieveTestToken(codec, TestDefaultInitialManagementToken, "dc1", acl.AnonymousTokenID)
 	require.NoError(t, err)
-	require.Equal(t, len(tokenResp.Token.Policies), 1)
+	require.Len(t, tokenResp.Token.Policies, 1)
 	require.Equal(t, tokenResp.Token.Policies[0].ID, policy.ID)
 
 }
@@ -2146,9 +2146,9 @@ func TestACLEndpoint_PolicySet(t *testing.T) {
 		policy := policyResp.Policy
 
 		require.NotNil(t, policy.ID)
-		require.Equal(t, policy.Description, "foobar")
-		require.Equal(t, policy.Name, "baz")
-		require.Equal(t, policy.Rules, "service \"\" { policy = \"read\" }")
+		require.Equal(t, "foobar", policy.Description)
+		require.Equal(t, "baz", policy.Name)
+		require.Equal(t, "service \"\" { policy = \"read\" }", policy.Rules)
 
 		policyID = policy.ID
 	})
@@ -2192,9 +2192,9 @@ func TestACLEndpoint_PolicySet(t *testing.T) {
 		policy := policyResp.Policy
 
 		require.NotNil(t, policy.ID)
-		require.Equal(t, policy.Description, "bat")
-		require.Equal(t, policy.Name, "bar")
-		require.Equal(t, policy.Rules, "service \"\" { policy = \"write\" }")
+		require.Equal(t, "bat", policy.Description)
+		require.Equal(t, "bar", policy.Name)
+		require.Equal(t, "service \"\" { policy = \"write\" }", policy.Rules)
 	})
 }
 
@@ -2572,8 +2572,8 @@ func TestACLEndpoint_RoleSet(t *testing.T) {
 		role := roleResp.Role
 
 		require.NotNil(t, role.ID)
-		require.Equal(t, role.Description, "foobar")
-		require.Equal(t, role.Name, "baz")
+		require.Equal(t, "foobar", role.Description)
+		require.Equal(t, "baz", role.Name)
 		require.Len(t, role.Policies, 1)
 		require.Equal(t, testPolicy1.ID, role.Policies[0].ID)
 		require.Len(t, role.NodeIdentities, 1)
@@ -2610,8 +2610,8 @@ func TestACLEndpoint_RoleSet(t *testing.T) {
 		role := roleResp.Role
 
 		require.NotNil(t, role.ID)
-		require.Equal(t, role.Description, "bat")
-		require.Equal(t, role.Name, "bar")
+		require.Equal(t, "bat", role.Description)
+		require.Equal(t, "bar", role.Name)
 		require.Len(t, role.Policies, 1)
 		require.Equal(t, testPolicy2.ID, role.Policies[0].ID)
 		require.Empty(t, role.NodeIdentities)
@@ -2656,10 +2656,10 @@ func TestACLEndpoint_RoleSet(t *testing.T) {
 		role := roleResp.Role
 
 		require.NotNil(t, role.ID)
-		require.Equal(t, role.Description, "foobar")
-		require.Equal(t, role.Name, "baz")
+		require.Equal(t, "foobar", role.Description)
+		require.Equal(t, "baz", role.Name)
 
-		require.Len(t, role.Policies, 0)
+		require.Empty(t, role.Policies)
 	})
 
 	roleNameGen := func(t *testing.T) string {
@@ -2703,7 +2703,7 @@ func TestACLEndpoint_RoleSet(t *testing.T) {
 		resp := structs.ACLRole{}
 
 		err := a.RoleSet(&req, &resp)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 
 	for _, test := range []struct {
@@ -2757,7 +2757,7 @@ func TestACLEndpoint_RoleSet(t *testing.T) {
 				role := roleResp.Role
 				require.ElementsMatch(t, req.Role.ServiceIdentities, role.ServiceIdentities)
 			} else {
-				require.NotNil(t, err)
+				require.Error(t, err)
 			}
 		})
 	}
@@ -3121,9 +3121,9 @@ func TestACLEndpoint_AuthMethodSet(t *testing.T) {
 		require.NoError(t, err)
 		method := methodResp.AuthMethod
 
-		require.Equal(t, method.Name, "test")
-		require.Equal(t, method.Description, "test")
-		require.Equal(t, method.Type, "testing")
+		require.Equal(t, "test", method.Name)
+		require.Equal(t, "test", method.Description)
+		require.Equal(t, "testing", method.Type)
 	})
 
 	t.Run("Update fails; not allowed to change types", func(t *testing.T) {
@@ -3162,10 +3162,10 @@ func TestACLEndpoint_AuthMethodSet(t *testing.T) {
 		require.NoError(t, err)
 		method := methodResp.AuthMethod
 
-		require.Equal(t, method.Name, "test")
-		require.Equal(t, method.DisplayName, "updated display name 1")
-		require.Equal(t, method.Description, "test modified 1")
-		require.Equal(t, method.Type, "testing")
+		require.Equal(t, "test", method.Name)
+		require.Equal(t, "updated display name 1", method.DisplayName)
+		require.Equal(t, "test modified 1", method.Description)
+		require.Equal(t, "testing", method.Type)
 	})
 
 	t.Run("Update - specify type", func(t *testing.T) {
@@ -3188,10 +3188,10 @@ func TestACLEndpoint_AuthMethodSet(t *testing.T) {
 		require.NoError(t, err)
 		method := methodResp.AuthMethod
 
-		require.Equal(t, method.Name, "test")
-		require.Equal(t, method.DisplayName, "updated display name 2")
-		require.Equal(t, method.Description, "test modified 2")
-		require.Equal(t, method.Type, "testing")
+		require.Equal(t, "test", method.Name)
+		require.Equal(t, "updated display name 2", method.DisplayName)
+		require.Equal(t, "test modified 2", method.Description)
+		require.Equal(t, "testing", method.Type)
 	})
 
 	t.Run("Create with no name", func(t *testing.T) {
@@ -3269,7 +3269,7 @@ func TestACLEndpoint_AuthMethodSet(t *testing.T) {
 				method := methodResp.AuthMethod
 
 				require.Equal(t, method.Name, test.name)
-				require.Equal(t, method.Type, "testing")
+				require.Equal(t, "testing", method.Type)
 			} else {
 				require.Error(t, err)
 			}
@@ -3295,10 +3295,10 @@ func TestACLEndpoint_AuthMethodSet(t *testing.T) {
 		require.NoError(t, err)
 		method := methodResp.AuthMethod
 
-		require.Equal(t, method.Name, "test")
-		require.Equal(t, method.Description, "test")
-		require.Equal(t, method.Type, "testing")
-		require.Equal(t, method.MaxTokenTTL, 5*time.Minute)
+		require.Equal(t, "test", method.Name)
+		require.Equal(t, "test", method.Description)
+		require.Equal(t, "testing", method.Type)
+		require.Equal(t, 5*time.Minute, method.MaxTokenTTL)
 	})
 
 	t.Run("Update - change MaxTokenTTL", func(t *testing.T) {
@@ -3322,11 +3322,11 @@ func TestACLEndpoint_AuthMethodSet(t *testing.T) {
 		require.NoError(t, err)
 		method := methodResp.AuthMethod
 
-		require.Equal(t, method.Name, "test")
-		require.Equal(t, method.DisplayName, "updated display name 2")
-		require.Equal(t, method.Description, "test modified 2")
-		require.Equal(t, method.Type, "testing")
-		require.Equal(t, method.MaxTokenTTL, 8*time.Minute)
+		require.Equal(t, "test", method.Name)
+		require.Equal(t, "updated display name 2", method.DisplayName)
+		require.Equal(t, "test modified 2", method.Description)
+		require.Equal(t, "testing", method.Type)
+		require.Equal(t, 8*time.Minute, method.MaxTokenTTL)
 	})
 
 	t.Run("Create with MaxTokenTTL too small", func(t *testing.T) {
@@ -3623,7 +3623,7 @@ func TestACLEndpoint_BindingRuleSet(t *testing.T) {
 		rule := ruleResp.BindingRule
 
 		require.NotEmpty(t, rule.ID)
-		require.Equal(t, rule.Description, "foobar")
+		require.Equal(t, "foobar", rule.Description)
 		require.Equal(t, rule.AuthMethod, testAuthMethod.Name)
 		require.Equal(t, "serviceaccount.name==abc", rule.Selector)
 		require.Equal(t, structs.BindingRuleBindTypeService, rule.BindType)
@@ -3656,7 +3656,7 @@ func TestACLEndpoint_BindingRuleSet(t *testing.T) {
 		rule := ruleResp.BindingRule
 
 		require.NotEmpty(t, rule.ID)
-		require.Equal(t, rule.Description, "foobar")
+		require.Equal(t, "foobar", rule.Description)
 		require.Equal(t, rule.AuthMethod, testAuthMethod.Name)
 		require.Equal(t, "serviceaccount.name==abc", rule.Selector)
 		require.Equal(t, structs.BindingRuleBindTypeNode, rule.BindType)
@@ -3687,7 +3687,7 @@ func TestACLEndpoint_BindingRuleSet(t *testing.T) {
 		rule := ruleResp.BindingRule
 
 		require.NotEmpty(t, rule.ID)
-		require.Equal(t, rule.Description, "foobar policy")
+		require.Equal(t, "foobar policy", rule.Description)
 		require.Equal(t, rule.AuthMethod, testAuthMethod.Name)
 		require.Equal(t, "serviceaccount.name==abc", rule.Selector)
 		require.Equal(t, structs.BindingRuleBindTypePolicy, rule.BindType)
@@ -3721,7 +3721,7 @@ func TestACLEndpoint_BindingRuleSet(t *testing.T) {
 		rule := ruleResp.BindingRule
 
 		require.NotEmpty(t, rule.ID)
-		require.Equal(t, rule.Description, "templated policy binding rule")
+		require.Equal(t, "templated policy binding rule", rule.Description)
 		require.Equal(t, rule.AuthMethod, testAuthMethod.Name)
 		require.Equal(t, "serviceaccount.name==abc", rule.Selector)
 		require.Equal(t, structs.BindingRuleBindTypeTemplatedPolicy, rule.BindType)
@@ -3761,7 +3761,7 @@ func TestACLEndpoint_BindingRuleSet(t *testing.T) {
 		rule := ruleResp.BindingRule
 
 		require.NotEmpty(t, rule.ID)
-		require.Equal(t, rule.Description, "foobar modified 1")
+		require.Equal(t, "foobar modified 1", rule.Description)
 		require.Equal(t, rule.AuthMethod, testAuthMethod.Name)
 		require.Equal(t, "serviceaccount.namespace==def", rule.Selector)
 		require.Equal(t, structs.BindingRuleBindTypeRole, rule.BindType)
@@ -3793,7 +3793,7 @@ func TestACLEndpoint_BindingRuleSet(t *testing.T) {
 		rule := ruleResp.BindingRule
 
 		require.NotEmpty(t, rule.ID)
-		require.Equal(t, rule.Description, "foobar modified 2")
+		require.Equal(t, "foobar modified 2", rule.Description)
 		require.Equal(t, rule.AuthMethod, testAuthMethod.Name)
 		require.Equal(t, "serviceaccount.namespace==def", rule.Selector)
 		require.Equal(t, structs.BindingRuleBindTypeRole, rule.BindType)
@@ -4250,7 +4250,7 @@ func TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData(t *testing.T) {
 		}
 		resp = structs.ACLAuthMethodListResponse{}
 		require.NoError(t, aclEp.AuthMethodList(&req, &resp))
-		require.Len(t, resp.AuthMethods, 0)
+		require.Empty(t, resp.AuthMethods)
 	})
 
 	var ruleID string
@@ -4351,7 +4351,7 @@ func TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData(t *testing.T) {
 		}
 		resp = structs.ACLBindingRuleListResponse{}
 		require.NoError(t, aclEp.BindingRuleList(&req, &resp))
-		require.Len(t, resp.BindingRules, 0)
+		require.Empty(t, resp.BindingRules)
 	})
 
 	var remoteToken *structs.ACLToken
@@ -4736,7 +4736,7 @@ func TestACLEndpoint_Login(t *testing.T) {
 		require.Equal(t, method.Name, resp.AuthMethod)
 		require.Equal(t, `token created via login: {"pod":"pod1"}`, resp.Description)
 		require.True(t, resp.Local)
-		require.Len(t, resp.ServiceIdentities, 0)
+		require.Empty(t, resp.ServiceIdentities)
 		require.Len(t, resp.Roles, 1)
 		role := resp.Roles[0]
 		require.Equal(t, vaultRoleID, role.ID)
@@ -4760,9 +4760,9 @@ func TestACLEndpoint_Login(t *testing.T) {
 		require.Equal(t, `token created via login: {"pod":"pod1"}`, resp.Description)
 		require.True(t, resp.Local)
 		require.Len(t, resp.ServiceIdentities, 1)
-		require.Len(t, resp.Roles, 0)
+		require.Empty(t, resp.Roles)
 		svcid := resp.ServiceIdentities[0]
-		require.Len(t, svcid.Datacenters, 0)
+		require.Empty(t, svcid.Datacenters)
 		require.Equal(t, "method-monolith", svcid.ServiceName)
 	})
 
@@ -4805,7 +4805,7 @@ func TestACLEndpoint_Login(t *testing.T) {
 		require.Equal(t, monolithRoleID, role.ID)
 		require.Equal(t, "method-monolith", role.Name)
 		svcid := resp.ServiceIdentities[0]
-		require.Len(t, svcid.Datacenters, 0)
+		require.Empty(t, svcid.Datacenters)
 		require.Equal(t, "method-monolith", svcid.ServiceName)
 	})
 
@@ -4825,10 +4825,10 @@ func TestACLEndpoint_Login(t *testing.T) {
 		require.Equal(t, method.Name, resp.AuthMethod)
 		require.Equal(t, `token created via login: {"pod":"pod1"}`, resp.Description)
 		require.True(t, resp.Local)
-		require.Len(t, resp.Roles, 0)
+		require.Empty(t, resp.Roles)
 		require.Len(t, resp.ServiceIdentities, 1)
 		svcid := resp.ServiceIdentities[0]
-		require.Len(t, svcid.Datacenters, 0)
+		require.Empty(t, svcid.Datacenters)
 		require.Equal(t, "method-db", svcid.ServiceName)
 	})
 
@@ -4888,10 +4888,10 @@ func TestACLEndpoint_Login(t *testing.T) {
 		require.Equal(t, method.Name, resp.AuthMethod)
 		require.Equal(t, `token created via login: {"pod":"pod1"}`, resp.Description)
 		require.True(t, resp.Local)
-		require.Len(t, resp.Roles, 0)
+		require.Empty(t, resp.Roles)
 		require.Len(t, resp.ServiceIdentities, 1)
 		svcid := resp.ServiceIdentities[0]
-		require.Len(t, svcid.Datacenters, 0)
+		require.Empty(t, svcid.Datacenters)
 		require.Equal(t, "method-db", svcid.ServiceName)
 	})
 
@@ -5234,10 +5234,10 @@ func TestACLEndpoint_Login_k8s(t *testing.T) {
 		require.Equal(t, method.Name, resp.AuthMethod)
 		require.Equal(t, `token created via login: {"pod":"pod1"}`, resp.Description)
 		require.True(t, resp.Local)
-		require.Len(t, resp.Roles, 0)
+		require.Empty(t, resp.Roles)
 		require.Len(t, resp.ServiceIdentities, 1)
 		svcid := resp.ServiceIdentities[0]
-		require.Len(t, svcid.Datacenters, 0)
+		require.Empty(t, svcid.Datacenters)
 		require.Equal(t, "demo", svcid.ServiceName)
 	})
 
@@ -5266,10 +5266,10 @@ func TestACLEndpoint_Login_k8s(t *testing.T) {
 		require.Equal(t, method.Name, resp.AuthMethod)
 		require.Equal(t, `token created via login: {"pod":"pod1"}`, resp.Description)
 		require.True(t, resp.Local)
-		require.Len(t, resp.Roles, 0)
+		require.Empty(t, resp.Roles)
 		require.Len(t, resp.ServiceIdentities, 1)
 		svcid := resp.ServiceIdentities[0]
-		require.Len(t, svcid.Datacenters, 0)
+		require.Empty(t, svcid.Datacenters)
 		require.Equal(t, "alternate-name", svcid.ServiceName)
 	})
 }
@@ -5412,10 +5412,10 @@ func TestACLEndpoint_Login_jwt(t *testing.T) {
 				require.Equal(t, method.Name, resp.AuthMethod)
 				require.Equal(t, `token created via login`, resp.Description)
 				require.True(t, resp.Local)
-				require.Len(t, resp.Roles, 0)
+				require.Empty(t, resp.Roles)
 				require.Len(t, resp.ServiceIdentities, 1)
 				svcid := resp.ServiceIdentities[0]
-				require.Len(t, svcid.Datacenters, 0)
+				require.Empty(t, svcid.Datacenters)
 				require.Equal(t, "test--jeff2--engineering", svcid.ServiceName)
 			})
 		})

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -116,7 +116,7 @@ func TestACLReplication_diffACLPolicies(t *testing.T) {
 	require.Equal(t, "e9d33298-6490-4466-99cb-ba93af64fa76", deletions[0])
 
 	deletions, updates = diffACLPolicies(local, nil, 28)
-	require.Len(t, updates, 0)
+	require.Empty(t, updates)
 	require.Len(t, deletions, 4)
 	require.ElementsMatch(t, deletions, []string{
 		"44ef9aec-7654-4401-901b-4d4a8b3c80fc",
@@ -125,7 +125,7 @@ func TestACLReplication_diffACLPolicies(t *testing.T) {
 		"e9d33298-6490-4466-99cb-ba93af64fa76"})
 
 	deletions, updates = diffACLPolicies(nil, remote, 28)
-	require.Len(t, deletions, 0)
+	require.Empty(t, deletions)
 	require.Len(t, updates, 4)
 	require.ElementsMatch(t, updates, []string{
 		"44ef9aec-7654-4401-901b-4d4a8b3c80fc",
@@ -268,7 +268,7 @@ func TestACLReplication_diffACLTokens(t *testing.T) {
 		res := diffACLTokens(local, nil, 28)
 		require.Equal(t, 1, res.LocalSkipped)
 		require.Equal(t, 0, res.RemoteSkipped)
-		require.Len(t, res.LocalUpserts, 0)
+		require.Empty(t, res.LocalUpserts)
 		require.Len(t, res.LocalDeletes, 4)
 		require.ElementsMatch(t, res.LocalDeletes, []string{
 			"44ef9aec-7654-4401-901b-4d4a8b3c80fc",
@@ -281,7 +281,7 @@ func TestACLReplication_diffACLTokens(t *testing.T) {
 		res := diffACLTokens(nil, remote, 28)
 		require.Equal(t, 0, res.LocalSkipped)
 		require.Equal(t, 1, res.RemoteSkipped)
-		require.Len(t, res.LocalDeletes, 0)
+		require.Empty(t, res.LocalDeletes)
 		require.Len(t, res.LocalUpserts, 5)
 		require.ElementsMatch(t, res.LocalUpserts, []string{
 			"72fac6a3-a014-41c8-9cb2-8d9a5e935f3d",
@@ -401,9 +401,9 @@ func TestACLReplication_Tokens(t *testing.T) {
 
 		require.True(t, status.Enabled)
 		require.True(t, status.Running)
-		require.Equal(t, status.ReplicationType, structs.ACLReplicateTokens)
+		require.Equal(t, structs.ACLReplicateTokens, status.ReplicationType)
 		require.Equal(t, status.ReplicatedTokenIndex, index)
-		require.Equal(t, status.SourceDatacenter, "dc1")
+		require.Equal(t, "dc1", status.SourceDatacenter)
 	}
 	// Wait for the replica to converge.
 	retry.Run(t, func(r *retry.R) {
@@ -579,9 +579,9 @@ func TestACLReplication_Policies(t *testing.T) {
 
 		require.True(t, status.Enabled)
 		require.True(t, status.Running)
-		require.Equal(t, status.ReplicationType, structs.ACLReplicatePolicies)
+		require.Equal(t, structs.ACLReplicatePolicies, status.ReplicationType)
 		require.Equal(t, status.ReplicatedIndex, index)
-		require.Equal(t, status.SourceDatacenter, "dc1")
+		require.Equal(t, "dc1", status.SourceDatacenter)
 	}
 	// Wait for the replica to converge.
 	retry.Run(t, func(r *retry.R) {
@@ -714,7 +714,7 @@ func TestACLReplication_TokensRedacted(t *testing.T) {
 		}
 		require.NoError(r, s2.RPC(context.Background(), "ACL.ReplicationStatus", &statusReq, &status))
 		// ensures that tokens are not being synced
-		require.True(r, status.ReplicatedTokenIndex > 0, "ReplicatedTokenIndex not greater than 0")
+		require.Greater(r, status.ReplicatedTokenIndex, 0, "ReplicatedTokenIndex not greater than 0")
 
 	})
 
@@ -770,10 +770,10 @@ func TestACLReplication_TokensRedacted(t *testing.T) {
 		}
 		require.NoError(r, s2.RPC(context.Background(), "ACL.ReplicationStatus", &statusReq, &status))
 		// ensures that tokens are not being synced
-		require.True(r, status.ReplicatedTokenIndex < token2.CreateIndex, "ReplicatedTokenIndex is not less than the token2s create index")
+		require.Less(r, status.ReplicatedTokenIndex, token2.CreateIndex, "ReplicatedTokenIndex is not less than the token2s create index")
 		// ensures that token replication is erroring
 		require.True(r, status.LastError.After(minErrorTime), "Replication LastError not after the minErrorTime")
-		require.Equal(r, status.LastErrorMessage, "failed to retrieve unredacted tokens - replication token in use does not grant acl:write")
+		require.Equal(r, "failed to retrieve unredacted tokens - replication token in use does not grant acl:write", status.LastErrorMessage)
 	})
 }
 
@@ -843,9 +843,9 @@ func TestACLReplication_AllTypes(t *testing.T) {
 
 		require.True(t, status.Enabled)
 		require.True(t, status.Running)
-		require.Equal(t, status.ReplicationType, structs.ACLReplicateTokens)
+		require.Equal(t, structs.ACLReplicateTokens, status.ReplicationType)
 		require.Equal(t, status.ReplicatedTokenIndex, index)
-		require.Equal(t, status.SourceDatacenter, "dc1")
+		require.Equal(t, "dc1", status.SourceDatacenter)
 	}
 	checkSamePolicies := func(t *retry.R) {
 		index, remote, err := s1.fsm.State().ACLPolicyList(nil, nil)
@@ -864,9 +864,9 @@ func TestACLReplication_AllTypes(t *testing.T) {
 
 		require.True(t, status.Enabled)
 		require.True(t, status.Running)
-		require.Equal(t, status.ReplicationType, structs.ACLReplicateTokens)
+		require.Equal(t, structs.ACLReplicateTokens, status.ReplicationType)
 		require.Equal(t, status.ReplicatedIndex, index)
-		require.Equal(t, status.SourceDatacenter, "dc1")
+		require.Equal(t, "dc1", status.SourceDatacenter)
 	}
 	checkSameRoles := func(t *retry.R) {
 		index, remote, err := s1.fsm.State().ACLRoleList(nil, "", nil)
@@ -885,9 +885,9 @@ func TestACLReplication_AllTypes(t *testing.T) {
 
 		require.True(t, status.Enabled)
 		require.True(t, status.Running)
-		require.Equal(t, status.ReplicationType, structs.ACLReplicateTokens)
+		require.Equal(t, structs.ACLReplicateTokens, status.ReplicationType)
 		require.Equal(t, status.ReplicatedRoleIndex, index)
-		require.Equal(t, status.SourceDatacenter, "dc1")
+		require.Equal(t, "dc1", status.SourceDatacenter)
 	}
 	checkSame := func(t *retry.R) {
 		checkSameTokens(t)
@@ -955,7 +955,7 @@ func TestACLReplication_AllTypes(t *testing.T) {
 }
 
 func createACLTestData(t *testing.T, srv *Server, namePrefix string, numObjects, numItemsThatAreLocal int) (policyIDs, roleIDs, tokenIDs []string) {
-	require.True(t, numItemsThatAreLocal <= numObjects, 0, "numItemsThatAreLocal <= numObjects")
+	require.LessOrEqual(t, numItemsThatAreLocal, numObjects, 0, "numItemsThatAreLocal <= numObjects")
 
 	// Create some policies.
 	for i := 0; i < numObjects; i++ {

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -64,7 +64,7 @@ func verifyAuthorizerChain(t *testing.T, expected resolver.Result, actual resolv
 		actualAuthz := actualChain[idx]
 
 		// pointer equality - because we want to verify authorizer reuse
-		require.True(t, expectedAuthz == actualAuthz, "Authorizer pointers are not equal")
+		require.Equal(t, expectedAuthz, actualAuthz, "Authorizer pointers are not equal")
 	}
 }
 
@@ -733,7 +733,7 @@ func TestACLResolver_Disabled(t *testing.T) {
 
 	authz, err := r.ResolveToken("does not exist")
 	require.Equal(t, resolver.Result{Authorizer: acl.ManageAll()}, authz)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestACLResolver_ResolveRootACL(t *testing.T) {
@@ -902,7 +902,7 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 		authz2, err := r.ResolveToken("found-role")
 		require.NoError(t, err)
 		require.NotNil(t, authz2)
-		require.False(t, authz == authz2)
+		require.NotEqual(t, authz, authz2)
 		require.Equal(t, acl.Deny, authz2.NodeWrite("foo", nil))
 	})
 
@@ -1089,7 +1089,7 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 		// the go routine spawned will eventually return with a authz that doesn't have the policy
 		retry.Run(t, func(t *retry.R) {
 			authz3, err := r.ResolveToken("found")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, authz3)
 			assert.Equal(t, acl.Deny, authz3.NodeWrite("foo", nil))
 		})
@@ -1133,7 +1133,7 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 		// the go routine spawned will eventually return with a authz that doesn't have the policy
 		retry.Run(t, func(t *retry.R) {
 			authz3, err := r.ResolveToken("found-role")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, authz3)
 			assert.Equal(t, acl.Deny, authz3.NodeWrite("foo", nil))
 		})
@@ -1240,7 +1240,7 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 		// the go routine spawned will eventually return and this will be a not found error
 		retry.Run(t, func(t *retry.R) {
 			_, err := r.ResolveToken("found")
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.True(t, acl.IsErrNotFound(err))
 		})
 
@@ -1507,8 +1507,8 @@ func TestACLResolver_Client(t *testing.T) {
 
 		require.True(t, modified)
 		require.True(t, deleted)
-		require.Equal(t, tokenReads, int32(2))
-		require.Equal(t, policyResolves, int32(3))
+		require.Equal(t, int32(2), tokenReads)
+		require.Equal(t, int32(3), policyResolves)
 	})
 
 	t.Run("Concurrent-Token-Resolve", func(t *testing.T) {

--- a/agent/consul/auth/token_writer_test.go
+++ b/agent/consul/auth/token_writer_test.go
@@ -4,7 +4,6 @@
 package auth
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -684,7 +683,7 @@ func TestTokenWriter_Delete(t *testing.T) {
 		})
 		err := writer.Delete(generateID(t), false)
 		require.Error(t, err)
-		require.True(t, errors.Is(err, acl.ErrNotFound))
+		require.ErrorIs(t, err, acl.ErrNotFound)
 	})
 
 	t.Run("logout requires token to be created by login", func(t *testing.T) {
@@ -703,7 +702,7 @@ func TestTokenWriter_Delete(t *testing.T) {
 		})
 		err := writer.Delete(token.SecretID, true)
 		require.Error(t, err)
-		require.True(t, errors.Is(err, acl.ErrPermissionDenied))
+		require.ErrorIs(t, err, acl.ErrPermissionDenied)
 		require.Contains(t, err.Error(), "wasn't created via login")
 	})
 }

--- a/agent/consul/authmethod/kubeauth/k8s_test.go
+++ b/agent/consul/authmethod/kubeauth/k8s_test.go
@@ -239,7 +239,7 @@ func TestNewValidator(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, v)
 			} else {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.Nil(t, v)
 			}
 		})

--- a/agent/consul/autopilot_test.go
+++ b/agent/consul/autopilot_test.go
@@ -91,7 +91,7 @@ func TestAutopilot_CleanupDeadServer(t *testing.T) {
 			break
 		}
 	}
-	require.NotEqual(t, leaderIndex, -1)
+	require.NotEqual(t, -1, leaderIndex)
 
 	// Shutdown two non-leader servers
 	killed := make(map[string]struct{})

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -705,7 +705,7 @@ func TestConfigEntry_List_Filter(t *testing.T) {
 
 			var out structs.IndexedConfigEntries
 			require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.List", &args, &out))
-			require.Equal(t, out.Entries, c.expected)
+			require.Equal(t, c.expected, out.Entries)
 		})
 	}
 }
@@ -1916,7 +1916,7 @@ func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
 		))
 
 		// Should block at least 100ms
-		require.True(t, time.Since(start) >= 100*time.Millisecond, "too fast")
+		require.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond, "too fast")
 
 		// Check the indexes
 		require.Equal(t, out.Index, index+1)
@@ -1981,7 +1981,7 @@ func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
 		))
 
 		// Should block at least 100ms
-		require.True(t, time.Since(start) >= 100*time.Millisecond, "too fast")
+		require.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond, "too fast")
 
 		// Check the indexes
 		require.Equal(t, out.Index, index+1)
@@ -2102,7 +2102,7 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams_Blocking(t *testing.T) {
 		))
 
 		// Should block at least 100ms
-		require.True(t, time.Since(start) >= 100*time.Millisecond, "too fast")
+		require.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond, "too fast")
 
 		// Check the indexes
 		require.Equal(t, out.Index, index+1)
@@ -2181,7 +2181,7 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams_Blocking(t *testing.T) {
 		))
 
 		// Should block at least 100ms
-		require.True(t, time.Since(start) >= 100*time.Millisecond, "too fast")
+		require.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond, "too fast")
 
 		// Check the indexes
 		require.Equal(t, out.Index, index+1)

--- a/agent/consul/federation_state_endpoint_test.go
+++ b/agent/consul/federation_state_endpoint_test.go
@@ -567,7 +567,7 @@ func TestFederationState_List_ACLDeny(t *testing.T) {
 					}
 				} else if tc.listEmpty {
 					require.NoError(t, err)
-					require.Len(t, out.States, 0)
+					require.Empty(t, out.States)
 				} else {
 					require.NoError(t, err)
 
@@ -589,7 +589,7 @@ func TestFederationState_List_ACLDeny(t *testing.T) {
 
 				if tc.gwListEmpty {
 					require.NoError(t, err)
-					require.Len(t, out.DatacenterNodes, 0)
+					require.Empty(t, out.DatacenterNodes)
 				} else {
 					require.NoError(t, err)
 					require.Equal(t, expectedMeshGateways.DatacenterNodes, out.DatacenterNodes)
@@ -866,7 +866,7 @@ func federationStateUpsert(t *testing.T, codec rpc.ClientCodec, token string, fe
 
 func zeroFedStateIndexes(t *testing.T, fedState *structs.FederationState) {
 	require.NotNil(t, fedState)
-	require.True(t, fedState.PrimaryModifyIndex > 0, "this should be set")
+	require.Greater(t, fedState.PrimaryModifyIndex, 0, "this should be set")
 	fedState.PrimaryModifyIndex = 0          // zero out so the equality works
 	fedState.RaftIndex = structs.RaftIndex{} // zero these out so the equality works
 }

--- a/agent/consul/fsm/commands_ce_test.go
+++ b/agent/consul/fsm/commands_ce_test.go
@@ -1114,7 +1114,7 @@ func TestFSM_Intention_CRUD(t *testing.T) {
 
 	logger := testutil.Logger(t)
 	fsm, err := New(nil, logger)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Create a new intention.
 	ixn := structs.IntentionRequest{
@@ -1128,14 +1128,14 @@ func TestFSM_Intention_CRUD(t *testing.T) {
 
 	{
 		buf, err := structs.Encode(structs.IntentionRequestType, ixn)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Nil(t, fsm.Apply(makeLog(buf)))
 	}
 
 	// Verify it's in the state store.
 	{
 		_, _, actual, err := fsm.state.IntentionGet(nil, ixn.Intention.ID)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		actual.CreateIndex, actual.ModifyIndex = 0, 0
 		actual.CreatedAt = ixn.Intention.CreatedAt
@@ -1148,14 +1148,14 @@ func TestFSM_Intention_CRUD(t *testing.T) {
 	ixn.Intention.SourceName = "api"
 	{
 		buf, err := structs.Encode(structs.IntentionRequestType, ixn)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Nil(t, fsm.Apply(makeLog(buf)))
 	}
 
 	// Verify the update.
 	{
 		_, _, actual, err := fsm.state.IntentionGet(nil, ixn.Intention.ID)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		actual.CreateIndex, actual.ModifyIndex = 0, 0
 		actual.CreatedAt = ixn.Intention.CreatedAt
@@ -1167,14 +1167,14 @@ func TestFSM_Intention_CRUD(t *testing.T) {
 	ixn.Op = structs.IntentionOpDelete
 	{
 		buf, err := structs.Encode(structs.IntentionRequestType, ixn)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Nil(t, fsm.Apply(makeLog(buf)))
 	}
 
 	// Make sure it's gone.
 	{
 		_, _, actual, err := fsm.state.IntentionGet(nil, ixn.Intention.ID)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Nil(t, actual)
 	}
 }
@@ -1184,7 +1184,7 @@ func TestFSM_CAConfig(t *testing.T) {
 
 	logger := testutil.Logger(t)
 	fsm, err := New(nil, logger)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Set the autopilot config using a request.
 	req := structs.CARequest{
@@ -1199,7 +1199,7 @@ func TestFSM_CAConfig(t *testing.T) {
 		},
 	}
 	buf, err := structs.Encode(structs.ConnectCARequestType, req)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	resp := fsm.Apply(makeLog(buf))
 	if _, ok := resp.(error); ok {
 		t.Fatalf("bad: %v", resp)
@@ -1240,7 +1240,7 @@ func TestFSM_CAConfig(t *testing.T) {
 	}
 
 	_, config, err = fsm.state.CAConfig(nil)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	if config.Provider != "static" {
 		t.Fatalf("bad: %v", config.Provider)
 	}
@@ -1251,7 +1251,7 @@ func TestFSM_CARoots(t *testing.T) {
 
 	logger := testutil.Logger(t)
 	fsm, err := New(nil, logger)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Roots
 	ca1 := connect.TestCA(t, nil)
@@ -1266,14 +1266,14 @@ func TestFSM_CARoots(t *testing.T) {
 
 	{
 		buf, err := structs.Encode(structs.ConnectCARequestType, req)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.True(t, fsm.Apply(makeLog(buf)).(bool))
 	}
 
 	// Verify it's in the state store.
 	{
 		_, roots, err := fsm.state.CARoots(nil)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Len(t, roots, 2)
 	}
 }
@@ -1283,7 +1283,7 @@ func TestFSM_CABuiltinProvider(t *testing.T) {
 
 	logger := testutil.Logger(t)
 	fsm, err := New(nil, logger)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Provider state.
 	expected := &structs.CAConsulProviderState{
@@ -1304,14 +1304,14 @@ func TestFSM_CABuiltinProvider(t *testing.T) {
 
 	{
 		buf, err := structs.Encode(structs.ConnectCARequestType, req)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.True(t, fsm.Apply(makeLog(buf)).(bool))
 	}
 
 	// Verify it's in the state store.
 	{
 		_, state, err := fsm.state.CAProviderState("foo")
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expected, state)
 	}
 }
@@ -1697,7 +1697,7 @@ func TestFSM_Chunking_Lifecycle(t *testing.T) {
 		_, checks, err := fsm2.state.NodeChecks(nil, fmt.Sprintf("foo%d", i), nil, "")
 		require.NoError(t, err)
 		require.NotNil(t, checks)
-		assert.Equal(t, string(checks[0].CheckID), "db")
+		assert.Equal(t, "db", string(checks[0].CheckID))
 	}
 }
 

--- a/agent/consul/fsm/fsm_test.go
+++ b/agent/consul/fsm/fsm_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type MockSink struct {
@@ -44,7 +45,7 @@ func TestFSM_IgnoreUnknown(t *testing.T) {
 	t.Parallel()
 	logger := testutil.Logger(t)
 	fsm, err := New(nil, logger)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Create a new reap request
 	type UnknownRequest struct {
@@ -53,7 +54,7 @@ func TestFSM_IgnoreUnknown(t *testing.T) {
 	req := UnknownRequest{Foo: "bar"}
 	msgType := structs.IgnoreUnknownTypeFlag | 75
 	buf, err := structs.Encode(msgType, req)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Apply should work, even though not supported
 	resp := fsm.Apply(makeLog(buf))
@@ -63,6 +64,6 @@ func TestFSM_IgnoreUnknown(t *testing.T) {
 
 func TestFSM_NilLogger(t *testing.T) {
 	fsm, err := New(nil, nil)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, fsm)
 }

--- a/agent/consul/fsm/snapshot_test.go
+++ b/agent/consul/fsm/snapshot_test.go
@@ -84,7 +84,7 @@ func TestFSM_SnapshotRestore_CE(t *testing.T) {
 	psn := structs.PeeredServiceName{ServiceName: structs.NewServiceName("web", nil)}
 	vip, err := fsm.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.1")
+	require.Equal(t, "240.0.0.1", vip)
 
 	fsm.state.EnsureService(4, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "127.0.0.1", Port: 5000})
 	fsm.state.EnsureService(5, "baz", &structs.NodeService{ID: "web", Service: "web", Tags: nil, Address: "127.0.0.2", Port: 80})
@@ -453,7 +453,7 @@ func TestFSM_SnapshotRestore_CE(t *testing.T) {
 	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("foo", nil)}
 	vip, err = fsm.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.2")
+	require.Equal(t, "240.0.0.2", vip)
 
 	// mesh config entry
 	meshConfig := &structs.MeshConfigEntry{
@@ -480,7 +480,7 @@ func TestFSM_SnapshotRestore_CE(t *testing.T) {
 	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("frontend", nil)}
 	vip, err = fsm.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.3")
+	require.Equal(t, "240.0.0.3", vip)
 
 	fsm.state.EnsureService(30, "foo", &structs.NodeService{
 		ID:      "backend",
@@ -492,7 +492,7 @@ func TestFSM_SnapshotRestore_CE(t *testing.T) {
 	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("backend", nil)}
 	vip, err = fsm.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.4")
+	require.Equal(t, "240.0.0.4", vip)
 
 	_, serviceNames, err := fsm.state.ServiceNamesOfKind(nil, structs.ServiceKindTypical)
 	require.NoError(t, err)
@@ -554,7 +554,7 @@ func TestFSM_SnapshotRestore_CE(t *testing.T) {
 	require.NoError(t, fsm.state.EnsureConfigEntry(34, resolverEntry))
 	vip, err = fsm.state.VirtualIPForService(structs.PeeredServiceName{ServiceName: structs.NewServiceName("goo", nil)})
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.5")
+	require.Equal(t, "240.0.0.5", vip)
 
 	// Resources
 	resource, err := storageBackend.WriteCAS(context.Background(), &pbresource.Resource{
@@ -679,23 +679,23 @@ func TestFSM_SnapshotRestore_CE(t *testing.T) {
 	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("web", nil)}
 	vip, err = fsm2.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.1")
+	require.Equal(t, "240.0.0.1", vip)
 	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("foo", nil)}
 	vip, err = fsm2.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.2")
+	require.Equal(t, "240.0.0.2", vip)
 	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("frontend", nil)}
 	vip, err = fsm2.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.3")
+	require.Equal(t, "240.0.0.3", vip)
 	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("backend", nil)}
 	vip, err = fsm2.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.4")
+	require.Equal(t, "240.0.0.4", vip)
 	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("goo", nil)}
 	vip, err = fsm2.state.VirtualIPForService(psn)
 	require.NoError(t, err)
-	require.Equal(t, vip, "240.0.0.5")
+	require.Equal(t, "240.0.0.5", vip)
 
 	// Verify key is set
 	_, d, err := fsm2.state.KVSGet(nil, "/test", nil)
@@ -749,7 +749,7 @@ func TestFSM_SnapshotRestore_CE(t *testing.T) {
 	canBootstrap, index, err := fsm2.state.CanBootstrapACLToken()
 	require.NoError(t, err)
 	require.False(t, canBootstrap)
-	require.True(t, index > 0)
+	require.Greater(t, index, 0)
 
 	// Verify ACL Role is restored
 	_, role2, err := fsm2.state.ACLRoleGetByID(nil, role.ID, nil)
@@ -846,7 +846,7 @@ func TestFSM_SnapshotRestore_CE(t *testing.T) {
 	// Verify usage data is correctly updated
 	idx, nodeUsage, err := fsm2.state.NodeUsage()
 	require.NoError(t, err)
-	require.Equal(t, len(nodes), nodeUsage.Nodes)
+	require.Len(t, nodes, nodeUsage.Nodes)
 	require.NotZero(t, idx)
 
 	// Verify system metadata is restored.

--- a/agent/consul/gateway_locator_test.go
+++ b/agent/consul/gateway_locator_test.go
@@ -71,7 +71,7 @@ func TestGatewayLocator(t *testing.T) {
 
 				t.Run("before first run", func(t *testing.T) {
 					assert.False(t, g.DialPrimaryThroughLocalGateway()) // not important
-					assert.Len(t, tsd.Calls, 0)
+					assert.Empty(t, tsd.Calls)
 					assert.Equal(t, []string(nil), g.listGateways(false))
 					assert.Equal(t, []string(nil), g.listGateways(true))
 					assert.False(t, tsd.datacenterSupportsFederationStates())
@@ -112,7 +112,7 @@ func TestGatewayLocator(t *testing.T) {
 
 				t.Run("before first run", func(t *testing.T) {
 					assert.True(t, g.DialPrimaryThroughLocalGateway()) // defaults to sure!
-					assert.Len(t, tsd.Calls, 0)
+					assert.Empty(t, tsd.Calls)
 					assert.Equal(t, []string(nil), g.listGateways(false))
 					assert.Equal(t, []string(nil), g.listGateways(true))
 					assert.False(t, tsd.datacenterSupportsFederationStates())
@@ -157,7 +157,7 @@ func TestGatewayLocator(t *testing.T) {
 
 				t.Run("before first run", func(t *testing.T) {
 					assert.True(t, g.DialPrimaryThroughLocalGateway()) // defaults to sure!
-					assert.Len(t, tsd.Calls, 0)
+					assert.Empty(t, tsd.Calls)
 					assert.Equal(t, []string(nil), g.listGateways(false))
 					assert.Equal(t, []string(nil), g.listGateways(true)) // don't return any data until we initialize
 					assert.False(t, tsd.datacenterSupportsFederationStates())
@@ -205,7 +205,7 @@ func TestGatewayLocator(t *testing.T) {
 
 				t.Run("before first run", func(t *testing.T) {
 					assert.False(t, g.DialPrimaryThroughLocalGateway()) // not important
-					assert.Len(t, tsd.Calls, 0)
+					assert.Empty(t, tsd.Calls)
 					assert.Equal(t, []string(nil), g.listGateways(false))
 					assert.Equal(t, []string(nil), g.listGateways(true)) // don't return any data until we initialize
 					assert.False(t, tsd.datacenterSupportsFederationStates())
@@ -252,7 +252,7 @@ func TestGatewayLocator(t *testing.T) {
 
 				t.Run("before first run", func(t *testing.T) {
 					assert.True(t, g.DialPrimaryThroughLocalGateway()) // defaults to sure!
-					assert.Len(t, tsd.Calls, 0)
+					assert.Empty(t, tsd.Calls)
 					assert.Equal(t, []string(nil), g.listGateways(false))
 					assert.Equal(t, []string(nil), g.listGateways(true)) // don't return any data until we initialize
 					assert.False(t, tsd.datacenterSupportsFederationStates())
@@ -301,7 +301,7 @@ func TestGatewayLocator(t *testing.T) {
 
 		t.Run("before first run", func(t *testing.T) {
 			assert.True(t, g.DialPrimaryThroughLocalGateway()) // defaults to sure!
-			assert.Len(t, tsd.Calls, 0)
+			assert.Empty(t, tsd.Calls)
 			assert.Equal(t, []string(nil), g.listGateways(false))
 			assert.Equal(t, []string(nil), g.listGateways(true)) // don't return any data until we initialize
 			assert.False(t, tsd.datacenterSupportsFederationStates())
@@ -349,7 +349,7 @@ func TestGatewayLocator(t *testing.T) {
 
 		t.Run("before first run", func(t *testing.T) {
 			assert.True(t, g.DialPrimaryThroughLocalGateway()) // defaults to sure!
-			assert.Len(t, tsd.Calls, 0)
+			assert.Empty(t, tsd.Calls)
 			assert.Equal(t, []string(nil), g.listGateways(false))
 			assert.Equal(t, []string(nil), g.listGateways(true)) // don't return any data until we initialize
 			assert.False(t, tsd.datacenterSupportsFederationStates())
@@ -398,7 +398,7 @@ func TestGatewayLocator(t *testing.T) {
 
 		t.Run("before first run", func(t *testing.T) {
 			assert.False(t, g.DialPrimaryThroughLocalGateway()) // too many errors
-			assert.Len(t, tsd.Calls, 0)
+			assert.Empty(t, tsd.Calls)
 			assert.Equal(t, []string(nil), g.listGateways(false))
 			assert.Equal(t, []string(nil), g.listGateways(true)) // don't return any data until we initialize
 			assert.False(t, tsd.datacenterSupportsFederationStates())
@@ -450,7 +450,7 @@ func TestGatewayLocator(t *testing.T) {
 
 		t.Run("before first run", func(t *testing.T) {
 			assert.True(t, g.DialPrimaryThroughLocalGateway()) // all better again
-			assert.Len(t, tsd.Calls, 0)
+			assert.Empty(t, tsd.Calls)
 			assert.Equal(t, []string(nil), g.listGateways(false))
 			assert.Equal(t, []string(nil), g.listGateways(true)) // don't return any data until we initialize
 			assert.False(t, tsd.datacenterSupportsFederationStates())

--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -744,7 +744,7 @@ func TestHealth_ServiceNodes_BlockingQuery_withFilter(t *testing.T) {
 		}
 
 		require.Equal(t, structs.QueryBackendBlocking, out.Backend)
-		require.Len(t, out.Nodes, 0)
+		require.Empty(t, out.Nodes)
 	})
 }
 
@@ -808,10 +808,10 @@ func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
 
 	nodes := out2.Nodes
 	require.Len(t, nodes, 1)
-	require.Equal(t, nodes[0].Node.Node, "foo")
+	require.Equal(t, "foo", nodes[0].Node.Node)
 	require.Contains(t, nodes[0].Service.Tags, "v2")
 	require.Contains(t, nodes[0].Service.Tags, "primary")
-	require.Equal(t, nodes[0].Checks[0].Status, api.HealthPassing)
+	require.Equal(t, api.HealthPassing, nodes[0].Checks[0].Status)
 }
 
 func TestHealth_ServiceNodes_NodeMetaFilter(t *testing.T) {
@@ -1089,7 +1089,7 @@ node "foo" {
 			Status:    api.HealthPassing,
 			ServiceID: args.Service.ID,
 		}
-		assert.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
 
 		// Register a service
 		args = structs.TestRegisterRequestProxy(t)
@@ -1101,7 +1101,7 @@ node "foo" {
 			Status:    api.HealthPassing,
 			ServiceID: args.Service.Service,
 		}
-		assert.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
 
 		// Register a service
 		args = structs.TestRegisterRequestProxy(t)
@@ -1113,7 +1113,7 @@ node "foo" {
 			Status:    api.HealthPassing,
 			ServiceID: args.Service.Service,
 		}
-		assert.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
 	}
 
 	// List w/ token. This should disallow because we don't have permission
@@ -1125,8 +1125,8 @@ node "foo" {
 		QueryOptions: structs.QueryOptions{Token: token},
 	}
 	var resp structs.IndexedCheckServiceNodes
-	assert.ErrorContains(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &resp), "Permission denied")
-	assert.Len(t, resp.Nodes, 0)
+	require.ErrorContains(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &resp), "Permission denied")
+	assert.Empty(t, resp.Nodes)
 
 	// List w/ token. This should work since we're requesting "foo", but should
 	// also only contain the proxies with names that adhere to our ACL.
@@ -1136,7 +1136,7 @@ node "foo" {
 		ServiceName:  "foo",
 		QueryOptions: structs.QueryOptions{Token: token},
 	}
-	assert.Nil(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &resp))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &resp))
 	assert.Len(t, resp.Nodes, 1)
 }
 
@@ -1166,7 +1166,7 @@ func TestHealth_ServiceNodes_Gateway(t *testing.T) {
 			Status:    api.HealthPassing,
 			ServiceID: args.Service.Service,
 		}
-		assert.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
 
 		// Register a proxy for api
 		args = structs.TestRegisterRequestProxy(t)
@@ -1177,7 +1177,7 @@ func TestHealth_ServiceNodes_Gateway(t *testing.T) {
 			Status:    api.HealthPassing,
 			ServiceID: args.Service.Service,
 		}
-		assert.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
 
 		// Register a service "web"
 		args = structs.TestRegisterRequest(t)
@@ -1186,7 +1186,7 @@ func TestHealth_ServiceNodes_Gateway(t *testing.T) {
 			Status:    api.HealthPassing,
 			ServiceID: args.Service.Service,
 		}
-		assert.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
 
 		// Register a proxy for web
 		args = structs.TestRegisterRequestProxy(t)
@@ -1195,7 +1195,7 @@ func TestHealth_ServiceNodes_Gateway(t *testing.T) {
 			Status:    api.HealthPassing,
 			ServiceID: args.Service.Service,
 		}
-		assert.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
 
 		// Register a gateway for web
 		args = &structs.RegisterRequest{
@@ -1213,7 +1213,7 @@ func TestHealth_ServiceNodes_Gateway(t *testing.T) {
 				ServiceID: args.Service.Service,
 			},
 		}
-		assert.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out))
 
 		entryArgs := &structs.ConfigEntryRequest{
 			Op:         structs.ConfigEntryUpsert,
@@ -1229,7 +1229,7 @@ func TestHealth_ServiceNodes_Gateway(t *testing.T) {
 			},
 		}
 		var entryResp bool
-		assert.Nil(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &entryArgs, &entryResp))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &entryArgs, &entryResp))
 	}
 
 	retry.Run(t, func(r *retry.R) {
@@ -1240,7 +1240,7 @@ func TestHealth_ServiceNodes_Gateway(t *testing.T) {
 			ServiceName: "web",
 		}
 		var resp structs.IndexedCheckServiceNodes
-		assert.Nil(r, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &resp))
+		require.NoError(r, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &resp))
 		assert.Len(r, resp.Nodes, 2)
 
 		// Check sidecar
@@ -1289,7 +1289,7 @@ func TestHealth_ServiceNodes_Ingress(t *testing.T) {
 		},
 	}
 	var out struct{}
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
 
 	arg = structs.RegisterRequest{
 		Datacenter: "dc1",
@@ -1306,7 +1306,7 @@ func TestHealth_ServiceNodes_Ingress(t *testing.T) {
 			ServiceID: "ingress-gateway",
 		},
 	}
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
 
 	// Register ingress-gateway config entry
 	{
@@ -1329,7 +1329,7 @@ func TestHealth_ServiceNodes_Ingress(t *testing.T) {
 			Entry:      args,
 		}
 		var out bool
-		require.Nil(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &req, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &req, &out))
 		require.True(t, out)
 	}
 
@@ -1339,14 +1339,14 @@ func TestHealth_ServiceNodes_Ingress(t *testing.T) {
 		ServiceName: "db",
 		Ingress:     true,
 	}
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2))
 
 	nodes := out2.Nodes
 	require.Len(t, nodes, 2)
-	require.Equal(t, nodes[0].Node.Node, "bar")
-	require.Equal(t, nodes[0].Checks[0].Status, api.HealthWarning)
-	require.Equal(t, nodes[1].Node.Node, "foo")
-	require.Equal(t, nodes[1].Checks[0].Status, api.HealthPassing)
+	require.Equal(t, "bar", nodes[0].Node.Node)
+	require.Equal(t, api.HealthWarning, nodes[0].Checks[0].Status)
+	require.Equal(t, "foo", nodes[1].Node.Node)
+	require.Equal(t, api.HealthPassing, nodes[1].Checks[0].Status)
 }
 
 func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
@@ -1391,7 +1391,7 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 		WriteRequest: structs.WriteRequest{Token: "root"},
 	}
 	var out struct{}
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
 
 	arg = structs.RegisterRequest{
 		Datacenter: "dc1",
@@ -1408,7 +1408,7 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 		},
 		WriteRequest: structs.WriteRequest{Token: "root"},
 	}
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
 
 	// Register proxy-defaults with 'http' protocol
 	{
@@ -1425,7 +1425,7 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 			WriteRequest: structs.WriteRequest{Token: "root"},
 		}
 		var out bool
-		require.Nil(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &req, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &req, &out))
 		require.True(t, out)
 	}
 
@@ -1453,7 +1453,7 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 			WriteRequest: structs.WriteRequest{Token: "root"},
 		}
 		var out bool
-		require.Nil(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &req, &out))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &req, &out))
 		require.True(t, out)
 	}
 
@@ -1465,7 +1465,7 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 		Ingress:     true,
 	}
 	require.ErrorContains(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2), "Permission denied")
-	require.Len(t, out2.Nodes, 0)
+	require.Empty(t, out2.Nodes)
 
 	// Requesting a service that is not covered by the token's policy
 	req = structs.ServiceSpecificRequest{
@@ -1475,7 +1475,7 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Token: token.SecretID},
 	}
 	require.ErrorContains(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2), "Permission denied")
-	require.Len(t, out2.Nodes, 0)
+	require.Empty(t, out2.Nodes)
 
 	// Requesting service covered by the token's policy
 	req = structs.ServiceSpecificRequest{
@@ -1484,14 +1484,14 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 		Ingress:      true,
 		QueryOptions: structs.QueryOptions{Token: token.SecretID},
 	}
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2))
 
 	nodes := out2.Nodes
 	require.Len(t, nodes, 2)
-	require.Equal(t, nodes[0].Node.Node, "bar")
-	require.Equal(t, nodes[0].Checks[0].Status, api.HealthWarning)
-	require.Equal(t, nodes[1].Node.Node, "foo")
-	require.Equal(t, nodes[1].Checks[0].Status, api.HealthPassing)
+	require.Equal(t, "bar", nodes[0].Node.Node)
+	require.Equal(t, api.HealthWarning, nodes[0].Checks[0].Status)
+	require.Equal(t, "foo", nodes[1].Node.Node)
+	require.Equal(t, api.HealthPassing, nodes[1].Checks[0].Status)
 }
 
 func TestHealth_NodeChecks_FilterACL(t *testing.T) {

--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -227,9 +227,9 @@ func waitForNewACLReplication(t *testing.T, server *Server, expectedReplicationT
 		status := server.getACLReplicationStatus()
 		require.Equal(r, expectedReplicationType, status.ReplicationType, "Server not running new replicator yet")
 		require.True(r, status.Running, "Server not running new replicator yet")
-		require.True(r, status.ReplicatedIndex >= minPolicyIndex, "Server hasn't replicated enough policies")
-		require.True(r, status.ReplicatedTokenIndex >= minTokenIndex, "Server hasn't replicated enough tokens")
-		require.True(r, status.ReplicatedRoleIndex >= minRoleIndex, "Server hasn't replicated enough roles")
+		require.GreaterOrEqual(r, status.ReplicatedIndex, minPolicyIndex, "Server hasn't replicated enough policies")
+		require.GreaterOrEqual(r, status.ReplicatedTokenIndex, minTokenIndex, "Server hasn't replicated enough tokens")
+		require.GreaterOrEqual(r, status.ReplicatedRoleIndex, minRoleIndex, "Server hasn't replicated enough roles")
 	})
 }
 

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -138,7 +138,7 @@ func TestIntentionApply_defaultSourceType(t *testing.T) {
 	var reply string
 
 	// Create
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 	require.NotEmpty(t, reply)
 
 	// Read
@@ -149,7 +149,7 @@ func TestIntentionApply_defaultSourceType(t *testing.T) {
 			IntentionID: ixn.Intention.ID,
 		}
 		var resp structs.IndexedIntentions
-		require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Get", req, &resp))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Get", req, &resp))
 		require.Len(t, resp.Intentions, 1)
 		actual := resp.Intentions[0]
 		require.Equal(t, structs.IntentionSourceConsul, actual.SourceType)
@@ -186,7 +186,7 @@ func TestIntentionApply_createWithID(t *testing.T) {
 
 	// Create
 	err := msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Contains(t, err, "ID must be empty")
 }
 
@@ -340,7 +340,7 @@ func TestIntentionApply_updateNonExist(t *testing.T) {
 
 	// Create
 	err := msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Contains(t, err, "Cannot modify non-existent intention")
 }
 
@@ -381,13 +381,13 @@ func TestIntentionApply_deleteGood(t *testing.T) {
 	}, &reply), "Cannot delete non-existent intention")
 
 	// Create
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 	require.NotEmpty(t, reply)
 
 	// Delete
 	ixn.Op = structs.IntentionOpDelete
 	ixn.Intention.ID = reply
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 
 	// Read
 	ixn.Intention.ID = reply
@@ -398,7 +398,7 @@ func TestIntentionApply_deleteGood(t *testing.T) {
 		}
 		var resp structs.IndexedIntentions
 		err := msgpackrpc.CallWithCodec(codec, "Intention.Get", req, &resp)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Contains(t, err, ErrIntentionNotFound.Error())
 	}
 }
@@ -933,7 +933,7 @@ service "foobar" {
 
 	// Now add the token and try again.
 	ixn.WriteRequest.Token = token
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 
 	// Read
 	ixn.Intention.ID = reply
@@ -944,7 +944,7 @@ service "foobar" {
 			QueryOptions: structs.QueryOptions{Token: "root"},
 		}
 		var resp structs.IndexedIntentions
-		require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Get", req, &resp))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Get", req, &resp))
 		require.Len(t, resp.Intentions, 1)
 		actual := resp.Intentions[0]
 		require.Equal(t, resp.Index, actual.ModifyIndex)
@@ -1318,7 +1318,7 @@ service "foobar" {
 
 	// Create
 	var reply string
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 
 	// Try to do a delete with no token; this should get rejected.
 	ixn.Op = structs.IntentionOpDelete
@@ -1329,7 +1329,7 @@ service "foobar" {
 
 	// Try again with the original token. This should go through.
 	ixn.WriteRequest.Token = token
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 
 	// Verify it is gone
 	{
@@ -1339,7 +1339,7 @@ service "foobar" {
 		}
 		var resp structs.IndexedIntentions
 		err := msgpackrpc.CallWithCodec(codec, "Intention.Get", req, &resp)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Contains(t, err.Error(), ErrIntentionNotFound.Error())
 	}
 }
@@ -1383,7 +1383,7 @@ service "foobar" {
 
 	// Create
 	var reply string
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 
 	// Try to do an update without a token; this should get rejected.
 	ixn.Op = structs.IntentionOpUpdate
@@ -1394,7 +1394,7 @@ service "foobar" {
 
 	// Try again with the original token; this should go through.
 	ixn.WriteRequest.Token = token
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 }
 
 // Test apply with a management token
@@ -1429,16 +1429,16 @@ func TestIntentionApply_aclManagement(t *testing.T) {
 
 	// Create
 	var reply string
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 	ixn.Intention.ID = reply
 
 	// Update
 	ixn.Op = structs.IntentionOpUpdate
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 
 	// Delete
 	ixn.Op = structs.IntentionOpDelete
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 }
 
 // Test update changing the name where an ACL won't allow it
@@ -1480,7 +1480,7 @@ service "foobar" {
 
 	// Create
 	var reply string
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 
 	// Try to do an update without a token; this should get rejected.
 	ixn.Op = structs.IntentionOpUpdate
@@ -1543,7 +1543,7 @@ func TestIntentionGet_acl(t *testing.T) {
 		var resp structs.IndexedIntentions
 		err := msgpackrpc.CallWithCodec(codec, "Intention.Get", req, &resp)
 		require.True(t, acl.IsErrPermissionDenied(err))
-		require.Len(t, resp.Intentions, 0)
+		require.Empty(t, resp.Intentions)
 	})
 
 	t.Run("Read by ID with token should work", func(t *testing.T) {
@@ -1572,7 +1572,7 @@ func TestIntentionGet_acl(t *testing.T) {
 		var resp structs.IndexedIntentions
 		err := msgpackrpc.CallWithCodec(codec, "Intention.Get", req, &resp)
 		require.True(t, acl.IsErrPermissionDenied(err))
-		require.Len(t, resp.Intentions, 0)
+		require.Empty(t, resp.Intentions)
 	})
 
 	t.Run("Read by Exact with token should work", func(t *testing.T) {
@@ -1614,9 +1614,9 @@ func TestIntentionList(t *testing.T) {
 			Datacenter: "dc1",
 		}
 		var resp structs.IndexedIntentions
-		require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.List", req, &resp))
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.List", req, &resp))
 		require.NotNil(t, resp.Intentions)
-		require.Len(t, resp.Intentions, 0)
+		require.Empty(t, resp.Intentions)
 	}
 }
 
@@ -1663,7 +1663,7 @@ func TestIntentionList_acl(t *testing.T) {
 		}
 		var resp structs.IndexedIntentions
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.List", req, &resp))
-		require.Len(t, resp.Intentions, 0)
+		require.Empty(t, resp.Intentions)
 		require.False(t, resp.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be false")
 	})
 
@@ -1747,7 +1747,7 @@ func TestIntentionMatch_good(t *testing.T) {
 
 			// Create
 			var reply string
-			require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+			require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 		}
 	}
 
@@ -1762,7 +1762,7 @@ func TestIntentionMatch_good(t *testing.T) {
 		},
 	}
 	var resp structs.IndexedIntentionMatches
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Match", req, &resp))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Match", req, &resp))
 	require.Len(t, resp.Matches, 1)
 
 	expected := [][]string{
@@ -1906,7 +1906,7 @@ func TestIntentionMatch_acl(t *testing.T) {
 
 			// Create
 			var reply string
-			require.Nil(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
+			require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply))
 		}
 	}
 
@@ -1928,7 +1928,7 @@ func TestIntentionMatch_acl(t *testing.T) {
 		err := msgpackrpc.CallWithCodec(codec, "Intention.Match", req, &resp)
 		require.Error(t, err)
 		require.True(t, acl.IsErrPermissionDenied(err))
-		require.Len(t, resp.Matches, 0)
+		require.Empty(t, resp.Matches)
 	}
 
 	// Test with proper token

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -106,7 +106,7 @@ func TestInternal_NodeInfo(t *testing.T) {
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.NodeInfo", &req, &out))
 
 		nodes := out.Dump
-		require.Equal(t, 1, len(nodes))
+		require.Len(t, nodes, 1)
 		require.Equal(t, "foo", nodes[0].Node)
 		require.Equal(t, "peer1", nodes[0].PeerName)
 	})
@@ -310,8 +310,8 @@ func TestInternal_NodeDump_Filter(t *testing.T) {
 		}
 
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.NodeDump", &req2, &out3))
-		require.Len(t, out3.Dump, 0)
-		require.Len(t, out3.ImportedDump, 0)
+		require.Empty(t, out3.Dump)
+		require.Empty(t, out3.ImportedDump)
 	})
 
 	t.Run("filter look for peer nodes (non local nodes)", func(t *testing.T) {
@@ -321,7 +321,7 @@ func TestInternal_NodeDump_Filter(t *testing.T) {
 		}
 
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.NodeDump", &req2, &out3))
-		require.Len(t, out3.Dump, 0)
+		require.Empty(t, out3.Dump)
 		require.Len(t, out3.ImportedDump, 1)
 	})
 
@@ -332,7 +332,7 @@ func TestInternal_NodeDump_Filter(t *testing.T) {
 		}
 
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.NodeDump", &req2, &out3))
-		require.Len(t, out3.Dump, 0)
+		require.Empty(t, out3.Dump)
 		require.Len(t, out3.ImportedDump, 1)
 	})
 }
@@ -1400,9 +1400,9 @@ func TestInternal_GatewayServiceDump_Terminating_ACL(t *testing.T) {
 
 	nodes := out.Dump
 	require.Len(t, nodes, 1)
-	require.Equal(t, nodes[0].Node.Node, "bar")
-	require.Equal(t, nodes[0].Service.Service, "db")
-	require.Equal(t, nodes[0].Checks[0].Status, api.HealthWarning)
+	require.Equal(t, "bar", nodes[0].Node.Node)
+	require.Equal(t, "db", nodes[0].Service.Service)
+	require.Equal(t, api.HealthWarning, nodes[0].Checks[0].Status)
 	require.True(t, out.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 }
 
@@ -1761,9 +1761,9 @@ func TestInternal_GatewayServiceDump_Ingress_ACL(t *testing.T) {
 
 	nodes := out.Dump
 	require.Len(t, nodes, 1)
-	require.Equal(t, nodes[0].Node.Node, "bar")
-	require.Equal(t, nodes[0].Service.Service, "db")
-	require.Equal(t, nodes[0].Checks[0].Status, api.HealthWarning)
+	require.Equal(t, "bar", nodes[0].Node.Node)
+	require.Equal(t, "db", nodes[0].Service.Service)
+	require.Equal(t, api.HealthWarning, nodes[0].Checks[0].Status)
 }
 
 func TestInternal_ServiceDump_Peering(t *testing.T) {
@@ -1799,7 +1799,7 @@ func TestInternal_ServiceDump_Peering(t *testing.T) {
 		nodes := doRequest(t, "", false)
 		// redis (3), web (3), critical (1), warning (1) and consul (1)
 		require.Len(t, nodes.Nodes, 9)
-		require.Len(t, nodes.ImportedNodes, 0)
+		require.Empty(t, nodes.ImportedNodes)
 	})
 
 	addPeerService(t, codec)
@@ -1825,16 +1825,16 @@ func TestInternal_ServiceDump_Peering(t *testing.T) {
 		// redis (3), web (3), critical (1), warning (1) and consul (1)
 		require.Len(t, nodes.Nodes, 9)
 		// service (1)
-		require.Len(t, nodes.ImportedNodes, 0)
+		require.Empty(t, nodes.ImportedNodes)
 	})
 
 	t.Run("peerings w filter", func(t *testing.T) {
 		nodes := doRequest(t, "Node.PeerName == foo", false)
-		require.Len(t, nodes.Nodes, 0)
-		require.Len(t, nodes.ImportedNodes, 0)
+		require.Empty(t, nodes.Nodes)
+		require.Empty(t, nodes.ImportedNodes)
 
 		nodes2 := doRequest(t, "Node.PeerName == peer1", false)
-		require.Len(t, nodes2.Nodes, 0)
+		require.Empty(t, nodes2.Nodes)
 		require.Len(t, nodes2.ImportedNodes, 1)
 	})
 }
@@ -1936,7 +1936,7 @@ func TestInternal_GatewayIntentions(t *testing.T) {
 			req.Intention.DestinationName = v
 
 			var reply string
-			assert.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &req, &reply))
+			require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &req, &reply))
 
 			req = structs.IntentionRequest{
 				Datacenter: "dc1",
@@ -1945,7 +1945,7 @@ func TestInternal_GatewayIntentions(t *testing.T) {
 			}
 			req.Intention.SourceName = v
 			req.Intention.DestinationName = "api"
-			assert.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &req, &reply))
+			require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &req, &reply))
 		}
 	}
 
@@ -1964,7 +1964,7 @@ func TestInternal_GatewayIntentions(t *testing.T) {
 		},
 	}
 	var reply structs.IndexedIntentions
-	assert.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.GatewayIntentions", &req, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.GatewayIntentions", &req, &reply))
 	assert.Len(t, reply.Intentions, 3)
 
 	// Only intentions with linked services as a destination should be returned, and wildcard matches should be deduped
@@ -2052,7 +2052,7 @@ func TestInternal_GatewayIntentions_aclDeny(t *testing.T) {
 			req.Intention.DestinationName = v
 
 			var reply string
-			assert.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &req, &reply))
+			require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &req, &reply))
 
 			req = structs.IntentionRequest{
 				Datacenter:   "dc1",
@@ -2062,7 +2062,7 @@ func TestInternal_GatewayIntentions_aclDeny(t *testing.T) {
 			}
 			req.Intention.SourceName = v
 			req.Intention.DestinationName = "api"
-			assert.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &req, &reply))
+			require.NoError(t, msgpackrpc.CallWithCodec(codec, "Intention.Apply", &req, &reply))
 		}
 	}
 
@@ -2088,7 +2088,7 @@ service_prefix "terminating-gateway" { policy = "read" }
 		QueryOptions: structs.QueryOptions{Token: userToken.SecretID},
 	}
 	var reply structs.IndexedIntentions
-	assert.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.GatewayIntentions", &req, &reply))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.GatewayIntentions", &req, &reply))
 	assert.Len(t, reply.Intentions, 2)
 
 	// Only intentions for redis should be returned, due to ACLs
@@ -2151,7 +2151,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 
 			// foo/api, foo/api-proxy
 			require.Len(r, out.ServiceTopology.Upstreams, 2)
-			require.Len(r, out.ServiceTopology.Downstreams, 0)
+			require.Empty(r, out.ServiceTopology.Downstreams)
 
 			expectUp := map[string]structs.IntentionDecisionSummary{
 				api.String(): {
@@ -2299,7 +2299,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 			require.False(r, out.QueryMeta.ResultsFilteredByACLs)
 			require.Equal(r, "http", out.ServiceTopology.MetricsProtocol)
 
-			require.Len(r, out.ServiceTopology.Upstreams, 0)
+			require.Empty(r, out.ServiceTopology.Upstreams)
 
 			// bar/web, bar/web-proxy, baz/web, baz/web-proxy
 			require.Len(r, out.ServiceTopology.Downstreams, 4)
@@ -2439,7 +2439,7 @@ service "web" { policy = "read" }
 		require.Equal(t, "web", out.ServiceTopology.Upstreams[0].Service.Service)
 		require.Equal(t, "web", out.ServiceTopology.Upstreams[1].Service.Service)
 
-		require.Len(t, out.ServiceTopology.Downstreams, 0)
+		require.Empty(t, out.ServiceTopology.Downstreams)
 	})
 
 	t.Run("web can't read redis", func(t *testing.T) {
@@ -2456,7 +2456,7 @@ service "web" { policy = "read" }
 		require.Equal(t, "http", out.ServiceTopology.MetricsProtocol)
 
 		// The redis upstream gets filtered out but the api and proxy downstream are returned
-		require.Len(t, out.ServiceTopology.Upstreams, 0)
+		require.Empty(t, out.ServiceTopology.Upstreams)
 		require.Len(t, out.ServiceTopology.Downstreams, 2)
 	})
 

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -22,7 +22,6 @@ import (
 	msgpackrpc "github.com/hashicorp/consul-net-rpc/net-rpc-msgpackrpc"
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	vaultapi "github.com/hashicorp/vault/api"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -357,7 +356,7 @@ func TestCAManager_Initialize(t *testing.T) {
 	errCh := make(chan error)
 	go func() {
 		err := manager.Initialize()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		errCh <- err
 	}()
 
@@ -416,7 +415,7 @@ func TestCAManager_UpdateConfigWhileRenewIntermediate(t *testing.T) {
 	// make sure we get an error about the state being occupied.
 	go func() {
 		require.EqualValues(t, caStateRenewIntermediate, manager.state)
-		require.Error(t, errors.New("already in state"), manager.UpdateConfiguration(&structs.CARequest{}))
+		require.ErrorIs(t, errors.New("already in state"), manager.UpdateConfiguration(&structs.CARequest{}))
 	}()
 
 	waitForCh(t, delegate.callbackCh, "forwardDC/ConnectCA.SignIntermediate")
@@ -1092,7 +1091,7 @@ func TestCAManager_Initialize_Vault_WithExternalTrustedCA(t *testing.T) {
 		var resp error
 		err := msgpackrpc.CallWithCodec(codec, "ConnectCA.ConfigurationSet", req, &resp)
 		require.NoError(t, err)
-		require.Nil(t, resp)
+		require.NoError(t, resp)
 
 		roots = structs.IndexedCARoots{}
 		err = msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", &structs.DCSpecificRequest{}, &roots)
@@ -1167,7 +1166,7 @@ func TestCAManager_Initialize_Vault_WithExternalTrustedCA(t *testing.T) {
 		var resp error
 		err := msgpackrpc.CallWithCodec(codec, "ConnectCA.ConfigurationSet", req, &resp)
 		require.NoError(t, err)
-		require.Nil(t, resp)
+		require.NoError(t, resp)
 
 		roots = structs.IndexedCARoots{}
 		err = msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", &structs.DCSpecificRequest{}, &roots)

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -645,7 +645,7 @@ func TestConnectCA_ConfigurationSet_RootRotation_Secondary(t *testing.T) {
 	state2 := s2.fsm.State()
 	_, roots2, err := state2.CARoots(nil)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(roots2))
+	require.Len(t, roots2, 2)
 
 	newRoot := roots2[0]
 	oldRoot := roots2[1]
@@ -1223,7 +1223,7 @@ func TestLeader_CARootPruning(t *testing.T) {
 		Datacenter: "dc1",
 	}
 	var rootList structs.IndexedCARoots
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
 	require.Len(t, rootList.Roots, 1)
 	oldRoot := rootList.Roots[0]
 
@@ -1296,7 +1296,7 @@ func TestConnectCA_ConfigurationSet_PersistsRoots(t *testing.T) {
 		Datacenter: "dc1",
 	}
 	var rootList structs.IndexedCARoots
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
 	require.Len(t, rootList.Roots, 1)
 
 	// Update the provider config to use a new private key, which should
@@ -1678,7 +1678,7 @@ func TestConnectCA_ConfigurationSet_ForceWithoutCrossSigning(t *testing.T) {
 		Datacenter: "dc1",
 	}
 	var rootList structs.IndexedCARoots
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
 	require.Len(t, rootList.Roots, 1)
 	oldRoot := rootList.Roots[0]
 
@@ -1755,7 +1755,7 @@ func TestConnectCA_ConfigurationSet_Vault_ForceWithoutCrossSigning(t *testing.T)
 		Datacenter: "dc1",
 	}
 	var rootList structs.IndexedCARoots
-	require.Nil(t, msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
 	require.Len(t, rootList.Roots, 1)
 	oldRoot := rootList.Roots[0]
 

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -352,7 +352,7 @@ func TestLeader_PeeringSync_Lifecycle_UnexportWhileDown(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		_, nodes, err := dialerRestart.fsm.State().CheckServiceNodes(nil, "foo", nil, "my-peer-acceptor")
 		require.NoError(r, err)
-		require.Len(r, nodes, 0)
+		require.Empty(r, nodes)
 	})
 }
 
@@ -659,15 +659,15 @@ func TestLeader_Peering_DeferredDeletion(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		_, csn, err := s1.fsm.State().ServiceDump(nil, "", false, defaultMeta, peerName)
 		require.NoError(r, err)
-		require.Len(r, csn, 0)
+		require.Empty(r, csn)
 
 		_, checks, err := s1.fsm.State().ChecksInState(nil, api.HealthAny, defaultMeta, peerName)
 		require.NoError(r, err)
-		require.Len(r, checks, 0)
+		require.Empty(r, checks)
 
 		_, nodes, err := s1.fsm.State().NodeDump(nil, defaultMeta, peerName)
 		require.NoError(r, err)
-		require.Len(r, nodes, 0)
+		require.Empty(r, nodes)
 
 		_, tb, err := s1.fsm.State().PeeringTrustBundleRead(nil, state.Query{Value: peerName})
 		require.NoError(r, err)
@@ -1306,13 +1306,13 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 				resp, err := peeringClient2.PeeringRead(context.Background(), &pbpeering.PeeringReadRequest{Name: "my-peer-s1"})
 				require.NoError(r, err)
 				require.NotNil(r, resp.Peering)
-				require.Equal(r, tc.expectedImportedServsCount, len(resp.Peering.StreamStatus.ImportedServices))
+				require.Len(r, resp.Peering.StreamStatus.ImportedServices, tc.expectedImportedServsCount)
 
 				// on List
 				resp2, err2 := peeringClient2.PeeringList(context.Background(), &pbpeering.PeeringListRequest{})
 				require.NoError(r, err2)
 				require.NotEmpty(r, resp2.Peerings)
-				require.Equal(r, tc.expectedExportedServsCount, len(resp2.Peerings[0].StreamStatus.ImportedServices))
+				require.Len(r, resp2.Peerings[0].StreamStatus.ImportedServices, tc.expectedExportedServsCount)
 			})
 
 			// Check that exported services count on S1 are what we expect
@@ -1321,13 +1321,13 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 				resp, err := peeringClient.PeeringRead(context.Background(), &pbpeering.PeeringReadRequest{Name: "my-peer-s2"})
 				require.NoError(r, err)
 				require.NotNil(r, resp.Peering)
-				require.Equal(r, tc.expectedImportedServsCount, len(resp.Peering.StreamStatus.ExportedServices))
+				require.Len(r, resp.Peering.StreamStatus.ExportedServices, tc.expectedImportedServsCount)
 
 				// on List
 				resp2, err2 := peeringClient.PeeringList(context.Background(), &pbpeering.PeeringListRequest{})
 				require.NoError(r, err2)
 				require.NotEmpty(r, resp2.Peerings)
-				require.Equal(r, tc.expectedExportedServsCount, len(resp2.Peerings[0].StreamStatus.ExportedServices))
+				require.Len(r, resp2.Peerings[0].StreamStatus.ExportedServices, tc.expectedExportedServsCount)
 			})
 		})
 	}
@@ -1711,7 +1711,7 @@ func TestLeader_Peering_retryLoopBackoffPeering(t *testing.T) {
 			// Can't compare first time.
 			continue
 		}
-		require.True(t, loopTimes[i].Sub(loopTimes[i-1]) >= 1*time.Millisecond,
+		require.GreaterOrEqual(t, loopTimes[i].Sub(loopTimes[i-1]), 1*time.Millisecond,
 			"time between indices %d and %d was > 1ms", i, i-1)
 	}
 }

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -85,8 +85,8 @@ func Test_InitConsulService(t *testing.T) {
 		require.NoError(r, err)
 
 		// Spot check the Service
-		require.Equal(r, service.GetWorkloads().GetPrefixes(), []string{consulWorkloadPrefix})
-		require.GreaterOrEqual(r, len(service.GetPorts()), 1)
+		require.Equal(r, []string{consulWorkloadPrefix}, service.GetWorkloads().GetPrefixes())
+		require.NotEmpty(r, service.GetPorts())
 
 		//Since we're not running a full agent w/ serf, we can't check for valid endpoints
 	})
@@ -1649,7 +1649,7 @@ func TestLeader_EnableVirtualIPs(t *testing.T) {
 	sn := structs.ServiceName{Name: "api"}
 	key := structs.ServiceGatewayVirtualIPTag(sn)
 	require.Contains(t, node.TaggedAddresses, key)
-	require.Equal(t, node.TaggedAddresses[key].Address, "240.0.0.1")
+	require.Equal(t, "240.0.0.1", node.TaggedAddresses[key].Address)
 
 	// Make sure the baz service (only referenced in the config entry so far)
 	// has a virtual IP.
@@ -1682,7 +1682,7 @@ func TestLeader_ACL_Initialization_AnonymousToken(t *testing.T) {
 		_, anon, err := s1.fsm.State().ACLTokenGetBySecret(nil, anonymousToken, nil)
 		require.NoError(r, err)
 		require.NotNil(r, anon)
-		require.Len(r, anon.Policies, 0)
+		require.Empty(r, anon.Policies)
 	})
 
 	reqToken := structs.ACLTokenSetRequest{

--- a/agent/consul/logging_test.go
+++ b/agent/consul/logging_test.go
@@ -20,7 +20,7 @@ func TestLoggerStore_Named(t *testing.T) {
 
 	l1 := store.Named("test1")
 	l2 := store.Named("test2")
-	require.Truef(t, l1 != l2,
+	require.NotEqualf(t, l1, l2,
 		"expected %p and %p to have a different memory address",
 		l1,
 		l2,
@@ -36,7 +36,7 @@ func TestLoggerStore_NamedCache(t *testing.T) {
 
 	l1 := store.Named("test")
 	l2 := store.Named("test")
-	require.Truef(t, l1 == l2,
+	require.Equalf(t, l1, l2,
 		"expected %p and %p to have the same memory address",
 		l1,
 		l2,

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -1535,8 +1535,8 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 		var reply structs.PreparedQueryExecuteResponse
 		err := msgpackrpc.CallWithCodec(es.server.codec, "PreparedQuery.Execute", &req, &reply)
-		assert.EqualError(t, err, structs.ErrQueryNotFound.Error())
-		assert.Len(t, reply.Nodes, 0)
+		require.EqualError(t, err, structs.ErrQueryNotFound.Error())
+		assert.Empty(t, reply.Nodes)
 	})
 
 	expectNodes := func(t require.TestingT, query *structs.PreparedQueryRequest, reply *structs.PreparedQueryExecuteResponse, n int) {

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -209,7 +209,7 @@ func TestRPC_getLeader_ErrLeaderNotTracked(t *testing.T) {
 
 	isLeader, meta, err := follower.getLeader()
 	require.Error(t, err)
-	require.True(t, errors.Is(err, structs.ErrLeaderNotTracked))
+	require.ErrorIs(t, err, structs.ErrLeaderNotTracked)
 	require.Nil(t, meta)
 	require.False(t, isLeader)
 }
@@ -321,7 +321,7 @@ func TestServer_blockingQuery(t *testing.T) {
 		assert.Equal(t, 2, calls)
 		assert.Equal(t, uint64(1), meta.Index,
 			"expect fake index of 1 to force client to block on next update")
-		assert.True(t, t1.Sub(t0) > 20*time.Millisecond,
+		assert.Greater(t, t1.Sub(t0), 20*time.Millisecond,
 			"should have actually blocked waiting for timeout")
 
 	})
@@ -452,7 +452,7 @@ func TestServer_blockingQuery(t *testing.T) {
 
 		start := time.Now()
 		err := s.blockingQuery(&opts, &meta, fn)
-		require.True(t, time.Since(start) < opts.MaxQueryTime, "query timed out")
+		require.Less(t, time.Since(start), opts.MaxQueryTime, "query timed out")
 		require.NoError(t, err)
 		require.Equal(t, 2, calls)
 	})
@@ -477,7 +477,7 @@ func TestServer_blockingQuery(t *testing.T) {
 
 		start := time.Now()
 		err := s.blockingQuery(&opts, &meta, fn)
-		require.True(t, time.Since(start) < opts.MaxQueryTime, "query timed out")
+		require.Less(t, time.Since(start), opts.MaxQueryTime, "query timed out")
 		require.NoError(t, err)
 		require.Equal(t, 2, calls)
 	})
@@ -1003,7 +1003,7 @@ func TestRPC_LocalTokenStrippedOnForward(t *testing.T) {
 	// Wait for it to replicate
 	retry.Run(t, func(r *retry.R) {
 		_, p, err := s2.fsm.State().ACLPolicyGetByID(nil, kvPolicy.ID, &acl.EnterpriseMeta{})
-		require.Nil(r, err)
+		require.NoError(r, err)
 		require.NotNil(r, p)
 	})
 
@@ -1136,7 +1136,7 @@ func TestRPC_LocalTokenStrippedOnForward_GRPC(t *testing.T) {
 	// Wait for it to replicate
 	retry.Run(t, func(r *retry.R) {
 		_, p, err := s2.fsm.State().ACLPolicyGetByID(nil, policy.ID, &acl.EnterpriseMeta{})
-		require.Nil(r, err)
+		require.NoError(r, err)
 		require.NotNil(r, p)
 	})
 

--- a/agent/consul/server_ce_test.go
+++ b/agent/consul/server_ce_test.go
@@ -28,7 +28,7 @@ func TestAgent_ReloadConfig_Reporting(t *testing.T) {
 
 	testrpc.WaitForTestAgent(t, s.RPC, "dc1")
 
-	require.Equal(t, false, s.config.Reporting.License.Enabled)
+	require.False(t, s.config.Reporting.License.Enabled)
 
 	rc := ReloadableConfig{
 		Reporting: Reporting{
@@ -41,5 +41,5 @@ func TestAgent_ReloadConfig_Reporting(t *testing.T) {
 	require.NoError(t, s.ReloadConfig(rc))
 
 	// Check config reload is no-op
-	require.Equal(t, false, s.config.Reporting.License.Enabled)
+	require.False(t, s.config.Reporting.License.Enabled)
 }

--- a/agent/consul/server_metadata_test.go
+++ b/agent/consul/server_metadata_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockServerMetadataWriter struct {
@@ -56,46 +57,46 @@ func TestWriteServerMetadata(t *testing.T) {
 		}
 
 		err := WriteServerMetadata(m)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("TestOK", func(t *testing.T) {
 		b := new(bytes.Buffer)
 
 		err := WriteServerMetadata(b)
-		assert.NoError(t, err)
-		assert.True(t, b.Len() > 0)
+		require.NoError(t, err)
+		assert.Greater(t, b.Len(), 0)
 	})
 }
 
 func TestWriteServerMetadata_MultipleTimes(t *testing.T) {
 	file, err := os.CreateTemp("", "server_metadata.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
 	// prepare some data in server_metadata.json
 	_, err = OpenServerMetadata(file.Name())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = WriteServerMetadata(file)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	stat, err := file.Stat()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("reopen not truncate file", func(t *testing.T) {
 		_, err = OpenServerMetadata(file.Name())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// file size unchanged
 		stat2, err := file.Stat()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, stat.Size(), stat2.Size())
 	})
 
 	t.Run("write updates the file", func(t *testing.T) {
 		err = WriteServerMetadata(file)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		stat2, err := file.Stat()
-		assert.NoError(t, err)
-		assert.Equal(t, stat2.ModTime(), stat2.ModTime())
+		require.NoError(t, err)
+		assert.Equal(t, stat.ModTime(), stat2.ModTime())
 	})
 }

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -1335,7 +1335,7 @@ func TestServer_RPC_RequestRecorder(t *testing.T) {
 		s1, err := NewServer(conf, deps, grpc.NewServer(), nil, deps.Logger, nil)
 
 		require.Error(t, err, "need err when provider func is nil")
-		require.Equal(t, err.Error(), "cannot initialize server without an RPC request recorder provider")
+		require.Equal(t, "cannot initialize server without an RPC request recorder provider", err.Error())
 
 		t.Cleanup(func() {
 			if s1 != nil {
@@ -1354,7 +1354,7 @@ func TestServer_RPC_RequestRecorder(t *testing.T) {
 		s2, err := NewServer(conf, deps, grpc.NewServer(), nil, deps.Logger, nil)
 
 		require.Error(t, err, "need err when RequestRecorder is nil")
-		require.Equal(t, err.Error(), "cannot initialize server with a nil RPC request recorder")
+		require.Equal(t, "cannot initialize server with a nil RPC request recorder", err.Error())
 
 		t.Cleanup(func() {
 			if s2 != nil {
@@ -2104,7 +2104,7 @@ func TestServer_hcpManager(t *testing.T) {
 	hcp1.EXPECT().PushServerStatus(mock.Anything, mock.MatchedBy(func(status *hcpclient.ServerStatus) bool {
 		return status.ID == string(conf1.NodeID)
 	})).Run(func(ctx context.Context, status *hcpclient.ServerStatus) {
-		require.Equal(t, status.LanAddress, "127.0.0.2")
+		require.Equal(t, "127.0.0.2", status.LanAddress)
 	}).Call.Return(nil)
 
 	// Configure the server for the ManagementTokenUpserterFn

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -497,8 +497,8 @@ func TestStateStore_ACLToken_SetGet(t *testing.T) {
 		require.Equal(t, uint64(2), rtoken.CreateIndex)
 		require.Equal(t, uint64(2), rtoken.ModifyIndex)
 		require.Equal(t, "test", rtoken.AuthMethod)
-		require.Len(t, rtoken.Policies, 0)
-		require.Len(t, rtoken.ServiceIdentities, 0)
+		require.Empty(t, rtoken.Policies)
+		require.Empty(t, rtoken.ServiceIdentities)
 		require.Len(t, rtoken.Roles, 1)
 		require.Equal(t, "node-read-role", rtoken.Roles[0].Name)
 	})
@@ -1208,7 +1208,7 @@ func TestStateStore_ACLToken_FixupPolicyLinks(t *testing.T) {
 	_, retrieved, err := s.ACLTokenGetByAccessor(nil, token.AccessorID, nil)
 	require.NoError(t, err)
 	// pointer equality check these should be identical
-	require.True(t, token == retrieved)
+	require.Equal(t, token, retrieved)
 	require.Len(t, retrieved.Policies, 1)
 	require.Equal(t, "node-read", retrieved.Policies[0].Name)
 
@@ -1226,7 +1226,7 @@ func TestStateStore_ACLToken_FixupPolicyLinks(t *testing.T) {
 	_, retrieved, err = s.ACLTokenGetByAccessor(nil, token.AccessorID, nil)
 	require.NoError(t, err)
 	// pointer equality check these should be different if we cloned things appropriately
-	require.True(t, token != retrieved)
+	require.NotEqual(t, token, retrieved)
 	require.Len(t, retrieved.Policies, 1)
 	require.Equal(t, "node-read-renamed", retrieved.Policies[0].Name)
 
@@ -1239,7 +1239,7 @@ func TestStateStore_ACLToken_FixupPolicyLinks(t *testing.T) {
 	for _, tok := range tokens {
 		if tok.AccessorID == token.AccessorID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, tok != token)
+			require.NotEqual(t, tok, token)
 			require.Len(t, tok.Policies, 1)
 			require.Equal(t, "node-read-renamed", tok.Policies[0].Name)
 			found = true
@@ -1256,7 +1256,7 @@ func TestStateStore_ACLToken_FixupPolicyLinks(t *testing.T) {
 	for _, tok := range tokens {
 		if tok.AccessorID == token.AccessorID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, tok != token)
+			require.NotEqual(t, tok, token)
 			require.Len(t, tok.Policies, 1)
 			require.Equal(t, "node-read-renamed", tok.Policies[0].Name)
 			found = true
@@ -1272,8 +1272,8 @@ func TestStateStore_ACLToken_FixupPolicyLinks(t *testing.T) {
 	_, retrieved, err = s.ACLTokenGetByAccessor(nil, token.AccessorID, nil)
 	require.NoError(t, err)
 	// pointer equality check these should be different if we cloned things appropriately
-	require.True(t, token != retrieved)
-	require.Len(t, retrieved.Policies, 0)
+	require.NotEqual(t, token, retrieved)
+	require.Empty(t, retrieved.Policies)
 
 	// list tokens without stale links
 	// nolint:staticcheck
@@ -1284,8 +1284,8 @@ func TestStateStore_ACLToken_FixupPolicyLinks(t *testing.T) {
 	for _, tok := range tokens {
 		if tok.AccessorID == token.AccessorID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, tok != token)
-			require.Len(t, tok.Policies, 0)
+			require.NotEqual(t, tok, token)
+			require.Empty(t, tok.Policies)
 			found = true
 			break
 		}
@@ -1300,8 +1300,8 @@ func TestStateStore_ACLToken_FixupPolicyLinks(t *testing.T) {
 	for _, tok := range tokens {
 		if tok.AccessorID == token.AccessorID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, tok != token)
-			require.Len(t, tok.Policies, 0)
+			require.NotEqual(t, tok, token)
+			require.Empty(t, tok.Policies)
 			found = true
 			break
 		}
@@ -1335,7 +1335,7 @@ func TestStateStore_ACLToken_FixupRoleLinks(t *testing.T) {
 	_, retrieved, err := s.ACLTokenGetByAccessor(nil, token.AccessorID, nil)
 	require.NoError(t, err)
 	// pointer equality check these should be identical
-	require.True(t, token == retrieved)
+	require.Equal(t, token, retrieved)
 	require.Len(t, retrieved.Roles, 1)
 	require.Equal(t, "node-read-role", retrieved.Roles[0].Name)
 
@@ -1357,7 +1357,7 @@ func TestStateStore_ACLToken_FixupRoleLinks(t *testing.T) {
 	_, retrieved, err = s.ACLTokenGetByAccessor(nil, token.AccessorID, nil)
 	require.NoError(t, err)
 	// pointer equality check these should be different if we cloned things appropriately
-	require.True(t, token != retrieved)
+	require.NotEqual(t, token, retrieved)
 	require.Len(t, retrieved.Roles, 1)
 	require.Equal(t, "node-read-role-renamed", retrieved.Roles[0].Name)
 
@@ -1370,7 +1370,7 @@ func TestStateStore_ACLToken_FixupRoleLinks(t *testing.T) {
 	for _, tok := range tokens {
 		if tok.AccessorID == token.AccessorID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, tok != token)
+			require.NotEqual(t, tok, token)
 			require.Len(t, tok.Roles, 1)
 			require.Equal(t, "node-read-role-renamed", tok.Roles[0].Name)
 			found = true
@@ -1387,7 +1387,7 @@ func TestStateStore_ACLToken_FixupRoleLinks(t *testing.T) {
 	for _, tok := range tokens {
 		if tok.AccessorID == token.AccessorID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, tok != token)
+			require.NotEqual(t, tok, token)
 			require.Len(t, tok.Roles, 1)
 			require.Equal(t, "node-read-role-renamed", tok.Roles[0].Name)
 			found = true
@@ -1403,8 +1403,8 @@ func TestStateStore_ACLToken_FixupRoleLinks(t *testing.T) {
 	_, retrieved, err = s.ACLTokenGetByAccessor(nil, token.AccessorID, nil)
 	require.NoError(t, err)
 	// pointer equality check these should be different if we cloned things appropriately
-	require.True(t, token != retrieved)
-	require.Len(t, retrieved.Roles, 0)
+	require.NotEqual(t, token, retrieved)
+	require.Empty(t, retrieved.Roles)
 
 	// list tokens without stale links
 	// nolint:staticcheck
@@ -1415,8 +1415,8 @@ func TestStateStore_ACLToken_FixupRoleLinks(t *testing.T) {
 	for _, tok := range tokens {
 		if tok.AccessorID == token.AccessorID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, tok != token)
-			require.Len(t, tok.Roles, 0)
+			require.NotEqual(t, tok, token)
+			require.Empty(t, tok.Roles)
 			found = true
 			break
 		}
@@ -1431,8 +1431,8 @@ func TestStateStore_ACLToken_FixupRoleLinks(t *testing.T) {
 	for _, tok := range tokens {
 		if tok.AccessorID == token.AccessorID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, tok != token)
-			require.Len(t, tok.Roles, 0)
+			require.NotEqual(t, tok, token)
+			require.Empty(t, tok.Roles)
 			found = true
 			break
 		}
@@ -1653,7 +1653,7 @@ func TestStateStore_ACLPolicy_SetGet(t *testing.T) {
 		require.Equal(t, "global-management", rpolicy.Name)
 		require.Equal(t, structs.ACLPolicyGlobalManagementDesc, rpolicy.Description)
 		require.Equal(t, structs.ACLPolicyGlobalManagementRules, rpolicy.Rules)
-		require.Len(t, rpolicy.Datacenters, 0)
+		require.Empty(t, rpolicy.Datacenters)
 		require.Equal(t, uint64(1), rpolicy.CreateIndex)
 		require.Equal(t, uint64(1), rpolicy.ModifyIndex)
 	})
@@ -2092,7 +2092,7 @@ func TestStateStore_ACLRole_SetGet(t *testing.T) {
 			require.Equal(t, "test", rrole.Description)
 			require.Equal(t, uint64(3), rrole.CreateIndex)
 			require.Equal(t, uint64(3), rrole.ModifyIndex)
-			require.Len(t, rrole.ServiceIdentities, 0)
+			require.Empty(t, rrole.ServiceIdentities)
 			// require.ElementsMatch(t, role.Policies, rrole.Policies)
 			require.Len(t, rrole.Policies, 1)
 			require.Equal(t, "node-read", rrole.Policies[0].Name)
@@ -2147,7 +2147,7 @@ func TestStateStore_ACLRole_SetGet(t *testing.T) {
 			require.Equal(t, "Modified", rrole.Description)
 			require.Equal(t, uint64(2), rrole.CreateIndex)
 			require.Equal(t, uint64(3), rrole.ModifyIndex)
-			require.Len(t, rrole.ServiceIdentities, 0)
+			require.Empty(t, rrole.ServiceIdentities)
 			require.Len(t, rrole.Policies, 1)
 			require.Equal(t, structs.ACLPolicyGlobalManagementID, rrole.Policies[0].ID)
 			require.Equal(t, "global-management", rrole.Policies[0].Name)
@@ -2454,7 +2454,7 @@ func TestStateStore_ACLRole_FixupPolicyLinks(t *testing.T) {
 	_, retrieved, err := s.ACLRoleGetByID(nil, role.ID, nil)
 	require.NoError(t, err)
 	// pointer equality check these should be identical
-	require.True(t, role == retrieved)
+	require.Equal(t, role, retrieved)
 	require.Len(t, retrieved.Policies, 1)
 	require.Equal(t, "node-read", retrieved.Policies[0].Name)
 
@@ -2472,7 +2472,7 @@ func TestStateStore_ACLRole_FixupPolicyLinks(t *testing.T) {
 	_, retrieved, err = s.ACLRoleGetByID(nil, role.ID, nil)
 	require.NoError(t, err)
 	// pointer equality check these should be different if we cloned things appropriately
-	require.True(t, role != retrieved)
+	require.NotEqual(t, role, retrieved)
 	require.Len(t, retrieved.Policies, 1)
 	require.Equal(t, "node-read-renamed", retrieved.Policies[0].Name)
 
@@ -2484,7 +2484,7 @@ func TestStateStore_ACLRole_FixupPolicyLinks(t *testing.T) {
 	for _, r := range roles {
 		if r.ID == role.ID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, r != role)
+			require.NotEqual(t, r, role)
 			require.Len(t, r.Policies, 1)
 			require.Equal(t, "node-read-renamed", r.Policies[0].Name)
 			found = true
@@ -2501,7 +2501,7 @@ func TestStateStore_ACLRole_FixupPolicyLinks(t *testing.T) {
 	for _, r := range roles {
 		if r.ID == role.ID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, r != role)
+			require.NotEqual(t, r, role)
 			require.Len(t, r.Policies, 1)
 			require.Equal(t, "node-read-renamed", r.Policies[0].Name)
 			found = true
@@ -2517,8 +2517,8 @@ func TestStateStore_ACLRole_FixupPolicyLinks(t *testing.T) {
 	_, retrieved, err = s.ACLRoleGetByID(nil, role.ID, nil)
 	require.NoError(t, err)
 	// pointer equality check these should be different if we cloned things appropriately
-	require.True(t, role != retrieved)
-	require.Len(t, retrieved.Policies, 0)
+	require.NotEqual(t, role, retrieved)
+	require.Empty(t, retrieved.Policies)
 
 	// list roles without stale links
 	_, roles, err = s.ACLRoleList(nil, "", nil)
@@ -2528,8 +2528,8 @@ func TestStateStore_ACLRole_FixupPolicyLinks(t *testing.T) {
 	for _, r := range roles {
 		if r.ID == role.ID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, r != role)
-			require.Len(t, r.Policies, 0)
+			require.NotEqual(t, r, role)
+			require.Empty(t, r.Policies)
 			found = true
 			break
 		}
@@ -2544,8 +2544,8 @@ func TestStateStore_ACLRole_FixupPolicyLinks(t *testing.T) {
 	for _, r := range roles {
 		if r.ID == role.ID {
 			// these pointers shouldn't be equal because the link should have been fixed
-			require.True(t, r != role)
-			require.Len(t, r.Policies, 0)
+			require.NotEqual(t, r, role)
+			require.Empty(t, r.Policies)
 			found = true
 			break
 		}
@@ -3846,11 +3846,11 @@ func TestTokenPoliciesIndex(t *testing.T) {
 	t.Run("no expiration", func(t *testing.T) {
 		dump, err := dumpItems("local")
 		require.NoError(t, err)
-		require.Len(t, dump, 0)
+		require.Empty(t, dump)
 
 		dump, err = dumpItems("global")
 		require.NoError(t, err)
-		require.Len(t, dump, 0)
+		require.Empty(t, dump)
 	})
 
 	{ // insert things with laddered expiration time, inserted in random order
@@ -4355,6 +4355,6 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		})
 
 		require.Error(t, err)
-		require.Equal(t, err.Error(), "Resolver Error")
+		require.Equal(t, "Resolver Error", err.Error())
 	})
 }

--- a/agent/consul/state/config_entry_exported_services_ce_test.go
+++ b/agent/consul/state/config_entry_exported_services_ce_test.go
@@ -308,7 +308,7 @@ func TestStore_getUniqueExportedServices(t *testing.T) {
 		},
 	}
 
-	require.Equal(t, 2, len(resp))
+	require.Len(t, resp, 2)
 
 	for idx, expSvc := range expected {
 		require.Equal(t, expSvc.Name, resp[idx].Name)

--- a/agent/consul/state/config_entry_test.go
+++ b/agent/consul/state/config_entry_test.go
@@ -358,7 +358,7 @@ func TestStore_ServiceDefaults_Kind_Destination(t *testing.T) {
 	_, gatewayServices, err := s.GatewayServices(nil, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindUnknown)
+	require.Equal(t, structs.GatewayServiceKindUnknown, gatewayServices[0].ServiceKind)
 
 	ws := memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -373,12 +373,12 @@ func TestStore_ServiceDefaults_Kind_Destination(t *testing.T) {
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindDestination)
+	require.Equal(t, structs.GatewayServiceKindDestination, gatewayServices[0].ServiceKind)
 
 	_, kindServices, err := s.ServiceNamesOfKind(ws, structs.ServiceKindDestination)
 	require.NoError(t, err)
 	require.Len(t, kindServices, 1)
-	require.Equal(t, kindServices[0].Kind, structs.ServiceKindDestination)
+	require.Equal(t, structs.ServiceKindDestination, kindServices[0].Kind)
 
 	ws = memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -396,7 +396,7 @@ func TestStore_ServiceDefaults_Kind_Destination(t *testing.T) {
 
 	_, kindServices, err = s.ServiceNamesOfKind(ws, structs.ServiceKindDestination)
 	require.NoError(t, err)
-	require.Len(t, kindServices, 0)
+	require.Empty(t, kindServices)
 
 }
 
@@ -424,7 +424,7 @@ func TestStore_ServiceDefaults_Kind_NotDestination(t *testing.T) {
 	_, gatewayServices, err := s.GatewayServices(nil, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindUnknown)
+	require.Equal(t, structs.GatewayServiceKindUnknown, gatewayServices[0].ServiceKind)
 
 	ws := memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -439,7 +439,7 @@ func TestStore_ServiceDefaults_Kind_NotDestination(t *testing.T) {
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindUnknown)
+	require.Equal(t, structs.GatewayServiceKindUnknown, gatewayServices[0].ServiceKind)
 
 	ws = memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -453,7 +453,7 @@ func TestStore_ServiceDefaults_Kind_NotDestination(t *testing.T) {
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindUnknown)
+	require.Equal(t, structs.GatewayServiceKindUnknown, gatewayServices[0].ServiceKind)
 
 }
 
@@ -486,7 +486,7 @@ func TestStore_Service_TerminatingGateway_Kind_Service_Destination(t *testing.T)
 	_, gatewayServices, err := s.GatewayServices(nil, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindUnknown)
+	require.Equal(t, structs.GatewayServiceKindUnknown, gatewayServices[0].ServiceKind)
 
 	ws := memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -502,24 +502,24 @@ func TestStore_Service_TerminatingGateway_Kind_Service_Destination(t *testing.T)
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindService)
+	require.Equal(t, structs.GatewayServiceKindService, gatewayServices[0].ServiceKind)
 
 	_, kindServices, err := s.ServiceNamesOfKind(ws, structs.ServiceKindTypical)
 	require.NoError(t, err)
 	require.Len(t, kindServices, 1)
-	require.Equal(t, kindServices[0].Kind, structs.ServiceKindTypical)
+	require.Equal(t, structs.ServiceKindTypical, kindServices[0].Kind)
 
 	require.NoError(t, s.EnsureConfigEntry(0, destination))
 
 	_, gatewayServices, err = s.GatewayServices(nil, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindService)
+	require.Equal(t, structs.GatewayServiceKindService, gatewayServices[0].ServiceKind)
 
 	_, kindServices, err = s.ServiceNamesOfKind(ws, structs.ServiceKindTypical)
 	require.NoError(t, err)
 	require.Len(t, kindServices, 1)
-	require.Equal(t, kindServices[0].Kind, structs.ServiceKindTypical)
+	require.Equal(t, structs.ServiceKindTypical, kindServices[0].Kind)
 
 	ws = memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -533,12 +533,12 @@ func TestStore_Service_TerminatingGateway_Kind_Service_Destination(t *testing.T)
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindDestination)
+	require.Equal(t, structs.GatewayServiceKindDestination, gatewayServices[0].ServiceKind)
 
 	_, kindServices, err = s.ServiceNamesOfKind(ws, structs.ServiceKindDestination)
 	require.NoError(t, err)
 	require.Len(t, kindServices, 1)
-	require.Equal(t, kindServices[0].Kind, structs.ServiceKindDestination)
+	require.Equal(t, structs.ServiceKindDestination, kindServices[0].Kind)
 
 }
 
@@ -571,7 +571,7 @@ func TestStore_Service_TerminatingGateway_Kind_Destination_Service(t *testing.T)
 	_, gatewayServices, err := s.GatewayServices(nil, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindUnknown)
+	require.Equal(t, structs.GatewayServiceKindUnknown, gatewayServices[0].ServiceKind)
 
 	ws := memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -583,12 +583,12 @@ func TestStore_Service_TerminatingGateway_Kind_Destination_Service(t *testing.T)
 	_, gatewayServices, err = s.GatewayServices(nil, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindDestination)
+	require.Equal(t, structs.GatewayServiceKindDestination, gatewayServices[0].ServiceKind)
 
 	_, kindServices, err := s.ServiceNamesOfKind(ws, structs.ServiceKindDestination)
 	require.NoError(t, err)
 	require.Len(t, kindServices, 1)
-	require.Equal(t, kindServices[0].Kind, structs.ServiceKindDestination)
+	require.Equal(t, structs.ServiceKindDestination, kindServices[0].Kind)
 
 	require.NoError(t, s.EnsureNode(0, &structs.Node{Node: "node1"}))
 	require.NoError(t, s.EnsureService(0, "node1", service))
@@ -599,12 +599,12 @@ func TestStore_Service_TerminatingGateway_Kind_Destination_Service(t *testing.T)
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindService)
+	require.Equal(t, structs.GatewayServiceKindService, gatewayServices[0].ServiceKind)
 
 	_, kindServices, err = s.ServiceNamesOfKind(ws, structs.ServiceKindTypical)
 	require.NoError(t, err)
 	require.Len(t, kindServices, 1)
-	require.Equal(t, kindServices[0].Kind, structs.ServiceKindTypical)
+	require.Equal(t, structs.ServiceKindTypical, kindServices[0].Kind)
 
 	ws = memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -618,12 +618,12 @@ func TestStore_Service_TerminatingGateway_Kind_Destination_Service(t *testing.T)
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindDestination)
+	require.Equal(t, structs.GatewayServiceKindDestination, gatewayServices[0].ServiceKind)
 
 	_, kindServices, err = s.ServiceNamesOfKind(ws, structs.ServiceKindDestination)
 	require.NoError(t, err)
 	require.Len(t, kindServices, 1)
-	require.Equal(t, kindServices[0].Kind, structs.ServiceKindDestination)
+	require.Equal(t, structs.ServiceKindDestination, kindServices[0].Kind)
 
 }
 
@@ -651,7 +651,7 @@ func TestStore_Service_TerminatingGateway_Kind_Service(t *testing.T) {
 	_, gatewayServices, err := s.GatewayServices(nil, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindUnknown)
+	require.Equal(t, structs.GatewayServiceKindUnknown, gatewayServices[0].ServiceKind)
 
 	ws := memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -667,7 +667,7 @@ func TestStore_Service_TerminatingGateway_Kind_Service(t *testing.T) {
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindService)
+	require.Equal(t, structs.GatewayServiceKindService, gatewayServices[0].ServiceKind)
 
 	ws = memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -681,7 +681,7 @@ func TestStore_Service_TerminatingGateway_Kind_Service(t *testing.T) {
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindUnknown)
+	require.Equal(t, structs.GatewayServiceKindUnknown, gatewayServices[0].ServiceKind)
 
 }
 
@@ -709,7 +709,7 @@ func TestStore_ServiceDefaults_Kind_Destination_Wildcard(t *testing.T) {
 
 	_, gatewayServices, err := s.GatewayServices(nil, "Gtwy1", nil)
 	require.NoError(t, err)
-	require.Len(t, gatewayServices, 0)
+	require.Empty(t, gatewayServices)
 
 	ws := memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -722,7 +722,7 @@ func TestStore_ServiceDefaults_Kind_Destination_Wildcard(t *testing.T) {
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindDestination)
+	require.Equal(t, structs.GatewayServiceKindDestination, gatewayServices[0].ServiceKind)
 
 	ws = memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -735,7 +735,7 @@ func TestStore_ServiceDefaults_Kind_Destination_Wildcard(t *testing.T) {
 
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
-	require.Len(t, gatewayServices, 0)
+	require.Empty(t, gatewayServices)
 
 	t.Run("delete service instance before config entry", func(t *testing.T) {
 		// Set up a service with both a real instance and destination from a config entry.
@@ -893,7 +893,7 @@ func TestStore_Service_TerminatingGateway_Kind_Service_Wildcard(t *testing.T) {
 
 	_, gatewayServices, err := s.GatewayServices(nil, "Gtwy1", nil)
 	require.NoError(t, err)
-	require.Len(t, gatewayServices, 0)
+	require.Empty(t, gatewayServices)
 
 	ws := memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -909,7 +909,7 @@ func TestStore_Service_TerminatingGateway_Kind_Service_Wildcard(t *testing.T) {
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.Equal(t, gatewayServices[0].ServiceKind, structs.GatewayServiceKindService)
+	require.Equal(t, structs.GatewayServiceKindService, gatewayServices[0].ServiceKind)
 
 	ws = memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -922,7 +922,7 @@ func TestStore_Service_TerminatingGateway_Kind_Service_Wildcard(t *testing.T) {
 
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
-	require.Len(t, gatewayServices, 0)
+	require.Empty(t, gatewayServices)
 }
 
 func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
@@ -2356,7 +2356,7 @@ func TestStore_ReadDiscoveryChainConfigEntries_SubsetSplit(t *testing.T) {
 	_, entrySet, err := s.readDiscoveryChainConfigEntries(nil, "main", nil, nil)
 	require.NoError(t, err)
 
-	require.Len(t, entrySet.Routers, 0)
+	require.Empty(t, entrySet.Routers)
 	require.Len(t, entrySet.Splitters, 1)
 	require.Len(t, entrySet.Resolvers, 1)
 	require.Len(t, entrySet.Services, 1)
@@ -2399,8 +2399,8 @@ func TestStore_ReadDiscoveryChainConfigEntries_FetchPeers(t *testing.T) {
 	_, entrySet, err := s.readDiscoveryChainConfigEntries(nil, "main", nil, nil)
 	require.NoError(t, err)
 
-	require.Len(t, entrySet.Routers, 0)
-	require.Len(t, entrySet.Splitters, 0)
+	require.Empty(t, entrySet.Routers)
+	require.Empty(t, entrySet.Splitters)
 	require.Len(t, entrySet.Resolvers, 1)
 	require.Len(t, entrySet.Services, 1)
 	prototest.AssertDeepEqual(t, entrySet.Peers, map[string]*pbpeering.Peering{

--- a/agent/consul/state/connect_ca_events_test.go
+++ b/agent/consul/state/connect_ca_events_test.go
@@ -83,7 +83,7 @@ func TestCARootsSnapshot(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), idx)
 
-		require.Equal(t, buf.events, [][]stream.Event{
+		require.Equal(t, [][]stream.Event{
 			{
 				{
 					Topic: EventTopicCARoots,
@@ -93,7 +93,7 @@ func TestCARootsSnapshot(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, buf.events)
 	})
 }
 

--- a/agent/consul/state/connect_ca_test.go
+++ b/agent/consul/state/connect_ca_test.go
@@ -193,18 +193,18 @@ func TestStore_CARootSetList(t *testing.T) {
 	// Call list to populate the watch set
 	ws := memdb.NewWatchSet()
 	_, _, err := s.CARoots(ws)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Build a valid value
 	ca1 := connect.TestCA(t, nil)
 	expected := *ca1
 	// Set
 	ok, err := s.CARootSetCAS(1, 0, []*structs.CARoot{ca1})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 
 	// Make sure the index got updated.
-	assert.Equal(t, s.maxIndex(tableConnectCARoots), uint64(1))
+	assert.Equal(t, uint64(1), s.maxIndex(tableConnectCARoots))
 	assert.True(t, watchFired(ws), "watch fired")
 
 	// Read it back out and verify it.
@@ -215,7 +215,7 @@ func TestStore_CARootSetList(t *testing.T) {
 	}
 	ws = memdb.NewWatchSet()
 	_, roots, err := s.CARoots(ws)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Len(t, roots, 1)
 	actual := roots[0]
 	prototest.AssertDeepEqual(t, expected, *actual)
@@ -227,7 +227,7 @@ func TestStore_CARootSet_emptyID(t *testing.T) {
 	// Call list to populate the watch set
 	ws := memdb.NewWatchSet()
 	_, _, err := s.CARoots(ws)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Build a valid value
 	ca1 := connect.TestCA(t, nil)
@@ -235,19 +235,19 @@ func TestStore_CARootSet_emptyID(t *testing.T) {
 
 	// Set
 	ok, err := s.CARootSetCAS(1, 0, []*structs.CARoot{ca1})
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), ErrMissingCARootID.Error())
 	assert.False(t, ok)
 
 	// Make sure the index got updated.
-	assert.Equal(t, s.maxIndex(tableConnectCARoots), uint64(0))
+	assert.Equal(t, uint64(0), s.maxIndex(tableConnectCARoots))
 	assert.False(t, watchFired(ws), "watch fired")
 
 	// Read it back out and verify it.
 	ws = memdb.NewWatchSet()
 	_, roots, err := s.CARoots(ws)
-	assert.Nil(t, err)
-	assert.Len(t, roots, 0)
+	require.NoError(t, err)
+	assert.Empty(t, roots)
 }
 
 func TestStore_CARootSet_noActive(t *testing.T) {
@@ -256,7 +256,7 @@ func TestStore_CARootSet_noActive(t *testing.T) {
 	// Call list to populate the watch set
 	ws := memdb.NewWatchSet()
 	_, _, err := s.CARoots(ws)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Build a valid value
 	ca1 := connect.TestCA(t, nil)
@@ -266,7 +266,7 @@ func TestStore_CARootSet_noActive(t *testing.T) {
 
 	// Set
 	ok, err := s.CARootSetCAS(1, 0, []*structs.CARoot{ca1, ca2})
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exactly one active")
 	assert.False(t, ok)
 }
@@ -277,7 +277,7 @@ func TestStore_CARootSet_multipleActive(t *testing.T) {
 	// Call list to populate the watch set
 	ws := memdb.NewWatchSet()
 	_, _, err := s.CARoots(ws)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Build a valid value
 	ca1 := connect.TestCA(t, nil)
@@ -285,7 +285,7 @@ func TestStore_CARootSet_multipleActive(t *testing.T) {
 
 	// Set
 	ok, err := s.CARootSetCAS(1, 0, []*structs.CARoot{ca1, ca2})
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exactly one active")
 	assert.False(t, ok)
 }
@@ -302,14 +302,14 @@ func TestStore_CARootActive_valid(t *testing.T) {
 
 	// Set
 	ok, err := s.CARootSetCAS(1, 0, []*structs.CARoot{ca1, ca2, ca3})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 
 	// Query
 	ws := memdb.NewWatchSet()
 	idx, res, err := s.CARootActive(ws)
-	assert.Equal(t, idx, uint64(1))
-	assert.Nil(t, err)
+	assert.Equal(t, uint64(1), idx)
+	require.NoError(t, err)
 	assert.NotNil(t, res)
 	assert.Equal(t, ca2.ID, res.ID)
 }
@@ -321,9 +321,9 @@ func TestStore_CARootActive_none(t *testing.T) {
 	// Querying with no results returns nil.
 	ws := memdb.NewWatchSet()
 	idx, res, err := s.CARootActive(ws)
-	assert.Equal(t, idx, uint64(0))
+	assert.Equal(t, uint64(0), idx)
 	assert.Nil(t, res)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestStore_CARoot_Snapshot_Restore(t *testing.T) {
@@ -348,7 +348,7 @@ func TestStore_CARoot_Snapshot_Restore(t *testing.T) {
 
 	// Now create
 	ok, err := s.CARootSetCAS(1, 0, roots)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 
 	// Snapshot the queries.
@@ -357,13 +357,13 @@ func TestStore_CARoot_Snapshot_Restore(t *testing.T) {
 
 	// Alter the real state store.
 	ok, err = s.CARootSetCAS(2, 1, roots[:1])
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 
 	// Verify the snapshot.
-	assert.Equal(t, snap.LastIndex(), uint64(1))
+	assert.Equal(t, uint64(1), snap.LastIndex())
 	dump, err := snap.CARoots()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, roots, dump)
 
 	// Restore the values into a new state store.
@@ -371,14 +371,14 @@ func TestStore_CARoot_Snapshot_Restore(t *testing.T) {
 		s := testStateStore(t)
 		restore := s.Restore()
 		for _, r := range dump {
-			assert.Nil(t, restore.CARoot(r))
+			require.NoError(t, restore.CARoot(r))
 		}
 		restore.Commit()
 
 		// Read the restored values back out and verify that they match.
 		idx, actual, err := s.CARoots(nil)
-		assert.Nil(t, err)
-		assert.Equal(t, idx, uint64(2))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(2), idx)
 		assert.Equal(t, roots, actual)
 	}()
 }
@@ -394,12 +394,12 @@ func TestStore_CABuiltinProvider(t *testing.T) {
 		}
 
 		ok, err := s.CASetProviderState(0, expected)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, ok)
 
 		idx, state, err := s.CAProviderState(expected.ID)
-		assert.NoError(t, err)
-		assert.Equal(t, idx, uint64(0))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), idx)
 		assert.Equal(t, expected, state)
 	}
 
@@ -411,12 +411,12 @@ func TestStore_CABuiltinProvider(t *testing.T) {
 		}
 
 		ok, err := s.CASetProviderState(1, expected)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, ok)
 
 		idx, state, err := s.CAProviderState(expected.ID)
-		assert.NoError(t, err)
-		assert.Equal(t, idx, uint64(1))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(1), idx)
 		assert.Equal(t, expected, state)
 	}
 
@@ -425,15 +425,15 @@ func TestStore_CABuiltinProvider(t *testing.T) {
 		// numbers will initialize from the max index of the provider table.
 		// That's why this first serial is 2 and not 1.
 		sn, err := s.CAIncrementProviderSerialNumber(10)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, uint64(2), sn)
 
 		sn, err = s.CAIncrementProviderSerialNumber(10)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, uint64(3), sn)
 
 		sn, err = s.CAIncrementProviderSerialNumber(10)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, uint64(4), sn)
 	}
 }
@@ -457,7 +457,7 @@ func TestStore_CABuiltinProvider_Snapshot_Restore(t *testing.T) {
 
 	for i, state := range before {
 		ok, err := s.CASetProviderState(uint64(98+i), state)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, ok)
 	}
 
@@ -472,26 +472,26 @@ func TestStore_CABuiltinProvider_Snapshot_Restore(t *testing.T) {
 		RootCert:   "d",
 	}
 	ok, err := s.CASetProviderState(100, after)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 
 	snapped, err := snap.CAProviderState()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, before, snapped)
 
 	// Restore onto a new state store.
 	s2 := testStateStore(t)
 	restore := s2.Restore()
 	for _, entry := range snapped {
-		assert.NoError(t, restore.CAProviderState(entry))
+		require.NoError(t, restore.CAProviderState(entry))
 	}
 	restore.Commit()
 
 	// Verify the restored values match those from before the snapshot.
 	for _, state := range before {
 		idx, res, err := s2.CAProviderState(state.ID)
-		assert.NoError(t, err)
-		assert.Equal(t, idx, uint64(99))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(99), idx)
 		assert.Equal(t, state, res)
 	}
 }

--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -55,7 +55,7 @@ func TestStore_IntentionGet_none(t *testing.T) {
 		idx, _, res, err := s.IntentionGet(ws, testUUID())
 		assert.Equal(t, uint64(1), idx)
 		assert.Nil(t, res)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -66,7 +66,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 		// Call Get to populate the watch set
 		ws := memdb.NewWatchSet()
 		_, _, _, err := s.IntentionGet(ws, testUUID())
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// Build a valid intention
 		var (
@@ -820,7 +820,7 @@ func TestStore_LegacyIntentionSet_emptyId(t *testing.T) {
 	require.Contains(t, err.Error(), ErrMissingIntentionID.Error())
 
 	// Index is not updated if nothing is saved.
-	require.Equal(t, s.maxIndex(tableConnectIntentions), uint64(0))
+	require.Equal(t, uint64(0), s.maxIndex(tableConnectIntentions))
 	require.Equal(t, uint64(0), s.maxIndex(tableConfigEntries))
 
 	require.False(t, watchFired(ws), "watch fired")
@@ -1782,8 +1782,8 @@ func TestStore_IntentionMatch_WatchesDuringUpgrade(t *testing.T) {
 	ws := memdb.NewWatchSet()
 	_, matches, err := s.IntentionMatch(ws, &args)
 	require.NoError(t, err)
-	require.Len(t, matches, 1)    // one request gets one response
-	require.Len(t, matches[0], 0) // but no intentions
+	require.Len(t, matches, 1)   // one request gets one response
+	require.Empty(t, matches[0]) // but no intentions
 
 	disableLegacyIntentions(s)
 	conf := &structs.ServiceIntentionsConfigEntry{
@@ -1835,7 +1835,7 @@ func TestStore_LegacyIntention_Snapshot_Restore(t *testing.T) {
 	require.NoError(t, s.LegacyIntentionDelete(7, ixns[0].ID))
 
 	// Verify the snapshot.
-	require.Equal(t, snap.LastIndex(), uint64(6))
+	require.Equal(t, uint64(6), snap.LastIndex())
 
 	// Expect them sorted in insertion order
 	expected := structs.Intentions{
@@ -1891,7 +1891,7 @@ func TestStore_LegacyIntention_Snapshot_Restore(t *testing.T) {
 		entMeta := structs.WildcardEnterpriseMetaInDefaultPartition()
 		idx, actual, fromConfig, err := s.Intentions(nil, entMeta)
 		require.NoError(t, err)
-		require.Equal(t, idx, uint64(6))
+		require.Equal(t, uint64(6), idx)
 		require.False(t, fromConfig)
 		require.Equal(t, expected, actual)
 	}()

--- a/agent/consul/state/kvs_test.go
+++ b/agent/consul/state/kvs_test.go
@@ -368,11 +368,11 @@ func TestStateStore_KVSSet_KVSGet(t *testing.T) {
 		Key:   "foo",
 		Value: []byte("bar"),
 	}
-	require.Nil(t, s.KVSSet(1, entry))
-	require.Nil(t, s.KVSSet(2, entry))
+	require.NoError(t, s.KVSSet(1, entry))
+	require.NoError(t, s.KVSSet(2, entry))
 
 	idx, _, err = s.KVSGet(ws, entry.Key, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, uint64(1), idx)
 }

--- a/agent/consul/state/memdb_test.go
+++ b/agent/consul/state/memdb_test.go
@@ -92,8 +92,8 @@ func Test_txn_Commit(t *testing.T) {
 	require.NotNil(t, next)
 
 	val := next.(TestObject)
-	require.Equal(t, val.ID, "1")
-	require.Equal(t, val.Foo, "foo")
+	require.Equal(t, "1", val.ID)
+	require.Equal(t, "foo", val.Foo)
 
 	err = group.Wait()
 	require.NoError(t, err)

--- a/agent/consul/state/peering_test.go
+++ b/agent/consul/state/peering_test.go
@@ -2592,7 +2592,7 @@ func TestStore_TrustBundleListByService(t *testing.T) {
 		idx, resp, err := store.TrustBundleListByService(ws, "foo", "dc1", entMeta)
 		require.NoError(t, err)
 		require.Equal(t, lastIdx, idx)
-		require.Len(t, resp, 0)
+		require.Empty(t, resp)
 	})
 
 	testutil.RunStep(t, "registering service does not yield trust bundles", func(t *testing.T) {
@@ -2613,7 +2613,7 @@ func TestStore_TrustBundleListByService(t *testing.T) {
 
 		idx, resp, err := store.TrustBundleListByService(ws, "foo", "dc1", entMeta)
 		require.NoError(t, err)
-		require.Len(t, resp, 0)
+		require.Empty(t, resp)
 		require.Equal(t, lastIdx-2, idx)
 	})
 
@@ -2631,7 +2631,7 @@ func TestStore_TrustBundleListByService(t *testing.T) {
 
 		idx, resp, err := store.TrustBundleListByService(ws, "foo", "dc1", entMeta)
 		require.NoError(t, err)
-		require.Len(t, resp, 0)
+		require.Empty(t, resp)
 		require.Equal(t, lastIdx-3, idx)
 	})
 
@@ -2658,7 +2658,7 @@ func TestStore_TrustBundleListByService(t *testing.T) {
 		idx, resp, err := store.TrustBundleListByService(ws, "foo", "dc1", entMeta)
 		require.NoError(t, err)
 		require.Equal(t, lastIdx, idx)
-		require.Len(t, resp, 0)
+		require.Empty(t, resp)
 	})
 
 	testutil.RunStep(t, "trust bundles are returned after they are created", func(t *testing.T) {
@@ -2689,7 +2689,7 @@ func TestStore_TrustBundleListByService(t *testing.T) {
 		idx, resp, err := store.TrustBundleListByService(ws, "foo", "dc1", entMeta)
 		require.NoError(t, err)
 		require.Equal(t, lastIdx, idx)
-		require.Len(t, resp, 0)
+		require.Empty(t, resp)
 	})
 
 	testutil.RunStep(t, "trust bundles are returned after config entry is restored", func(t *testing.T) {

--- a/agent/consul/state/usage_test.go
+++ b/agent/consul/state/usage_test.go
@@ -21,16 +21,16 @@ func TestStateStore_Usage_NodeUsage(t *testing.T) {
 	// No nodes have been registered, and thus no usage entry exists
 	idx, usage, err := s.NodeUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(0))
-	require.Equal(t, usage.Nodes, 0)
+	require.Equal(t, uint64(0), idx)
+	require.Equal(t, 0, usage.Nodes)
 
 	testRegisterNode(t, s, 0, "node1")
 	testRegisterNode(t, s, 1, "node2")
 
 	idx, usage, err = s.NodeUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(1))
-	require.Equal(t, usage.Nodes, 2)
+	require.Equal(t, uint64(1), idx)
+	require.Equal(t, 2, usage.Nodes)
 }
 
 func TestStateStore_Usage_NodeUsage_Delete(t *testing.T) {
@@ -41,14 +41,14 @@ func TestStateStore_Usage_NodeUsage_Delete(t *testing.T) {
 
 	idx, usage, err := s.NodeUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(1))
-	require.Equal(t, usage.Nodes, 2)
+	require.Equal(t, uint64(1), idx)
+	require.Equal(t, 2, usage.Nodes)
 
 	require.NoError(t, s.DeleteNode(2, "node2", nil, ""))
 	idx, usage, err = s.NodeUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(2))
-	require.Equal(t, usage.Nodes, 1)
+	require.Equal(t, uint64(2), idx)
+	require.Equal(t, 1, usage.Nodes)
 }
 
 // Test that nodes added/deleted from peers are not counted.
@@ -83,16 +83,16 @@ func TestStateStore_Usage_PeeringUsage(t *testing.T) {
 	// No nodes have been registered, and thus no usage entry exists
 	idx, usage, err := s.PeeringUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(0))
-	require.Equal(t, usage.Peerings, 0)
+	require.Equal(t, uint64(0), idx)
+	require.Equal(t, 0, usage.Peerings)
 
 	testRegisterPeering(t, s, 0, "test-peering1")
 	testRegisterPeering(t, s, 1, "test-peering2")
 
 	idx, usage, err = s.PeeringUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(1))
-	require.Equal(t, usage.Peerings, 2)
+	require.Equal(t, uint64(1), idx)
+	require.Equal(t, 2, usage.Peerings)
 }
 
 func TestStateStore_Usage_PeeringUsage_Delete(t *testing.T) {
@@ -103,8 +103,8 @@ func TestStateStore_Usage_PeeringUsage_Delete(t *testing.T) {
 
 	idx, usage, err := s.PeeringUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(1))
-	require.Equal(t, usage.Peerings, 2)
+	require.Equal(t, uint64(1), idx)
+	require.Equal(t, 2, usage.Peerings)
 
 	require.NoError(t, s.PeeringTerminateByID(2, peering2.ID))
 	idx, usage, err = s.PeeringUsage()
@@ -119,8 +119,8 @@ func TestStateStore_Usage_KVUsage(t *testing.T) {
 	// No keys have been registered, and thus no usage entry exists
 	idx, usage, err := s.KVUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(0))
-	require.Equal(t, usage.KVCount, 0)
+	require.Equal(t, uint64(0), idx)
+	require.Equal(t, 0, usage.KVCount)
 
 	testSetKey(t, s, 0, "key-1", "0", nil)
 	testSetKey(t, s, 1, "key-2", "0", nil)
@@ -128,8 +128,8 @@ func TestStateStore_Usage_KVUsage(t *testing.T) {
 
 	idx, usage, err = s.KVUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(2))
-	require.Equal(t, usage.KVCount, 2)
+	require.Equal(t, uint64(2), idx)
+	require.Equal(t, 2, usage.KVCount)
 }
 
 func TestStateStore_Usage_KVUsage_Delete(t *testing.T) {
@@ -141,14 +141,14 @@ func TestStateStore_Usage_KVUsage_Delete(t *testing.T) {
 
 	idx, usage, err := s.KVUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(2))
-	require.Equal(t, usage.KVCount, 2)
+	require.Equal(t, uint64(2), idx)
+	require.Equal(t, 2, usage.KVCount)
 
 	require.NoError(t, s.KVSDelete(3, "key-2", nil))
 	idx, usage, err = s.KVUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(3))
-	require.Equal(t, usage.KVCount, 1)
+	require.Equal(t, uint64(3), idx)
+	require.Equal(t, 1, usage.KVCount)
 }
 
 func TestStateStore_Usage_ServiceUsageEmpty(t *testing.T) {
@@ -157,9 +157,9 @@ func TestStateStore_Usage_ServiceUsageEmpty(t *testing.T) {
 	// No services have been registered, and thus no usage entry exists
 	idx, usage, err := s.ServiceUsage(nil, true)
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(0))
-	require.Equal(t, usage.Services, 0)
-	require.Equal(t, usage.ServiceInstances, 0)
+	require.Equal(t, uint64(0), idx)
+	require.Equal(t, 0, usage.Services)
+	require.Equal(t, 0, usage.ServiceInstances)
 	for k := range usage.ConnectServiceInstances {
 		require.Equal(t, 0, usage.ConnectServiceInstances[k])
 	}
@@ -188,7 +188,7 @@ func TestStateStore_Usage_ServiceUsage(t *testing.T) {
 	ws := memdb.NewWatchSet()
 	idx, usage, err := s.ServiceUsage(ws, true)
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(20))
+	require.Equal(t, uint64(20), idx)
 	require.Equal(t, 9, usage.Services)
 	require.Equal(t, 13, usage.ServiceInstances)
 	require.Equal(t, 2, usage.ConnectServiceInstances[string(structs.ServiceKindConnectProxy)])
@@ -234,7 +234,7 @@ func TestStateStore_Usage_ServiceUsage_DeleteNode(t *testing.T) {
 
 	idx, usage, err := s.ServiceUsage(nil, true)
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(4))
+	require.Equal(t, uint64(4), idx)
 	require.Equal(t, 3, usage.Services)
 	require.Equal(t, 4, usage.ServiceInstances)
 	require.Equal(t, 1, usage.ConnectServiceInstances[string(structs.ServiceKindConnectProxy)])
@@ -245,9 +245,9 @@ func TestStateStore_Usage_ServiceUsage_DeleteNode(t *testing.T) {
 
 	idx, usage, err = s.ServiceUsage(nil, true)
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(4))
-	require.Equal(t, usage.Services, 0)
-	require.Equal(t, usage.ServiceInstances, 0)
+	require.Equal(t, uint64(4), idx)
+	require.Equal(t, 0, usage.Services)
+	require.Equal(t, 0, usage.ServiceInstances)
 	for k := range usage.ConnectServiceInstances {
 		require.Equal(t, 0, usage.ConnectServiceInstances[k])
 	}
@@ -321,15 +321,15 @@ func TestStateStore_Usage_Restore(t *testing.T) {
 
 	idx, nodeUsage, err := s.NodeUsage()
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(9))
-	require.Equal(t, nodeUsage.Nodes, 1)
+	require.Equal(t, uint64(9), idx)
+	require.Equal(t, 1, nodeUsage.Nodes)
 
 	idx, usage, err := s.ServiceUsage(nil, true)
 	require.NoError(t, err)
-	require.Equal(t, idx, uint64(9))
-	require.Equal(t, usage.Services, 1)
-	require.Equal(t, usage.ServiceInstances, 2)
-	require.Equal(t, usage.BillableServiceInstances, 2)
+	require.Equal(t, uint64(9), idx)
+	require.Equal(t, 1, usage.Services)
+	require.Equal(t, 2, usage.ServiceInstances)
+	require.Equal(t, 2, usage.BillableServiceInstances)
 }
 
 func TestStateStore_Usage_updateUsage_Underflow(t *testing.T) {
@@ -427,10 +427,10 @@ func TestStateStore_Usage_ServiceUsage_updatingService(t *testing.T) {
 		// We renamed a service with a single instance, so we maintain 1 service.
 		idx, usage, err := s.ServiceUsage(nil, true)
 		require.NoError(t, err)
-		require.Equal(t, idx, uint64(2))
-		require.Equal(t, usage.Services, 1)
-		require.Equal(t, usage.ServiceInstances, 1)
-		require.Equal(t, usage.BillableServiceInstances, 1)
+		require.Equal(t, uint64(2), idx)
+		require.Equal(t, 1, usage.Services)
+		require.Equal(t, 1, usage.ServiceInstances)
+		require.Equal(t, 1, usage.BillableServiceInstances)
 	})
 
 	t.Run("update service to be connect native", func(t *testing.T) {
@@ -448,9 +448,9 @@ func TestStateStore_Usage_ServiceUsage_updatingService(t *testing.T) {
 		// We renamed a service with a single instance, so we maintain 1 service.
 		idx, usage, err := s.ServiceUsage(nil, true)
 		require.NoError(t, err)
-		require.Equal(t, idx, uint64(3))
-		require.Equal(t, usage.Services, 1)
-		require.Equal(t, usage.ServiceInstances, 1)
+		require.Equal(t, uint64(3), idx)
+		require.Equal(t, 1, usage.Services)
+		require.Equal(t, 1, usage.ServiceInstances)
 		require.Equal(t, 1, usage.ConnectServiceInstances[connectNativeInstancesTable])
 		require.Equal(t, 1, usage.BillableServiceInstances)
 	})
@@ -470,9 +470,9 @@ func TestStateStore_Usage_ServiceUsage_updatingService(t *testing.T) {
 		// We renamed a service with a single instance, so we maintain 1 service.
 		idx, usage, err := s.ServiceUsage(nil, true)
 		require.NoError(t, err)
-		require.Equal(t, idx, uint64(4))
-		require.Equal(t, usage.Services, 1)
-		require.Equal(t, usage.ServiceInstances, 1)
+		require.Equal(t, uint64(4), idx)
+		require.Equal(t, 1, usage.Services)
+		require.Equal(t, 1, usage.ServiceInstances)
 		require.Equal(t, 0, usage.ConnectServiceInstances[connectNativeInstancesTable])
 		require.Equal(t, 1, usage.BillableServiceInstances)
 	})
@@ -502,9 +502,9 @@ func TestStateStore_Usage_ServiceUsage_updatingService(t *testing.T) {
 
 		idx, usage, err := s.ServiceUsage(nil, true)
 		require.NoError(t, err)
-		require.Equal(t, idx, uint64(6))
-		require.Equal(t, usage.Services, 2)
-		require.Equal(t, usage.ServiceInstances, 3)
+		require.Equal(t, uint64(6), idx)
+		require.Equal(t, 2, usage.Services)
+		require.Equal(t, 3, usage.ServiceInstances)
 		require.Equal(t, 2, usage.ConnectServiceInstances[connectNativeInstancesTable])
 		require.Equal(t, 3, usage.BillableServiceInstances)
 
@@ -521,9 +521,9 @@ func TestStateStore_Usage_ServiceUsage_updatingService(t *testing.T) {
 
 		idx, usage, err = s.ServiceUsage(nil, true)
 		require.NoError(t, err)
-		require.Equal(t, idx, uint64(7))
-		require.Equal(t, usage.Services, 3)
-		require.Equal(t, usage.ServiceInstances, 3)
+		require.Equal(t, uint64(7), idx)
+		require.Equal(t, 3, usage.Services)
+		require.Equal(t, 3, usage.ServiceInstances)
 		require.Equal(t, 2, usage.ConnectServiceInstances[connectNativeInstancesTable])
 		require.Equal(t, 3, usage.BillableServiceInstances)
 
@@ -548,9 +548,9 @@ func TestStateStore_Usage_ServiceUsage_updatingConnectProxy(t *testing.T) {
 		// We renamed a service with a single instance, so we maintain 1 service.
 		idx, usage, err := s.ServiceUsage(nil, true)
 		require.NoError(t, err)
-		require.Equal(t, idx, uint64(2))
-		require.Equal(t, usage.Services, 1)
-		require.Equal(t, usage.ServiceInstances, 1)
+		require.Equal(t, uint64(2), idx)
+		require.Equal(t, 1, usage.Services)
+		require.Equal(t, 1, usage.ServiceInstances)
 		require.Equal(t, 1, usage.ConnectServiceInstances[string(structs.ServiceKindConnectProxy)])
 		require.Equal(t, 0, usage.BillableServiceInstances)
 	})
@@ -575,9 +575,9 @@ func TestStateStore_Usage_ServiceUsage_updatingConnectProxy(t *testing.T) {
 
 		idx, usage, err := s.ServiceUsage(nil, true)
 		require.NoError(t, err)
-		require.Equal(t, idx, uint64(4))
-		require.Equal(t, usage.Services, 2)
-		require.Equal(t, usage.ServiceInstances, 3)
+		require.Equal(t, uint64(4), idx)
+		require.Equal(t, 2, usage.Services)
+		require.Equal(t, 3, usage.ServiceInstances)
 		require.Equal(t, 2, usage.ConnectServiceInstances[string(structs.ServiceKindConnectProxy)])
 		require.Equal(t, 1, usage.BillableServiceInstances)
 
@@ -591,9 +591,9 @@ func TestStateStore_Usage_ServiceUsage_updatingConnectProxy(t *testing.T) {
 
 		idx, usage, err = s.ServiceUsage(nil, true)
 		require.NoError(t, err)
-		require.Equal(t, idx, uint64(5))
-		require.Equal(t, usage.Services, 3)
-		require.Equal(t, usage.ServiceInstances, 3)
+		require.Equal(t, uint64(5), idx)
+		require.Equal(t, 3, usage.Services)
+		require.Equal(t, 3, usage.ServiceInstances)
 		require.Equal(t, 1, usage.ConnectServiceInstances[string(structs.ServiceKindConnectProxy)])
 		require.Equal(t, 2, usage.BillableServiceInstances)
 	})

--- a/agent/consul/stream/event_buffer_test.go
+++ b/agent/consul/stream/event_buffer_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	time "time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // A property-based test to ensure that under heavy concurrent use trivial
@@ -87,6 +87,6 @@ func TestEventBufferFuzz(t *testing.T) {
 	// Wait for all readers to finish one way or other
 	for i := 0; i < nReaders; i++ {
 		err := <-errCh
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }

--- a/agent/consul/stream/event_snapshot_test.go
+++ b/agent/consul/stream/event_snapshot_test.go
@@ -64,7 +64,7 @@ func TestEventSnapshot(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			require.True(t, tc.updatesBeforeSnap < 999,
+			require.Less(t, tc.updatesBeforeSnap, 999,
 				"bad test param updatesBeforeSnap must be less than the snapshot"+
 					" index (%d) minus one (%d), got: %d", snapIndex, snapIndex-1,
 				tc.updatesBeforeSnap)

--- a/agent/consul/stream/subscription_test.go
+++ b/agent/consul/stream/subscription_test.go
@@ -41,7 +41,7 @@ func TestSubscription(t *testing.T) {
 	got, err := sub.Next(ctx)
 	elapsed := time.Since(start)
 	require.NoError(t, err)
-	require.True(t, elapsed < 200*time.Millisecond,
+	require.Less(t, elapsed, 200*time.Millisecond,
 		"Event should have been delivered immediately, took %s", elapsed)
 	require.Equal(t, index, got.Index)
 
@@ -56,9 +56,9 @@ func TestSubscription(t *testing.T) {
 	got, err = sub.Next(ctx)
 	elapsed = time.Since(start)
 	require.NoError(t, err)
-	require.True(t, elapsed > 200*time.Millisecond,
+	require.Greater(t, elapsed, 200*time.Millisecond,
 		"Event should have been delivered after blocking 200ms, took %s", elapsed)
-	require.True(t, elapsed < 2*time.Second,
+	require.Less(t, elapsed, 2*time.Second,
 		"Event should have been delivered after short time, took %s", elapsed)
 	require.Equal(t, index, got.Index)
 
@@ -69,7 +69,7 @@ func TestSubscription(t *testing.T) {
 	got, err = sub.Next(ctx)
 	elapsed = time.Since(start)
 	require.NoError(t, err)
-	require.True(t, elapsed < 200*time.Millisecond,
+	require.Less(t, elapsed, 200*time.Millisecond,
 		"Event should have been delivered immediately, took %s", elapsed)
 	require.Equal(t, index, got.Index)
 	require.Equal(t, "test", got.Payload.(simplePayload).key)
@@ -83,9 +83,9 @@ func TestSubscription(t *testing.T) {
 	_, err = sub.Next(ctx)
 	elapsed = time.Since(start)
 	require.Error(t, err)
-	require.True(t, elapsed > 200*time.Millisecond,
+	require.Greater(t, elapsed, 200*time.Millisecond,
 		"Event should have been delivered after blocking 200ms, took %s", elapsed)
-	require.True(t, elapsed < 2*time.Second,
+	require.Less(t, elapsed, 2*time.Second,
 		"Event should have been delivered after short time, took %s", elapsed)
 }
 
@@ -115,7 +115,7 @@ func TestSubscription_Close(t *testing.T) {
 	got, err := sub.Next(ctx)
 	elapsed := time.Since(start)
 	require.NoError(t, err)
-	require.True(t, elapsed < 200*time.Millisecond,
+	require.Less(t, elapsed, 200*time.Millisecond,
 		"Event should have been delivered immediately, took %s", elapsed)
 	require.Equal(t, index, got.Index)
 
@@ -130,9 +130,9 @@ func TestSubscription_Close(t *testing.T) {
 	elapsed = time.Since(start)
 	require.Error(t, err)
 	require.Equal(t, ErrSubForceClosed, err)
-	require.True(t, elapsed > 200*time.Millisecond,
+	require.Greater(t, elapsed, 200*time.Millisecond,
 		"Reload should have happened after blocking 200ms, took %s", elapsed)
-	require.True(t, elapsed < 2*time.Second,
+	require.Less(t, elapsed, 2*time.Second,
 		"Reload should have been delivered after short time, took %s", elapsed)
 }
 

--- a/agent/consul/subscribe_backend_test.go
+++ b/agent/consul/subscribe_backend_test.go
@@ -371,7 +371,7 @@ func TestSubscribeBackend_IntegrationWithServer_DeliversAllMessages(t *testing.T
 	// Sanity check that at least some non-snapshot messages were delivered. We
 	// can't know exactly how many because it's timing dependent based on when
 	// each subscribers snapshot occurs.
-	require.True(t, atomic.LoadUint64(&updateCount) > 0,
+	require.Greater(t, atomic.LoadUint64(&updateCount), 0,
 		"at least some of the subscribers should have received non-snapshot updates")
 }
 

--- a/agent/consul/system_metadata_test.go
+++ b/agent/consul/system_metadata_test.go
@@ -39,7 +39,7 @@ func TestLeader_SystemMetadata_CRUD(t *testing.T) {
 	// Initially has no entries
 	_, entries, err := state.SystemMetadataList(nil)
 	require.NoError(t, err)
-	require.Len(t, entries, 0)
+	require.Empty(t, entries)
 
 	// Create 3
 	require.NoError(t, srv.SetSystemMetadataKey("key1", "val1"))

--- a/agent/consul/v2_config_entry_exports_shim_test.go
+++ b/agent/consul/v2_config_entry_exports_shim_test.go
@@ -68,7 +68,7 @@ func v1ServiceExportsShimTests(t *testing.T, shim *v1ServiceExportsShim, configs
 
 	for _, entMeta := range partitions {
 		exportedServices, err := shim.GetExportedServicesConfigEntry(ctx, entMeta.PartitionOrDefault(), entMeta)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Nil(t, exportedServices)
 	}
 

--- a/agent/discovery/discovery_test.go
+++ b/agent/discovery/discovery_test.go
@@ -57,7 +57,7 @@ func TestQueryByName(t *testing.T) {
 		results, err := qp.QueryByName(&q, testContext)
 		if tc.expectedError != nil {
 			require.Error(t, err)
-			require.True(t, errors.Is(err, tc.expectedError))
+			require.ErrorIs(t, err, tc.expectedError)
 			require.Nil(t, results)
 			return
 		}
@@ -188,7 +188,7 @@ func TestQueryByIP(t *testing.T) {
 		results, err := qp.QueryByIP(testIP, testContext)
 		if tc.expectedError != nil {
 			require.Error(t, err)
-			require.True(t, errors.Is(err, tc.expectedError))
+			require.ErrorIs(t, err, tc.expectedError)
 			require.Nil(t, results)
 			return
 		}

--- a/agent/discovery/query_fetcher_v2_test.go
+++ b/agent/discovery/query_fetcher_v2_test.go
@@ -236,7 +236,7 @@ func Test_FetchWorkload(t *testing.T) {
 			df := NewV2DataFetcher(rc, client, logger)
 
 			result, err := df.FetchWorkload(tc.context, tc.queryPayload)
-			require.True(t, errors.Is(err, tc.expectedErr))
+			require.ErrorIs(t, err, tc.expectedErr)
 			require.Equal(t, tc.expectedResult, result)
 		})
 	}
@@ -741,7 +741,7 @@ func Test_V2FetchEndpoints(t *testing.T) {
 			df := NewV2DataFetcher(tc.rc, client, logger)
 
 			result, err := df.FetchEndpoints(tc.context, tc.queryPayload, LookupTypeService)
-			require.True(t, errors.Is(err, tc.expectedErr))
+			require.ErrorIs(t, err, tc.expectedErr)
 
 			if tc.verifyShuffle {
 				require.NotEqualf(t, tc.expectedResult, result, "expected result to be shuffled. There is a small probability that it shuffled back to the original order. In that case, you may want to play the lottery.")

--- a/agent/dns_catalogv2_test.go
+++ b/agent/dns_catalogv2_test.go
@@ -187,7 +187,7 @@ func TestDNS_CatalogV2_Basic(t *testing.T) {
 	// Ensure endpoints exist and have health status, which is required for inclusion in DNS results.
 	retry.Run(t, func(r *retry.R) {
 		endpoints := readResource(r, client, resource.ReplaceType(pbcatalog.ServiceEndpointsType, dbServiceId), new(pbcatalog.ServiceEndpoints)).(*pbcatalog.ServiceEndpoints)
-		require.Equal(r, 3, len(endpoints.GetEndpoints()))
+		require.Len(r, endpoints.GetEndpoints(), 3)
 		for _, e := range endpoints.GetEndpoints() {
 			require.True(r,
 				// We only return results for passing and warning health checks.
@@ -216,9 +216,9 @@ func TestDNS_CatalogV2_Basic(t *testing.T) {
 					t.Fatalf("err: %v", err)
 				}
 
-				require.Equal(t, 0, len(in.Answer), "Bad: %s", in.String())
-				require.Equal(t, 0, len(in.Extra), "Bad: %s", in.String())
-				require.Equal(t, 1, len(in.Ns), "Bad: %s", in.String())
+				require.Empty(t, in.Answer, "Bad: %s", in.String())
+				require.Empty(t, in.Extra, "Bad: %s", in.String())
+				require.Len(t, in.Ns, 1, "Bad: %s", in.String())
 
 				soaRec, ok := in.Ns[0].(*dns.SOA)
 				require.True(t, ok, "Bad: %s", in.Ns[0].String())
@@ -258,12 +258,12 @@ func TestDNS_CatalogV2_Basic(t *testing.T) {
 				}
 
 				// Expect 1 result per port, per workload.
-				require.Equal(t, 9, len(in.Answer), "answer count did not match expected\n\n%s", in.String())
-				require.Equal(t, 9, len(in.Extra), "extra answer count did not match expected\n\n%s", in.String())
+				require.Len(t, in.Answer, 9, "answer count did not match expected\n\n%s", in.String())
+				require.Len(t, in.Extra, 9, "extra answer count did not match expected\n\n%s", in.String())
 			} else {
 				// Expect 1 result per port, per workload, up to the default limit of 3. In practice the results are truncated at 2.
-				require.Equal(t, 2, len(in.Answer), "answer count did not match expected\n\n%s", in.String())
-				require.Equal(t, 2, len(in.Extra), "extra answer count did not match expected\n\n%s", in.String())
+				require.Len(t, in.Answer, 2, "answer count did not match expected\n\n%s", in.String())
+				require.Len(t, in.Extra, 2, "extra answer count did not match expected\n\n%s", in.String())
 			}
 		}
 
@@ -292,8 +292,8 @@ func TestDNS_CatalogV2_Basic(t *testing.T) {
 				require.EqualValues(t, 0, a.Hdr.Ttl, "Bad: %s", a.Original.String())
 
 				// Expect 1 result per port.
-				require.Equal(t, 3, len(in.Answer), "answer count did not match expected\n\n%s", in.String())
-				require.Equal(t, 3, len(in.Extra), "extra answer count did not match expected\n\n%s", in.String())
+				require.Len(t, in.Answer, 3, "answer count did not match expected\n\n%s", in.String())
+				require.Len(t, in.Extra, 3, "extra answer count did not match expected\n\n%s", in.String())
 			}
 		}
 
@@ -325,11 +325,11 @@ func TestDNS_CatalogV2_Basic(t *testing.T) {
 
 				// Expect 1 answer per workload. For A records, expect 2 answers because there's 2 IPv4 workloads.
 				if dnsType == dns.TypeA {
-					require.Equal(t, 2, len(in.Answer), "answer count did not match expected\n\n%s", in.String())
+					require.Len(t, in.Answer, 2, "answer count did not match expected\n\n%s", in.String())
 				} else {
-					require.Equal(t, 1, len(in.Answer), "answer count did not match expected\n\n%s", in.String())
+					require.Len(t, in.Answer, 1, "answer count did not match expected\n\n%s", in.String())
 				}
-				require.Equal(t, 0, len(in.Extra), "extra answer count did not match expected\n\n%s", in.String())
+				require.Empty(t, in.Extra, "extra answer count did not match expected\n\n%s", in.String())
 			}
 		}
 
@@ -347,7 +347,7 @@ func TestDNS_CatalogV2_Basic(t *testing.T) {
 				t.Fatalf("err: %v", err)
 			}
 
-			require.Equal(t, 1, len(in.Ns), "Bad: %s", in.String())
+			require.Len(t, in.Ns, 1, "Bad: %s", in.String())
 
 			soaRec, ok := in.Ns[0].(*dns.SOA)
 			require.True(t, ok, "Bad: %s", in.Ns[0].String())
@@ -377,7 +377,7 @@ func TestDNS_CatalogV2_Basic(t *testing.T) {
 					t.Fatalf("err: %v", err)
 				}
 
-				require.Equal(t, 1, len(in.Answer), "Bad: %s", in.String())
+				require.Len(t, in.Answer, 1, "Bad: %s", in.String())
 
 				a := findAorAAAAForName(t, in, in.Answer, question)
 				require.Equal(t, workloadHost, a.AorAAAA.String(), "Bad: %s", a.Original.String())
@@ -397,7 +397,7 @@ func TestDNS_CatalogV2_Basic(t *testing.T) {
 				t.Fatalf("err: %v", err)
 			}
 
-			require.Equal(t, 0, len(in.Answer), "Bad: %s", in.String())
+			require.Empty(t, in.Answer, "Bad: %s", in.String())
 			require.Equal(t, dns.RcodeNameError, in.Rcode, "Bad: %s", in.String())
 		}
 	}

--- a/agent/dns_ce_test.go
+++ b/agent/dns_ce_test.go
@@ -87,7 +87,7 @@ func TestDNS_CE_PeeredServices(t *testing.T) {
 				// Query the addr to make sure it's also valid.
 				q = dnsQuery(t, addr, dns.TypeA)
 				require.Len(t, q.Answer, 1)
-				require.Len(t, q.Extra, 0)
+				require.Empty(t, q.Extra)
 				assertARec(t, q.Answer[0], addr, "199.0.0.1")
 			})
 
@@ -107,7 +107,7 @@ func TestDNS_CE_PeeredServices(t *testing.T) {
 				// Query the node to make sure it's also valid.
 				q = dnsQuery(t, nodeName, dns.TypeA)
 				require.Len(t, q.Answer, 1)
-				require.Len(t, q.Extra, 0)
+				require.Empty(t, q.Extra)
 				assertARec(t, q.Answer[0], nodeName, "198.18.1.1")
 			})
 
@@ -119,7 +119,7 @@ func TestDNS_CE_PeeredServices(t *testing.T) {
 				require.NoError(t, a.RPC(context.Background(), "Catalog.Register", req, &struct{}{}))
 				q := dnsQuery(t, "web-proxy.service.peer1.peer.consul.", dns.TypeSRV)
 				require.Len(t, q.Answer, 1)
-				require.Len(t, q.Extra, 0)
+				require.Empty(t, q.Extra)
 				assertSRVRec(t, q.Answer[0], "localhost.", 12345)
 			})
 
@@ -127,7 +127,7 @@ func TestDNS_CE_PeeredServices(t *testing.T) {
 				require.NoError(t, a.RPC(context.Background(), "Catalog.Register", makeReq(), &struct{}{}))
 				q := dnsQuery(t, "web-proxy.service.peer1.peer.consul.", dns.TypeA)
 				require.Len(t, q.Answer, 1)
-				require.Len(t, q.Extra, 0)
+				require.Empty(t, q.Extra)
 				assertARec(t, q.Answer[0], "web-proxy.service.peer1.peer.consul.", "199.0.0.1")
 			})
 		})

--- a/agent/dns_node_lookup_test.go
+++ b/agent/dns_node_lookup_test.go
@@ -50,7 +50,7 @@ func TestDNS_NodeLookup(t *testing.T) {
 			in, _, err := c.Exchange(m, a.DNSAddr())
 			require.NoError(t, err)
 			require.Len(t, in.Answer, 2)
-			require.Len(t, in.Extra, 0)
+			require.Empty(t, in.Extra)
 
 			aRec, ok := in.Answer[0].(*dns.A)
 			require.True(t, ok, "First answer is not an A record")
@@ -91,7 +91,7 @@ func TestDNS_NodeLookup(t *testing.T) {
 			in, _, err = c.Exchange(m, a.DNSAddr())
 			require.NoError(t, err)
 			require.Len(t, in.Answer, 2)
-			require.Len(t, in.Extra, 0)
+			require.Empty(t, in.Extra)
 
 			aRec, ok = in.Answer[0].(*dns.A)
 			require.True(t, ok, "First answer is not an A record")
@@ -565,7 +565,7 @@ func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
 			require.Equal(t, wantAnswer, in.Answer)
 
 			// ensure TXT RR suppression
-			require.Len(t, in.Extra, 0)
+			require.Empty(t, in.Extra)
 		})
 	}
 }

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -464,7 +464,7 @@ func TestDNS_ConnectServiceLookup(t *testing.T) {
 				args.Service.Address = ""
 				args.Service.Port = 12345
 				var out struct{}
-				require.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+				require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
 			}
 
 			// Look up the service
@@ -477,7 +477,7 @@ func TestDNS_ConnectServiceLookup(t *testing.T) {
 
 				c := new(dns.Client)
 				in, _, err := c.Exchange(m, a.DNSAddr())
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.Len(t, in.Answer, 1)
 
 				srvRec, ok := in.Answer[0].(*dns.SRV)
@@ -511,7 +511,7 @@ func TestDNS_IngressServiceLookup(t *testing.T) {
 			{
 				args := structs.TestRegisterIngressGateway(t)
 				var out struct{}
-				require.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+				require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
 			}
 
 			// Register db service
@@ -528,7 +528,7 @@ func TestDNS_IngressServiceLookup(t *testing.T) {
 				}
 
 				var out struct{}
-				require.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+				require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
 			}
 
 			// Register proxy-defaults with 'http' protocol
@@ -546,7 +546,7 @@ func TestDNS_IngressServiceLookup(t *testing.T) {
 					WriteRequest: structs.WriteRequest{Token: "root"},
 				}
 				var out bool
-				require.Nil(t, a.RPC(context.Background(), "ConfigEntry.Apply", req, &out))
+				require.NoError(t, a.RPC(context.Background(), "ConfigEntry.Apply", req, &out))
 				require.True(t, out)
 			}
 
@@ -573,7 +573,7 @@ func TestDNS_IngressServiceLookup(t *testing.T) {
 					Entry:      args,
 				}
 				var out bool
-				require.Nil(t, a.RPC(context.Background(), "ConfigEntry.Apply", req, &out))
+				require.NoError(t, a.RPC(context.Background(), "ConfigEntry.Apply", req, &out))
 				require.True(t, out)
 			}
 
@@ -591,7 +591,7 @@ func TestDNS_IngressServiceLookup(t *testing.T) {
 
 					c := new(dns.Client)
 					in, _, err := c.Exchange(m, a.DNSAddr())
-					require.Nil(t, err)
+					require.NoError(t, err)
 					require.Len(t, in.Answer, 1)
 
 					cnameRec, ok := in.Answer[0].(*dns.A)
@@ -2598,7 +2598,7 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 			in, _, err := c.Exchange(m, a.DNSAddr())
 			require.NoError(t, err)
 
-			require.Equal(t, 2, len(in.Answer))
+			require.Len(t, in.Answer, 2)
 			ips := []string{in.Answer[0].(*dns.A).A.String(), in.Answer[1].(*dns.A).A.String()}
 			sort.Strings(ips)
 			require.Equal(t, []string{"127.0.0.1", "127.0.0.2"}, ips)
@@ -3064,7 +3064,7 @@ func checkDNSService(
 
 					t.Logf("DNS Response for %+v - %+v", m, in)
 
-					require.Equal(t, expectedResultsCount, len(in.Answer),
+					require.Len(t, in.Answer, expectedResultsCount,
 						"%d/%d answers received for type %v for %s (%s)", len(in.Answer), expectedResultsCount, qType, question, protocol)
 				})
 			}

--- a/agent/envoyextensions/builtin/aws-lambda/aws_lambda_test.go
+++ b/agent/envoyextensions/builtin/aws-lambda/aws_lambda_test.go
@@ -207,10 +207,10 @@ func TestPatchCluster(t *testing.T) {
 				Message:       tc.input,
 			})
 			if tc.isErrExpected {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.False(t, patchSuccess)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.True(t, patchSuccess)
 				assert.Equal(t, expectedCluster, patchedCluster)
 			}

--- a/agent/grpc-external/services/configentry/server_test.go
+++ b/agent/grpc-external/services/configentry/server_test.go
@@ -159,7 +159,7 @@ func TestGetResolvedExportedServices_Index(t *testing.T) {
 	ctx := grpc.NewContextWithServerTransportStream(context.Background(), headerStream)
 	resp, err := server.GetResolvedExportedServices(ctx, &pbconfigentry.GetResolvedExportedServicesRequest{})
 	require.NoError(t, err)
-	require.Equal(t, 2, len(resp.Services))
+	require.Len(t, resp.Services, 2)
 	require.Equal(t, []string{"1"}, headerStream.MD.Get("index"))
 
 	// Updating the index
@@ -170,7 +170,7 @@ func TestGetResolvedExportedServices_Index(t *testing.T) {
 	ctx = grpc.NewContextWithServerTransportStream(context.Background(), headerStream)
 	resp, err = server.GetResolvedExportedServices(ctx, &pbconfigentry.GetResolvedExportedServicesRequest{})
 	require.NoError(t, err)
-	require.Equal(t, 2, len(resp.Services))
+	require.Len(t, resp.Services, 2)
 	require.Equal(t, []string{"2"}, headerStream.MD.Get("index"))
 }
 
@@ -225,7 +225,7 @@ func TestGetResolvedExportedServices_Metrics(t *testing.T) {
 	ctx := grpc.NewContextWithServerTransportStream(context.Background(), &testutils.MockServerTransportStream{})
 	resp, err := server.GetResolvedExportedServices(ctx, &pbconfigentry.GetResolvedExportedServicesRequest{})
 	require.NoError(t, err)
-	require.Equal(t, 2, len(resp.Services))
+	require.Len(t, resp.Services, 2)
 
 	// Checking if metrics were added
 	require.NotNil(t, sink.Data()[0].Samples[`consul.configentry.get_resolved_exported_services`])

--- a/agent/grpc-external/services/dataplane/get_supported_features_test.go
+++ b/agent/grpc-external/services/dataplane/get_supported_features_test.go
@@ -41,7 +41,7 @@ func TestSupportedDataplaneFeatures_Success(t *testing.T) {
 	client := testClient(t, server)
 	resp, err := client.GetSupportedDataplaneFeatures(ctx, &pbdataplane.GetSupportedDataplaneFeaturesRequest{})
 	require.NoError(t, err)
-	require.Equal(t, 4, len(resp.SupportedDataplaneFeatures))
+	require.Len(t, resp.SupportedDataplaneFeatures, 4)
 
 	for _, feature := range resp.SupportedDataplaneFeatures {
 		switch feature.GetFeatureName() {
@@ -75,7 +75,7 @@ func TestSupportedDataplaneFeatures_ACLsDisabled(t *testing.T) {
 	client := testClient(t, server)
 	resp, err := client.GetSupportedDataplaneFeatures(ctx, &pbdataplane.GetSupportedDataplaneFeaturesRequest{})
 	require.NoError(t, err)
-	require.Equal(t, 4, len(resp.SupportedDataplaneFeatures))
+	require.Len(t, resp.SupportedDataplaneFeatures, 4)
 }
 
 func TestSupportedDataplaneFeatures_InvalidACLToken(t *testing.T) {

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -934,7 +934,7 @@ func TestStreamResources_Server_ServiceUpdates(t *testing.T) {
 
 				var nodes pbpeerstream.ExportedService
 				require.NoError(t, msg.GetResponse().Resource.UnmarshalTo(&nodes))
-				require.Len(t, nodes.Nodes, 0)
+				require.Empty(t, nodes.Nodes)
 			},
 			func(t *testing.T, msg *pbpeerstream.ReplicationMessage) {
 				require.Equal(t, pbpeerstream.TypeURLExportedService, msg.GetResponse().ResourceURL)
@@ -953,7 +953,7 @@ func TestStreamResources_Server_ServiceUpdates(t *testing.T) {
 
 				var nodes pbpeerstream.ExportedService
 				require.NoError(t, msg.GetResponse().Resource.UnmarshalTo(&nodes))
-				require.Len(t, nodes.Nodes, 0)
+				require.Empty(t, nodes.Nodes)
 			},
 			func(t *testing.T, msg *pbpeerstream.ReplicationMessage) {
 				require.Equal(t, pbpeerstream.TypeURLExportedServiceList, msg.GetResponse().ResourceURL)
@@ -1099,7 +1099,7 @@ func TestStreamResources_Server_ServiceUpdates(t *testing.T) {
 
 			var exportedServices pbpeerstream.ExportedServiceList
 			require.NoError(r, msg.GetResponse().Resource.UnmarshalTo(&exportedServices))
-			require.Len(r, exportedServices.Services, 0)
+			require.Empty(r, exportedServices.Services)
 		})
 	})
 }
@@ -2008,7 +2008,7 @@ func processResponse_ExportedServiceUpdates(
 			_, err = srv.processResponse(peerName, localEntMeta.PartitionOrDefault(), mst, resp)
 			require.NoError(t, err)
 			// Test the count and contents separately to ensure the count code path is hit.
-			require.Equal(t, mst.GetImportedServicesCount(), len(tc.exportedServices))
+			require.Len(t, tc.exportedServices, mst.GetImportedServicesCount())
 			require.ElementsMatch(t, mst.ImportedServices, tc.exportedServices)
 		}
 

--- a/agent/grpc-external/services/peerstream/subscription_manager_test.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager_test.go
@@ -408,7 +408,7 @@ func TestSubscriptionManager_RegisterDeregister(t *testing.T) {
 			res := got.Result.(*pbservice.IndexedCheckServiceNodes)
 			require.Equal(t, uint64(0), res.Index)
 
-			require.Len(t, res.Nodes, 0)
+			require.Empty(t, res.Nodes)
 		})
 	})
 
@@ -421,7 +421,7 @@ func TestSubscriptionManager_RegisterDeregister(t *testing.T) {
 				res := got.Result.(*pbservice.IndexedCheckServiceNodes)
 				require.Equal(t, uint64(0), res.Index)
 
-				require.Len(t, res.Nodes, 0)
+				require.Empty(t, res.Nodes)
 			},
 		)
 	})
@@ -1223,7 +1223,7 @@ func checkEvent(
 	serviceKindPairs ...string) {
 	t.Helper()
 
-	require.True(t, len(serviceKindPairs) == 2*expectNodes, "sanity check")
+	require.Len(t, serviceKindPairs, 2*expectNodes, "sanity check")
 
 	require.Equal(t, correlationID, got.CorrelationID)
 
@@ -1231,7 +1231,7 @@ func checkEvent(
 	require.Equal(t, uint64(0), evt.Index)
 
 	if expectNodes == 0 {
-		require.Len(t, evt.Nodes, 0)
+		require.Empty(t, evt.Nodes)
 	} else {
 		require.Len(t, evt.Nodes, expectNodes)
 

--- a/agent/grpc-external/services/peerstream/subscription_state_test.go
+++ b/agent/grpc-external/services/peerstream/subscription_state_test.go
@@ -37,7 +37,7 @@ func TestSubscriptionState_Events(t *testing.T) {
 		}()
 
 		got := drainEvents(t, ch)
-		require.Len(t, got, 0)
+		require.Empty(t, got)
 	})
 
 	meshNode1 := &pbservice.CheckServiceNode{
@@ -92,7 +92,7 @@ func TestSubscriptionState_Events(t *testing.T) {
 		}()
 
 		got := drainEvents(t, ch)
-		require.Len(t, got, 0)
+		require.Empty(t, got)
 	})
 
 	webNode1 := &pbservice.CheckServiceNode{

--- a/agent/grpc-external/services/resource/write_test.go
+++ b/agent/grpc-external/services/resource/write_test.go
@@ -510,7 +510,7 @@ func TestWrite_NoData(t *testing.T) {
 	rsp, err := client.Write(testContext(t), &pbresource.WriteRequest{Resource: res})
 	require.NoError(t, err)
 	require.NotEmpty(t, rsp.Resource.Version)
-	require.Equal(t, rsp.Resource.Id.Name, "jazz")
+	require.Equal(t, "jazz", rsp.Resource.Id.Name)
 }
 
 func TestWrite_Owner_Immutable(t *testing.T) {

--- a/agent/grpc-internal/client_test.go
+++ b/agent/grpc-internal/client_test.go
@@ -191,8 +191,8 @@ func TestNewDialer_IntegrationWithTLSEnabledHandler(t *testing.T) {
 	resp, err := client.Something(ctx, &testservice.Req{})
 	require.NoError(t, err)
 	require.Equal(t, "server-1", resp.ServerName)
-	require.True(t, atomic.LoadInt32(&srv.rpc.tlsConnEstablished) > 0)
-	require.True(t, atomic.LoadInt32(&srv.rpc.alpnConnEstablished) == 0)
+	require.Greater(t, atomic.LoadInt32(&srv.rpc.tlsConnEstablished), 0)
+	require.Equal(t, 0, atomic.LoadInt32(&srv.rpc.alpnConnEstablished))
 }
 
 func TestNewDialer_IntegrationWithTLSEnabledHandler_viaMeshGateway(t *testing.T) {
@@ -270,8 +270,8 @@ func TestNewDialer_IntegrationWithTLSEnabledHandler_viaMeshGateway(t *testing.T)
 	resp, err := client.Something(ctx, &testservice.Req{})
 	require.NoError(t, err)
 	require.Equal(t, "bob", resp.ServerName)
-	require.True(t, atomic.LoadInt32(&srv.rpc.tlsConnEstablished) == 0)
-	require.True(t, atomic.LoadInt32(&srv.rpc.alpnConnEstablished) > 0)
+	require.Equal(t, 0, atomic.LoadInt32(&srv.rpc.tlsConnEstablished))
+	require.Greater(t, atomic.LoadInt32(&srv.rpc.alpnConnEstablished), 0)
 }
 
 func TestClientConnPool_IntegrationWithGRPCResolver_Failover(t *testing.T) {

--- a/agent/grpc-middleware/auth_interceptor_test.go
+++ b/agent/grpc-middleware/auth_interceptor_test.go
@@ -82,7 +82,7 @@ func TestGRPCMiddleware_restrictPeeringEndpoints(t *testing.T) {
 			if tc.expectErr == "" {
 				require.NoError(t, err)
 			} else {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expectErr)
 			}
 		})

--- a/agent/hcp/client/metrics_client_test.go
+++ b/agent/hcp/client/metrics_client_test.go
@@ -77,7 +77,7 @@ func TestExportMetrics(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			randomBody := randStringRunes(1000)
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				require.Equal(t, r.Header.Get("content-type"), "application/x-protobuf")
+				require.Equal(t, "application/x-protobuf", r.Header.Get("content-type"))
 
 				body := colpb.ExportMetricsServiceResponse{}
 				bytes, err := proto.Marshal(&body)
@@ -149,7 +149,7 @@ func TestTruncate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			truncatedBody := truncate(tc.body, defaultErrRespBodyLength)
 			truncatedRunes := []rune(truncatedBody)
-			require.Equal(t, len(truncatedRunes), tc.expectedSize)
+			require.Len(t, truncatedRunes, tc.expectedSize)
 		})
 	}
 }

--- a/agent/hcp/client/telemetry_config_test.go
+++ b/agent/hcp/client/telemetry_config_test.go
@@ -337,7 +337,7 @@ func TestConvertMetricLabels(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			labels := convertMetricLabels(tc.payloadLabels, tc.cfg)
-			require.Equal(t, labels, tc.expectedLabels)
+			require.Equal(t, tc.expectedLabels, labels)
 		})
 	}
 }

--- a/agent/hcp/telemetry/gauge_store_test.go
+++ b/agent/hcp/telemetry/gauge_store_test.go
@@ -30,7 +30,7 @@ func TestGaugeStore(t *testing.T) {
 	// Should store a new gauge.
 	val, ok := gaugeStore.LoadAndDelete("test")
 	require.True(t, ok)
-	require.Equal(t, val.Value, 1.23)
+	require.Equal(t, 1.23, val.Value)
 	require.Equal(t, val.Attributes, attributes)
 
 	// Gauge with key "test" have been deleted.
@@ -44,7 +44,7 @@ func TestGaugeStore(t *testing.T) {
 	// Gauge with key "duplicate" should hold the latest (last seen) value.
 	val, ok = gaugeStore.LoadAndDelete("duplicate")
 	require.True(t, ok)
-	require.Equal(t, val.Value, 6.7)
+	require.Equal(t, 6.7, val.Value)
 }
 
 func TestGaugeCallback_Failure(t *testing.T) {

--- a/agent/hcp/telemetry/otlp_transform_test.go
+++ b/agent/hcp/telemetry/otlp_transform_test.go
@@ -273,7 +273,7 @@ func TestTransformOTLP(t *testing.T) {
 	// Metrics Test Case
 	m := metricsToPB(inputMetrics)
 	require.Equal(t, expectedMetrics, m)
-	require.Equal(t, len(expectedMetrics), 3)
+	require.Len(t, expectedMetrics, 3)
 
 	// Scope Metrics Test Case
 	sm := scopeMetricsToPB(inputScopeMetrics)

--- a/agent/hcp/telemetry_provider_test.go
+++ b/agent/hcp/telemetry_provider_test.go
@@ -281,7 +281,7 @@ func TestTelemetryConfigProvider_UpdateConfig(t *testing.T) {
 			require.NotNil(t, interval, 1)
 			sv := interval.Counters[tc.metricKey]
 			assert.NotNil(t, sv.AggregateSample)
-			require.Equal(t, sv.AggregateSample.Count, 1)
+			require.Equal(t, 1, sv.AggregateSample.Count)
 		})
 	}
 }

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -655,7 +655,7 @@ func TestHealthServiceNodes(t *testing.T) {
 			require.Len(t, nodes, 1)
 		} else {
 			require.NotNil(t, nodes)
-			require.Len(t, nodes, 0)
+			require.Empty(t, nodes)
 		}
 
 		req, err = http.NewRequest("GET", "/v1/health/service/nope?dc=dc1"+peerQuerySuffix(peerName), nil)
@@ -669,7 +669,7 @@ func TestHealthServiceNodes(t *testing.T) {
 		// Should be a non-nil empty list
 		nodes = obj.(structs.CheckServiceNodes)
 		require.NotNil(t, nodes)
-		require.Len(t, nodes, 0)
+		require.Empty(t, nodes)
 	}
 
 	// TODO(peering): will have to seed this data differently in the future
@@ -699,7 +699,7 @@ func TestHealthServiceNodes(t *testing.T) {
 		require.Equal(t, peerName, nodes[0].Service.PeerName)
 		require.Equal(t, "test", nodes[0].Service.Service)
 		require.NotNil(t, nodes[0].Checks)
-		require.Len(t, nodes[0].Checks, 0)
+		require.Empty(t, nodes[0].Checks)
 	}
 
 	for _, peerName := range testingPeerNames {
@@ -878,7 +878,7 @@ use_streaming_backend = true
 			verify(t, 2, nodes)
 
 			idx := getIndex(t, resp)
-			require.True(t, idx > 0)
+			require.Greater(t, idx, 0)
 
 			// errCh collects errors from goroutines since it's unsafe for them to use
 			// t to fail tests directly.
@@ -930,17 +930,17 @@ use_streaming_backend = true
 				obj, err := a.srv.HealthServiceNodes(resp, req)
 				require.NoError(t, err)
 				elapsed := time.Since(start)
-				require.True(t, elapsed > sleep, "request should block for at "+
+				require.Greater(t, elapsed, sleep, "request should block for at "+
 					" least as long as sleep. sleep=%s, elapsed=%s", sleep, elapsed)
 
-				require.True(t, elapsed < timeout, "request should unblock before"+
+				require.Less(t, elapsed, timeout, "request should unblock before"+
 					" it timed out. timeout=%s, elapsed=%s", timeout, elapsed)
 
 				nodes := obj.(structs.CheckServiceNodes)
 				verify(t, 3, nodes)
 
 				newIdx := getIndex(t, resp)
-				require.True(t, idx < newIdx, "index should have increased."+
+				require.Less(t, idx, newIdx, "index should have increased."+
 					"idx=%d, newIdx=%d", idx, newIdx)
 
 				require.Equal(t, tc.queryBackend, resp.Header().Get("X-Consul-Query-Backend"))
@@ -963,7 +963,7 @@ use_streaming_backend = true
 				elapsed := time.Since(start)
 				// Note that servers add jitter to timeout requested but don't remove it
 				// so this should always be true.
-				require.True(t, elapsed > timeout, "request should block for at "+
+				require.Greater(t, elapsed, timeout, "request should block for at "+
 					" least as long as timeout. timeout=%s, elapsed=%s", timeout, elapsed)
 
 				nodes := obj.(structs.CheckServiceNodes)
@@ -1075,7 +1075,7 @@ use_streaming_backend = true
 				require.Equal(t, "blocking-query", resp.Header().Get("X-Consul-Query-Backend"))
 
 				idx := getIndex(t, resp)
-				require.True(t, idx > 0)
+				require.Greater(t, idx, 0)
 
 				lastIndex = idx
 			})
@@ -1116,7 +1116,7 @@ use_streaming_backend = true
 					require.NoError(t, err)
 				}
 
-				require.Len(t, out, 0)
+				require.Empty(t, out)
 				require.Equal(t, tc.queryBackend, resp.Header().Get("X-Consul-Query-Backend"))
 			})
 		})
@@ -1171,7 +1171,7 @@ func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
 				require.NoError(t, err)
 
 				lastIndex = getIndex(t, resp)
-				require.True(t, lastIndex > 0)
+				require.Greater(t, lastIndex, 0)
 
 				// Should be a non-nil empty list
 				nodes := obj.(structs.CheckServiceNodes)
@@ -1179,7 +1179,7 @@ func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
 				require.Empty(t, nodes)
 			})
 
-			require.True(t, lastIndex > 0, "lastindex = %d", lastIndex)
+			require.Greater(t, lastIndex, 0, "lastindex = %d", lastIndex)
 
 			testutil.RunStep(t, "register item 1", func(t *testing.T) {
 				args := &structs.RegisterRequest{
@@ -1602,10 +1602,10 @@ func TestHealthServiceNodes_WanTranslation(t *testing.T) {
 	require.Len(t, nodes1, 1)
 	node1 := nodes1[0]
 	require.NotNil(t, node1.Node)
-	require.Equal(t, node1.Node.Address, "127.0.0.2")
+	require.Equal(t, "127.0.0.2", node1.Node.Address)
 	require.NotNil(t, node1.Service)
-	require.Equal(t, node1.Service.Address, "1.2.3.4")
-	require.Equal(t, node1.Service.Port, 80)
+	require.Equal(t, "1.2.3.4", node1.Service.Address)
+	require.Equal(t, 80, node1.Service.Port)
 
 	// Query DC2 from DC2.
 	resp2 := httptest.NewRecorder()
@@ -1619,10 +1619,10 @@ func TestHealthServiceNodes_WanTranslation(t *testing.T) {
 	require.Len(t, nodes2, 1)
 	node2 := nodes2[0]
 	require.NotNil(t, node2.Node)
-	require.Equal(t, node2.Node.Address, "127.0.0.1")
+	require.Equal(t, "127.0.0.1", node2.Node.Address)
 	require.NotNil(t, node2.Service)
-	require.Equal(t, node2.Service.Address, "127.0.0.1")
-	require.Equal(t, node2.Service.Port, 8080)
+	require.Equal(t, "127.0.0.1", node2.Service.Address)
+	require.Equal(t, 8080, node2.Service.Port)
 }
 
 func TestHealthConnectServiceNodes(t *testing.T) {
@@ -1638,20 +1638,20 @@ func TestHealthConnectServiceNodes(t *testing.T) {
 	// Register
 	args := structs.TestRegisterRequestProxy(t)
 	var out struct{}
-	assert.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+	require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
 
 	// Request
 	req, _ := http.NewRequest("GET", fmt.Sprintf(
 		"/v1/health/connect/%s?dc=dc1", args.Service.Proxy.DestinationServiceName), nil)
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.HealthConnectServiceNodes(resp, req)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assertIndex(t, resp)
 
 	// Should be a non-nil empty list for checks
 	nodes := obj.(structs.CheckServiceNodes)
 	assert.Len(t, nodes, 1)
-	assert.Len(t, nodes[0].Checks, 0)
+	assert.Empty(t, nodes[0].Checks)
 }
 
 func TestHealthIngressServiceNodes(t *testing.T) {
@@ -1703,7 +1703,7 @@ func testHealthIngressServiceNodes(t *testing.T, agentHCL string) {
 		Entry:      cfgArgs,
 	}
 	var outB bool
-	require.Nil(t, a.RPC(context.Background(), "ConfigEntry.Apply", req, &outB))
+	require.NoError(t, a.RPC(context.Background(), "ConfigEntry.Apply", req, &outB))
 	require.True(t, outB)
 
 	checkResults := func(t *testing.T, obj interface{}) {
@@ -1734,7 +1734,7 @@ func testHealthIngressServiceNodes(t *testing.T, agentHCL string) {
 		assertIndex(t, resp)
 
 		nodes := obj.(structs.CheckServiceNodes)
-		require.Len(t, nodes, 0)
+		require.Empty(t, nodes)
 	}))
 
 	require.True(t, t.Run("test caching miss", func(t *testing.T) {
@@ -1831,19 +1831,19 @@ func TestHealthConnectServiceNodes_PassingFilter(t *testing.T) {
 		Status:    api.HealthCritical,
 	}
 	var out struct{}
-	assert.Nil(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+	require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
 
 	t.Run("bc_no_query_value", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", fmt.Sprintf(
 			"/v1/health/connect/%s?passing", args.Service.Proxy.DestinationServiceName), nil)
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.HealthConnectServiceNodes(resp, req)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assertIndex(t, resp)
 
 		// Should be 0 health check for consul
 		nodes := obj.(structs.CheckServiceNodes)
-		assert.Len(t, nodes, 0)
+		assert.Empty(t, nodes)
 	})
 
 	t.Run("passing_true", func(t *testing.T) {
@@ -1851,12 +1851,12 @@ func TestHealthConnectServiceNodes_PassingFilter(t *testing.T) {
 			"/v1/health/connect/%s?passing=true", args.Service.Proxy.DestinationServiceName), nil)
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.HealthConnectServiceNodes(resp, req)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assertIndex(t, resp)
 
 		// Should be 0 health check for consul
 		nodes := obj.(structs.CheckServiceNodes)
-		assert.Len(t, nodes, 0)
+		assert.Empty(t, nodes)
 	})
 
 	t.Run("passing_false", func(t *testing.T) {
@@ -1864,7 +1864,7 @@ func TestHealthConnectServiceNodes_PassingFilter(t *testing.T) {
 			"/v1/health/connect/%s?passing=false", args.Service.Proxy.DestinationServiceName), nil)
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.HealthConnectServiceNodes(resp, req)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assertIndex(t, resp)
 
 		// Should be 1
@@ -1877,7 +1877,7 @@ func TestHealthConnectServiceNodes_PassingFilter(t *testing.T) {
 			"/v1/health/connect/%s?passing=nope-nope", args.Service.Proxy.DestinationServiceName), nil)
 		resp := httptest.NewRecorder()
 		_, err := a.srv.HealthConnectServiceNodes(resp, req)
-		assert.NotNil(t, err)
+		require.Error(t, err)
 		assert.True(t, isHTTPBadRequest(err))
 
 		assert.True(t, strings.Contains(err.Error(), "Invalid value for ?passing"))

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -39,7 +39,7 @@ func TestIntentionList(t *testing.T) {
 
 		value := obj.(structs.Intentions)
 		require.NotNil(t, value)
-		require.Len(t, value, 0)
+		require.Empty(t, value)
 	})
 
 	t.Run("values", func(t *testing.T) {
@@ -736,7 +736,7 @@ func TestIntentionDeleteExact(t *testing.T) {
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.IntentionExact(resp, req)
 		require.NoError(t, err) // by-name deletions are idempotent
-		require.Equal(t, true, obj)
+		require.True(t, obj.(bool))
 	})
 
 	exact := ixn.ToExact()
@@ -794,7 +794,7 @@ func TestIntentionDeleteExact(t *testing.T) {
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.IntentionExact(resp, req)
 		require.NoError(t, err)
-		require.Equal(t, true, obj)
+		require.True(t, obj.(bool))
 
 		// Verify the intention is gone
 		{
@@ -865,7 +865,7 @@ func TestIntentionSpecificDelete(t *testing.T) {
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.IntentionSpecific(resp, req)
 	require.NoError(t, err)
-	require.Equal(t, true, obj)
+	require.True(t, obj.(bool))
 
 	// Verify the intention is gone
 	{

--- a/agent/leafcert/leafcert_test.go
+++ b/agent/leafcert/leafcert_test.go
@@ -52,7 +52,7 @@ func TestManager_changingRoots(t *testing.T) {
 		require.NoError(t, result.Err)
 		require.NotNil(t, result.Value)
 		requireLeafValidUnderCA(t, result.Value, caRoot)
-		require.True(t, result.Index > 0)
+		require.Greater(t, result.Index, 0)
 
 		idx = result.Index
 	}
@@ -75,7 +75,7 @@ func TestManager_changingRoots(t *testing.T) {
 	case result := <-getCh:
 		require.NoError(t, result.Err)
 		require.NotNil(t, result.Value)
-		require.True(t, result.Index > idx)
+		require.Greater(t, result.Index, idx)
 		requireLeafValidUnderCA(t, result.Value, caRoot2)
 	}
 
@@ -130,7 +130,7 @@ func TestManager_changingRootsJitterBetweenCalls(t *testing.T) {
 	case result := <-getCh:
 		require.NoError(t, result.Err)
 		require.NotNil(t, result.Value)
-		require.True(t, result.Index > 0)
+		require.Greater(t, result.Index, 0)
 		requireLeafValidUnderCA(t, result.Value, caRoot)
 		idx = result.Index
 		issued = result.Value
@@ -178,7 +178,7 @@ func TestManager_changingRootsJitterBetweenCalls(t *testing.T) {
 				require.NotNil(t, result.Value)
 				requireLeafValidUnderCA(t, result.Value, caRoot2)
 				// Should not have been delivered before the delay
-				require.True(t, time.Since(earliestRootDelivery) > TestOverrideCAChangeInitialDelay)
+				require.Greater(t, time.Since(earliestRootDelivery), TestOverrideCAChangeInitialDelay)
 				// All good. We are done!
 				rootsDelivered = true
 			} else {
@@ -187,7 +187,7 @@ func TestManager_changingRootsJitterBetweenCalls(t *testing.T) {
 				require.Equal(t, idx, result.Index)
 				requireLeafValidUnderCA(t, result.Value, caRoot)
 				// Sanity check we blocked for the whole timeout
-				require.Truef(t, timeTaken > req.MaxQueryTime,
+				require.Greaterf(t, timeTaken, req.MaxQueryTime,
 					"should block for at least %s, returned after %s",
 					req.MaxQueryTime, timeTaken)
 				// Sanity check that the forceExpireAfter state was set correctly
@@ -248,7 +248,7 @@ func TestManager_changingRootsBetweenBlockingCalls(t *testing.T) {
 		require.NoError(t, result.Err)
 		require.NotNil(t, result.Value)
 		requireLeafValidUnderCA(t, result.Value, caRoot)
-		require.True(t, result.Index > 0)
+		require.Greater(t, result.Index, 0)
 		idx = result.Index
 		issued = result.Value
 	}
@@ -265,7 +265,7 @@ func TestManager_changingRootsBetweenBlockingCalls(t *testing.T) {
 		// Still the initial cached result
 		require.Equal(t, idx, result.Index)
 		// Sanity check that it waited
-		require.True(t, time.Since(start) > req.MaxQueryTime)
+		require.Greater(t, time.Since(start), req.MaxQueryTime)
 	}
 
 	// No active requests, simulate root change now
@@ -282,9 +282,9 @@ func TestManager_changingRootsBetweenBlockingCalls(t *testing.T) {
 		require.NoError(t, result.Err)
 		require.NotEqual(t, issued, result.Value)
 		requireLeafValidUnderCA(t, result.Value, caRoot2)
-		require.True(t, result.Index > idx)
+		require.Greater(t, result.Index, idx)
 		// Sanity check that we didn't wait too long
-		require.True(t, time.Since(earliestRootDelivery) < req.MaxQueryTime)
+		require.Less(t, time.Since(earliestRootDelivery), req.MaxQueryTime)
 	}
 }
 
@@ -345,7 +345,7 @@ func TestManager_CSRRateLimiting(t *testing.T) {
 	case result := <-getCh:
 		require.NoError(t, result.Err)
 		require.NotNil(t, result.Value)
-		require.True(t, result.Index > 0)
+		require.Greater(t, result.Index, 0)
 		idx = result.Index
 		issued = result.Value
 	}
@@ -369,7 +369,7 @@ func TestManager_CSRRateLimiting(t *testing.T) {
 		// We should block for _at least_ one jitter period since we set that to
 		// 100ms and in test override mode we always pick the max jitter not a
 		// random amount.
-		require.True(t, time.Since(earliestRootDelivery) > 100*time.Millisecond)
+		require.Greater(t, time.Since(earliestRootDelivery), 100*time.Millisecond)
 		require.Equal(t, uint64(2), signer.GetSignCallErrorCount())
 
 		require.NoError(t, result.Err)
@@ -388,7 +388,7 @@ func TestManager_CSRRateLimiting(t *testing.T) {
 		t.Fatal("shouldn't block too long waiting for fetch")
 	case result := <-getCh:
 		// We should block for _at least_ two jitter periods now.
-		require.True(t, time.Since(earliestRootDelivery) > 200*time.Millisecond)
+		require.Greater(t, time.Since(earliestRootDelivery), 200*time.Millisecond)
 		require.Equal(t, uint64(3), signer.GetSignCallErrorCount())
 
 		require.NoError(t, result.Err)
@@ -408,13 +408,13 @@ func TestManager_CSRRateLimiting(t *testing.T) {
 		t.Fatal("shouldn't block too long waiting for fetch")
 	case result := <-getCh:
 		// We should block for _at least_ three jitter periods now.
-		require.True(t, time.Since(earliestRootDelivery) > 300*time.Millisecond)
+		require.Greater(t, time.Since(earliestRootDelivery), 300*time.Millisecond)
 		require.Equal(t, uint64(3), signer.GetSignCallErrorCount())
 
 		require.NoError(t, result.Err)
 		require.NotEqual(t, issued, result.Value)
 		// 3 since the rootCA change used 2
-		require.True(t, result.Index > idx)
+		require.Greater(t, result.Index, idx)
 	}
 }
 
@@ -602,7 +602,7 @@ func TestManager_expiringLeaf(t *testing.T) {
 	case result := <-getCh:
 		require.NoError(t, result.Err)
 		require.NotNil(t, result.Value)
-		require.True(t, result.Index > 0)
+		require.Greater(t, result.Index, 0)
 		idx = result.Index
 		issued = result.Value
 	}
@@ -616,7 +616,7 @@ func TestManager_expiringLeaf(t *testing.T) {
 	case result := <-getCh:
 		require.NoError(t, result.Err)
 		require.NotEqual(t, issued, result.Value)
-		require.True(t, result.Index > idx)
+		require.Greater(t, result.Index, idx)
 		requireLeafValidUnderCA(t, result.Value, caRoot)
 		idx = result.Index
 	}
@@ -654,7 +654,7 @@ func TestManager_DNSSANForService(t *testing.T) {
 	pemBlock, _ := pem.Decode([]byte(caReq.CSR))
 	csr, err := x509.ParseCertificateRequest(pemBlock.Bytes)
 	require.NoError(t, err)
-	require.Equal(t, csr.DNSNames, []string{"test.example.com"})
+	require.Equal(t, []string{"test.example.com"}, csr.DNSNames)
 }
 
 func TestManager_workflow_good(t *testing.T) {
@@ -689,7 +689,7 @@ func TestManager_workflow_good(t *testing.T) {
 	requireLeafValidUnderCA(t, issued, ca1)
 
 	// Verify blocking index
-	require.True(t, issued.ModifyIndex > 0)
+	require.Greater(t, issued.ModifyIndex, 0)
 	require.Equal(t, issued.ModifyIndex, meta.Index)
 
 	index := meta.Index
@@ -838,7 +838,7 @@ func TestManager_workflow_goodNotLocal(t *testing.T) {
 	requireLeafValidUnderCA(t, issued, ca1)
 
 	// Verify blocking index
-	require.True(t, issued.ModifyIndex > 0)
+	require.Greater(t, issued.ModifyIndex, 0)
 	require.Equal(t, issued.ModifyIndex, meta.Index)
 
 	// Fetch it again

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -2091,7 +2091,7 @@ func loadRuntimeConfig(t *testing.T, hcl string) *config.RuntimeConfig {
 	t.Helper()
 	result, err := config.Load(config.LoadOpts{HCL: []string{hcl}})
 	require.NoError(t, err)
-	require.Len(t, result.Warnings, 0)
+	require.Empty(t, result.Warnings)
 	return result.RuntimeConfig
 }
 

--- a/agent/nodeid_test.go
+++ b/agent/nodeid_test.go
@@ -38,7 +38,7 @@ func TestNewNodeIDFromConfig(t *testing.T) {
 	t.Run("running again should get the NodeID that was persisted to disk", func(t *testing.T) {
 		nodeID, err := newNodeIDFromConfig(cfg, logger)
 		require.NoError(t, err)
-		require.NotEqual(t, nodeID, "")
+		require.NotEqual(t, "", nodeID)
 		require.Equal(t, nodeID, randomNodeID)
 	})
 
@@ -78,7 +78,7 @@ func TestNewNodeIDFromConfig(t *testing.T) {
 
 		nodeID, err := newNodeIDFromConfig(cfg, logger)
 		require.NoError(t, err)
-		require.Equal(t, string(nodeID), "adf4238a-882b-9ddc-4a9d-5b6758e4159e")
+		require.Equal(t, "adf4238a-882b-9ddc-4a9d-5b6758e4159e", string(nodeID))
 	})
 }
 

--- a/agent/peering_endpoint_test.go
+++ b/agent/peering_endpoint_test.go
@@ -576,8 +576,8 @@ func TestHTTP_Peering_Read(t *testing.T) {
 		require.Equal(t, foo.Peering.Name, apiResp.Name)
 		require.Equal(t, foo.Peering.Meta, apiResp.Meta)
 
-		require.Equal(t, 0, len(apiResp.StreamStatus.ImportedServices))
-		require.Equal(t, 0, len(apiResp.StreamStatus.ExportedServices))
+		require.Empty(t, apiResp.StreamStatus.ImportedServices)
+		require.Empty(t, apiResp.StreamStatus.ExportedServices)
 	})
 
 	t.Run("not found", func(t *testing.T) {
@@ -712,8 +712,8 @@ func TestHTTP_Peering_List(t *testing.T) {
 		require.Len(t, apiResp, 2)
 
 		for _, p := range apiResp {
-			require.Equal(t, 0, len(p.StreamStatus.ImportedServices))
-			require.Equal(t, 0, len(p.StreamStatus.ExportedServices))
+			require.Empty(t, p.StreamStatus.ImportedServices)
+			require.Empty(t, p.StreamStatus.ExportedServices)
 		}
 	})
 }

--- a/agent/proxycfg-glue/health_blocking_test.go
+++ b/agent/proxycfg-glue/health_blocking_test.go
@@ -116,7 +116,7 @@ func TestServerHealthBlocking(t *testing.T) {
 			result := getEventResult[*structs.IndexedCheckServiceNodes](t, eventCh)
 			require.Len(t, result.Nodes, 1)
 			result = getEventResult[*structs.IndexedCheckServiceNodes](t, filteredCh)
-			require.Len(t, result.Nodes, 0)
+			require.Empty(t, result.Nodes)
 		})
 
 		testutil.RunStep(t, "acl enforcement", func(t *testing.T) {
@@ -172,7 +172,7 @@ func TestServerHealthBlocking(t *testing.T) {
 			aclResolver.SwapAuthorizer(authzDeny)
 			time.Sleep(dataSource.watchTimeout)
 			result = getEventResult[*structs.IndexedCheckServiceNodes](t, aclAllowCh)
-			require.Len(t, result.Nodes, 0)
+			require.Empty(t, result.Nodes)
 
 			// Adding ACL permissions will send valid data
 			aclResolver.SwapAuthorizer(authzAllow)

--- a/agent/proxycfg-glue/intention_upstreams_test.go
+++ b/agent/proxycfg-glue/intention_upstreams_test.go
@@ -73,7 +73,7 @@ func TestServerIntentionUpstreams(t *testing.T) {
 	require.NoError(t, err)
 
 	result := getEventResult[*structs.IndexedServiceList](t, ch)
-	require.Len(t, result.Services, 0)
+	require.Empty(t, result.Services)
 
 	// Create an allow intention for the db service. This should *not* be filtered
 	// out because the ACL token *does* have read access on it.

--- a/agent/proxycfg-glue/intentions_test.go
+++ b/agent/proxycfg-glue/intentions_test.go
@@ -68,8 +68,8 @@ func TestServerIntentions(t *testing.T) {
 		require.Len(t, result, 1)
 
 		intention := result[0]
-		require.Equal(t, intention.DestinationName, serviceName)
-		require.Equal(t, intention.SourceName, "db")
+		require.Equal(t, serviceName, intention.DestinationName)
+		require.Equal(t, "db", intention.SourceName)
 	})
 
 	testutil.RunStep(t, "updating an intention", func(t *testing.T) {
@@ -92,7 +92,7 @@ func TestServerIntentions(t *testing.T) {
 
 		for i, src := range []string{"api", "db"} {
 			intention := result[i]
-			require.Equal(t, intention.DestinationName, serviceName)
+			require.Equal(t, serviceName, intention.DestinationName)
 			require.Equal(t, intention.SourceName, src)
 		}
 	})
@@ -101,7 +101,7 @@ func TestServerIntentions(t *testing.T) {
 		require.NoError(t, store.DeleteConfigEntry(nextIndex(), structs.ServiceIntentions, serviceName, nil))
 
 		result := getEventResult[structs.SimplifiedIntentions](t, eventCh)
-		require.Len(t, result, 0)
+		require.Empty(t, result)
 	})
 }
 
@@ -149,7 +149,7 @@ func TestServerIntentions_ACLDeny(t *testing.T) {
 
 	testutil.RunStep(t, "initial snapshot", func(t *testing.T) {
 		result := getEventResult[structs.SimplifiedIntentions](t, eventCh)
-		require.Len(t, result, 0)
+		require.Empty(t, result)
 	})
 }
 

--- a/agent/proxycfg-glue/trust_bundle_test.go
+++ b/agent/proxycfg-glue/trust_bundle_test.go
@@ -197,7 +197,7 @@ func TestServerTrustBundleList(t *testing.T) {
 			}))
 
 			result := getEventResult[*pbpeering.TrustBundleListByServiceResponse](t, eventCh)
-			require.Len(t, result.Bundles, 0)
+			require.Empty(t, result.Bundles)
 		})
 	})
 

--- a/agent/proxycfg/internal/watch/watchmap_test.go
+++ b/agent/proxycfg/internal/watch/watchmap_test.go
@@ -133,7 +133,7 @@ func TestMap_ForEachE(t *testing.T) {
 			return nil
 		})
 		require.Equal(t, 3, count)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	// returning an error should exit immediately

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -393,7 +393,7 @@ func testManager_BasicLifecycle(
 	// coalesce timeout
 	start := time.Now()
 	assertWatchChanRecvs(t, wCh, expectSnap)
-	require.True(t, time.Since(start) >= coalesceTimeout)
+	require.GreaterOrEqual(t, time.Since(start), coalesceTimeout)
 
 	assertLastReqArgs(t, dataSources, "my-token", source)
 
@@ -467,8 +467,8 @@ func testManager_BasicLifecycle(
 	// Sanity check the state is clean
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	require.Len(t, m.proxies, 0)
-	require.Len(t, m.watchers, 0)
+	require.Empty(t, m.proxies)
+	require.Empty(t, m.watchers)
 }
 
 func assertWatchChanBlocks(t *testing.T, ch <-chan proxysnapshot.ProxySnapshot) {

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -314,7 +314,7 @@ func genVerifyPreparedQueryWatch(expectedName string, expectedDatacenter string)
 		require.Equal(t, aclToken, reqReal.Token)
 		require.Equal(t, expectedDatacenter, reqReal.Datacenter)
 		require.Equal(t, expectedName, reqReal.QueryIDOrName)
-		require.Equal(t, true, reqReal.Connect)
+		require.True(t, reqReal.Connect)
 	}
 }
 
@@ -771,8 +771,8 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				require.Len(t, snap.ConnectProxy.WatchedGateways, 6, "%+v", snap.ConnectProxy.WatchedGateways)
 				require.Len(t, snap.ConnectProxy.WatchedGatewayEndpoints, 6, "%+v", snap.ConnectProxy.WatchedGatewayEndpoints)
 
-				require.Len(t, snap.ConnectProxy.WatchedServiceChecks, 0, "%+v", snap.ConnectProxy.WatchedServiceChecks)
-				require.Len(t, snap.ConnectProxy.PreparedQueryEndpoints, 0, "%+v", snap.ConnectProxy.PreparedQueryEndpoints)
+				require.Empty(t, snap.ConnectProxy.WatchedServiceChecks, "%+v", snap.ConnectProxy.WatchedServiceChecks)
+				require.Empty(t, snap.ConnectProxy.PreparedQueryEndpoints, "%+v", snap.ConnectProxy.PreparedQueryEndpoints)
 
 				require.Equal(t, 1, snap.ConnectProxy.ConfigSnapshotUpstreams.PeerUpstreamEndpoints.Len())
 				require.Equal(t, 1, snap.ConnectProxy.ConfigSnapshotUpstreams.UpstreamPeerTrustBundles.Len())
@@ -811,8 +811,8 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				require.Len(t, snap.ConnectProxy.WatchedGateways, 6, "%+v", snap.ConnectProxy.WatchedGateways)
 				require.Len(t, snap.ConnectProxy.WatchedGatewayEndpoints, 6, "%+v", snap.ConnectProxy.WatchedGatewayEndpoints)
 
-				require.Len(t, snap.ConnectProxy.WatchedServiceChecks, 0, "%+v", snap.ConnectProxy.WatchedServiceChecks)
-				require.Len(t, snap.ConnectProxy.PreparedQueryEndpoints, 0, "%+v", snap.ConnectProxy.PreparedQueryEndpoints)
+				require.Empty(t, snap.ConnectProxy.WatchedServiceChecks, "%+v", snap.ConnectProxy.WatchedServiceChecks)
+				require.Empty(t, snap.ConnectProxy.PreparedQueryEndpoints, "%+v", snap.ConnectProxy.PreparedQueryEndpoints)
 
 				require.Equal(t, 1, snap.ConnectProxy.ConfigSnapshotUpstreams.PeerUpstreamEndpoints.Len())
 				require.Equal(t, 1, snap.ConnectProxy.ConfigSnapshotUpstreams.UpstreamPeerTrustBundles.Len())
@@ -1063,8 +1063,8 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				require.Len(t, snap.ConnectProxy.WatchedGateways, 4, "%+v", snap.ConnectProxy.WatchedGateways)
 				require.Len(t, snap.ConnectProxy.WatchedGatewayEndpoints, 4, "%+v", snap.ConnectProxy.WatchedGatewayEndpoints)
 
-				require.Len(t, snap.ConnectProxy.WatchedServiceChecks, 0, "%+v", snap.ConnectProxy.WatchedServiceChecks)
-				require.Len(t, snap.ConnectProxy.PreparedQueryEndpoints, 0, "%+v", snap.ConnectProxy.PreparedQueryEndpoints)
+				require.Empty(t, snap.ConnectProxy.WatchedServiceChecks, "%+v", snap.ConnectProxy.WatchedServiceChecks)
+				require.Empty(t, snap.ConnectProxy.PreparedQueryEndpoints, "%+v", snap.ConnectProxy.PreparedQueryEndpoints)
 
 				require.Equal(t, 1, snap.ConnectProxy.ConfigSnapshotUpstreams.PeerUpstreamEndpoints.Len())
 				require.Equal(t, 1, snap.ConnectProxy.ConfigSnapshotUpstreams.UpstreamPeerTrustBundles.Len())
@@ -1096,8 +1096,8 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				require.Len(t, snap.ConnectProxy.WatchedGateways, 4, "%+v", snap.ConnectProxy.WatchedGateways)
 				require.Len(t, snap.ConnectProxy.WatchedGatewayEndpoints, 4, "%+v", snap.ConnectProxy.WatchedGatewayEndpoints)
 
-				require.Len(t, snap.ConnectProxy.WatchedServiceChecks, 0, "%+v", snap.ConnectProxy.WatchedServiceChecks)
-				require.Len(t, snap.ConnectProxy.PreparedQueryEndpoints, 0, "%+v", snap.ConnectProxy.PreparedQueryEndpoints)
+				require.Empty(t, snap.ConnectProxy.WatchedServiceChecks, "%+v", snap.ConnectProxy.WatchedServiceChecks)
+				require.Empty(t, snap.ConnectProxy.PreparedQueryEndpoints, "%+v", snap.ConnectProxy.PreparedQueryEndpoints)
 
 				require.Equal(t, 1, snap.ConnectProxy.ConfigSnapshotUpstreams.PeerUpstreamEndpoints.Len())
 				require.Equal(t, 1, snap.ConnectProxy.ConfigSnapshotUpstreams.UpstreamPeerTrustBundles.Len())
@@ -1339,7 +1339,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.Len(t, snap.MeshGateway.WatchedPeers, 2)
 						require.Len(t, snap.MeshGateway.WatchedPeeringServices, 2)
 						require.Len(t, snap.MeshGateway.WatchedPeeringServices["peer-a"], 3)
-						require.Len(t, snap.MeshGateway.WatchedPeeringServices["peer-b"], 0)
+						require.Empty(t, snap.MeshGateway.WatchedPeeringServices["peer-b"])
 					},
 				},
 				{
@@ -1741,10 +1741,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.False(t, snap.Valid(), "gateway without leaf is not valid")
 						require.True(t, snap.IngressGateway.HostsSet)
-						require.Len(t, snap.IngressGateway.Hosts, 0)
+						require.Empty(t, snap.IngressGateway.Hosts)
 						require.Len(t, snap.IngressGateway.Upstreams, 1)
 						key := IngressListenerKey{Protocol: "http", Port: 9999}
-						require.Equal(t, snap.IngressGateway.Upstreams[key], structs.Upstreams{
+						require.Equal(t, structs.Upstreams{
 							{
 								DestinationNamespace: "default",
 								DestinationPartition: "default",
@@ -1754,7 +1754,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 									"protocol": "http",
 								},
 							},
-						})
+						}, snap.IngressGateway.Upstreams[key])
 						require.Len(t, snap.IngressGateway.WatchedDiscoveryChains, 1)
 						require.Contains(t, snap.IngressGateway.WatchedDiscoveryChains, apiUID)
 					},
@@ -1831,19 +1831,18 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.Contains(t, snap.IngressGateway.WatchedUpstreamEndpoints, apiUID)
 						require.Len(t, snap.IngressGateway.WatchedUpstreamEndpoints[apiUID], 1)
 						require.Contains(t, snap.IngressGateway.WatchedUpstreamEndpoints[apiUID], "api.default.default.dc1")
-						require.Equal(t, snap.IngressGateway.WatchedUpstreamEndpoints[apiUID]["api.default.default.dc1"],
-							structs.CheckServiceNodes{
-								{
-									Node: &structs.Node{
-										Node:    "node1",
-										Address: "127.0.0.1",
-									},
-									Service: &structs.NodeService{
-										ID:      "api1",
-										Service: "api",
-									},
+						require.Equal(t, structs.CheckServiceNodes{
+							{
+								Node: &structs.Node{
+									Node:    "node1",
+									Address: "127.0.0.1",
+								},
+								Service: &structs.NodeService{
+									ID:      "api1",
+									Service: "api",
 								},
 							},
+						}, snap.IngressGateway.WatchedUpstreamEndpoints[apiUID]["api.default.default.dc1"],
 						)
 					},
 				},
@@ -1922,8 +1921,8 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid())
-						require.Len(t, snap.IngressGateway.Upstreams, 0)
-						require.Len(t, snap.IngressGateway.WatchedDiscoveryChains, 0)
+						require.Empty(t, snap.IngressGateway.Upstreams)
+						require.Empty(t, snap.IngressGateway.WatchedDiscoveryChains)
 						require.NotContains(t, snap.IngressGateway.WatchedDiscoveryChains, "api")
 					},
 				},
@@ -2015,8 +2014,8 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid())
-						require.Len(t, snap.IngressGateway.Upstreams, 0)
-						require.Len(t, snap.IngressGateway.WatchedDiscoveryChains, 0)
+						require.Empty(t, snap.IngressGateway.Upstreams)
+						require.Empty(t, snap.IngressGateway.WatchedDiscoveryChains)
 						require.NotContains(t, snap.IngressGateway.WatchedDiscoveryChains, "api")
 					},
 				},
@@ -2100,7 +2099,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "gateway with service list is valid")
-						require.Len(t, snap.TerminatingGateway.ValidServices(), 0)
+						require.Empty(t, snap.TerminatingGateway.ValidServices())
 
 						require.Len(t, snap.TerminatingGateway.WatchedServices, 1)
 						require.Contains(t, snap.TerminatingGateway.WatchedServices, db)
@@ -2131,7 +2130,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "gateway with service list is valid")
-						require.Len(t, snap.TerminatingGateway.ValidServices(), 0)
+						require.Empty(t, snap.TerminatingGateway.ValidServices())
 
 						require.Len(t, snap.TerminatingGateway.WatchedServices, 3)
 						require.Contains(t, snap.TerminatingGateway.WatchedServices, db)
@@ -2190,22 +2189,21 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "gateway with service list is valid")
-						require.Len(t, snap.TerminatingGateway.ValidServices(), 0)
+						require.Empty(t, snap.TerminatingGateway.ValidServices())
 
 						require.Len(t, snap.TerminatingGateway.ServiceGroups, 1)
-						require.Equal(t, snap.TerminatingGateway.ServiceGroups[db],
-							structs.CheckServiceNodes{
-								{
-									Node: &structs.Node{
-										Node:    "node1",
-										Address: "127.0.0.1",
-									},
-									Service: &structs.NodeService{
-										ID:      "db",
-										Service: "db",
-									},
+						require.Equal(t, structs.CheckServiceNodes{
+							{
+								Node: &structs.Node{
+									Node:    "node1",
+									Address: "127.0.0.1",
+								},
+								Service: &structs.NodeService{
+									ID:      "db",
+									Service: "db",
 								},
 							},
+						}, snap.TerminatingGateway.ServiceGroups[db],
 						)
 					},
 				},
@@ -2258,7 +2256,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "gateway with service list is valid")
-						require.Len(t, snap.TerminatingGateway.ValidServices(), 0)
+						require.Empty(t, snap.TerminatingGateway.ValidServices())
 
 						require.Len(t, snap.TerminatingGateway.ServiceGroups, 2)
 						expect := structs.CheckServiceNodes{
@@ -2315,7 +2313,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "gateway with service list is valid")
-						require.Len(t, snap.TerminatingGateway.ValidServices(), 0)
+						require.Empty(t, snap.TerminatingGateway.ValidServices())
 
 						require.Equal(t, snap.TerminatingGateway.ServiceLeaves[db], issuedCert)
 					},
@@ -2333,7 +2331,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "gateway with service list is valid")
-						require.Len(t, snap.TerminatingGateway.ValidServices(), 0)
+						require.Empty(t, snap.TerminatingGateway.ValidServices())
 
 						require.Len(t, snap.TerminatingGateway.Intentions, 1)
 						dbIxn, ok := snap.TerminatingGateway.Intentions[db]
@@ -2354,7 +2352,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "gateway with service list is valid")
-						require.Len(t, snap.TerminatingGateway.ValidServices(), 0)
+						require.Empty(t, snap.TerminatingGateway.ValidServices())
 
 						require.Len(t, snap.TerminatingGateway.ServiceConfigs, 1)
 						require.Equal(t, snap.TerminatingGateway.ServiceConfigs[db], dbConfig)
@@ -2422,7 +2420,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "gateway with service list is valid")
-						require.Len(t, snap.TerminatingGateway.ValidServices(), 0)
+						require.Empty(t, snap.TerminatingGateway.ValidServices())
 
 						// All the watches should have been cancelled for db
 						require.Len(t, snap.TerminatingGateway.WatchedServices, 1)
@@ -2441,10 +2439,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.Contains(t, snap.TerminatingGateway.GatewayServices, billing)
 
 						// There was no update event for billing's leaf/endpoints/resolvers, so length is 0
-						require.Len(t, snap.TerminatingGateway.ServiceGroups, 0)
-						require.Len(t, snap.TerminatingGateway.ServiceLeaves, 0)
-						require.Len(t, snap.TerminatingGateway.ServiceResolvers, 0)
-						require.Len(t, snap.TerminatingGateway.HostnameServices, 0)
+						require.Empty(t, snap.TerminatingGateway.ServiceGroups)
+						require.Empty(t, snap.TerminatingGateway.ServiceLeaves)
+						require.Empty(t, snap.TerminatingGateway.ServiceResolvers)
+						require.Empty(t, snap.TerminatingGateway.HostnameServices)
 					},
 				},
 			},
@@ -2648,7 +2646,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.True(t, ok)
 
 						// Upstream config should have been inherited from defaults under wildcard key
-						require.Equal(t, cfg.Config["connect_timeout_ms"], 6000)
+						require.Equal(t, 6000, cfg.Config["connect_timeout_ms"])
 					},
 				},
 				// Discovery chain updates should be stored
@@ -2756,69 +2754,68 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.Contains(t, snap.ConnectProxy.WatchedUpstreamEndpoints, dbUID)
 						require.Len(t, snap.ConnectProxy.WatchedUpstreamEndpoints[dbUID], 1)
 						require.Contains(t, snap.ConnectProxy.WatchedUpstreamEndpoints[dbUID], "db.default.default.dc1")
-						require.Equal(t, snap.ConnectProxy.WatchedUpstreamEndpoints[dbUID]["db.default.default.dc1"],
-							structs.CheckServiceNodes{
-								{
-									Node: &structs.Node{
-										Datacenter: "dc1",
-										Node:       "node1",
-										Address:    "10.0.0.1",
+						require.Equal(t, structs.CheckServiceNodes{
+							{
+								Node: &structs.Node{
+									Datacenter: "dc1",
+									Node:       "node1",
+									Address:    "10.0.0.1",
+								},
+								Service: &structs.NodeService{
+									Kind:    structs.ServiceKindConnectProxy,
+									ID:      "db-sidecar-proxy",
+									Service: "db-sidecar-proxy",
+									Address: "10.10.10.10",
+									TaggedAddresses: map[string]structs.ServiceAddress{
+										structs.TaggedAddressWAN:     {Address: "17.5.7.8"},
+										structs.TaggedAddressWANIPv6: {Address: "2607:f0d0:1002:51::4"},
 									},
-									Service: &structs.NodeService{
-										Kind:    structs.ServiceKindConnectProxy,
-										ID:      "db-sidecar-proxy",
-										Service: "db-sidecar-proxy",
-										Address: "10.10.10.10",
-										TaggedAddresses: map[string]structs.ServiceAddress{
-											structs.TaggedAddressWAN:     {Address: "17.5.7.8"},
-											structs.TaggedAddressWANIPv6: {Address: "2607:f0d0:1002:51::4"},
+									Proxy: structs.ConnectProxyConfig{
+										DestinationServiceName: "db",
+										TransparentProxy: structs.TransparentProxyConfig{
+											DialedDirectly: false,
 										},
-										Proxy: structs.ConnectProxyConfig{
-											DestinationServiceName: "db",
-											TransparentProxy: structs.TransparentProxyConfig{
-												DialedDirectly: false,
-											},
-										},
-										RaftIndex: structs.RaftIndex{
-											ModifyIndex: 12,
-										},
+									},
+									RaftIndex: structs.RaftIndex{
+										ModifyIndex: 12,
 									},
 								},
-								{
-									Node: &structs.Node{
-										Datacenter: "dc1",
-										Node:       "node2",
-										Address:    "10.0.0.2",
-										RaftIndex: structs.RaftIndex{
-											ModifyIndex: 21,
-										},
+							},
+							{
+								Node: &structs.Node{
+									Datacenter: "dc1",
+									Node:       "node2",
+									Address:    "10.0.0.2",
+									RaftIndex: structs.RaftIndex{
+										ModifyIndex: 21,
 									},
-									Service: &structs.NodeService{
-										Kind:    structs.ServiceKindConnectProxy,
-										ID:      "db-sidecar-proxy2",
-										Service: "db-sidecar-proxy",
-										Proxy: structs.ConnectProxyConfig{
-											DestinationServiceName: "db",
-											TransparentProxy: structs.TransparentProxyConfig{
-												DialedDirectly: true,
-											},
+								},
+								Service: &structs.NodeService{
+									Kind:    structs.ServiceKindConnectProxy,
+									ID:      "db-sidecar-proxy2",
+									Service: "db-sidecar-proxy",
+									Proxy: structs.ConnectProxyConfig{
+										DestinationServiceName: "db",
+										TransparentProxy: structs.TransparentProxyConfig{
+											DialedDirectly: true,
 										},
 									},
 								},
 							},
+						}, snap.ConnectProxy.WatchedUpstreamEndpoints[dbUID]["db.default.default.dc1"],
 						)
 						// The LAN service address is used below because transparent proxying
 						// does not support querying service nodes in other DCs, and the WAN address
 						// should not be used in DC-local calls.
-						require.Equal(t, snap.ConnectProxy.PassthroughUpstreams, map[UpstreamID]map[string]map[string]struct{}{
+						require.Equal(t, map[UpstreamID]map[string]map[string]struct{}{
 							dbUID: {
 								"db.default.default.dc1": map[string]struct{}{
 									"10.10.10.10": {},
 									"10.0.0.2":    {},
 								},
 							},
-						})
-						require.Equal(t, snap.ConnectProxy.PassthroughIndices, map[string]indexedTarget{
+						}, snap.ConnectProxy.PassthroughUpstreams)
+						require.Equal(t, map[string]indexedTarget{
 							"10.0.0.2": {
 								upstreamID: dbUID,
 								targetID:   "db.default.default.dc1",
@@ -2829,7 +2826,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 								targetID:   "db.default.default.dc1",
 								idx:        12,
 							},
-						})
+						}, snap.ConnectProxy.PassthroughIndices)
 					},
 				},
 				// Discovery chain updates should be stored
@@ -2914,45 +2911,44 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.Contains(t, snap.ConnectProxy.WatchedUpstreamEndpoints[dbUID], "db.default.default.dc1")
 
 						// THe endpoint and passthrough address for proxy1 should be gone.
-						require.Equal(t, snap.ConnectProxy.WatchedUpstreamEndpoints[dbUID]["db.default.default.dc1"],
-							structs.CheckServiceNodes{
-								{
-									Node: &structs.Node{
-										Datacenter: "dc1",
-										Node:       "node2",
-										Address:    "10.0.0.2",
-										RaftIndex: structs.RaftIndex{
-											ModifyIndex: 21,
-										},
+						require.Equal(t, structs.CheckServiceNodes{
+							{
+								Node: &structs.Node{
+									Datacenter: "dc1",
+									Node:       "node2",
+									Address:    "10.0.0.2",
+									RaftIndex: structs.RaftIndex{
+										ModifyIndex: 21,
 									},
-									Service: &structs.NodeService{
-										Kind:    structs.ServiceKindConnectProxy,
-										ID:      "db-sidecar-proxy2",
-										Service: "db-sidecar-proxy",
-										Proxy: structs.ConnectProxyConfig{
-											DestinationServiceName: "db",
-											TransparentProxy: structs.TransparentProxyConfig{
-												DialedDirectly: true,
-											},
+								},
+								Service: &structs.NodeService{
+									Kind:    structs.ServiceKindConnectProxy,
+									ID:      "db-sidecar-proxy2",
+									Service: "db-sidecar-proxy",
+									Proxy: structs.ConnectProxyConfig{
+										DestinationServiceName: "db",
+										TransparentProxy: structs.TransparentProxyConfig{
+											DialedDirectly: true,
 										},
 									},
 								},
 							},
+						}, snap.ConnectProxy.WatchedUpstreamEndpoints[dbUID]["db.default.default.dc1"],
 						)
-						require.Equal(t, snap.ConnectProxy.PassthroughUpstreams, map[UpstreamID]map[string]map[string]struct{}{
+						require.Equal(t, map[UpstreamID]map[string]map[string]struct{}{
 							dbUID: {
 								"db.default.default.dc1": map[string]struct{}{
 									"10.0.0.2": {},
 								},
 							},
-						})
-						require.Equal(t, snap.ConnectProxy.PassthroughIndices, map[string]indexedTarget{
+						}, snap.ConnectProxy.PassthroughUpstreams)
+						require.Equal(t, map[string]indexedTarget{
 							"10.0.0.2": {
 								upstreamID: dbUID,
 								targetID:   "db.default.default.dc1",
 								idx:        21,
 							},
-						})
+						}, snap.ConnectProxy.PassthroughIndices)
 					},
 				},
 				{
@@ -2995,46 +2991,45 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.Contains(t, snap.ConnectProxy.WatchedUpstreamEndpoints[apiUID], "api.default.default.dc1")
 
 						// THe endpoint and passthrough address for proxy1 should be gone.
-						require.Equal(t, snap.ConnectProxy.WatchedUpstreamEndpoints[apiUID]["api.default.default.dc1"],
-							structs.CheckServiceNodes{
-								{
-									Node: &structs.Node{
-										Datacenter: "dc1",
-										Node:       "node2",
+						require.Equal(t, structs.CheckServiceNodes{
+							{
+								Node: &structs.Node{
+									Datacenter: "dc1",
+									Node:       "node2",
+								},
+								Service: &structs.NodeService{
+									Kind:    structs.ServiceKindConnectProxy,
+									ID:      "api-sidecar-proxy",
+									Service: "api-sidecar-proxy",
+									Address: "10.0.0.2",
+									Proxy: structs.ConnectProxyConfig{
+										DestinationServiceName: "api",
+										TransparentProxy: structs.TransparentProxyConfig{
+											DialedDirectly: true,
+										},
 									},
-									Service: &structs.NodeService{
-										Kind:    structs.ServiceKindConnectProxy,
-										ID:      "api-sidecar-proxy",
-										Service: "api-sidecar-proxy",
-										Address: "10.0.0.2",
-										Proxy: structs.ConnectProxyConfig{
-											DestinationServiceName: "api",
-											TransparentProxy: structs.TransparentProxyConfig{
-												DialedDirectly: true,
-											},
-										},
-										RaftIndex: structs.RaftIndex{
-											ModifyIndex: 32,
-										},
+									RaftIndex: structs.RaftIndex{
+										ModifyIndex: 32,
 									},
 								},
 							},
+						}, snap.ConnectProxy.WatchedUpstreamEndpoints[apiUID]["api.default.default.dc1"],
 						)
-						require.Equal(t, snap.ConnectProxy.PassthroughUpstreams, map[UpstreamID]map[string]map[string]struct{}{
+						require.Equal(t, map[UpstreamID]map[string]map[string]struct{}{
 							apiUID: {
-								// This target has a higher index so the old passthrough address should be discarded.
+
 								"api.default.default.dc1": map[string]struct{}{
 									"10.0.0.2": {},
 								},
 							},
-						})
-						require.Equal(t, snap.ConnectProxy.PassthroughIndices, map[string]indexedTarget{
+						}, snap.ConnectProxy.PassthroughUpstreams)
+						require.Equal(t, map[string]indexedTarget{
 							"10.0.0.2": {
 								upstreamID: apiUID,
 								targetID:   "api.default.default.dc1",
 								idx:        32,
 							},
-						})
+						}, snap.ConnectProxy.PassthroughIndices)
 					},
 				},
 				{
@@ -3776,12 +3771,12 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.False(t, snap.Valid(), "should not be valid")
 						require.True(t, snap.MeshGateway.isEmpty())
 
-						require.Len(t, snap.ConnectProxy.DiscoveryChain, 0, "%+v", snap.ConnectProxy.DiscoveryChain)
-						require.Len(t, snap.ConnectProxy.WatchedDiscoveryChains, 0, "%+v", snap.ConnectProxy.WatchedDiscoveryChains)
-						require.Len(t, snap.ConnectProxy.WatchedUpstreams, 0, "%+v", snap.ConnectProxy.WatchedUpstreams)
-						require.Len(t, snap.ConnectProxy.WatchedUpstreamEndpoints, 0, "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
-						require.Len(t, snap.ConnectProxy.WatchedGateways, 0, "%+v", snap.ConnectProxy.WatchedGateways)
-						require.Len(t, snap.ConnectProxy.WatchedGatewayEndpoints, 0, "%+v", snap.ConnectProxy.WatchedGatewayEndpoints)
+						require.Empty(t, snap.ConnectProxy.DiscoveryChain, "%+v", snap.ConnectProxy.DiscoveryChain)
+						require.Empty(t, snap.ConnectProxy.WatchedDiscoveryChains, "%+v", snap.ConnectProxy.WatchedDiscoveryChains)
+						require.Empty(t, snap.ConnectProxy.WatchedUpstreams, "%+v", snap.ConnectProxy.WatchedUpstreams)
+						require.Empty(t, snap.ConnectProxy.WatchedUpstreamEndpoints, "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
+						require.Empty(t, snap.ConnectProxy.WatchedGateways, "%+v", snap.ConnectProxy.WatchedGateways)
+						require.Empty(t, snap.ConnectProxy.WatchedGatewayEndpoints, "%+v", snap.ConnectProxy.WatchedGatewayEndpoints)
 
 						// watch initialized
 						require.True(t, snap.ConnectProxy.UpstreamPeerTrustBundles.IsWatched("peer-a"))
@@ -3798,9 +3793,9 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						_, ok = snap.ConnectProxy.WatchedLocalGWEndpoints.Get("dc1")
 						require.False(t, ok)
 
-						require.Len(t, snap.ConnectProxy.WatchedServiceChecks, 0, "%+v", snap.ConnectProxy.WatchedServiceChecks)
-						require.Len(t, snap.ConnectProxy.PreparedQueryEndpoints, 0, "%+v", snap.ConnectProxy.PreparedQueryEndpoints)
-						require.Len(t, snap.ConnectProxy.InboundPeerTrustBundles, 0, "%+v", snap.ConnectProxy.InboundPeerTrustBundles)
+						require.Empty(t, snap.ConnectProxy.WatchedServiceChecks, "%+v", snap.ConnectProxy.WatchedServiceChecks)
+						require.Empty(t, snap.ConnectProxy.PreparedQueryEndpoints, "%+v", snap.ConnectProxy.PreparedQueryEndpoints)
+						require.Empty(t, snap.ConnectProxy.InboundPeerTrustBundles, "%+v", snap.ConnectProxy.InboundPeerTrustBundles)
 						require.False(t, snap.ConnectProxy.InboundPeerTrustBundlesSet)
 					},
 				},
@@ -3947,10 +3942,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.False(t, snap.Valid(), "should not be valid")
 
-						require.Len(t, snap.ConnectProxy.DiscoveryChain, 0, "%+v", snap.ConnectProxy.DiscoveryChain)
-						require.Len(t, snap.ConnectProxy.WatchedDiscoveryChains, 0, "%+v", snap.ConnectProxy.WatchedDiscoveryChains)
-						require.Len(t, snap.ConnectProxy.WatchedUpstreams, 0, "%+v", snap.ConnectProxy.WatchedUpstreams)
-						require.Len(t, snap.ConnectProxy.WatchedUpstreamEndpoints, 0, "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
+						require.Empty(t, snap.ConnectProxy.DiscoveryChain, "%+v", snap.ConnectProxy.DiscoveryChain)
+						require.Empty(t, snap.ConnectProxy.WatchedDiscoveryChains, "%+v", snap.ConnectProxy.WatchedDiscoveryChains)
+						require.Empty(t, snap.ConnectProxy.WatchedUpstreams, "%+v", snap.ConnectProxy.WatchedUpstreams)
+						require.Empty(t, snap.ConnectProxy.WatchedUpstreamEndpoints, "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
 					},
 				},
 				{
@@ -4010,7 +4005,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.Equal(t, &expectUpstream, snap.ConnectProxy.UpstreamConfig[uid])
 
 						// No endpoints have arrived yet.
-						require.Len(t, snap.ConnectProxy.WatchedUpstreamEndpoints[telemetryCollectorUID], 0, "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
+						require.Empty(t, snap.ConnectProxy.WatchedUpstreamEndpoints[telemetryCollectorUID], "%+v", snap.ConnectProxy.WatchedUpstreamEndpoints)
 					},
 				},
 				{

--- a/agent/rpc/middleware/interceptors_test.go
+++ b/agent/rpc/middleware/interceptors_test.go
@@ -269,7 +269,7 @@ func TestRequestRecorder(t *testing.T) {
 
 			require.Equal(t, o.key, metricRPCRequest)
 			require.LessOrEqual(t, o.elapsed, float32(time.Now().Sub(start).Microseconds())/1000)
-			require.Equal(t, o.labels, tc.expectedLabels)
+			require.Equal(t, tc.expectedLabels, o.labels)
 
 		})
 	}

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -1146,8 +1146,8 @@ func TestPeeringService_List(t *testing.T) {
 		require.NoError(t, err)
 
 		// The query should return after the async change, but before the timeout
-		require.True(t, time.Since(marker) >= 100*time.Millisecond)
-		require.True(t, time.Since(marker) < 1*time.Second)
+		require.GreaterOrEqual(t, time.Since(marker), 100*time.Millisecond)
+		require.Less(t, time.Since(marker), 1*time.Second)
 
 		// Verify query results
 		meta, err := external.QueryMetaFromGRPCMeta(header)
@@ -1299,8 +1299,8 @@ func TestPeeringService_TrustBundleRead(t *testing.T) {
 		require.NoError(t, err)
 
 		// The query should return after the async change, but before the timeout
-		require.True(t, time.Since(marker) >= 100*time.Millisecond)
-		require.True(t, time.Since(marker) < 1*time.Second)
+		require.GreaterOrEqual(t, time.Since(marker), 100*time.Millisecond)
+		require.Less(t, time.Since(marker), 1*time.Second)
 
 		// Verify query results
 		meta, err := external.QueryMetaFromGRPCMeta(header)
@@ -1521,8 +1521,8 @@ func TestPeeringService_TrustBundleListByService(t *testing.T) {
 		require.NoError(t, err)
 
 		// The query should return after the async change, but before the timeout
-		require.True(t, time.Since(marker) >= 100*time.Millisecond)
-		require.True(t, time.Since(marker) < 1*time.Second)
+		require.GreaterOrEqual(t, time.Since(marker), 100*time.Millisecond)
+		require.Less(t, time.Since(marker), 1*time.Second)
 
 		// Verify query results
 		meta, err := external.QueryMetaFromGRPCMeta(header)

--- a/agent/rpcclient/configentry/configentry_test.go
+++ b/agent/rpcclient/configentry/configentry_test.go
@@ -141,8 +141,8 @@ func useRPC(t *testing.T, c *Client, err error) {
 	store, ok := c.ViewStore.(*fakeViewStore)
 	require.True(t, ok, "test setup error, expected *fakeViewSTore, got %T", c.ViewStore)
 
-	require.Len(t, cache.calls, 0)
-	require.Len(t, store.calls, 0)
+	require.Empty(t, cache.calls)
+	require.Empty(t, store.calls)
 	require.Equal(t, []string{"ConfigEntry.Get"}, rpc.calls)
 }
 
@@ -160,8 +160,8 @@ func useStreaming(t *testing.T, c *Client, err error) {
 	store, ok := c.ViewStore.(*fakeViewStore)
 	require.True(t, ok, "test setup error, expected *fakeViewSTore, got %T", c.ViewStore)
 
-	require.Len(t, cache.calls, 0)
-	require.Len(t, rpc.calls, 0)
+	require.Empty(t, cache.calls)
+	require.Empty(t, rpc.calls)
 	require.Len(t, store.calls, 1)
 }
 
@@ -179,8 +179,8 @@ func useCache(t *testing.T, c *Client, err error) {
 	store, ok := c.ViewStore.(*fakeViewStore)
 	require.True(t, ok, "test setup error, expected *fakeViewSTore, got %T", c.ViewStore)
 
-	require.Len(t, rpc.calls, 0)
-	require.Len(t, store.calls, 0)
+	require.Empty(t, rpc.calls)
+	require.Empty(t, store.calls)
 	require.Equal(t, []string{"cache-no-streaming"}, cache.calls)
 }
 

--- a/agent/rpcclient/health/health_test.go
+++ b/agent/rpcclient/health/health_test.go
@@ -119,8 +119,8 @@ func useRPC(t *testing.T, c *Client) {
 	store, ok := c.ViewStore.(*fakeViewStore)
 	require.True(t, ok, "test setup error, expected *fakeViewSTore, got %T", c.ViewStore)
 
-	require.Len(t, cache.calls, 0)
-	require.Len(t, store.calls, 0)
+	require.Empty(t, cache.calls)
+	require.Empty(t, store.calls)
 	require.Equal(t, []string{"Health.ServiceNodes"}, rpc.calls)
 }
 
@@ -136,8 +136,8 @@ func useStreaming(t *testing.T, c *Client) {
 	store, ok := c.ViewStore.(*fakeViewStore)
 	require.True(t, ok, "test setup error, expected *fakeViewSTore, got %T", c.ViewStore)
 
-	require.Len(t, cache.calls, 0)
-	require.Len(t, rpc.calls, 0)
+	require.Empty(t, cache.calls)
+	require.Empty(t, rpc.calls)
 	require.Len(t, store.calls, 1)
 }
 
@@ -153,8 +153,8 @@ func useCache(t *testing.T, c *Client) {
 	store, ok := c.ViewStore.(*fakeViewStore)
 	require.True(t, ok, "test setup error, expected *fakeViewSTore, got %T", c.ViewStore)
 
-	require.Len(t, rpc.calls, 0)
-	require.Len(t, store.calls, 0)
+	require.Empty(t, rpc.calls)
+	require.Empty(t, store.calls)
 	require.Equal(t, []string{"cache-no-streaming"}, cache.calls)
 }
 

--- a/agent/rpcclient/health/view_test.go
+++ b/agent/rpcclient/health/view_test.go
@@ -139,7 +139,7 @@ func testHealthView_IntegrationWithStore_WithEmptySnapshot(t *testing.T, peerNam
 		result, err := store.Get(ctx, req)
 		require.NoError(t, err)
 		elapsed := time.Since(start)
-		require.True(t, elapsed >= 200*time.Millisecond,
+		require.GreaterOrEqual(t, elapsed, 200*time.Millisecond,
 			"Fetch should have blocked until timeout")
 
 		require.Equal(t, req.QueryOptions.MinQueryIndex, result.Index, "result index should not have changed")
@@ -163,9 +163,9 @@ func testHealthView_IntegrationWithStore_WithEmptySnapshot(t *testing.T, peerNam
 		result, err := store.Get(ctx, req)
 		require.NoError(t, err)
 		elapsed := time.Since(start)
-		require.True(t, elapsed >= 200*time.Millisecond,
+		require.GreaterOrEqual(t, elapsed, 200*time.Millisecond,
 			"Fetch should have blocked until the event was delivered")
-		require.True(t, elapsed < time.Second,
+		require.Less(t, elapsed, time.Second,
 			"Fetch should have returned before the timeout")
 
 		require.Equal(t, uint64(4), result.Index, "result index should not have changed")
@@ -189,7 +189,7 @@ func testHealthView_IntegrationWithStore_WithEmptySnapshot(t *testing.T, peerNam
 		result, err := store.Get(ctx, req)
 		require.NoError(t, err)
 		elapsed := time.Since(start)
-		require.True(t, elapsed >= 200*time.Millisecond,
+		require.GreaterOrEqual(t, elapsed, 200*time.Millisecond,
 			"Fetch should have blocked until timeout")
 
 		require.Equal(t, req.QueryOptions.MinQueryIndex, result.Index,
@@ -207,7 +207,7 @@ func testHealthView_IntegrationWithStore_WithEmptySnapshot(t *testing.T, peerNam
 		result, err = store.Get(ctx, req)
 		require.NoError(t, err)
 		elapsed = time.Since(start)
-		require.True(t, elapsed < time.Second,
+		require.Less(t, elapsed, time.Second,
 			"Fetch should have returned before the timeout")
 
 		require.Equal(t, uint64(10), result.Index, "result index should not have changed")
@@ -236,9 +236,9 @@ func testHealthView_IntegrationWithStore_WithEmptySnapshot(t *testing.T, peerNam
 		result, err := store.Get(ctx, req)
 		require.Error(t, err)
 		elapsed := time.Since(start)
-		require.True(t, elapsed >= 200*time.Millisecond,
+		require.GreaterOrEqual(t, elapsed, 200*time.Millisecond,
 			"Fetch should have blocked until error was sent")
-		require.True(t, elapsed < time.Second,
+		require.Less(t, elapsed, time.Second,
 			"Fetch should have returned before the timeout")
 
 		require.Equal(t, req.QueryOptions.MinQueryIndex, result.Index, "result index should not have changed")
@@ -253,7 +253,7 @@ func testHealthView_IntegrationWithStore_WithEmptySnapshot(t *testing.T, peerNam
 		result, err = store.Get(ctx, req)
 		require.NoError(t, err)
 		elapsed = time.Since(start)
-		require.True(t, elapsed < time.Second, "Fetch should have returned before the timeout")
+		require.Less(t, elapsed, time.Second, "Fetch should have returned before the timeout")
 
 		require.Equal(t, req.QueryOptions.MinQueryIndex+5, result.Index, "result index should not have changed")
 		lastResultValue = result.Value.(*structs.IndexedCheckServiceNodes).Nodes
@@ -354,9 +354,9 @@ func testHealthView_IntegrationWithStore_WithFullSnapshot(t *testing.T, peerName
 		result, err := store.Get(ctx, req)
 		require.NoError(t, err)
 		elapsed := time.Since(start)
-		require.True(t, elapsed >= 200*time.Millisecond,
+		require.GreaterOrEqual(t, elapsed, 200*time.Millisecond,
 			"Fetch should have blocked until the event was delivered")
-		require.True(t, elapsed < time.Second,
+		require.Less(t, elapsed, time.Second,
 			"Fetch should have returned before the timeout")
 
 		require.Equal(t, uint64(20), result.Index)
@@ -386,7 +386,7 @@ func testHealthView_IntegrationWithStore_WithFullSnapshot(t *testing.T, peerName
 		result, err := store.Get(ctx, req)
 		require.NoError(t, err)
 		elapsed := time.Since(start)
-		require.True(t, elapsed < time.Second,
+		require.Less(t, elapsed, time.Second,
 			"Fetch should have returned before the timeout")
 
 		require.Equal(t, uint64(50), result.Index)
@@ -413,7 +413,7 @@ func testHealthView_IntegrationWithStore_WithFullSnapshot(t *testing.T, peerName
 		result, err := store.Get(ctx, req)
 		require.NoError(t, err)
 		elapsed := time.Since(start)
-		require.True(t, elapsed < time.Second,
+		require.Less(t, elapsed, time.Second,
 			"Fetch should have returned before the timeout")
 
 		require.Equal(t, uint64(50), result.Index)

--- a/agent/session_endpoint_test.go
+++ b/agent/session_endpoint_test.go
@@ -279,7 +279,7 @@ func TestSessionCreate_DefaultCheck(t *testing.T) {
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.SessionCreate(resp, req)
 		require.NoError(r, err)
-		require.Equal(r, resp.Code, http.StatusOK)
+		require.Equal(r, http.StatusOK, resp.Code)
 
 		want := structs.Session{
 			ID:         obj.(sessionCreateResponse).ID,
@@ -320,7 +320,7 @@ func TestSessionCreate_NoCheck(t *testing.T) {
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.SessionCreate(resp, req)
 			require.NoError(r, err)
-			require.Equal(r, resp.Code, http.StatusOK, resp.Body.String())
+			require.Equal(r, http.StatusOK, resp.Code, resp.Body.String())
 
 			want := structs.Session{
 				ID:         obj.(sessionCreateResponse).ID,
@@ -350,7 +350,7 @@ func TestSessionCreate_NoCheck(t *testing.T) {
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.SessionCreate(resp, req)
 			require.NoError(r, err)
-			require.Equal(r, resp.Code, http.StatusOK)
+			require.Equal(r, http.StatusOK, resp.Code)
 
 			want := structs.Session{
 				ID:         obj.(sessionCreateResponse).ID,
@@ -381,7 +381,7 @@ func TestSessionCreate_NoCheck(t *testing.T) {
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.SessionCreate(resp, req)
 			require.NoError(r, err)
-			require.Equal(r, resp.Code, http.StatusOK)
+			require.Equal(r, http.StatusOK, resp.Code)
 
 			want := structs.Session{
 				ID:         obj.(sessionCreateResponse).ID,
@@ -518,7 +518,7 @@ func TestSessionCustomTTL(t *testing.T) {
 		}
 		respObj, ok = obj.(structs.Sessions)
 		require.True(r, ok, "unexpected type: %T", obj)
-		require.Len(r, respObj, 0)
+		require.Empty(r, respObj)
 	})
 }
 

--- a/agent/structs/acl_cache_test.go
+++ b/agent/structs/acl_cache_test.go
@@ -104,7 +104,7 @@ func TestStructs_ACLCaches(t *testing.T) {
 		entry := cache.GetAuthorizer("foo")
 		require.NotNil(t, entry)
 		require.NotNil(t, entry.Authorizer)
-		require.True(t, entry.Authorizer == acl.DenyAll())
+		require.Equal(t, entry.Authorizer, acl.DenyAll())
 	})
 
 	t.Run("Roles", func(t *testing.T) {

--- a/agent/structs/acl_templated_policy_test.go
+++ b/agent/structs/acl_templated_policy_test.go
@@ -97,7 +97,7 @@ func TestDeduplicate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			policies := tcase.templatedPolicies.Deduplicate()
 
-			require.Equal(t, tcase.expectedCount, len(policies))
+			require.Len(t, policies, tcase.expectedCount)
 		})
 	}
 }

--- a/agent/structs/acl_test.go
+++ b/agent/structs/acl_test.go
@@ -43,7 +43,7 @@ func TestStructs_ACLToken_PolicyIDs(t *testing.T) {
 		token := &ACLToken{}
 
 		policyIDs := token.PolicyIDs()
-		require.Len(t, policyIDs, 0)
+		require.Empty(t, policyIDs)
 	})
 }
 
@@ -238,10 +238,10 @@ func TestStructs_ACLTokens_Sort(t *testing.T) {
 	}
 
 	tokens.Sort()
-	require.Equal(t, tokens[0].AccessorID, "614a4cef-9149-4271-b878-7edb1ad661f8")
-	require.Equal(t, tokens[1].AccessorID, "6bd01084-1695-43b8-898d-b2dd7874754d")
-	require.Equal(t, tokens[2].AccessorID, "9db509a9-c809-48c1-895d-99f845b7a9d5")
-	require.Equal(t, tokens[3].AccessorID, "c9dd9980-8d54-472f-9e5e-74c02143e1f4")
+	require.Equal(t, "614a4cef-9149-4271-b878-7edb1ad661f8", tokens[0].AccessorID)
+	require.Equal(t, "6bd01084-1695-43b8-898d-b2dd7874754d", tokens[1].AccessorID)
+	require.Equal(t, "9db509a9-c809-48c1-895d-99f845b7a9d5", tokens[2].AccessorID)
+	require.Equal(t, "c9dd9980-8d54-472f-9e5e-74c02143e1f4", tokens[3].AccessorID)
 }
 
 func TestStructs_ACLTokenListStubs_Sort(t *testing.T) {
@@ -262,10 +262,10 @@ func TestStructs_ACLTokenListStubs_Sort(t *testing.T) {
 	}
 
 	tokens.Sort()
-	require.Equal(t, tokens[0].AccessorID, "614a4cef-9149-4271-b878-7edb1ad661f8")
-	require.Equal(t, tokens[1].AccessorID, "6bd01084-1695-43b8-898d-b2dd7874754d")
-	require.Equal(t, tokens[2].AccessorID, "9db509a9-c809-48c1-895d-99f845b7a9d5")
-	require.Equal(t, tokens[3].AccessorID, "c9dd9980-8d54-472f-9e5e-74c02143e1f4")
+	require.Equal(t, "614a4cef-9149-4271-b878-7edb1ad661f8", tokens[0].AccessorID)
+	require.Equal(t, "6bd01084-1695-43b8-898d-b2dd7874754d", tokens[1].AccessorID)
+	require.Equal(t, "9db509a9-c809-48c1-895d-99f845b7a9d5", tokens[2].AccessorID)
+	require.Equal(t, "c9dd9980-8d54-472f-9e5e-74c02143e1f4", tokens[3].AccessorID)
 }
 
 func TestStructs_ACLPolicy_Stub(t *testing.T) {
@@ -356,10 +356,10 @@ func TestStructs_ACLPolicies_Sort(t *testing.T) {
 	}
 
 	policies.Sort()
-	require.Equal(t, policies[0].ID, "614a4cef-9149-4271-b878-7edb1ad661f8")
-	require.Equal(t, policies[1].ID, "6bd01084-1695-43b8-898d-b2dd7874754d")
-	require.Equal(t, policies[2].ID, "9db509a9-c809-48c1-895d-99f845b7a9d5")
-	require.Equal(t, policies[3].ID, "c9dd9980-8d54-472f-9e5e-74c02143e1f4")
+	require.Equal(t, "614a4cef-9149-4271-b878-7edb1ad661f8", policies[0].ID)
+	require.Equal(t, "6bd01084-1695-43b8-898d-b2dd7874754d", policies[1].ID)
+	require.Equal(t, "9db509a9-c809-48c1-895d-99f845b7a9d5", policies[2].ID)
+	require.Equal(t, "c9dd9980-8d54-472f-9e5e-74c02143e1f4", policies[3].ID)
 }
 
 func TestStructs_ACLPolicyListStubs_Sort(t *testing.T) {
@@ -380,10 +380,10 @@ func TestStructs_ACLPolicyListStubs_Sort(t *testing.T) {
 	}
 
 	policies.Sort()
-	require.Equal(t, policies[0].ID, "614a4cef-9149-4271-b878-7edb1ad661f8")
-	require.Equal(t, policies[1].ID, "6bd01084-1695-43b8-898d-b2dd7874754d")
-	require.Equal(t, policies[2].ID, "9db509a9-c809-48c1-895d-99f845b7a9d5")
-	require.Equal(t, policies[3].ID, "c9dd9980-8d54-472f-9e5e-74c02143e1f4")
+	require.Equal(t, "614a4cef-9149-4271-b878-7edb1ad661f8", policies[0].ID)
+	require.Equal(t, "6bd01084-1695-43b8-898d-b2dd7874754d", policies[1].ID)
+	require.Equal(t, "9db509a9-c809-48c1-895d-99f845b7a9d5", policies[2].ID)
+	require.Equal(t, "c9dd9980-8d54-472f-9e5e-74c02143e1f4", policies[3].ID)
 }
 
 func TestStructs_ACLPolicies_resolveWithCache(t *testing.T) {

--- a/agent/structs/aclfilter/filter_test.go
+++ b/agent/structs/aclfilter/filter_test.go
@@ -1237,8 +1237,8 @@ func TestACL_filterServiceTopology(t *testing.T) {
 		if !filtered {
 			t.Fatalf("should have been marked as filtered")
 		}
-		assert.Len(t, topo.Upstreams, 0)
-		assert.Len(t, topo.Upstreams, 0)
+		assert.Empty(t, topo.Upstreams)
+		assert.Empty(t, topo.Upstreams)
 	})
 
 	t.Run("only upstream permissions", func(t *testing.T) {
@@ -1266,7 +1266,7 @@ service "foo" {
 			t.Fatalf("should have been marked as filtered")
 		}
 		assert.Equal(t, original.Upstreams, topo.Upstreams)
-		assert.Len(t, topo.Downstreams, 0)
+		assert.Empty(t, topo.Downstreams)
 	})
 
 	t.Run("only downstream permissions", func(t *testing.T) {
@@ -1294,7 +1294,7 @@ service "bar" {
 			t.Fatalf("should have been marked as filtered")
 		}
 		assert.Equal(t, original.Downstreams, topo.Downstreams)
-		assert.Len(t, topo.Upstreams, 0)
+		assert.Empty(t, topo.Upstreams)
 	})
 
 	t.Run("upstream and downstream permissions", func(t *testing.T) {
@@ -1754,7 +1754,7 @@ func TestACL_filterNodes(t *testing.T) {
 	filt = New(acl.DenyAll(), nil)
 	removed = filt.filterNodes(&nodes)
 	require.True(t, removed)
-	require.Len(t, nodes, 0)
+	require.Empty(t, nodes)
 }
 
 func TestACL_filterIndexedNodesWithGateways(t *testing.T) {

--- a/agent/structs/config_entry_gateways_test.go
+++ b/agent/structs/config_entry_gateways_test.go
@@ -1649,7 +1649,7 @@ func Test_ServiceRouteReferences_AddService(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tc.subject.AddService(key, tc.routeRef)
 
-			require.Equal(t, tc.subject, tc.expectedRefs)
+			require.Equal(t, tc.expectedRefs, tc.subject)
 		})
 	}
 }
@@ -1784,7 +1784,7 @@ func Test_ServiceRouteReferences_RemoveRouteRef(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tc.subject.RemoveRouteRef(tc.routeRef)
 
-			require.Equal(t, tc.subject, tc.expectedRefs)
+			require.Equal(t, tc.expectedRefs, tc.subject)
 		})
 	}
 }

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -216,14 +216,14 @@ func testConfigEntries_ListRelatedServices_AndACLs(t *testing.T, cases []configE
 					t.Run(a.name, func(t *testing.T) {
 						canRead := tc.entry.CanRead(a.authorizer)
 						if a.canRead {
-							require.Nil(t, canRead)
+							require.NoError(t, canRead)
 						} else {
 							require.Error(t, canRead)
 							require.True(t, acl.IsErrPermissionDenied(canRead))
 						}
 						canWrite := tc.entry.CanWrite(a.authorizer)
 						if a.canWrite {
-							require.Nil(t, canWrite)
+							require.NoError(t, canWrite)
 						} else {
 							require.Error(t, canWrite)
 							require.True(t, acl.IsErrPermissionDenied(canWrite))

--- a/agent/structs/connect_ca_test.go
+++ b/agent/structs/connect_ca_test.go
@@ -162,7 +162,7 @@ func TestCAProviderConfig_Validate(t *testing.T) {
 				require.False(t, tt.wantErr)
 				return
 			}
-			require.Equal(t, err.Error(), tt.wantMsg)
+			require.Equal(t, tt.wantMsg, err.Error())
 		})
 	}
 }

--- a/agent/structs/dns_test.go
+++ b/agent/structs/dns_test.go
@@ -40,5 +40,5 @@ func TestDNS_Recursor_StrategySequential(t *testing.T) {
 
 	// The list of recursors should match the order in which they were defined
 	// in the configuration
-	require.Equal(t, recursorsToQuery, expectedRecursors)
+	require.Equal(t, expectedRecursors, recursorsToQuery)
 }

--- a/agent/structs/service_definition_test.go
+++ b/agent/structs/service_definition_test.go
@@ -53,7 +53,7 @@ func TestAgentStructs_CheckTypes(t *testing.T) {
 			svc.Check = *tc.in
 			checks, err := svc.CheckTypes()
 			require.Error(t, err, tc.err.Error())
-			require.Len(t, checks, 0)
+			require.Empty(t, checks)
 		})
 
 	}

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -1220,7 +1220,7 @@ func TestStructs_NodeService_ValidateConnectProxyWithAgentAutoAssign(t *testing.
 		ns.Port = 0
 
 		err := ns.ValidateForAgent()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -1362,7 +1362,7 @@ func TestStructs_NodeService_ConnectNativeEmptyPortError(t *testing.T) {
 	ns.Connect.Native = true
 	ns.Port = 0
 	err := ns.Validate()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Port or SocketPath must be set for a Connect native service.")
 }
 

--- a/agent/submatview/store_integration_test.go
+++ b/agent/submatview/store_integration_test.go
@@ -88,7 +88,7 @@ func TestStore_IntegrationWithBackend(t *testing.T) {
 
 	for i, consumer := range consumers {
 		t.Run(fmt.Sprintf("consumer %d", i), func(t *testing.T) {
-			require.True(t, len(consumer.states) > 2, "expected more than %d events", len(consumer.states))
+			require.Greater(t, len(consumer.states), 2, "expected more than %d events", len(consumer.states))
 
 			expected := producers[state.EventSubjectService{Key: consumer.srvName}.String()].nodesByIndex
 			for idx, nodes := range consumer.states {

--- a/agent/submatview/store_test.go
+++ b/agent/submatview/store_test.go
@@ -509,7 +509,7 @@ func TestStore_Run_ExpiresEntries(t *testing.T) {
 
 	store.lock.Lock()
 	defer store.lock.Unlock()
-	require.Len(t, store.byKey, 0)
+	require.Empty(t, store.byKey)
 	require.Equal(t, ttlcache.NotIndexed, e.expiry.Index())
 }
 
@@ -544,7 +544,7 @@ func TestStore_Run_FailingMaterializer(t *testing.T) {
 			store.lock.Lock()
 			defer store.lock.Unlock()
 
-			require.Len(r, store.byKey, 0)
+			require.Empty(r, store.byKey)
 		})
 	})
 
@@ -561,7 +561,7 @@ func TestStore_Run_FailingMaterializer(t *testing.T) {
 			store.lock.Lock()
 			defer store.lock.Unlock()
 
-			require.Len(r, store.byKey, 0)
+			require.Empty(r, store.byKey)
 		})
 	})
 }

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -747,7 +747,7 @@ func TestTxnEndpoint_NodeService(t *testing.T) {
 	if !ok {
 		t.Fatalf("bad type: %T", obj)
 	}
-	require.Equal(t, 2, len(txnResp.Results))
+	require.Len(t, txnResp.Results, 2)
 
 	index := txnResp.Results[0].Service.ModifyIndex
 	expected := structs.TxnResponse{

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -173,17 +173,17 @@ func TestUINodes(t *testing.T) {
 	require.Len(t, nodes[0].Checks, 1)
 	require.Equal(t, "test", nodes[1].Node)
 	require.NotNil(t, nodes[1].Services)
-	require.Len(t, nodes[1].Services, 0)
+	require.Empty(t, nodes[1].Services)
 	require.NotNil(t, nodes[1].Checks)
-	require.Len(t, nodes[1].Checks, 0)
+	require.Empty(t, nodes[1].Checks)
 
 	// peered node
 	require.Equal(t, "foo-peer", nodes[2].Node)
 	require.Equal(t, "peer1", nodes[2].PeerName)
 	require.NotNil(t, nodes[2].Services)
-	require.Len(t, nodes[2].Services, 0)
+	require.Empty(t, nodes[2].Services)
 	require.NotNil(t, nodes[1].Checks)
-	require.Len(t, nodes[2].Services, 0)
+	require.Empty(t, nodes[2].Services)
 
 	// check for consul-version in node meta
 	require.Equal(t, nodes[0].Meta[structs.MetaConsulVersion], a.Config.Version)
@@ -230,7 +230,7 @@ func TestUINodes_Filter(t *testing.T) {
 	// Should be 2 nodes, and all the empty lists should be non-nil
 	nodes := obj.(structs.NodeDump)
 	require.Len(t, nodes, 1)
-	require.Equal(t, nodes[0].Node, "test")
+	require.Equal(t, "test", nodes[0].Node)
 	require.Empty(t, nodes[0].Services)
 	require.Empty(t, nodes[0].Checks)
 }
@@ -249,7 +249,7 @@ func TestUINodeInfo(t *testing.T) {
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.UINodeInfo(resp, req)
 	require.NoError(t, err)
-	require.Equal(t, resp.Code, http.StatusOK)
+	require.Equal(t, http.StatusOK, resp.Code)
 	assertIndex(t, resp)
 
 	// Should be 1 node for the server
@@ -697,7 +697,7 @@ func TestUIServices(t *testing.T) {
 		require.NotNil(t, obj)
 
 		summary := obj.([]*ServiceListingSummary)
-		require.Len(t, summary, 0)
+		require.Empty(t, summary)
 	})
 }
 
@@ -872,7 +872,7 @@ func TestUIExportedServices(t *testing.T) {
 		require.NoError(t, decoder.Decode(&summary))
 		assertIndex(t, resp)
 
-		require.Len(t, summary, 0)
+		require.Empty(t, summary)
 	})
 }
 
@@ -947,7 +947,7 @@ func TestUIGatewayServiceNodes_Terminating(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/internal/ui/gateway-services-nodes/terminating-gateway", nil)
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.UIGatewayServicesNodes(resp, req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, obj)
 	}
 
@@ -983,7 +983,7 @@ func TestUIGatewayServiceNodes_Terminating(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/v1/internal/ui/gateway-services-nodes/terminating-gateway", nil)
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.UIGatewayServicesNodes(resp, req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assertIndex(t, resp)
 
 	summary := obj.([]*ServiceSummary)
@@ -1140,7 +1140,7 @@ func TestUIGatewayServiceNodes_Ingress(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/v1/internal/ui/gateway-services-nodes/ingress-gateway", nil)
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.UIGatewayServicesNodes(resp, req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assertIndex(t, resp)
 
 	// Construct expected addresses so that differences between CE/Ent are
@@ -1278,7 +1278,7 @@ func TestUIGatewayIntentions(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/v1/internal/ui/gateway-intentions/terminating-gateway", nil)
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.UIGatewayIntentions(resp, req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assertIndex(t, resp)
 
 	intentions := obj.(structs.Intentions)
@@ -1908,13 +1908,13 @@ func TestUIServiceTopology(t *testing.T) {
 			obj, err := a.srv.UIServiceTopology(resp, tc.httpReq)
 
 			if tc.wantErr != "" {
-				assert.NotNil(r, err)
+				require.Error(r, err)
 				assert.Nil(r, tc.want) // should not define a non-nil want
 				require.Contains(r, err.Error(), tc.wantErr)
 				require.Nil(r, obj)
 				return
 			}
-			assert.Nil(r, err)
+			require.NoError(r, err)
 
 			require.NoError(r, checkIndex(resp))
 			require.NotNil(r, obj)
@@ -2447,7 +2447,7 @@ func TestUIServiceTopology_RoutingConfigs(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.UIServiceTopology(resp, tc.httpReq)
-			assert.Nil(r, err)
+			require.NoError(r, err)
 
 			if tc.wantErr != "" {
 				assert.Nil(r, tc.want) // should not define a non-nil want

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -462,10 +462,10 @@ func TestCompiledJS(t *testing.T) {
 			h.ServeHTTP(rec, req)
 
 			require.Equal(t, http.StatusOK, rec.Code)
-			require.Equal(t, rec.Result().Header["Content-Type"][0], "application/javascript")
+			require.Equal(t, "application/javascript", rec.Result().Header["Content-Type"][0])
 			wantCompiled, err := os.ReadFile("testdata/compiled-metrics-providers-golden.js")
 			require.NoError(t, err)
-			require.Equal(t, rec.Body.String(), string(wantCompiled))
+			require.Equal(t, string(wantCompiled), rec.Body.String())
 		})
 	}
 

--- a/agent/watch_handler_test.go
+++ b/agent/watch_handler_test.go
@@ -98,8 +98,8 @@ func TestMakeWatchPlan(t *testing.T) {
 				"handler":      "./script.sh",
 			},
 			expected: func(t *testing.T, plan *watch.Plan) {
-				require.Equal(t, plan.HandlerType, "script")
-				require.Equal(t, plan.Exempt["handler"], "./script.sh")
+				require.Equal(t, "script", plan.HandlerType)
+				require.Equal(t, "./script.sh", plan.Exempt["handler"])
 			},
 		},
 		{
@@ -111,8 +111,8 @@ func TestMakeWatchPlan(t *testing.T) {
 				"args":         "./script.sh",
 			},
 			expected: func(t *testing.T, plan *watch.Plan) {
-				require.Equal(t, plan.HandlerType, "script")
-				require.Equal(t, plan.Exempt["args"], []string{"./script.sh"})
+				require.Equal(t, "script", plan.HandlerType)
+				require.Equal(t, []string{"./script.sh"}, plan.Exempt["args"])
 			},
 		},
 		{
@@ -124,8 +124,8 @@ func TestMakeWatchPlan(t *testing.T) {
 				"args":         []interface{}{"./script.sh", "arg1"},
 			},
 			expected: func(t *testing.T, plan *watch.Plan) {
-				require.Equal(t, plan.HandlerType, "script")
-				require.Equal(t, plan.Exempt["args"], []string{"./script.sh", "arg1"})
+				require.Equal(t, "script", plan.HandlerType)
+				require.Equal(t, []string{"./script.sh", "arg1"}, plan.Exempt["args"])
 			},
 		},
 		{
@@ -137,8 +137,8 @@ func TestMakeWatchPlan(t *testing.T) {
 				"args":         []string{"./script.sh", "arg1"},
 			},
 			expected: func(t *testing.T, plan *watch.Plan) {
-				require.Equal(t, plan.HandlerType, "script")
-				require.Equal(t, plan.Exempt["args"], []string{"./script.sh", "arg1"})
+				require.Equal(t, "script", plan.HandlerType)
+				require.Equal(t, []string{"./script.sh", "arg1"}, plan.Exempt["args"])
 			},
 		},
 		{

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -468,9 +468,9 @@ func TestParseJWTRemoteURL(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, host, tt.expectedHost)
-				require.Equal(t, scheme, tt.expectedScheme)
-				require.Equal(t, port, tt.expectedPort)
+				require.Equal(t, tt.expectedHost, host)
+				require.Equal(t, tt.expectedScheme, scheme)
+				require.Equal(t, tt.expectedPort, port)
 			}
 		})
 	}

--- a/agent/xds/jwt_authn_test.go
+++ b/agent/xds/jwt_authn_test.go
@@ -376,7 +376,7 @@ func TestBuildJWTProviderConfig(t *testing.T) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
 			} else {
-				require.Equal(t, res, tt.expected)
+				require.Equal(t, tt.expected, res)
 			}
 		})
 	}
@@ -429,7 +429,7 @@ func TestMakeLocalJWKS(t *testing.T) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
 			} else {
-				require.Equal(t, res, tt.expected)
+				require.Equal(t, tt.expected, res)
 			}
 		})
 	}
@@ -481,7 +481,7 @@ func TestMakeRemoteJWKS(t *testing.T) {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
 			res := makeRemoteJWKS(tt.jwks, tt.providerName)
-			require.Equal(t, res, tt.expected)
+			require.Equal(t, tt.expected, res)
 		})
 	}
 }
@@ -532,7 +532,7 @@ func TestBuildJWTRetryPolicy(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			res := buildJWTRetryPolicy(tt.retryPolicy)
 
-			require.Equal(t, res, tt.expected)
+			require.Equal(t, tt.expected, res)
 		})
 	}
 }
@@ -568,7 +568,7 @@ func TestHasJWTconfig(t *testing.T) {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
 			res := hasJWTconfig(tt.perms)
-			require.Equal(t, res, tt.expected)
+			require.Equal(t, tt.expected, res)
 		})
 	}
 }

--- a/agent/xds/rbac_test.go
+++ b/agent/xds/rbac_test.go
@@ -1744,7 +1744,7 @@ func TestJWTClaimsToPrincipals(t *testing.T) {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
 			principal := jwtClaimsToPrincipals(tt.claims, tt.metadataPayloadKey)
-			require.Equal(t, principal, tt.expected)
+			require.Equal(t, tt.expected, principal)
 		})
 	}
 }

--- a/agent/xdsv2/resources_test.go
+++ b/agent/xdsv2/resources_test.go
@@ -96,7 +96,7 @@ func (suite *resourceTestSuite) TestAllResourcesFromIR_XDSGoldenFileInputs() {
 				ps := jsonToProxyState(suite.T(), inputValueInput)
 				generator := NewResourceGenerator(testutil.Logger(suite.T()))
 				resources, err := generator.AllResourcesFromIR(&proxytracker.ProxyState{ProxyState: ps})
-				require.NoError(suite.T(), err)
+				suite.Require().NoError(err)
 
 				// Assert.
 				// Assert all resources were generated.
@@ -108,7 +108,7 @@ func (suite *resourceTestSuite) TestAllResourcesFromIR_XDSGoldenFileInputs() {
 					// TODO(proxystate): add in future
 					//xdscommon.SecretType,
 				}
-				require.Len(suite.T(), resources, len(typeUrls))
+				suite.Require().Len(resources, len(typeUrls))
 
 				// Assert each resource type has actual XDS matching expected XDS.
 				for _, typeUrl := range typeUrls {

--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -305,7 +305,7 @@ func TestAPI_ACLBootstrap(t *testing.T) {
 	// not bootstrapped, default allow
 	mems, err := c.Agent().Members(false)
 	require.NoError(t, err)
-	require.True(t, len(mems) == 1)
+	require.Len(t, mems, 1)
 
 	s.Stop()
 	c, s = makeNonBootstrappedACLClient(t, "deny")
@@ -700,7 +700,7 @@ func TestAPI_AuthMethod_List(t *testing.T) {
 	entries, _, err := acl.AuthMethodList(nil)
 	require.NoError(t, err)
 	require.NotNil(t, entries)
-	require.Equal(t, 2, len(entries))
+	require.Len(t, entries, 2)
 
 	{
 		entry := entries[0]

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -169,7 +169,7 @@ func TestAPI_AgentMembersOpts(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	require.Equal(t, 1, len(members))
+	require.Len(t, members, 1)
 
 	members, err = agent.MembersOpts(MembersOpts{
 		WAN:    true,
@@ -178,7 +178,7 @@ func TestAPI_AgentMembersOpts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	require.Equal(t, 0, len(members))
+	require.Empty(t, members)
 
 	_, err = agent.MembersOpts(MembersOpts{
 		WAN:    true,
@@ -272,14 +272,14 @@ func TestAPI_AgentServiceAndReplaceChecks(t *testing.T) {
 	}
 
 	state, out, err := agent.AgentHealthServiceByID("foo")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, out)
 	require.Equal(t, HealthPassing, state)
 	require.Equal(t, 9000, out.Service.Port)
 	require.Equal(t, locality, out.Service.Locality)
 
 	state, outs, err := agent.AgentHealthServiceByName("foo")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, outs)
 	require.Equal(t, HealthPassing, state)
 	require.Equal(t, 9000, outs[0].Service.Port)
@@ -425,19 +425,19 @@ func TestAPI_AgentServices(t *testing.T) {
 	}
 
 	state, out, err := agent.AgentHealthServiceByID("foo2")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, out)
 	require.Equal(t, HealthCritical, state)
 
 	state, out, err = agent.AgentHealthServiceByID("foo")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, out)
 	require.Equal(t, HealthCritical, state)
 	require.Equal(t, 8000, out.Service.Port)
 	require.Equal(t, locality, out.Service.Locality)
 
 	state, outs, err := agent.AgentHealthServiceByName("foo")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, outs)
 	require.Equal(t, HealthCritical, state)
 	require.Equal(t, 8000, outs[0].Service.Port)
@@ -727,10 +727,10 @@ func TestAPI_AgentServiceAddress(t *testing.T) {
 	require.NotNil(t, services["foo2"].TaggedAddresses)
 	require.Contains(t, services["foo2"].TaggedAddresses, "lan")
 	require.Contains(t, services["foo2"].TaggedAddresses, "wan")
-	require.Equal(t, services["foo2"].TaggedAddresses["lan"].Address, "192.168.0.43")
-	require.Equal(t, services["foo2"].TaggedAddresses["lan"].Port, 8000)
-	require.Equal(t, services["foo2"].TaggedAddresses["wan"].Address, "198.18.0.1")
-	require.Equal(t, services["foo2"].TaggedAddresses["wan"].Port, 80)
+	require.Equal(t, "192.168.0.43", services["foo2"].TaggedAddresses["lan"].Address)
+	require.Equal(t, 8000, services["foo2"].TaggedAddresses["lan"].Port)
+	require.Equal(t, "198.18.0.1", services["foo2"].TaggedAddresses["wan"].Address)
+	require.Equal(t, 80, services["foo2"].TaggedAddresses["wan"].Port)
 
 	if err := agent.ServiceDeregister("foo1"); err != nil {
 		t.Fatalf("err: %v", err)
@@ -922,7 +922,7 @@ func TestAPI_AgentService(t *testing.T) {
 	_, _, err = agent.Service("foo", &opts)
 	elapsed := time.Since(start)
 	require.NoError(t, err)
-	require.True(t, elapsed >= opts.WaitTime)
+	require.GreaterOrEqual(t, elapsed, opts.WaitTime)
 }
 
 func TestAPI_AgentSetTTLStatus(t *testing.T) {
@@ -1793,7 +1793,7 @@ func TestAPI_AgentConnectCARoots_list(t *testing.T) {
 	s.WaitForSerfCheck(t)
 	list, meta, err := agent.ConnectCARoots(nil)
 	require.NoError(t, err)
-	require.True(t, meta.LastIndex > 0)
+	require.Greater(t, meta.LastIndex, 0)
 	require.Len(t, list.Roots, 1)
 }
 
@@ -1817,7 +1817,7 @@ func TestAPI_AgentConnectCALeaf(t *testing.T) {
 
 	leaf, meta, err := agent.ConnectCALeaf("foo", nil)
 	require.NoError(t, err)
-	require.True(t, meta.LastIndex > 0)
+	require.Greater(t, meta.LastIndex, 0)
 	// Sanity checks here as we have actual certificate validation checks at many
 	// other levels.
 	require.NotEmpty(t, leaf.SerialNumber)
@@ -1825,7 +1825,7 @@ func TestAPI_AgentConnectCALeaf(t *testing.T) {
 	require.NotEmpty(t, leaf.PrivateKeyPEM)
 	require.Equal(t, "foo", leaf.Service)
 	require.True(t, strings.HasSuffix(leaf.ServiceURI, "/svc/foo"))
-	require.True(t, leaf.ModifyIndex > 0)
+	require.Greater(t, leaf.ModifyIndex, 0)
 	require.True(t, leaf.ValidAfter.Before(time.Now()))
 	require.True(t, leaf.ValidBefore.After(time.Now()))
 }
@@ -1844,9 +1844,9 @@ func TestAPI_AgentConnectAuthorize(t *testing.T) {
 		ClientCertURI: "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/ny1/svc/web",
 	}
 	auth, err := agent.ConnectAuthorize(params)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, auth.Authorized)
-	require.Equal(t, auth.Reason, "Default behavior configured by ACLs")
+	require.Equal(t, "Default behavior configured by ACLs", auth.Reason)
 }
 
 func TestAPI_AgentHealthServiceOpts(t *testing.T) {
@@ -1861,7 +1861,7 @@ func TestAPI_AgentHealthServiceOpts(t *testing.T) {
 
 		opts := &QueryOptions{Namespace: defaultNamespace}
 		state, out, err := agent.AgentHealthServiceByIDOpts(serviceID, opts)
-		require.Nil(t, err, msg, "err")
+		require.NoError(t, err, msg, "err")
 		require.Equal(t, expected, state, msg, "state")
 		if !shouldExist {
 			require.Nil(t, out, msg, "shouldExist")
@@ -1875,12 +1875,12 @@ func TestAPI_AgentHealthServiceOpts(t *testing.T) {
 
 		opts := &QueryOptions{Namespace: defaultNamespace}
 		state, outs, err := agent.AgentHealthServiceByNameOpts(serviceName, opts)
-		require.Nil(t, err, msg, "err")
+		require.NoError(t, err, msg, "err")
 		require.Equal(t, expected, state, msg, "state")
 		if !shouldExist {
-			require.Equal(t, 0, len(outs), msg, "output")
+			require.Empty(t, outs, msg, "output")
 		} else {
-			require.True(t, len(outs) > 0, msg, "output")
+			require.NotEmpty(t, outs, msg, "output")
 			for _, o := range outs {
 				require.Equal(t, serviceName, o.Service.Service, msg, "output")
 			}
@@ -1904,22 +1904,22 @@ func TestAPI_AgentHealthServiceOpts(t *testing.T) {
 		},
 	}
 	err := agent.ServiceRegister(reg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireServiceHealthID(t, testServiceID1, HealthCritical, true)
 	requireServiceHealthName(t, testServiceName, HealthCritical, true)
 
 	err = agent.WarnTTL(fmt.Sprintf("service:%s", testServiceID1), "I am warn")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireServiceHealthName(t, testServiceName, HealthWarning, true)
 	requireServiceHealthID(t, testServiceID1, HealthWarning, true)
 
 	err = agent.PassTTL(fmt.Sprintf("service:%s", testServiceID1), "I am good :)")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireServiceHealthName(t, testServiceName, HealthPassing, true)
 	requireServiceHealthID(t, testServiceID1, HealthPassing, true)
 
 	err = agent.FailTTL(fmt.Sprintf("service:%s", testServiceID1), "I am dead.")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireServiceHealthName(t, testServiceName, HealthCritical, true)
 	requireServiceHealthID(t, testServiceID1, HealthCritical, true)
 
@@ -1933,19 +1933,19 @@ func TestAPI_AgentHealthServiceOpts(t *testing.T) {
 		},
 	}
 	err = agent.ServiceRegister(reg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireServiceHealthName(t, testServiceName, HealthCritical, true)
 
 	err = agent.PassTTL(fmt.Sprintf("service:%s", testServiceID1), "I am good :)")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireServiceHealthName(t, testServiceName, HealthCritical, true)
 
 	err = agent.WarnTTL(fmt.Sprintf("service:%s", testServiceID2), "I am warn")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireServiceHealthName(t, testServiceName, HealthWarning, true)
 
 	err = agent.PassTTL(fmt.Sprintf("service:%s", testServiceID2), "I am good :)")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireServiceHealthName(t, testServiceName, HealthPassing, true)
 }
 

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -44,7 +44,7 @@ func TestAPI_CatalogNodes(t *testing.T) {
 		nodes, meta, err := catalog.Nodes(nil)
 		require.NoError(r, err)
 		require.Len(r, nodes, 1)
-		require.True(r, meta.LastIndex >= 1, "Last index must be greater than 1")
+		require.GreaterOrEqual(r, meta.LastIndex, 1, "Last index must be greater than 1")
 
 		// The raft indexes are not relevant for this test.
 		got := nodes[0]
@@ -410,9 +410,9 @@ func TestAPI_CatalogService_SingleTag(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		services, meta, err := catalog.Service("foo", "bar", nil)
 		require.NoError(r, err)
-		require.NotEqual(r, meta.LastIndex, 0)
+		require.NotEqual(r, 0, meta.LastIndex)
 		require.Len(r, services, 1)
-		require.Equal(r, services[0].ServiceID, "foo1")
+		require.Equal(r, "foo1", services[0].ServiceID)
 		require.Equal(r, locality, services[0].ServiceLocality)
 	})
 }
@@ -449,7 +449,7 @@ func TestAPI_CatalogService_MultipleTags(t *testing.T) {
 		services, meta, err := catalog.ServiceMultipleTags("foo", []string{"bar"}, nil)
 
 		require.NoError(r, err)
-		require.NotEqual(r, meta.LastIndex, 0)
+		require.NotEqual(r, 0, meta.LastIndex)
 
 		// Should be 2 services with the `bar` tag
 		require.Len(r, services, 2)
@@ -460,11 +460,11 @@ func TestAPI_CatalogService_MultipleTags(t *testing.T) {
 		services, meta, err := catalog.ServiceMultipleTags("foo", []string{"bar", "v2"}, nil)
 
 		require.NoError(r, err)
-		require.NotEqual(r, meta.LastIndex, 0)
+		require.NotEqual(r, 0, meta.LastIndex)
 
 		// Should be exactly 1 service, named "foo2"
 		require.Len(r, services, 1)
-		require.Equal(r, services[0].ServiceID, "foo2")
+		require.Equal(r, "foo2", services[0].ServiceID)
 	})
 }
 
@@ -1238,7 +1238,7 @@ func TestAPI_CatalogGatewayServices_Terminating(t *testing.T) {
 	}
 	retry.Run(t, func(r *retry.R) {
 		resp, _, err := catalog.GatewayServices("terminating", nil)
-		assert.NoError(r, err)
+		require.NoError(r, err)
 		assert.Equal(r, expect, resp)
 	})
 }
@@ -1301,7 +1301,7 @@ func TestAPI_CatalogGatewayServices_Ingress(t *testing.T) {
 	}
 	retry.Run(t, func(r *retry.R) {
 		resp, _, err := catalog.GatewayServices("ingress", nil)
-		assert.NoError(r, err)
+		require.NoError(r, err)
 		assert.Equal(r, expect, resp)
 	})
 }

--- a/api/config_entry_inline_certificate_test.go
+++ b/api/config_entry_inline_certificate_test.go
@@ -125,5 +125,5 @@ func TestAPI_ConfigEntries_InlineCertificate(t *testing.T) {
 
 	// try to get it
 	_, _, err = configEntries.Get(InlineCertificate, cert1.Name, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/api/connect_intention_test.go
+++ b/api/connect_intention_test.go
@@ -22,12 +22,12 @@ func TestAPI_ConnectIntentionCreateListGetUpdateDelete(t *testing.T) {
 	// Create
 	ixn := testIntention()
 	id, _, err := connect.IntentionCreate(ixn, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, id)
 
 	// List it
 	list, _, err := connect.Intentions(nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, list, 1)
 
 	actual := list[0]
@@ -43,7 +43,7 @@ func TestAPI_ConnectIntentionCreateListGetUpdateDelete(t *testing.T) {
 
 	// Get it
 	actual, _, err = connect.IntentionGet(id, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, ixn, actual)
 
 	// Update it
@@ -61,11 +61,11 @@ func TestAPI_ConnectIntentionCreateListGetUpdateDelete(t *testing.T) {
 
 	// Delete it
 	_, err = connect.IntentionDelete(id, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Get it (should be gone)
 	actual, _, err = connect.IntentionGet(id, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, actual)
 }
 
@@ -109,7 +109,7 @@ func TestAPI_ConnectIntentionMatch(t *testing.T) {
 			ixn.DestinationNS = v[0]
 			ixn.DestinationName = v[1]
 			id, _, err := connect.IntentionCreate(ixn, nil)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.NotEmpty(t, id)
 		}
 	}
@@ -119,7 +119,7 @@ func TestAPI_ConnectIntentionMatch(t *testing.T) {
 		By:    IntentionMatchDestination,
 		Names: []string{"bar"},
 	}, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, result, 1)
 
 	var actual [][]string
@@ -159,7 +159,7 @@ func TestAPI_ConnectIntentionCheck(t *testing.T) {
 			ixn.DestinationName = v[3]
 			ixn.Action = IntentionAction(v[4])
 			id, _, err := connect.IntentionCreate(ixn, nil)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.NotEmpty(t, id)
 		}
 	}

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -360,9 +360,9 @@ func TestAPI_HealthService_SingleTag(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		services, meta, err := health.Service("foo", "bar", true, nil)
 		require.NoError(r, err)
-		require.NotEqual(r, meta.LastIndex, 0)
+		require.NotEqual(r, 0, meta.LastIndex)
 		require.Len(r, services, 1)
-		require.Equal(r, services[0].Service.ID, "foo1")
+		require.Equal(r, "foo1", services[0].Service.ID)
 
 		for _, check := range services[0].Checks {
 			if check.CheckID == "service:foo1" && check.Type != "ttl" {
@@ -409,7 +409,7 @@ func TestAPI_HealthService_MultipleTags(t *testing.T) {
 		services, meta, err := health.ServiceMultipleTags("foo", []string{"bar"}, true, nil)
 
 		require.NoError(r, err)
-		require.NotEqual(r, meta.LastIndex, 0)
+		require.NotEqual(r, 0, meta.LastIndex)
 		require.Len(r, services, 2)
 	})
 
@@ -418,9 +418,9 @@ func TestAPI_HealthService_MultipleTags(t *testing.T) {
 		services, meta, err := health.ServiceMultipleTags("foo", []string{"bar", "v2"}, true, nil)
 
 		require.NoError(r, err)
-		require.NotEqual(r, meta.LastIndex, 0)
+		require.NotEqual(r, 0, meta.LastIndex)
 		require.Len(r, services, 1)
-		require.Equal(r, services[0].Service.ID, "foo2")
+		require.Equal(r, "foo2", services[0].Service.ID)
 	})
 }
 
@@ -439,9 +439,9 @@ func TestAPI_HealthService_NodeMetaFilter(t *testing.T) {
 		// consul service should always exist...
 		checks, meta, err := health.Service("consul", "", true, &QueryOptions{NodeMeta: meta})
 		require.NoError(r, err)
-		require.NotEqual(r, meta.LastIndex, 0)
-		require.NotEqual(r, len(checks), 0)
-		require.Equal(r, checks[0].Node.Datacenter, "dc1")
+		require.NotEqual(r, 0, meta.LastIndex)
+		require.NotEmpty(r, checks)
+		require.Equal(r, "dc1", checks[0].Node.Datacenter)
 		require.Contains(r, checks[0].Node.TaggedAddresses, "wan")
 	})
 }
@@ -600,7 +600,7 @@ func TestAPI_HealthIngress(t *testing.T) {
 		// Should be exactly 1 service - the original shouldn't show up as a connect
 		// endpoint, only it's proxy.
 		require.Len(r, services, 1)
-		require.Equal(r, services[0].Node.Datacenter, "dc1")
+		require.Equal(r, "dc1", services[0].Node.Datacenter)
 		require.Equal(r, services[0].Service.Service, gatewayReg.Name)
 	})
 }

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -295,7 +295,7 @@ func TestKeyPrefixWatch(t *testing.T) {
 
 	{
 		v := wakeups[0]
-		require.Len(t, v, 0)
+		require.Empty(t, v)
 	}
 	{
 		v := wakeups[1]
@@ -666,7 +666,7 @@ func TestServiceWatch(t *testing.T) {
 
 	{
 		v := wakeups[0]
-		require.Len(t, v, 0)
+		require.Empty(t, v)
 	}
 	{
 		v := wakeups[1]
@@ -757,7 +757,7 @@ func TestServiceMultipleTagsWatch(t *testing.T) {
 
 	{
 		v := wakeups[0]
-		require.Len(t, v, 0)
+		require.Empty(t, v)
 	}
 	{
 		v := wakeups[1]
@@ -922,7 +922,7 @@ func TestChecksWatch_State(t *testing.T) {
 
 	{
 		v := wakeups[0]
-		require.Len(t, v, 0)
+		require.Empty(t, v)
 	}
 	{
 		v := wakeups[1]
@@ -1003,7 +1003,7 @@ func TestChecksWatch_Service(t *testing.T) {
 
 	{
 		v := wakeups[0]
-		require.Len(t, v, 0)
+		require.Empty(t, v)
 	}
 	{
 		v := wakeups[1]
@@ -1083,7 +1083,7 @@ func TestChecksWatch_Service_Filter(t *testing.T) {
 
 	{
 		v := wakeups[0]
-		require.Len(t, v, 0)
+		require.Empty(t, v)
 	}
 	{
 		v := wakeups[1]
@@ -1187,7 +1187,7 @@ func TestChecksWatch_Filter(t *testing.T) {
 
 	{
 		v := wakeups[0]
-		require.Len(t, v, 0)
+		require.Empty(t, v)
 	}
 	{
 		v := wakeups[1]
@@ -1291,7 +1291,7 @@ func TestChecksWatch_Filter_by_ServiceNameStatus(t *testing.T) {
 
 	{
 		v := wakeups[0]
-		require.Len(t, v, 0)
+		require.Empty(t, v)
 	}
 	{
 		v := wakeups[1]
@@ -1354,7 +1354,7 @@ func TestEventWatch(t *testing.T) {
 
 	{
 		v := wakeups[0]
-		require.Len(t, v, 0)
+		require.Empty(t, v)
 	}
 	{
 		v := wakeups[1]
@@ -1442,7 +1442,7 @@ func TestConnectLeafWatch(t *testing.T) {
 			Port: 9090,
 		}
 		err := agent.ServiceRegister(&reg)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	var (

--- a/command/acl/agenttokens/agent_tokens_test.go
+++ b/command/acl/agenttokens/agent_tokens_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAgentTokensCommand_noTabs(t *testing.T) {
@@ -52,7 +53,7 @@ func TestAgentTokensCommand(t *testing.T) {
 		&api.ACLToken{Description: "test"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// default token
 	{
@@ -63,7 +64,7 @@ func TestAgentTokensCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		assert.Equal(t, code, 0)
+		assert.Equal(t, 0, code)
 		assert.Empty(t, ui.ErrorWriter.String())
 	}
 
@@ -76,7 +77,7 @@ func TestAgentTokensCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		assert.Equal(t, code, 0)
+		assert.Equal(t, 0, code)
 		assert.Empty(t, ui.ErrorWriter.String())
 	}
 
@@ -89,7 +90,7 @@ func TestAgentTokensCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		assert.Equal(t, code, 0)
+		assert.Equal(t, 0, code)
 		assert.Empty(t, ui.ErrorWriter.String())
 	}
 
@@ -102,7 +103,7 @@ func TestAgentTokensCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		assert.Equal(t, code, 0)
+		assert.Equal(t, 0, code)
 		assert.Empty(t, ui.ErrorWriter.String())
 	}
 }

--- a/command/acl/authmethod/create/authmethod_create_test.go
+++ b/command/acl/authmethod/create/authmethod_create_test.go
@@ -65,7 +65,7 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-type' flag")
 	})
 
@@ -80,7 +80,7 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-name' flag")
 	})
 
@@ -96,7 +96,7 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Invalid Auth Method: Type should be one of")
 	})
 
@@ -115,7 +115,7 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		got := getTestMethod(t, client, name)
@@ -144,7 +144,7 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: "+ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: "+ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		got := getTestMethod(t, client, name)
@@ -174,7 +174,7 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: "+ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: "+ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		got := getTestMethod(t, client, name)
@@ -220,7 +220,7 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-type' flag")
 	})
 
@@ -242,7 +242,7 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 		code := cmd.Run(args)
 		out := ui.OutputWriter.String()
 
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 		require.Contains(t, out, name)
 
@@ -278,7 +278,7 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 		code := cmd.Run(args)
 		out := ui.OutputWriter.String()
 
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 		require.Contains(t, out, name)
 
@@ -328,7 +328,7 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 		code := cmd.Run(args)
 		out := ui.OutputWriter.String()
 
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 		require.Contains(t, out, name)
 
@@ -395,7 +395,7 @@ func TestAuthMethodCreateCommand_k8s(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-kubernetes-host' flag")
 	})
 
@@ -413,7 +413,7 @@ func TestAuthMethodCreateCommand_k8s(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-kubernetes-ca-cert' flag")
 	})
 
@@ -434,7 +434,7 @@ func TestAuthMethodCreateCommand_k8s(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-kubernetes-service-account-jwt' flag")
 	})
 
@@ -489,7 +489,7 @@ func TestAuthMethodCreateCommand_k8s(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		got := getTestMethod(t, client, name)

--- a/command/acl/authmethod/delete/authmethod_delete_test.go
+++ b/command/acl/authmethod/delete/authmethod_delete_test.go
@@ -59,7 +59,7 @@ func TestAuthMethodDeleteCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Must specify the -name parameter")
 	})
 
@@ -113,7 +113,7 @@ func TestAuthMethodDeleteCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()

--- a/command/acl/authmethod/list/authmethod_list_test.go
+++ b/command/acl/authmethod/list/authmethod_list_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	// activate testing auth method
@@ -57,7 +56,7 @@ func TestAuthMethodListCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 		require.Empty(t, ui.OutputWriter.String())
 	})
@@ -99,7 +98,7 @@ func TestAuthMethodListCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 		output := ui.OutputWriter.String()
 
@@ -166,7 +165,7 @@ func TestAuthMethodListCommand_JSON(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 		output := ui.OutputWriter.String()
 
@@ -176,6 +175,6 @@ func TestAuthMethodListCommand_JSON(t *testing.T) {
 
 		var jsonOutput json.RawMessage
 		err := json.Unmarshal([]byte(output), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/command/acl/authmethod/read/authmethod_read_test.go
+++ b/command/acl/authmethod/read/authmethod_read_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	// activate testing auth method
@@ -59,7 +58,7 @@ func TestAuthMethodReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Must specify the -name parameter")
 	})
 
@@ -74,7 +73,7 @@ func TestAuthMethodReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Auth method not found with name")
 	})
 
@@ -110,7 +109,7 @@ func TestAuthMethodReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -172,7 +171,7 @@ func TestAuthMethodReadCommand_JSON(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -180,6 +179,6 @@ func TestAuthMethodReadCommand_JSON(t *testing.T) {
 
 		var jsonOutput json.RawMessage
 		err := json.Unmarshal([]byte(output), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/command/acl/authmethod/update/authmethod_update_test.go
+++ b/command/acl/authmethod/update/authmethod_update_test.go
@@ -65,7 +65,7 @@ func TestAuthMethodUpdateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Cannot update an auth method without specifying the -name parameter")
 	})
 
@@ -81,7 +81,7 @@ func TestAuthMethodUpdateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Auth method not found with name")
 	})
 
@@ -121,7 +121,7 @@ func TestAuthMethodUpdateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		got := getTestMethod(t, client, name)
@@ -152,7 +152,7 @@ func TestAuthMethodUpdateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		got := getTestMethod(t, client, name)
@@ -203,7 +203,7 @@ func TestAuthMethodUpdateCommand_JSON(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Cannot update an auth method without specifying the -name parameter")
 	})
 
@@ -244,7 +244,7 @@ func TestAuthMethodUpdateCommand_JSON(t *testing.T) {
 		code := cmd.Run(args)
 		output := ui.OutputWriter.String()
 
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		var jsonOutput json.RawMessage
@@ -294,7 +294,7 @@ func TestAuthMethodUpdateCommand_noMerge(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Cannot update an auth method without specifying the -name parameter")
 	})
 
@@ -311,7 +311,7 @@ func TestAuthMethodUpdateCommand_noMerge(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Auth method not found with name")
 	})
 
@@ -350,7 +350,7 @@ func TestAuthMethodUpdateCommand_noMerge(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		got := getTestMethod(t, client, name)
@@ -432,7 +432,7 @@ func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		got := getTestMethod(t, client, name)
@@ -477,7 +477,7 @@ func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		method, _, err := client.ACL().AuthMethodRead(
@@ -512,7 +512,7 @@ func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		method, _, err := client.ACL().AuthMethodRead(
@@ -547,7 +547,7 @@ func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		method, _, err := client.ACL().AuthMethodRead(
@@ -582,7 +582,7 @@ func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		method, _, err := client.ACL().AuthMethodRead(
@@ -669,7 +669,7 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-kubernetes-host' flag")
 	})
 
@@ -690,7 +690,7 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-kubernetes-ca-cert' flag")
 	})
 
@@ -711,7 +711,7 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-kubernetes-service-account-jwt' flag")
 	})
 
@@ -733,7 +733,7 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		method, _, err := client.ACL().AuthMethodRead(
@@ -773,7 +773,7 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		method, _, err := client.ACL().AuthMethodRead(

--- a/command/acl/bindingrule/create/bindingrule_create_test.go
+++ b/command/acl/bindingrule/create/bindingrule_create_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	// activate testing auth method
@@ -70,7 +69,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-method' flag")
 	})
 
@@ -86,7 +85,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-bind-type' flag")
 	})
 
@@ -102,7 +101,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-bind-name' flag")
 	})
 
@@ -120,7 +119,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Cannot specify -bind-vars when -bind-type is not templated-policy")
 	})
 
@@ -138,7 +137,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Selector is invalid")
 	})
 
@@ -155,7 +154,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 	})
 
@@ -173,7 +172,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 	})
 
@@ -191,7 +190,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 	})
 
@@ -209,7 +208,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 	})
 
@@ -226,7 +225,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "templated policy failed validation")
 	})
 }
@@ -278,12 +277,12 @@ func TestBindingRuleCreateCommand_JSON(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
 		var jsonOutput json.RawMessage
 		err := json.Unmarshal([]byte(output), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/command/acl/bindingrule/delete/bindingrule_delete_test.go
+++ b/command/acl/bindingrule/delete/bindingrule_delete_test.go
@@ -108,7 +108,7 @@ func TestBindingRuleDeleteCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Must specify the -id parameter")
 	})
 
@@ -125,7 +125,7 @@ func TestBindingRuleDeleteCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -153,7 +153,7 @@ func TestBindingRuleDeleteCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -181,7 +181,7 @@ func TestBindingRuleDeleteCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Error determining binding rule ID")
 	})
 

--- a/command/acl/bindingrule/list/bindingrule_list_test.go
+++ b/command/acl/bindingrule/list/bindingrule_list_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	// activate testing auth method
@@ -110,7 +109,7 @@ func TestBindingRuleListCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 		output := ui.OutputWriter.String()
 
@@ -131,7 +130,7 @@ func TestBindingRuleListCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 		output := ui.OutputWriter.String()
 
@@ -154,7 +153,7 @@ func TestBindingRuleListCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 		output := ui.OutputWriter.String()
 
@@ -177,7 +176,7 @@ func TestBindingRuleListCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 		output := ui.OutputWriter.String()
 
@@ -188,6 +187,6 @@ func TestBindingRuleListCommand(t *testing.T) {
 
 		var jsonOutput json.RawMessage
 		err := json.Unmarshal([]byte(output), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/command/acl/bindingrule/read/bindingrule_read_test.go
+++ b/command/acl/bindingrule/read/bindingrule_read_test.go
@@ -85,7 +85,7 @@ func TestBindingRuleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Must specify the -id parameter")
 	})
 
@@ -103,7 +103,7 @@ func TestBindingRuleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Binding rule not found with ID")
 	})
 
@@ -120,7 +120,7 @@ func TestBindingRuleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -141,7 +141,7 @@ func TestBindingRuleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -163,7 +163,7 @@ func TestBindingRuleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()

--- a/command/acl/bindingrule/update/bindingrule_update_test.go
+++ b/command/acl/bindingrule/update/bindingrule_update_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	// activate testing auth method
@@ -87,7 +86,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Cannot update a binding rule without specifying the -id parameter")
 	})
 
@@ -105,7 +104,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Error determining binding rule ID")
 	})
 
@@ -123,7 +122,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Binding rule not found with ID")
 	})
 
@@ -187,7 +186,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Error determining binding rule ID")
 	})
 
@@ -205,7 +204,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Selector is invalid")
 	})
 
@@ -226,7 +225,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -259,7 +258,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -293,7 +292,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -327,7 +326,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -363,7 +362,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -395,7 +394,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -427,7 +426,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -459,7 +458,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -491,7 +490,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -524,7 +523,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -558,7 +557,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -576,7 +575,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 		output := ui.OutputWriter.String()
 		var jsonOutput json.RawMessage
 		err = json.Unmarshal([]byte(output), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -640,7 +639,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		cmd := New(ui)
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Cannot update a binding rule without specifying the -id parameter")
 	})
 
@@ -659,7 +658,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Error determining binding rule ID")
 	})
 
@@ -678,7 +677,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Binding rule not found with ID")
 	})
 
@@ -744,7 +743,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Error determining binding rule ID")
 	})
 
@@ -766,7 +765,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Selector is invalid")
 	})
 
@@ -788,7 +787,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -822,7 +821,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -858,7 +857,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -895,7 +894,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -928,7 +927,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(
@@ -960,7 +959,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-bind-name' flag")
 	})
 
@@ -981,7 +980,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		rule, _, err := client.ACL().BindingRuleRead(

--- a/command/acl/bootstrap/bootstrap_test.go
+++ b/command/acl/bootstrap/bootstrap_test.go
@@ -49,7 +49,7 @@ func TestBootstrapCommand_Pretty(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 	output := ui.OutputWriter.String()
 	assert.Contains(t, output, "Bootstrap Token")
@@ -81,7 +81,7 @@ func TestBootstrapCommand_JSON(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 	output := ui.OutputWriter.String()
 	assert.Contains(t, output, "Bootstrap Token")
@@ -113,12 +113,12 @@ func TestBootstrapCommand_Initial(t *testing.T) {
 
 	// Create temp file
 	f, err := os.CreateTemp("", "consul-token.token")
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
 	// Write the token to the file
 	err = os.WriteFile(f.Name(), []byte("2b778dd9-f5f1-6f29-b4b4-9a5fa948757a"), 0700)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -127,7 +127,7 @@ func TestBootstrapCommand_Initial(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 	output := ui.OutputWriter.String()
 	assert.Contains(t, output, "Bootstrap Token")

--- a/command/acl/policy/create/policy_create_test.go
+++ b/command/acl/policy/create/policy_create_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,7 +60,7 @@ func TestPolicyCreateCommand(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	require.Equal(t, code, 0)
+	require.Equal(t, 0, code)
 	require.Empty(t, ui.ErrorWriter.String())
 }
 
@@ -102,10 +101,10 @@ func TestPolicyCreateCommand_JSON(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	require.Equal(t, code, 0)
+	require.Equal(t, 0, code)
 	require.Empty(t, ui.ErrorWriter.String())
 
 	var jsonOutput json.RawMessage
 	err = json.Unmarshal([]byte(ui.OutputWriter.String()), &jsonOutput)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/command/acl/policy/delete/policy_delete_test.go
+++ b/command/acl/policy/delete/policy_delete_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
@@ -53,7 +54,7 @@ func TestPolicyDeleteCommand(t *testing.T) {
 		&api.ACLPolicy{Name: "test-policy"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -62,7 +63,7 @@ func TestPolicyDeleteCommand(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	output := ui.OutputWriter.String()

--- a/command/acl/policy/list/policy_list_test.go
+++ b/command/acl/policy/list/policy_list_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPolicyListCommand_noTabs(t *testing.T) {
@@ -59,7 +60,7 @@ func TestPolicyListCommand(t *testing.T) {
 		)
 		policyIDs = append(policyIDs, policy.ID)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	args := []string{
@@ -68,7 +69,7 @@ func TestPolicyListCommand(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 	output := ui.OutputWriter.String()
 
@@ -113,7 +114,7 @@ func TestPolicyListCommand_JSON(t *testing.T) {
 		)
 		policyIDs = append(policyIDs, policy.ID)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	args := []string{
@@ -123,7 +124,7 @@ func TestPolicyListCommand_JSON(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 	output := ui.OutputWriter.String()
 
@@ -134,5 +135,5 @@ func TestPolicyListCommand_JSON(t *testing.T) {
 
 	var jsonOutput json.RawMessage
 	err := json.Unmarshal([]byte(output), &jsonOutput)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/command/acl/policy/read/policy_read_test.go
+++ b/command/acl/policy/read/policy_read_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPolicyReadCommand_noTabs(t *testing.T) {
@@ -53,7 +54,7 @@ func TestPolicyReadCommand(t *testing.T) {
 		&api.ACLPolicy{Name: "test-policy"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test querying by id field
 	args := []string{
@@ -63,7 +64,7 @@ func TestPolicyReadCommand(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	output := ui.OutputWriter.String()
@@ -79,7 +80,7 @@ func TestPolicyReadCommand(t *testing.T) {
 
 	cmd = New(ui)
 	code = cmd.Run(argsName)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	output = ui.OutputWriter.String()
@@ -95,7 +96,7 @@ func TestPolicyReadCommand(t *testing.T) {
 
 	cmd = New(ui)
 	code = cmd.Run(argsName)
-	assert.Equal(t, code, 1)
+	assert.Equal(t, 1, code)
 }
 
 func TestPolicyReadCommand_JSON(t *testing.T) {
@@ -127,7 +128,7 @@ func TestPolicyReadCommand_JSON(t *testing.T) {
 		&api.ACLPolicy{Name: "test-policy"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -137,7 +138,7 @@ func TestPolicyReadCommand_JSON(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	output := ui.OutputWriter.String()
@@ -146,5 +147,5 @@ func TestPolicyReadCommand_JSON(t *testing.T) {
 
 	var jsonOutput json.RawMessage
 	err = json.Unmarshal([]byte(output), &jsonOutput)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/command/acl/policy/update/policy_update_test.go
+++ b/command/acl/policy/update/policy_update_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPolicyUpdateCommand_noTabs(t *testing.T) {
@@ -51,7 +52,7 @@ func TestPolicyUpdateCommand(t *testing.T) {
 
 	rules := []byte("service \"\" { policy = \"write\" }")
 	err := os.WriteFile(testDir+"/rules.hcl", rules, 0644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create a policy
 	client := a.Client()
@@ -60,7 +61,7 @@ func TestPolicyUpdateCommand(t *testing.T) {
 		&api.ACLPolicy{Name: "test-policy"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -71,7 +72,7 @@ func TestPolicyUpdateCommand(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 }
 
@@ -101,7 +102,7 @@ func TestPolicyUpdateCommand_JSON(t *testing.T) {
 
 	rules := []byte("service \"\" { policy = \"write\" }")
 	err := os.WriteFile(testDir+"/rules.hcl", rules, 0644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create a policy
 	client := a.Client()
@@ -110,7 +111,7 @@ func TestPolicyUpdateCommand_JSON(t *testing.T) {
 		&api.ACLPolicy{Name: "test-policy"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -122,10 +123,10 @@ func TestPolicyUpdateCommand_JSON(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	var jsonOutput json.RawMessage
 	err = json.Unmarshal([]byte(ui.OutputWriter.String()), &jsonOutput)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/command/acl/role/create/role_create_test.go
+++ b/command/acl/role/create/role_create_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -176,11 +175,11 @@ func TestRoleCreateCommand_JSON(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		var jsonOutput json.RawMessage
 		err = json.Unmarshal([]byte(ui.OutputWriter.String()), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }

--- a/command/acl/role/delete/role_delete_test.go
+++ b/command/acl/role/delete/role_delete_test.go
@@ -54,7 +54,7 @@ func TestRoleDeleteCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Must specify the -id or -name parameters")
 	})
 
@@ -83,7 +83,7 @@ func TestRoleDeleteCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -123,7 +123,7 @@ func TestRoleDeleteCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()

--- a/command/acl/role/list/role_list_test.go
+++ b/command/acl/role/list/role_list_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,7 +71,7 @@ func TestRoleListCommand(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	require.Equal(t, code, 0)
+	require.Equal(t, 0, code)
 	require.Empty(t, ui.ErrorWriter.String())
 	output := ui.OutputWriter.String()
 
@@ -130,7 +129,7 @@ func TestRoleListCommand_JSON(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	require.Equal(t, code, 0)
+	require.Equal(t, 0, code)
 	require.Empty(t, ui.ErrorWriter.String())
 	output := ui.OutputWriter.String()
 
@@ -141,5 +140,5 @@ func TestRoleListCommand_JSON(t *testing.T) {
 
 	var jsonOutput json.RawMessage
 	err := json.Unmarshal([]byte(output), &jsonOutput)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/command/acl/role/read/role_read_test.go
+++ b/command/acl/role/read/role_read_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,7 +56,7 @@ func TestRoleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Must specify either the -id or -name parameters")
 	})
 
@@ -75,7 +74,7 @@ func TestRoleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Role not found with ID")
 	})
 
@@ -90,7 +89,7 @@ func TestRoleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Role not found with name")
 	})
 
@@ -119,7 +118,7 @@ func TestRoleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -152,7 +151,7 @@ func TestRoleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -185,7 +184,7 @@ func TestRoleReadCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -241,7 +240,7 @@ func TestRoleReadCommand_JSON(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -250,6 +249,6 @@ func TestRoleReadCommand_JSON(t *testing.T) {
 
 		var jsonOutput json.RawMessage
 		err = json.Unmarshal([]byte(output), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/command/acl/role/update/role_update_test.go
+++ b/command/acl/role/update/role_update_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	uuid "github.com/hashicorp/go-uuid"
@@ -104,7 +103,7 @@ func TestRoleUpdateCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Role not found with ID")
 	})
 
@@ -302,7 +301,7 @@ func TestRoleUpdateCommand_JSON(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Role not found with ID")
 	})
 
@@ -319,12 +318,12 @@ func TestRoleUpdateCommand_JSON(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		var jsonOutput json.RawMessage
 		err := json.Unmarshal([]byte(ui.OutputWriter.String()), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -411,7 +410,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1)
+		require.Equal(t, 1, code)
 		require.Contains(t, ui.ErrorWriter.String(), "Role not found with ID")
 	})
 
@@ -430,7 +429,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		role, _, err := client.ACL().RoleRead(
@@ -441,7 +440,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		require.NotNil(t, role)
 		require.Equal(t, "", role.Description)
 		require.Len(t, role.Policies, 1)
-		require.Len(t, role.ServiceIdentities, 0)
+		require.Empty(t, role.ServiceIdentities)
 	})
 
 	t.Run("update with policy by id", func(t *testing.T) {
@@ -459,7 +458,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		role, _, err := client.ACL().RoleRead(
@@ -470,7 +469,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		require.NotNil(t, role)
 		require.Equal(t, "", role.Description)
 		require.Len(t, role.Policies, 1)
-		require.Len(t, role.ServiceIdentities, 0)
+		require.Empty(t, role.ServiceIdentities)
 	})
 
 	t.Run("update with service identity", func(t *testing.T) {
@@ -488,7 +487,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		role, _, err := client.ACL().RoleRead(
@@ -498,7 +497,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, role)
 		require.Equal(t, "", role.Description)
-		require.Len(t, role.Policies, 0)
+		require.Empty(t, role.Policies)
 		require.Len(t, role.ServiceIdentities, 1)
 	})
 
@@ -517,7 +516,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		role, _, err := client.ACL().RoleRead(
@@ -527,7 +526,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, role)
 		require.Equal(t, "", role.Description)
-		require.Len(t, role.Policies, 0)
+		require.Empty(t, role.Policies)
 		require.Len(t, role.ServiceIdentities, 1)
 	})
 
@@ -547,7 +546,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		role, _, err := client.ACL().RoleRead(
@@ -557,7 +556,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, role)
 		require.Equal(t, "", role.Description)
-		require.Len(t, role.Policies, 0)
+		require.Empty(t, role.Policies)
 		require.Len(t, role.TemplatedPolicies, 1)
 	})
 
@@ -577,7 +576,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 
 		role, _, err := client.ACL().RoleRead(
@@ -587,7 +586,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, role)
 		require.Equal(t, "", role.Description)
-		require.Len(t, role.Policies, 0)
+		require.Empty(t, role.Policies)
 		require.Len(t, role.TemplatedPolicies, 1)
 	})
 }

--- a/command/acl/templatedpolicy/list/templated_policy_list_test.go
+++ b/command/acl/templatedpolicy/list/templated_policy_list_test.go
@@ -52,7 +52,7 @@ func TestTemplatedPolicyListCommand(t *testing.T) {
 
 	cmd := New(ui)
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	output := ui.OutputWriter.String()
@@ -88,7 +88,7 @@ func TestTemplatedPolicyListCommand_JSON(t *testing.T) {
 
 	cmd := New(ui)
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 	output := ui.OutputWriter.String()
 	require.Contains(t, output, api.ACLTemplatedPolicyServiceName)
@@ -96,7 +96,7 @@ func TestTemplatedPolicyListCommand_JSON(t *testing.T) {
 
 	var jsonOutput map[string]api.ACLTemplatedPolicyResponse
 	err := json.Unmarshal([]byte(output), &jsonOutput)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	outputTemplate := jsonOutput[api.ACLTemplatedPolicyDNSName]
 	assert.Equal(t, structs.ACLTemplatedPolicyNoRequiredVariablesSchema, outputTemplate.Schema)
 }

--- a/command/acl/templatedpolicy/preview/templated_policy_preview_test.go
+++ b/command/acl/templatedpolicy/preview/templated_policy_preview_test.go
@@ -54,7 +54,7 @@ func TestTemplatedPolicyPreviewCommand(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 1)
+		assert.Equal(t, 1, code)
 		assert.Contains(t, ui.ErrorWriter.String(), "Cannot preview a templated policy without specifying -name or -file")
 	})
 
@@ -68,7 +68,7 @@ func TestTemplatedPolicyPreviewCommand(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 1)
+		assert.Equal(t, 1, code)
 		assert.Contains(t, ui.ErrorWriter.String(), "Failed to generate the templated policy preview")
 	})
 
@@ -83,7 +83,7 @@ func TestTemplatedPolicyPreviewCommand(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 0)
+		assert.Equal(t, 0, code)
 		assert.Empty(t, ui.ErrorWriter.String())
 		output := ui.OutputWriter.String()
 		require.Contains(t, output, "synthetic policy generated from templated policy: builtin/node")
@@ -103,7 +103,7 @@ func TestTemplatedPolicyPreviewCommand(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 0)
+		assert.Equal(t, 0, code)
 		assert.Empty(t, ui.ErrorWriter.String())
 		output := ui.OutputWriter.String()
 		require.Contains(t, output, "synthetic policy generated from templated policy: builtin/service")
@@ -126,7 +126,7 @@ func TestTemplatedPolicyPreviewCommand(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 1)
+		assert.Equal(t, 1, code)
 		assert.Contains(t, ui.ErrorWriter.String(), "Can only preview a single templated policy at a time.")
 	})
 }
@@ -160,7 +160,7 @@ func TestTemplatedPolicyPreviewCommand_JSON(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 1)
+		assert.Equal(t, 1, code)
 		assert.Contains(t, ui.ErrorWriter.String(), "Cannot preview a templated policy without specifying -name or -file")
 	})
 
@@ -175,7 +175,7 @@ func TestTemplatedPolicyPreviewCommand_JSON(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 1)
+		assert.Equal(t, 1, code)
 		assert.Contains(t, ui.ErrorWriter.String(), "Failed to generate the templated policy preview")
 	})
 
@@ -191,7 +191,7 @@ func TestTemplatedPolicyPreviewCommand_JSON(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 0)
+		assert.Equal(t, 0, code)
 		assert.Empty(t, ui.ErrorWriter.String())
 		output := ui.OutputWriter.String()
 		require.Contains(t, output, "synthetic policy generated from templated policy: builtin/node")
@@ -199,6 +199,6 @@ func TestTemplatedPolicyPreviewCommand_JSON(t *testing.T) {
 		// ensure valid json
 		var jsonOutput json.RawMessage
 		err := json.Unmarshal([]byte(output), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/command/acl/templatedpolicy/read/templated_policy_read_test.go
+++ b/command/acl/templatedpolicy/read/templated_policy_read_test.go
@@ -53,7 +53,7 @@ func TestTemplatedPolicyReadCommand(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 1)
+		assert.Equal(t, 1, code)
 		assert.Contains(t, ui.ErrorWriter.String(), "Must specify the -name parameter")
 	})
 
@@ -67,7 +67,7 @@ func TestTemplatedPolicyReadCommand(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 0)
+		assert.Equal(t, 0, code)
 		assert.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
@@ -105,7 +105,7 @@ func TestTemplatedPolicyReadCommand_JSON(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 1)
+		assert.Equal(t, 1, code)
 		assert.Contains(t, ui.ErrorWriter.String(), "Must specify the -name parameter")
 	})
 
@@ -120,14 +120,14 @@ func TestTemplatedPolicyReadCommand_JSON(t *testing.T) {
 
 		cmd := New(ui)
 		code := cmd.Run(args)
-		assert.Equal(t, code, 0)
+		assert.Equal(t, 0, code)
 		assert.Empty(t, ui.ErrorWriter.String())
 
 		output := ui.OutputWriter.String()
 		var templatedPolicy api.ACLTemplatedPolicyResponse
 		err := json.Unmarshal([]byte(output), &templatedPolicy)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, structs.ACLTemplatedPolicyNodeSchema, templatedPolicy.Schema)
 		assert.Equal(t, api.ACLTemplatedPolicyNodeName, templatedPolicy.TemplateName)
 	})

--- a/command/acl/token/clone/token_clone_test.go
+++ b/command/acl/token/clone/token_clone_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent"
@@ -110,7 +109,7 @@ func TestTokenCloneCommand_Pretty(t *testing.T) {
 
 		code := cmd.Run(args)
 		require.Empty(t, ui.ErrorWriter.String())
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 
 		cloned := parseCloneOutput(t, ui.OutputWriter.String())
 
@@ -144,7 +143,7 @@ func TestTokenCloneCommand_Pretty(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		cloned := parseCloneOutput(t, ui.OutputWriter.String())
@@ -225,12 +224,12 @@ func TestTokenCloneCommand_JSON(t *testing.T) {
 
 		code := cmd.Run(args)
 		require.Empty(t, ui.ErrorWriter.String())
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 
 		output := ui.OutputWriter.String()
 		var jsonOutput json.RawMessage
 		err = json.Unmarshal([]byte(output), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	// clone without description
@@ -247,11 +246,11 @@ func TestTokenCloneCommand_JSON(t *testing.T) {
 
 		code := cmd.Run(args)
 		require.Empty(t, ui.ErrorWriter.String())
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 
 		output := ui.OutputWriter.String()
 		var jsonOutput json.RawMessage
 		err = json.Unmarshal([]byte(output), &jsonOutput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/command/acl/token/create/token_create_test.go
+++ b/command/acl/token/create/token_create_test.go
@@ -229,7 +229,7 @@ func TestTokenCreateCommand_JSON(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0)
+		require.Equal(t, 0, code)
 		require.Empty(t, ui.ErrorWriter.String())
 
 		var jsonOutput json.RawMessage

--- a/command/acl/token/delete/token_delete_test.go
+++ b/command/acl/token/delete/token_delete_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
@@ -53,7 +54,7 @@ func TestTokenDeleteCommand(t *testing.T) {
 		&api.ACLToken{Description: "test"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -62,7 +63,7 @@ func TestTokenDeleteCommand(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	output := ui.OutputWriter.String()
@@ -73,6 +74,6 @@ func TestTokenDeleteCommand(t *testing.T) {
 		token.AccessorID,
 		&api.QueryOptions{Token: "root"},
 	)
-	assert.ErrorContains(t, err, "Unexpected response code: 403")
-	assert.ErrorContains(t, err, "ACL not found")
+	require.ErrorContains(t, err, "Unexpected response code: 403")
+	require.ErrorContains(t, err, "ACL not found")
 }

--- a/command/acl/token/list/token_list_test.go
+++ b/command/acl/token/list/token_list_test.go
@@ -60,7 +60,7 @@ func TestTokenListCommand_Pretty(t *testing.T) {
 		)
 		tokenIds = append(tokenIds, token.AccessorID)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	args := []string{
@@ -69,7 +69,7 @@ func TestTokenListCommand_Pretty(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 	output := ui.OutputWriter.String()
 
@@ -114,7 +114,7 @@ func TestTokenListCommand_JSON(t *testing.T) {
 		)
 		tokenIds = append(tokenIds, token.AccessorID)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	args := []string{
@@ -124,7 +124,7 @@ func TestTokenListCommand_JSON(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	var jsonOutput []api.ACLTokenListEntry

--- a/command/acl/token/read/token_read_test.go
+++ b/command/acl/token/read/token_read_test.go
@@ -55,7 +55,7 @@ func TestTokenReadCommand_Pretty(t *testing.T) {
 		&api.ACLToken{Description: "test"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -64,7 +64,7 @@ func TestTokenReadCommand_Pretty(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	output := ui.OutputWriter.String()
@@ -102,7 +102,7 @@ func TestTokenReadCommand_JSON(t *testing.T) {
 		&api.ACLToken{Description: "test"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -112,7 +112,7 @@ func TestTokenReadCommand_JSON(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	var jsonOutput json.RawMessage
@@ -149,7 +149,7 @@ func TestTokenReadCommand_Self(t *testing.T) {
 		&api.ACLToken{Description: "test"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -158,7 +158,7 @@ func TestTokenReadCommand_Self(t *testing.T) {
 	}
 
 	code := cmd.Run(args)
-	assert.Equal(t, code, 0)
+	assert.Equal(t, 0, code)
 	assert.Empty(t, ui.ErrorWriter.String())
 
 	output := ui.OutputWriter.String()

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -399,7 +399,7 @@ func TestTokenUpdateCommand_JSON(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		assert.Equal(t, code, 0)
+		assert.Equal(t, 0, code)
 		assert.Empty(t, ui.ErrorWriter.String())
 
 		var jsonOutput json.RawMessage

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -1412,7 +1412,7 @@ func TestEnvoy_GatewayRegistration(t *testing.T) {
 			}
 
 			data, _, err := client.Agent().Service(tc.id, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.NotNil(t, data)
 			assert.Equal(t, tc.kind, data.Kind)
@@ -1494,7 +1494,7 @@ func TestEnvoy_proxyRegistration(t *testing.T) {
 			}
 
 			result, err := c.proxyRegistration(&tc.args.svcForProxy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			tc.testFn(t, tc.args, result)
 		})
 	}
@@ -1904,9 +1904,9 @@ func TestCheckEnvoyVersionCompatibility(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := checkEnvoyVersionCompatibility(tc.envoyVersion, tc.unsupportedList)
 			if tc.isErrorExpected {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.expectedCompat, actual)
 		})

--- a/command/connect/envoy/flags_test.go
+++ b/command/connect/envoy/flags_test.go
@@ -13,39 +13,39 @@ import (
 func TestServiceAddressValue_Value(t *testing.T) {
 	t.Run("nil receiver", func(t *testing.T) {
 		var addr *ServiceAddressValue
-		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultGatewayPort})
+		require.Equal(t, api.ServiceAddress{Port: defaultGatewayPort}, addr.Value())
 	})
 
 	t.Run("default value", func(t *testing.T) {
 		addr := &ServiceAddressValue{}
-		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultGatewayPort})
+		require.Equal(t, api.ServiceAddress{Port: defaultGatewayPort}, addr.Value())
 	})
 
 	t.Run("set value", func(t *testing.T) {
 		addr := &ServiceAddressValue{}
 		require.NoError(t, addr.Set("localhost:3333"))
-		require.Equal(t, addr.Value(), api.ServiceAddress{
+		require.Equal(t, api.ServiceAddress{
 			Address: "localhost",
 			Port:    3333,
-		})
+		}, addr.Value())
 	})
 }
 
 func TestServiceAddressValue_String(t *testing.T) {
 	t.Run("nil receiver", func(t *testing.T) {
 		var addr *ServiceAddressValue
-		require.Equal(t, addr.String(), ":8443")
+		require.Equal(t, ":8443", addr.String())
 	})
 
 	t.Run("default value", func(t *testing.T) {
 		addr := &ServiceAddressValue{}
-		require.Equal(t, addr.String(), ":8443")
+		require.Equal(t, ":8443", addr.String())
 	})
 
 	t.Run("set value", func(t *testing.T) {
 		addr := &ServiceAddressValue{}
 		require.NoError(t, addr.Set("localhost:3333"))
-		require.Equal(t, addr.String(), "localhost:3333")
+		require.Equal(t, "localhost:3333", addr.String())
 	})
 }
 
@@ -103,7 +103,7 @@ func TestServiceAddressValue_Set(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, addr.Value(), tc.expectedValue)
+			require.Equal(t, tc.expectedValue, addr.Value())
 		})
 	}
 }

--- a/command/connect/proxy/proxy_test.go
+++ b/command/connect/proxy/proxy_test.go
@@ -32,7 +32,7 @@ func TestCommandConfigWatcher(t *testing.T) {
 			Flags: []string{"-service", "web"},
 			Test: func(t *testing.T, cfg *proxy.Config) {
 				require.Equal(t, 0, cfg.PublicListener.BindPort)
-				require.Len(t, cfg.Upstreams, 0)
+				require.Empty(t, cfg.Upstreams)
 			},
 		},
 
@@ -57,7 +57,7 @@ func TestCommandConfigWatcher(t *testing.T) {
 			Test: func(t *testing.T, cfg *proxy.Config) {
 				// -service-addr has no affect since -listen isn't set
 				require.Equal(t, 0, cfg.PublicListener.BindPort)
-				require.Len(t, cfg.Upstreams, 0)
+				require.Empty(t, cfg.Upstreams)
 			},
 		},
 
@@ -69,7 +69,7 @@ func TestCommandConfigWatcher(t *testing.T) {
 				"-listen", ":4567",
 			},
 			Test: func(t *testing.T, cfg *proxy.Config) {
-				require.Len(t, cfg.Upstreams, 0)
+				require.Empty(t, cfg.Upstreams)
 
 				require.Equal(t, "", cfg.PublicListener.BindAddress)
 				require.Equal(t, 4567, cfg.PublicListener.BindPort)

--- a/command/connect/redirecttraffic/redirect_traffic_test.go
+++ b/command/connect/redirecttraffic/redirect_traffic_test.go
@@ -54,7 +54,7 @@ func TestRun_FlagValidation(t *testing.T) {
 			cmd := New(ui)
 
 			code := cmd.Run(c.args)
-			require.Equal(t, code, 1)
+			require.Equal(t, 1, code)
 			require.Contains(t, ui.ErrorWriter.String(), c.expError)
 		})
 	}

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -545,7 +545,7 @@ func TestDebugCommand_DebugDisabled(t *testing.T) {
 	// Glob ignores file system errors
 	for _, v := range profiles {
 		fs, _ := filepath.Glob(fmt.Sprintf("%s/*r/%s", outputPath, v))
-		require.True(t, len(fs) == 0)
+		require.Empty(t, fs)
 	}
 
 	errOutput := ui.ErrorWriter.String()

--- a/command/intention/delete/delete_test.go
+++ b/command/intention/delete/delete_test.go
@@ -157,6 +157,6 @@ func TestIntentionDelete(t *testing.T) {
 	{
 		ixns, _, err := client.Connect().Intentions(nil)
 		require.NoError(t, err)
-		require.Len(t, ixns, 0)
+		require.Empty(t, ixns)
 	}
 }

--- a/command/login/login_test.go
+++ b/command/login/login_test.go
@@ -56,7 +56,7 @@ func TestLoginCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-method' flag")
 	})
 
@@ -73,7 +73,7 @@ func TestLoginCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-token-sink-file' flag")
 	})
 
@@ -91,7 +91,7 @@ func TestLoginCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "Missing required '-bearer-token-file' flag")
 	})
 
@@ -111,7 +111,7 @@ func TestLoginCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "Cannot use '-bearer-token-file' flag with '-aws-auto-bearer-token'")
 	})
 
@@ -136,7 +136,7 @@ func TestLoginCommand(t *testing.T) {
 		} {
 			ui := cli.NewMockUi()
 			code := New(ui).Run(append(baseArgs, extraArgs...))
-			require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+			require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 			require.Contains(t, ui.ErrorWriter.String(), "Missing '-aws-auto-bearer-token' flag")
 		}
 	})
@@ -154,17 +154,17 @@ func TestLoginCommand(t *testing.T) {
 
 		ui := cli.NewMockUi()
 		code := New(ui).Run(append(baseArgs, "-aws-access-key-id", "some-key"))
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "Missing '-aws-secret-access-key' flag")
 
 		ui = cli.NewMockUi()
 		code = New(ui).Run(append(baseArgs, "-aws-secret-access-key", "some-key"))
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "Missing '-aws-access-key-id' flag")
 
 		ui = cli.NewMockUi()
 		code = New(ui).Run(append(baseArgs, "-aws-session-token", "some-token"))
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(),
 			"Missing '-aws-access-key-id' and '-aws-secret-access-key' flags")
 
@@ -189,7 +189,7 @@ func TestLoginCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "No bearer token found in")
 	})
 
@@ -210,7 +210,7 @@ func TestLoginCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "403 (ACL not found: auth method \"test\" not found")
 	})
 

--- a/command/logout/logout_test.go
+++ b/command/logout/logout_test.go
@@ -57,7 +57,7 @@ func TestLogoutCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "401 (Supplied token does not exist)")
 	})
 
@@ -74,7 +74,7 @@ func TestLogoutCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "403 (ACL not found)")
 	})
 
@@ -94,7 +94,7 @@ func TestLogoutCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "403 (Permission denied: token wasn't created via login)")
 	})
 
@@ -152,7 +152,7 @@ func TestLogoutCommand(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 	})
 }
@@ -187,7 +187,7 @@ func TestLogoutCommand_k8s(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "401 (Supplied token does not exist)")
 	})
 
@@ -204,7 +204,7 @@ func TestLogoutCommand_k8s(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "403 (ACL not found)")
 	})
 
@@ -224,7 +224,7 @@ func TestLogoutCommand_k8s(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 1, code, "err: %s", ui.ErrorWriter.String())
 		require.Contains(t, ui.ErrorWriter.String(), "403 (Permission denied: token wasn't created via login)")
 	})
 
@@ -289,7 +289,7 @@ func TestLogoutCommand_k8s(t *testing.T) {
 		}
 
 		code := cmd.Run(args)
-		require.Equal(t, code, 0, "err: %s", ui.ErrorWriter.String())
+		require.Equal(t, 0, code, "err: %s", ui.ErrorWriter.String())
 		require.Empty(t, ui.ErrorWriter.String())
 	})
 }

--- a/command/operator/autopilot/state/operator_autopilot_state_test.go
+++ b/command/operator/autopilot/state/operator_autopilot_state_test.go
@@ -68,7 +68,7 @@ func TestStateCommand_Pretty(t *testing.T) {
 
 	code := cmd.Run(args)
 	require.Empty(t, ui.ErrorWriter.String())
-	require.Equal(t, code, 0)
+	require.Equal(t, 0, code)
 	output := ui.OutputWriter.String()
 
 	// Just a few quick checks to ensure we got output
@@ -98,7 +98,7 @@ func TestStateCommand_JSON(t *testing.T) {
 
 	code := cmd.Run(args)
 	require.Empty(t, ui.ErrorWriter.String())
-	require.Equal(t, code, 0)
+	require.Equal(t, 0, code)
 	output := ui.OutputWriter.String()
 
 	var state api.AutopilotState

--- a/command/peering/exportedservices/exported_services_test.go
+++ b/command/peering/exportedservices/exported_services_test.go
@@ -123,7 +123,7 @@ func TestExportedServicesCommand(t *testing.T) {
 
 		code := cmd.Run(args)
 		require.Equal(t, 0, code)
-		require.Equal(t, ui.ErrorWriter.String(), "")
+		require.Equal(t, "", ui.ErrorWriter.String())
 	})
 
 	t.Run("exported-services with pretty print", func(t *testing.T) {

--- a/command/resource/client/grpc-client_test.go
+++ b/command/resource/client/grpc-client_test.go
@@ -49,7 +49,7 @@ func TestResourceRead(t *testing.T) {
 
 		readRsp, err := gRPCClient.Client.Read(context.Background(), &pbresource.ReadRequest{Id: v2Artist.Id})
 		require.NoError(t, err)
-		require.Equal(t, proto.Equal(readRsp.Resource.Id.Type, demo.TypeV2Artist), true)
+		require.True(t, proto.Equal(readRsp.Resource.Id.Type, demo.TypeV2Artist))
 		prototest.AssertDeepEqual(t, writeRsp.Resource, readRsp.Resource)
 	})
 }
@@ -140,7 +140,7 @@ func TestResourceReadInTLS(t *testing.T) {
 
 			readRsp, err := gRPCClient.Client.Read(context.Background(), &pbresource.ReadRequest{Id: v2Artist.Id})
 			require.NoError(t, err)
-			require.Equal(t, proto.Equal(readRsp.Resource.Id.Type, demo.TypeV2Artist), true)
+			require.True(t, proto.Equal(readRsp.Resource.Id.Type, demo.TypeV2Artist))
 			prototest.AssertDeepEqual(t, writeRsp.Resource, readRsp.Resource)
 		})
 	}

--- a/command/resource/client/grpc-config_test.go
+++ b/command/resource/client/grpc-config_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadGRPCConfig(t *testing.T) {
 	t.Run("Default Config", func(t *testing.T) {
 		// Test when defaultConfig is nil
 		config, err := LoadGRPCConfig(nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, GetDefaultGRPCConfig(), config)
 	})
 
@@ -32,7 +33,7 @@ func TestLoadGRPCConfig(t *testing.T) {
 
 		// Load and validate the configuration
 		config, err := LoadGRPCConfig(nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expectedConfig := &GRPCConfig{
 			Address:       "localhost:8500",
 			GRPCTLS:       true,
@@ -54,7 +55,7 @@ func TestLoadGRPCConfig(t *testing.T) {
 
 		// Load and expect an error
 		config, err := LoadGRPCConfig(nil)
-		assert.Error(t, err, "failed to parse CONSUL_GRPC_TLS: strconv.ParseBool: parsing \"invalid_boolean_value\": invalid syntax")
+		require.Error(t, err, "failed to parse CONSUL_GRPC_TLS: strconv.ParseBool: parsing \"invalid_boolean_value\": invalid syntax")
 		assert.Nil(t, config)
 	})
 }

--- a/command/resource/client/helper_test.go
+++ b/command/resource/client/helper_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTValue(t *testing.T) {
@@ -14,9 +15,9 @@ func TestTValue(t *testing.T) {
 		var tv TValue[string]
 
 		err := tv.Set("testString")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		assert.Equal(t, *tv.v, "testString")
+		assert.Equal(t, "testString", *tv.v)
 	})
 
 	t.Run("String: merge", func(t *testing.T) {
@@ -27,7 +28,7 @@ func TestTValue(t *testing.T) {
 		tv.v = &testStr
 		tv.Merge(&onto)
 
-		assert.Equal(t, onto, "testString")
+		assert.Equal(t, "testString", onto)
 	})
 
 	t.Run("String: merge nil", func(t *testing.T) {
@@ -38,23 +39,23 @@ func TestTValue(t *testing.T) {
 		tv.v = &testStr
 		err := tv.Merge(onto)
 
-		assert.Equal(t, err.Error(), "onto is nil")
+		assert.Equal(t, "onto is nil", err.Error())
 	})
 
 	t.Run("Get string", func(t *testing.T) {
 		var tv TValue[string]
 		testStr := "testString"
 		tv.v = &testStr
-		assert.Equal(t, tv.String(), "testString")
+		assert.Equal(t, "testString", tv.String())
 	})
 
 	t.Run("Bool: set", func(t *testing.T) {
 		var tv TValue[bool]
 
 		err := tv.Set("true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		assert.Equal(t, *tv.v, true)
+		assert.True(t, *tv.v)
 	})
 
 	t.Run("Bool: merge", func(t *testing.T) {
@@ -65,6 +66,6 @@ func TestTValue(t *testing.T) {
 		tv.v = &testBool
 		tv.Merge(&onto)
 
-		assert.Equal(t, onto, true)
+		assert.True(t, onto)
 	})
 }

--- a/command/services/config_test.go
+++ b/command/services/config_test.go
@@ -25,8 +25,8 @@ func TestDevModeHasNoServices(t *testing.T) {
 	}
 	result, err := config.Load(opts)
 	require.NoError(t, err)
-	require.Len(t, result.Warnings, 0)
-	require.Len(t, result.RuntimeConfig.Services, 0)
+	require.Empty(t, result.Warnings)
+	require.Empty(t, result.RuntimeConfig.Services)
 }
 
 func TestInvalidNodeNameWarning(t *testing.T) {

--- a/command/services/exportedservices/exported_services_test.go
+++ b/command/services/exportedservices/exported_services_test.go
@@ -170,7 +170,7 @@ func TestExportedServices_JSON(t *testing.T) {
 	err = json.Unmarshal(ui.OutputWriter.Bytes(), &resp)
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(resp))
+	require.Len(t, resp, 2)
 	require.Equal(t, "db", resp[0].Service)
 	require.Equal(t, "web", resp[1].Service)
 	require.Equal(t, []string{"east", "west"}, resp[0].Consumers.Peers)
@@ -251,7 +251,7 @@ func TestExportedServices_filter(t *testing.T) {
 		err = json.Unmarshal(ui.OutputWriter.Bytes(), &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, 2, len(resp))
+		require.Len(t, resp, 2)
 		require.Equal(t, "db", resp[0].Service)
 		require.Equal(t, "web", resp[1].Service)
 		require.Equal(t, []string{"east", "west"}, resp[0].Consumers.Peers)
@@ -276,7 +276,7 @@ func TestExportedServices_filter(t *testing.T) {
 		err = json.Unmarshal(ui.OutputWriter.Bytes(), &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, 2, len(resp))
+		require.Len(t, resp, 2)
 		require.Equal(t, "backend", resp[0].Service)
 		require.Equal(t, "db", resp[1].Service)
 		require.Equal(t, []string{"west"}, resp[0].Consumers.Peers)
@@ -300,7 +300,7 @@ func TestExportedServices_filter(t *testing.T) {
 		err = json.Unmarshal(ui.OutputWriter.Bytes(), &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, 1, len(resp))
+		require.Len(t, resp, 1)
 		require.Equal(t, "frontend", resp[0].Service)
 		require.Equal(t, []string{"peer1", "peer2"}, resp[0].Consumers.Peers)
 	})

--- a/command/services/register/register_test.go
+++ b/command/services/register/register_test.go
@@ -162,10 +162,10 @@ func TestCommand_Flags_TaggedAddresses(t *testing.T) {
 	require.Len(t, svc.TaggedAddresses, 2)
 	require.Contains(t, svc.TaggedAddresses, "lan")
 	require.Contains(t, svc.TaggedAddresses, "v6")
-	require.Equal(t, svc.TaggedAddresses["lan"].Address, "127.0.0.1")
-	require.Equal(t, svc.TaggedAddresses["lan"].Port, 1234)
-	require.Equal(t, svc.TaggedAddresses["v6"].Address, "2001:db8::12")
-	require.Equal(t, svc.TaggedAddresses["v6"].Port, 1234)
+	require.Equal(t, "127.0.0.1", svc.TaggedAddresses["lan"].Address)
+	require.Equal(t, 1234, svc.TaggedAddresses["lan"].Port)
+	require.Equal(t, "2001:db8::12", svc.TaggedAddresses["v6"].Address)
+	require.Equal(t, 1234, svc.TaggedAddresses["v6"].Port)
 }
 
 func TestCommand_FileWithUnnamedCheck(t *testing.T) {

--- a/command/tls/ca/create/tls_ca_create_test.go
+++ b/command/tls/ca/create/tls_ca_create_test.go
@@ -47,7 +47,7 @@ func TestCACreateCommand(t *testing.T) {
 			func(t *testing.T, cert *x509.Certificate) {
 				require.Equal(t, 1825*24*time.Hour, time.Until(cert.NotAfter).Round(24*time.Hour))
 				require.False(t, cert.PermittedDNSDomainsCritical)
-				require.Len(t, cert.PermittedDNSDomains, 0)
+				require.Empty(t, cert.PermittedDNSDomains)
 			},
 		},
 		{"ca options",
@@ -75,7 +75,7 @@ func TestCACreateCommand(t *testing.T) {
 			"foo-agent-ca-key.pem",
 			func(t *testing.T, cert *x509.Certificate) {
 				require.Len(t, cert.URIs, 1)
-				require.Equal(t, cert.URIs[0].String(), "spiffe://uuid.foo")
+				require.Equal(t, "spiffe://uuid.foo", cert.URIs[0].String())
 			},
 		},
 		{"with common-name",
@@ -85,7 +85,7 @@ func TestCACreateCommand(t *testing.T) {
 			"consul-agent-ca.pem",
 			"consul-agent-ca-key.pem",
 			func(t *testing.T, cert *x509.Certificate) {
-				require.Equal(t, cert.Subject.CommonName, "foo")
+				require.Equal(t, "foo", cert.Subject.CommonName)
 			},
 		},
 		{"without common-name",

--- a/command/tls/cert/create/tls_cert_create_test.go
+++ b/command/tls/cert/create/tls_cert_create_test.go
@@ -231,7 +231,7 @@ func TestTlsCertCreateCommand_fileCreate(t *testing.T) {
 					[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 					cert.ExtKeyUsage)
 			case "cli":
-				require.Len(t, cert.ExtKeyUsage, 0)
+				require.Empty(t, cert.ExtKeyUsage)
 			}
 			require.False(t, cert.IsCA)
 			require.Equal(t, tc.expectDNS, cert.DNSNames)

--- a/command/validate/validate_test.go
+++ b/command/validate/validate_test.go
@@ -38,7 +38,7 @@ func TestValidateCommand_SucceedOnMinimalConfigFile(t *testing.T) {
 
 	fp := filepath.Join(td, "config.json")
 	err := os.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
-	require.Nilf(t, err, "err: %s", err)
+	require.NoErrorf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
 	args := []string{fp}
@@ -53,7 +53,7 @@ func TestValidateCommand_SucceedWithMinimalJSONConfigFormat(t *testing.T) {
 
 	fp := filepath.Join(td, "json.conf")
 	err := os.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
-	require.Nilf(t, err, "err: %s", err)
+	require.NoErrorf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
 	args := []string{"--config-format", "json", fp}
@@ -68,7 +68,7 @@ func TestValidateCommand_SucceedWithMinimalHCLConfigFormat(t *testing.T) {
 
 	fp := filepath.Join(td, "hcl.conf")
 	err := os.WriteFile(fp, []byte("bind_addr = \"10.0.0.1\"\ndata_dir = \""+td+"\""), 0644)
-	require.Nilf(t, err, "err: %s", err)
+	require.NoErrorf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
 	args := []string{"--config-format", "hcl", fp}
@@ -83,7 +83,7 @@ func TestValidateCommand_SucceedWithJSONAsHCL(t *testing.T) {
 
 	fp := filepath.Join(td, "json.conf")
 	err := os.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
-	require.Nilf(t, err, "err: %s", err)
+	require.NoErrorf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
 	args := []string{"--config-format", "hcl", fp}
@@ -97,7 +97,7 @@ func TestValidateCommand_SucceedOnMinimalConfigDir(t *testing.T) {
 	td := testutil.TempDir(t, "consul")
 
 	err := os.WriteFile(filepath.Join(td, "config.json"), []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
-	require.Nilf(t, err, "err: %s", err)
+	require.NoErrorf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
 	args := []string{td}
@@ -112,7 +112,7 @@ func TestValidateCommand_FailForInvalidJSONConfigFormat(t *testing.T) {
 
 	fp := filepath.Join(td, "hcl.conf")
 	err := os.WriteFile(fp, []byte(`bind_addr = "10.0.0.1"\ndata_dir = "`+td+`"`), 0644)
-	require.Nilf(t, err, "err: %s", err)
+	require.NoErrorf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
 	args := []string{"--config-format", "json", fp}
@@ -127,7 +127,7 @@ func TestValidateCommand_Quiet(t *testing.T) {
 
 	fp := filepath.Join(td, "config.json")
 	err := os.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
-	require.Nilf(t, err, "err: %s", err)
+	require.NoErrorf(t, err, "err: %s", err)
 
 	ui := cli.NewMockUi()
 	cmd := New(ui)

--- a/connect/proxy/conn_test.go
+++ b/connect/proxy/conn_test.go
@@ -26,17 +26,17 @@ func testConnPairSetup(t *testing.T) (net.Conn, net.Conn, func()) {
 	t.Helper()
 
 	l, err := net.Listen("tcp", "localhost:0")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ch := make(chan net.Conn, 1)
 	go func() {
 		src, err := l.Accept()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		ch <- src
 	}()
 
 	dst, err := net.Dial("tcp", l.Addr().String())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	src := <-ch
 
@@ -82,16 +82,16 @@ func TestConn(t *testing.T) {
 	dstR := bufio.NewReader(dst)
 
 	_, err := src.Write([]byte("ping 1\n"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = dst.Write([]byte("ping 2\n"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	got, err := dstR.ReadString('\n')
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "ping 1\n", got)
 
 	got, err = srcR.ReadString('\n')
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "ping 2\n", got)
 
 	retry.Run(t, func(r *retry.R) {
@@ -101,16 +101,16 @@ func TestConn(t *testing.T) {
 	})
 
 	_, err = src.Write([]byte("pong 1\n"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = dst.Write([]byte("pong 2\n"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	got, err = dstR.ReadString('\n')
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "pong 1\n", got)
 
 	got, err = srcR.ReadString('\n')
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "pong 2\n", got)
 
 	retry.Run(t, func(r *retry.R) {
@@ -122,7 +122,7 @@ func TestConn(t *testing.T) {
 	c.Close()
 
 	ret := <-retCh
-	require.Nil(t, ret, "Close() should not cause error return")
+	require.NoError(t, ret, "Close() should not cause error return")
 }
 
 func TestConnSrcClosing(t *testing.T) {
@@ -140,15 +140,15 @@ func TestConnSrcClosing(t *testing.T) {
 	dstR := bufio.NewReader(dst)
 
 	_, err := src.Write([]byte("ping 1\n"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = dst.Write([]byte("ping 2\n"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	got, err := dstR.ReadString('\n')
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "ping 1\n", got)
 	got, err = srcR.ReadString('\n')
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "ping 2\n", got)
 
 	// If we close the src conn, we expect CopyBytes to return and dst to be
@@ -178,15 +178,15 @@ func TestConnDstClosing(t *testing.T) {
 	dstR := bufio.NewReader(dst)
 
 	_, err := src.Write([]byte("ping 1\n"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = dst.Write([]byte("ping 2\n"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	got, err := dstR.ReadString('\n')
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "ping 1\n", got)
 	got, err = srcR.ReadString('\n')
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "ping 2\n", got)
 
 	// If we close the dst conn, we expect CopyBytes to return and src to be

--- a/connect/proxy/testing.go
+++ b/connect/proxy/testing.go
@@ -89,7 +89,7 @@ func TestEchoConn(t testing.T, conn net.Conn, prefix string) {
 	// Write some bytes and read them back
 	n, err := conn.Write([]byte("Hello World"))
 	require.Equal(t, 11, n)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	expectLen := 11 + len(prefix)
 
@@ -99,7 +99,7 @@ func TestEchoConn(t testing.T, conn net.Conn, prefix string) {
 	got := 0
 	for got < expectLen {
 		n, err = conn.Read(buf[got:])
-		require.Nilf(t, err, "err: %s", err)
+		require.NoErrorf(t, err, "err: %s", err)
 		got += n
 	}
 	require.Equal(t, expectLen, got)

--- a/connect/resolver_test.go
+++ b/connect/resolver_test.go
@@ -35,7 +35,7 @@ func TestStaticResolver_Resolve(t *testing.T) {
 				CertURI: tt.fields.CertURI,
 			}
 			addr, certURI, err := sr.Resolve(context.Background())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, sr.Addr, addr)
 			require.Equal(t, sr.CertURI, certURI)
 		})
@@ -54,7 +54,7 @@ func TestConsulResolver_Resolve(t *testing.T) {
 	cfg := api.DefaultConfig()
 	cfg.Address = agent.HTTPAddr()
 	client, err := api.NewClient(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Setup a service with a connect proxy instance
 	regSrv := &api.AgentServiceRegistration{
@@ -62,7 +62,7 @@ func TestConsulResolver_Resolve(t *testing.T) {
 		Port: 8080,
 	}
 	err = client.Agent().ServiceRegister(regSrv)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	regProxy := &api.AgentServiceRegistration{
 		Kind: "connect-proxy",
@@ -76,14 +76,14 @@ func TestConsulResolver_Resolve(t *testing.T) {
 		},
 	}
 	err = client.Agent().ServiceRegister(regProxy)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// And another proxy so we can test handling with multiple endpoints returned
 	regProxy.Port = 9091
 	regProxy.ID = "web-proxy-2"
 	regProxy.Meta = map[string]string{}
 	err = client.Agent().ServiceRegister(regProxy)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Add a native service
 	{
@@ -251,11 +251,11 @@ func TestConsulResolver_Resolve(t *testing.T) {
 			defer cancel()
 			gotAddr, gotCertURI, err := cr.Resolve(ctx)
 			if tt.wantErr {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				return
 			}
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, tt.wantCertURI, gotCertURI)
 			if len(tt.addrs) > 0 {
 				require.Contains(t, tt.addrs, gotAddr)

--- a/connect/tls_test.go
+++ b/connect/tls_test.go
@@ -67,9 +67,9 @@ func Test_verifyServerCertMatchesURI(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := verifyServerCertMatchesURI(tt.certs, tt.expected)
 			if tt.wantErr {
-				require.NotNil(t, err)
+				require.Error(t, err)
 			} else {
-				require.Nil(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -130,9 +130,9 @@ func TestClientSideVerifier(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := clientSideVerifier(tt.tlsCfg, tt.rawCerts)
 			if tt.wantErr == "" {
-				require.Nil(t, err)
+				require.NoError(t, err)
 			} else {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.wantErr)
 			}
 		})
@@ -256,9 +256,9 @@ func TestServerSideVerifier(t *testing.T) {
 			v := newServerSideVerifier(testutil.Logger(t), client, tt.service)
 			err := v(tt.tlsCfg, tt.rawCerts)
 			if tt.wantErr == "" {
-				require.Nil(t, err)
+				require.NoError(t, err)
 			} else {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.wantErr)
 			}
 		})
@@ -283,17 +283,17 @@ func requireEqualTLSConfig(t *testing.T, expect, got *tls.Config) {
 	var err error
 	if expect.GetCertificate != nil {
 		expectLeaf, err = expect.GetCertificate(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	} else if len(expect.Certificates) > 0 {
 		expectLeaf = &expect.Certificates[0]
 	}
 
 	gotLeaf, err := got.GetCertificate(nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expectLeaf, gotLeaf)
 
 	gotLeaf, err = got.GetClientCertificate(nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expectLeaf, gotLeaf)
 }
 
@@ -315,7 +315,7 @@ func requireCorrectVerifier(t *testing.T, expect, got *tls.Config,
 	ch chan *tls.Config) {
 
 	err := got.VerifyPeerCertificate(nil, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	verifierCfg := <-ch
 	// The tls.Cfg passed to verifyFunc should be the expected (current) value.
 	requireEqualTLSConfig(t, expect, verifierCfg)
@@ -358,7 +358,7 @@ func TestDynamicTLSConfig(t *testing.T) {
 
 	// Now change the roots as if we just loaded new roots from Consul
 	err := c.SetRoots(newCfg.RootCAs)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// The dynamic config should have the new roots, but old leaf
 	gotAfter := c.Get(verify2)
@@ -375,7 +375,7 @@ func TestDynamicTLSConfig(t *testing.T) {
 
 	// Now change the leaf
 	err = c.SetLeaf(&newCfg.Certificates[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// The dynamic config should have the new roots, AND new leaf
 	gotAfterLeaf := c.Get(verify3)

--- a/internal/auth/internal/controllers/trafficpermissions/controller_test.go
+++ b/internal/auth/internal/controllers/trafficpermissions/controller_test.go
@@ -72,9 +72,11 @@ func (suite *controllerSuite) SetupTest() {
 }
 
 func (suite *controllerSuite) requireTrafficPermissionsTracking(tp *pbresource.Resource, ids ...*pbresource.ID) {
+	suite.T().Helper()
+
 	reqs, err := suite.mapper.MapTrafficPermissions(suite.ctx, suite.rt, tp)
-	require.NoError(suite.T(), err)
-	require.Len(suite.T(), reqs, len(ids))
+	suite.Require().NoError(err)
+	suite.Require().Len(reqs, len(ids))
 	for _, id := range ids {
 		prototest.AssertContainsElement(suite.T(), reqs, controller.Request{ID: id})
 	}
@@ -84,10 +86,12 @@ func (suite *controllerSuite) requireTrafficPermissionsTracking(tp *pbresource.R
 }
 
 func (suite *controllerSuite) requireCTP(resource *pbresource.Resource, allowExpected []*pbauth.Permission, denyExpected []*pbauth.Permission) {
+	suite.T().Helper()
+
 	dec := rtest.MustDecode[*pbauth.ComputedTrafficPermissions](suite.T(), resource)
 	ctp := dec.Data
-	require.Len(suite.T(), ctp.AllowPermissions, len(allowExpected))
-	require.Len(suite.T(), ctp.DenyPermissions, len(denyExpected))
+	suite.Require().Len(ctp.AllowPermissions, len(allowExpected))
+	suite.Require().Len(ctp.DenyPermissions, len(denyExpected))
 	prototest.AssertElementsMatch(suite.T(), allowExpected, ctp.AllowPermissions)
 	prototest.AssertElementsMatch(suite.T(), denyExpected, ctp.DenyPermissions)
 }
@@ -139,7 +143,7 @@ func (suite *controllerSuite) TestReconcile_CTPCreate_NoReferencingTrafficPermis
 		id := resource.ReplaceType(pbauth.ComputedTrafficPermissionsType, wi.Id)
 
 		err := suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Ensure that the CTP was created
 		ctp := suite.client.RequireResourceExists(suite.T(), id)
@@ -446,14 +450,14 @@ func (suite *controllerSuite) TestReconcile_WorkloadIdentityDelete_ReferencingTr
 		id := resource.ReplaceType(pbauth.ComputedTrafficPermissionsType, wi1ID)
 
 		err := suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// delete the workload identity
 		suite.client.MustDelete(suite.T(), wi.Id)
 
 		// re-reconcile: should untrack the CTP
 		err = suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	})
 }
 
@@ -464,18 +468,18 @@ func (suite *controllerSuite) TestReconcile_WorkloadIdentityDelete_NoReferencing
 		id := resource.ReplaceType(pbauth.ComputedTrafficPermissionsType, wi.Id)
 
 		err := suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// delete the workload identity
 		suite.client.MustDelete(suite.T(), wi.Id)
 
 		// re-reconcile: should untrack the CTP
 		err = suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// there should not be any traffic permissions to compute
 		tps := suite.mapper.GetTrafficPermissionsForCTP(id)
-		require.Len(suite.T(), tps, 0)
+		suite.Require().Empty(tps)
 	})
 }
 
@@ -486,7 +490,7 @@ func (suite *controllerSuite) TestReconcile_TrafficPermissionsCreate_Destination
 		id := resource.ReplaceType(pbauth.ComputedTrafficPermissionsType, wi.Id)
 
 		err := suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		ctpResource := suite.client.RequireResourceExists(suite.T(), id)
 		assertCTPDefaultStatus(suite.T(), ctpResource, true)
@@ -529,7 +533,7 @@ func (suite *controllerSuite) TestReconcile_TrafficPermissionsCreate_Destination
 		suite.requireTrafficPermissionsTracking(tp2, id)
 
 		err = suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Ensure that the CTP was updated
 		ctpResource = suite.client.RequireResourceExists(suite.T(), id)
@@ -557,7 +561,7 @@ func (suite *controllerSuite) TestReconcile_TrafficPermissionsCreate_Destination
 		suite.requireTrafficPermissionsTracking(tp3, id)
 
 		err = suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Ensure that the CTP was updated
 		ctpResource = suite.client.RequireResourceExists(suite.T(), id)
@@ -571,7 +575,7 @@ func (suite *controllerSuite) TestReconcile_TrafficPermissionsCreate_Destination
 		suite.client.MustDelete(suite.T(), tp3.Id)
 
 		err = suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		ctpResource = suite.client.RequireResourceExists(suite.T(), id)
 		suite.requireCTP(ctpResource, []*pbauth.Permission{}, []*pbauth.Permission{})
@@ -587,7 +591,7 @@ func (suite *controllerSuite) TestReconcile_TrafficPermissionsDelete_Destination
 		id := resource.ReplaceType(pbauth.ComputedTrafficPermissionsType, wi.Id)
 
 		err := suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// create traffic permissions
 		p1 := &pbauth.Permission{
@@ -630,7 +634,7 @@ func (suite *controllerSuite) TestReconcile_TrafficPermissionsDelete_Destination
 		suite.requireTrafficPermissionsTracking(tp2, id)
 
 		err = suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		ctp := suite.client.RequireResourceExists(suite.T(), id)
 		suite.requireCTP(ctp, []*pbauth.Permission{p1, p2}, []*pbauth.Permission{})
@@ -640,7 +644,7 @@ func (suite *controllerSuite) TestReconcile_TrafficPermissionsDelete_Destination
 		suite.client.MustDelete(suite.T(), tp2.Id)
 
 		err = suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Ensure that the CTP was updated
 		ctp = suite.client.RequireResourceExists(suite.T(), id)
@@ -648,8 +652,8 @@ func (suite *controllerSuite) TestReconcile_TrafficPermissionsDelete_Destination
 
 		// Ensure TP2 is untracked
 		newTps := suite.mapper.GetTrafficPermissionsForCTP(ctp.Id)
-		require.Len(suite.T(), newTps, 1)
-		require.Equal(suite.T(), newTps[0].Name, tp1.Id.Name)
+		suite.Require().Len(newTps, 1)
+		suite.Require().Equal(newTps[0].Name, tp1.Id.Name)
 	})
 }
 
@@ -708,8 +712,8 @@ func (suite *controllerSuite) TestReconcile_TrafficPermissionsDelete_Destination
 			Type:    pbauth.ComputedTrafficPermissionsType,
 			Tenancy: resource.DefaultNamespacedTenancy(),
 		})
-		require.NoError(suite.T(), err)
-		require.Empty(suite.T(), rsp.Resources)
+		suite.Require().NoError(err)
+		suite.Require().Empty(rsp.Resources)
 	})
 }
 

--- a/internal/catalog/internal/controllers/endpoints/controller_test.go
+++ b/internal/catalog/internal/controllers/endpoints/controller_test.go
@@ -462,9 +462,11 @@ func (suite *controllerSuite) SetupTest() {
 }
 
 func (suite *controllerSuite) requireEndpoints(resource *pbresource.Resource, expected ...*pbcatalog.Endpoint) {
+	suite.T().Helper()
+
 	var svcEndpoints pbcatalog.ServiceEndpoints
-	require.NoError(suite.T(), resource.Data.UnmarshalTo(&svcEndpoints))
-	require.Len(suite.T(), svcEndpoints.Endpoints, len(expected))
+	suite.Require().NoError(resource.Data.UnmarshalTo(&svcEndpoints))
+	suite.Require().Len(svcEndpoints.Endpoints, len(expected))
 	prototest.AssertElementsMatch(suite.T(), expected, svcEndpoints.Endpoints)
 }
 
@@ -476,7 +478,7 @@ func (suite *controllerSuite) TestReconcile_ServiceNotFound() {
 
 		// Because the endpoints don't exist, this reconcile call not error but also shouldn't do anything useful.
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	})
 }
 
@@ -499,7 +501,7 @@ func (suite *controllerSuite) TestReconcile_NoSelector_NoEndpoints() {
 		endpointsID := rtest.Resource(pbcatalog.ServiceEndpointsType, "test").WithTenancy(tenancy).ID()
 
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: endpointsID})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireStatusCondition(suite.T(), service.Id, ControllerID, ConditionUnmanaged)
 	})
@@ -528,7 +530,7 @@ func (suite *controllerSuite) TestReconcile_NoSelector_ManagedEndpoints() {
 			Write(suite.T(), suite.client)
 
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: endpoints.Id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		// the status should indicate the services endpoints are not being managed
 		suite.client.RequireStatusCondition(suite.T(), service.Id, ControllerID, ConditionUnmanaged)
 		// endpoints under management should be deleted
@@ -557,7 +559,7 @@ func (suite *controllerSuite) TestReconcile_NoSelector_UnmanagedEndpoints() {
 			Write(suite.T(), suite.client)
 
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: endpoints.Id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		// the status should indicate the services endpoints are not being managed
 		suite.client.RequireStatusCondition(suite.T(), service.Id, ControllerID, ConditionUnmanaged)
 		// unmanaged endpoints should not be deleted when the service is unmanaged
@@ -595,7 +597,7 @@ func (suite *controllerSuite) TestReconcile_Managed_NoPreviousEndpoints() {
 			Write(suite.T(), suite.client)
 
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: endpointsID})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Verify that the services status has been set to indicate endpoints are automatically managed.
 		suite.client.RequireStatusCondition(suite.T(), service.Id, ControllerID, ConditionManaged)
@@ -605,8 +607,8 @@ func (suite *controllerSuite) TestReconcile_Managed_NoPreviousEndpoints() {
 
 		var endpoints pbcatalog.ServiceEndpoints
 		err = res.Data.UnmarshalTo(&endpoints)
-		require.NoError(suite.T(), err)
-		require.Len(suite.T(), endpoints.Endpoints, 1)
+		suite.Require().NoError(err)
+		suite.Require().Len(endpoints.Endpoints, 1)
 	})
 	// We are not going to retest that the workloads to endpoints conversion process
 	// The length check should be sufficient to prove the endpoints are being
@@ -648,15 +650,15 @@ func (suite *controllerSuite) TestReconcile_Managed_ExistingEndpoints() {
 			Write(suite.T(), suite.client)
 
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: endpoints.Id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireStatusCondition(suite.T(), service.Id, ControllerID, ConditionManaged)
 		res := suite.client.RequireResourceMeta(suite.T(), endpoints.Id, endpointsMetaManagedBy, ControllerID)
 
 		var newEndpoints pbcatalog.ServiceEndpoints
 		err = res.Data.UnmarshalTo(&newEndpoints)
-		require.NoError(suite.T(), err)
-		require.Len(suite.T(), newEndpoints.Endpoints, 1)
+		suite.Require().NoError(err)
+		suite.Require().Len(newEndpoints.Endpoints, 1)
 	})
 }
 

--- a/internal/catalog/internal/controllers/failover/expander/expander_ce/expander_test.go
+++ b/internal/catalog/internal/controllers/failover/expander/expander_ce/expander_test.go
@@ -15,7 +15,6 @@ import (
 	pbmulticluster "github.com/hashicorp/consul/proto-public/pbmulticluster/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -59,9 +58,9 @@ func (suite *expanderSuite) Test_ComputeFailoverDestinationsFromSamenessGroup() 
 		WithTenancy(resource.DefaultNamespacedTenancy()).
 		Build()
 	decFp, err := resource.Decode[*pbcatalog.FailoverPolicy](fp)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	dests, sg, err := suite.samenessGroupExpander.ComputeFailoverDestinationsFromSamenessGroup(suite.rt, decFp.Id, "sg1", "http")
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dests)
-	require.Equal(suite.T(), "", sg)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dests)
+	suite.Require().Equal("", sg)
 }

--- a/internal/catalog/internal/controllers/nodehealth/controller_test.go
+++ b/internal/catalog/internal/controllers/nodehealth/controller_test.go
@@ -114,8 +114,8 @@ func (suite *nodeHealthControllerTestSuite) TestGetNodeHealthNoNode() {
 		ref.Uid = ulid.Make().String()
 		health, err := getNodeHealth(suite.runtime, ref)
 
-		require.NoError(suite.T(), err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_PASSING, health)
+		suite.Require().NoError(err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_PASSING, health)
 	})
 }
 
@@ -123,8 +123,8 @@ func (suite *nodeHealthControllerTestSuite) TestGetNodeHealthNoStatus() {
 	suite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
 
 		health, err := getNodeHealth(suite.runtime, suite.nodeNoHealth)
-		require.NoError(suite.T(), err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_PASSING, health)
+		suite.Require().NoError(err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_PASSING, health)
 	})
 }
 
@@ -132,8 +132,8 @@ func (suite *nodeHealthControllerTestSuite) TestGetNodeHealthPassingStatus() {
 	suite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
 
 		health, err := getNodeHealth(suite.runtime, suite.nodePassing)
-		require.NoError(suite.T(), err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_PASSING, health)
+		suite.Require().NoError(err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_PASSING, health)
 	})
 }
 
@@ -141,8 +141,8 @@ func (suite *nodeHealthControllerTestSuite) TestGetNodeHealthCriticalStatus() {
 	suite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
 
 		health, err := getNodeHealth(suite.runtime, suite.nodeCritical)
-		require.NoError(suite.T(), err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_CRITICAL, health)
+		suite.Require().NoError(err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_CRITICAL, health)
 	})
 }
 
@@ -150,8 +150,8 @@ func (suite *nodeHealthControllerTestSuite) TestGetNodeHealthWarningStatus() {
 	suite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
 
 		health, err := getNodeHealth(suite.runtime, suite.nodeWarning)
-		require.NoError(suite.T(), err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_WARNING, health)
+		suite.Require().NoError(err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_WARNING, health)
 	})
 }
 
@@ -159,8 +159,8 @@ func (suite *nodeHealthControllerTestSuite) TestGetNodeHealthMaintenanceStatus()
 	suite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
 
 		health, err := getNodeHealth(suite.runtime, suite.nodeMaintenance)
-		require.NoError(suite.T(), err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_MAINTENANCE, health)
+		suite.Require().NoError(err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_MAINTENANCE, health)
 	})
 }
 
@@ -173,7 +173,7 @@ func (suite *nodeHealthControllerTestSuite) TestReconcileNodeNotFound() {
 				Partition: tenancy.Partition,
 			}),
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	})
 }
 
@@ -183,17 +183,17 @@ func (suite *nodeHealthControllerTestSuite) testReconcileStatus(id *pbresource.I
 	err := suite.ctl.Reconcile(context.Background(), controller.Request{
 		ID: id,
 	})
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	rsp, err := suite.resourceClient.Read(context.Background(), &pbresource.ReadRequest{
 		Id: id,
 	})
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	nodeHealthStatus, found := rsp.Resource.Status[StatusKey]
-	require.True(suite.T(), found)
-	require.Equal(suite.T(), rsp.Resource.Generation, nodeHealthStatus.ObservedGeneration)
-	require.Len(suite.T(), nodeHealthStatus.Conditions, 1)
+	suite.Require().True(found)
+	suite.Require().Equal(rsp.Resource.Generation, nodeHealthStatus.ObservedGeneration)
+	suite.Require().Len(nodeHealthStatus.Conditions, 1)
 	prototest.AssertDeepEqual(suite.T(),
 		nodeHealthStatus.Conditions[0],
 		expectedStatus)
@@ -269,7 +269,7 @@ func (suite *nodeHealthControllerTestSuite) TestReconcile_AvoidRereconciliationW
 		// If another status write was performed then the versions would differ. This
 		// therefore proves that after a second reconciliation without any change in status
 		// that we are not making subsequent status writes.
-		require.Equal(suite.T(), res1.Version, res2.Version)
+		suite.Require().Equal(res1.Version, res2.Version)
 	})
 }
 

--- a/internal/catalog/internal/controllers/workloadhealth/controller_test.go
+++ b/internal/catalog/internal/controllers/workloadhealth/controller_test.go
@@ -174,7 +174,7 @@ func (suite *workloadHealthControllerTestSuite) testReconcileWithNode(nodeHealth
 		ID: workload.Id,
 	})
 
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	return suite.checkWorkloadStatus(workload.Id, status)
 }
@@ -204,7 +204,7 @@ func (suite *workloadHealthControllerTestSuite) testReconcileWithoutNode(workloa
 		ID: workload.Id,
 	})
 
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	// Read the resource back so we can detect the status changes
 	return suite.checkWorkloadStatus(workload.Id, status)
@@ -219,12 +219,12 @@ func (suite *workloadHealthControllerTestSuite) checkWorkloadStatus(id *pbresour
 		Id: id,
 	})
 
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	actualStatus, found := rsp.Resource.Status[ControllerID]
-	require.True(suite.T(), found)
-	require.Equal(suite.T(), rsp.Resource.Generation, actualStatus.ObservedGeneration)
-	require.Len(suite.T(), actualStatus.Conditions, 1)
+	suite.Require().True(found)
+	suite.Require().Equal(rsp.Resource.Generation, actualStatus.ObservedGeneration)
+	suite.Require().Len(actualStatus.Conditions, 1)
 	prototest.AssertDeepEqual(suite.T(), status, actualStatus.Conditions[0])
 
 	return rsp.Resource
@@ -378,8 +378,8 @@ func (suite *workloadHealthControllerTestSuite) TestReconcileReadError() {
 		id := resourceID(fakeType, "blah", tenancy)
 
 		err := suite.ctl.Reconcile(context.Background(), controller.Request{ID: id})
-		require.Error(suite.T(), err)
-		require.Equal(suite.T(), codes.InvalidArgument, status.Code(err))
+		suite.Require().Error(err)
+		suite.Require().Equal(codes.InvalidArgument, status.Code(err))
 	})
 }
 
@@ -416,8 +416,8 @@ func (suite *workloadHealthControllerTestSuite) TestGetNodeHealthError() {
 			ID: workload.Id,
 		})
 
-		require.Error(suite.T(), err)
-		require.Equal(suite.T(), errNodeUnreconciled, err)
+		suite.Require().Error(err)
+		suite.Require().Equal(errNodeUnreconciled, err)
 	})
 }
 
@@ -437,7 +437,7 @@ func (suite *workloadHealthControllerTestSuite) TestReconcile_AvoidReconciliatio
 		res1 := suite.testReconcileWithoutNode(pbcatalog.Health_HEALTH_WARNING, tenancy, status)
 
 		err := suite.ctl.Reconcile(context.Background(), controller.Request{ID: res1.Id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// check that the status hasn't changed
 		res2 := suite.checkWorkloadStatus(res1.Id, status)
@@ -445,7 +445,7 @@ func (suite *workloadHealthControllerTestSuite) TestReconcile_AvoidReconciliatio
 		// If another status write was performed then the versions would differ. This
 		// therefore proves that after a second reconciliation without any change
 		// in status that the controller is not making extra status writes.
-		require.Equal(suite.T(), res1.Version, res2.Version)
+		suite.Require().Equal(res1.Version, res2.Version)
 	})
 }
 
@@ -579,9 +579,9 @@ func (suite *getWorkloadHealthTestSuite) TestListError() {
 	suite.controllerSuite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
 		health, err := getWorkloadHealth(context.Background(), suite.runtime, resourceID(fakeType, "foo", tenancy))
 
-		require.Error(suite.T(), err)
-		require.Equal(suite.T(), codes.InvalidArgument, status.Code(err))
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_CRITICAL, health)
+		suite.Require().Error(err)
+		suite.Require().Equal(codes.InvalidArgument, status.Code(err))
+		suite.Require().Equal(pbcatalog.Health_HEALTH_CRITICAL, health)
 	})
 }
 
@@ -595,8 +595,8 @@ func (suite *getWorkloadHealthTestSuite) TestNoHealthStatuses() {
 			Write(suite.T(), suite.client)
 
 		health, err := getWorkloadHealth(context.Background(), suite.runtime, workload.Id)
-		require.NoError(suite.T(), err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_PASSING, health)
+		suite.Require().NoError(err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_PASSING, health)
 	})
 }
 
@@ -622,8 +622,8 @@ func (suite *getWorkloadHealthTestSuite) TestWithStatuses() {
 				suite.addHealthStatuses(workload.Id, tenancy, health)
 
 				actualHealth, err := getWorkloadHealth(context.Background(), suite.runtime, workload.Id)
-				require.NoError(suite.T(), err)
-				require.Equal(suite.T(), health, actualHealth)
+				suite.Require().NoError(err)
+				suite.Require().Equal(health, actualHealth)
 			})
 		}
 	})
@@ -646,8 +646,8 @@ func (suite *getNodeHealthTestSuite) TestNotfound() {
 		health, err := getNodeHealth(context.Background(), suite.runtime, resourceID(pbcatalog.NodeType, "not-found", &pbresource.Tenancy{
 			Partition: tenancy.Partition,
 		}))
-		require.NoError(suite.T(), err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_CRITICAL, health)
+		suite.Require().NoError(err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_CRITICAL, health)
 	})
 }
 
@@ -656,9 +656,9 @@ func (suite *getNodeHealthTestSuite) TestReadError() {
 	// its resource read call back to the caller.
 	suite.controllerSuite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
 		health, err := getNodeHealth(context.Background(), suite.runtime, resourceID(fakeType, "not-found", tenancy))
-		require.Error(suite.T(), err)
-		require.Equal(suite.T(), codes.InvalidArgument, status.Code(err))
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_CRITICAL, health)
+		suite.Require().Error(err)
+		suite.Require().Equal(codes.InvalidArgument, status.Code(err))
+		suite.Require().Equal(pbcatalog.Health_HEALTH_CRITICAL, health)
 	})
 }
 
@@ -676,9 +676,9 @@ func (suite *getNodeHealthTestSuite) TestUnreconciled() {
 			GetId()
 
 		health, err := getNodeHealth(context.Background(), suite.runtime, node)
-		require.Error(suite.T(), err)
-		require.Equal(suite.T(), errNodeUnreconciled, err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_CRITICAL, health)
+		suite.Require().Error(err)
+		suite.Require().Equal(errNodeUnreconciled, err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_CRITICAL, health)
 	})
 }
 
@@ -700,9 +700,9 @@ func (suite *getNodeHealthTestSuite) TestNoConditions() {
 			GetId()
 
 		health, err := getNodeHealth(context.Background(), suite.runtime, node)
-		require.Error(suite.T(), err)
-		require.Equal(suite.T(), errNodeHealthConditionNotFound, err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_CRITICAL, health)
+		suite.Require().Error(err)
+		suite.Require().Equal(errNodeHealthConditionNotFound, err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_CRITICAL, health)
 	})
 }
 
@@ -733,9 +733,9 @@ func (suite *getNodeHealthTestSuite) TestInvalidReason() {
 			GetId()
 
 		health, err := getNodeHealth(context.Background(), suite.runtime, node)
-		require.Error(suite.T(), err)
-		require.Equal(suite.T(), errNodeHealthInvalid, err)
-		require.Equal(suite.T(), pbcatalog.Health_HEALTH_CRITICAL, health)
+		suite.Require().Error(err)
+		suite.Require().Equal(errNodeHealthInvalid, err)
+		suite.Require().Equal(pbcatalog.Health_HEALTH_CRITICAL, health)
 	})
 }
 

--- a/internal/catalog/workloadselector/acls_test.go
+++ b/internal/catalog/workloadselector/acls_test.go
@@ -6,7 +6,6 @@ package workloadselector
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/hashicorp/consul/acl"
@@ -59,7 +58,7 @@ func (suite *aclHookSuite) TestReadHook_Allowed() {
 		Return(acl.Allow).
 		Once()
 
-	require.NoError(suite.T(), suite.hooks.Read(suite.authz, suite.ctx, suite.res.Id, nil))
+	suite.Require().NoError(suite.hooks.Read(suite.authz, suite.ctx, suite.res.Id, nil))
 }
 
 func (suite *aclHookSuite) TestReadHook_Denied() {
@@ -67,7 +66,7 @@ func (suite *aclHookSuite) TestReadHook_Denied() {
 		Return(acl.Deny).
 		Once()
 
-	require.Error(suite.T(), suite.hooks.Read(suite.authz, suite.ctx, suite.res.Id, nil))
+	suite.Require().Error(suite.hooks.Read(suite.authz, suite.ctx, suite.res.Id, nil))
 }
 
 func (suite *aclHookSuite) TestWriteHook_ServiceWriteDenied() {
@@ -75,7 +74,7 @@ func (suite *aclHookSuite) TestWriteHook_ServiceWriteDenied() {
 		Return(acl.Deny).
 		Once()
 
-	require.Error(suite.T(), suite.hooks.Write(suite.authz, suite.ctx, suite.res))
+	suite.Require().Error(suite.hooks.Write(suite.authz, suite.ctx, suite.res))
 }
 
 func (suite *aclHookSuite) TestWriteHook_ServiceReadNameDenied() {
@@ -87,7 +86,7 @@ func (suite *aclHookSuite) TestWriteHook_ServiceReadNameDenied() {
 		Return(acl.Deny).
 		Once()
 
-	require.Error(suite.T(), suite.hooks.Write(suite.authz, suite.ctx, suite.res))
+	suite.Require().Error(suite.hooks.Write(suite.authz, suite.ctx, suite.res))
 }
 
 func (suite *aclHookSuite) TestWriteHook_ServiceReadPrefixDenied() {
@@ -103,7 +102,7 @@ func (suite *aclHookSuite) TestWriteHook_ServiceReadPrefixDenied() {
 		Return(acl.Deny).
 		Once()
 
-	require.Error(suite.T(), suite.hooks.Write(suite.authz, suite.ctx, suite.res))
+	suite.Require().Error(suite.hooks.Write(suite.authz, suite.ctx, suite.res))
 }
 
 func (suite *aclHookSuite) TestWriteHook_Allowed() {
@@ -119,5 +118,5 @@ func (suite *aclHookSuite) TestWriteHook_Allowed() {
 		Return(acl.Allow).
 		Once()
 
-	require.NoError(suite.T(), suite.hooks.Write(suite.authz, suite.ctx, suite.res))
+	suite.Require().NoError(suite.hooks.Write(suite.authz, suite.ctx, suite.res))
 }

--- a/internal/catalog/workloadselector/gather_test.go
+++ b/internal/catalog/workloadselector/gather_test.go
@@ -74,12 +74,12 @@ func (suite *gatherWorkloadsDataSuite) TestGetWorkloadData() {
 	// unique workloads are returned and that they are ordered.
 
 	suite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
-		require.NotNil(suite.T(), suite.apiService)
+		suite.Require().NotNil(suite.apiService)
 
 		data, err := GetWorkloadsWithSelector(suite.cache, suite.apiService)
 
-		require.NoError(suite.T(), err)
-		require.Len(suite.T(), data, 5)
+		suite.Require().NoError(err)
+		suite.Require().Len(data, 5)
 		requireDecodedWorkloadEquals(suite.T(), suite.api1Workload, data[0])
 		requireDecodedWorkloadEquals(suite.T(), suite.api1Workload, data[0])
 		requireDecodedWorkloadEquals(suite.T(), suite.api123Workload, data[1])
@@ -93,12 +93,12 @@ func (suite *gatherWorkloadsDataSuite) TestGetWorkloadDataWithFilter() {
 	// This is like TestGetWorkloadData except it exercises the post-read
 	// filter on the selector.
 	suite.runTestCaseWithTenancies(func(tenancy *pbresource.Tenancy) {
-		require.NotNil(suite.T(), suite.apiServiceSubset)
+		suite.Require().NotNil(suite.apiServiceSubset)
 
 		data, err := GetWorkloadsWithSelector(suite.cache, suite.apiServiceSubset)
 
-		require.NoError(suite.T(), err)
-		require.Len(suite.T(), data, 2)
+		suite.Require().NoError(err)
+		suite.Require().Len(data, 2)
 		requireDecodedWorkloadEquals(suite.T(), suite.api123Workload, data[0])
 		requireDecodedWorkloadEquals(suite.T(), suite.web1Workload, data[1])
 	})
@@ -231,11 +231,13 @@ func (suite *gatherWorkloadsDataSuite) setupResourcesWithTenancy(tenancy *pbreso
 }
 
 func (suite *gatherWorkloadsDataSuite) cleanupResources() {
-	require.NoError(suite.T(), suite.cache.Delete(suite.api1Workload.Resource))
-	require.NoError(suite.T(), suite.cache.Delete(suite.api2Workload.Resource))
-	require.NoError(suite.T(), suite.cache.Delete(suite.api123Workload.Resource))
-	require.NoError(suite.T(), suite.cache.Delete(suite.web1Workload.Resource))
-	require.NoError(suite.T(), suite.cache.Delete(suite.web2Workload.Resource))
+	suite.T().Helper()
+
+	suite.Require().NoError(suite.cache.Delete(suite.api1Workload.Resource))
+	suite.Require().NoError(suite.cache.Delete(suite.api2Workload.Resource))
+	suite.Require().NoError(suite.cache.Delete(suite.api123Workload.Resource))
+	suite.Require().NoError(suite.cache.Delete(suite.web1Workload.Resource))
+	suite.Require().NoError(suite.cache.Delete(suite.web2Workload.Resource))
 }
 
 func (suite *gatherWorkloadsDataSuite) runTestCaseWithTenancies(testFunc func(*pbresource.Tenancy)) {

--- a/internal/controller/cache/cache_test.go
+++ b/internal/controller/cache/cache_test.go
@@ -174,13 +174,13 @@ type cacheSuite struct {
 func (suite *cacheSuite) SetupTest() {
 	suite.c = New()
 
-	require.NoError(suite.T(), suite.c.AddIndex(pbdemo.AlbumType, namePrefixIndexer()))
-	require.NoError(suite.T(), suite.c.AddQuery(okQueryName, func(c ReadOnlyCache, args ...any) (ResourceIterator, error) {
+	suite.Require().NoError(suite.c.AddIndex(pbdemo.AlbumType, namePrefixIndexer()))
+	suite.Require().NoError(suite.c.AddQuery(okQueryName, func(c ReadOnlyCache, args ...any) (ResourceIterator, error) {
 		return c.ParentsIterator(pbdemo.AlbumType, "name_prefix", args...)
 	}))
-	require.NoError(suite.T(), suite.c.AddIndex(pbdemo.AlbumType, releaseYearIndexer()))
-	require.NoError(suite.T(), suite.c.AddQuery(errQueryName, errQuery))
-	require.NoError(suite.T(), suite.c.AddIndex(pbdemo.AlbumType, tracksIndexer()))
+	suite.Require().NoError(suite.c.AddIndex(pbdemo.AlbumType, releaseYearIndexer()))
+	suite.Require().NoError(suite.c.AddQuery(errQueryName, errQuery))
+	suite.Require().NoError(suite.c.AddIndex(pbdemo.AlbumType, tracksIndexer()))
 
 	suite.album1 = resourcetest.Resource(pbdemo.AlbumType, "one").
 		WithTenancy(resource.DefaultNamespacedTenancy()).
@@ -218,136 +218,136 @@ func (suite *cacheSuite) SetupTest() {
 		}).
 		Build()
 
-	require.NoError(suite.T(), suite.c.Insert(suite.album1))
-	require.NoError(suite.T(), suite.c.Insert(suite.album2))
-	require.NoError(suite.T(), suite.c.Insert(suite.album3))
-	require.NoError(suite.T(), suite.c.Insert(suite.album4))
+	suite.Require().NoError(suite.c.Insert(suite.album1))
+	suite.Require().NoError(suite.c.Insert(suite.album2))
+	suite.Require().NoError(suite.c.Insert(suite.album3))
+	suite.Require().NoError(suite.c.Insert(suite.album4))
 }
 
 func (suite *cacheSuite) TestGet() {
 	res, err := suite.c.Get(pbdemo.AlbumType, "id", suite.album1.Id)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.album1, res)
 
 	res, err = suite.c.Get(pbdemo.AlbumType, "year", int32(2022))
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.album3, res)
 
 	res, err = suite.c.Get(pbdemo.AlbumType, "tracks", "fangorn")
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.album2, res)
 }
 
 func (suite *cacheSuite) TestGet_NilType() {
 	res, err := suite.c.Get(nil, "id", suite.album1.Id)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, TypeUnspecifiedError)
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, TypeUnspecifiedError)
+	suite.Require().Nil(res)
 }
 
 func (suite *cacheSuite) TestGet_UncachedType() {
 	res, err := suite.c.Get(pbdemo.ArtistType, "id", suite.album1.Id)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, TypeNotIndexedError)
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, TypeNotIndexedError)
+	suite.Require().Nil(res)
 }
 
 func (suite *cacheSuite) TestGet_IndexNotFound() {
 	res, err := suite.c.Get(pbdemo.AlbumType, "blah", suite.album1.Id)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, IndexNotFoundError{name: "blah"})
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, IndexNotFoundError{name: "blah"})
+	suite.Require().Nil(res)
 }
 
 func (suite *cacheSuite) TestList() {
 	resources, err := suite.c.List(pbdemo.AlbumType, "year", int32(2023))
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertElementsMatch(suite.T(), []*pbresource.Resource{suite.album1, suite.album2}, resources)
 
 	resources, err = suite.c.List(pbdemo.AlbumType, "tracks", "f", true)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertElementsMatch(suite.T(), []*pbresource.Resource{suite.album1, suite.album2, suite.album4}, resources)
 }
 
 func (suite *cacheSuite) TestList_NilType() {
 	res, err := suite.c.List(nil, "id", suite.album1.Id)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, TypeUnspecifiedError)
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, TypeUnspecifiedError)
+	suite.Require().Nil(res)
 }
 
 func (suite *cacheSuite) TestList_UncachedType() {
 	res, err := suite.c.List(pbdemo.ArtistType, "id", suite.album1.Id)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, TypeNotIndexedError)
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, TypeNotIndexedError)
+	suite.Require().Nil(res)
 }
 
 func (suite *cacheSuite) TestList_IndexNotFound() {
 	res, err := suite.c.List(pbdemo.AlbumType, "blah", suite.album1.Id)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, IndexNotFoundError{name: "blah"})
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, IndexNotFoundError{name: "blah"})
+	suite.Require().Nil(res)
 }
 
 func (suite *cacheSuite) TestParents() {
 	resources, err := suite.c.Parents(pbdemo.AlbumType, "name_prefix", "food")
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertElementsMatch(suite.T(), []*pbresource.Resource{suite.album3, suite.album4}, resources)
 }
 
 func (suite *cacheSuite) TestQuery() {
 	resources, err := expandIterator(suite.c.Query(okQueryName, "food"))
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertElementsMatch(suite.T(), []*pbresource.Resource{suite.album3, suite.album4}, resources)
 }
 
 func (suite *cacheSuite) TestParents_NilType() {
 	res, err := suite.c.Parents(nil, "id", suite.album1.Id)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, TypeUnspecifiedError)
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, TypeUnspecifiedError)
+	suite.Require().Nil(res)
 }
 
 func (suite *cacheSuite) TestParents_UncachedType() {
 	res, err := suite.c.Parents(pbdemo.ArtistType, "id", suite.album1.Id)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, TypeNotIndexedError)
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, TypeNotIndexedError)
+	suite.Require().Nil(res)
 }
 
 func (suite *cacheSuite) TestParents_IndexNotFound() {
 	res, err := suite.c.Parents(pbdemo.AlbumType, "blah", suite.album1.Id)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, IndexNotFoundError{name: "blah"})
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, IndexNotFoundError{name: "blah"})
+	suite.Require().Nil(res)
 }
 
 func (suite *cacheSuite) TestInsert_UncachedType() {
 	err := suite.c.Insert(resourcetest.Resource(pbdemo.ArtistType, "blah").Build())
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, TypeNotIndexedError)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, TypeNotIndexedError)
 }
 
 func (suite *cacheSuite) TestDelete() {
 	err := suite.c.Delete(suite.album1)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	res, err := suite.c.Get(pbdemo.AlbumType, "id", suite.album1.Id)
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), res)
+	suite.Require().NoError(err)
+	suite.Require().Nil(res)
 
 	resources, err := suite.c.List(pbdemo.AlbumType, "year", int32(2023))
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertElementsMatch(suite.T(), []*pbresource.Resource{suite.album2}, resources)
 
 	resources, err = suite.c.Parents(pbdemo.AlbumType, "name_prefix", "onesie")
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), resources)
+	suite.Require().NoError(err)
+	suite.Require().Nil(resources)
 }
 
 func (suite *cacheSuite) TestDelete_UncachedType() {
 	err := suite.c.Delete(resourcetest.Resource(pbdemo.ArtistType, "blah").Build())
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, TypeNotIndexedError)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, TypeNotIndexedError)
 }

--- a/internal/controller/cache/client_test.go
+++ b/internal/controller/cache/client_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	mockpbresource "github.com/hashicorp/consul/grpcmocks/proto-public/pbresource"
@@ -40,9 +39,9 @@ func (suite *cacheClientSuite) SetupTest() {
 	client := mockpbresource.NewResourceServiceClient(suite.T())
 	suite.mclient = client.EXPECT()
 
-	require.NoError(suite.T(), suite.cache.AddIndex(pbdemo.AlbumType, namePrefixIndexer()))
-	require.NoError(suite.T(), suite.cache.AddIndex(pbdemo.AlbumType, releaseYearIndexer()))
-	require.NoError(suite.T(), suite.cache.AddIndex(pbdemo.AlbumType, tracksIndexer()))
+	suite.Require().NoError(suite.cache.AddIndex(pbdemo.AlbumType, namePrefixIndexer()))
+	suite.Require().NoError(suite.cache.AddIndex(pbdemo.AlbumType, releaseYearIndexer()))
+	suite.Require().NoError(suite.cache.AddIndex(pbdemo.AlbumType, tracksIndexer()))
 
 	suite.album1 = resourcetest.Resource(pbdemo.AlbumType, "one").
 		WithTenancy(resource.DefaultNamespacedTenancy()).
@@ -89,10 +88,10 @@ func (suite *cacheClientSuite) performWrite(res *pbresource.Resource, shouldErro
 	// Now use the wrapper client to perform the request
 	out, err := suite.client.Write(context.Background(), req)
 	if shouldError {
-		require.ErrorIs(suite.T(), err, fakeWrappedErr)
-		require.Nil(suite.T(), out)
+		suite.Require().ErrorIs(err, fakeWrappedErr)
+		suite.Require().Nil(out)
 	} else {
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		prototest.AssertDeepEqual(suite.T(), res, out.Resource)
 	}
 }
@@ -116,11 +115,11 @@ func (suite *cacheClientSuite) performDelete(id *pbresource.ID, shouldError bool
 	// Now use the wrapper client to perform the request
 	out, err := suite.client.Delete(context.Background(), req)
 	if shouldError {
-		require.ErrorIs(suite.T(), err, fakeWrappedErr)
-		require.Nil(suite.T(), out)
+		suite.Require().ErrorIs(err, fakeWrappedErr)
+		suite.Require().Nil(out)
 	} else {
-		require.NoError(suite.T(), err)
-		require.NotNil(suite.T(), out)
+		suite.Require().NoError(err)
+		suite.Require().NotNil(out)
 	}
 }
 
@@ -147,10 +146,10 @@ func (suite *cacheClientSuite) performWriteStatus(res *pbresource.Resource, key 
 	// Now use the wrapper client to perform the request
 	out, err := suite.client.WriteStatus(context.Background(), req)
 	if shouldError {
-		require.ErrorIs(suite.T(), err, fakeWrappedErr)
-		require.Nil(suite.T(), out)
+		suite.Require().ErrorIs(err, fakeWrappedErr)
+		suite.Require().Nil(out)
 	} else {
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		prototest.AssertDeepEqual(suite.T(), res, out.Resource)
 	}
 }
@@ -172,8 +171,8 @@ func (suite *cacheClientSuite) TestWrite_Ok() {
 
 	// now ensure the entry was updated in the cache
 	res, err := suite.cache.Get(suite.album1.Id.Type, "id", suite.album1.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), res)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
 	prototest.AssertDeepEqual(suite.T(), newRes, res)
 }
 
@@ -191,8 +190,8 @@ func (suite *cacheClientSuite) TestWrite_Error() {
 
 	// now ensure the entry was not updated in the cache
 	res, err := suite.cache.Get(suite.album1.Id.Type, "id", suite.album1.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), res)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
 	prototest.AssertDeepEqual(suite.T(), suite.album1, res)
 }
 
@@ -213,10 +212,10 @@ func (suite *cacheClientSuite) TestWriteStatus_Ok() {
 
 	// now ensure the entry was updated in the cache
 	res, err := suite.cache.Get(suite.album1.Id.Type, "id", suite.album1.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), res)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
 	_, updated := res.Status["testing"]
-	require.True(suite.T(), updated)
+	suite.Require().True(updated)
 }
 
 func (suite *cacheClientSuite) TestWriteStatus_Error() {
@@ -236,10 +235,10 @@ func (suite *cacheClientSuite) TestWriteStatus_Error() {
 
 	// now ensure the entry was not updated in the cache
 	res, err := suite.cache.Get(suite.album1.Id.Type, "id", suite.album1.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), res)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
 	_, updated := res.Status["testing"]
-	require.False(suite.T(), updated)
+	suite.Require().False(updated)
 }
 
 func (suite *cacheClientSuite) TestDelete_Ok() {
@@ -247,8 +246,8 @@ func (suite *cacheClientSuite) TestDelete_Ok() {
 
 	// now ensure the entry was removed from the cache
 	res, err := suite.cache.Get(suite.album1.Id.Type, "id", suite.album1.Id)
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), res)
+	suite.Require().NoError(err)
+	suite.Require().Nil(res)
 }
 
 func (suite *cacheClientSuite) TestDelete_Error() {
@@ -256,8 +255,8 @@ func (suite *cacheClientSuite) TestDelete_Error() {
 
 	// now ensure the entry was NOT removed from the cache
 	res, err := suite.cache.Get(suite.album1.Id.Type, "id", suite.album1.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), res)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
 }
 
 func TestCacheClient(t *testing.T) {

--- a/internal/controller/cache/clone_test.go
+++ b/internal/controller/cache/clone_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/consul/internal/controller/cache/cachemock"
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	"github.com/hashicorp/consul/proto-public/pbresource"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -67,8 +66,10 @@ func (suite *cloningReadOnlyCacheSuite) makeMockIterator(resources ...*pbresourc
 }
 
 func (suite *cloningReadOnlyCacheSuite) requireEqualNotSame(expected, actual *pbresource.Resource) {
-	require.Equal(suite.T(), expected, actual)
-	require.NotSame(suite.T(), expected, actual)
+	suite.T().Helper()
+
+	suite.Require().Equal(expected, actual)
+	suite.Require().NotSame(expected, actual)
 }
 
 func (suite *cloningReadOnlyCacheSuite) TestGet_Ok() {
@@ -77,7 +78,7 @@ func (suite *cloningReadOnlyCacheSuite) TestGet_Ok() {
 		Return(suite.res1, nil)
 
 	actual, err := suite.ccache.Get(suite.rtype, indexName, "ok")
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	suite.requireEqualNotSame(suite.res1, actual)
 }
 
@@ -87,8 +88,8 @@ func (suite *cloningReadOnlyCacheSuite) TestGet_Error() {
 		Return(nil, injectedError)
 
 	actual, err := suite.ccache.Get(suite.rtype, indexName, "error")
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), actual)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(actual)
 }
 
 func (suite *cloningReadOnlyCacheSuite) TestList_Ok() {
@@ -99,8 +100,8 @@ func (suite *cloningReadOnlyCacheSuite) TestList_Ok() {
 		Return(preClone, nil)
 
 	postClone, err := suite.ccache.List(suite.rtype, indexName, "ok")
-	require.NoError(suite.T(), err)
-	require.Len(suite.T(), postClone, len(preClone))
+	suite.Require().NoError(err)
+	suite.Require().Len(postClone, len(preClone))
 	for i, actual := range postClone {
 		suite.requireEqualNotSame(preClone[i], actual)
 	}
@@ -112,8 +113,8 @@ func (suite *cloningReadOnlyCacheSuite) TestList_Error() {
 		Return(nil, injectedError)
 
 	actual, err := suite.ccache.List(suite.rtype, indexName, "error")
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), actual)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(actual)
 }
 
 func (suite *cloningReadOnlyCacheSuite) TestParents_Ok() {
@@ -124,8 +125,8 @@ func (suite *cloningReadOnlyCacheSuite) TestParents_Ok() {
 		Return(preClone, nil)
 
 	postClone, err := suite.ccache.Parents(suite.rtype, indexName, "ok")
-	require.NoError(suite.T(), err)
-	require.Len(suite.T(), postClone, len(preClone))
+	suite.Require().NoError(err)
+	suite.Require().Len(postClone, len(preClone))
 	for i, actual := range postClone {
 		suite.requireEqualNotSame(preClone[i], actual)
 	}
@@ -137,8 +138,8 @@ func (suite *cloningReadOnlyCacheSuite) TestParents_Error() {
 		Return(nil, injectedError)
 
 	actual, err := suite.ccache.Parents(suite.rtype, indexName, "error")
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), actual)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(actual)
 }
 
 func (suite *cloningReadOnlyCacheSuite) TestListIterator_Ok() {
@@ -147,12 +148,12 @@ func (suite *cloningReadOnlyCacheSuite) TestListIterator_Ok() {
 		Return(suite.makeMockIterator(suite.res1, suite.res2), nil)
 
 	iter, err := suite.ccache.ListIterator(suite.rtype, indexName, "ok")
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), iter)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(iter)
 
 	suite.requireEqualNotSame(suite.res1, iter.Next())
 	suite.requireEqualNotSame(suite.res2, iter.Next())
-	require.Nil(suite.T(), iter.Next())
+	suite.Require().Nil(iter.Next())
 }
 
 func (suite *cloningReadOnlyCacheSuite) TestListIterator_Error() {
@@ -161,8 +162,8 @@ func (suite *cloningReadOnlyCacheSuite) TestListIterator_Error() {
 		Return(nil, injectedError)
 
 	actual, err := suite.ccache.ListIterator(suite.rtype, indexName, "error")
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), actual)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(actual)
 }
 
 func (suite *cloningReadOnlyCacheSuite) TestParentsIterator_Ok() {
@@ -171,12 +172,12 @@ func (suite *cloningReadOnlyCacheSuite) TestParentsIterator_Ok() {
 		Return(suite.makeMockIterator(suite.res1, suite.res2), nil)
 
 	iter, err := suite.ccache.ParentsIterator(suite.rtype, indexName, "ok")
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), iter)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(iter)
 
 	suite.requireEqualNotSame(suite.res1, iter.Next())
 	suite.requireEqualNotSame(suite.res2, iter.Next())
-	require.Nil(suite.T(), iter.Next())
+	suite.Require().Nil(iter.Next())
 }
 
 func (suite *cloningReadOnlyCacheSuite) TestParentsIterator_Error() {
@@ -185,8 +186,8 @@ func (suite *cloningReadOnlyCacheSuite) TestParentsIterator_Error() {
 		Return(nil, injectedError)
 
 	actual, err := suite.ccache.ParentsIterator(suite.rtype, indexName, "error")
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), actual)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(actual)
 }
 
 func (suite *cloningReadOnlyCacheSuite) TestQuery_Ok() {
@@ -195,12 +196,12 @@ func (suite *cloningReadOnlyCacheSuite) TestQuery_Ok() {
 		Return(suite.makeMockIterator(suite.res1, suite.res2), nil)
 
 	iter, err := suite.ccache.Query(indexName, "ok")
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), iter)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(iter)
 
 	suite.requireEqualNotSame(suite.res1, iter.Next())
 	suite.requireEqualNotSame(suite.res2, iter.Next())
-	require.Nil(suite.T(), iter.Next())
+	suite.Require().Nil(iter.Next())
 }
 
 func (suite *cloningReadOnlyCacheSuite) TestQuery_Error() {
@@ -209,6 +210,6 @@ func (suite *cloningReadOnlyCacheSuite) TestQuery_Error() {
 		Return(nil, injectedError)
 
 	actual, err := suite.ccache.Query(indexName, "error")
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), actual)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(actual)
 }

--- a/internal/controller/cache/decoded_test.go
+++ b/internal/controller/cache/decoded_test.go
@@ -6,7 +6,6 @@ package cache_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/hashicorp/consul/internal/controller/cache"
@@ -32,24 +31,24 @@ func (suite *decodedSuite) SetupTest() {
 	suite.rc = cachemock.NewReadOnlyCache(suite.T())
 	suite.iter = cachemock.NewResourceIterator(suite.T())
 	artist, err := demo.GenerateV2Artist()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	suite.artistGood, err = resource.Decode[*pbdemo.Artist](artist)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	artist2, err := demo.GenerateV2Artist()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	suite.artistGood2, err = resource.Decode[*pbdemo.Artist](artist2)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	suite.artistBad, err = demo.GenerateV2Album(artist.Id)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 }
 
 func (suite *decodedSuite) TestGetDecoded_Ok() {
 	suite.rc.EXPECT().Get(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(suite.artistGood.Resource, nil)
 
 	dec, err := cache.GetDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Resource, dec.Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Data, dec.Data)
 }
@@ -58,24 +57,24 @@ func (suite *decodedSuite) TestGetDecoded_DecodeError() {
 	suite.rc.EXPECT().Get(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(suite.artistBad, nil)
 
 	dec, err := cache.GetDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.Error(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().Error(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestGetDecoded_CacheError() {
 	suite.rc.EXPECT().Get(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(nil, injectedError)
 
 	dec, err := cache.GetDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), dec)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestGetDecoded_Nil() {
 	suite.rc.EXPECT().Get(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(nil, nil)
 
 	dec, err := cache.GetDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestListDecoded_Ok() {
@@ -83,8 +82,8 @@ func (suite *decodedSuite) TestListDecoded_Ok() {
 		Return([]*pbresource.Resource{suite.artistGood.Resource, suite.artistGood2.Resource}, nil)
 
 	dec, err := cache.ListDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.Len(suite.T(), dec, 2)
+	suite.Require().NoError(err)
+	suite.Require().Len(dec, 2)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Resource, dec[0].Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Data, dec[0].Data)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood2.Resource, dec[1].Resource)
@@ -96,24 +95,24 @@ func (suite *decodedSuite) TestListDecoded_DecodeError() {
 		Return([]*pbresource.Resource{suite.artistGood.Resource, suite.artistBad}, nil)
 
 	dec, err := cache.ListDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.Error(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().Error(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestListDecoded_CacheError() {
 	suite.rc.EXPECT().List(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(nil, injectedError)
 
 	dec, err := cache.ListDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), dec)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestListDecoded_Nil() {
 	suite.rc.EXPECT().List(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(nil, nil)
 
 	dec, err := cache.ListDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestListIteratorDecoded_Ok() {
@@ -124,22 +123,22 @@ func (suite *decodedSuite) TestListIteratorDecoded_Ok() {
 		Return(suite.iter, nil)
 
 	iter, err := cache.ListIteratorDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), iter)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(iter)
 
 	dec, err := iter.Next()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Resource, dec.Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Data, dec.Data)
 
 	dec, err = iter.Next()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood2.Resource, dec.Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood2.Data, dec.Data)
 
 	dec, err = iter.Next()
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestListIteratorDecoded_DecodeError() {
@@ -150,37 +149,37 @@ func (suite *decodedSuite) TestListIteratorDecoded_DecodeError() {
 		Return(suite.iter, nil)
 
 	iter, err := cache.ListIteratorDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), iter)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(iter)
 
 	dec, err := iter.Next()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Resource, dec.Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Data, dec.Data)
 
 	dec, err = iter.Next()
-	require.Error(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().Error(err)
+	suite.Require().Nil(dec)
 
 	dec, err = iter.Next()
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestListIteratorDecoded_CacheError() {
 	suite.rc.EXPECT().ListIterator(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(nil, injectedError)
 
 	iter, err := cache.ListIteratorDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), iter)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(iter)
 }
 
 func (suite *decodedSuite) TestListIteratorDecoded_Nil() {
 	suite.rc.EXPECT().ListIterator(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(nil, nil)
 
 	dec, err := cache.ListIteratorDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestParentsDecoded_Ok() {
@@ -188,8 +187,8 @@ func (suite *decodedSuite) TestParentsDecoded_Ok() {
 		Return([]*pbresource.Resource{suite.artistGood.Resource, suite.artistGood2.Resource}, nil)
 
 	dec, err := cache.ParentsDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.Len(suite.T(), dec, 2)
+	suite.Require().NoError(err)
+	suite.Require().Len(dec, 2)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Resource, dec[0].Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Data, dec[0].Data)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood2.Resource, dec[1].Resource)
@@ -201,24 +200,24 @@ func (suite *decodedSuite) TestParentsDecoded_DecodeError() {
 		Return([]*pbresource.Resource{suite.artistGood.Resource, suite.artistBad}, nil)
 
 	dec, err := cache.ParentsDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.Error(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().Error(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestParentsDecoded_CacheError() {
 	suite.rc.EXPECT().Parents(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(nil, injectedError)
 
 	dec, err := cache.ParentsDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), dec)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestParentsDecoded_Nil() {
 	suite.rc.EXPECT().Parents(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(nil, nil)
 
 	dec, err := cache.ParentsDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestParentsIteratorDecoded_Ok() {
@@ -229,22 +228,22 @@ func (suite *decodedSuite) TestParentsIteratorDecoded_Ok() {
 		Return(suite.iter, nil)
 
 	iter, err := cache.ParentsIteratorDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), iter)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(iter)
 
 	dec, err := iter.Next()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Resource, dec.Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Data, dec.Data)
 
 	dec, err = iter.Next()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood2.Resource, dec.Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood2.Data, dec.Data)
 
 	dec, err = iter.Next()
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestParentsIteratorDecoded_DecodeError() {
@@ -255,37 +254,37 @@ func (suite *decodedSuite) TestParentsIteratorDecoded_DecodeError() {
 		Return(suite.iter, nil)
 
 	iter, err := cache.ParentsIteratorDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), iter)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(iter)
 
 	dec, err := iter.Next()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Resource, dec.Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Data, dec.Data)
 
 	dec, err = iter.Next()
-	require.Error(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().Error(err)
+	suite.Require().Nil(dec)
 
 	dec, err = iter.Next()
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestParentsIteratorDecoded_CacheError() {
 	suite.rc.EXPECT().ParentsIterator(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(nil, injectedError)
 
 	iter, err := cache.ParentsIteratorDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), iter)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(iter)
 }
 
 func (suite *decodedSuite) TestParentsIteratorDecoded_Nil() {
 	suite.rc.EXPECT().ParentsIterator(pbdemo.ArtistType, "id", suite.artistGood.Id).Return(nil, nil)
 
 	dec, err := cache.ParentsIteratorDecoded[*pbdemo.Artist](suite.rc, pbdemo.ArtistType, "id", suite.artistGood.Id)
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestQueryDecoded_Ok() {
@@ -296,22 +295,22 @@ func (suite *decodedSuite) TestQueryDecoded_Ok() {
 		Return(suite.iter, nil)
 
 	iter, err := cache.QueryDecoded[*pbdemo.Artist](suite.rc, "query", "blah")
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), iter)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(iter)
 
 	dec, err := iter.Next()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Resource, dec.Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Data, dec.Data)
 
 	dec, err = iter.Next()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood2.Resource, dec.Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood2.Data, dec.Data)
 
 	dec, err = iter.Next()
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestQueryDecoded_DecodeError() {
@@ -322,37 +321,37 @@ func (suite *decodedSuite) TestQueryDecoded_DecodeError() {
 		Return(suite.iter, nil)
 
 	iter, err := cache.QueryDecoded[*pbdemo.Artist](suite.rc, "query", "blah")
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), iter)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(iter)
 
 	dec, err := iter.Next()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Resource, dec.Resource)
 	prototest.AssertDeepEqual(suite.T(), suite.artistGood.Data, dec.Data)
 
 	dec, err = iter.Next()
-	require.Error(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().Error(err)
+	suite.Require().Nil(dec)
 
 	dec, err = iter.Next()
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestQueryDecoded_CacheError() {
 	suite.rc.EXPECT().Query("query", "blah").Return(nil, injectedError)
 
 	dec, err := cache.QueryDecoded[*pbdemo.Artist](suite.rc, "query", "blah")
-	require.ErrorIs(suite.T(), err, injectedError)
-	require.Nil(suite.T(), dec)
+	suite.Require().ErrorIs(err, injectedError)
+	suite.Require().Nil(dec)
 }
 
 func (suite *decodedSuite) TestQueryDecoded_Nil() {
 	suite.rc.EXPECT().Query("query", "blah").Return(nil, nil)
 
 	dec, err := cache.QueryDecoded[*pbdemo.Artist](suite.rc, "query", "blah")
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), dec)
+	suite.Require().NoError(err)
+	suite.Require().Nil(dec)
 }
 
 func TestDecodedCache(t *testing.T) {

--- a/internal/controller/cache/index/convenience_test.go
+++ b/internal/controller/cache/index/convenience_test.go
@@ -111,14 +111,14 @@ func TestPrefixIndexFromRefOrID(t *testing.T) {
 func TestPrefixIndexFromTenancy(t *testing.T) {
 	t.Run("nil tenancy", func(t *testing.T) {
 		idx, done := prefixIndexFromTenancy(nil)
-		require.Len(t, idx, 0)
+		require.Empty(t, idx)
 		require.True(t, done)
 	})
 
 	t.Run("partition empty", func(t *testing.T) {
 		tenant := &pbresource.Tenancy{}
 		idx, done := prefixIndexFromTenancy(tenant)
-		require.Len(t, idx, 0)
+		require.Empty(t, idx)
 		require.True(t, done)
 	})
 
@@ -127,7 +127,7 @@ func TestPrefixIndexFromTenancy(t *testing.T) {
 			Partition: storage.Wildcard,
 		}
 		idx, done := prefixIndexFromTenancy(tenant)
-		require.Len(t, idx, 0)
+		require.Empty(t, idx)
 		require.True(t, done)
 	})
 

--- a/internal/controller/cache/index/index_test.go
+++ b/internal/controller/cache/index/index_test.go
@@ -122,7 +122,7 @@ func TestSingleIndexWrapper(t *testing.T) {
 		indexed, vals, err := wrapper.FromResource(res)
 		require.False(t, indexed)
 		require.Nil(t, vals)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("FromResource ok", func(t *testing.T) {

--- a/internal/controller/cache/index/txn_test.go
+++ b/internal/controller/cache/index/txn_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/consul/internal/controller/cache/index/indexmock"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/proto/private/prototest"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -62,8 +61,8 @@ func (suite *txnSuite) TestGet() {
 		Once()
 
 	actual, err := suite.index.Txn().Get(suite.r1.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), actual)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(actual)
 	prototest.AssertDeepEqual(suite.T(), suite.r1, actual)
 }
 
@@ -74,8 +73,8 @@ func (suite *txnSuite) TestGet_NotFound() {
 		Once()
 
 	actual, err := suite.index.Txn().Get(suite.r1.Id)
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), actual)
+	suite.Require().NoError(err)
+	suite.Require().Nil(actual)
 }
 
 func (suite *txnSuite) TestGet_Error() {
@@ -85,8 +84,8 @@ func (suite *txnSuite) TestGet_Error() {
 		Once()
 
 	actual, err := suite.index.Txn().Get(suite.r1.Id)
-	require.ErrorIs(suite.T(), err, fakeTestError)
-	require.Nil(suite.T(), actual)
+	suite.Require().ErrorIs(err, fakeTestError)
+	suite.Require().Nil(actual)
 }
 
 func (suite *txnSuite) TestListIterator() {
@@ -101,26 +100,26 @@ func (suite *txnSuite) TestListIterator() {
 		Once()
 
 	iter, err := suite.index.Txn().ListIterator(refQuery)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	r := iter.Next()
-	require.NotNil(suite.T(), r)
+	suite.Require().NotNil(r)
 	prototest.AssertDeepEqual(suite.T(), suite.r1, r)
 
 	r = iter.Next()
-	require.NotNil(suite.T(), r)
+	suite.Require().NotNil(r)
 	prototest.AssertDeepEqual(suite.T(), suite.r11, r)
 
 	r = iter.Next()
-	require.NotNil(suite.T(), r)
+	suite.Require().NotNil(r)
 	prototest.AssertDeepEqual(suite.T(), suite.r123, r)
 
 	r = iter.Next()
-	require.NotNil(suite.T(), r)
+	suite.Require().NotNil(r)
 	prototest.AssertDeepEqual(suite.T(), suite.r2, r)
 
 	r = iter.Next()
-	require.Nil(suite.T(), r)
+	suite.Require().Nil(r)
 }
 
 func (suite *txnSuite) TestListIterator_Error() {
@@ -131,8 +130,8 @@ func (suite *txnSuite) TestListIterator_Error() {
 		Once()
 
 	iter, err := suite.index.Txn().ListIterator("sentinel")
-	require.ErrorIs(suite.T(), err, fakeTestError)
-	require.Nil(suite.T(), iter)
+	suite.Require().ErrorIs(err, fakeTestError)
+	suite.Require().Nil(iter)
 }
 
 func (suite *txnSuite) TestParentsIterator() {
@@ -143,18 +142,18 @@ func (suite *txnSuite) TestParentsIterator() {
 		Once()
 
 	iter, err := suite.index.Txn().ParentsIterator(suite.r123.Id)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	r := iter.Next()
-	require.NotNil(suite.T(), r)
+	suite.Require().NotNil(r)
 	prototest.AssertDeepEqual(suite.T(), suite.r1, r)
 
 	r = iter.Next()
-	require.NotNil(suite.T(), r)
+	suite.Require().NotNil(r)
 	prototest.AssertDeepEqual(suite.T(), suite.r123, r)
 
 	r = iter.Next()
-	require.Nil(suite.T(), r)
+	suite.Require().Nil(r)
 }
 
 func (suite *txnSuite) TestParentsIterator_Error() {
@@ -165,8 +164,8 @@ func (suite *txnSuite) TestParentsIterator_Error() {
 		Once()
 
 	iter, err := suite.index.Txn().ParentsIterator("sentinel")
-	require.ErrorIs(suite.T(), err, fakeTestError)
-	require.Nil(suite.T(), iter)
+	suite.Require().ErrorIs(err, fakeTestError)
+	suite.Require().Nil(iter)
 }
 
 func (suite *txnSuite) TestInsert_MissingRequiredIndex() {
@@ -176,8 +175,8 @@ func (suite *txnSuite) TestInsert_MissingRequiredIndex() {
 		Once()
 
 	err := suite.index.Txn().Insert(suite.r1)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, MissingRequiredIndexError{Name: "test"})
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, MissingRequiredIndexError{Name: "test"})
 }
 
 func (suite *txnSuite) TestInsert_IndexError() {
@@ -187,8 +186,8 @@ func (suite *txnSuite) TestInsert_IndexError() {
 		Once()
 
 	err := suite.index.Txn().Insert(suite.r1)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, fakeTestError)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, fakeTestError)
 }
 
 func (suite *txnSuite) TestInsert_UpdateInternalSlice() {
@@ -212,8 +211,8 @@ func (suite *txnSuite) TestInsert_UpdateInternalSlice() {
 
 	// Actually index the resource
 	txn := suite.index.Txn()
-	require.NoError(suite.T(), txn.Insert(newR))
-	require.NoError(suite.T(), txn.Insert(newR1))
+	suite.Require().NoError(txn.Insert(newR))
+	suite.Require().NoError(txn.Insert(newR1))
 	txn.Commit()
 
 	// No validate that the insertions worked correctly.
@@ -222,7 +221,7 @@ func (suite *txnSuite) TestInsert_UpdateInternalSlice() {
 		RunAndReturn(PrefixReferenceOrIDFromArgs).
 		Once()
 	iter, err := suite.index.Txn().ListIterator(newR1.Id)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	var resources []*pbresource.Resource
 	for r := iter.Next(); r != nil; r = iter.Next() {
@@ -241,7 +240,7 @@ func (suite *txnSuite) TestDelete() {
 
 	// perform the deletion
 	txn := suite.index.Txn()
-	require.NoError(suite.T(), txn.Delete(suite.r1))
+	suite.Require().NoError(txn.Delete(suite.r1))
 	txn.Commit()
 
 	// expect to index the ID during the query
@@ -252,8 +251,8 @@ func (suite *txnSuite) TestDelete() {
 
 	// ensure that the deletion worked
 	res, err := suite.index.Txn().Get(suite.r1.Id)
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), res)
+	suite.Require().NoError(err)
+	suite.Require().Nil(res)
 }
 
 func (suite *txnSuite) TestDelete_NotFound() {
@@ -265,7 +264,7 @@ func (suite *txnSuite) TestDelete_NotFound() {
 
 	// attempt the deletion
 	txn := suite.index.Txn()
-	require.NoError(suite.T(), txn.Delete(res))
+	suite.Require().NoError(txn.Delete(res))
 	txn.Commit()
 }
 
@@ -286,7 +285,7 @@ func (suite *txnSuite) TestDelete_IdxPresentValNotFound() {
 		Once()
 
 	txn := suite.index.Txn()
-	require.NoError(suite.T(), txn.Delete(newR))
+	suite.Require().NoError(txn.Delete(newR))
 	txn.Commit()
 }
 
@@ -301,7 +300,7 @@ func (suite *txnSuite) TestDelete_SliceModifications() {
 			Once()
 
 		txn := suite.index.Txn()
-		require.NoError(suite.T(), txn.Insert(r))
+		suite.Require().NoError(txn.Insert(r))
 		txn.Commit()
 
 		return r
@@ -321,7 +320,7 @@ func (suite *txnSuite) TestDelete_SliceModifications() {
 		Return(true, commonIndex, nil).
 		Once()
 
-	require.NoError(suite.T(), txn.Delete(fr1))
+	suite.Require().NoError(txn.Delete(fr1))
 
 	// excercise deletion of the last slice element
 	suite.indexer.EXPECT().
@@ -329,7 +328,7 @@ func (suite *txnSuite) TestDelete_SliceModifications() {
 		Return(true, commonIndex, nil).
 		Once()
 
-	require.NoError(suite.T(), txn.Delete(fr5))
+	suite.Require().NoError(txn.Delete(fr5))
 
 	// excercise deletion from the middle of the list
 	suite.indexer.EXPECT().
@@ -337,7 +336,7 @@ func (suite *txnSuite) TestDelete_SliceModifications() {
 		Return(true, commonIndex, nil).
 		Once()
 
-	require.NoError(suite.T(), txn.Delete(fr3))
+	suite.Require().NoError(txn.Delete(fr3))
 
 	txn.Commit()
 
@@ -348,8 +347,8 @@ func (suite *txnSuite) TestDelete_SliceModifications() {
 		Once()
 
 	iter, err := suite.index.Txn().ListIterator(fr2.Id)
-	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), iter)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(iter)
 
 	var resources []*pbresource.Resource
 	for r := iter.Next(); r != nil; r = iter.Next() {
@@ -366,8 +365,8 @@ func (suite *txnSuite) TestDelete_MissingRequiredIndex() {
 		Once()
 
 	err := suite.index.Txn().Delete(suite.r1)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, MissingRequiredIndexError{Name: "test"})
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, MissingRequiredIndexError{Name: "test"})
 }
 
 func (suite *txnSuite) TestDelete_IndexError() {
@@ -377,6 +376,6 @@ func (suite *txnSuite) TestDelete_IndexError() {
 		Once()
 
 	err := suite.index.Txn().Delete(suite.r1)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, fakeTestError)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, fakeTestError)
 }

--- a/internal/controller/cache/indexers/decoded_indexer_test.go
+++ b/internal/controller/cache/indexers/decoded_indexer_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/consul/internal/resource/resourcetest"
 	pbdemo "github.com/hashicorp/consul/proto/private/pbdemo/v1"
 	"github.com/hashicorp/consul/proto/private/prototest"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -49,8 +48,8 @@ func (suite *decodedSingleIndexerSuite) TestFromArgs() {
 		Once()
 
 	val, err := suite.index.FromArgs("blah", 1, true)
-	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), []byte("foo"), val)
+	suite.Require().NoError(err)
+	suite.Require().Equal([]byte("foo"), val)
 }
 
 func (suite *decodedSingleIndexerSuite) TestFromArgs_Error() {
@@ -60,8 +59,8 @@ func (suite *decodedSingleIndexerSuite) TestFromArgs_Error() {
 		Once()
 
 	val, err := suite.index.FromArgs("blah", 1, true)
-	require.ErrorIs(suite.T(), err, fakeTestError)
-	require.Nil(suite.T(), val)
+	suite.Require().ErrorIs(err, fakeTestError)
+	suite.Require().Nil(val)
 }
 
 func (suite *decodedSingleIndexerSuite) TestFromResource() {
@@ -79,9 +78,9 @@ func (suite *decodedSingleIndexerSuite) TestFromResource() {
 		Once()
 
 	indexed, val, err := suite.index.FromResource(res)
-	require.True(suite.T(), indexed)
-	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), []byte{1, 2, 3}, val)
+	suite.Require().True(indexed)
+	suite.Require().NoError(err)
+	suite.Require().Equal([]byte{1, 2, 3}, val)
 }
 
 func (suite *decodedSingleIndexerSuite) TestFromResource_Error() {
@@ -99,9 +98,9 @@ func (suite *decodedSingleIndexerSuite) TestFromResource_Error() {
 		Once()
 
 	indexed, val, err := suite.index.FromResource(res)
-	require.False(suite.T(), indexed)
-	require.ErrorIs(suite.T(), err, fakeTestError)
-	require.Nil(suite.T(), val)
+	suite.Require().False(indexed)
+	suite.Require().ErrorIs(err, fakeTestError)
+	suite.Require().Nil(val)
 }
 
 func (suite *decodedSingleIndexerSuite) TestFromResource_DecodeError() {
@@ -113,9 +112,9 @@ func (suite *decodedSingleIndexerSuite) TestFromResource_DecodeError() {
 
 	var expectedErr resource.ErrDataParse
 	indexed, val, err := suite.index.FromResource(res)
-	require.False(suite.T(), indexed)
-	require.ErrorAs(suite.T(), err, &expectedErr)
-	require.Nil(suite.T(), val)
+	suite.Require().False(indexed)
+	suite.Require().ErrorAs(err, &expectedErr)
+	suite.Require().Nil(val)
 }
 
 func (suite *decodedSingleIndexerSuite) TestIntegration() {
@@ -139,7 +138,7 @@ func (suite *decodedSingleIndexerSuite) TestIntegration() {
 		Once()
 
 	txn := idx.Txn()
-	require.NoError(suite.T(), txn.Insert(res))
+	suite.Require().NoError(txn.Insert(res))
 	txn.Commit()
 
 	suite.args.EXPECT().
@@ -148,7 +147,7 @@ func (suite *decodedSingleIndexerSuite) TestIntegration() {
 		Once()
 
 	r, err := idx.Txn().Get("fake")
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), res, r)
 }
 
@@ -181,8 +180,8 @@ func (suite *decodedMultiIndexerSuite) TestFromArgs() {
 		Once()
 
 	val, err := suite.index.FromArgs("blah", 1, true)
-	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), []byte("foo"), val)
+	suite.Require().NoError(err)
+	suite.Require().Equal([]byte("foo"), val)
 }
 
 func (suite *decodedMultiIndexerSuite) TestFromArgs_Error() {
@@ -192,8 +191,8 @@ func (suite *decodedMultiIndexerSuite) TestFromArgs_Error() {
 		Once()
 
 	val, err := suite.index.FromArgs("blah", 1, true)
-	require.ErrorIs(suite.T(), err, fakeTestError)
-	require.Nil(suite.T(), val)
+	suite.Require().ErrorIs(err, fakeTestError)
+	suite.Require().Nil(val)
 }
 
 func (suite *decodedMultiIndexerSuite) TestFromResource() {
@@ -211,9 +210,9 @@ func (suite *decodedMultiIndexerSuite) TestFromResource() {
 		Once()
 
 	indexed, val, err := suite.index.FromResource(res)
-	require.True(suite.T(), indexed)
-	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), [][]byte{{1, 2}, {3}}, val)
+	suite.Require().True(indexed)
+	suite.Require().NoError(err)
+	suite.Require().Equal([][]byte{{1, 2}, {3}}, val)
 }
 
 func (suite *decodedMultiIndexerSuite) TestFromResource_Error() {
@@ -231,9 +230,9 @@ func (suite *decodedMultiIndexerSuite) TestFromResource_Error() {
 		Once()
 
 	indexed, val, err := suite.index.FromResource(res)
-	require.False(suite.T(), indexed)
-	require.ErrorIs(suite.T(), err, fakeTestError)
-	require.Nil(suite.T(), val)
+	suite.Require().False(indexed)
+	suite.Require().ErrorIs(err, fakeTestError)
+	suite.Require().Nil(val)
 }
 
 func (suite *decodedMultiIndexerSuite) TestFromResource_DecodeError() {
@@ -245,9 +244,9 @@ func (suite *decodedMultiIndexerSuite) TestFromResource_DecodeError() {
 
 	var expectedErr resource.ErrDataParse
 	indexed, val, err := suite.index.FromResource(res)
-	require.False(suite.T(), indexed)
-	require.ErrorAs(suite.T(), err, &expectedErr)
-	require.Nil(suite.T(), val)
+	suite.Require().False(indexed)
+	suite.Require().ErrorAs(err, &expectedErr)
+	suite.Require().Nil(val)
 }
 
 func (suite *decodedMultiIndexerSuite) TestIntegration() {
@@ -271,7 +270,7 @@ func (suite *decodedMultiIndexerSuite) TestIntegration() {
 		Once()
 
 	txn := idx.Txn()
-	require.NoError(suite.T(), txn.Insert(res))
+	suite.Require().NoError(txn.Insert(res))
 	txn.Commit()
 
 	suite.args.EXPECT().
@@ -286,10 +285,10 @@ func (suite *decodedMultiIndexerSuite) TestIntegration() {
 
 	txn = idx.Txn()
 	r, err := txn.Get("fake")
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), res, r)
 
 	r, err = txn.Get("fake2")
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), res, r)
 }

--- a/internal/controller/cache/kind_test.go
+++ b/internal/controller/cache/kind_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	pbdemo "github.com/hashicorp/consul/proto/private/pbdemo/v1"
 	"github.com/hashicorp/consul/proto/private/prototest"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -56,9 +55,9 @@ type kindSuite struct {
 func (suite *kindSuite) SetupTest() {
 	suite.k = newKindIndices()
 
-	require.NoError(suite.T(), suite.k.addIndex(namePrefixIndexer()))
-	require.NoError(suite.T(), suite.k.addIndex(releaseYearIndexer()))
-	require.NoError(suite.T(), suite.k.addIndex(tracksIndexer()))
+	suite.Require().NoError(suite.k.addIndex(namePrefixIndexer()))
+	suite.Require().NoError(suite.k.addIndex(releaseYearIndexer()))
+	suite.Require().NoError(suite.k.addIndex(tracksIndexer()))
 
 	suite.album1 = resourcetest.Resource(pbdemo.AlbumType, "one").
 		WithTenancy(resource.DefaultNamespacedTenancy()).
@@ -96,77 +95,77 @@ func (suite *kindSuite) SetupTest() {
 		}).
 		Build()
 
-	require.NoError(suite.T(), suite.k.insert(suite.album1))
-	require.NoError(suite.T(), suite.k.insert(suite.album2))
-	require.NoError(suite.T(), suite.k.insert(suite.album3))
-	require.NoError(suite.T(), suite.k.insert(suite.album4))
+	suite.Require().NoError(suite.k.insert(suite.album1))
+	suite.Require().NoError(suite.k.insert(suite.album2))
+	suite.Require().NoError(suite.k.insert(suite.album3))
+	suite.Require().NoError(suite.k.insert(suite.album4))
 }
 
 func (suite *kindSuite) TestGet() {
 	res, err := suite.k.get("id", suite.album1.Id)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.album1, res)
 
 	res, err = suite.k.get("year", int32(2022))
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.album3, res)
 
 	res, err = suite.k.get("tracks", "fangorn")
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertDeepEqual(suite.T(), suite.album2, res)
 }
 
 func (suite *kindSuite) TestGet_IndexNotFound() {
 	res, err := suite.k.get("blah", suite.album1.Id)
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, IndexNotFoundError{name: "blah"})
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, IndexNotFoundError{name: "blah"})
+	suite.Require().Nil(res)
 }
 
 func (suite *kindSuite) TestList() {
 	resources, err := expandIterator(suite.k.listIterator("year", int32(2023)))
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertElementsMatch(suite.T(), []*pbresource.Resource{suite.album1, suite.album2}, resources)
 
 	resources, err = expandIterator(suite.k.listIterator("tracks", "f", true))
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertElementsMatch(suite.T(), []*pbresource.Resource{suite.album1, suite.album2, suite.album4}, resources)
 }
 
 func (suite *kindSuite) TestList_IndexNotFound() {
 	res, err := expandIterator(suite.k.listIterator("blah", suite.album1.Id))
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, IndexNotFoundError{name: "blah"})
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, IndexNotFoundError{name: "blah"})
+	suite.Require().Nil(res)
 }
 
 func (suite *kindSuite) TestParents() {
 	resources, err := expandIterator(suite.k.parentsIterator("name_prefix", "food"))
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertElementsMatch(suite.T(), []*pbresource.Resource{suite.album3, suite.album4}, resources)
 }
 
 func (suite *kindSuite) TestParents_IndexNotFound() {
 	res, err := expandIterator(suite.k.parentsIterator("blah", suite.album1.Id))
-	require.Error(suite.T(), err)
-	require.ErrorIs(suite.T(), err, IndexNotFoundError{name: "blah"})
-	require.Nil(suite.T(), res)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, IndexNotFoundError{name: "blah"})
+	suite.Require().Nil(res)
 }
 func (suite *kindSuite) TestDelete() {
 	err := suite.k.delete(suite.album1)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	res, err := suite.k.get("id", suite.album1.Id)
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), res)
+	suite.Require().NoError(err)
+	suite.Require().Nil(res)
 
 	resources, err := expandIterator(suite.k.listIterator("year", int32(2023)))
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertElementsMatch(suite.T(), []*pbresource.Resource{suite.album2}, resources)
 
 	resources, err = expandIterator(suite.k.parentsIterator("name_prefix", "onesie"))
-	require.NoError(suite.T(), err)
-	require.Nil(suite.T(), resources)
+	suite.Require().NoError(err)
+	suite.Require().Nil(resources)
 }
 
 func (suite *kindSuite) TestInsertIndexError() {
@@ -176,27 +175,27 @@ func (suite *kindSuite) TestInsertIndexError() {
 			WithData(suite.T(), &pbdemo.Concept{}).
 			Build())
 
-	require.Error(suite.T(), err)
-	require.ErrorAs(suite.T(), err, &IndexError{})
+	suite.Require().Error(err)
+	suite.Require().ErrorAs(err, &IndexError{})
 }
 
 func (suite *kindSuite) TestGetIndexError() {
 	val, err := suite.k.get("year", "blah")
-	require.Error(suite.T(), err)
-	require.ErrorAs(suite.T(), err, &IndexError{})
-	require.Nil(suite.T(), val)
+	suite.Require().Error(err)
+	suite.Require().ErrorAs(err, &IndexError{})
+	suite.Require().Nil(val)
 }
 
 func (suite *kindSuite) TestListIteratorIndexError() {
 	vals, err := suite.k.listIterator("year", "blah")
-	require.Error(suite.T(), err)
-	require.ErrorAs(suite.T(), err, &IndexError{})
-	require.Nil(suite.T(), vals)
+	suite.Require().Error(err)
+	suite.Require().ErrorAs(err, &IndexError{})
+	suite.Require().Nil(vals)
 }
 
 func (suite *kindSuite) TestParentsIteratorIndexError() {
 	vals, err := suite.k.parentsIterator("year", "blah")
-	require.Error(suite.T(), err)
-	require.ErrorAs(suite.T(), err, &IndexError{})
-	require.Nil(suite.T(), vals)
+	suite.Require().Error(err)
+	suite.Require().ErrorAs(err, &IndexError{})
+	suite.Require().Nil(vals)
 }

--- a/internal/controller/dependency/cache_test.go
+++ b/internal/controller/dependency/cache_test.go
@@ -54,8 +54,8 @@ func (suite *cacheSuite) TestGetMapper_ModErr() {
 		suite.res,
 	)
 
-	require.Nil(suite.T(), reqs)
-	require.ErrorIs(suite.T(), err, injectedErr)
+	suite.Require().Nil(reqs)
+	suite.Require().ErrorIs(err, injectedErr)
 }
 
 func (suite *cacheSuite) TestGetMapper_CacheErr() {
@@ -76,8 +76,8 @@ func (suite *cacheSuite) TestGetMapper_CacheErr() {
 		suite.res,
 	)
 
-	require.Nil(suite.T(), reqs)
-	require.ErrorIs(suite.T(), err, injectedErr)
+	suite.Require().Nil(reqs)
+	suite.Require().ErrorIs(err, injectedErr)
 }
 
 func (suite *cacheSuite) TestGetMapper_Ok() {
@@ -101,8 +101,8 @@ func (suite *cacheSuite) TestGetMapper_Ok() {
 		suite.res,
 	)
 
-	require.NoError(suite.T(), err)
-	require.Len(suite.T(), reqs, 1)
+	suite.Require().NoError(err)
+	suite.Require().Len(reqs, 1)
 	prototest.AssertDeepEqual(suite.T(), out.Id, reqs[0].ID)
 }
 
@@ -118,8 +118,8 @@ func (suite *cacheSuite) TestListMapper_ModErr() {
 		suite.res,
 	)
 
-	require.Nil(suite.T(), reqs)
-	require.ErrorIs(suite.T(), err, injectedErr)
+	suite.Require().Nil(reqs)
+	suite.Require().ErrorIs(err, injectedErr)
 }
 
 func (suite *cacheSuite) TestListMapper_CacheErr() {
@@ -140,8 +140,8 @@ func (suite *cacheSuite) TestListMapper_CacheErr() {
 		suite.res,
 	)
 
-	require.Nil(suite.T(), reqs)
-	require.ErrorIs(suite.T(), err, injectedErr)
+	suite.Require().Nil(reqs)
+	suite.Require().ErrorIs(err, injectedErr)
 }
 
 func (suite *cacheSuite) TestListMapper_Ok() {
@@ -173,8 +173,8 @@ func (suite *cacheSuite) TestListMapper_Ok() {
 		suite.res,
 	)
 
-	require.NoError(suite.T(), err)
-	require.Len(suite.T(), reqs, 2)
+	suite.Require().NoError(err)
+	suite.Require().Len(reqs, 2)
 	expected := []controller.Request{
 		{ID: out.Id},
 		{ID: out2.Id},
@@ -194,8 +194,8 @@ func (suite *cacheSuite) TestParentsMapper_ModErr() {
 		suite.res,
 	)
 
-	require.Nil(suite.T(), reqs)
-	require.ErrorIs(suite.T(), err, injectedErr)
+	suite.Require().Nil(reqs)
+	suite.Require().ErrorIs(err, injectedErr)
 }
 
 func (suite *cacheSuite) TestParentsMapper_CacheErr() {
@@ -216,8 +216,8 @@ func (suite *cacheSuite) TestParentsMapper_CacheErr() {
 		suite.res,
 	)
 
-	require.Nil(suite.T(), reqs)
-	require.ErrorIs(suite.T(), err, injectedErr)
+	suite.Require().Nil(reqs)
+	suite.Require().ErrorIs(err, injectedErr)
 }
 
 func (suite *cacheSuite) TestParentsMapper_Ok() {
@@ -249,8 +249,8 @@ func (suite *cacheSuite) TestParentsMapper_Ok() {
 		suite.res,
 	)
 
-	require.NoError(suite.T(), err)
-	require.Len(suite.T(), reqs, 2)
+	suite.Require().NoError(err)
+	suite.Require().Len(reqs, 2)
 	expected := []controller.Request{
 		{ID: out.Id},
 		{ID: out2.Id},
@@ -270,8 +270,8 @@ func (suite *cacheSuite) TestListTransform_ModErr() {
 		suite.res,
 	)
 
-	require.Nil(suite.T(), reqs)
-	require.ErrorIs(suite.T(), err, injectedErr)
+	suite.Require().Nil(reqs)
+	suite.Require().ErrorIs(err, injectedErr)
 }
 
 func (suite *cacheSuite) TestListTransform_CacheErr() {
@@ -292,8 +292,8 @@ func (suite *cacheSuite) TestListTransform_CacheErr() {
 		suite.res,
 	)
 
-	require.Nil(suite.T(), resources)
-	require.ErrorIs(suite.T(), err, injectedErr)
+	suite.Require().Nil(resources)
+	suite.Require().ErrorIs(err, injectedErr)
 }
 
 func (suite *cacheSuite) TestListTransform_Ok() {
@@ -321,7 +321,7 @@ func (suite *cacheSuite) TestListTransform_Ok() {
 		suite.res,
 	)
 
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	prototest.AssertElementsMatch(suite.T(), expected, resources)
 }
 

--- a/internal/hcp/internal/controllers/link/controller_test.go
+++ b/internal/hcp/internal/controllers/link/controller_test.go
@@ -105,9 +105,9 @@ func (suite *controllerSuite) TestController_Ok() {
 	suite.client.WaitForStatusCondition(suite.T(), link.Id, StatusKey, ConditionLinked(linkData.ResourceId))
 	var updatedLink pbhcp.Link
 	updatedLinkResource := suite.client.WaitForNewVersion(suite.T(), link.Id, link.Version)
-	require.NoError(suite.T(), updatedLinkResource.Data.UnmarshalTo(&updatedLink))
-	require.Equal(suite.T(), "http://test.com", updatedLink.HcpClusterUrl)
-	require.Equal(suite.T(), pbhcp.AccessLevel_ACCESS_LEVEL_GLOBAL_READ_WRITE, updatedLink.AccessLevel)
+	suite.Require().NoError(updatedLinkResource.Data.UnmarshalTo(&updatedLink))
+	suite.Require().Equal("http://test.com", updatedLink.HcpClusterUrl)
+	suite.Require().Equal(pbhcp.AccessLevel_ACCESS_LEVEL_GLOBAL_READ_WRITE, updatedLink.AccessLevel)
 }
 
 func (suite *controllerSuite) TestController_Initialize() {
@@ -147,12 +147,12 @@ func (suite *controllerSuite) TestController_Initialize() {
 	// Check that created link has expected values
 	var link pbhcp.Link
 	err := r.Data.UnmarshalTo(&link)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
-	require.Equal(suite.T(), cloudCfg.ResourceID, link.ResourceId)
-	require.Equal(suite.T(), cloudCfg.ClientID, link.ClientId)
-	require.Equal(suite.T(), cloudCfg.ClientSecret, link.ClientSecret)
-	require.Equal(suite.T(), types.MetadataSourceConfig, r.Metadata[types.MetadataSourceKey])
+	suite.Require().Equal(cloudCfg.ResourceID, link.ResourceId)
+	suite.Require().Equal(cloudCfg.ClientID, link.ClientId)
+	suite.Require().Equal(cloudCfg.ClientSecret, link.ClientSecret)
+	suite.Require().Equal(types.MetadataSourceConfig, r.Metadata[types.MetadataSourceKey])
 
 	// Wait for link to be connected successfully
 	suite.client.WaitForStatusCondition(suite.T(), id, StatusKey, ConditionLinked(link.ResourceId))

--- a/internal/hcp/internal/controllers/telemetrystate/controller_test.go
+++ b/internal/hcp/internal/controllers/telemetrystate/controller_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	svctest "github.com/hashicorp/consul/agent/grpc-external/services/resource/testing"
@@ -101,10 +100,10 @@ func (suite *controllerSuite) TestController_Ok() {
 
 	tsRes := suite.client.WaitForResourceExists(suite.T(), &pbresource.ID{Name: "global", Type: pbhcp.TelemetryStateType})
 	decodedState, err := resource.Decode[*pbhcp.TelemetryState](tsRes)
-	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), link.GetData().GetResourceId(), decodedState.GetData().ResourceId)
-	require.Equal(suite.T(), "xxx", decodedState.GetData().ClientId)
-	require.Equal(suite.T(), "http://localhost/test", decodedState.GetData().Metrics.Endpoint)
+	suite.Require().NoError(err)
+	suite.Require().Equal(link.GetData().GetResourceId(), decodedState.GetData().ResourceId)
+	suite.Require().Equal("xxx", decodedState.GetData().ClientId)
+	suite.Require().Equal("http://localhost/test", decodedState.GetData().Metrics.Endpoint)
 
 	suite.client.MustDelete(suite.T(), link.Id)
 	suite.client.WaitForDeletion(suite.T(), tsRes.Id)
@@ -169,6 +168,6 @@ func (suite *controllerSuite) writeLinkResource() *types.DecodedLink {
 
 	suite.T().Cleanup(suite.deleteResourceFunc(res.Id))
 	link, err := resource.Decode[*pbhcp.Link](res)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	return link
 }

--- a/internal/mesh/internal/controllers/apigateways/controller_test.go
+++ b/internal/mesh/internal/controllers/apigateways/controller_test.go
@@ -95,8 +95,8 @@ func (suite *apigatewayControllerSuite) TestReconciler_Reconcile() {
 
 			dec, err := resource.GetDecodedResource[*pbcatalog.Service](ctx, suite.client, resource.ReplaceType(pbcatalog.ServiceType, req.ID))
 			require.NoError(t, err)
-			require.Equal(t, dec.Data.Ports, expectedWrittenService.Ports)
-			require.Equal(t, dec.Data.Workloads, expectedWrittenService.Workloads)
+			require.Equal(t, expectedWrittenService.Ports, dec.Data.Ports)
+			require.Equal(t, expectedWrittenService.Workloads, dec.Data.Workloads)
 		})
 
 		testutil.RunStep(suite.T(), "api-gateway does not exist", func(t *testing.T) {

--- a/internal/mesh/internal/controllers/explicitdestinations/controller_test.go
+++ b/internal/mesh/internal/controllers/explicitdestinations/controller_test.go
@@ -399,18 +399,18 @@ func (suite *controllerTestSuite) TestReconcile_NoWorkload() {
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: id,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireResourceNotFound(suite.T(), id)
 
 		// Check that we're not tracking services for this workload anymore.
 		reqs, err := suite.ctl.mapper.MapService(context.TODO(), controller.Runtime{}, suite.destService1)
-		require.NoError(suite.T(), err)
-		require.Nil(suite.T(), reqs)
+		suite.Require().NoError(err)
+		suite.Require().Nil(reqs)
 
 		reqs, err = suite.ctl.mapper.MapService(context.TODO(), controller.Runtime{}, suite.destService2)
-		require.NoError(suite.T(), err)
-		require.Nil(suite.T(), reqs)
+		suite.Require().NoError(err)
+		suite.Require().Nil(reqs)
 	})
 }
 
@@ -440,18 +440,18 @@ func (suite *controllerTestSuite) TestReconcile_NonMeshWorkload() {
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: cdID,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireResourceNotFound(suite.T(), cdID)
 
 		// Check that we're not tracking services for this workload anymore.
 		reqs, err := suite.ctl.mapper.MapService(context.TODO(), controller.Runtime{}, suite.destService1)
-		require.NoError(suite.T(), err)
-		require.Nil(suite.T(), reqs)
+		suite.Require().NoError(err)
+		suite.Require().Nil(reqs)
 
 		reqs, err = suite.ctl.mapper.MapService(context.TODO(), controller.Runtime{}, suite.destService2)
-		require.NoError(suite.T(), err)
-		require.Nil(suite.T(), reqs)
+		suite.Require().NoError(err)
+		suite.Require().Nil(reqs)
 	})
 }
 
@@ -495,14 +495,14 @@ func (suite *controllerTestSuite) TestReconcile_HappyPath() {
 			WithData(suite.T(), suite.dest2).
 			Write(suite.T(), suite.client)
 		_, err := suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, d2)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		d1 := resourcetest.Resource(pbmesh.DestinationsType, "dest1").
 			WithTenancy(tenancy).
 			WithData(suite.T(), suite.dest1).
 			Write(suite.T(), suite.client)
 		_, err = suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, d1)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.writeServices(suite.T(), tenancy)
 		suite.writeComputedRoutes(suite.T(), tenancy)
@@ -512,7 +512,7 @@ func (suite *controllerTestSuite) TestReconcile_HappyPath() {
 			ID: cdID,
 		})
 
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.requireComputedDestinations(suite.T(), cdID)
 		suite.client.RequireStatusCondition(suite.T(), d1.Id, ControllerName, ConditionDestinationsAccepted())
@@ -526,7 +526,7 @@ func (suite *controllerTestSuite) TestReconcile_NoDestinations() {
 			WithData(suite.T(), suite.dest1).
 			Build()
 		_, err := suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, dest)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		cdID := resourcetest.Resource(pbmesh.ComputedExplicitDestinationsType, suite.workloadRes.Id.Name).
 			WithTenancy(tenancy).
@@ -535,7 +535,7 @@ func (suite *controllerTestSuite) TestReconcile_NoDestinations() {
 			ID: cdID,
 		})
 
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireResourceNotFound(suite.T(), cdID)
 	})
@@ -550,7 +550,7 @@ func (suite *controllerTestSuite) TestReconcile_AllDestinationsInvalid() {
 			WithData(suite.T(), suite.dest1).
 			Write(suite.T(), suite.client)
 		_, err := suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, dest)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		cdID := resourcetest.Resource(pbmesh.ComputedExplicitDestinationsType, suite.workloadRes.Id.Name).
 			WithTenancy(tenancy).
@@ -559,7 +559,7 @@ func (suite *controllerTestSuite) TestReconcile_AllDestinationsInvalid() {
 			ID: cdID,
 		})
 
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireResourceNotFound(suite.T(), cdID)
 	})
@@ -572,7 +572,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_ConflictingDestinat
 			WithData(suite.T(), suite.dest1).
 			Write(suite.T(), suite.client)
 		_, err := suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, dest1)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Write a conflicting destinations resource.
 		destData := proto.Clone(suite.dest2).(*pbmesh.Destinations)
@@ -583,7 +583,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_ConflictingDestinat
 			WithData(suite.T(), destData).
 			Write(suite.T(), suite.client)
 		_, err = suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, dest2)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		cdID := resourcetest.Resource(pbmesh.ComputedExplicitDestinationsType, suite.workloadRes.Id.Name).
 			WithTenancy(tenancy).
@@ -591,7 +591,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_ConflictingDestinat
 		err = suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: cdID,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		suite.client.RequireResourceNotFound(suite.T(), cdID)
 
 		// Expect that the status on both resource is updated showing conflict.
@@ -606,12 +606,12 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_ConflictingDestinat
 			WithData(suite.T(), suite.dest2).
 			Write(suite.T(), suite.client)
 		_, err = suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, dest2)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		err = suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: cdID,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Expect status on both to be updated to say that there's no conflict.
 		suite.client.RequireStatusCondition(suite.T(), dest1.Id, ControllerName,
@@ -628,14 +628,14 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_NoService() {
 			WithData(suite.T(), suite.dest2).
 			Write(suite.T(), suite.client)
 		_, err := suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, dest)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		cdID := resourcetest.Resource(pbmesh.ComputedExplicitDestinationsType, suite.workloadRes.Id.Name).
 			WithTenancy(tenancy).
 			Write(suite.T(), suite.client).Id
 		err = suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: cdID,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		suite.client.RequireResourceNotFound(suite.T(), cdID)
 
 		suite.client.RequireStatusCondition(suite.T(), dest.Id, ControllerName,
@@ -650,7 +650,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_ServiceNotOnMesh() 
 			WithData(suite.T(), suite.dest2).
 			Write(suite.T(), suite.client)
 		_, err := suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, dest)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		resourcetest.Resource(pbcatalog.ServiceType, suite.destService3Ref.Name).
 			WithTenancy(tenancy).
@@ -672,7 +672,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_ServiceNotOnMesh() 
 		err = suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: cdID,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		suite.client.RequireResourceNotFound(suite.T(), cdID)
 
 		suite.client.RequireStatusCondition(suite.T(), dest.Id, ControllerName,
@@ -687,7 +687,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_DestinationPortIsMe
 			WithData(suite.T(), suite.dest2).
 			Write(suite.T(), suite.client)
 		_, err := suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, dest)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		resourcetest.Resource(pbcatalog.ServiceType, suite.destService3Ref.Name).
 			WithTenancy(tenancy).
@@ -709,7 +709,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_DestinationPortIsMe
 		err = suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: cdID,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		suite.client.RequireResourceNotFound(suite.T(), cdID)
 
 		suite.client.RequireStatusCondition(suite.T(), dest.Id, ControllerName,
@@ -724,7 +724,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_ComputedRoutesNotFo
 			WithData(suite.T(), suite.dest2).
 			Write(suite.T(), suite.client)
 		_, err := suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, dest)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		resourcetest.Resource(pbcatalog.ServiceType, suite.destService3Ref.Name).
 			WithTenancy(tenancy).
@@ -750,7 +750,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_ComputedRoutesNotFo
 		err = suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: cdID,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		suite.client.RequireResourceNotFound(suite.T(), cdID)
 
 		suite.client.RequireStatusCondition(suite.T(), dest.Id, ControllerName,
@@ -765,7 +765,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_ComputedRoutesPortN
 			WithData(suite.T(), suite.dest2).
 			Write(suite.T(), suite.client)
 		_, err := suite.ctl.mapper.MapDestinations(suite.ctx, suite.runtime, dest)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		destService := resourcetest.Resource(pbcatalog.ServiceType, suite.destService3Ref.Name).
 			WithTenancy(tenancy).
@@ -805,7 +805,7 @@ func (suite *controllerTestSuite) TestReconcile_StatusUpdate_ComputedRoutesPortN
 		err = suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: cdID,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		suite.client.RequireResourceNotFound(suite.T(), cdID)
 
 		suite.client.RequireStatusCondition(suite.T(), dest.Id, ControllerName,

--- a/internal/mesh/internal/controllers/gatewayproxy/controller_test.go
+++ b/internal/mesh/internal/controllers/gatewayproxy/controller_test.go
@@ -117,7 +117,7 @@ func (suite *gatewayproxyControllerSuite) TestReconciler_Reconcile() {
 			require.NoError(t, err)
 			require.NotNil(t, dec)
 			require.Equal(t, dec.Id.Name, expectedWrittenResource.Id.Name)
-			require.Equal(t, dec.Metadata, expectedWrittenResource.Metadata)
+			require.Equal(t, expectedWrittenResource.Metadata, dec.Metadata)
 			require.Equal(t, dec.Owner.Name, expectedWrittenResource.Owner.Name)
 		})
 	})

--- a/internal/mesh/internal/controllers/implicitdestinations/controller_test.go
+++ b/internal/mesh/internal/controllers/implicitdestinations/controller_test.go
@@ -182,7 +182,7 @@ func (suite *controllerSuite) createTrafficPermissions(
 	// Insert just enough to get the default one made for free.
 	for _, n := range defaults {
 		some := tpByDest[n]
-		require.Empty(suite.T(), some)
+		suite.Require().Empty(some)
 		tpByDest[n] = nil
 	}
 
@@ -753,8 +753,10 @@ func (suite *controllerSuite) TestReconcile_CIDUpdate_Multiple_Workloads_Service
 }
 
 func (suite *controllerSuite) reconcileOnce(id *pbresource.ID) {
+	suite.T().Helper()
+
 	err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: id})
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	suite.T().Cleanup(func() {
 		suite.client.CleanupDelete(suite.T(), id)
 	})
@@ -1496,7 +1498,7 @@ func TestController_DefaultDeny(t *testing.T) {
 
 func (suite *controllerSuite) runStep(name string, fn func()) {
 	suite.T().Helper()
-	require.True(suite.T(), suite.Run(name, fn))
+	suite.Require().True(suite.Run(name, fn))
 }
 
 func requireNewCIDVersion(
@@ -1562,7 +1564,7 @@ func (suite *controllerSuite) assertMapper(
 ) {
 	suite.T().Helper()
 	reqs, err := ctl.DryRunMapper(suite.ctx, res)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	var got []*pbresource.ID
 	for _, req := range reqs {

--- a/internal/mesh/internal/controllers/proxyconfiguration/controller_test.go
+++ b/internal/mesh/internal/controllers/proxyconfiguration/controller_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -74,7 +73,7 @@ func (suite *controllerTestSuite) TestReconcile_NoWorkload() {
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: id,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireResourceNotFound(suite.T(), id)
 	})
@@ -99,7 +98,7 @@ func (suite *controllerTestSuite) TestReconcile_NonMeshWorkload() {
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: cpcID,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireResourceNotFound(suite.T(), cpcID)
 	})
@@ -113,28 +112,28 @@ func (suite *controllerTestSuite) TestReconcile_HappyPath() {
 			WithData(suite.T(), suite.proxyCfg1).
 			Write(suite.T(), suite.client)
 		_, err := suite.ctl.proxyConfigMapper.MapToComputedType(suite.ctx, suite.runtime, pCfg1)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		pCfg2 := resourcetest.Resource(pbmesh.ProxyConfigurationType, "cfg2").
 			WithTenancy(tenancy).
 			WithData(suite.T(), suite.proxyCfg2).
 			Write(suite.T(), suite.client)
 		_, err = suite.ctl.proxyConfigMapper.MapToComputedType(suite.ctx, suite.runtime, pCfg2)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		pCfg3 := resourcetest.Resource(pbmesh.ProxyConfigurationType, "cfg3").
 			WithTenancy(tenancy).
 			WithData(suite.T(), suite.proxyCfg3).
 			Write(suite.T(), suite.client)
 		_, err = suite.ctl.proxyConfigMapper.MapToComputedType(suite.ctx, suite.runtime, pCfg3)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		cpcID := resource.ReplaceType(pbmesh.ComputedProxyConfigurationType, suite.workloadRes.Id)
 		err = suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: cpcID,
 		})
 
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.requireComputedProxyConfiguration(suite.T(), cpcID)
 	})
@@ -148,7 +147,7 @@ func (suite *controllerTestSuite) TestReconcile_NoProxyConfigs() {
 			WithData(suite.T(), suite.proxyCfg1).
 			Build()
 		_, err := suite.ctl.proxyConfigMapper.MapToComputedType(suite.ctx, suite.runtime, pCfg1)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		cpcID := resourcetest.Resource(pbmesh.ComputedProxyConfigurationType, suite.workloadRes.Id.Name).
 			WithTenancy(tenancy).
@@ -157,7 +156,7 @@ func (suite *controllerTestSuite) TestReconcile_NoProxyConfigs() {
 			ID: cpcID,
 		})
 
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireResourceNotFound(suite.T(), cpcID)
 	})

--- a/internal/mesh/internal/controllers/sidecarproxy/controller_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/controller_test.go
@@ -227,7 +227,7 @@ func (suite *controllerTestSuite) TestWorkloadPortProtocolsFromService_NoService
 
 		decWorkload := resourcetest.MustDecode[*pbcatalog.Workload](suite.T(), workload)
 		workloadPorts, err := workloadPortProtocolsFromService(suite.rt, decWorkload)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		prototest.AssertDeepEqual(suite.T(), pbcatalog.Protocol_PROTOCOL_TCP, workloadPorts["tcp"].GetProtocol())
 	})
 }
@@ -255,7 +255,7 @@ func (suite *controllerTestSuite) TestWorkloadPortProtocolsFromService_ServiceNo
 		decWorkload := resourcetest.MustDecode[*pbcatalog.Workload](suite.T(), workload)
 
 		workloadPorts, err := workloadPortProtocolsFromService(suite.rt, decWorkload)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		prototest.AssertDeepEqual(suite.T(), pbcatalog.Protocol_PROTOCOL_TCP, workloadPorts["tcp"].GetProtocol())
 	})
 }
@@ -323,7 +323,7 @@ func (suite *controllerTestSuite) TestWorkloadPortProtocolsFromService() {
 		}
 
 		workloadPorts, err := workloadPortProtocolsFromService(suite.rt, decWorkload)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		prototest.AssertDeepEqual(suite.T(), expWorkloadPorts, workloadPorts)
 	})
@@ -402,7 +402,7 @@ func (suite *controllerTestSuite) TestReconcile_NoExistingProxyStateTemplate() {
 		suite.reconcileOnce(resourceID(pbmesh.ProxyStateTemplateType, api.workloadID.Name, tenancy))
 
 		res := suite.client.RequireResourceExists(suite.T(), resourceID(pbmesh.ProxyStateTemplateType, api.workloadID.Name, tenancy))
-		require.NotNil(suite.T(), res.Data)
+		suite.Require().NotNil(res.Data)
 		prototest.AssertDeepEqual(suite.T(), api.workloadID, res.Owner)
 	})
 }
@@ -430,20 +430,20 @@ func (suite *controllerTestSuite) TestReconcile_ExistingProxyStateTemplate_WithU
 		suite.reconcileOnce(resourceID(pbmesh.ProxyStateTemplateType, updatedWorkloadID.Name, tenancy))
 
 		res := suite.client.RequireResourceExists(suite.T(), resourceID(pbmesh.ProxyStateTemplateType, updatedWorkloadID.Name, tenancy))
-		require.NotNil(suite.T(), res.Data)
+		suite.Require().NotNil(res.Data)
 		prototest.AssertDeepEqual(suite.T(), updatedWorkloadID, res.Owner)
 
 		var updatedProxyStateTemplate pbmesh.ProxyStateTemplate
 		err := res.Data.UnmarshalTo(&updatedProxyStateTemplate)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Check that our value is updated in the proxy state template.
-		require.Len(suite.T(), updatedProxyStateTemplate.ProxyState.Listeners, 1)
-		require.Len(suite.T(), updatedProxyStateTemplate.ProxyState.Listeners[0].Routers, 1)
+		suite.Require().Len(updatedProxyStateTemplate.ProxyState.Listeners, 1)
+		suite.Require().Len(updatedProxyStateTemplate.ProxyState.Listeners[0].Routers, 1)
 
 		l4InboundRouter := updatedProxyStateTemplate.ProxyState.Listeners[0].
 			Routers[0].GetL4()
-		require.NotNil(suite.T(), l4InboundRouter)
+		suite.Require().NotNil(l4InboundRouter)
 	})
 }
 
@@ -628,7 +628,7 @@ func (suite *controllerTestSuite) TestController() {
 			// Delete the proxy state template resource and check that it gets regenerated.
 			suite.rt.Logger.Trace("deleting web proxy")
 			_, err := suite.client.Delete(suite.ctx, &pbresource.DeleteRequest{Id: webProxyStateTemplateID})
-			require.NoError(suite.T(), err)
+			suite.Require().NoError(err)
 
 			webProxyStateTemplate = suite.client.WaitForNewVersion(suite.T(), webProxyStateTemplateID, webProxyStateTemplate.Version)
 
@@ -984,8 +984,10 @@ func (suite *controllerTestSuite) runTestCaseWithTenancies(t func(*pbresource.Te
 }
 
 func (suite *controllerTestSuite) reconcileOnce(id *pbresource.ID) {
+	suite.T().Helper()
+
 	err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: id})
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	suite.T().Cleanup(func() {
 		suite.client.CleanupDelete(suite.T(), id)
 	})

--- a/internal/mesh/internal/controllers/sidecarproxy/data_fetcher_test.go
+++ b/internal/mesh/internal/controllers/sidecarproxy/data_fetcher_test.go
@@ -249,7 +249,7 @@ func (suite *dataFetcherSuite) TestFetcher_FetchExplicitDestinationsData() {
 			api1ComputedRoutes := routestest.ReconcileComputedRoutes(suite.T(), suite.client, api1ComputedRoutesID,
 				resourcetest.MustDecode[*pbcatalog.Service](suite.T(), apiNonTCPService),
 			)
-			require.NotNil(suite.T(), api1ComputedRoutes)
+			suite.Require().NotNil(api1ComputedRoutes)
 
 			// This destination points to TCP, but the computed routes is stale and only knows about HTTP.
 			destinations, err := fetchComputedExplicitDestinationsData(suite.rt, webWrk, mgwMode)
@@ -268,11 +268,11 @@ func (suite *dataFetcherSuite) TestFetcher_FetchExplicitDestinationsData() {
 			api1ComputedRoutes := routestest.ReconcileComputedRoutes(suite.T(), suite.client, api1ComputedRoutesID,
 				resourcetest.MustDecode[*pbcatalog.Service](suite.T(), suite.api1Service),
 			)
-			require.NotNil(suite.T(), api1ComputedRoutes)
+			suite.Require().NotNil(api1ComputedRoutes)
 			api2ComputedRoutes := routestest.ReconcileComputedRoutes(suite.T(), suite.client, api2ComputedRoutesID,
 				resourcetest.MustDecode[*pbcatalog.Service](suite.T(), suite.api2Service),
 			)
-			require.NotNil(suite.T(), api2ComputedRoutes)
+			suite.Require().NotNil(api2ComputedRoutes)
 
 			expectedDestinations := []*intermediate.Destination{
 				{
@@ -362,15 +362,15 @@ func (suite *dataFetcherSuite) TestFetcher_FetchImplicitDestinationsData() {
 		api1ComputedRoutes := routestest.ReconcileComputedRoutes(suite.T(), suite.client, api1ComputedRoutesID,
 			resourcetest.MustDecode[*pbcatalog.Service](suite.T(), suite.api1Service),
 		)
-		require.NotNil(suite.T(), api1ComputedRoutes)
+		suite.Require().NotNil(api1ComputedRoutes)
 		api2ComputedRoutes := routestest.ReconcileComputedRoutes(suite.T(), suite.client, api2ComputedRoutesID,
 			resourcetest.MustDecode[*pbcatalog.Service](suite.T(), suite.api2Service),
 		)
-		require.NotNil(suite.T(), api2ComputedRoutes)
+		suite.Require().NotNil(api2ComputedRoutes)
 		api3ComputedRoutes := routestest.ReconcileComputedRoutes(suite.T(), suite.client, api3ComputedRoutesID,
 			resourcetest.MustDecode[*pbcatalog.Service](suite.T(), api3Service),
 		)
-		require.NotNil(suite.T(), api3ComputedRoutes)
+		suite.Require().NotNil(api3ComputedRoutes)
 
 		cidID := &pbresource.ID{
 			Type:    pbmesh.ComputedImplicitDestinationsType,
@@ -451,7 +451,7 @@ func (suite *dataFetcherSuite) TestFetcher_FetchImplicitDestinationsData() {
 		actualDestinations, err := fetchComputedImplicitDestinationsData(
 			suite.rt, webWrk, mgwMode, slices.Clone(existingDestinations),
 		)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		existingDestinations = append(existingDestinations, &intermediate.Destination{
 			// implicit

--- a/internal/mesh/internal/controllers/xds/controller_test.go
+++ b/internal/mesh/internal/controllers/xds/controller_test.go
@@ -126,18 +126,18 @@ func (suite *xdsControllerTestSuite) TestReconcile_NoProxyStateTemplate() {
 
 		suite.mapper.TrackItem(proxyStateTemplateId, []resource.ReferenceOrID{})
 		suite.leafMapper.TrackItem(proxyStateTemplateId, []resource.ReferenceOrID{})
-		require.False(suite.T(), suite.mapper.IsEmpty())
-		require.False(suite.T(), suite.leafMapper.IsEmpty())
+		suite.Require().False(suite.mapper.IsEmpty())
+		suite.Require().False(suite.leafMapper.IsEmpty())
 
 		// Run the reconcile, and since no ProxyStateTemplate is stored, this simulates a deletion.
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: proxyStateTemplateId,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Assert that nothing is tracked in the endpoints mapper.
-		require.True(suite.T(), suite.mapper.IsEmpty())
-		require.True(suite.T(), suite.leafMapper.IsEmpty())
+		suite.Require().True(suite.mapper.IsEmpty())
+		suite.Require().True(suite.leafMapper.IsEmpty())
 	})
 }
 
@@ -163,10 +163,10 @@ func (suite *xdsControllerTestSuite) TestReconcile_RemoveTrackingProxiesNotConne
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: proxyStateTemplate.Id,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Assert that nothing is tracked in the mapper.
-		require.True(suite.T(), suite.mapper.IsEmpty())
+		suite.Require().True(suite.mapper.IsEmpty())
 	})
 }
 
@@ -184,7 +184,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_PushChangeError() {
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: suite.fooProxyStateTemplate.Id,
 		})
-		require.Error(suite.T(), err)
+		suite.Require().Error(err)
 
 		// Assert on the status reflecting endpoint not found.
 		suite.client.RequireStatusCondition(suite.T(), suite.fooProxyStateTemplate.Id, ControllerName, status.ConditionRejectedPushChangeFailed(status.KeyFromID(suite.fooProxyStateTemplate.Id)))
@@ -223,7 +223,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_MissingEndpoint() {
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: fooProxyStateTemplate.Id,
 		})
-		require.Error(suite.T(), err)
+		suite.Require().Error(err)
 
 		// Assert on the status reflecting endpoint not found.
 		suite.client.RequireStatusCondition(suite.T(), fooProxyStateTemplate.Id, ControllerName, status.ConditionRejectedErrorReadingEndpoints(status.KeyFromID(fooEndpointsId), "rpc error: code = NotFound desc = resource not found"))
@@ -267,7 +267,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_ReadEndpointError() {
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: fooProxyStateTemplate.Id,
 		})
-		require.Error(suite.T(), err)
+		suite.Require().Error(err)
 
 		// Assert on the status reflecting endpoint couldn't be read.
 		suite.client.RequireStatusCondition(suite.T(), fooProxyStateTemplate.Id, ControllerName, status.ConditionRejectedErrorReadingEndpoints(
@@ -290,7 +290,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_ProxyStateTemplateComputesEnd
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: suite.fooProxyStateTemplate.Id,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Assert on the status.
 		suite.client.RequireStatusCondition(suite.T(), suite.fooProxyStateTemplate.Id, ControllerName, status.ConditionAccepted())
@@ -311,7 +311,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_ProxyStateTemplateComputesLea
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: suite.fooProxyStateTemplate.Id,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Assert on the status.
 		suite.client.RequireStatusCondition(suite.T(), suite.fooProxyStateTemplate.Id, ControllerName, status.ConditionAccepted())
@@ -322,8 +322,8 @@ func (suite *xdsControllerTestSuite) TestReconcile_ProxyStateTemplateComputesLea
 		for k, l := range actualLeafs {
 			pemDecode, _ := pem.Decode([]byte(l.Cert))
 			cert, err := x509.ParseCertificate(pemDecode.Bytes)
-			require.NoError(suite.T(), err)
-			require.Equal(suite.T(), cert.URIs[0].String(), suite.expectedFooProxyStateSpiffes[k])
+			suite.Require().NoError(err)
+			suite.Require().Equal(cert.URIs[0].String(), suite.expectedFooProxyStateSpiffes[k])
 		}
 	})
 }
@@ -338,7 +338,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_ProxyStateTemplateSetsTrustBu
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: suite.fooProxyStateTemplate.Id,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Assert on the status.
 		suite.client.RequireStatusCondition(suite.T(), suite.fooProxyStateTemplate.Id, ControllerName, status.ConditionAccepted())
@@ -363,7 +363,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_MultipleProxyStateTemplatesCo
 		err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: suite.fooProxyStateTemplate.Id,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Assert on the status.
 		suite.client.RequireStatusCondition(suite.T(), suite.fooProxyStateTemplate.Id, ControllerName, status.ConditionAccepted())
@@ -376,7 +376,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_MultipleProxyStateTemplatesCo
 		err = suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 			ID: suite.barProxyStateTemplate.Id,
 		})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Assert on the status.
 		suite.client.RequireStatusCondition(suite.T(), suite.barProxyStateTemplate.Id, ControllerName, status.ConditionAccepted())
@@ -684,7 +684,7 @@ func (suite *xdsControllerTestSuite) TestController_ComputeLeafReferencesDeleteP
 			Id: suite.fooProxyStateTemplate.Id,
 		}
 		_, err := suite.client.Delete(suite.ctx, req)
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Ensure the leaf certificate watches were cancelled since we deleted the leaf reference.
 		retry.Run(suite.T(), func(r *retry.R) {
@@ -723,7 +723,7 @@ func (suite *xdsControllerTestSuite) TestController_ComputeEndpointForProxyConne
 
 		// Wait for the proxy state template to be re-evaluated.
 		proxyStateTemp := suite.client.WaitForNewVersion(suite.T(), suite.fooProxyStateTemplate.Id, suite.fooProxyStateTemplate.Version)
-		require.NotNil(suite.T(), proxyStateTemp)
+		suite.Require().NotNil(proxyStateTemp)
 	})
 }
 
@@ -1124,7 +1124,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_prevWatchesToCancel() {
 
 		for _, tc := range cases {
 			toCancel := prevWatchesToCancel(tc.old, convert(tc.new))
-			require.ElementsMatch(suite.T(), toCancel, tc.expect)
+			suite.Require().ElementsMatch(toCancel, tc.expect)
 		}
 	})
 }
@@ -1207,15 +1207,15 @@ func (suite *xdsControllerTestSuite) TestReconcile_SidecarProxyGoldenFileInputs(
 				err := suite.ctl.Reconcile(context.Background(), suite.runtime, controller.Request{
 					ID: proxyStateTemplate.Id,
 				})
-				require.NoError(suite.T(), err)
-				require.NotNil(suite.T(), proxyStateTemplate)
+				suite.Require().NoError(err)
+				suite.Require().NotNil(proxyStateTemplate)
 
 				// Get the reconciled proxyStateTemplate to check the reconcile results.
 				reconciledPS := suite.updater.Get(proxyStateTemplate.Id.Name)
 
 				// Verify leaf cert contents then hard code them for comparison
 				// and downstream tests since they change from test run to test run.
-				require.NotEmpty(suite.T(), reconciledPS.LeafCertificates)
+				suite.Require().NotEmpty(reconciledPS.LeafCertificates)
 				reconciledPS.LeafCertificates = map[string]*pbproxystate.LeafCertificate{
 					"test-identity": {
 						Cert: "-----BEGIN CERTIFICATE-----\nMIICDjCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAjAUMRIwEAYDVQQDEwlUZXN0IENB\nIDEwHhcNMjMxMDE2MTYxMzI5WhcNMjMxMDE2MTYyMzI5WjAAMFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAErErAIosDPheZQGbxFQ4hYC/e9Fi4MG9z/zjfCnCq/oK9\nta/bGT+5orZqTmdN/ICsKQDhykxZ2u/Xr6845zhcJaOCAQowggEGMA4GA1UdDwEB\n/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/\nBAIwADApBgNVHQ4EIgQg3ogXVz9cqaK2B6xdiJYMa5NtT0KkYv7BA2dR7h9EcwUw\nKwYDVR0jBCQwIoAgq+C1mPlPoGa4lt7sSft1goN5qPGyBIB/3mUHJZKSFY8wbwYD\nVR0RAQH/BGUwY4Zhc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9hcC9kZWZhdWx0L25zL2RlZmF1bHQvaWRlbnRpdHkv\ndGVzdC1pZGVudGl0eTAKBggqhkjOPQQDAgNHADBEAiB6L+t5bzRrBPhiQYNeA7fF\nUCuLWrdjW4Xbv3SLg0IKMgIgfRC5hEx+DqzQxTCP4sexX3hVWMjKoWmHdwiUcg+K\n/IE=\n-----END CERTIFICATE-----\n",
@@ -1226,7 +1226,7 @@ func (suite *xdsControllerTestSuite) TestReconcile_SidecarProxyGoldenFileInputs(
 				// Compare actual vs expected.
 				actual := prototest.ProtoToJSON(suite.T(), reconciledPS)
 				expected := golden.Get(suite.T(), actual, name+"-"+tenancy.Partition+"-"+tenancy.Namespace+".golden")
-				require.JSONEq(suite.T(), expected, actual)
+				suite.Require().JSONEq(expected, actual)
 			})
 		}
 	})

--- a/internal/mesh/internal/types/computed_implicit_destinations_test.go
+++ b/internal/mesh/internal/types/computed_implicit_destinations_test.go
@@ -189,7 +189,7 @@ func TestComputedImplicitDestinationsACLs(t *testing.T) {
 				t.Fatal("should be denied")
 			}
 		case DEFAULT:
-			require.Nil(t, got, "expected fallthrough decision")
+			require.NoError(t, got, "expected fallthrough decision")
 		default:
 			t.Fatalf("unexpected expectation: %q", expect)
 		}

--- a/internal/mesh/internal/types/proxy_configuration_test.go
+++ b/internal/mesh/internal/types/proxy_configuration_test.go
@@ -120,7 +120,7 @@ func TestValidateProxyConfiguration_MissingBothDynamicAndBootstrapConfig(t *test
 			Wrapped: errMissingProxyConfigData,
 		},
 	)
-	require.Equal(t, err, expError)
+	require.Equal(t, expError, err)
 }
 
 func TestValidateProxyConfiguration_AllFieldsInvalid(t *testing.T) {
@@ -235,7 +235,7 @@ func TestValidateProxyConfiguration_AllFieldsInvalid(t *testing.T) {
 		},
 	)
 
-	require.Equal(t, err, expError)
+	require.Equal(t, expError, err)
 }
 
 func TestValidateProxyConfiguration_AllFieldsValid(t *testing.T) {

--- a/internal/multicluster/internal/controllers/exportedservices/controller_test.go
+++ b/internal/multicluster/internal/controllers/exportedservices/controller_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 
@@ -93,10 +92,10 @@ func (suite *controllerSuite) TestReconcile_DeleteOldCES_NoExportedServices() {
 			WithData(suite.T(), oldCESData).
 			WithTenancy(&pbresource.Tenancy{Partition: tenancy.Partition}).
 			Write(suite.T(), suite.client)
-		require.NotNil(suite.T(), oldCES)
+		suite.Require().NotNil(oldCES)
 
 		err := suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: oldCES.Id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireResourceNotFound(suite.T(), oldCES.Id)
 	})
@@ -131,7 +130,7 @@ func (suite *controllerSuite) TestReconcile_DeleteOldCES_NoMatchingServices() {
 			WithData(suite.T(), oldCESData).
 			WithTenancy(&pbresource.Tenancy{Partition: tenancy.Partition}).
 			Write(suite.T(), suite.client)
-		require.NotNil(suite.T(), oldCES)
+		suite.Require().NotNil(oldCES)
 
 		exportedSvcData := &pbmulticluster.ExportedServices{
 			Services: []string{"random-service-1", "random-service-2"},
@@ -159,7 +158,7 @@ func (suite *controllerSuite) TestReconcile_DeleteOldCES_NoMatchingServices() {
 		}
 
 		err := suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: oldCES.Id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		suite.client.RequireResourceNotFound(suite.T(), oldCES.Id)
 	})
@@ -200,7 +199,7 @@ func (suite *controllerSuite) TestReconcile_SkipWritingNewCES() {
 			WithTenancy(&pbresource.Tenancy{Partition: tenancy.Partition}).
 			WithStatus(statusKey, oldStatus).
 			Write(suite.T(), suite.client)
-		require.NotNil(suite.T(), oldCES)
+		suite.Require().NotNil(oldCES)
 
 		// Export the svc-0 service to just a peer
 		exportedSvcData := &pbmulticluster.ExportedServices{
@@ -238,7 +237,7 @@ func (suite *controllerSuite) TestReconcile_SkipWritingNewCES() {
 			Write(suite.T(), suite.client)
 
 		err := suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: oldCES.Id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Checking no-op with version
 		suite.client.RequireVersionUnchanged(suite.T(), oldCES.Id, oldCES.Version)
@@ -275,7 +274,7 @@ func (suite *controllerSuite) TestReconcile_SkipWritingNewCES_WithStatusUpdate()
 			WithData(suite.T(), oldCESData).
 			WithTenancy(&pbresource.Tenancy{Partition: tenancy.Partition}).
 			Write(suite.T(), suite.client)
-		require.NotNil(suite.T(), oldCES)
+		suite.Require().NotNil(oldCES)
 
 		// Export the svc-0 service to just a peer
 		exportedSvcData := &pbmulticluster.ExportedServices{
@@ -315,12 +314,12 @@ func (suite *controllerSuite) TestReconcile_SkipWritingNewCES_WithStatusUpdate()
 		passThroughClient := newPassThroughResourceClient(suite.client)
 		rt := suite.controllerRuntimeWithPassThroughClient(passThroughClient)
 		err := suite.reconciler.Reconcile(suite.ctx, rt, controller.Request{ID: oldCES.Id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		// Checking version change to ensure that the status gets updated
 		newCES := suite.client.RequireVersionChanged(suite.T(), oldCES.Id, oldCES.Version)
 		rtest.RequireStatusCondition(suite.T(), newCES, statusKey, conditionComputed())
-		require.Equal(suite.T(), 0, passThroughClient.writesCount)
+		suite.Require().Equal(0, passThroughClient.writesCount)
 	})
 }
 
@@ -362,10 +361,10 @@ func (suite *controllerSuite) TestReconcile_ComputeCES() {
 		}
 
 		id := rtest.Resource(pbmulticluster.ComputedExportedServicesType, "global").WithTenancy(&pbresource.Tenancy{Partition: tenancy.Partition}).ID()
-		require.NotNil(suite.T(), id)
+		suite.Require().NotNil(id)
 
 		err := suite.reconciler.Reconcile(suite.ctx, suite.rt, controller.Request{ID: id})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 
 		res := suite.client.RequireResourceExists(suite.T(), id)
 		computedCES := suite.getComputedExportedSvcData(res)
@@ -447,7 +446,7 @@ func (suite *controllerSuite) TestController() {
 		id := rtest.Resource(pbmulticluster.ComputedExportedServicesType, "global").WithTenancy(&pbresource.Tenancy{
 			Partition: tenancy.Partition,
 		}).ID()
-		require.NotNil(suite.T(), id)
+		suite.Require().NotNil(id)
 
 		svc1 := suite.writeService("svc1", tenancy)
 		exportedSvcData := &pbmulticluster.ExportedServices{
@@ -464,7 +463,7 @@ func (suite *controllerSuite) TestController() {
 		}
 
 		expSvc := suite.writeExportedService("expsvc", tenancy, exportedSvcData)
-		require.NotNil(suite.T(), expSvc)
+		suite.Require().NotNil(expSvc)
 
 		res := suite.client.WaitForResourceExists(suite.T(), id)
 		computedCES := suite.getComputedExportedSvcData(res)

--- a/internal/multicluster/internal/controllers/exportedservices/expander/expander_ce/expander_test.go
+++ b/internal/multicluster/internal/controllers/exportedservices/expander/expander_ce/expander_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	pbmulticluster "github.com/hashicorp/consul/proto-public/pbmulticluster/v2"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -49,9 +48,9 @@ func (suite *expanderSuite) TestExpand_NoSamenessGroupsPresent() {
 	}
 
 	expandedConsumers, err := suite.samenessGroupExpander.Expand(consumers, nil)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
-	require.Equal(suite.T(), []string{"peer-1", "peer-2", "peer-3"}, expandedConsumers.Peers)
-	require.Nil(suite.T(), expandedConsumers.Partitions)
-	require.Len(suite.T(), expandedConsumers.MissingSamenessGroups, 0)
+	suite.Require().Equal([]string{"peer-1", "peer-2", "peer-3"}, expandedConsumers.Peers)
+	suite.Require().Nil(expandedConsumers.Partitions)
+	suite.Require().Empty(expandedConsumers.MissingSamenessGroups)
 }

--- a/internal/multicluster/internal/controllers/v1compat/controller_test.go
+++ b/internal/multicluster/internal/controllers/v1compat/controller_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/hashicorp/consul/acl"
@@ -72,7 +71,7 @@ func (suite *controllerSuite) TestReconcile_V1ExportsExist() {
 			Name:    types.ComputedExportedServicesName,
 		}
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: resID})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	})
 }
 
@@ -92,7 +91,7 @@ func (suite *controllerSuite) TestReconcile_GetExportedServicesConfigEntry_Error
 			Name:    types.ComputedExportedServicesName,
 		}
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: resID})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	})
 }
 
@@ -120,7 +119,7 @@ func (suite *controllerSuite) TestReconcile_DeleteConfig_MissingResources() {
 			Name:    types.ComputedExportedServicesName,
 		}
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: resID})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	})
 }
 
@@ -182,7 +181,7 @@ func (suite *controllerSuite) TestReconcile_NewExport_PartitionExport() {
 			Name:    types.ComputedExportedServicesName,
 		}
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: cesID})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	})
 }
 
@@ -244,7 +243,7 @@ func (suite *controllerSuite) TestReconcile_NewExport_PeerExport() {
 			Name:    types.ComputedExportedServicesName,
 		}
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: cesID})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	})
 }
 
@@ -306,7 +305,7 @@ func (suite *controllerSuite) TestReconcile_NewExport_SamenessGroupsExport() {
 			Name:    types.ComputedExportedServicesName,
 		}
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: cesID})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	})
 }
 
@@ -407,7 +406,7 @@ func (suite *controllerSuite) TestReconcile_MultipleExports() {
 			Return(nil)
 
 		err := suite.ctl.Reconcile(suite.ctx, controller.Request{ID: cesID})
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	})
 }
 

--- a/internal/protohcl/unmarshal_test.go
+++ b/internal/protohcl/unmarshal_test.go
@@ -45,20 +45,20 @@ func TestPrimitives(t *testing.T) {
 	err := Unmarshal([]byte(hcl), &out)
 	require.NoError(t, err)
 
-	require.Equal(t, out.DoubleVal, float64(1.234))
-	require.Equal(t, out.FloatVal, float32(2.345))
-	require.Equal(t, out.Int32Val, int32(536870912))
-	require.Equal(t, out.Int64Val, int64(25769803776))
-	require.Equal(t, out.Uint32Val, uint32(2148532224))
-	require.Equal(t, out.Uint64Val, uint64(9223372041149743104))
-	require.Equal(t, out.Sint32Val, int32(536870912))
-	require.Equal(t, out.Sint64Val, int64(25769803776))
-	require.Equal(t, out.Fixed32Val, uint32(2148532224))
-	require.Equal(t, out.Fixed64Val, uint64(9223372041149743104))
-	require.Equal(t, out.Sfixed32Val, int32(536870912))
-	require.Equal(t, out.Sfixed64Val, int64(25769803776))
-	require.Equal(t, out.BoolVal, true)
-	require.Equal(t, out.StringVal, "foo")
+	require.Equal(t, float64(1.234), out.DoubleVal)
+	require.Equal(t, float32(2.345), out.FloatVal)
+	require.Equal(t, int32(536870912), out.Int32Val)
+	require.Equal(t, int64(25769803776), out.Int64Val)
+	require.Equal(t, uint32(2148532224), out.Uint32Val)
+	require.Equal(t, uint64(9223372041149743104), out.Uint64Val)
+	require.Equal(t, int32(536870912), out.Sint32Val)
+	require.Equal(t, int64(25769803776), out.Sint64Val)
+	require.Equal(t, uint32(2148532224), out.Fixed32Val)
+	require.Equal(t, uint64(9223372041149743104), out.Fixed64Val)
+	require.Equal(t, int32(536870912), out.Sfixed32Val)
+	require.Equal(t, int64(25769803776), out.Sfixed64Val)
+	require.True(t, out.BoolVal)
+	require.Equal(t, "foo", out.StringVal)
 	require.Equal(t, out.ByteVal, []byte("bar"))
 }
 
@@ -97,16 +97,16 @@ func TestNestedAndCollections(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, out.Primitives)
-	require.Equal(t, out.Primitives.Uint32Val, uint32(42))
+	require.Equal(t, uint32(42), out.Primitives.Uint32Val)
 	require.NotNil(t, out.PrimitivesMap)
-	require.Equal(t, out.PrimitivesMap["foo"].Uint32Val, uint32(42))
+	require.Equal(t, uint32(42), out.PrimitivesMap["foo"].Uint32Val)
 	require.NotNil(t, out.ProtocolMap)
-	require.Equal(t, out.ProtocolMap["foo"], testproto.Protocol_PROTOCOL_TCP)
+	require.Equal(t, testproto.Protocol_PROTOCOL_TCP, out.ProtocolMap["foo"])
 	require.Len(t, out.PrimitivesList, 2)
-	require.Equal(t, out.PrimitivesList[0].Uint32Val, uint32(42))
-	require.Equal(t, out.PrimitivesList[1].Uint32Val, uint32(56))
+	require.Equal(t, uint32(42), out.PrimitivesList[0].Uint32Val)
+	require.Equal(t, uint32(56), out.PrimitivesList[1].Uint32Val)
 	require.Len(t, out.IntList, 2)
-	require.Equal(t, out.IntList[1], int32(2))
+	require.Equal(t, int32(2), out.IntList[1])
 }
 
 func TestNestedAndCollections_AttributeSyntax(t *testing.T) {
@@ -147,16 +147,16 @@ func TestNestedAndCollections_AttributeSyntax(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, out.Primitives)
-	require.Equal(t, out.Primitives.Uint32Val, uint32(42))
+	require.Equal(t, uint32(42), out.Primitives.Uint32Val)
 	require.NotNil(t, out.PrimitivesMap)
-	require.Equal(t, out.PrimitivesMap["foo"].Uint32Val, uint32(42))
+	require.Equal(t, uint32(42), out.PrimitivesMap["foo"].Uint32Val)
 	require.NotNil(t, out.ProtocolMap)
-	require.Equal(t, out.ProtocolMap["foo"], testproto.Protocol_PROTOCOL_TCP)
+	require.Equal(t, testproto.Protocol_PROTOCOL_TCP, out.ProtocolMap["foo"])
 	require.Len(t, out.PrimitivesList, 2)
-	require.Equal(t, out.PrimitivesList[0].Uint32Val, uint32(42))
-	require.Equal(t, out.PrimitivesList[1].Uint32Val, uint32(56))
+	require.Equal(t, uint32(42), out.PrimitivesList[0].Uint32Val)
+	require.Equal(t, uint32(56), out.PrimitivesList[1].Uint32Val)
 	require.Len(t, out.IntList, 2)
-	require.Equal(t, out.IntList[1], int32(2))
+	require.Equal(t, int32(2), out.IntList[1])
 }
 
 func TestPrimitiveWrappers(t *testing.T) {
@@ -176,14 +176,14 @@ func TestPrimitiveWrappers(t *testing.T) {
 
 	err := Unmarshal([]byte(hcl), &out)
 	require.NoError(t, err)
-	require.Equal(t, out.DoubleVal.Value, float64(1.234))
-	require.Equal(t, out.FloatVal.Value, float32(2.345))
-	require.Equal(t, out.Int32Val.Value, int32(536870912))
-	require.Equal(t, out.Int64Val.Value, int64(25769803776))
-	require.Equal(t, out.Uint32Val.Value, uint32(2148532224))
-	require.Equal(t, out.Uint64Val.Value, uint64(9223372041149743104))
-	require.Equal(t, out.BoolVal.Value, true)
-	require.Equal(t, out.StringVal.Value, "foo")
+	require.Equal(t, float64(1.234), out.DoubleVal.Value)
+	require.Equal(t, float32(2.345), out.FloatVal.Value)
+	require.Equal(t, int32(536870912), out.Int32Val.Value)
+	require.Equal(t, int64(25769803776), out.Int64Val.Value)
+	require.Equal(t, uint32(2148532224), out.Uint32Val.Value)
+	require.Equal(t, uint64(9223372041149743104), out.Uint64Val.Value)
+	require.True(t, out.BoolVal.Value)
+	require.Equal(t, "foo", out.StringVal.Value)
 	require.Equal(t, out.BytesVal.Value, []byte("bar"))
 }
 
@@ -199,9 +199,9 @@ func TestNonDynamicWellKnown(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, out.EmptyVal)
 	require.NotNil(t, out.TimestampVal)
-	require.Equal(t, out.TimestampVal.AsTime(), time.Date(2023, 2, 27, 12, 34, 56, 789000000, time.UTC))
+	require.Equal(t, time.Date(2023, 2, 27, 12, 34, 56, 789000000, time.UTC), out.TimestampVal.AsTime())
 	require.NotNil(t, out.DurationVal)
-	require.Equal(t, out.DurationVal.AsDuration(), time.Second*12)
+	require.Equal(t, time.Second*12, out.DurationVal.AsDuration())
 }
 
 func TestInvalidTimestamp(t *testing.T) {
@@ -273,13 +273,13 @@ func TestOneOf(t *testing.T) {
 
 	err := Unmarshal([]byte(hcl1), &out)
 	require.NoError(t, err)
-	require.Equal(t, out.GetInt32Val(), int32(3))
+	require.Equal(t, int32(3), out.GetInt32Val())
 
 	err = Unmarshal([]byte(hcl2), &out)
 	require.NoError(t, err)
 	primitives := out.GetPrimitives()
 	require.NotNil(t, primitives)
-	require.Equal(t, primitives.Int32Val, int32(3))
+	require.Equal(t, int32(3), primitives.Int32Val)
 
 	err = Unmarshal([]byte(hcl3), &out)
 	require.Error(t, err)
@@ -308,7 +308,7 @@ func TestAny(t *testing.T) {
 	err := Unmarshal([]byte(hcl), &out)
 	require.NoError(t, err)
 	require.NotNil(t, out.AnyVal)
-	require.Equal(t, out.AnyVal.TypeUrl, "hashicorp.consul.internal.protohcl.testproto.Primitives")
+	require.Equal(t, "hashicorp.consul.internal.protohcl.testproto.Primitives", out.AnyVal.TypeUrl)
 
 	raw, err := anypb.UnmarshalNew(out.AnyVal, proto.UnmarshalOptions{})
 	require.NoError(t, err)
@@ -316,7 +316,7 @@ func TestAny(t *testing.T) {
 
 	primitives, ok := raw.(*testproto.Primitives)
 	require.True(t, ok)
-	require.Equal(t, primitives.Uint32Val, uint32(42))
+	require.Equal(t, uint32(42), primitives.Uint32Val)
 }
 
 func TestAnyTypeDynamicWellKnown(t *testing.T) {
@@ -334,7 +334,7 @@ func TestAnyTypeDynamicWellKnown(t *testing.T) {
 	err := Unmarshal([]byte(hcl), &out)
 	require.NoError(t, err)
 	require.NotNil(t, out.AnyVal)
-	require.Equal(t, out.AnyVal.TypeUrl, "hashicorp.consul.internal.protohcl.testproto.DynamicWellKnown")
+	require.Equal(t, "hashicorp.consul.internal.protohcl.testproto.DynamicWellKnown", out.AnyVal.TypeUrl)
 
 	raw, err := anypb.UnmarshalNew(out.AnyVal, proto.UnmarshalOptions{})
 	require.NoError(t, err)
@@ -349,7 +349,7 @@ func TestAnyTypeDynamicWellKnown(t *testing.T) {
 
 	primitives, ok := res.(*testproto.Primitives)
 	require.True(t, ok)
-	require.Equal(t, primitives.Uint32Val, uint32(42))
+	require.Equal(t, uint32(42), primitives.Uint32Val)
 }
 
 func TestAnyTypeNestedAndCollections(t *testing.T) {
@@ -366,7 +366,7 @@ func TestAnyTypeNestedAndCollections(t *testing.T) {
 	err := Unmarshal([]byte(hcl), &out)
 	require.NoError(t, err)
 	require.NotNil(t, out.AnyVal)
-	require.Equal(t, out.AnyVal.TypeUrl, "hashicorp.consul.internal.protohcl.testproto.NestedAndCollections")
+	require.Equal(t, "hashicorp.consul.internal.protohcl.testproto.NestedAndCollections", out.AnyVal.TypeUrl)
 
 	raw, err := anypb.UnmarshalNew(out.AnyVal, proto.UnmarshalOptions{})
 	require.NoError(t, err)
@@ -375,7 +375,7 @@ func TestAnyTypeNestedAndCollections(t *testing.T) {
 	nestedCollections, ok := raw.(*testproto.NestedAndCollections)
 	require.True(t, ok)
 	require.NotNil(t, nestedCollections.Primitives)
-	require.Equal(t, nestedCollections.Primitives.Uint32Val, uint32(42))
+	require.Equal(t, uint32(42), nestedCollections.Primitives.Uint32Val)
 }
 
 func TestAnyTypeErrors(t *testing.T) {
@@ -576,9 +576,9 @@ func TestFunctionExecution(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, out.Primitives)
-	require.Equal(t, out.Primitives.StringVal, "test")
-	require.Equal(t, out.Primitives.Int32Val, int32(10))
-	require.Equal(t, out.Primitives.BoolVal, false)
+	require.Equal(t, "test", out.Primitives.StringVal)
+	require.Equal(t, int32(10), out.Primitives.Int32Val)
+	require.False(t, out.Primitives.BoolVal)
 }
 
 func TestSkipFields(t *testing.T) {

--- a/internal/resource/filter_test.go
+++ b/internal/resource/filter_test.go
@@ -22,7 +22,7 @@ func TestFilterResourcesByMetadata(t *testing.T) {
 	}
 
 	create := func(name string, kvs ...string) *pbresource.Resource {
-		require.True(t, len(kvs)%2 == 0)
+		require.Equal(t, 0, len(kvs)%2)
 
 		meta := make(map[string]string)
 		for i := 0; i < len(kvs); i += 2 {
@@ -129,7 +129,7 @@ func TestFilterMatchesResourceMetadata(t *testing.T) {
 	}
 
 	create := func(name string, kvs ...string) *pbresource.Resource {
-		require.True(t, len(kvs)%2 == 0)
+		require.Equal(t, 0, len(kvs)%2)
 
 		meta := make(map[string]string)
 		for i := 0; i < len(kvs); i += 2 {

--- a/internal/resource/http/http_test.go
+++ b/internal/resource/http/http_test.go
@@ -565,7 +565,7 @@ func TestResourceListHandler(t *testing.T) {
 		require.NoError(t, json.NewDecoder(rsp.Body).Decode(&result))
 
 		resources, _ := result["resources"].([]any)
-		require.Len(t, resources, 0)
+		require.Empty(t, resources)
 	})
 
 	t.Run("should return empty list when name prefix matches don't match", func(t *testing.T) {
@@ -584,7 +584,7 @@ func TestResourceListHandler(t *testing.T) {
 		require.NoError(t, json.NewDecoder(rsp.Body).Decode(&result))
 
 		resources, _ := result["resources"].([]any)
-		require.Len(t, resources, 0)
+		require.Empty(t, resources)
 
 		// clean up
 		deleteResource(t, handler, nil)

--- a/internal/resource/mappers/selectiontracker/selection_tracker_test.go
+++ b/internal/resource/mappers/selectiontracker/selection_tracker_test.go
@@ -188,10 +188,12 @@ func (suite *selectionTrackerSuite) TearDownTest() {
 }
 
 func (suite *selectionTrackerSuite) requireMappedIDs(t *testing.T, workload *pbresource.Resource, ids ...*pbresource.ID) {
+	suite.T().Helper()
+
 	t.Helper()
 
 	reqs, err := suite.tracker.MapWorkload(context.Background(), suite.rt, workload)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	require.Len(t, reqs, len(ids))
 	for _, id := range ids {
 		prototest.AssertContainsElement(t, reqs, controller.Request{ID: id})
@@ -203,7 +205,7 @@ func (suite *selectionTrackerSuite) requireMappedIDsAllTenancies(t *testing.T, w
 
 	for i := range suite.executedTenancies {
 		reqs, err := suite.tracker.MapWorkload(context.Background(), suite.rt, workloads[i])
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 		require.Len(t, reqs, len(ids))
 		for _, id := range ids {
 			prototest.AssertContainsElement(t, reqs, controller.Request{ID: id[i]})

--- a/internal/resource/resourcetest/acls.go
+++ b/internal/resource/resourcetest/acls.go
@@ -32,7 +32,7 @@ var checkF = func(t *testing.T, expect string, got error) {
 			t.Fatal("should be denied")
 		}
 	case DEFAULT:
-		require.Nil(t, got, "expected fallthrough decision")
+		require.NoError(t, got, "expected fallthrough decision")
 	default:
 		t.Fatalf("unexpected expectation: %q", expect)
 	}

--- a/internal/tenancy/tenancytest/namespace_controller_test.go
+++ b/internal/tenancy/tenancytest/namespace_controller_test.go
@@ -91,7 +91,7 @@ func (ts *nsTestSuite) TestNamespaceController_HappyPath() {
 
 	// Delete the namespace
 	_, err := ts.client.Delete(ts.ctx, &pbresource.DeleteRequest{Id: ns1.Id})
-	require.NoError(ts.T(), err)
+	ts.Require().NoError(err)
 
 	// Wait for the namespace to be deleted
 	ts.client.WaitForDeletion(ts.T(), ns1.Id)
@@ -144,7 +144,7 @@ func (ts *nsTestSuite) TestNamespaceController_DeleteBlockedByTenantsWithFinaliz
 	artist2 = ts.client.RequireResourceExists(ts.T(), artist2.Id)
 	resource.RemoveFinalizer(artist2, "finalizer2")
 	_, err := ts.client.Write(ts.ctx, &pbresource.WriteRequest{Resource: artist2})
-	require.NoError(ts.T(), err)
+	ts.Require().NoError(err)
 
 	// The final reconcile should delete artist since it was marked for deletion and
 	// and has no finalizers. Given no more tenants, wait for namespace to be deleted.

--- a/lib/decode/decode_test.go
+++ b/lib/decode/decode_test.go
@@ -133,7 +133,7 @@ func TestHookTranslateKeys(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NoError(t, decoder.Decode(tc.data))
-			require.Equal(t, cfg, tc.expected, "decode metadata: %#v", md)
+			require.Equal(t, tc.expected, cfg, "decode metadata: %#v", md)
 		})
 	}
 }
@@ -206,7 +206,7 @@ func TestHookTranslateKeys_DoesNotModifySourceData(t *testing.T) {
 			"oldtwo": "value2",
 		},
 	}
-	require.Equal(t, raw, expected)
+	require.Equal(t, expected, raw)
 }
 
 type translateExample struct {
@@ -283,7 +283,7 @@ sub {
 			},
 		},
 	}
-	require.Equal(t, target, expected)
+	require.Equal(t, expected, target)
 }
 
 func decodeHCLToMapStructure(source string, target interface{}) error {
@@ -337,7 +337,7 @@ func TestHookWeakDecodeFromSlice_DoesNotModifySliceTargetsFromSliceInterface(t *
 			Item: Item{Name: "subitem"},
 		},
 	}
-	require.Equal(t, target, expected)
+	require.Equal(t, expected, target)
 }
 
 func TestHookWeakDecodeFromSlice_ErrorsWithMultipleNestedBlocks(t *testing.T) {
@@ -368,7 +368,7 @@ item {
 	expected := &nested{
 		Item: Item{Name: "first"},
 	}
-	require.Equal(t, target, expected)
+	require.Equal(t, expected, target)
 }
 
 func TestHookWeakDecodeFromSlice_NestedOpaqueConfig(t *testing.T) {
@@ -404,7 +404,7 @@ service {
 			},
 		},
 	}
-	require.Equal(t, target, expected)
+	require.Equal(t, expected, target)
 }
 
 func TestFieldTags(t *testing.T) {

--- a/lib/hoststats/cpu_test.go
+++ b/lib/hoststats/cpu_test.go
@@ -18,7 +18,7 @@ import (
 func TestHostStats_CPU(t *testing.T) {
 	logger := testutil.Logger(t)
 	cwd, err := os.Getwd()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	hs := initCollector(logger, cwd)
 
 	// Collect twice so we can calculate percents we need to generate some work

--- a/lib/retry/retry_test.go
+++ b/lib/retry/retry_test.go
@@ -27,8 +27,8 @@ func TestJitter(t *testing.T) {
 		baseTime := 5000 * time.Millisecond
 		maxTime := 5500 * time.Millisecond
 		newTime := jitter(baseTime)
-		require.True(t, newTime > baseTime)
-		require.True(t, newTime <= maxTime)
+		require.Greater(t, newTime, baseTime)
+		require.LessOrEqual(t, newTime, maxTime)
 	})
 
 	repeat(t, "100 percent", func(t *testing.T) {
@@ -36,8 +36,8 @@ func TestJitter(t *testing.T) {
 		baseTime := 1234 * time.Millisecond
 		maxTime := 2468 * time.Millisecond
 		newTime := jitter(baseTime)
-		require.True(t, newTime > baseTime)
-		require.True(t, newTime <= maxTime)
+		require.Greater(t, newTime, baseTime)
+		require.LessOrEqual(t, newTime, maxTime)
 	})
 
 	repeat(t, "overflow", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestWaiter_Delay(t *testing.T) {
 		}
 
 		delay := w.delay()
-		require.True(t, delay > 20*time.Second, "expected delay %v to be greater than MaxWait %v", delay, w.MaxWait)
+		require.Greater(t, delay, 20*time.Second, "expected delay %v to be greater than MaxWait %v", delay, w.MaxWait)
 	})
 }
 
@@ -135,7 +135,7 @@ func TestWaiter_Wait(t *testing.T) {
 		elapsed, err := runWait(ctx, w)
 		require.NoError(t, err)
 		assertApproximateDuration(t, elapsed, time.Millisecond)
-		require.Equal(t, w.failures, uint(1))
+		require.Equal(t, uint(1), w.failures)
 	})
 
 	t.Run("max failures", func(t *testing.T) {
@@ -146,7 +146,7 @@ func TestWaiter_Wait(t *testing.T) {
 		elapsed, err := runWait(ctx, w)
 		require.NoError(t, err)
 		assertApproximateDuration(t, elapsed, 100*time.Millisecond)
-		require.Equal(t, w.failures, uint(201))
+		require.Equal(t, uint(201), w.failures)
 	})
 
 	t.Run("context deadline", func(t *testing.T) {
@@ -157,7 +157,7 @@ func TestWaiter_Wait(t *testing.T) {
 		elapsed, err := runWait(ctx, w)
 		require.Equal(t, err, context.DeadlineExceeded)
 		assertApproximateDuration(t, elapsed, 5*time.Millisecond)
-		require.Equal(t, w.failures, uint(201))
+		require.Equal(t, uint(201), w.failures)
 	})
 }
 
@@ -188,7 +188,7 @@ func TestWaiter_RetryLoop(t *testing.T) {
 		err := w.RetryLoop(ctx, func() error {
 			return fmt.Errorf("operation not successful")
 		})
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.EqualError(t, err, "could not retry operation: operation not successful")
 	})
 }

--- a/lib/telemetry_test.go
+++ b/lib/telemetry_test.go
@@ -30,7 +30,7 @@ func TestConfigureSinks(t *testing.T) {
 	sinks, err := configureSinks(cfg, nil, extraSinks)
 	require.Error(t, err)
 	// 4 sinks: statsd, statsite, inmem, extra sink (blackhole)
-	require.Equal(t, 4, len(sinks))
+	require.Len(t, sinks, 4)
 
 	cfg = TelemetryConfig{
 		DogstatsdAddr: "",

--- a/lib/template/hil_test.go
+++ b/lib/template/hil_test.go
@@ -147,8 +147,8 @@ func TestInterpolateHIL(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, test.exp, out)
 			} else {
-				require.NotNil(t, err)
-				require.Equal(t, out, "")
+				require.Error(t, err)
+				require.Equal(t, "", out)
 			}
 		})
 		t.Run(name+" lower=true", func(t *testing.T) {
@@ -157,8 +157,8 @@ func TestInterpolateHIL(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, test.expLower, out)
 			} else {
-				require.NotNil(t, err)
-				require.Equal(t, out, "")
+				require.Error(t, err)
+				require.Equal(t, "", out)
 			}
 		})
 	}

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -6,7 +6,6 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"os"
 	"testing"
 
@@ -122,9 +121,9 @@ func TestLogger_SetupLoggerWithJSON(t *testing.T) {
 	err = json.Unmarshal(buf.Bytes(), &jsonOutput)
 	require.NoError(t, err)
 	require.Contains(t, jsonOutput, "@level")
-	require.Equal(t, jsonOutput["@level"], "warn")
+	require.Equal(t, "warn", jsonOutput["@level"])
 	require.Contains(t, jsonOutput, "@message")
-	require.Equal(t, jsonOutput["@message"], "test warn msg")
+	require.Equal(t, "test warn msg", jsonOutput["@message"])
 }
 
 func TestLogger_SetupLoggerWithValidLogPath(t *testing.T) {
@@ -152,7 +151,7 @@ func TestLogger_SetupLoggerWithInValidLogPath(t *testing.T) {
 
 	logger, err := Setup(cfg, &buf)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 	require.Nil(t, logger)
 }
 
@@ -171,6 +170,6 @@ func TestLogger_SetupLoggerWithInValidLogPathPermission(t *testing.T) {
 
 	logger, err := Setup(cfg, &buf)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrPermission))
+	require.ErrorIs(t, err, os.ErrPermission)
 	require.Nil(t, logger)
 }

--- a/logging/monitor/monitor_test.go
+++ b/logging/monitor/monitor_test.go
@@ -178,6 +178,6 @@ func TestMonitor_WriteStopped(t *testing.T) {
 
 	mwriter.Stop()
 	n, err := mwriter.Write([]byte("write after close"))
-	require.Equal(t, n, 0)
+	require.Equal(t, 0, n)
 	require.EqualError(t, err, "monitor stopped")
 }

--- a/proto-public/pbcatalog/v2beta1/workload_addon_test.go
+++ b/proto-public/pbcatalog/v2beta1/workload_addon_test.go
@@ -215,7 +215,7 @@ func TestGetFirstNonExternalMeshAddress(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			actualAddress := c.workload.GetFirstNonExternalMeshAddress()
-			require.Equal(t, actualAddress, c.expAddress)
+			require.Equal(t, c.expAddress, actualAddress)
 		})
 	}
 }

--- a/proto/private/prototest/testing_test.go
+++ b/proto/private/prototest/testing_test.go
@@ -34,9 +34,9 @@ func TestDiffElements_noProtobufs(t *testing.T) {
 	run := func(t *testing.T, tc testcase) {
 		diff := diffElements(tc.a, tc.b)
 		if tc.notSame {
-			require.False(t, diff == "", "expected not to be the same")
+			require.NotEqual(t, "", diff, "expected not to be the same")
 		} else {
-			require.True(t, diff == "", "expected to be the same")
+			require.Equal(t, "", diff, "expected to be the same")
 		}
 	}
 

--- a/sdk/testutil/retry/retry_test.go
+++ b/sdk/testutil/retry/retry_test.go
@@ -56,7 +56,7 @@ func TestBasics(t *testing.T) {
 				return
 			}
 		})
-		assert.Equal(t, i, 2)
+		assert.Equal(t, 2, i)
 	})
 
 	t.Run("Fatal returns from func, but does not fail test", func(t *testing.T) {
@@ -73,9 +73,9 @@ func TestBasics(t *testing.T) {
 		})
 
 		assert.False(t, gotHere)
-		assert.Equal(t, i, 2)
+		assert.Equal(t, 2, i)
 		// surprisingly, r.FailNow() *does not* trigger ft.FailNow()!
-		assert.Equal(t, ft.fails, 0)
+		assert.Equal(t, 0, ft.fails)
 	})
 
 	t.Run("Func being run can panic with struct{}{}", func(t *testing.T) {
@@ -208,7 +208,7 @@ func TestCleanup(t *testing.T) {
 		require.Equal(t, 3, cleanupsExecuted)
 		// ensure that r.Stop hadn't been called. If it was then we would
 		// have log output
-		require.Len(t, ft.out, 0)
+		require.Empty(t, ft.out)
 	})
 
 	t.Run("passthrough-to-t", func(t *testing.T) {

--- a/test-integ/peering_commontopo/ac4_proxy_defaults_test.go
+++ b/test-integ/peering_commontopo/ac4_proxy_defaults_test.go
@@ -169,7 +169,7 @@ func (s *ac4ProxyDefaultsSuite) test(t *testing.T, ct *commonTopo) {
 
 		server := dc.WorkloadsByID(s.serverSID)
 		require.Len(t, server, 1, "expected exactly one server")
-		require.Len(t, server[0].Destinations, 0, "expected no upstream for server")
+		require.Empty(t, server[0].Destinations, "expected no upstream for server")
 	})
 
 	t.Run("peered upstream exists in catalog", func(t *testing.T) {

--- a/test-integ/peering_commontopo/ac5_1_no_svc_mesh_test.go
+++ b/test-integ/peering_commontopo/ac5_1_no_svc_mesh_test.go
@@ -124,7 +124,7 @@ func (s *ac5_1NoSvcMeshSuite) testProxyDisabledInDC2(t *testing.T, cl *api.Clien
 				Peer: peer,
 			})
 			require.NoError(r, err, "error reading service data")
-			require.Greater(r, len(services), 0, "did not find service(s) in catalog")
+			require.NotEmpty(r, services, "did not find service(s) in catalog")
 		})
 		require.NotContains(t, services, expected, fmt.Sprintf("error: should not create proxy for service: %s", services))
 	})

--- a/test-integ/peering_commontopo/ac5_2_pq_failover_test.go
+++ b/test-integ/peering_commontopo/ac5_2_pq_failover_test.go
@@ -262,7 +262,7 @@ func (s *ac5_2PQFailoverSuite) testPreparedQueryZeroFailover(t *testing.T, cl *a
 		queryDef, _, err := cl.PreparedQuery().Get(def.ID, nil)
 		require.NoError(t, err)
 		require.Len(t, queryDef, 1, "expected 1 prepared query")
-		require.Equal(t, 2, len(queryDef[0].Service.Failover.Targets), "expected 2 prepared query failover targets to dc2 and dc3")
+		require.Len(t, queryDef[0].Service.Failover.Targets, 2, "expected 2 prepared query failover targets to dc2 and dc3")
 
 		retry.RunWith(&retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}, t, func(r *retry.R) {
 			queryResult, _, err := cl.PreparedQuery().Execute(def.ID, nil)
@@ -406,6 +406,6 @@ func assertServiceHealth(t *testing.T, cl *api.Client, serverSVC string, count i
 			nil,
 		)
 		require.NoError(r, err)
-		require.Equal(r, count, len(svcs))
+		require.Len(r, svcs, count)
 	})
 }

--- a/test-integ/peering_commontopo/ac7_2_rotate_leader_test.go
+++ b/test-integ/peering_commontopo/ac7_2_rotate_leader_test.go
@@ -169,7 +169,7 @@ func (s *ac7_2RotateLeaderSuite) test(t *testing.T, ct *commonTopo) {
 			foundI = i
 		}
 	}
-	require.Equal(t, found, 1)
+	require.Equal(t, 1, found)
 	// remove found entry
 	ceAsES.Services = append(ceAsES.Services[:foundI], ceAsES.Services[foundI+1:]...)
 	_, _, err = clPeer.ConfigEntries().Set(ceAsES, nil)
@@ -188,7 +188,7 @@ func (s *ac7_2RotateLeaderSuite) test(t *testing.T, ct *commonTopo) {
 			Peer:      LocalPeerName(peer, "default"),
 		}))
 		require.NoError(r, err)
-		assert.Equal(r, len(svcs), 0, "health entry for imported service gone")
+		assert.Empty(r, svcs, "health entry for imported service gone")
 	})
 }
 

--- a/test-integ/peering_commontopo/commontopo.go
+++ b/test-integ/peering_commontopo/commontopo.go
@@ -206,7 +206,7 @@ func (ct *commonTopo) postLaunchChecks(t *testing.T) {
 					Partition: k.partition,
 					Namespace: k.namespace,
 				}))
-				require.Nil(r, err, "reading peering data")
+				require.NoError(r, err, "reading peering data")
 				require.NotNilf(r, peering, "peering not found %q", k.peer)
 				assert.Len(r, peering.StreamStatus.ExportedServices, v, "peering exported services")
 			})

--- a/test-integ/tenancy/namespace_ce_test.go
+++ b/test-integ/tenancy/namespace_ce_test.go
@@ -59,7 +59,7 @@ func TestNamespaceLifecycle(t *testing.T) {
 	}
 
 	// Verify test setup
-	require.Equal(t, len(tenants), numNamespaces*numServices)
+	require.Len(t, tenants, numNamespaces*numServices)
 
 	// List namespaces
 	listRsp, err := client.List(client.Context(t), &pbresource.ListRequest{

--- a/test-integ/topoutil/asserter.go
+++ b/test-integ/topoutil/asserter.go
@@ -177,7 +177,7 @@ func (a *Asserter) HTTPServiceEchoes(
 	path string,
 ) {
 	t.Helper()
-	require.True(t, port > 0)
+	require.Greater(t, port, 0)
 
 	node := workload.Node
 	ip := node.LocalAddress()
@@ -202,7 +202,7 @@ func (a *Asserter) HTTPServiceEchoesResHeader(
 	expectedResHeader map[string]string,
 ) {
 	t.Helper()
-	require.True(t, port > 0)
+	require.Greater(t, port, 0)
 
 	node := workload.Node
 	ip := node.LocalAddress()
@@ -219,7 +219,7 @@ func (a *Asserter) HTTPStatus(
 	status int,
 ) {
 	t.Helper()
-	require.True(t, port > 0)
+	require.Greater(t, port, 0)
 
 	node := workload.Node
 	ip := node.LocalAddress()
@@ -257,7 +257,7 @@ func (a *Asserter) HealthyWithPeer(t *testing.T, cluster string, sid topology.ID
 			}),
 		)
 		require.NoError(r, err)
-		assert.GreaterOrEqual(r, len(svcs), 1)
+		assert.NotEmpty(r, svcs)
 	})
 }
 
@@ -420,8 +420,8 @@ func (a *Asserter) HealthServiceEntries(t *testing.T, cluster string, node *topo
 	retry.RunWith(&retry.Timer{Timeout: 60 * time.Second, Wait: time.Millisecond * 500}, t, func(r *retry.R) {
 		serviceEntries, _, err = health.Service(svc, "", passingOnly, opts)
 		require.NoError(r, err)
-		require.Equalf(r, expectedInstance, len(serviceEntries), "dc: %s, service: %s", cluster, serviceEntries[0].Service.Service)
-		require.Equalf(r, expectedChecks, len(serviceEntries[0].Checks), "dc: %s, service: %s", cluster, serviceEntries[0].Service.Service)
+		require.Lenf(r, serviceEntries, expectedInstance, "dc: %s, service: %s", cluster, serviceEntries[0].Service.Service)
+		require.Lenf(r, serviceEntries[0].Checks, expectedChecks, "dc: %s, service: %s", cluster, serviceEntries[0].Service.Service)
 	})
 
 	return serviceEntries
@@ -538,5 +538,5 @@ func (a *Asserter) ValidateHealthEndpointAuditLog(t *testing.T, filePath string)
 			}
 		}
 	}
-	require.Equal(t, boolIsErrorJSON, true, "Unable to verify audit log health endpoint error message")
+	require.True(t, boolIsErrorJSON, "Unable to verify audit log health endpoint error message")
 }

--- a/test-integ/topoutil/asserter_blankspace.go
+++ b/test-integ/topoutil/asserter_blankspace.go
@@ -77,7 +77,7 @@ func (a *Asserter) checkBlankspaceNameViaHTTPWithCallback(
 	if useHTTP2 {
 		// We can't use the forward proxy for http2, so use the exposed port on localhost instead.
 		exposedPort := node.ExposedPort(internalPort)
-		require.True(t, exposedPort > 0)
+		require.Greater(t, exposedPort, 0)
 
 		addr = fmt.Sprintf("%s:%d", "127.0.0.1", exposedPort)
 
@@ -156,13 +156,13 @@ func (a *Asserter) checkBlankspaceNameViaTCPWithCallback(
 
 	require.False(t, dest.Implied, "helper does not support tproxy yet")
 	port := dest.LocalPort
-	require.True(t, port > 0)
+	require.Greater(t, port, 0)
 
 	node := workload.Node
 
 	// We can't use the forward proxy for TCP yet, so use the exposed port on localhost instead.
 	exposedPort := node.ExposedPort(port)
-	require.True(t, exposedPort > 0)
+	require.Greater(t, exposedPort, 0)
 
 	addr := fmt.Sprintf("%s:%d", "127.0.0.1", exposedPort)
 
@@ -224,13 +224,13 @@ func (a *Asserter) checkBlankspaceNameViaGRPCWithCallback(
 
 	require.False(t, dest.Implied, "helper does not support tproxy yet")
 	port := dest.LocalPort
-	require.True(t, port > 0)
+	require.Greater(t, port, 0)
 
 	node := workload.Node
 
 	// We can't use the forward proxy for gRPC yet, so use the exposed port on localhost instead.
 	exposedPort := node.ExposedPort(port)
-	require.True(t, exposedPort > 0)
+	require.Greater(t, exposedPort, 0)
 
 	addr := fmt.Sprintf("%s:%d", "127.0.0.1", exposedPort)
 

--- a/test/integration/consul-container/libs/assert/envoy.go
+++ b/test/integration/consul-container/libs/assert/envoy.go
@@ -26,7 +26,7 @@ import (
 
 // GetEnvoyListenerTCPFilters validates that proxy was configured with tcp protocol and one rbac listener filter
 func GetEnvoyListenerTCPFilters(t *testing.T, adminPort int) {
-	require.True(t, adminPort > 0)
+	require.Greater(t, adminPort, 0)
 
 	GetEnvoyListenerTCPFiltersWithClient(
 		t,
@@ -77,7 +77,7 @@ func GetEnvoyListenerTCPFiltersWithClient(
 // AssertUpstreamEndpointStatus validates that proxy was configured with provided clusterName in the healthStatus
 func AssertUpstreamEndpointStatus(t *testing.T, adminPort int, clusterName, healthStatus string, count int) {
 	t.Helper()
-	require.True(t, adminPort > 0)
+	require.Greater(t, adminPort, 0)
 	AssertUpstreamEndpointStatusWithClient(
 		t,
 		cleanhttp.DefaultClient(),
@@ -122,7 +122,7 @@ func AssertUpstreamEndpointStatusWithClient(
 		require.Len(r, results, 1, "clusters: "+clusters) // the final part of the pipeline is "length" which only ever returns 1 result
 
 		result, err := strconv.Atoi(results[0])
-		assert.NoError(r, err)
+		require.NoError(r, err)
 		require.Equal(r, count, result, "original results: %v", clusters)
 	})
 }
@@ -352,6 +352,6 @@ func AssertServiceHasHealthyInstances(t *testing.T, node libcluster.Agent, servi
 		for _, v := range services {
 			fmt.Printf("%s service status: %s\n", v.Service.ID, v.Checks.AggregatedStatus())
 		}
-		require.Equal(r, count, len(services))
+		require.Len(r, services, count)
 	})
 }

--- a/test/integration/consul-container/libs/assert/peering.go
+++ b/test/integration/consul-container/libs/assert/peering.go
@@ -54,7 +54,7 @@ func PeeringExportsOpts(t *testing.T, client *api.Client, peerName string, expor
 
 	retry.RunWith(failer(), t, func(r *retry.R) {
 		peering, _, err := client.Peerings().Read(context.Background(), peerName, opts)
-		require.Nil(r, err, "reading peering data")
+		require.NoError(r, err, "reading peering data")
 		require.NotNilf(r, peering, "peering not found %q", peerName)
 		assert.Len(r, peering.StreamStatus.ExportedServices, exports, "peering exported services")
 	})

--- a/test/integration/consul-container/libs/assert/service.go
+++ b/test/integration/consul-container/libs/assert/service.go
@@ -54,7 +54,7 @@ func CatalogV2ServiceDoesNotExist(t *testing.T, client pbresource.ResourceServic
 			Name:    svc,
 			Tenancy: tenancy,
 		})
-		require.NotNil(r, err, "error reading service data")
+		require.Error(r, err, "error reading service data")
 		require.Nil(r, got2, "unexpectedly found ServiceEndpoints resource for %q", svc)
 	})
 }

--- a/test/integration/consul-container/libs/topology/peering_topology.go
+++ b/test/integration/consul-container/libs/topology/peering_topology.go
@@ -216,7 +216,7 @@ func NewClusterWithConfig(
 		err     error
 	)
 	require.NotEmpty(t, config.BuildOpts.Datacenter)
-	require.True(t, config.NumServers > 0)
+	require.Greater(t, config.NumServers, 0)
 
 	opts := libcluster.BuildOptions{
 		Datacenter:             config.BuildOpts.Datacenter,

--- a/test/integration/consul-container/test/gateways/http_route_test.go
+++ b/test/integration/consul-container/test/gateways/http_route_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/api"
@@ -670,7 +669,7 @@ func TestHTTPRouteParentRefChange(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		entry, _, err := client.ConfigEntries().Get(api.HTTPRoute, routeName, &api.QueryOptions{Namespace: namespace})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if entry == nil {
 			return false
 		}
@@ -686,9 +685,9 @@ func TestHTTPRouteParentRefChange(t *testing.T) {
 
 	// fetch gateway listener ports
 	gatewayOnePort, err := gatewayOneService.GetPort(listenerOnePort)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	gatewayTwoPort, err := gatewayTwoService.GetPort(listenerTwoPort)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// hit service by requesting root path
 	// TODO: testName field in checkOptions struct looked to be unused, is it needed?
@@ -713,7 +712,7 @@ func TestHTTPRouteParentRefChange(t *testing.T) {
 	require.NoError(t, cluster.ConfigEntryWrite(route))
 	require.Eventually(t, func() bool {
 		entry, _, err := client.ConfigEntries().Get(api.HTTPRoute, routeName, &api.QueryOptions{Namespace: namespace})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if entry == nil {
 			return false
 		}

--- a/test/integration/consul-container/test/upgrade/basic/basic_test.go
+++ b/test/integration/consul-container/test/upgrade/basic/basic_test.go
@@ -77,7 +77,7 @@ func checkServiceHealth(t *testing.T, client *api.Client, serviceName string, in
 		case err := <-errCh:
 			require.NoError(r, err)
 		case service := <-ch:
-			require.Equal(r, 1, len(service))
+			require.Len(r, service, 1)
 
 			index = service[0].Service.ModifyIndex
 			require.Equal(r, serviceName, service[0].Service.Service)

--- a/test/integration/consul-container/test/upgrade/ingress_gateway_grpc_test.go
+++ b/test/integration/consul-container/test/upgrade/ingress_gateway_grpc_test.go
@@ -91,7 +91,7 @@ func TestIngressGateway_GRPC_UpgradeToTarget_fromLatest(t *testing.T) {
 	// Register an static-client service
 	serverNodes := cluster.Servers()
 	require.NoError(t, err)
-	require.True(t, len(serverNodes) > 0)
+	require.NotEmpty(t, serverNodes)
 	staticClientSvcSidecar, err := libservice.CreateAndRegisterStaticClientSidecar(serverNodes[0], "", true, false, nil)
 	require.NoError(t, err)
 

--- a/test/integration/consul-container/test/upgrade/ingress_gateway_sds_test.go
+++ b/test/integration/consul-container/test/upgrade/ingress_gateway_sds_test.go
@@ -231,8 +231,8 @@ func TestIngressGateway_SDS_UpgradeToTarget_fromLatest(t *testing.T) {
 			resp := mappedHTTPGET(t, urlbase, portMapped.Int(), nil, nil, httpClient)
 			defer resp.Body.Close()
 
-			require.Equal(t, 1, len(resp.TLS.PeerCertificates))
-			require.Equal(t, 1, len(resp.TLS.PeerCertificates[0].DNSNames))
+			require.Len(t, resp.TLS.PeerCertificates, 1)
+			require.Len(t, resp.TLS.PeerCertificates[0].DNSNames, 1)
 			assert.Equal(t, "*.ingress.consul", resp.TLS.PeerCertificates[0].DNSNames[0])
 		})
 
@@ -249,8 +249,8 @@ func TestIngressGateway_SDS_UpgradeToTarget_fromLatest(t *testing.T) {
 			resp := mappedHTTPGET(t, urlbase, portMapped.Int(), nil, nil, httpClient)
 			defer resp.Body.Close()
 
-			require.Equal(t, 1, len(resp.TLS.PeerCertificates))
-			require.Equal(t, 1, len(resp.TLS.PeerCertificates[0].DNSNames))
+			require.Len(t, resp.TLS.PeerCertificates, 1)
+			require.Len(t, resp.TLS.PeerCertificates[0].DNSNames, 1)
 			assert.Equal(t, hostnameWWW, resp.TLS.PeerCertificates[0].DNSNames[0])
 		})
 
@@ -267,8 +267,8 @@ func TestIngressGateway_SDS_UpgradeToTarget_fromLatest(t *testing.T) {
 			resp := mappedHTTPGET(t, urlbase, portMapped.Int(), nil, nil, httpClient)
 			defer resp.Body.Close()
 
-			require.Equal(t, 1, len(resp.TLS.PeerCertificates))
-			require.Equal(t, 1, len(resp.TLS.PeerCertificates[0].DNSNames))
+			require.Len(t, resp.TLS.PeerCertificates, 1)
+			require.Len(t, resp.TLS.PeerCertificates[0].DNSNames, 1)
 			assert.Equal(t, hostnameFoo, resp.TLS.PeerCertificates[0].DNSNames[0])
 		})
 	}

--- a/test/integration/consul-container/test/upgrade/ingress_gateway_test.go
+++ b/test/integration/consul-container/test/upgrade/ingress_gateway_test.go
@@ -549,7 +549,7 @@ func httpClientWithCA(t *testing.T, reqHost string, cacertPEM string) *http.Clie
 			InsecureSkipVerify: true,
 			RootCAs:            pool,
 			VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-				require.Equal(t, 1, len(rawCerts), "expected 1 cert")
+				require.Len(t, rawCerts, 1, "expected 1 cert")
 				cert, err := x509.ParseCertificate(rawCerts[0])
 				require.NoError(t, err)
 				for i, s := range cert.DNSNames {

--- a/testing/deployer/util/internal/ipamutils/utils_test.go
+++ b/testing/deployer/util/internal/ipamutils/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func initBroadPredefinedNetworks() []*net.IPNet {
@@ -88,7 +89,7 @@ func TestDefaultNetwork(t *testing.T) {
 
 func TestConfigGlobalScopeDefaultNetworks(t *testing.T) {
 	err := ConfigGlobalScopeDefaultNetworks([]*NetworkToSplit{{"30.0.0.0/8", 24}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	originalGlobalScopeNetworks := initGlobalScopeNetworks()
 	m := make(map[string]bool)

--- a/testrpc/wait.go
+++ b/testrpc/wait.go
@@ -238,8 +238,8 @@ func WaitForACLReplication(t *testing.T, rpc rpcFn, dc string, expectedReplicati
 
 		require.Equal(r, expectedReplicationType, reply.ReplicationType)
 		require.True(r, reply.Running, "Server not running new replicator yet")
-		require.True(r, reply.ReplicatedIndex >= minPolicyIndex, "Server hasn't replicated enough policies")
-		require.True(r, reply.ReplicatedTokenIndex >= minTokenIndex, "Server hasn't replicated enough tokens")
-		require.True(r, reply.ReplicatedRoleIndex >= minRoleIndex, "Server hasn't replicated enough roles")
+		require.GreaterOrEqual(r, reply.ReplicatedIndex, minPolicyIndex, "Server hasn't replicated enough policies")
+		require.GreaterOrEqual(r, reply.ReplicatedTokenIndex, minTokenIndex, "Server hasn't replicated enough tokens")
+		require.GreaterOrEqual(r, reply.ReplicatedRoleIndex, minRoleIndex, "Server hasn't replicated enough roles")
 	})
 }

--- a/tlsutil/generate_test.go
+++ b/tlsutil/generate_test.go
@@ -23,14 +23,14 @@ import (
 
 func TestSerialNumber(t *testing.T) {
 	n1, err := GenerateSerialNumber()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	n2, err := GenerateSerialNumber()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEqual(t, n1, n2)
 
 	n3, err := GenerateSerialNumber()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEqual(t, n1, n3)
 	require.NotEqual(t, n2, n3)
 
@@ -39,7 +39,7 @@ func TestSerialNumber(t *testing.T) {
 func TestGeneratePrivateKey(t *testing.T) {
 	t.Parallel()
 	_, p, err := GeneratePrivateKey()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, p)
 	require.Contains(t, p, "BEGIN EC PRIVATE KEY")
 	require.Contains(t, p, "END EC PRIVATE KEY")
@@ -47,7 +47,7 @@ func TestGeneratePrivateKey(t *testing.T) {
 	block, _ := pem.Decode([]byte(p))
 	pk, err := x509.ParseECPrivateKey(block.Bytes)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pk)
 	require.Equal(t, 256, pk.Params().BitSize)
 }
@@ -81,15 +81,15 @@ func TestGenerateCA(t *testing.T) {
 
 	t.Run("valid key", func(t *testing.T) {
 		ca, pk, err := GenerateCA(CAOpts{})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, ca)
 		require.NotEmpty(t, pk)
 
 		cert, err := parseCert(ca)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.True(t, strings.HasPrefix(cert.Subject.CommonName, "Consul Agent CA"))
-		require.Equal(t, true, cert.IsCA)
-		require.Equal(t, true, cert.BasicConstraintsValid)
+		require.True(t, cert.IsCA)
+		require.True(t, cert.BasicConstraintsValid)
 
 		require.WithinDuration(t, cert.NotBefore, time.Now(), time.Minute)
 		require.WithinDuration(t, cert.NotAfter, time.Now().AddDate(0, 0, 365), time.Minute)
@@ -106,8 +106,8 @@ func TestGenerateCA(t *testing.T) {
 		cert, err := parseCert(ca)
 		require.NoError(t, err)
 		require.True(t, strings.HasPrefix(cert.Subject.CommonName, "Consul Agent CA"))
-		require.Equal(t, true, cert.IsCA)
-		require.Equal(t, true, cert.BasicConstraintsValid)
+		require.True(t, cert.IsCA)
+		require.True(t, cert.BasicConstraintsValid)
 
 		require.WithinDuration(t, cert.NotBefore, time.Now(), time.Minute)
 		require.WithinDuration(t, cert.NotAfter, time.Now().AddDate(0, 0, 365), time.Minute)
@@ -119,9 +119,9 @@ func TestGenerateCA(t *testing.T) {
 func TestGenerateCert(t *testing.T) {
 	t.Parallel()
 	signer, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	ca, _, err := GenerateCA(CAOpts{Signer: signer})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	DNSNames := []string{"server.dc1.consul"}
 	IPAddresses := []net.IP{net.ParseIP("123.234.243.213")}
@@ -131,24 +131,24 @@ func TestGenerateCert(t *testing.T) {
 		Signer: signer, CA: ca, Name: name, Days: 365,
 		DNSNames: DNSNames, IPAddresses: IPAddresses, ExtKeyUsage: extKeyUsage,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, certificate)
 	require.NotEmpty(t, pk)
 
 	cert, err := parseCert(certificate)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, name, cert.Subject.CommonName)
-	require.Equal(t, true, cert.BasicConstraintsValid)
+	require.True(t, cert.BasicConstraintsValid)
 	signee, err := ParseSigner(pk)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	certID, err := keyID(signee.Public())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, certID, cert.SubjectKeyId)
 	caID, err := keyID(signer.Public())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, caID, cert.AuthorityKeyId)
 	require.Contains(t, cert.Issuer.CommonName, "Consul Agent CA")
-	require.Equal(t, false, cert.IsCA)
+	require.False(t, cert.IsCA)
 
 	require.WithinDuration(t, cert.NotBefore, time.Now(), time.Minute)
 	require.WithinDuration(t, cert.NotAfter, time.Now().AddDate(0, 0, 365), time.Minute)


### PR DESCRIPTION
### Description

Ensure best appliance of the best practices of testify with testifylint.
Sorry, it's a huge modification to review

### Testing & Reproduction steps

```bash
go install github.com/Antonboom/testifylint@latest
testifylint --disable-all --enable=bool-compare,compares,empty,error-nil,expected-actual,len,suite-dont-use-pkg,suite-extra-assert-call,suite-thelper -fix ./...
```

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
