### PR TITLE
Handle ACL errors consistently when blocking query timeout is reached.

### DIFF
--- a/.changelog/20876.txt
+++ b/.changelog/20876.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+streaming: Handle ACL errors consistently when blocking query timeout is reached.
+```

--- a/agent/consul/state/store_integration_test.go
+++ b/agent/consul/state/store_integration_test.go
@@ -72,7 +72,7 @@ func TestStore_IntegrationWithEventPublisher_ACLTokenUpdate(t *testing.T) {
 
 	// Ensure the reset event was sent.
 	err = assertErr(t, eventCh)
-	require.Equal(t, stream.ErrSubForceClosed, err)
+	require.Equal(t, stream.ErrACLChanged, err)
 
 	// Register another subscription.
 	subscription2 := &stream.SubscribeRequest{
@@ -101,7 +101,7 @@ func TestStore_IntegrationWithEventPublisher_ACLTokenUpdate(t *testing.T) {
 
 	// Ensure the reset event was sent.
 	err = assertErr(t, eventCh2)
-	require.Equal(t, stream.ErrSubForceClosed, err)
+	require.Equal(t, stream.ErrACLChanged, err)
 }
 
 func TestStore_IntegrationWithEventPublisher_ACLPolicyUpdate(t *testing.T) {
@@ -191,7 +191,7 @@ func TestStore_IntegrationWithEventPublisher_ACLPolicyUpdate(t *testing.T) {
 
 	// Ensure the reload event was sent.
 	err = assertErr(t, eventCh)
-	require.Equal(t, stream.ErrSubForceClosed, err)
+	require.Equal(t, stream.ErrACLChanged, err)
 
 	// Register another subscription.
 	subscription3 := &stream.SubscribeRequest{
@@ -381,7 +381,7 @@ func assertReset(t *testing.T, eventCh <-chan nextResult, allowEOS bool) {
 				}
 			}
 			require.Error(t, next.Err)
-			require.Equal(t, stream.ErrSubForceClosed, next.Err)
+			require.Equal(t, stream.ErrACLChanged, next.Err)
 			return
 		case <-time.After(100 * time.Millisecond):
 			t.Fatalf("no err after 100ms")

--- a/agent/consul/stream/event_publisher.go
+++ b/agent/consul/stream/event_publisher.go
@@ -393,7 +393,7 @@ func (s *subscriptions) closeSubscriptionsForTokens(tokenSecretIDs []string) {
 	for _, secretID := range tokenSecretIDs {
 		if subs, ok := s.byToken[secretID]; ok {
 			for _, sub := range subs {
-				sub.forceClose()
+				sub.closeACLChanged()
 			}
 		}
 	}

--- a/agent/grpc-external/services/connectca/watch_roots.go
+++ b/agent/grpc-external/services/connectca/watch_roots.go
@@ -47,7 +47,7 @@ func (s *Server) WatchRoots(_ *pbconnectca.WatchRootsRequest, serverStream pbcon
 	for {
 		var err error
 		idx, err = s.serveRoots(options.Token, idx, serverStream, logger)
-		if errors.Is(err, stream.ErrSubForceClosed) {
+		if errors.Is(err, stream.ErrSubForceClosed) || errors.Is(err, stream.ErrACLChanged) {
 			logger.Trace("subscription force-closed due to an ACL change or snapshot restore, will attempt to re-auth and resume")
 		} else {
 			return err
@@ -90,7 +90,7 @@ func (s *Server) serveRoots(
 	for {
 		event, err := sub.Next(serverStream.Context())
 		switch {
-		case errors.Is(err, stream.ErrSubForceClosed):
+		case errors.Is(err, stream.ErrSubForceClosed) || errors.Is(err, stream.ErrACLChanged):
 			// If the subscription was closed because the state store was abandoned (e.g.
 			// following a snapshot restore) reset idx to ensure we don't skip over the
 			// new store's events.

--- a/agent/grpc-external/services/serverdiscovery/watch_servers.go
+++ b/agent/grpc-external/services/serverdiscovery/watch_servers.go
@@ -40,7 +40,7 @@ func (s *Server) WatchServers(req *pbserverdiscovery.WatchServersRequest, server
 	for {
 		var err error
 		idx, err = s.serveReadyServers(options.Token, idx, req, serverStream, logger)
-		if errors.Is(err, stream.ErrSubForceClosed) {
+		if errors.Is(err, stream.ErrSubForceClosed) || errors.Is(err, stream.ErrACLChanged) {
 			logger.Trace("subscription force-closed due to an ACL change or snapshot restore, will attempt to re-auth and resume")
 		} else {
 			return err
@@ -69,7 +69,7 @@ func (s *Server) serveReadyServers(token string, index uint64, req *pbserverdisc
 	for {
 		event, err := sub.Next(serverStream.Context())
 		switch {
-		case errors.Is(err, stream.ErrSubForceClosed):
+		case errors.Is(err, stream.ErrSubForceClosed) || errors.Is(err, stream.ErrACLChanged):
 			return index, err
 		case errors.Is(err, context.Canceled):
 			return 0, nil

--- a/agent/grpc-internal/services/subscribe/subscribe.go
+++ b/agent/grpc-internal/services/subscribe/subscribe.go
@@ -79,8 +79,7 @@ func (h *Server) Subscribe(req *pbsubscribe.SubscribeRequest, serverStream pbsub
 			return status.Error(codes.Aborted, err.Error())
 		case errors.Is(err, stream.ErrACLChanged):
 			logger.Trace("ACL change occurred; re-authenticating")
-			var authzErr error
-			authz, authzErr = h.Backend.ResolveTokenAndDefaultMeta(req.Token, &entMeta, nil)
+			_, authzErr := h.Backend.ResolveTokenAndDefaultMeta(req.Token, &entMeta, nil)
 			if authzErr != nil {
 				return authzErr
 			}

--- a/agent/grpc-internal/services/subscribe/subscribe.go
+++ b/agent/grpc-internal/services/subscribe/subscribe.go
@@ -77,6 +77,12 @@ func (h *Server) Subscribe(req *pbsubscribe.SubscribeRequest, serverStream pbsub
 		case errors.Is(err, stream.ErrSubForceClosed):
 			logger.Trace("subscription reset by server")
 			return status.Error(codes.Aborted, err.Error())
+		case errors.Is(err, stream.ErrACLChanged):
+			logger.Trace("ACL change occurred; re-authenticating")
+			authz, err = h.Backend.ResolveTokenAndDefaultMeta(req.Token, &entMeta, nil)
+			if err != nil {
+				return err
+			}
 		case err != nil:
 			return err
 		}

--- a/agent/grpc-internal/services/subscribe/subscribe_test.go
+++ b/agent/grpc-internal/services/subscribe/subscribe_test.go
@@ -992,28 +992,28 @@ node "node1" {
 		}
 	})
 
-	testutil.RunStep(t, "invalid token should return an error", func(t *testing.T) {
-		// Re-subscribe because the previous test step terminated the stream.
-		chEvents = make(chan eventOrError, 0)
-		streamClient := pbsubscribe.NewStateChangeSubscriptionClient(conn)
-		streamHandle, err := streamClient.Subscribe(ctx, &pbsubscribe.SubscribeRequest{
-			Topic: pbsubscribe.Topic_ServiceHealth,
-			Subject: &pbsubscribe.SubscribeRequest_NamedSubject{
-				NamedSubject: &pbsubscribe.NamedSubject{
-					Key: "foo",
-				},
+	// Re-subscribe because the previous test step terminated the stream.
+	chEvents = make(chan eventOrError, 0)
+	streamClient := pbsubscribe.NewStateChangeSubscriptionClient(conn)
+	streamHandle, err := streamClient.Subscribe(ctx, &pbsubscribe.SubscribeRequest{
+		Topic: pbsubscribe.Topic_ServiceHealth,
+		Subject: &pbsubscribe.SubscribeRequest_NamedSubject{
+			NamedSubject: &pbsubscribe.NamedSubject{
+				Key: "foo",
 			},
-			Token: token,
-		})
-		require.NoError(t, err)
+		},
+		Token: token,
+	})
+	require.NoError(t, err)
 
-		go recvEvents(chEvents, streamHandle)
+	go recvEvents(chEvents, streamHandle)
 
-		// Stub out token authn function so that the token is no longer considered valid.
-		backend.resolveTokenAndDefaultMeta = func(t string, entMeta *acl.EnterpriseMeta, _ *acl.AuthorizerContext) (acl.Authorizer, error) {
-			return nil, fmt.Errorf("ACL not found")
-		}
+	// Stub out token authn function so that the token is no longer considered valid.
+	backend.resolveTokenAndDefaultMeta = func(t string, entMeta *acl.EnterpriseMeta, _ *acl.AuthorizerContext) (acl.Authorizer, error) {
+		return nil, fmt.Errorf("ACL not found")
+	}
 
+	testutil.RunStep(t, "invalid token should return an error", func(t *testing.T) {
 		// Force another ACL update.
 		tokenID, err := uuid.GenerateUUID()
 		require.NoError(t, err)

--- a/agent/grpc-internal/services/subscribe/subscribe_test.go
+++ b/agent/grpc-internal/services/subscribe/subscribe_test.go
@@ -6,6 +6,7 @@ package subscribe
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"testing"
@@ -323,17 +324,21 @@ func getEvent(t *testing.T, ch chan eventOrError) *pbsubscribe.Event {
 }
 
 type testBackend struct {
-	publisher   *stream.EventPublisher
-	store       *state.Store
-	authorizer  func(token string, entMeta *acl.EnterpriseMeta) acl.Authorizer
-	forwardConn *gogrpc.ClientConn
+	publisher                  *stream.EventPublisher
+	store                      *state.Store
+	authorizer                 func(token string, entMeta *acl.EnterpriseMeta) acl.Authorizer
+	resolveTokenAndDefaultMeta func(token string, entMeta *acl.EnterpriseMeta, _ *acl.AuthorizerContext) (acl.Authorizer, error)
+	forwardConn                *gogrpc.ClientConn
 }
 
 func (b testBackend) ResolveTokenAndDefaultMeta(
 	token string,
 	entMeta *acl.EnterpriseMeta,
-	_ *acl.AuthorizerContext,
+	authCtx *acl.AuthorizerContext,
 ) (acl.Authorizer, error) {
+	if b.resolveTokenAndDefaultMeta != nil {
+		return b.resolveTokenAndDefaultMeta(token, entMeta, authCtx)
+	}
 	return b.authorizer(token, entMeta), nil
 }
 
@@ -984,6 +989,47 @@ node "node1" {
 			require.Equal(t, codes.Aborted, s.Code())
 		case <-time.After(2 * time.Second):
 			t.Fatalf("timeout waiting for aborted error")
+		}
+	})
+
+	testutil.RunStep(t, "invalid token should return an error", func(t *testing.T) {
+		// Re-subscribe because the previous test step terminated the stream.
+		chEvents = make(chan eventOrError, 0)
+		streamClient := pbsubscribe.NewStateChangeSubscriptionClient(conn)
+		streamHandle, err := streamClient.Subscribe(ctx, &pbsubscribe.SubscribeRequest{
+			Topic: pbsubscribe.Topic_ServiceHealth,
+			Subject: &pbsubscribe.SubscribeRequest_NamedSubject{
+				NamedSubject: &pbsubscribe.NamedSubject{
+					Key: "foo",
+				},
+			},
+			Token: token,
+		})
+		require.NoError(t, err)
+
+		go recvEvents(chEvents, streamHandle)
+
+		// Stub out token authn function so that the token is no longer considered valid.
+		backend.resolveTokenAndDefaultMeta = func(t string, entMeta *acl.EnterpriseMeta, _ *acl.AuthorizerContext) (acl.Authorizer, error) {
+			return nil, fmt.Errorf("ACL not found")
+		}
+
+		// Force another ACL update.
+		tokenID, err := uuid.GenerateUUID()
+		require.NoError(t, err)
+
+		aclToken := &structs.ACLToken{
+			AccessorID: tokenID,
+			SecretID:   token,
+		}
+		require.NoError(t, backend.store.ACLTokenSet(ids.Next("update"), aclToken))
+
+		select {
+		case item := <-chEvents:
+			require.Error(t, item.err, "got event instead of an error: %v", item.event)
+			require.EqualError(t, item.err, "rpc error: code = Unknown desc = ACL not found")
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout waiting for ACL not found error")
 		}
 	})
 }


### PR DESCRIPTION
Please see #20790 for reproduction steps.

Currently, when a client starts a blocking query and an ACL token expires within that time, Consul will return an "ACL not found" error with a 403 status code. However, sometimes if an ACL token is invalidated at the same time as the query's deadline is reached, Consul will instead return an empty response with a 200 status code.

This is because of the events being executed:
1. Client issues a blocking query request with timeout `t`.
2. ACL is deleted.
3. Server detects a change in ACLs and force closes the gRPC stream.
4. Client resubscribes with the same token and resets its state (view).
5. Client sees "ACL not found" error.

If ACL is deleted before step 4, the client is unaware that the stream was closed due to an ACL error and will return an empty view (from the reset state) with the 200 status code.

To fix this problem, we introduce another state to the subsciption to indicate when a change to ACLs has occured. If the server sees that there was an error due to ACL change, it will re-authenticate the request and return an error if the token is no longer valid.

Fixes #20790

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
