### PR TITLE
Fix typo in example yaml for MeshService

### DIFF
--- a/website/content/docs/connect/gateways/api-gateway/configuration/meshservice.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/meshservice.mdx
@@ -48,7 +48,7 @@ The following example creates a mesh service called `example-mesh-service`. Rout
 <CodeBlockConfig filename="meshservice.yaml">
 
 ```yaml hideClipboard
-apiVersion: api-gateway.consul.hashicorp.com/v1alpha1
+apiVersion: consul.hashicorp.com/v1alpha1
 kind: MeshService
 metadata:
   name: example-mesh-service


### PR DESCRIPTION
### Description
The group for the `MeshService` CustomResourceDefinition is `consul.hashicorp.com`, not `api-gateway.consul.hashicorp.com`. The corresponding code definition is [here](https://github.com/hashicorp/consul-k8s/blob/2780dc2c2e9975957e6a2c6959e20d0fa77ab690/charts/consul/templates/crd-meshservices.yaml#L15).

This PR fixes this.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links
https://developer.hashicorp.com/consul/docs/connect/gateways/api-gateway/configuration/meshservice#example-configuration

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
