### PR TITLE
feat(dataplane): allow token and tenancy information for proxied DNS

### DIFF
--- a/agent/discovery/query_fetcher_v1_test.go
+++ b/agent/discovery/query_fetcher_v1_test.go
@@ -128,6 +128,7 @@ func Test_FetchVirtualIP(t *testing.T) {
 func Test_FetchEndpoints(t *testing.T) {
 	// set these to confirm that RPC call does not use them for this particular RPC
 	rc := &config.RuntimeConfig{
+		Datacenter:     "dc2",
 		DNSAllowStale:  true,
 		DNSMaxStale:    100,
 		DNSUseCache:    true,

--- a/agent/discovery/query_fetcher_v2.go
+++ b/agent/discovery/query_fetcher_v2.go
@@ -347,6 +347,7 @@ func queryTenancyToResourceTenancy(qTenancy QueryTenancy) *pbresource.Tenancy {
 		rTenancy.Namespace = qTenancy.Namespace
 	}
 	// In the case of partition, we have the agent's partition as the fallback.
+	// That is handled in NormalizeRequest.
 	if qTenancy.Partition != "" {
 		rTenancy.Partition = qTenancy.Partition
 	}

--- a/agent/dns/context.go
+++ b/agent/dns/context.go
@@ -1,0 +1,56 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package dns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"google.golang.org/grpc/metadata"
+)
+
+// Context is used augment a DNS message with Consul-specific metadata.
+type Context struct {
+	Token            string `mapstructure:"x-consul-token,omitempty"`
+	DefaultNamespace string `mapstructure:"x-consul-namespace,omitempty"`
+	DefaultPartition string `mapstructure:"x-consul-partition,omitempty"`
+}
+
+// NewContextFromGRPCContext returns the request context using the gRPC metadata attached to the
+// given context. If there is no gRPC metadata, it returns an empty context.
+func NewContextFromGRPCContext(ctx context.Context) (Context, error) {
+	if ctx == nil {
+		return Context{}, nil
+	}
+
+	reqCtx := Context{}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return reqCtx, nil
+	}
+
+	m := map[string]string{}
+	for k, v := range md {
+		m[k] = v[0]
+	}
+
+	decoderConfig := &mapstructure.DecoderConfig{
+		Metadata:         nil,
+		Result:           &reqCtx,
+		WeaklyTypedInput: true,
+	}
+
+	decoder, err := mapstructure.NewDecoder(decoderConfig)
+	if err != nil {
+		return Context{}, fmt.Errorf("error creating mapstructure decoder: %w", err)
+	}
+
+	err = decoder.Decode(m)
+	if err != nil {
+		return Context{}, fmt.Errorf("error decoding metadata: %w", err)
+	}
+
+	return reqCtx, nil
+}

--- a/agent/dns/context_test.go
+++ b/agent/dns/context_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package dns
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestNewContextFromGRPCContext(t *testing.T) {
+	t.Parallel()
+
+	md := metadata.MD{}
+	testMeta := map[string]string{
+		"x-consul-token":     "test-token",
+		"x-consul-namespace": "test-namespace",
+		"x-consul-partition": "test-partition",
+	}
+
+	for k, v := range testMeta {
+		md.Set(k, v)
+	}
+	testGRPCContext := metadata.NewIncomingContext(context.Background(), md)
+
+	testCases := []struct {
+		name     string
+		grpcCtx  context.Context
+		expected *Context
+		error    error
+	}{
+		{
+			name:     "nil grpc context",
+			grpcCtx:  nil,
+			expected: &Context{},
+		},
+		{
+			name:     "grpc context w/o metadata",
+			grpcCtx:  context.Background(),
+			expected: &Context{},
+		},
+		{
+			name:    "grpc context w/ kitchen sink",
+			grpcCtx: testGRPCContext,
+			expected: &Context{
+				Token:            "test-token",
+				DefaultNamespace: "test-namespace",
+				DefaultPartition: "test-partition",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, err := NewContextFromGRPCContext(tc.grpcCtx)
+			if tc.error != nil {
+				require.Error(t, err)
+				require.Equal(t, Context{}, &ctx)
+				require.Equal(t, tc.error, err)
+				return
+			}
+
+			require.NotNil(t, ctx)
+			require.Equal(t, tc.expected, &ctx)
+		})
+	}
+}

--- a/agent/dns/discovery_results_fetcher_test.go
+++ b/agent/dns/discovery_results_fetcher_test.go
@@ -160,8 +160,7 @@ func Test_buildQueryFromDNSMessage(t *testing.T) {
 				},
 			},
 			requestContext: &Context{
-				DefaultDatacenter: "default-dc",
-				DefaultPartition:  "default-partition",
+				DefaultPartition: "default-partition",
 			},
 			expectedQuery: &discovery.Query{
 				QueryType: discovery.QueryTypeWorkload,
@@ -169,10 +168,9 @@ func Test_buildQueryFromDNSMessage(t *testing.T) {
 					Name:     "foo",
 					PortName: "api",
 					Tenancy: discovery.QueryTenancy{
-						Namespace:  "banana",
-						Partition:  "orange",
-						Peer:       "apple",
-						Datacenter: "default-dc",
+						Namespace: "banana",
+						Partition: "orange",
+						Peer:      "apple",
 					},
 				},
 			},
@@ -192,8 +190,7 @@ func Test_buildQueryFromDNSMessage(t *testing.T) {
 				},
 			},
 			requestContext: &Context{
-				DefaultDatacenter: "default-dc",
-				DefaultPartition:  "default-partition",
+				DefaultPartition: "default-partition",
 			},
 			expectedQuery: &discovery.Query{
 				QueryType: discovery.QueryTypeService,
@@ -203,7 +200,6 @@ func Test_buildQueryFromDNSMessage(t *testing.T) {
 						Namespace:     "banana",
 						Partition:     "orange",
 						SamenessGroup: "apple",
-						Datacenter:    "default-dc",
 					},
 				},
 			},

--- a/agent/grpc-external/services/dns/server_v2.go
+++ b/agent/grpc-external/services/dns/server_v2.go
@@ -72,9 +72,10 @@ func (s *ServerV2) Query(ctx context.Context, req *pbdns.QueryRequest) (*pbdns.Q
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failure decoding dns request: %s", err.Error()))
 	}
 
-	// TODO (v2-dns): parse token and other context metadata from the grpc request/metadata (NET-7885)
-	reqCtx := agentdns.Context{
-		Token: s.TokenFunc(),
+	reqCtx, err := agentdns.NewContextFromGRPCContext(ctx)
+	if err != nil {
+		s.Logger.Error("error parsing DNS context from grpc metadata", "err", err)
+		return nil, status.Error(codes.Internal, fmt.Sprintf("error parsing DNS context from grpc metadata: %s", err.Error()))
 	}
 
 	resp := s.DNSRouter.HandleRequest(msg, reqCtx, remote)


### PR DESCRIPTION
### Description
This is the Consul component of https://github.com/hashicorp/consul-dataplane/pull/172

> By passing along the tenant of the service being proxied we can more intelligently select the correct partition/namespace to use as defaults for DNS.
> 
> This also passes along the Consul ACL token as the x-consul-token grpc metadata. Eventually Consul should be able to use this token instead of the servers default token for authorizing access.

This PR also includes a small bit of cleanup as noted in the comments.

### Testing & Reproduction steps
* Unit tests are updated

### Links
[Dataplane PR](https://github.com/hashicorp/consul-dataplane/pull/172) 

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] appropriate backport labels added
* [X] not a security concern
