### PR TITLE
security: enable go stdlib scans

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -49,6 +49,7 @@ container {
 binary {
 	go_modules   = true
 	osv          = true
+	go_stdlib 	 = true
 	# We can't enable npm for binary targets today because we don't yet embed the relevant file
 	# (yarn.lock) in the Consul binary. This is something we may investigate in the future.
 	

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -49,7 +49,7 @@ container {
 binary {
 	go_modules   = true
 	osv          = true
-	go_stdlib 	 = true
+	go_stdlib    = true
 	# We can't enable npm for binary targets today because we don't yet embed the relevant file
 	# (yarn.lock) in the Consul binary. This is something we may investigate in the future.
 	

--- a/scan.hcl
+++ b/scan.hcl
@@ -15,9 +15,10 @@
 # unlike the scans configured here, will block releases in CRT.
 
 repository {
-  go_modules   = true
-  npm          = true
-  osv          = true
+  go_modules              = true
+  npm                     = true
+  osv                     = true
+  go_stdlib_version_file  = ".go-version"
 
   secrets {
     all = true


### PR DESCRIPTION
### Description

Adding configuration to support go standard librairies (`stdlibs`) in security-scanner at the `repository` and `binary` level.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
