### PR TITLE
Backport of security: triage false positive for go-jose/v3 into release/1.18.1

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -67,4 +67,15 @@ binary {
 			]
 		}
 	}
+
+	# Triage items that are _safe_ to ignore here. Note that this list should be
+	# periodically cleaned up to remove items that are no longer found by the scanner.
+	triage {
+		suppress {
+			# N.b. `vulnerabilites` is the correct spelling for this tool.
+			vulnerabilites = [
+				"GO-2024-2631", # go-jose/v3@v3.0.3 (false positive)
+			]
+		}
+	}
 }

--- a/scan.hcl
+++ b/scan.hcl
@@ -22,4 +22,15 @@ repository {
   secrets {
     all = true
   }
+
+  # Triage items that are _safe_ to ignore here. Note that this list should be
+  # periodically cleaned up to remove items that are no longer found by the scanner.
+  triage {
+    suppress {
+      # N.b. `vulnerabilites` is the correct spelling for this tool.
+      vulnerabilites = [
+        "GO-2024-2631", # go-jose/v3@v3.0.3 (false positive)
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Backport

This PR is a manual backport of #20901.



The below text is copied from the body of the original PR.

---

Per https://osv.dev/vulnerability/GO-2024-2631 this vulnerability is not present in the version currently used (go-jose/v3@3.0.3).

I'm suspicious that the `Introduced               0` version in the [OSV](https://osv.dev/vulnerability/GO-2024-2631) entry is why we're flagging the fix version as invalid. Just a guess.

### Description

This unblocks the Consul patch release currently underway.

### Testing & Reproduction steps

CI continues to pass including Security Scan check.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [ ] not a security concern


---

<details>
<summary> Overview of commits </summary>

  - c8d6b2528cdf861bff796d6d8e5a93e7e4c660b7 

</details>


