### PR TITLE
Remove Enterprise callout from 1.18.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.18.1 Enterprise (March 26, 2024)
+## 1.18.1 (March 26, 2024)
 
 Enterprise LTS: Consul Enterprise 1.18 is a Long-Term Support (LTS) release.
 


### PR DESCRIPTION
This is a CE+Ent release, so there should not be an "Enterprise" designation in the changelog entry.
