### PR TITLE
Update Dockerfile: backport to 1.15.x

### DIFF
--- a/.changelog/20897.txt
+++ b/.changelog/20897.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Bump Dockerfile base image to `alpine:3.19`. 
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # Official docker image that includes binaries from releases.hashicorp.com. This
 # downloads the release from releases.hashicorp.com and therefore requires that
 # the release is published before building the Docker image.
-FROM docker.mirror.hashicorp.services/alpine:3.19 as official
+FROM docker.mirror.hashicorp.services/alpine:3.17 as official
 
 # This is the release of Consul to pull in.
 ARG VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # Official docker image that includes binaries from releases.hashicorp.com. This
 # downloads the release from releases.hashicorp.com and therefore requires that
 # the release is published before building the Docker image.
-FROM docker.mirror.hashicorp.services/alpine:3.17 as official
+FROM docker.mirror.hashicorp.services/alpine:3.19 as official
 
 # This is the release of Consul to pull in.
 ARG VERSION
@@ -112,7 +112,7 @@ CMD ["agent", "-dev", "-client", "0.0.0.0"]
 
 # Production docker image that uses CI built binaries.
 # Remember, this image cannot be built locally.
-FROM docker.mirror.hashicorp.services/alpine:3.17 as default
+FROM docker.mirror.hashicorp.services/alpine:3.19 as default
 
 ARG PRODUCT_VERSION
 ARG BIN_NAME


### PR DESCRIPTION
### Description

Manual backport of https://github.com/hashicorp/consul/pull/20897/files 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
