### PR TITLE
Documentation: update python SDKs list

### DIFF
--- a/website/content/api-docs/libraries-and-sdks.mdx
+++ b/website/content/api-docs/libraries-and-sdks.mdx
@@ -23,12 +23,8 @@ the community.
     the Consul HTTP API
   </li>
   <li>
-    <a href="https://github.com/cablehead/python-consul">python-consul</a> -
-    Python client for the Consul HTTP API (unmaintained)
-  </li>
-  <li>
-    <a href="https://github.com/poppyred/python-consul2">python-consul2</a> -
-    Python client for the Consul HTTP API (currently maintained)
+    <a href="https://github.com/criteo/py-consul">py-consul</a> -
+    Python client for the Consul HTTP API
   </li>
   <li>
     <a href="https://github.com/vdloo/consul-kv">consul-kv</a> - Python 3 client


### PR DESCRIPTION
### Description

The original [python-consul](https://github.com/python-consul/python-consul) is unmaintained with no activity for 6 years. The [python-consul2](https://github.com/poppyred/python-consul2) fork has had no activity for 3 years, whether it's commits or responding to PRs and issues.

[py-consul](https://github.com/criteo/py-consul) is a (now detached) fork of python-consul, maintained. It's compatible with more recent Python and Consul versions.

Fixes #20853 

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
