### PR TITLE
NET-8524 Remove registation of api gateway controller

### DIFF
--- a/internal/mesh/internal/controllers/register.go
+++ b/internal/mesh/internal/controllers/register.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/consul/agent/leafcert"
 	"github.com/hashicorp/consul/internal/controller"
-	"github.com/hashicorp/consul/internal/mesh/internal/controllers/apigateways"
 	"github.com/hashicorp/consul/internal/mesh/internal/controllers/explicitdestinations"
 	"github.com/hashicorp/consul/internal/mesh/internal/controllers/explicitdestinations/mapper"
 	"github.com/hashicorp/consul/internal/mesh/internal/controllers/gatewayproxy"
@@ -58,6 +57,4 @@ func Register(mgr *controller.Manager, deps Dependencies) {
 
 	mgr.Register(meshgateways.Controller())
 	mgr.Register(meshconfiguration.Controller())
-
-	mgr.Register(apigateways.Controller())
 }


### PR DESCRIPTION
### Description
Removing registration of API Gateway controller since it is not fully implemented and the work has been deprioritized. 

### Testing & Reproduction steps


### Links

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ X ] appropriate backport labels added
* [  X ] not a security concern
