### PR TITLE
security: ignore test and internal tool modules

### DIFF
--- a/scan.hcl
+++ b/scan.hcl
@@ -31,6 +31,13 @@ repository {
       vulnerabilites = [
         "GO-2024-2631", # go-jose/v3@v3.0.3 (false positive)
       ]
+      paths = [
+        "internal/tools/proto-gen-rpc-glue/e2e/consul/*",
+        "test/integration/connect/envoy/test-sds-server/*",
+        "test/integration/consul-container/*",
+        "testing/deployer/*",
+        "test-integ/*",
+      ]
     }
   }
 }


### PR DESCRIPTION
### Description

Ignore these submodules as they are not part of the production codebase (will never block a release pipeline scan) and produce significant noise in repository security scans.

Most of the dependencies flagged by these results will be updated naturally by other modules, esp. if/when we adopt `go.work` to keep deps in sync.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [ ] not a security concern
