### PR TITLE
ci: fix Envoy int test versions

### DIFF
--- a/.github/workflows/nightly-test-integrations-1.15.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.15.x.yml
@@ -74,7 +74,7 @@ jobs:
           # this is further going to multiplied in envoy-integration tests by the 
           # other dimensions in the matrix.  Currently TOTAL_RUNNERS would be
           # 14 based on these values:
-          # envoy-version: ["1.22.11", "1.23.12", "1.24.12", "1.25.11", "1.26.7", "1.27.3", "1.28.1"]
+          # envoy-version: ["1.22.11", "1.23.12", "1.24.12", "1.25.11", "1.26.8", "1.27.4", "1.28.2"]
           # xds-target: ["server", "client"]
           TOTAL_RUNNERS: 7
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        envoy-version: ["1.22.11", "1.23.12", "1.24.12", "1.25.11", "1.26.7", "1.27.3", "1.28.1"]
+        envoy-version: ["1.22.11", "1.23.12", "1.24.12", "1.25.11", "1.26.8", "1.27.4", "1.28.2"]
         xds-target: ["server", "client"]
         test-cases: ${{ fromJSON(needs.generate-envoy-job-matrices.outputs.envoy-matrix) }}
     env:

--- a/.github/workflows/nightly-test-integrations-1.16.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.16.x.yml
@@ -74,7 +74,7 @@ jobs:
           # this is further going to multiplied in envoy-integration tests by the 
           # other dimensions in the matrix.  Currently TOTAL_RUNNERS would be
           # multiplied by 8 based on these values:
-          # envoy-version: ["1.23.12", "1.24.12", "1.25.11", "1.26.7"]
+          # envoy-version: ["1.23.12", "1.24.12", "1.25.11", "1.26.8"]
           # xds-target: ["server", "client"]
           TOTAL_RUNNERS: 8
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        envoy-version: ["1.23.12", "1.24.12", "1.25.11", "1.26.7"]
+        envoy-version: ["1.23.12", "1.24.12", "1.25.11", "1.26.8"]
         xds-target: ["server", "client"]
         test-cases: ${{ fromJSON(needs.generate-envoy-job-matrices.outputs.envoy-matrix) }}
     env:

--- a/.github/workflows/nightly-test-integrations-1.17.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.17.x.yml
@@ -74,7 +74,7 @@ jobs:
           # this is further going to multiplied in envoy-integration tests by the 
           # other dimensions in the matrix.  Currently TOTAL_RUNNERS would be
           # multiplied by 8 based on these values:
-          # envoy-version: ["1.24.12", "1.25.11", "1.26.7", "1.27.3"]
+          # envoy-version: ["1.24.12", "1.25.11", "1.26.8", "1.27.4"]
           # xds-target: ["server", "client"]
           TOTAL_RUNNERS: 4 
           JQ_SLICER: '[ inputs ] | [_nwise(length / $runnercount | floor)]'
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        envoy-version: ["1.24.12", "1.25.11", "1.26.7", "1.27.3"]
+        envoy-version: ["1.24.12", "1.25.11", "1.26.8", "1.27.4"]
         xds-target: ["server", "client"]
         test-cases: ${{ fromJSON(needs.generate-envoy-job-matrices.outputs.envoy-matrix) }}
     env:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -395,7 +395,7 @@ jobs:
       id-token: write # NOTE: this permission is explicitly required for Vault auth.
       contents: read
     env:
-      ENVOY_VERSION: "1.28.1"
+      ENVOY_VERSION: "1.28.2"
       CONSUL_DATAPLANE_IMAGE: "docker.io/hashicorppreview/consul-dataplane:1.3-dev-ubi"
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
Follow-up to #20956

Nightly files do not require backport bc these only run on `main`, but backporting to update the `test-integrations` compatibility test env var.