### PR TITLE
FIX: wrong indentation of  to block in Example yaml

### DIFF
--- a/website/content/docs/connect/gateways/api-gateway/configuration/routes.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/routes.mdx
@@ -300,10 +300,10 @@ The following example creates a route named `example-route` in namespace `gatewa
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: gateway-namespace
-      to:
-        - group: ""
-          kind: Service
-          name: echo
+    to:
+      - group: ""
+        kind: Service
+        name: echo
   ```
 
 </CodeBlockConfig>


### PR DESCRIPTION
…Ref example yaml file

wrong indentation of
```yaml
to:
      - group: ""
        kind: Service
        name: echo
```
will cause error

```log
ReferenceGrant in version "v1beta1" cannot be handled as a ReferenceGrant: strict decoding error: unknown field "spec.from[0].to"
```

### Description

wrong indentation of 
```yaml
to:
      - group: ""
        kind: Service
        name: echo
```
will cause error

```log
ReferenceGrant in version "v1beta1" cannot be handled as a ReferenceGrant: strict decoding error: unknown field "spec.from[0].to"
```


### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [✓] external facing docs updated
* [ ] appropriate backport labels added
* [✓ ] not a security concern
