### PR TITLE
Fix miss makezero bug

### DIFF
--- a/agent/hcp/testing.go
+++ b/agent/hcp/testing.go
@@ -167,7 +167,7 @@ func (s *MockHCPServer) handleStatus(r *http.Request, cluster resource.Resource)
 }
 
 func (s *MockHCPServer) handleDiscover(r *http.Request, cluster resource.Resource) (interface{}, error) {
-	servers := make([]*gnmmod.HashicorpCloudGlobalNetworkManager20220215Server, len(s.servers))
+	servers := make([]*gnmmod.HashicorpCloudGlobalNetworkManager20220215Server, 0, len(s.servers))
 	for _, server := range s.servers {
 		servers = append(servers, server)
 	}


### PR DESCRIPTION
### Description

When I was adding features for linter [makezero](https://github.com/ashanbrown/makezero), I ran some GitHub Actions for some repos on GitHub, and it reported an error in this project.

### Testing & Reproduction steps

-

### Links

see https://github.com/hashicorp/packer-plugin-googlecompute/pull/218 
and 

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
