### PR TITLE
Fixed broken link in the ECS documentation

### DIFF
--- a/website/content/docs/ecs/deploy/bind-addresses.mdx
+++ b/website/content/docs/ecs/deploy/bind-addresses.mdx
@@ -17,8 +17,8 @@ Binding workloads to the loopback address ensures that your application only rec
 
 Consul service mesh must be deployed to ECS before you can bind a network address. For more information, refer to the following topics:
 
-- [Deploy Consul to ECS using the Terraform module](/consul/docs/ecs/deploy/install-terraform)
-- [Deploy Consul to ECS manually](/consul/docs/ecs/deploy/install-manual)
+- [Deploy Consul to ECS using the Terraform module](/consul/docs/ecs/deploy/terraform)
+- [Deploy Consul to ECS manually](/consul/docs/ecs/deploy/manual)
 
 ## Change the listening address
 

--- a/website/content/docs/ecs/deploy/configure-routes.mdx
+++ b/website/content/docs/ecs/deploy/configure-routes.mdx
@@ -20,8 +20,8 @@ To enable tasks to call through the service mesh, complete the following steps:
 
 Consul service mesh must be deployed to ECS before you can bind a network address. For more information, refer to the following topics:
 
-- [Deploy Consul to ECS using the Terraform module](/consul/docs/ecs/deploy/install-terraform)
-- [Deploy Consul to ECS manually](/consul/docs/ecs/deploy/install-manual)
+- [Deploy Consul to ECS using the Terraform module](/consul/docs/ecs/deploy/terraform)
+- [Deploy Consul to ECS manually](/consul/docs/ecs/deploy/manual)
 
 ## Configure the sidecar proxy 
 


### PR DESCRIPTION
### Description

Fixing broken links in the ECS documentation

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
