### PR TITLE
gossip: refactor some gossip related libraries into a central place

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/serf"
 
@@ -21,12 +23,11 @@ import (
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/types"
-
-	"github.com/stretchr/testify/require"
 )
 
 type authzResolver func(string) (structs.ACLIdentity, acl.Authorizer, error)
@@ -128,7 +129,7 @@ func (a *TestACLAgent) ResolveTokenAndDefaultMeta(secretID string, entMeta *acl.
 }
 
 // All of these are stubs to satisfy the interface
-func (a *TestACLAgent) GetLANCoordinate() (lib.CoordinateSet, error) {
+func (a *TestACLAgent) GetLANCoordinate() (librtt.CoordinateSet, error) {
 	return nil, fmt.Errorf("Unimplemented")
 }
 func (a *TestACLAgent) Leave() error {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -70,6 +70,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/api/watch"
 	libdns "github.com/hashicorp/consul/internal/dnsutil"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	proxytracker "github.com/hashicorp/consul/internal/mesh/proxy-tracker"
 	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/lib"
@@ -189,7 +190,7 @@ type delegate interface {
 	// are ancillary members of.
 	//
 	// NOTE: This assumes coordinates are enabled, so check that before calling.
-	GetLANCoordinate() (lib.CoordinateSet, error)
+	GetLANCoordinate() (librtt.CoordinateSet, error)
 
 	// JoinLAN is used to have Consul join the inner-DC pool The target address
 	// should be another node inside the DC listening on the Serf LAN address
@@ -2149,7 +2150,7 @@ func (a *Agent) SyncPausedCh() <-chan struct{} {
 
 // GetLANCoordinate returns the coordinates of this node in the local pools
 // (assumes coordinates are enabled, so check that before calling).
-func (a *Agent) GetLANCoordinate() (lib.CoordinateSet, error) {
+func (a *Agent) GetLANCoordinate() (librtt.CoordinateSet, error) {
 	return a.delegate.GetLANCoordinate()
 }
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -31,8 +31,8 @@ import (
 	token_store "github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/envoyextensions/xdscommon"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/ipaddr"
-	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/logging/monitor"
 	"github.com/hashicorp/consul/types"
@@ -82,7 +82,7 @@ func (s *HTTPHandlers) AgentSelf(resp http.ResponseWriter, req *http.Request) (i
 		return nil, err
 	}
 
-	var cs lib.CoordinateSet
+	var cs librtt.CoordinateSet
 	if !s.agent.config.DisableCoordinates {
 		var err error
 		if cs, err = s.agent.GetLANCoordinate(); err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -58,9 +58,9 @@ import (
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/internal/go-sso/oidcauth/oidcauthtest"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/ipaddr"
-	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/proto/private/pbautoconf"
 	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -3954,7 +3954,7 @@ func TestAgent_GetCoordinate(t *testing.T) {
 
 	coords, err := a.GetLANCoordinate()
 	require.NoError(t, err)
-	expected := lib.CoordinateSet{
+	expected := librtt.CoordinateSet{
 		"": &coordinate.Coordinate{
 			Error:  1.5,
 			Height: 1e-05,

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -10,19 +10,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-uuid"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	msgpackrpc "github.com/hashicorp/consul-net-rpc/net-rpc-msgpackrpc"
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
+	"github.com/hashicorp/go-uuid"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/acl/resolver"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/lib/stringslice"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -1234,9 +1233,9 @@ func TestCatalog_ListNodes_DistanceSort(t *testing.T) {
 
 	// Set all but one of the nodes to known coordinates.
 	updates := structs.Coordinates{
-		{Node: "foo", Coord: lib.GenerateCoordinate(2 * time.Millisecond)},
-		{Node: "bar", Coord: lib.GenerateCoordinate(5 * time.Millisecond)},
-		{Node: "baz", Coord: lib.GenerateCoordinate(1 * time.Millisecond)},
+		{Node: "foo", Coord: librtt.GenerateCoordinate(2 * time.Millisecond)},
+		{Node: "bar", Coord: librtt.GenerateCoordinate(5 * time.Millisecond)},
+		{Node: "baz", Coord: librtt.GenerateCoordinate(1 * time.Millisecond)},
 	}
 	if err := s1.fsm.State().CoordinateBatchUpdate(5, updates); err != nil {
 		t.Fatalf("err: %v", err)
@@ -2138,9 +2137,9 @@ func TestCatalog_ListServiceNodes_DistanceSort(t *testing.T) {
 
 	// Set all but one of the nodes to known coordinates.
 	updates := structs.Coordinates{
-		{Node: "foo", Coord: lib.GenerateCoordinate(2 * time.Millisecond)},
-		{Node: "bar", Coord: lib.GenerateCoordinate(5 * time.Millisecond)},
-		{Node: "baz", Coord: lib.GenerateCoordinate(1 * time.Millisecond)},
+		{Node: "foo", Coord: librtt.GenerateCoordinate(2 * time.Millisecond)},
+		{Node: "bar", Coord: librtt.GenerateCoordinate(5 * time.Millisecond)},
+		{Node: "baz", Coord: librtt.GenerateCoordinate(1 * time.Millisecond)},
 	}
 	if err := s1.fsm.State().CoordinateBatchUpdate(9, updates); err != nil {
 		t.Fatalf("err: %v", err)

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -14,15 +14,17 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"golang.org/x/time/rate"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/serf"
-	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/consul/acl"
 	rpcRate "github.com/hashicorp/consul/agent/consul/rate"
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/proto-public/pbresource"
@@ -439,13 +441,13 @@ func (c *Client) Stats() map[string]map[string]string {
 // are ancillary members of.
 //
 // NOTE: This assumes coordinates are enabled, so check that before calling.
-func (c *Client) GetLANCoordinate() (lib.CoordinateSet, error) {
+func (c *Client) GetLANCoordinate() (librtt.CoordinateSet, error) {
 	lan, err := c.serf.GetCoordinate()
 	if err != nil {
 		return nil, err
 	}
 
-	cs := lib.CoordinateSet{c.config.Segment: lan}
+	cs := librtt.CoordinateSet{c.config.Segment: lan}
 	return cs, nil
 }
 

--- a/agent/consul/client_serf.go
+++ b/agent/consul/client_serf.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/serf/serf"
 
 	"github.com/hashicorp/consul/agent/metadata"
+	"github.com/hashicorp/consul/internal/gossip/libserf"
 	"github.com/hashicorp/consul/lib"
-	libserf "github.com/hashicorp/consul/lib/serf"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/types"
 )

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -9,16 +9,17 @@ import (
 	"os"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
-	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/consul/agent/checks"
 	consulrate "github.com/hashicorp/consul/agent/consul/rate"
 	hcpconfig "github.com/hashicorp/consul/agent/hcp/config"
 	"github.com/hashicorp/consul/agent/structs"
-	libserf "github.com/hashicorp/consul/lib/serf"
+	"github.com/hashicorp/consul/internal/gossip/libserf"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/consul/version"

--- a/agent/consul/coordinate_endpoint_test.go
+++ b/agent/consul/coordinate_endpoint_test.go
@@ -12,15 +12,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/serf/coordinate"
 	"github.com/stretchr/testify/require"
 
 	msgpackrpc "github.com/hashicorp/consul-net-rpc/net-rpc-msgpackrpc"
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
+	"github.com/hashicorp/serf/coordinate"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 )
@@ -92,13 +92,13 @@ func TestCoordinate_Update(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	require.Equal(t, lib.CoordinateSet{}, c)
+	require.Equal(t, librtt.CoordinateSet{}, c)
 
 	_, c, err = state.Coordinate(nil, "node2", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	require.Equal(t, lib.CoordinateSet{}, c)
+	require.Equal(t, librtt.CoordinateSet{}, c)
 
 	// Send another update for the second node. It should take precedence
 	// since there will be two updates in the same batch.
@@ -113,7 +113,7 @@ func TestCoordinate_Update(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	expected := lib.CoordinateSet{
+	expected := librtt.CoordinateSet{
 		"": arg1.Coord,
 	}
 	require.Equal(t, expected, c)
@@ -122,7 +122,7 @@ func TestCoordinate_Update(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	expected = lib.CoordinateSet{
+	expected = librtt.CoordinateSet{
 		"": arg2.Coord,
 	}
 	require.Equal(t, expected, c)

--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
@@ -193,8 +193,8 @@ func TestHealth_ChecksInState_DistanceSort(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	updates := structs.Coordinates{
-		{Node: "foo", Coord: lib.GenerateCoordinate(1 * time.Millisecond)},
-		{Node: "bar", Coord: lib.GenerateCoordinate(2 * time.Millisecond)},
+		{Node: "foo", Coord: librtt.GenerateCoordinate(1 * time.Millisecond)},
+		{Node: "bar", Coord: librtt.GenerateCoordinate(2 * time.Millisecond)},
 	}
 	if err := s1.fsm.State().CoordinateBatchUpdate(3, updates); err != nil {
 		t.Fatalf("err: %v", err)
@@ -482,8 +482,8 @@ func TestHealth_ServiceChecks_DistanceSort(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	updates := structs.Coordinates{
-		{Node: "foo", Coord: lib.GenerateCoordinate(1 * time.Millisecond)},
-		{Node: "bar", Coord: lib.GenerateCoordinate(2 * time.Millisecond)},
+		{Node: "foo", Coord: librtt.GenerateCoordinate(1 * time.Millisecond)},
+		{Node: "bar", Coord: librtt.GenerateCoordinate(2 * time.Millisecond)},
 	}
 	if err := s1.fsm.State().CoordinateBatchUpdate(3, updates); err != nil {
 		t.Fatalf("err: %v", err)
@@ -969,8 +969,8 @@ func TestHealth_ServiceNodes_DistanceSort(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	updates := structs.Coordinates{
-		{Node: "foo", Coord: lib.GenerateCoordinate(1 * time.Millisecond)},
-		{Node: "bar", Coord: lib.GenerateCoordinate(2 * time.Millisecond)},
+		{Node: "foo", Coord: librtt.GenerateCoordinate(1 * time.Millisecond)},
+		{Node: "bar", Coord: librtt.GenerateCoordinate(2 * time.Millisecond)},
 	}
 	if err := s1.fsm.State().CoordinateBatchUpdate(3, updates); err != nil {
 		t.Fatalf("err: %v", err)

--- a/agent/consul/leader_ce_test.go
+++ b/agent/consul/leader_ce_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul/internal/gossip/libserf"
 	"github.com/hashicorp/consul/internal/resource"
 	"github.com/hashicorp/consul/internal/storage"
-	libserf "github.com/hashicorp/consul/lib/serf"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	pbtenancy "github.com/hashicorp/consul/proto-public/pbtenancy/v2beta1"
 	"github.com/hashicorp/consul/testrpc"

--- a/agent/consul/rtt.go
+++ b/agent/consul/rtt.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 )
 
 // nodeSorter takes a list of nodes and a parallel vector of distances and
@@ -21,7 +21,7 @@ type nodeSorter struct {
 
 // newNodeSorter returns a new sorter for the given source coordinate and set of
 // nodes.
-func (s *Server) newNodeSorter(cs lib.CoordinateSet, nodes structs.Nodes) (sort.Interface, error) {
+func (s *Server) newNodeSorter(cs librtt.CoordinateSet, nodes structs.Nodes) (sort.Interface, error) {
 	state := s.fsm.State()
 	vec := make([]float64, len(nodes))
 	for i, node := range nodes {
@@ -30,7 +30,7 @@ func (s *Server) newNodeSorter(cs lib.CoordinateSet, nodes structs.Nodes) (sort.
 			return nil, err
 		}
 		c1, c2 := cs.Intersect(other)
-		vec[i] = lib.ComputeDistance(c1, c2)
+		vec[i] = librtt.ComputeDistance(c1, c2)
 	}
 	return &nodeSorter{nodes, vec}, nil
 }
@@ -61,7 +61,7 @@ type serviceNodeSorter struct {
 
 // newServiceNodeSorter returns a new sorter for the given source coordinate and
 // set of service nodes.
-func (s *Server) newServiceNodeSorter(cs lib.CoordinateSet, nodes structs.ServiceNodes) (sort.Interface, error) {
+func (s *Server) newServiceNodeSorter(cs librtt.CoordinateSet, nodes structs.ServiceNodes) (sort.Interface, error) {
 	state := s.fsm.State()
 	vec := make([]float64, len(nodes))
 	for i, node := range nodes {
@@ -70,7 +70,7 @@ func (s *Server) newServiceNodeSorter(cs lib.CoordinateSet, nodes structs.Servic
 			return nil, err
 		}
 		c1, c2 := cs.Intersect(other)
-		vec[i] = lib.ComputeDistance(c1, c2)
+		vec[i] = librtt.ComputeDistance(c1, c2)
 	}
 	return &serviceNodeSorter{nodes, vec}, nil
 }
@@ -101,7 +101,7 @@ type healthCheckSorter struct {
 
 // newHealthCheckSorter returns a new sorter for the given source coordinate and
 // set of health checks with nodes.
-func (s *Server) newHealthCheckSorter(cs lib.CoordinateSet, checks structs.HealthChecks) (sort.Interface, error) {
+func (s *Server) newHealthCheckSorter(cs librtt.CoordinateSet, checks structs.HealthChecks) (sort.Interface, error) {
 	state := s.fsm.State()
 	vec := make([]float64, len(checks))
 	for i, check := range checks {
@@ -110,7 +110,7 @@ func (s *Server) newHealthCheckSorter(cs lib.CoordinateSet, checks structs.Healt
 			return nil, err
 		}
 		c1, c2 := cs.Intersect(other)
-		vec[i] = lib.ComputeDistance(c1, c2)
+		vec[i] = librtt.ComputeDistance(c1, c2)
 	}
 	return &healthCheckSorter{checks, vec}, nil
 }
@@ -141,7 +141,7 @@ type checkServiceNodeSorter struct {
 
 // newCheckServiceNodeSorter returns a new sorter for the given source coordinate
 // and set of nodes with health checks.
-func (s *Server) newCheckServiceNodeSorter(cs lib.CoordinateSet, nodes structs.CheckServiceNodes) (sort.Interface, error) {
+func (s *Server) newCheckServiceNodeSorter(cs librtt.CoordinateSet, nodes structs.CheckServiceNodes) (sort.Interface, error) {
 	state := s.fsm.State()
 	vec := make([]float64, len(nodes))
 	for i, node := range nodes {
@@ -150,7 +150,7 @@ func (s *Server) newCheckServiceNodeSorter(cs lib.CoordinateSet, nodes structs.C
 			return nil, err
 		}
 		c1, c2 := cs.Intersect(other)
-		vec[i] = lib.ComputeDistance(c1, c2)
+		vec[i] = librtt.ComputeDistance(c1, c2)
 	}
 	return &checkServiceNodeSorter{nodes, vec}, nil
 }
@@ -172,7 +172,7 @@ func (n *checkServiceNodeSorter) Less(i, j int) bool {
 }
 
 // newSorterByDistanceFrom returns a sorter for the given type.
-func (s *Server) newSorterByDistanceFrom(cs lib.CoordinateSet, subj interface{}) (sort.Interface, error) {
+func (s *Server) newSorterByDistanceFrom(cs librtt.CoordinateSet, subj interface{}) (sort.Interface, error) {
 	switch v := subj.(type) {
 	case structs.Nodes:
 		return s.newNodeSorter(cs, v)

--- a/agent/consul/rtt_test.go
+++ b/agent/consul/rtt_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/consul/testrpc"
-
-	"github.com/hashicorp/consul-net-rpc/net-rpc-msgpackrpc"
+	msgpackrpc "github.com/hashicorp/consul-net-rpc/net-rpc-msgpackrpc"
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
+	"github.com/hashicorp/consul/testrpc"
 )
 
 // verifyNodeSort makes sure the order of the nodes in the slice is the same as
@@ -98,27 +98,27 @@ func seedCoordinates(t *testing.T, codec rpc.ClientCodec, server *Server) {
 		{
 			Datacenter: "dc1",
 			Node:       "node1",
-			Coord:      lib.GenerateCoordinate(10 * time.Millisecond),
+			Coord:      librtt.GenerateCoordinate(10 * time.Millisecond),
 		},
 		{
 			Datacenter: "dc1",
 			Node:       "node2",
-			Coord:      lib.GenerateCoordinate(2 * time.Millisecond),
+			Coord:      librtt.GenerateCoordinate(2 * time.Millisecond),
 		},
 		{
 			Datacenter: "dc1",
 			Node:       "node3",
-			Coord:      lib.GenerateCoordinate(1 * time.Millisecond),
+			Coord:      librtt.GenerateCoordinate(1 * time.Millisecond),
 		},
 		{
 			Datacenter: "dc1",
 			Node:       "node4",
-			Coord:      lib.GenerateCoordinate(8 * time.Millisecond),
+			Coord:      librtt.GenerateCoordinate(8 * time.Millisecond),
 		},
 		{
 			Datacenter: "dc1",
 			Node:       "node5",
-			Coord:      lib.GenerateCoordinate(3 * time.Millisecond),
+			Coord:      librtt.GenerateCoordinate(3 * time.Millisecond),
 		},
 	}
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -66,6 +66,7 @@ import (
 	"github.com/hashicorp/consul/internal/auth"
 	"github.com/hashicorp/consul/internal/catalog"
 	"github.com/hashicorp/consul/internal/controller"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	hcpctl "github.com/hashicorp/consul/internal/hcp"
 	"github.com/hashicorp/consul/internal/mesh"
 	proxysnapshot "github.com/hashicorp/consul/internal/mesh/proxy-snapshot"
@@ -1958,13 +1959,13 @@ func (s *Server) Stats() map[string]map[string]string {
 // are ancillary members of.
 //
 // NOTE: This assumes coordinates are enabled, so check that before calling.
-func (s *Server) GetLANCoordinate() (lib.CoordinateSet, error) {
+func (s *Server) GetLANCoordinate() (librtt.CoordinateSet, error) {
 	lan, err := s.serfLAN.GetCoordinate()
 	if err != nil {
 		return nil, err
 	}
 
-	cs := lib.CoordinateSet{"": lan}
+	cs := librtt.CoordinateSet{"": lan}
 	if err := s.addEnterpriseLANCoordinates(cs); err != nil {
 		return nil, err
 	}

--- a/agent/consul/server_ce.go
+++ b/agent/consul/server_ce.go
@@ -20,8 +20,8 @@ import (
 	"github.com/hashicorp/consul/agent/consul/reporting"
 	resourcegrpc "github.com/hashicorp/consul/agent/grpc-external/services/resource"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/internal/resource"
-	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
 )
 
@@ -117,7 +117,7 @@ func (s *Server) GetMatchingLANCoordinate(_, _ string) (*coordinate.Coordinate, 
 	return s.serfLAN.GetCoordinate()
 }
 
-func (s *Server) addEnterpriseLANCoordinates(cs lib.CoordinateSet) error {
+func (s *Server) addEnterpriseLANCoordinates(cs librtt.CoordinateSet) error {
 	return nil
 }
 

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/raft"
@@ -20,8 +21,8 @@ import (
 	"github.com/hashicorp/consul/agent/consul/wanfed"
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/internal/gossip/libserf"
 	"github.com/hashicorp/consul/lib"
-	libserf "github.com/hashicorp/consul/lib/serf"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/types"
 )

--- a/agent/consul/state/coordinate.go
+++ b/agent/consul/state/coordinate.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 )
 
 const tableCoordinates = "coordinates"
@@ -117,7 +117,7 @@ func (s *Restore) Coordinates(idx uint64, updates structs.Coordinates) error {
 
 // Coordinate returns a map of coordinates for the given node, indexed by
 // network segment.
-func (s *Store) Coordinate(ws memdb.WatchSet, node string, entMeta *acl.EnterpriseMeta) (uint64, lib.CoordinateSet, error) {
+func (s *Store) Coordinate(ws memdb.WatchSet, node string, entMeta *acl.EnterpriseMeta) (uint64, librtt.CoordinateSet, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -137,7 +137,7 @@ func (s *Store) Coordinate(ws memdb.WatchSet, node string, entMeta *acl.Enterpri
 	}
 	ws.Add(iter.WatchCh())
 
-	results := make(lib.CoordinateSet)
+	results := make(librtt.CoordinateSet)
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
 		coord := raw.(*structs.Coordinate)
 		results[coord.Segment] = coord.Coord

--- a/agent/consul/state/coordinate_test.go
+++ b/agent/consul/state/coordinate_test.go
@@ -8,12 +8,13 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/serf/coordinate"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/serf/coordinate"
+
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/sdk/testutil"
 )
 
@@ -52,7 +53,7 @@ func TestStateStore_Coordinate_Updates(t *testing.T) {
 	coordinateWs := memdb.NewWatchSet()
 	_, coords, err := s.Coordinate(coordinateWs, "nope", nil)
 	require.NoError(t, err)
-	require.Equal(t, lib.CoordinateSet{}, coords)
+	require.Equal(t, librtt.CoordinateSet{}, coords)
 
 	// Make an update for nodes that don't exist and make sure they get
 	// ignored.
@@ -104,7 +105,7 @@ func TestStateStore_Coordinate_Updates(t *testing.T) {
 		idx, coords, err := s.Coordinate(nodeWs[i], update.Node, nil)
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), idx, "bad index")
-		expected := lib.CoordinateSet{
+		expected := librtt.CoordinateSet{
 			"": update.Coord,
 		}
 		require.Equal(t, expected, coords)
@@ -133,7 +134,7 @@ func TestStateStore_Coordinate_Updates(t *testing.T) {
 		idx, coords, err := s.Coordinate(nil, update.Node, nil)
 		require.NoError(t, err)
 		require.Equal(t, uint64(4), idx, "bad index")
-		expected := lib.CoordinateSet{
+		expected := librtt.CoordinateSet{
 			"": update.Coord,
 		}
 		require.Equal(t, expected, coords)
@@ -178,7 +179,7 @@ func TestStateStore_Coordinate_Cleanup(t *testing.T) {
 	// Make sure it's in there.
 	_, coords, err := s.Coordinate(nil, "node1", nil)
 	require.NoError(t, err)
-	expected := lib.CoordinateSet{
+	expected := librtt.CoordinateSet{
 		"alpha": updates[0].Coord,
 		"beta":  updates[1].Coord,
 	}
@@ -190,7 +191,7 @@ func TestStateStore_Coordinate_Cleanup(t *testing.T) {
 	// Make sure the coordinate is gone.
 	_, coords, err = s.Coordinate(nil, "node1", nil)
 	require.NoError(t, err)
-	require.Equal(t, lib.CoordinateSet{}, coords)
+	require.Equal(t, librtt.CoordinateSet{}, coords)
 
 	// Make sure the index got updated.
 	idx, all, err := s.Coordinates(nil, nil)

--- a/agent/delegate_mock_test.go
+++ b/agent/delegate_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/consul/acl/resolver"
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 )
 
@@ -22,9 +22,9 @@ type delegateMock struct {
 	mock.Mock
 }
 
-func (m *delegateMock) GetLANCoordinate() (lib.CoordinateSet, error) {
+func (m *delegateMock) GetLANCoordinate() (librtt.CoordinateSet, error) {
 	ret := m.Called()
-	return ret.Get(0).(lib.CoordinateSet), ret.Error(1)
+	return ret.Get(0).(librtt.CoordinateSet), ret.Error(1)
 }
 
 func (m *delegateMock) Leave() error {

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/consul/agent/discovery"
 	"math"
 	"math/rand"
 	"net"
@@ -34,9 +33,10 @@ import (
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/consul"
+	"github.com/hashicorp/consul/agent/discovery"
 	dnsConsul "github.com/hashicorp/consul/agent/dns"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 )
@@ -1069,15 +1069,15 @@ func TestDNS_PreparedQueryNearIPEDNS(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	ipCoord := lib.GenerateCoordinate(1 * time.Millisecond)
+	ipCoord := librtt.GenerateCoordinate(1 * time.Millisecond)
 	serviceNodes := []struct {
 		name    string
 		address string
 		coord   *coordinate.Coordinate
 	}{
-		{"foo1", "198.18.0.1", lib.GenerateCoordinate(1 * time.Millisecond)},
-		{"foo2", "198.18.0.2", lib.GenerateCoordinate(10 * time.Millisecond)},
-		{"foo3", "198.18.0.3", lib.GenerateCoordinate(30 * time.Millisecond)},
+		{"foo1", "198.18.0.1", librtt.GenerateCoordinate(1 * time.Millisecond)},
+		{"foo2", "198.18.0.2", librtt.GenerateCoordinate(10 * time.Millisecond)},
+		{"foo3", "198.18.0.3", librtt.GenerateCoordinate(30 * time.Millisecond)},
 	}
 
 	for name, experimentsHCL := range getVersionHCL(true) {
@@ -1203,15 +1203,15 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	ipCoord := lib.GenerateCoordinate(1 * time.Millisecond)
+	ipCoord := librtt.GenerateCoordinate(1 * time.Millisecond)
 	serviceNodes := []struct {
 		name    string
 		address string
 		coord   *coordinate.Coordinate
 	}{
-		{"foo1", "198.18.0.1", lib.GenerateCoordinate(1 * time.Millisecond)},
-		{"foo2", "198.18.0.2", lib.GenerateCoordinate(10 * time.Millisecond)},
-		{"foo3", "198.18.0.3", lib.GenerateCoordinate(30 * time.Millisecond)},
+		{"foo1", "198.18.0.1", librtt.GenerateCoordinate(1 * time.Millisecond)},
+		{"foo2", "198.18.0.2", librtt.GenerateCoordinate(10 * time.Millisecond)},
+		{"foo3", "198.18.0.3", librtt.GenerateCoordinate(30 * time.Millisecond)},
 	}
 
 	for name, experimentsHCL := range getVersionHCL(true) {

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/types"
 )
@@ -578,7 +578,7 @@ func (r *Router) GetDatacentersByDistance() ([]string, error) {
 				// It's OK to get a nil coordinate back, ComputeDistance
 				// will put the RTT at positive infinity.
 				other, _ := info.cluster.GetCachedCoordinate(parts.Name)
-				rtt := lib.ComputeDistance(coord, other)
+				rtt := librtt.ComputeDistance(coord, other)
 				index[parts.Datacenter] = append(existing, rtt)
 			}
 		}

--- a/agent/router/router_test.go
+++ b/agent/router/router_test.go
@@ -12,15 +12,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/hashicorp/serf/serf"
 
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/types"
-
-	"github.com/stretchr/testify/require"
 )
 
 type mockCluster struct {
@@ -109,12 +109,12 @@ func (m *mockCluster) AddLANMember(dc, name, role string, coord *coordinate.Coor
 // mysterious dcX with no nodes with known coordinates.
 func testCluster(self string) *mockCluster {
 	c := newMockCluster(self)
-	c.AddMember("dc0", "node0", lib.GenerateCoordinate(10*time.Millisecond))
-	c.AddMember("dc1", "node1", lib.GenerateCoordinate(3*time.Millisecond))
-	c.AddMember("dc1", "node2", lib.GenerateCoordinate(2*time.Millisecond))
-	c.AddMember("dc1", "node3", lib.GenerateCoordinate(5*time.Millisecond))
+	c.AddMember("dc0", "node0", librtt.GenerateCoordinate(10*time.Millisecond))
+	c.AddMember("dc1", "node1", librtt.GenerateCoordinate(3*time.Millisecond))
+	c.AddMember("dc1", "node2", librtt.GenerateCoordinate(2*time.Millisecond))
+	c.AddMember("dc1", "node3", librtt.GenerateCoordinate(5*time.Millisecond))
 	c.AddMember("dc1", "node4", nil)
-	c.AddMember("dc2", "node1", lib.GenerateCoordinate(8*time.Millisecond))
+	c.AddMember("dc2", "node1", librtt.GenerateCoordinate(8*time.Millisecond))
 	c.AddMember("dcX", "node1", nil)
 	return c
 }
@@ -427,8 +427,8 @@ func TestRouter_GetDatacentersByDistance(t *testing.T) {
 	// Now add another area with a closer route for dc1.
 	otherID := types.AreaID("other")
 	other := newMockCluster(self)
-	other.AddMember("dc0", "node0", lib.GenerateCoordinate(20*time.Millisecond))
-	other.AddMember("dc1", "node1", lib.GenerateCoordinate(21*time.Millisecond))
+	other.AddMember("dc0", "node0", librtt.GenerateCoordinate(20*time.Millisecond))
+	other.AddMember("dc1", "node1", librtt.GenerateCoordinate(21*time.Millisecond))
 	if err := r.AddArea(otherID, other, &fauxConnPool{}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -468,7 +468,7 @@ func TestRouter_GetDatacenterMaps(t *testing.T) {
 				Coordinates: structs.Coordinates{
 					&structs.Coordinate{
 						Node:  "node0.dc0",
-						Coord: lib.GenerateCoordinate(10 * time.Millisecond),
+						Coord: librtt.GenerateCoordinate(10 * time.Millisecond),
 					},
 				},
 			}) {
@@ -481,15 +481,15 @@ func TestRouter_GetDatacenterMaps(t *testing.T) {
 				Coordinates: structs.Coordinates{
 					&structs.Coordinate{
 						Node:  "node1.dc1",
-						Coord: lib.GenerateCoordinate(3 * time.Millisecond),
+						Coord: librtt.GenerateCoordinate(3 * time.Millisecond),
 					},
 					&structs.Coordinate{
 						Node:  "node2.dc1",
-						Coord: lib.GenerateCoordinate(2 * time.Millisecond),
+						Coord: librtt.GenerateCoordinate(2 * time.Millisecond),
 					},
 					&structs.Coordinate{
 						Node:  "node3.dc1",
-						Coord: lib.GenerateCoordinate(5 * time.Millisecond),
+						Coord: librtt.GenerateCoordinate(5 * time.Millisecond),
 					},
 				},
 			}) {
@@ -502,7 +502,7 @@ func TestRouter_GetDatacenterMaps(t *testing.T) {
 				Coordinates: structs.Coordinates{
 					&structs.Coordinate{
 						Node:  "node1.dc2",
-						Coord: lib.GenerateCoordinate(8 * time.Millisecond),
+						Coord: librtt.GenerateCoordinate(8 * time.Millisecond),
 					},
 				},
 			}) {
@@ -518,9 +518,9 @@ func TestRouter_FindLANServer(t *testing.T) {
 	r := testRouter(t, "dc0")
 
 	lan := newMockCluster("node4.dc0")
-	lan.AddLANMember("dc0", "node0", "consul", lib.GenerateCoordinate(10*time.Millisecond))
-	lan.AddLANMember("dc0", "node1", "", lib.GenerateCoordinate(20*time.Millisecond))
-	lan.AddLANMember("dc0", "node2", "", lib.GenerateCoordinate(21*time.Millisecond))
+	lan.AddLANMember("dc0", "node0", "consul", librtt.GenerateCoordinate(10*time.Millisecond))
+	lan.AddLANMember("dc0", "node1", "", librtt.GenerateCoordinate(20*time.Millisecond))
+	lan.AddLANMember("dc0", "node2", "", librtt.GenerateCoordinate(21*time.Millisecond))
 
 	require.NoError(t, r.AddArea(types.AreaLAN, lan, &fauxConnPool{}))
 

--- a/command/rtt/rtt.go
+++ b/command/rtt/rtt.go
@@ -8,11 +8,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/serf/coordinate"
 	"github.com/mitchellh/cli"
 
+	"github.com/hashicorp/serf/coordinate"
+
 	"github.com/hashicorp/consul/command/flags"
-	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/internal/gossip/librtt"
 )
 
 // TODO(partitions): how will this command work when asking for RTT between a
@@ -146,7 +147,7 @@ func (c *cmd) Run(args []string) int {
 		}
 
 		// Index all the coordinates by segment.
-		cs1, cs2 := make(lib.CoordinateSet), make(lib.CoordinateSet)
+		cs1, cs2 := make(librtt.CoordinateSet), make(librtt.CoordinateSet)
 		for _, entry := range entries {
 			if strings.EqualFold(entry.Node, nodes[0]) {
 				cs1[entry.Segment] = entry.Coord

--- a/internal/gossip/librtt/rtt.go
+++ b/internal/gossip/librtt/rtt.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package lib
+package librtt
 
 import (
 	"math"

--- a/internal/gossip/librtt/rtt_test.go
+++ b/internal/gossip/librtt/rtt_test.go
@@ -1,15 +1,16 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package lib
+package librtt
 
 import (
 	"math"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/serf/coordinate"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/serf/coordinate"
 )
 
 func TestRTT_ComputeDistance(t *testing.T) {

--- a/internal/gossip/libserf/serf.go
+++ b/internal/gossip/libserf/serf.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package serf
+package libserf
 
 import (
 	"time"


### PR DESCRIPTION
### Description

This refactors and relocates the following packages to live under `internal/gossip` instead of either in the toplevel `lib` or `agent/consul`:

- `librtt` : related to serf coordinates
- `libserf` : random serf stuff 