### PR TITLE
deployer: ensure the proxy/dns/pause containers do not continually get replaced due to a change in a docker default

### DIFF
--- a/testing/deployer/sprawl/internal/tfgen/templates/container-coredns.tf.tmpl
+++ b/testing/deployer/sprawl/internal/tfgen/templates/container-coredns.tf.tmpl
@@ -4,6 +4,7 @@ resource "docker_container" "{{.DockerNetworkName}}-coredns" {
   restart  = "always"
   dns      = ["8.8.8.8"]
 
+  network_mode = "bridge"
   networks_advanced {
     name         = docker_network.{{.DockerNetworkName}}.name
     ipv4_address = "{{.IPAddress}}"

--- a/testing/deployer/sprawl/internal/tfgen/templates/container-pause.tf.tmpl
+++ b/testing/deployer/sprawl/internal/tfgen/templates/container-pause.tf.tmpl
@@ -23,6 +23,7 @@ ports {
 }
 {{- end }}
 
+network_mode = "bridge"
 {{- range .Node.Addresses }}
 networks_advanced {
   name         = docker_network.{{.DockerNetworkName}}.name

--- a/testing/deployer/sprawl/internal/tfgen/templates/container-proxy.tf.tmpl
+++ b/testing/deployer/sprawl/internal/tfgen/templates/container-proxy.tf.tmpl
@@ -8,6 +8,7 @@ resource "docker_container" "{{.DockerNetworkName}}-forwardproxy" {
     internal = {{.InternalPort}}
   }
 
+  network_mode = "bridge"
   networks_advanced {
     name         = docker_network.{{.DockerNetworkName}}.name
     ipv4_address = "{{.IPAddress}}"


### PR DESCRIPTION
### Description

There must have been a change to the Docker API that caused the behavior of the `NetworkMode` field to default differently. Each terraform run would detect that this field differed and it needed to do a full destroy and recreate to update it, but it wouldn't "stick".

The forwardproxy and pause containers CANNOT churn like this. They are expected to launch once for the life of the test environment. Destroying and recreating them was causing the exposed ports to change, and then the test runner was trying to use ports that were closed forever.

Example:
```

2024-05-03T14:52:41.184-0500 [DEBUG] Test_Ratelimit.tfgen.terraform:
  # docker_container.cslc-dc1-41a09620a19d81b9-forwardproxy must be replaced
-/+ resource "docker_container" "cslc-dc1-41a09620a19d81b9-forwardproxy" {
      + bridge                                      = (known after apply)
      ~ command                                     = [
          - "nginx",
          - "-g",
          - "daemon off;",
        ] -> (known after apply)
      + container_logs                              = (known after apply)
      - cpu_shares                                  = 0 -> null
      - dns_opts                                    = [] -> null
      - dns_search                                  = [] -> null
      ~ entrypoint                                  = [
          - "/docker-entrypoint.sh",
        ] -> (known after apply)
      + exit_code                                   = (known after apply)
      - group_add                                   = [] -> null
      ~ hostname                                    = "a2d398332a56" -> (known after apply)
      ~ id                                          = "a2d398332a56c87b9ad05e58f0644bd7bb27577ce80ff5f39887b08668f92831" -> (known after apply)
      ~ init                                        = false -> (known after apply)
      ~ ipc_mode                                    = "private" -> (known after apply)
      ~ log_driver                                  = "json-file" -> (known after apply)
      - log_opts                                    = {} -> null
      - max_retry_count                             = 0 -> null
      - memory                                      = 0 -> null
      - memory_swap                                 = 0 -> null
        name                                        = "cslc-dc1-41a09620a19d81b9-forwardproxy"
      ~ network_data                                = [
          - {
              - gateway                   = "10.72.174.1"
              - global_ipv6_prefix_length = 0
              - ip_address                = "10.72.174.252"
              - ip_prefix_length          = 24
              - mac_address               = "02:42:0a:48:ae:fc"
              - network_name              = "cslc-dc1-41a09620a19d81b9"
                # (2 unchanged attributes hidden)
            },
        ] -> (known after apply)
      - network_mode                                = "bridge" -> null # forces replacement
      - privileged                                  = false -> null
      - publish_all_ports                           = false -> null
      ~ runtime                                     = "runc" -> (known after apply)
      ~ security_opts                               = [] -> (known after apply)
      ~ shm_size                                    = 64 -> (known after apply)
      ~ stop_signal                                 = "SIGQUIT" -> (known after apply)
      ~ stop_timeout                                = 0 -> (known after apply)
      - storage_opts                                = {} -> null
      - tmpfs                                       = {} -> null
        # (23 unchanged attributes hidden)

      ~ ports {
          ~ external = 33257 -> (known after apply)
            # (3 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }
    ```
    
    