### PR TITLE
ci: skip `LICENSE.txt` copy for Ent releases

### DIFF
--- a/.github/scripts/copy-legal.sh
+++ b/.github/scripts/copy-legal.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -euo pipefail
+
+repository_name=${1}
+target_dirs="${@:2}"
+
+if [ -z "$repository_name" ] || [ -z "$target_dirs" ]; then
+    echo "Error: repository_name and at least one value for target_dirs must be non-empty strings."
+    exit 1
+fi
+
+function copy_file {
+  for dir in $target_dirs; do
+      mkdir -p $dir
+      target_path="$dir/${2}"
+      echo "-> Copying $1 to $target_path"
+      cp "${1}" $target_path
+  done
+}
+
+if [[ $repository_name == *"-enterprise" ]]; then
+    echo "Copying legal (Ent)"
+    echo "Downloading EULA.txt and TermsOfEvaluation.txt"
+    curl -so /tmp/EULA.txt https://eula.hashicorp.com/EULA.txt
+    curl -so /tmp/TermsOfEvaluation.txt https://eula.hashicorp.com/TermsOfEvaluation.txt
+    copy_file /tmp/EULA.txt EULA.txt
+    copy_file /tmp/TermsOfEvaluation.txt TermsOfEvaluation.txt
+else
+    echo "Copying legal (CE)"
+    copy_file LICENSE LICENSE.txt
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       # Push events on the main branch
       - main
       - release/**
+  workflow_dispatch:
 
 env:
   PKG_NAME: consul
@@ -141,15 +142,10 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |-
-            cp LICENSE $TARGET_DIR/LICENSE.txt
-            go build -ldflags="$GOLDFLAGS" -o "$BIN_PATH" -trimpath -buildvcs=false
-
-      - name: Copy license file
-        env:
-          LICENSE_DIR: ".release/linux/package/usr/share/doc/${{ env.PKG_NAME }}"
-        run: |
-          mkdir -p "$LICENSE_DIR"
-          cp LICENSE "$LICENSE_DIR/LICENSE.txt"
+            # Note that for non-linux builds, .release/linux/package... is a no-op, 
+            # but files will always included in the zip root directory (TARGET_DIR) on all platforms.
+            ./.github/scripts/copy-legal.sh "${{ github.repository }}" "$TARGET_DIR" ".release/linux/package/usr/share/doc/${{ env.PKG_NAME }}"
+            ${{ matrix.env }} go build -ldflags="$GOLDFLAGS" -tags="${{ matrix.gotags }}" -o "$BIN_PATH" -trimpath -buildvcs=false
 
       - name: Package
         if: ${{ matrix.goos == 'linux' }}
@@ -240,8 +236,10 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |-
-            cp LICENSE $TARGET_DIR/LICENSE.txt
-            go build -ldflags="$GOLDFLAGS" -o "$BIN_PATH" -trimpath -buildvcs=false
+            # Note that for non-linux builds, .release/linux/package... is a no-op, 
+            # but files will always included in the zip root directory (TARGET_DIR) on all platforms.
+            ./.github/scripts/copy-legal.sh "${{ github.repository }}" "$TARGET_DIR" ".release/linux/package/usr/share/doc/${{ env.PKG_NAME }}"
+            go build -ldflags="$GOLDFLAGS" -tags="${{ matrix.gotags }}" -o "$BIN_PATH" -trimpath -buildvcs=false
 
   build-darwin:
     needs:
@@ -291,8 +289,10 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |-
-            cp LICENSE $TARGET_DIR/LICENSE.txt
-            go build -ldflags="$GOLDFLAGS" -tags netcgo -o "$BIN_PATH" -trimpath -buildvcs=false
+            # Note that for non-linux builds, .release/linux/package... is a no-op, 
+            # but files will always included in the zip root directory (TARGET_DIR) on all platforms.
+            ./.github/scripts/copy-legal.sh "${{ github.repository }}" "$TARGET_DIR" ".release/linux/package/usr/share/doc/${{ env.PKG_NAME }}"
+            go build -ldflags="$GOLDFLAGS" -tags="${{ matrix.gotags }}" -o "$BIN_PATH" -trimpath -buildvcs=false
 
   build-docker:
     name: Docker ${{ matrix.arch }} build


### PR DESCRIPTION
Follow-up to https://github.com/hashicorp/consul/pull/21035 to avoid unintentional side-effects when run outside of CE repo.

* Ensure we do not unintentionally copy CE `LICENSE.txt` to Ent release artifacts.
* Rework Go Build jobs to avoid future sync conflicts by handling CE and Ent builds simultaneously.

Tested here: https://github.com/hashicorp/consul/actions/runs/8974943569