### PR TITLE
Backport assistant onboarding with LTS support #9224

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -19,7 +19,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.8
+    container: hashicorpdev/backport-assistant:0.4.0
     steps:
       - name: Run Backport Assistant for release branches
         run: |
@@ -46,12 +46,12 @@ jobs:
   backport-ent:
     if: github.event.pull_request.merged && contains(join(github.event.pull_request.labels.*.name), 'backport/ent')
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.8
+    container: hashicorpdev/backport-assistant:0.4.0
     steps:
       - name: Trigger backport for Enterprise
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-          repository: <putconsulentrepohere>
+          repository: hashicorp/consul-enterprise
           event-type: ent-backport
           client-payload: ${{ toJson(github.event) }}

--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -45,7 +45,7 @@ jobs:
     needs:
       - backport
       - backport-ent
-    if: always() && needs.backport.result == 'failure'
+    if: always() && (needs.backport.result == 'failure' || needs.backport-ent.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Comment on PR

--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -19,7 +19,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.4
+    container: hashicorpdev/backport-assistant:0.3.8
     steps:
       - name: Run Backport Assistant for release branches
         run: |
@@ -28,6 +28,8 @@ jobs:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          ENABLE_VERSION_MANIFESTS: true
+
   handle-failure:
     needs:
       - backport
@@ -41,3 +43,15 @@ jobs:
             -X POST \
             -d "{ \"body\": \"${github_message}\"}" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments"
+  backport-ent:
+    if: github.event.pull_request.merged && contains(join(github.event.pull_request.labels.*.name), 'backport/ent')
+    runs-on: ubuntu-latest
+    container: hashicorpdev/backport-assistant:0.3.8
+    steps:
+      - name: Trigger backport for Enterprise
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          repository: <putconsulentrepohere>
+          event-type: ent-backport
+          client-payload: ${{ toJson(github.event) }}

--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -49,7 +49,7 @@ jobs:
     container: hashicorpdev/backport-assistant:0.3.8
     steps:
       - name: Trigger backport for Enterprise
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           repository: <putconsulentrepohere>

--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -29,7 +29,6 @@ jobs:
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           ENABLE_VERSION_MANIFESTS: true
-
   handle-failure:
     needs:
       - backport

--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -29,19 +29,6 @@ jobs:
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           ENABLE_VERSION_MANIFESTS: true
-  handle-failure:
-    needs:
-      - backport
-    if: always() && needs.backport.result == 'failure'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Comment on PR
-        run: |
-          github_message="Backport failed @${{ github.event.sender.login }}. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          curl -s -H "Authorization: token ${{ secrets.PR_COMMENT_TOKEN }}" \
-            -X POST \
-            -d "{ \"body\": \"${github_message}\"}" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments"
   backport-ent:
     if: github.event.pull_request.merged && contains(join(github.event.pull_request.labels.*.name), 'backport/ent')
     runs-on: ubuntu-latest
@@ -54,3 +41,18 @@ jobs:
           repository: hashicorp/consul-enterprise
           event-type: ent-backport
           client-payload: ${{ toJson(github.event) }}
+  handle-failure:
+    needs:
+      - backport
+      - backport-ent
+    if: always() && needs.backport.result == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on PR
+        run: |
+          github_message="Backport failed @${{ github.event.sender.login }}. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -s -H "Authorization: token ${{ secrets.PR_COMMENT_TOKEN }}" \
+            -X POST \
+            -d "{ \"body\": \"${github_message}\"}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments"
+

--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -1,3 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# This file is solely for CE repos and exists in ENT repos to prevent merge conflicts
+
 schema = 1
 active_versions {
   version "1.18" {

--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -1,0 +1,12 @@
+schema = 1
+active_versions {
+  version "1.18.x" {
+    ce_active = true
+    lts       = true
+  }
+  version "1.17.x" {}
+  version "1.16.x" {}
+  version "1.15.x" {
+    lts = true
+  }
+}

--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-# This file is solely for CE repos and exists in ENT repos to prevent merge conflicts
+# This manifest file describes active releases and is consumed by the backport tooling.
 
 schema = 1
 active_versions {

--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -1,12 +1,12 @@
 schema = 1
 active_versions {
-  version "1.18.x" {
+  version "1.18" {
     ce_active = true
     lts       = true
   }
-  version "1.17.x" {}
-  version "1.16.x" {}
-  version "1.15.x" {
+  version "1.17" {}
+  version "1.16" {}
+  version "1.15" {
     lts = true
   }
 }


### PR DESCRIPTION
### Description

Configuration changes to use backport assistant with LTS support. These include:
- adding a manifest file for active releases 
- adding configuration to send backport to ENT repo

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
