### PR TITLE
[NET-9141] ci: skip LICENSE copy for Ent linux packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
             go build -ldflags="$GOLDFLAGS" -o "$BIN_PATH" -trimpath -buildvcs=false
 
       - name: Copy license file
+        if: ${{ !endsWith(github.repository, '-enterprise') }}
         env:
           LICENSE_DIR: ".release/linux/package/usr/share/doc/${{ env.PKG_NAME }}"
         run: |


### PR DESCRIPTION
Follow-up to https://github.com/hashicorp/consul/pull/21035 to skip copying license file for linux packages.

Exclusion of copy actions in uses of `hashicorp/actions-go-build` are already handled separately in Ent.