### PR TITLE
Doc Update: MaxTTL no longer capped at 24h

### DIFF
--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -64,8 +64,7 @@ The corresponding CLI command is [`consul acl auth-method create`](/consul/comma
   [`ExpirationTime`](/consul/api-docs/acl/tokens#expirationtime) field on all tokens
   to a value of `Token.CreateTime + AuthMethod.MaxTokenTTL`. This field is not
   persisted beyond its initial use. Can be specified in the form of `"60s"` or
-  `"5m"` (i.e., 60 seconds or 5 minutes, respectively). This value must be no
-  smaller than 1 minute and no longer than 24 hours. Added in Consul 1.8.0.
+  `"5m"` (i.e., 60 seconds or 5 minutes, respectively). Added in Consul 1.8.0.
 
   This must be set to a nonzero value for `type=oidc`.
 


### PR DESCRIPTION
### Description

This was uncapped in https://github.com/hashicorp/consul/commit/eded58b62a236d58dd739fc3a507f5c56583f7fa

### Testing & Reproduction steps

n/a

### Links

https://developer.hashicorp.com/consul/api-docs/acl/auth-methods#maxtokenttl

I don't know how the version drop down works; maybe there's a better way to do this that applies to 1.16+ docs

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
