### PR TITLE
doc: add clarifying note to versions.hcl

### DIFF
--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 # This manifest file describes active releases and is consumed by the backport tooling.
+# It is only consumed from the default branch, so backporting changes to this file is not necessary.
 
 schema = 1
 active_versions {


### PR DESCRIPTION
Make it obvious that this file is only consumed from the default branch.

I only thought to add this just after the first PR was merged.