### PR TITLE
Update create-a-replication-token.mdx

### DIFF
--- a/website/content/docs/security/acl/tokens/create/create-a-replication-token.mdx
+++ b/website/content/docs/security/acl/tokens/create/create-a-replication-token.mdx
@@ -304,9 +304,9 @@ acl = {
 
 ### Apply the token with a command
 
-Set the `replication` token using the [`consul set-agent-token`](/consul/commands/acl/set-agent-token) command. The following command configures a running Consul agent token with the specified token.
+Set the `replication` token using the [`consul acl set-agent-token`](/consul/commands/acl/set-agent-token) command. The following command configures a running Consul agent token with the specified token.
 
 ```shell-session
-$ consul set-agent-token replication <acl-token-secret-id>
+$ consul acl set-agent-token replication <acl-token-secret-id>
 ```
 


### PR DESCRIPTION
While testing the changes in my labs, found out one wrong command. Instead of "consul set-agent-token" it will be "consul acl set-agent-token".

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
