### PR TITLE
ci: test BPA 0.4.1 with no-op doc change

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -86,3 +86,4 @@ in the editor) to maintain a consistent Consul style for the diagrams.
 [mermaid-js live editor]: https://mermaid-js.github.io/mermaid-live-editor/edit/
 [mermaid-js docs]: https://mermaid-js.github.io/mermaid/
 [consul-mermaid-theme.json]: ./consul-mermaid-theme.json
+


### PR DESCRIPTION
Add a newline to docs/README.md to test a backport without functional changes.

Uses BPA 0.4.1: https://github.com/hashicorp/consul/blob/zalimeni/test-bpa-0.4.1/.github/workflows/backport-assistant.yml#L22

### Description

This is a no-op change.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
