### PR TITLE
ci: temporarily re-enable retired CE backport labels

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -19,7 +19,10 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.4.1
+    # Temporarily use 0.4.0 to enable old + new label functionality prior
+    # to this fix in BPA that excludes CE labels: https://github.com/hashicorp/backport-assistant/pull/84
+    # After the Consul May patches, this can be removed and the version updated to latest.
+    container: hashicorpdev/backport-assistant:0.4.0
     steps:
       - name: Run Backport Assistant for release branches
         run: |


### PR DESCRIPTION
To ease migration during this week's patch releases, temporarily use the more permissive version of BPA to allow old + new backport labels to be used simultaneously.

Partially reverts https://github.com/hashicorp/consul/pull/21091

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
