### PR TITLE
Doc-PR-NET-4882

### DIFF
--- a/website/content/docs/k8s/upgrade/index.mdx
+++ b/website/content/docs/k8s/upgrade/index.mdx
@@ -15,6 +15,8 @@ As of Consul v1.14.0 and the corresponding Helm chart version v1.0.0, Kubernetes
 
 The v1.0.0 release of the Consul on Kubernetes Helm chart also introduced a change to the [`externalServers[].hosts` parameter](/consul/docs/k8s/helm#v-externalservers-hosts). Previously, you were able to enter a provider lookup as a string in this field. Now, you must include `exec=` at the start of a string containing a provider lookup. Otherwise, the string is treated as a DNS name. Refer to the [`go-netaddrs`](https://github.com/hashicorp/go-netaddrs) library and command line tool for more information.
 
+When upgrading to v1.0.0 or higher, in the multi datacenter use case, where the servers are running outside of Kubernetes and in the  gRPC TLS configuration ports.grpc_tls is set, then the externalServers.tlsServerName need to be set to server.<datacenter>.domain
+
 ## Upgrade types
 
 We recommend updating Consul on Kubernetes when:


### PR DESCRIPTION
### Description

Customer upgraded from 0.49 chart to 1.0.0 and also to 1.1.0. They are running consul servers on VMs outside Consul Client EKS in Secondary DC and have externalServers.tlsServerName unset(which is null by default) in regards to 0.49.5 chart. However, upon upgrade and making [changes](https://developer.hashicorp.com/consul/docs/upgrading/upgrade-specific#changes-to-grpc-tls-configuration) of ports.grpc to ports.grpc_tls, they started to see following error of TRANSIENT_FAILURE across multiple PODs

### Testing & Reproduction steps

<!--

Make changes to [gRPC TLS configuration](https://developer.hashicorp.com/consul/docs/upgrading/upgrade-specific#changes-to-grpc-tls-configuration) to replace ports.grpc with ports.grpc_tls
Perform an upgrading from helm chart 0.49.0 to 1.0.0, add following line in values.yaml
externalServers.tlsServerName = null

-->

### Links

<!--

https://hashicorp.atlassian.net/browse/NET-4882

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
