### PR TITLE
docs: Fix two small typos in "What is Consul?" introduction

### DIFF
--- a/website/content/docs/intro/index.mdx
+++ b/website/content/docs/intro/index.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # What is Consul?
 
-HashiCorp Consul is a service networking solution that enables teams to manage secure network connectivity between services and across on-prem and multi-cloud environments and runtimes. Consul offers service discovery, service mesh, traffic management, and automated updates to network infrastructure device. You can use these features individually or together in a single Consul deployment.
+HashiCorp Consul is a service networking solution that enables teams to manage secure network connectivity between services and across on-prem and multi-cloud environments and runtimes. Consul offers service discovery, service mesh, traffic management, and automated updates to network infrastructure devices. You can use these features individually or together in a single Consul deployment.
 
 > **Hands-on**: Complete the Getting Started tutorials to learn how to deploy Consul:
 - [Get Started on Kubernetes](/consul/tutorials/get-started-kubernetes)
@@ -55,7 +55,7 @@ You can also schedule Consul workloads with [HashiCorp Nomad](https://www.nomadp
 
 ### Enable zero-trust network security
 
-Microservice architectures are complex and difficult to secure against accidental discloser to malicious actors. Consul provides several mechanisms that enhance network security without any changes to your application code, including mutual transport layer security (mTLS) encryption on all traffic between services and  Consul intentions, which are service-to-service permissions that you can manage through the Consul UI, API, and CLI.
+Microservice architectures are complex and difficult to secure against accidental disclosure to malicious actors. Consul provides several mechanisms that enhance network security without any changes to your application code, including mutual transport layer security (mTLS) encryption on all traffic between services and  Consul intentions, which are service-to-service permissions that you can manage through the Consul UI, API, and CLI.
 
 When you deploy Consul to Kubernetes clusters, you can also integrate with [HashiCorp Vault](https://www.vaultproject.io/) to manage sensitive data. By default, Consul on Kubernetes leverages Kubernetes secrets as the backend system. Kubernetes secrets are base64 encoded, unencrypted, and lack lease or time-to-live properties. By leveraging Vault as a secrets backend for Consul on Kubernetes, you can manage and store Consul related secrets within a centralized Vault cluster to use across one or many Consul on Kubernetes datacenters. Refer to [Vault as the Secrets Backend](/consul/docs/k8s/deployment-configurations/vault) for additional information.
 


### PR DESCRIPTION
### Description

This PR fixes #21109. It addresses two small typos in the [What is Consul?](https://developer.hashicorp.com/consul/docs/intro) introductory documentation.

This is my first contribution to Consul, so please let me know if there's anything I need to change. Thanks!

### Testing & Reproduction steps

Not applicable

### Links

- [What is Consul?](https://developer.hashicorp.com/consul/docs/intro) documentation

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [x] appropriate backport labels added
* [X] not a security concern
