### PR TITLE
docs: FIPS certification

### DIFF
--- a/website/content/docs/enterprise/fips.mdx
+++ b/website/content/docs/enterprise/fips.mdx
@@ -131,16 +131,16 @@ On both Linux and Windows non-FIPS builds, the search output yields no results.
 In 2024, Leidos certified the integration of FIPS 140-2 cryptographic module [BoringCrypto Cert. #4407](https://csrc.nist.gov/Projects/Cryptographic-Module-Validation-Program/Certificate/4407) for the following Consul releases:
 
 - Consul Enterprise builds:
-  - [consul_1.16.0+ent.fips1402](https://releases.hashicorp.com/consul/1.16.0+ent.fips1402/)
-  - [consul_1.16.1+ent.fips1402](https://releases.hashicorp.com/consul/1.16.1+ent.fips1402/)
+  - [`consul_1.16.0+ent.fips1402`](https://releases.hashicorp.com/consul/1.16.0+ent.fips1402/)
+  - [`consul_1.16.1+ent.fips1402`](https://releases.hashicorp.com/consul/1.16.1+ent.fips1402/)
 - Consul Dataplane builds:
-  - [consul-dataplane_1.2.0+fips1402](https://releases.hashicorp.com/consul-dataplane/1.2.0+fips1402/)
-  - [consul-dataplane_1.2.1+fips1402](https://releases.hashicorp.com/consul-dataplane/1.2.1+fips1402/)
+  - [`consul-dataplane_1.2.0+fips1402`](https://releases.hashicorp.com/consul-dataplane/1.2.0+fips1402/)
+  - [`consul-dataplane_1.2.1+fips1402`](https://releases.hashicorp.com/consul-dataplane/1.2.1+fips1402/)
 - Consul K8s builds:
-  - [consul-k8s_1.2.0+fips1402](https://releases.hashicorp.com/consul-k8s/1.2.0+fips1402/)
-  - [consul-k8s_1.2.1+fips1402](https://releases.hashicorp.com/consul-k8s/1.2.1+fips1402/)
+  - [`consul-k8s_1.2.0+fips1402`](https://releases.hashicorp.com/consul-k8s/1.2.0+fips1402/)
+  - [`consul-k8s_1.2.1+fips1402`](https://releases.hashicorp.com/consul-k8s/1.2.1+fips1402/)
 - Consul K8s Control Plane builds:
-  - [consul-k8s-control-plane_1.2.0+fips1402](https://releases.hashicorp.com/consul-k8s-control-plane/1.2.0+fips1402/)
-  - [consul-k8s-control-plane_1.2.1+fips1402](https://releases.hashicorp.com/consul-k8s-control-plane/1.2.2+fips1402/)
+  - [`consul-k8s-control-plane_1.2.0+fips1402`](https://releases.hashicorp.com/consul-k8s-control-plane/1.2.0+fips1402/)
+  - [`consul-k8s-control-plane_1.2.1+fips1402`](https://releases.hashicorp.com/consul-k8s-control-plane/1.2.2+fips1402/)
 
 For more information about verified platform architectures and confirmed feature support, [review the Leidos certification letter](https://www.datocms-assets.com/2885/1715791547-boringcrypto_compliance_letter_signed.pdf).


### PR DESCRIPTION
### Description

This PR updates the FIPS 140-2 page to include a section on Leidos validation. This section includes a link to a certification letter and provides details about the supported FIPS releases.

[Deployment preview direct link](https://consul-git-docs-fips-compliance-letter-hashicorp.vercel.app/consul/docs/enterprise/fips#leidos-validation)

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
