### PR TITLE
deployer: remove catalog/mesh v2 support

### DIFF
--- a/test-integ/README.md
+++ b/test-integ/README.md
@@ -25,7 +25,7 @@ You can run the entire set of deployer integration tests using:
 
 You can also run them one by one if you like:
 
-    go test ./catalogv2 -run TestBasicL4ExplicitDestinations -v
+    go test ./connect/ -run Test_Snapshot_Restore_Agentless -v
 
 You can have the logs stream unbuffered directly to your terminal which can
 help diagnose stuck tests that would otherwise need to fully timeout before the
@@ -65,26 +65,18 @@ These are comprised of 4 main parts:
   - **Nodes**: A "box with ip address(es)". This should feel a bit like a VM or
                a Kubernetes Pod as an enclosing entity.
 
-    - **Workloads**: The list of service instances (v1) or workloads
-                     (v2) that will execute on the given node. v2 Services will
-                     be implied by similarly named workloads here unless opted
-                     out. This helps define a v1-compatible topology and
-                     repurpose it for v2 without reworking it.
+    - **Workloads**: The list of service instances that will execute on the given node.
 
-  - **Services** (v2): v2 Service definitions to define explicitly, in addition
-                       to the inferred ones.
+  - **InitialConfigEntries**: Config entries that should be created as
+                              part of the fixture and that make sense to
+                              include as part of the test definition, rather
+                              than something created during the test assertion
+                              phase.
 
-  - **InitialConfigEntries** (v1): Config entries that should be created as
-                                   part of the fixture and that make sense to
-                                   include as part of the test definition,
-                                   rather than something created during the
-                                   test assertion phase.
-
-  - **InitialResources** (v2): v2 Resources that should be created as part of
-                               the fixture and that make sense to include as
-                               part of the test definition, rather than
-                               something created during the test assertion
-                               phase.
+  - **InitialResources**: Resources that should be created as part of
+                          the fixture and that make sense to include as part of
+                          the test definition, rather than something created
+                          during the test assertion phase.
 
 - **Peerings**: The peering relationships between Clusters to establish.
 
@@ -102,15 +94,13 @@ a variety of axes:
 - agentful (clients) vs agentless (dataplane)
 - tenancies (partitions, namespaces)
 - locally or across a peering
-- catalog v1 or v2 object model
 
 Since the topology is just a declarative struct, a test author could rewrite
-any one of these attributes with a single field (such as `Node.Kind` or
-`Node.Version`) and cause the identical test to run against the other
-configuration. With the addition of a few `if enterprise {}` blocks and `for`
-loops, a test author could easily write one test of a behavior and execute it
-to cover agentless, agentful, non-default tenancy, and v1/v2 in a few extra
-lines of code.
+any one of these attributes with a single field (such as `Node.Kind`) and cause
+the identical test to run against the other configuration. With the addition of
+a few `if enterprise {}` blocks and `for` loops, a test author could easily
+write one test of a behavior and execute it to cover agentless, agentful, and
+non-default tenancy in a few extra lines of code.
 
 #### Non-optional security settings
 
@@ -197,12 +187,3 @@ and Envoy that you can create in your test:
     asserter := topoutil.NewAsserter(sp)
 
     asserter.UpstreamEndpointStatus(t, svc, clusterPrefix+".", "HEALTHY", 1)
-
-## Examples
-
-- `catalogv2`
-  - [Explicit L4 destinations](./catalogv2/explicit_destinations_test.go)
-  - [Implicit L4 destinations](./catalogv2/implicit_destinations_test.go)
-  - [Explicit L7 destinations with traffic splits](./catalogv2/explicit_destinations_l7_test.go)
-- [`peering_commontopo`](./peering_commontopo)
-  - A variety of extensive v1 Peering tests. 

--- a/test-integ/connect/snapshot_test.go
+++ b/test-integ/connect/snapshot_test.go
@@ -27,7 +27,7 @@ import (
 //  1. The test spins up a one-server cluster with static-server and static-client.
 //  2. A snapshot is taken and the cluster is restored from the snapshot
 //  3. A new static-server replaces the old one
-//  4. At the end, we assert the static-client's destination is updated with the
+//  4. At the end, we assert the static-client's upstream is updated with the
 //     new static-server
 func Test_Snapshot_Restore_Agentless(t *testing.T) {
 	t.Parallel()
@@ -89,7 +89,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 									"-http-port", "8080",
 									"-redirect-port", "-disabled",
 								},
-								Destinations: []*topology.Destination{
+								Upstreams: []*topology.Upstream{
 									{
 										ID:        staticServerSID,
 										LocalPort: 5000,
@@ -153,7 +153,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 		topology.NewNodeID("dc1-client2", "default"),
 		staticClientSID,
 	)
-	asserter.FortioFetch2HeaderEcho(t, staticClient, &topology.Destination{
+	asserter.FortioFetch2HeaderEcho(t, staticClient, &topology.Upstream{
 		ID:        staticServerSID,
 		LocalPort: 5000,
 	})
@@ -182,7 +182,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 	require.NoError(t, sp.Relaunch(cfg))
 
 	// Ensure the static-client connected to the new static-server
-	asserter.FortioFetch2HeaderEcho(t, staticClient, &topology.Destination{
+	asserter.FortioFetch2HeaderEcho(t, staticClient, &topology.Upstream{
 		ID:        staticServerSID,
 		LocalPort: 5000,
 	})

--- a/test-integ/peering_commontopo/ac1_basic_test.go
+++ b/test-integ/peering_commontopo/ac1_basic_test.go
@@ -30,8 +30,8 @@ type ac1BasicSuite struct {
 	sidClientHTTP  topology.ID
 	nodeClientHTTP topology.NodeID
 
-	upstreamHTTP *topology.Destination
-	upstreamTCP  *topology.Destination
+	upstreamHTTP *topology.Upstream
+	upstreamTCP  *topology.Upstream
 }
 
 var ac1BasicSuites []sharedTopoSuite = []sharedTopoSuite{
@@ -65,7 +65,7 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 		Name:      prefix + "server-http",
 		Partition: partition,
 	}
-	upstreamHTTP := &topology.Destination{
+	upstreamHTTP := &topology.Upstream{
 		ID: topology.ID{
 			Name:      httpServerSID.Name,
 			Partition: partition,
@@ -73,7 +73,7 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 		LocalPort: 5001,
 		Peer:      peer,
 	}
-	upstreamTCP := &topology.Destination{
+	upstreamTCP := &topology.Upstream{
 		ID: topology.ID{
 			Name:      tcpServerSID.Name,
 			Partition: partition,
@@ -93,7 +93,7 @@ func (s *ac1BasicSuite) setup(t *testing.T, ct *commonTopo) {
 				clu.Datacenter,
 				sid,
 				func(s *topology.Workload) {
-					s.Destinations = []*topology.Destination{
+					s.Upstreams = []*topology.Upstream{
 						upstreamTCP,
 						upstreamHTTP,
 					}

--- a/test-integ/peering_commontopo/ac6_failovers_test.go
+++ b/test-integ/peering_commontopo/ac6_failovers_test.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 	"github.com/hashicorp/consul/testing/deployer/sprawl"
 	"github.com/hashicorp/consul/testing/deployer/topology"
-	"github.com/stretchr/testify/require"
 )
 
 type ac6FailoversSuite struct {
@@ -347,8 +348,8 @@ func (s *ac6FailoversSuite) setup(t *testing.T, ct *commonTopo) {
 		nearClu.Datacenter,
 		clientSID,
 		func(s *topology.Workload) {
-			// Destination per partition
-			s.Destinations = []*topology.Destination{
+			// Upstream per partition
+			s.Upstreams = []*topology.Upstream{
 				{
 					ID: topology.ID{
 						Name:      nearServerSID.Name,
@@ -437,8 +438,8 @@ func (s *ac6FailoversSuite) test(t *testing.T, ct *commonTopo) {
 	require.Len(t, svcs, 1, "expected exactly one client in datacenter")
 
 	client := svcs[0]
-	require.Len(t, client.Destinations, 1, "expected one upstream for client")
-	upstream := client.Destinations[0]
+	require.Len(t, client.Upstreams, 1, "expected one upstream for client")
+	upstream := client.Upstreams[0]
 
 	fmt.Println("### preconditions")
 

--- a/test-integ/peering_commontopo/ac7_1_rotate_gw_test.go
+++ b/test-integ/peering_commontopo/ac7_1_rotate_gw_test.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testing/deployer/topology"
-	"github.com/stretchr/testify/require"
 )
 
 // TestRotateGW ensures that peered services continue to be able to talk to their
@@ -27,7 +28,7 @@ type suiteRotateGW struct {
 	sidClient  topology.ID
 	nodeClient topology.NodeID
 
-	upstream *topology.Destination
+	upstream *topology.Upstream
 
 	newMGWNodeName string
 }
@@ -70,7 +71,7 @@ func (s *suiteRotateGW) setup(t *testing.T, ct *commonTopo) {
 	)
 
 	// Make clients which have server upstreams
-	upstream := &topology.Destination{
+	upstream := &topology.Upstream{
 		ID: topology.ID{
 			Name:      server.ID.Name,
 			Partition: partition,
@@ -88,7 +89,7 @@ func (s *suiteRotateGW) setup(t *testing.T, ct *commonTopo) {
 			Partition: partition,
 		},
 		func(s *topology.Workload) {
-			s.Destinations = []*topology.Destination{
+			s.Upstreams = []*topology.Upstream{
 				upstream,
 			}
 		},

--- a/test-integ/peering_commontopo/ac7_2_rotate_leader_test.go
+++ b/test-integ/peering_commontopo/ac7_2_rotate_leader_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mitchellh/copystructure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 	"github.com/hashicorp/consul/testing/deployer/topology"
-	"github.com/mitchellh/copystructure"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestAC7_2RotateLeader ensures that after a leader rotation, information continues to replicate to peers
@@ -29,7 +30,7 @@ type ac7_2RotateLeaderSuite struct {
 	sidClient  topology.ID
 	nodeClient topology.NodeID
 
-	upstream *topology.Destination
+	upstream *topology.Upstream
 }
 
 func TestAC7_2RotateLeader(t *testing.T) {
@@ -71,7 +72,7 @@ func (s *ac7_2RotateLeaderSuite) setup(t *testing.T, ct *commonTopo) {
 	)
 
 	// Make clients which have server upstreams
-	upstream := &topology.Destination{
+	upstream := &topology.Upstream{
 		ID: topology.ID{
 			Name:      server.ID.Name,
 			Partition: partition,
@@ -87,7 +88,7 @@ func (s *ac7_2RotateLeaderSuite) setup(t *testing.T, ct *commonTopo) {
 			Partition: partition,
 		},
 		func(s *topology.Workload) {
-			s.Destinations = []*topology.Destination{
+			s.Upstreams = []*topology.Upstream{
 				upstream,
 			}
 		},

--- a/test-integ/peering_commontopo/commontopo.go
+++ b/test-integ/peering_commontopo/commontopo.go
@@ -9,16 +9,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/test-integ/topoutil"
 	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
 	"github.com/hashicorp/consul/testing/deployer/sprawl"
 	"github.com/hashicorp/consul/testing/deployer/sprawl/sprawltest"
 	"github.com/hashicorp/consul/testing/deployer/topology"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/hashicorp/consul/test-integ/topoutil"
 )
 
 // commonTopo helps create a shareable topology configured to represent
@@ -509,7 +509,7 @@ func NewFortioServiceWithDefaults(
 	sid topology.ID,
 	mut func(s *topology.Workload),
 ) *topology.Workload {
-	return topoutil.NewFortioServiceWithDefaults(cluster, sid, topology.NodeVersionV1, mut)
+	return topoutil.NewFortioServiceWithDefaults(cluster, sid, mut)
 }
 
 func newTopologyMeshGatewaySet(

--- a/test-integ/topoutil/asserter.go
+++ b/test-integ/topoutil/asserter.go
@@ -6,16 +6,6 @@ package topoutil
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/proto-public/pbresource"
-	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
-	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
-	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
-	"github.com/hashicorp/consul/testing/deployer/topology"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"net/url"
@@ -24,6 +14,18 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	libassert "github.com/hashicorp/consul/test/integration/consul-container/libs/assert"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+	"github.com/hashicorp/consul/testing/deployer/topology"
 )
 
 // Asserter is a utility to help in reducing boilerplate in invoking test
@@ -33,7 +35,7 @@ import (
 // ip/ports if there is only one port that makes sense for the assertion (such
 // as use of the envoy admin port 19000).
 //
-// If it's up to the test (like picking a destination) leave port as an argument
+// If it's up to the test (like picking an upstream) leave port as an argument
 // but still take the service and use that to grab the local ip from the
 // topology.Node.
 type Asserter struct {
@@ -82,12 +84,12 @@ func (a *Asserter) httpClientFor(cluster string) (*http.Client, error) {
 	return client, nil
 }
 
-// DestinationEndpointStatus validates that proxy was configured with provided clusterName in the healthStatus
+// UpstreamEndpointStatus validates that proxy was configured with provided clusterName in the healthStatus
 //
 // Exposes libassert.UpstreamEndpointStatus for use against a Sprawl.
 //
 // NOTE: this doesn't take a port b/c you always want to use the envoy admin port.
-func (a *Asserter) DestinationEndpointStatus(
+func (a *Asserter) UpstreamEndpointStatus(
 	t *testing.T,
 	workload *topology.Workload,
 	clusterName string,
@@ -169,7 +171,7 @@ func (a *Asserter) AssertEnvoyHTTPrbacFiltersContainIntentions(t *testing.T, wor
 //
 // Exposes libassert.HTTPServiceEchoes for use against a Sprawl.
 //
-// NOTE: this takes a port b/c you may want to reach this via your choice of destination.
+// NOTE: this takes a port b/c you may want to reach this via your choice of upstream.
 func (a *Asserter) HTTPServiceEchoes(
 	t *testing.T,
 	workload *topology.Workload,
@@ -193,7 +195,7 @@ func (a *Asserter) HTTPServiceEchoes(
 //
 // Exposes libassert.HTTPServiceEchoes for use against a Sprawl.
 //
-// NOTE: this takes a port b/c you may want to reach this via your choice of destination.
+// NOTE: this takes a port b/c you may want to reach this via your choice of upstream.
 func (a *Asserter) HTTPServiceEchoesResHeader(
 	t *testing.T,
 	workload *topology.Workload,
@@ -266,27 +268,27 @@ type testingT interface {
 	Helper()
 }
 
-// does a fortio /fetch2 to the given fortio service, targetting the given destination. Returns
+// does a fortio /fetch2 to the given fortio service, targetting the given upstream. Returns
 // the body, and response with response.Body already Closed.
 //
 // We treat 400, 503, and 504s as retryable errors
-func (a *Asserter) fortioFetch2Destination(
+func (a *Asserter) fortioFetch2Upstream(
 	t testutil.TestingTB,
 	client *http.Client,
 	addr string,
-	dest *topology.Destination,
+	us *topology.Upstream,
 	path string,
 ) (body []byte, res *http.Response) {
 	t.Helper()
 
-	err, res := getFortioFetch2DestinationResponse(t, client, addr, dest, path, nil)
+	err, res := getFortioFetch2UpstreamResponse(t, client, addr, us, path, nil)
 	require.NoError(t, err)
 	defer res.Body.Close()
 
 	// not sure when these happen, suspect it's when the mesh gateway in the peer is not yet ready
 	require.NotEqual(t, http.StatusServiceUnavailable, res.StatusCode)
 	require.NotEqual(t, http.StatusGatewayTimeout, res.StatusCode)
-	// not sure when this happens, suspect it's when envoy hasn't configured the local destination yet
+	// not sure when this happens, suspect it's when envoy hasn't configured the local upstream yet
 	require.NotEqual(t, http.StatusBadRequest, res.StatusCode)
 	body, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
@@ -294,19 +296,8 @@ func (a *Asserter) fortioFetch2Destination(
 	return body, res
 }
 
-func getFortioFetch2DestinationResponse(t testutil.TestingTB, client *http.Client, addr string, dest *topology.Destination, path string, headers map[string]string) (error, *http.Response) {
-	var actualURL string
-	if dest.Implied {
-		actualURL = fmt.Sprintf("http://%s--%s--%s.virtual.consul:%d/%s",
-			dest.ID.Name,
-			dest.ID.Namespace,
-			dest.ID.Partition,
-			dest.VirtualPort,
-			path,
-		)
-	} else {
-		actualURL = fmt.Sprintf("http://localhost:%d/%s", dest.LocalPort, path)
-	}
+func getFortioFetch2UpstreamResponse(t testutil.TestingTB, client *http.Client, addr string, us *topology.Upstream, path string, headers map[string]string) (error, *http.Response) {
+	actualURL := fmt.Sprintf("http://localhost:%d/%s", us.LocalPort, path)
 
 	url := fmt.Sprintf("http://%s/fortio/fetch2?url=%s", addr,
 		url.QueryEscape(actualURL),
@@ -324,20 +315,20 @@ func getFortioFetch2DestinationResponse(t testutil.TestingTB, client *http.Clien
 }
 
 // uses the /fortio/fetch2 endpoint to do a header echo check against an
-// destination fortio
-func (a *Asserter) FortioFetch2HeaderEcho(t *testing.T, fortioWrk *topology.Workload, dest *topology.Destination) {
+// upstream fortio
+func (a *Asserter) FortioFetch2HeaderEcho(t *testing.T, fortioWrk *topology.Workload, us *topology.Upstream) {
 	const kPassphrase = "x-passphrase"
 	const passphrase = "hello"
 	path := (fmt.Sprintf("/?header=%s:%s", kPassphrase, passphrase))
 
 	var (
 		node   = fortioWrk.Node
-		addr   = fmt.Sprintf("%s:%d", node.LocalAddress(), fortioWrk.PortOrDefault(dest.PortName))
+		addr   = fmt.Sprintf("%s:%d", node.LocalAddress(), fortioWrk.Port)
 		client = a.mustGetHTTPClient(t, node.Cluster)
 	)
 
 	retry.RunWith(&retry.Timer{Timeout: 60 * time.Second, Wait: time.Millisecond * 500}, t, func(r *retry.R) {
-		_, res := a.fortioFetch2Destination(r, client, addr, dest, path)
+		_, res := a.fortioFetch2Upstream(r, client, addr, us, path)
 		require.Equal(r, http.StatusOK, res.StatusCode)
 		v := res.Header.Get(kPassphrase)
 		require.Equal(r, passphrase, v)
@@ -345,12 +336,12 @@ func (a *Asserter) FortioFetch2HeaderEcho(t *testing.T, fortioWrk *topology.Work
 }
 
 // similar to libassert.AssertFortioName,
-// uses the /fortio/fetch2 endpoint to hit the debug endpoint on the destination,
+// uses the /fortio/fetch2 endpoint to hit the debug endpoint on the upstream,
 // and assert that the FORTIO_NAME == name
 func (a *Asserter) FortioFetch2FortioName(
 	t *testing.T,
 	fortioWrk *topology.Workload,
-	dest *topology.Destination,
+	us *topology.Upstream,
 	clusterName string,
 	sid topology.ID,
 ) {
@@ -358,7 +349,7 @@ func (a *Asserter) FortioFetch2FortioName(
 
 	var (
 		node   = fortioWrk.Node
-		addr   = fmt.Sprintf("%s:%d", node.LocalAddress(), fortioWrk.PortOrDefault(dest.PortName))
+		addr   = fmt.Sprintf("%s:%d", node.LocalAddress(), fortioWrk.Port)
 		client = a.mustGetHTTPClient(t, node.Cluster)
 	)
 
@@ -366,7 +357,7 @@ func (a *Asserter) FortioFetch2FortioName(
 	path := "/debug?env=dump"
 
 	retry.RunWith(&retry.Timer{Timeout: 60 * time.Second, Wait: time.Millisecond * 500}, t, func(r *retry.R) {
-		body, res := a.fortioFetch2Destination(r, client, addr, dest, path)
+		body, res := a.fortioFetch2Upstream(r, client, addr, us, path)
 
 		require.Equal(r, http.StatusOK, res.StatusCode)
 
@@ -378,24 +369,24 @@ func (a *Asserter) FortioFetch2FortioName(
 	})
 }
 
-func (a *Asserter) FortioFetch2ServiceUnavailable(t *testing.T, fortioWrk *topology.Workload, dest *topology.Destination) {
+func (a *Asserter) FortioFetch2ServiceUnavailable(t *testing.T, fortioWrk *topology.Workload, us *topology.Upstream) {
 	const kPassphrase = "x-passphrase"
 	const passphrase = "hello"
 	path := (fmt.Sprintf("/?header=%s:%s", kPassphrase, passphrase))
-	a.FortioFetch2ServiceStatusCodes(t, fortioWrk, dest, path, nil, []int{http.StatusServiceUnavailable})
+	a.FortioFetch2ServiceStatusCodes(t, fortioWrk, us, path, nil, []int{http.StatusServiceUnavailable})
 }
 
-// FortioFetch2ServiceStatusCodes uses the /fortio/fetch2 endpoint to do a header echo check against a destination
+// FortioFetch2ServiceStatusCodes uses the /fortio/fetch2 endpoint to do a header echo check against a upstream
 // fortio and asserts that the returned status code matches the desired one(s)
-func (a *Asserter) FortioFetch2ServiceStatusCodes(t *testing.T, fortioWrk *topology.Workload, dest *topology.Destination, path string, headers map[string]string, statuses []int) {
+func (a *Asserter) FortioFetch2ServiceStatusCodes(t *testing.T, fortioWrk *topology.Workload, us *topology.Upstream, path string, headers map[string]string, statuses []int) {
 	var (
 		node   = fortioWrk.Node
-		addr   = fmt.Sprintf("%s:%d", node.LocalAddress(), fortioWrk.PortOrDefault(dest.PortName))
+		addr   = fmt.Sprintf("%s:%d", node.LocalAddress(), fortioWrk.Port)
 		client = a.mustGetHTTPClient(t, node.Cluster)
 	)
 
 	retry.RunWith(&retry.Timer{Timeout: 60 * time.Second, Wait: time.Millisecond * 500}, t, func(r *retry.R) {
-		_, res := getFortioFetch2DestinationResponse(r, client, addr, dest, path, headers)
+		_, res := getFortioFetch2UpstreamResponse(r, client, addr, us, path, headers)
 		defer res.Body.Close()
 		require.Contains(r, statuses, res.StatusCode)
 	})

--- a/test-integ/topoutil/fixtures.go
+++ b/test-integ/topoutil/fixtures.go
@@ -15,12 +15,8 @@ const HashicorpDockerProxy = "docker.mirror.hashicorp.services"
 func NewFortioWorkloadWithDefaults(
 	cluster string,
 	sid topology.ID,
-	nodeVersion topology.NodeVersion,
 	mut func(*topology.Workload),
 ) *topology.Workload {
-	if nodeVersion == topology.NodeVersionV2 {
-		panic("v2 nodes are not supported")
-	}
 	const (
 		httpPort  = 8080
 		grpcPort  = 8079
@@ -56,12 +52,8 @@ func NewFortioWorkloadWithDefaults(
 func NewBlankspaceWorkloadWithDefaults(
 	cluster string,
 	sid topology.ID,
-	nodeVersion topology.NodeVersion,
 	mut func(*topology.Workload),
 ) *topology.Workload {
-	if nodeVersion == topology.NodeVersionV2 {
-		panic("v2 nodes are not supported")
-	}
 	const (
 		httpPort  = 8080
 		grpcPort  = 8079

--- a/test-integ/topoutil/naming_shim.go
+++ b/test-integ/topoutil/naming_shim.go
@@ -4,38 +4,23 @@
 package topoutil
 
 import (
-	"testing"
-
 	"github.com/hashicorp/consul/testing/deployer/topology"
 )
-
-// Deprecated: DestinationEndpointStatus
-func (a *Asserter) UpstreamEndpointStatus(
-	t *testing.T,
-	workload *topology.Workload,
-	clusterName string,
-	healthStatus string,
-	count int,
-) {
-	a.DestinationEndpointStatus(t, workload, clusterName, healthStatus, count)
-}
 
 // Deprecated: NewFortioWorkloadWithDefaults
 func NewFortioServiceWithDefaults(
 	cluster string,
 	sid topology.ID,
-	nodeVersion topology.NodeVersion,
 	mut func(*topology.Workload),
 ) *topology.Workload {
-	return NewFortioWorkloadWithDefaults(cluster, sid, nodeVersion, mut)
+	return NewFortioWorkloadWithDefaults(cluster, sid, mut)
 }
 
 // Deprecated: NewBlankspaceWorkloadWithDefaults
 func NewBlankspaceServiceWithDefaults(
 	cluster string,
 	sid topology.ID,
-	nodeVersion topology.NodeVersion,
 	mut func(*topology.Workload),
 ) *topology.Workload {
-	return NewBlankspaceWorkloadWithDefaults(cluster, sid, nodeVersion, mut)
+	return NewBlankspaceWorkloadWithDefaults(cluster, sid, mut)
 }

--- a/test-integ/upgrade/basic/common.go
+++ b/test-integ/upgrade/basic/common.go
@@ -130,7 +130,7 @@ func newCommonTopo(t *testing.T) *commonTopo {
 									"-http-port", "8080",
 									"-redirect-port", "-disabled",
 								},
-								Upstreams: []*topology.Destination{
+								Upstreams: []*topology.Upstream{
 									{
 										ID:        staticServerSID,
 										LocalPort: 5000,
@@ -218,7 +218,7 @@ func (ct *commonTopo) PostUpgradeValidation(t *testing.T) {
 	cluster.Nodes[ct.StaticServerInstTwo].Disabled = false //  client 3 -- new static-server
 	require.NoError(t, ct.Sprawl.RelaunchWithPhase(cfg, sprawl.LaunchPhaseRegular))
 	// Ensure the static-client connected to the new static-server
-	ct.Assert.FortioFetch2HeaderEcho(t, ct.StaticClientWorkload, &topology.Destination{
+	ct.Assert.FortioFetch2HeaderEcho(t, ct.StaticClientWorkload, &topology.Upstream{
 		ID:        ct.StaticServerSID,
 		LocalPort: 5000,
 	})
@@ -244,7 +244,7 @@ func (ct *commonTopo) Launch(t *testing.T) {
 		topology.NewNodeID("dc1-client2", "default"),
 		ct.StaticClientSID,
 	)
-	ct.Assert.FortioFetch2HeaderEcho(t, staticClientWorkload, &topology.Destination{
+	ct.Assert.FortioFetch2HeaderEcho(t, staticClientWorkload, &topology.Upstream{
 		ID:        ct.StaticServerSID,
 		LocalPort: 5000,
 	})

--- a/test-integ/upgrade/l7_traffic_management/resolver_test.go
+++ b/test-integ/upgrade/l7_traffic_management/resolver_test.go
@@ -38,15 +38,15 @@ func TestTrafficManagement_ResolverDefaultSubset_Agentless(t *testing.T) {
 			topology.NewNodeID("dc1-client2", defaultPartition),
 			ct.StaticClientSID,
 		)
-		ct.Assert.FortioFetch2HeaderEcho(t, staticClientWorkload, &topology.Destination{
+		ct.Assert.FortioFetch2HeaderEcho(t, staticClientWorkload, &topology.Upstream{
 			ID:        ct.StaticServerSID,
 			LocalPort: 5000,
 		})
-		ct.Assert.FortioFetch2FortioName(t, staticClientWorkload, &topology.Destination{
+		ct.Assert.FortioFetch2FortioName(t, staticClientWorkload, &topology.Upstream{
 			ID:        ct.StaticServerSID,
 			LocalPort: 5000,
 		}, dc1, staticServerSID)
-		ct.Assert.DestinationEndpointStatus(t, staticClientWorkload, "v2.static-server.default", "HEALTHY", 1)
+		ct.Assert.UpstreamEndpointStatus(t, staticClientWorkload, "v2.static-server.default", "HEALTHY", 1)
 	}
 	resolverV2AssertFn()
 
@@ -82,7 +82,7 @@ func TestTrafficManagement_ResolverDefaultSubset_Agentless(t *testing.T) {
 			topology.NewNodeID("dc1-client2", defaultPartition),
 			ct.StaticClientSID,
 		)
-		ct.Assert.FortioFetch2ServiceUnavailable(t, staticClientWorkload, &topology.Destination{
+		ct.Assert.FortioFetch2ServiceUnavailable(t, staticClientWorkload, &topology.Upstream{
 			ID:        ct.StaticServerSID,
 			LocalPort: 5000,
 		})

--- a/testing/deployer/README.md
+++ b/testing/deployer/README.md
@@ -12,7 +12,7 @@ provider to manage a fleet of local docker containers and networks.
 
 The complete topology of Consul clusters is defined using a topology.Config
 which allows you to define a set of networks and reference those networks when
-assigning nodes and services to clusters. Both Consul clients and
+assigning nodes and workloads to clusters. Both Consul clients and
 `consul-dataplane` instances are supported.
 
 Here is an example configuration with two peered clusters:
@@ -39,9 +39,9 @@ cfg := &topology.Config{
                 {
                     Kind: topology.NodeKindClient,
                     Name: "dc1-client1",
-                    Services: []*topology.Service{
+                    Workloads: []*topology.Workload{
                         {
-                            ID:             topology.ServiceID{Name: "mesh-gateway"},
+                            ID:             topology.ID{Name: "mesh-gateway"},
                             Port:           8443,
                             EnvoyAdminPort: 19000,
                             IsMeshGateway:  true,
@@ -51,9 +51,9 @@ cfg := &topology.Config{
                 {
                     Kind: topology.NodeKindClient,
                     Name: "dc1-client2",
-                    Services: []*topology.Service{
+                    Workloads: []*topology.Workload{
                         {
-                            ID:             topology.ServiceID{Name: "ping"},
+                            ID:             topology.ID{Name: "ping"},
                             Image:          "rboyer/pingpong:latest",
                             Port:           8080,
                             EnvoyAdminPort: 19000,
@@ -65,7 +65,7 @@ cfg := &topology.Config{
                                 "-name", "ping",
                             },
                             Upstreams: []*topology.Upstream{{
-                                ID:        topology.ServiceID{Name: "pong"},
+                                ID:        topology.ID{Name: "pong"},
                                 LocalPort: 9090,
                                 Peer:      "peer-dc2-default",
                             }},
@@ -99,9 +99,9 @@ cfg := &topology.Config{
                 {
                     Kind: topology.NodeKindClient,
                     Name: "dc2-client1",
-                    Services: []*topology.Service{
+                    Workloads: []*topology.Workload{
                         {
-                            ID:             topology.ServiceID{Name: "mesh-gateway"},
+                            ID:             topology.ID{Name: "mesh-gateway"},
                             Port:           8443,
                             EnvoyAdminPort: 19000,
                             IsMeshGateway:  true,
@@ -111,9 +111,9 @@ cfg := &topology.Config{
                 {
                     Kind: topology.NodeKindDataplane,
                     Name: "dc2-client2",
-                    Services: []*topology.Service{
+                    Workloads: []*topology.Workload{
                         {
-                            ID:             topology.ServiceID{Name: "pong"},
+                            ID:             topology.ID{Name: "pong"},
                             Image:          "rboyer/pingpong:latest",
                             Port:           8080,
                             EnvoyAdminPort: 19000,
@@ -125,7 +125,7 @@ cfg := &topology.Config{
                                 "-name", "pong",
                             },
                             Upstreams: []*topology.Upstream{{
-                                ID:        topology.ServiceID{Name: "ping"},
+                                ID:        topology.ID{Name: "ping"},
                                 LocalPort: 9090,
                                 Peer:      "peer-dc1-default",
                             }},

--- a/testing/deployer/sprawl/acl_rules.go
+++ b/testing/deployer/sprawl/acl_rules.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/consul/api"
-
 	"github.com/hashicorp/consul/testing/deployer/topology"
 )
 
@@ -98,13 +97,6 @@ func tokenForWorkload(wrk *topology.Workload, overridePolicy *api.ACLPolicy, ent
 	}
 	if overridePolicy != nil {
 		token.Policies = []*api.ACLTokenPolicyLink{{ID: overridePolicy.ID}}
-	} else if wrk.IsV2() {
-		token.TemplatedPolicies = []*api.ACLTemplatedPolicy{{
-			TemplateName: api.ACLTemplatedPolicyWorkloadIdentityName,
-			TemplateVariables: &api.ACLTemplatedPolicyVariables{
-				Name: wrk.WorkloadIdentity,
-			},
-		}}
 	} else {
 		token.ServiceIdentities = []*api.ACLServiceIdentity{{
 			ServiceName: wrk.ID.Name,

--- a/testing/deployer/sprawl/details.go
+++ b/testing/deployer/sprawl/details.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	retry "github.com/avast/retry-go"
+
 	"github.com/hashicorp/consul/api"
 )
 
@@ -86,15 +87,10 @@ func (s *Sprawl) PrintDetails() error {
 						Service:               wrk.ID.String(),
 					})
 				} else {
-					ports := make(map[string]int)
-					for name, port := range wrk.Ports {
-						ports[name] = node.ExposedPort(port.Number)
-					}
 					cd.Apps = append(cd.Apps, appDetail{
 						Type:                  "app",
 						Container:             node.DockerName(),
 						ExposedPort:           node.ExposedPort(wrk.Port),
-						ExposedPorts:          ports,
 						ExposedEnvoyAdminPort: node.ExposedPort(wrk.EnvoyAdminPort),
 						Addresses:             addrs,
 						Service:               wrk.ID.String(),
@@ -142,17 +138,7 @@ func (s *Sprawl) PrintDetails() error {
 			if d.Type == "server" && d.Container == cluster.Leader {
 				d.Type = "leader"
 			}
-			var portStr string
-			if len(d.ExposedPorts) > 0 {
-				var out []string
-				for name, exposed := range d.ExposedPorts {
-					out = append(out, fmt.Sprintf("app:%s=%d", name, exposed))
-				}
-				sort.Strings(out)
-				portStr = strings.Join(out, " ")
-			} else {
-				portStr = "app=" + strconv.Itoa(d.ExposedPort)
-			}
+			portStr := "app=" + strconv.Itoa(d.ExposedPort)
 			if d.ExposedEnvoyAdminPort > 0 {
 				portStr += " envoy=" + strconv.Itoa(d.ExposedEnvoyAdminPort)
 			}
@@ -191,9 +177,8 @@ type appDetail struct {
 	Type                  string // server|mesh-gateway|app
 	Container             string
 	Addresses             []string
-	ExposedPort           int            `json:",omitempty"`
-	ExposedPorts          map[string]int `json:",omitempty"`
-	ExposedEnvoyAdminPort int            `json:",omitempty"`
+	ExposedPort           int `json:",omitempty"`
+	ExposedEnvoyAdminPort int `json:",omitempty"`
 	// just services
 	Service string `json:",omitempty"`
 }

--- a/testing/deployer/sprawl/internal/build/docker.go
+++ b/testing/deployer/sprawl/internal/build/docker.go
@@ -102,7 +102,7 @@ func DockerImages(
 	built := make(map[string]struct{})
 	for _, c := range t.Clusters {
 		for _, n := range c.Nodes {
-			needsTproxy := n.NeedsTransparentProxy()
+			const needsTproxy = false // TODO: see if we can bring this back for v1 CDP
 
 			joint := n.Images.EnvoyConsulImage()
 			if _, ok := built[joint]; joint != "" && !ok {

--- a/testing/deployer/sprawl/internal/tfgen/agent.go
+++ b/testing/deployer/sprawl/internal/tfgen/agent.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/consul/testing/deployer/topology"
 )
 
-func (g *Generator) generateAgentHCL(node *topology.Node, enableV2, enableV2Tenancy bool) string {
+func (g *Generator) generateAgentHCL(node *topology.Node) string {
 	if !node.IsAgent() {
 		panic("generateAgentHCL only applies to agents")
 	}
@@ -40,17 +40,6 @@ func (g *Generator) generateAgentHCL(node *topology.Node, enableV2, enableV2Tena
 	b.add("log_level", "trace")
 	b.add("enable_debug", true)
 	b.add("use_streaming_backend", true)
-
-	var experiments []string
-	if enableV2 {
-		experiments = append(experiments, "resource-apis")
-	}
-	if enableV2Tenancy {
-		experiments = append(experiments, "v2tenancy")
-	}
-	if len(experiments) > 0 {
-		b.addSlice("experiments", experiments)
-	}
 
 	// speed up leaves
 	b.addBlock("performance", func() {

--- a/testing/deployer/sprawl/internal/tfgen/gen.go
+++ b/testing/deployer/sprawl/internal/tfgen/gen.go
@@ -262,9 +262,6 @@ func (g *Generator) Generate(step Step) error {
 				addImage("", node.Images.Consul)
 				addImage("", node.Images.EnvoyConsulImage())
 				addImage("", node.Images.LocalDataplaneImage())
-				if node.NeedsTransparentProxy() {
-					addImage("", node.Images.LocalDataplaneTProxyImage())
-				}
 
 				if node.IsAgent() {
 					addVolume(node.DockerName())

--- a/testing/deployer/sprawl/internal/tfgen/nodes.go
+++ b/testing/deployer/sprawl/internal/tfgen/nodes.go
@@ -67,7 +67,7 @@ func (g *Generator) generateNodeContainers(
 			}{
 				terraformPod:      pod,
 				ImageResource:     DockerImageResourceName(node.Images.Consul),
-				HCL:               g.generateAgentHCL(node, cluster.EnableV2 && node.IsServer(), cluster.EnableV2Tenancy && node.IsServer()),
+				HCL:               g.generateAgentHCL(node),
 				EnterpriseLicense: g.license,
 			}))
 		}
@@ -125,11 +125,7 @@ func (g *Generator) generateNodeContainers(
 			var img string
 			if node.IsDataplane() {
 				tmpl = tfAppDataplaneT
-				if wrk.EnableTransparentProxy {
-					img = DockerImageResourceName(node.Images.LocalDataplaneTProxyImage())
-				} else {
-					img = DockerImageResourceName(node.Images.LocalDataplaneImage())
-				}
+				img = DockerImageResourceName(node.Images.LocalDataplaneImage())
 			} else {
 				img = DockerImageResourceName(node.Images.EnvoyConsulImage())
 			}

--- a/testing/deployer/sprawl/internal/tfgen/templates/container-app-dataplane.tf.tmpl
+++ b/testing/deployer/sprawl/internal/tfgen/templates/container-app-dataplane.tf.tmpl
@@ -17,37 +17,18 @@ resource "docker_container" "{{.Node.DockerName}}-{{.Workload.ID.TFString}}-side
     read_only      = true
   }
 
-{{ if .Workload.EnableTransparentProxy }}
-  capabilities {
-    add = ["NET_ADMIN"]
-  }
-  entrypoint = [ "/bin/tproxy-startup.sh" ]
-{{ end }}
-
   env = [
     "DP_CONSUL_ADDRESSES=server.{{.Node.Cluster}}-consulcluster.lan",
-{{ if .Node.IsV2 }}
-    "DP_PROXY_ID={{.Workload.Workload}}",
-{{ if .Enterprise }}
-    "DP_PROXY_NAMESPACE={{.Workload.ID.Namespace}}",
-    "DP_PROXY_PARTITION={{.Workload.ID.Partition}}",
-{{ end }}
-{{ else }}
     "DP_SERVICE_NODE_NAME={{.Node.PodName}}",
     "DP_PROXY_SERVICE_ID={{.Workload.ID.Name}}-sidecar-proxy",
 {{ if .Enterprise }}
     "DP_SERVICE_NAMESPACE={{.Workload.ID.Namespace}}",
     "DP_SERVICE_PARTITION={{.Workload.ID.Partition}}",
 {{ end }}
-{{ end }}
 
 {{ if .Token }}
     "DP_CREDENTIAL_TYPE=static",
     "DP_CREDENTIAL_STATIC_TOKEN={{.Token}}",
-{{ end }}
-
-{{ if .Workload.EnableTransparentProxy }}
-    "REDIRECT_TRAFFIC_ARGS=-exclude-inbound-port=19000",
 {{ end }}
 
     // for demo purposes

--- a/testing/deployer/sprawl/sprawltest/test_test.go
+++ b/testing/deployer/sprawl/sprawltest/test_test.go
@@ -12,146 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/api"
-	pbauth "github.com/hashicorp/consul/proto-public/pbauth/v2beta1"
-	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
-	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
-	"github.com/hashicorp/consul/proto-public/pbresource"
 	"github.com/hashicorp/consul/testing/deployer/sprawl/sprawltest"
 	"github.com/hashicorp/consul/testing/deployer/topology"
 )
-
-func TestSprawl_CatalogV2(t *testing.T) {
-	serversDC1 := newTopologyServerSet("dc1-server", 3, []string{"dc1", "wan"}, nil)
-
-	cfg := &topology.Config{
-		Images: topology.Images{
-			ConsulCE:         "hashicorppreview/consul:1.17-dev",
-			ConsulEnterprise: "hashicorppreview/consul-enterprise:1.17-dev",
-			Dataplane:        "hashicorppreview/consul-dataplane:1.3-dev",
-		},
-		Networks: []*topology.Network{
-			{Name: "dc1"},
-			{Name: "wan", Type: "wan"},
-		},
-		Clusters: []*topology.Cluster{
-			{
-				Enterprise: true,
-				Name:       "dc1",
-				Nodes: topology.MergeSlices(serversDC1, []*topology.Node{
-					{
-						Kind:    topology.NodeKindDataplane,
-						Version: topology.NodeVersionV2,
-						Name:    "dc1-client1",
-						Workloads: []*topology.Workload{
-							{
-								ID:             topology.ID{Name: "ping"},
-								Image:          "rboyer/pingpong:latest",
-								Port:           8080,
-								EnvoyAdminPort: 19000,
-								Command: []string{
-									"-bind", "0.0.0.0:8080",
-									"-dial", "127.0.0.1:9090",
-									"-pong-chaos",
-									"-dialfreq", "250ms",
-									"-name", "ping",
-								},
-								Destinations: []*topology.Destination{{
-									ID:        topology.ID{Name: "pong"},
-									LocalPort: 9090,
-								}},
-							},
-						},
-					},
-					{
-						Kind:    topology.NodeKindDataplane,
-						Version: topology.NodeVersionV2,
-						Name:    "dc1-client2",
-						Workloads: []*topology.Workload{
-							{
-								ID:             topology.ID{Name: "pong"},
-								Image:          "rboyer/pingpong:latest",
-								Port:           8080,
-								EnvoyAdminPort: 19000,
-								Command: []string{
-									"-bind", "0.0.0.0:8080",
-									"-dial", "127.0.0.1:9090",
-									"-pong-chaos",
-									"-dialfreq", "250ms",
-									"-name", "pong",
-								},
-								Destinations: []*topology.Destination{{
-									ID:        topology.ID{Name: "ping"},
-									LocalPort: 9090,
-								}},
-							},
-						},
-					},
-				}),
-				InitialResources: []*pbresource.Resource{
-					sprawltest.MustSetResourceData(t, &pbresource.Resource{
-						Id: &pbresource.ID{
-							Type: pbmesh.HTTPRouteType,
-							Name: "test-http-route",
-						},
-					}, &pbmesh.HTTPRoute{
-						ParentRefs: []*pbmesh.ParentReference{{
-							Ref: &pbresource.Reference{
-								Type: pbcatalog.ServiceType,
-								Name: "test",
-							},
-						}},
-					}),
-					sprawltest.MustSetResourceData(t, &pbresource.Resource{
-						Id: &pbresource.ID{
-							Type: pbauth.TrafficPermissionsType,
-							Name: "ping-perms",
-						},
-					}, &pbauth.TrafficPermissions{
-						Destination: &pbauth.Destination{
-							IdentityName: "ping",
-						},
-						Action: pbauth.Action_ACTION_ALLOW,
-						Permissions: []*pbauth.Permission{{
-							Sources: []*pbauth.Source{{
-								IdentityName: "pong",
-							}},
-						}},
-					}),
-					sprawltest.MustSetResourceData(t, &pbresource.Resource{
-						Id: &pbresource.ID{
-							Type: pbauth.TrafficPermissionsType,
-							Name: "pong-perms",
-						},
-					}, &pbauth.TrafficPermissions{
-						Destination: &pbauth.Destination{
-							IdentityName: "pong",
-						},
-						Action: pbauth.Action_ACTION_ALLOW,
-						Permissions: []*pbauth.Permission{{
-							Sources: []*pbauth.Source{{
-								IdentityName: "ping",
-							}},
-						}},
-					}),
-				},
-			},
-		},
-	}
-
-	sp := sprawltest.Launch(t, cfg)
-
-	for _, cluster := range sp.Topology().Clusters {
-		leader, err := sp.Leader(cluster.Name)
-		require.NoError(t, err)
-		t.Logf("%s: leader = %s", cluster.Name, leader.ID())
-
-		followers, err := sp.Followers(cluster.Name)
-		require.NoError(t, err)
-		for _, f := range followers {
-			t.Logf("%s: follower = %s", cluster.Name, f.ID())
-		}
-	}
-}
 
 func TestSprawl(t *testing.T) {
 	serversDC1 := newTopologyServerSet("dc1-server", 3, []string{"dc1", "wan"}, nil)
@@ -201,7 +64,7 @@ func TestSprawl(t *testing.T) {
 									"-dialfreq", "250ms",
 									"-name", "ping",
 								},
-								Destinations: []*topology.Destination{{
+								Upstreams: []*topology.Upstream{{
 									ID:        topology.ID{Name: "pong"},
 									LocalPort: 9090,
 									Peer:      "peer-dc2-default",
@@ -253,32 +116,7 @@ func TestSprawl(t *testing.T) {
 									"-dialfreq", "250ms",
 									"-name", "pong",
 								},
-								Destinations: []*topology.Destination{{
-									ID:        topology.ID{Name: "ping"},
-									LocalPort: 9090,
-									Peer:      "peer-dc1-default",
-								}},
-							},
-						},
-					},
-					{
-						Kind:    topology.NodeKindDataplane,
-						Version: topology.NodeVersionV2,
-						Name:    "dc2-client3",
-						Workloads: []*topology.Workload{
-							{
-								ID:             topology.ID{Name: "pong"},
-								Image:          "rboyer/pingpong:latest",
-								Port:           8080,
-								EnvoyAdminPort: 19000,
-								Command: []string{
-									"-bind", "0.0.0.0:8080",
-									"-dial", "127.0.0.1:9090",
-									"-pong-chaos",
-									"-dialfreq", "250ms",
-									"-name", "pong",
-								},
-								Destinations: []*topology.Destination{{
+								Upstreams: []*topology.Upstream{{
 									ID:        topology.ID{Name: "ping"},
 									LocalPort: 9090,
 									Peer:      "peer-dc1-default",

--- a/testing/deployer/topology/naming_shim.go
+++ b/testing/deployer/topology/naming_shim.go
@@ -39,5 +39,5 @@ func NewServiceID(name, namespace, partition string) ID {
 	return NewID(name, namespace, partition)
 }
 
-// Deprecated: Destination
-type Upstream = Destination
+// Deprecated:
+type Destination = Upstream


### PR DESCRIPTION
### Description

- Low level plumbing for resources is still retained for now.
- Retain "Workload" terminology over "Service".
- Revert "Destination" terminology back to "Upstream".
- Remove TPROXY support as it only worked for v2.
- 
### Links

https://hashicorp.atlassian.net/browse/NET-9091
