### PR TITLE
set go toolchain to go1.22.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/consul
 
 go 1.20
 
+toolchain go1.22.3
+
 replace (
 	github.com/hashicorp/consul/api => ./api
 	github.com/hashicorp/consul/envoyextensions => ./envoyextensions


### PR DESCRIPTION
### Description

Set toolchain directive to 1.22.3 to avoid compilation errors as the generated code since go was updated to 1.22.3 will not be compatible with older versions of go.