### PR TITLE
Fixes annotation and introduce tabs for static-client spec

### DIFF
--- a/website/content/docs/k8s/connect/terminating-gateways.mdx
+++ b/website/content/docs/k8s/connect/terminating-gateways.mdx
@@ -317,6 +317,57 @@ $ kubectl apply --filename service-intentions.yaml
 As a final step, you may define and deploy the external services as upstreams for the internal mesh services that wish to talk to them.
 An example deployment is provided which will serve as a static client for the terminating gateway service.
 
+<Tabs>
+<Tab heading="Registered with ServiceDefaults destinations">
+
+<CodeBlockConfig filename="static-client.yaml">
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: static-client
+spec:
+  selector:
+    app: static-client
+  ports:
+    - port: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: static-client
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: static-client
+  template:
+    metadata:
+      name: static-client
+      labels:
+        app: static-client
+      annotations:
+        'consul.hashicorp.com/connect-inject': 'true'
+    spec:
+      containers:
+        - name: static-client
+          image: curlimages/curl:latest
+          command: ['/bin/sh', '-c', '--']
+          args: ['while true; do sleep 30; done;']
+      serviceAccountName: static-client
+```
+
+</CodeBlockConfig>
+
+</Tab>
+<Tab heading="Registered with the Consul catalog">
+
 <CodeBlockConfig filename="static-client.yaml">
 
 ```yaml
@@ -362,6 +413,9 @@ spec:
 ```
 
 </CodeBlockConfig>
+
+</Tab>
+</Tabs>
 
 Deploy the service with `kubectl apply`.
 


### PR DESCRIPTION

### Description

The upstream annotation is not required for external services defined using the ServiceDefaults Destinations. Created a Tab that separates the static client spec for ServiceDefaults Destinations and directly registered into catalog scenarios.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

Preview: https://consul-git-docs-k8s-terminating-gw-hashicorp.vercel.app/consul/docs/k8s/connect/terminating-gateways#define-the-external-services-as-upstreams-for-services-in-the-mesh

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
