### PR TITLE
chore: disable CRT for inactive release (1.17)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,13 @@ env:
 
 jobs:
   get-go-version:
+    # Skip build for inactive CE branches
+    if: ${{ endsWith(github.repository, '-enterprise') }}
     uses: ./.github/workflows/reusable-get-go-version.yml
 
   set-product-version:
+    # Skip build for inactive CE branches
+    if: ${{ endsWith(github.repository, '-enterprise') }}
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.set-product-version.outputs.product-version }}


### PR DESCRIPTION
### Description

Disable CRT (and by extension, security scans and preview builds) for disabled CE branches.

### Testing & Reproduction steps

Tested here: https://github.com/hashicorp/consul/actions/runs/9198792600

The skip on the top jobs trickles down into all the actual build jobs.

I'm not 100% certain this will work due to release branch config in `.release/ci.hcl` but it's faster to just try. Will follow up as needed.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
