### PR TITLE
Allow creating TTL'd sessions without a node

### DIFF
--- a/.changelog/21208.txt
+++ b/.changelog/21208.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+http: Fix regression preventing sessions from being created without a node, as long as a TTL was specified and there are no `NodeChecks`.
+```

--- a/agent/consul/session_endpoint.go
+++ b/agent/consul/session_endpoint.go
@@ -57,8 +57,8 @@ func (s *Session) Apply(args *structs.SessionRequest, reply *string) error {
 	if args.Session.ID == "" && args.Op == structs.SessionDestroy {
 		return fmt.Errorf("Must provide ID")
 	}
-	if args.Session.Node == "" && args.Op == structs.SessionCreate {
-		return fmt.Errorf("Must provide Node")
+	if args.Session.Node == "" && len(args.Session.NodeChecks) > 0 && args.Op == structs.SessionCreate {
+		return fmt.Errorf("Must provide Node when NodeChecks are specified")
 	}
 
 	//  The entMeta to populate is the one in the Session struct, not SessionRequest

--- a/agent/consul/state/session_test.go
+++ b/agent/consul/state/session_test.go
@@ -53,7 +53,11 @@ func TestStateStore_SessionCreate_SessionGet(t *testing.T) {
 	}
 
 	// Registering with an unknown node is disallowed
-	sess = &structs.Session{ID: testUUID()}
+	sess = &structs.Session{
+		ID:         testUUID(),
+		Node:       "nonextant-node",
+		NodeChecks: []string{string(structs.SerfCheckID)},
+	}
 	if err := s.SessionCreate(1, sess); err != ErrMissingNode {
 		t.Fatalf("expected %#v, got: %#v", ErrMissingNode, err)
 	}

--- a/api/lock.go
+++ b/api/lock.go
@@ -355,9 +355,11 @@ func (l *Lock) createSession() (string, error) {
 	se := l.opts.SessionOpts
 	if se == nil {
 		se = &SessionEntry{
-			Name:      l.opts.SessionName,
-			TTL:       l.opts.SessionTTL,
-			LockDelay: l.opts.LockDelay,
+			Name:       l.opts.SessionName,
+			TTL:        l.opts.SessionTTL,
+			LockDelay:  l.opts.LockDelay,
+			Node:       "",
+			NodeChecks: []string{},
 		}
 	}
 	w := WriteOptions{Namespace: l.opts.Namespace}

--- a/api/session.go
+++ b/api/session.go
@@ -102,7 +102,7 @@ func (s *Session) Create(se *SessionEntry, q *WriteOptions) (string, *WriteMeta,
 		if len(se.Checks) > 0 {
 			body["Checks"] = se.Checks
 		}
-		if len(se.NodeChecks) > 0 {
+		if se.NodeChecks != nil {
 			body["NodeChecks"] = se.NodeChecks
 		}
 		if len(se.ServiceChecks) > 0 {

--- a/website/content/api-docs/session.mdx
+++ b/website/content/api-docs/session.mdx
@@ -10,7 +10,7 @@ The `/session` endpoints create, destroy, and query sessions in Consul.
 
 ## Create Session
 
-This endpoint initializes a new session. Sessions must be associated with a
+This endpoint initializes a new session. Sessions may be associated with a
 node and may be associated with any number of checks.
 
 | Method | Path              | Produces           |
@@ -35,7 +35,9 @@ The table below shows this endpoint's support for
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
   the datacenter of the agent being queried. This is specified as part of the
-  URL as a query parameter. Using this parameter across datacenters is not recommended.
+  URL as a query parameter. Using this parameter across datacenters on client
+  nodes requires that you specify a TTL, specify the `Node` as `null`, and pass
+  in an empty `NodeChecks` array.
 
 ### JSON Request Body Schema
 
@@ -146,7 +148,6 @@ The table below shows this endpoint's support for
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
   the datacenter of the agent being queried.
-  Using this parameter across datacenters is not recommended.
 
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace to query.
   You can also [specify the namespace through other methods](#methods-to-specify-namespace).
@@ -191,7 +192,6 @@ The table below shows this endpoint's support for
 
 - `dc` `(string: "")` - Specifies the datacenter to query.
   This defaults to the datacenter of the agent being queried.
-  Using this parameter across datacenters is not recommended.
 
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace to query.
   You can also [specify the namespace through other methods](#methods-to-specify-namespace).
@@ -254,7 +254,6 @@ The table below shows this endpoint's support for
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
   the datacenter of the agent being queried.
-  Using this parameter across datacenters is not recommended.
 
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace to query.
   You can also [specify the namespace through other methods](#methods-to-specify-namespace).
@@ -313,7 +312,6 @@ The table below shows this endpoint's support for
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
   the datacenter of the agent being queried.
-  Using this parameter across datacenters is not recommended.
 
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace to query.
   You can also [specify the namespace through other methods](#methods-to-specify-namespace).
@@ -375,7 +373,6 @@ The table below shows this endpoint's support for
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
   the datacenter of the agent being queried.
-  Using this parameter across datacenters is not recommended.
 
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace to query.
   You can also [specify the namespace through other methods](#methods-to-specify-namespace).

--- a/website/content/commands/lock.mdx
+++ b/website/content/commands/lock.mdx
@@ -24,7 +24,8 @@ If the lock holder count is more than one, then a semaphore is used instead.
 A semaphore allows more than a single holder, but this is less efficient than
 a simple lock. This follows the [semaphore algorithm](/consul/tutorials/developer-configuration/distributed-semaphore).
 
-To apply a lock to a remote WAN federated datacenter, run the command with the `-datacenter=<name>` flag on a server agent. You cannot use the command with `-datacenter` on client agents because they are unavailable to the remote datacenter.
+To apply a lock to a remote WAN federated datacenter, run the command with the
+`-datacenter=<name>` flag.
 
 All locks using the same prefix must agree on the value of `-n`. If conflicting
 values of `-n` are provided, an error will be returned.


### PR DESCRIPTION
### Description

This is required to be able to hold cross-DC locks.

### Testing & Reproduction steps

- Start a cluster with two datacenters, dc1 and dc2, and join a non-server node to dc1.
- Against the client node, execute: `xh PUT :8500/v1/session/create dc==dc2 Name=foo TTL=10s 'NodeChecks:=[]' 'Node:=null'`

Previously it would fail with an error, with this PR it successfully creates a TTL'd session.  After a little bit the new session will correctly disappear from the `xh :8500/v1/session/list dc==dc2` output.

### Links

Fixes #6828.
<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
