### PR TITLE
chore: disable CRT for inactive release (1.15)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,13 @@ env:
 
 jobs:
   get-go-version:
+    # Skip build for inactive CE branches
+    if: ${{ endsWith(github.repository, '-enterprise') }}
     uses: ./.github/workflows/reusable-get-go-version.yml
 
   set-product-version:
+    # Skip build for inactive CE branches
+    if: ${{ endsWith(github.repository, '-enterprise') }}
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.set-product-version.outputs.product-version }}


### PR DESCRIPTION
### Description

Disable CRT (and by extension, security scans and preview builds) for disabled CE branches.

### Testing & Reproduction steps

Verified working on 1.17: https://github.com/hashicorp/consul/pull/21206 (CRT build skipped on this [commit](https://github.com/hashicorp/consul/commit/679abd54dfbfdce583f6b5072b0a6e3fbb15b57e))

The skip on the top jobs trickles down into all the actual build jobs.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
