### PR TITLE
HCPCP-1619: allow unix socket path to the host

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -368,7 +368,8 @@ type Config struct {
 	// HttpAuth is the auth info to use for http access.
 	HttpAuth *HttpBasicAuth
 
-	// HostOverride is the override to host. Default is Address.
+	// HostOverride forces a specific host header value to be sent with requests.
+	// If not specified, defaults to the value parsed from the `Address` field.
 	HostOverride string
 
 	// WaitTime limits how long a Watch will block. If not provided,

--- a/api/api.go
+++ b/api/api.go
@@ -368,6 +368,9 @@ type Config struct {
 	// HttpAuth is the auth info to use for http access.
 	HttpAuth *HttpBasicAuth
 
+	// HostOverride is the override to host. Default is Address.
+	HostOverride string
+
 	// WaitTime limits how long a Watch will block. If not provided,
 	// the agent default values will be used.
 	WaitTime time.Duration
@@ -1029,6 +1032,9 @@ func (r *request) toHTTP() (*http.Request, error) {
 	req.URL.Host = r.url.Host
 	req.URL.Scheme = r.url.Scheme
 	req.Host = r.url.Host
+	if r.config.HostOverride != "" {
+		req.Host = r.config.HostOverride
+	}
 	req.Header = r.header
 
 	// Content-Type must always be set when a body is present

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -994,6 +994,22 @@ func TestAPI_RequestToHTTP(t *testing.T) {
 	}
 }
 
+func TestAPI_RequestToHTTP_HostOverride(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	r := c.newRequest("DELETE", "/v1/kv/foo")
+	q := &QueryOptions{
+		Datacenter: "foo",
+	}
+	r.setQueryOptions(q)
+	r.config.HostOverride = "https.consul.unix.socket"
+	req, err := r.toHTTP()
+	require.NoError(t, err)
+	require.Equal(t, "https.consul.unix.socket", req.Host)
+}
+
 func TestAPI_ParseQueryMeta(t *testing.T) {
 	t.Parallel()
 	resp := &http.Response{


### PR DESCRIPTION
### Description

Allow unix socket to be the host. Without the change, we'll get an error message 

```
failed to initialize service broker. error checking Consul status:
Get "https://%2Falloc%2Ftmp%2Fconsul_http.sock/v1/status/leader": http2: invalid Host header
```
In the above example, the host is a UNIX socket `https:///alloc/tmp/consu_http.sock`

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
