### PR TITLE
build: set go-build reproducible to false

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
           go_version: ${{ needs.get-go-version.outputs.go-version }}
           os: ${{ matrix.goos }}
           arch: ${{ matrix.goarch }}
-          reproducible: report
+          reproducible: nope
           clean: false
           instructions: |-
             cp LICENSE $TARGET_DIR/LICENSE.txt
@@ -240,7 +240,7 @@ jobs:
           go_version: ${{ needs.get-go-version.outputs.go-version }}
           os: ${{ matrix.goos }}
           arch: ${{ matrix.goarch }}
-          reproducible: report
+          reproducible: nope
           clean: false
           instructions: |-
             cp LICENSE $TARGET_DIR/LICENSE.txt
@@ -292,7 +292,7 @@ jobs:
           go_version: ${{ needs.get-go-version.outputs.go-version }}
           os: ${{ matrix.goos }}
           arch: ${{ matrix.goarch }}
-          reproducible: report
+          reproducible: nope
           clean: false
           instructions: |-
             cp LICENSE $TARGET_DIR/LICENSE.txt


### PR DESCRIPTION
### Description
In #21217 , it should have included `reproducible: nope`, similar to this [commit from the 1.18 branch](https://github.com/hashicorp/consul/commit/0dbf501920970348942553447cd57004686de3f8). The CRT build on `main` is still failing.