### PR TITLE
[NET-9445] Re-enable 1.18 backports during 1.19 RC

### DIFF
--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -10,6 +10,8 @@ active_versions {
     ce_active = true
   }
   version "1.18" {
+    # This release should remain active until 1.19 GA
+    ce_active = true
     lts       = true
   }
   version "1.17" {}


### PR DESCRIPTION
Follow-up to #21219.

### Description

Does not need backporting as this file is only read on `main`.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
