### PR TITLE
Fix Consul versions in nightly 1.19 int tests

### DIFF
--- a/.github/workflows/nightly-test-integrations-1.19.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.19.x.yml
@@ -204,7 +204,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consul-version: ["1.15", "1.16", "1.17"]
+        consul-version: ["1.15", "1.17", "1.18"]
     env:
       CONSUL_LATEST_VERSION: ${{ matrix.consul-version }}
       ENVOY_VERSION: "1.24.6"
@@ -330,7 +330,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consul-version: [ "1.15", "1.16", "1.17"]
+        consul-version: ["1.15", "1.17", "1.18"]
     env:
       CONSUL_LATEST_VERSION: ${{ matrix.consul-version }}
     steps:


### PR DESCRIPTION
We should be testing against n-2 + LTS, so we need to replace 1.16 with 1.18.

Follow-up to #21219.

### Description

cc @DanStough in case I messed this up due to bad assumptions

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
