### PR TITLE
dns v2 - both empty string and default should be allowed for namespace and partition in CE

### DIFF
--- a/.changelog/21230.txt
+++ b/.changelog/21230.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+dns: new version was not supporting partition or namespace being set to 'default' in CE version.
+```

--- a/acl/acl_ce.go
+++ b/acl/acl_ce.go
@@ -8,12 +8,25 @@ package acl
 const (
 	WildcardPartitionName = ""
 	DefaultPartitionName  = ""
-)
+	// NonEmptyDefaultPartitionName is the name of the default partition that is
+	// not empty.  An example of this being supplied is when a partition is specified
+	// in the request for DNS by consul-dataplane.  This has been added to support
+	// DNS v1.5, which needs to be compatible with the original DNS subsystem which
+	// supports partition being "default" or empty.  Otherwise, use DefaultPartitionName.
+	NonEmptyDefaultPartitionName = "default"
 
-// Reviewer Note: This is a little bit strange; one might want it to be "" like partition name
-// However in consul/structs/intention.go we define IntentionDefaultNamespace as 'default' and so
-// we use the same here
-const DefaultNamespaceName = "default"
+	// DefaultNamespaceName is used to mimic the behavior in consul/structs/intention.go,
+	// where we define IntentionDefaultNamespace as 'default' and so we use the same here.
+	// This is a little bit strange; one might want it to be "" like DefaultPartitionName.
+	DefaultNamespaceName = "default"
+
+	// EmptyNamespaceName is the name of the default partition that is an empty string.
+	// An example of this being supplied is when a namespace is specifiedDNS v1.
+	// EmptyNamespaceName has been added to support DNS v1.5, which needs to be
+	// compatible with the original DNS subsystem which supports partition being "default" or empty.
+	// Otherwise, use DefaultNamespaceName.
+	EmptyNamespaceName = ""
+)
 
 type EnterpriseConfig struct {
 	// no fields in CE

--- a/agent/discovery/query_fetcher_v1.go
+++ b/agent/discovery/query_fetcher_v1.go
@@ -424,6 +424,7 @@ RPC:
 }
 
 func (f *V1DataFetcher) ValidateRequest(_ Context, req *QueryPayload) error {
+	f.logger.Debug(fmt.Sprintf("req %+v", req))
 	if req.EnableFailover {
 		return ErrNotSupported
 	}

--- a/agent/discovery/query_fetcher_v1.go
+++ b/agent/discovery/query_fetcher_v1.go
@@ -424,7 +424,6 @@ RPC:
 }
 
 func (f *V1DataFetcher) ValidateRequest(_ Context, req *QueryPayload) error {
-	f.logger.Debug(fmt.Sprintf("req %+v", req))
 	if req.EnableFailover {
 		return ErrNotSupported
 	}

--- a/agent/discovery/query_fetcher_v1_ce.go
+++ b/agent/discovery/query_fetcher_v1_ce.go
@@ -7,7 +7,6 @@ package discovery
 
 import (
 	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/api"
 )
 
 func (f *V1DataFetcher) NormalizeRequest(req *QueryPayload) {
@@ -15,8 +14,12 @@ func (f *V1DataFetcher) NormalizeRequest(req *QueryPayload) {
 	return
 }
 
+// validateEnterpriseTenancy validates the tenancy fields for an enterprise request to
+// make sure that they are either set to an empty string or "default" to align with the behavior
+// in CE.
 func validateEnterpriseTenancy(req QueryTenancy) error {
-	if !(req.Namespace == "" || req.Namespace == acl.DefaultNamespaceName) || !(req.Partition == "" || req.Partition == api.PartitionDefaultName) {
+	if !(req.Namespace == acl.EmptyNamespaceName || req.Namespace == acl.DefaultNamespaceName) ||
+		!(req.Partition == acl.DefaultPartitionName || req.Partition == acl.NonEmptyDefaultPartitionName) {
 		return ErrNotSupported
 	}
 	return nil

--- a/agent/discovery/query_fetcher_v1_ce.go
+++ b/agent/discovery/query_fetcher_v1_ce.go
@@ -7,6 +7,7 @@ package discovery
 
 import (
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/api"
 )
 
 func (f *V1DataFetcher) NormalizeRequest(req *QueryPayload) {
@@ -15,7 +16,7 @@ func (f *V1DataFetcher) NormalizeRequest(req *QueryPayload) {
 }
 
 func validateEnterpriseTenancy(req QueryTenancy) error {
-	if !(req.Namespace == "" || req.Namespace == acl.DefaultNamespaceName) || !(req.Partition == acl.DefaultPartitionName || req.Partition == "default") {
+	if !(req.Namespace == "" || req.Namespace == acl.DefaultNamespaceName) || !(req.Partition == "" || req.Partition == api.PartitionDefaultName) {
 		return ErrNotSupported
 	}
 	return nil

--- a/agent/discovery/query_fetcher_v1_ce.go
+++ b/agent/discovery/query_fetcher_v1_ce.go
@@ -15,7 +15,7 @@ func (f *V1DataFetcher) NormalizeRequest(req *QueryPayload) {
 }
 
 func validateEnterpriseTenancy(req QueryTenancy) error {
-	if req.Namespace != "" || req.Partition != acl.DefaultPartitionName {
+	if !(req.Namespace == "" || req.Namespace == acl.DefaultNamespaceName) || !(req.Partition == acl.DefaultPartitionName || req.Partition == "default") {
 		return ErrNotSupported
 	}
 	return nil

--- a/agent/discovery/query_fetcher_v1_ce_test.go
+++ b/agent/discovery/query_fetcher_v1_ce_test.go
@@ -5,7 +5,60 @@
 
 package discovery
 
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
 const (
 	defaultTestNamespace = ""
 	defaultTestPartition = ""
 )
+
+func Test_validateEnterpriseTenancy(t *testing.T) {
+	testCases := []struct {
+		name     string
+		req      QueryTenancy
+		expected error
+	}{
+		{
+			name: "empty namespace and partition returns no error",
+			req: QueryTenancy{
+				Namespace: defaultTestNamespace,
+				Partition: defaultTestPartition,
+			},
+			expected: nil,
+		},
+		{
+			name: "namespace and partition set to 'default' returns no error",
+			req: QueryTenancy{
+				Namespace: "default",
+				Partition: "default",
+			},
+			expected: nil,
+		},
+		{
+			name: "namespace set to something other than empty string or `default` returns not supported error",
+			req: QueryTenancy{
+				Namespace: "namespace-1",
+				Partition: "default",
+			},
+			expected: ErrNotSupported,
+		},
+		{
+			name: "partition set to something other than empty string or `default` returns not supported error",
+			req: QueryTenancy{
+				Namespace: "default",
+				Partition: "partition-1",
+			},
+			expected: ErrNotSupported,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateEnterpriseTenancy(tc.req)
+			require.Equal(t, tc.expected, err)
+		})
+	}
+}


### PR DESCRIPTION
### Description

tenancy was being validated on DNS queries from consul-dataplane to only allow partition to be set to an empty string.  It was not allow `default` in either case.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
