### PR TITLE
Backport of [NET-9510] Document known OpenShift issue for consul-k8s 1.2.x, 1.3.x and 1.4.x into release/1.17.x

### DIFF
--- a/website/content/docs/release-notes/consul-k8s/v1_2_x.mdx
+++ b/website/content/docs/release-notes/consul-k8s/v1_2_x.mdx
@@ -75,6 +75,14 @@ We are pleased to announce the following Consul updates.
 
 For more detailed information, please refer to the [upgrade details page](/consul/docs/upgrading/upgrade-specific) and the changelogs.
 
+## Known Issues
+
+The following issues are known to exist in the v1.2.x releases. Refer to the changelog for more information.
+
+- v1.2.8 - Service-to-service networking is broken when deployed on OpenShift. OpenShift users are advised to avoid deploying this version of consul-k8s.
+    A fix is present in the v1.2.9 release [[GH-4038](https://github.com/hashicorp/consul-k8s/pull/4038)].
+
+
 ## Changelogs
 
 The changelogs for this major release version and any maintenance versions are listed below.

--- a/website/content/docs/release-notes/consul-k8s/v1_3_x.mdx
+++ b/website/content/docs/release-notes/consul-k8s/v1_3_x.mdx
@@ -46,6 +46,8 @@ For more detailed information, please refer to the [upgrade details page](/consu
 The following issues are known to exist in the v1.3.x releases. Refer to the changelog for more information.
 
 - When using the v2 API with transparent proxy, Kubernetes pods cannot use L7 liveness, readiness, or startup probes.
+- v1.3.5 - Service-to-service networking is broken when deployed on OpenShift. OpenShift users are advised to avoid deploying this version of consul-k8s.
+    A fix is present in the v1.3.6 release [[GH-4037](https://github.com/hashicorp/consul-k8s/pull/4037)].
 
 ## Changelogs
 


### PR DESCRIPTION
## Backport

This PR generated from #21224 to be assessed for backporting.



The below text is copied from the body of the original PR.

---

### Description
https://github.com/hashicorp/consul-k8s/pull/3813 was recently reverted due to broken service→service networking when deployed on OpenShift. This change is to document the consul-k8s releases that should not be consumed on OpenShift as a result and point to the fix in the subsequent patch releases.

> [!NOTE]
> This will need to be backported to 1.18, 1.17 and 1.16 in order to cover the corresponding docs for each version of consul-k8s that was impacted.

### Testing & Reproduction steps
N/A

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links
[Docs deployed with change
](https://consul-gpbinz31c-hashicorp.vercel.app/consul/docs/release-notes/consul-k8s/v1_4_x#known-issues)

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
