### PR TITLE
update TestHTTPHandlers_AgentMetrics_LeaderShipMetrics to use 3 servers instead of 2 to allow quorum when leadership flails.

### DIFF
--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -229,6 +229,7 @@ func TestHTTPHandlers_AgentMetrics_LeaderShipMetrics(t *testing.T) {
 	t.Run("check that metric isLeader is set properly on server", func(t *testing.T) {
 		metricsPrefix1 := getUniqueMetricsPrefix()
 		metricsPrefix2 := getUniqueMetricsPrefix()
+		metricsPrefix3 := getUniqueMetricsPrefix()
 
 		hcl1 := fmt.Sprintf(`
 		server = true
@@ -248,15 +249,26 @@ func TestHTTPHandlers_AgentMetrics_LeaderShipMetrics(t *testing.T) {
 		}
 		`, metricsPrefix2)
 
+		hcl3 := fmt.Sprintf(`
+		server = true
+		telemetry = {
+			prometheus_retention_time = "25s",
+			disable_hostname = true
+			metrics_prefix = "%s"
+		}
+		`, metricsPrefix3)
+
 		overrides := `
 		  bootstrap = false
-		  bootstrap_expect = 2
+		  bootstrap_expect = 3
 		`
 
 		s1 := StartTestAgent(t, TestAgent{Name: "s1", HCL: hcl1, Overrides: overrides})
 		s2 := StartTestAgent(t, TestAgent{Name: "s2", HCL: hcl2, Overrides: overrides})
+		s3 := StartTestAgent(t, TestAgent{Name: "s3", HCL: hcl3, Overrides: overrides})
 		defer s1.Shutdown()
 		defer s2.Shutdown()
+		defer s3.Shutdown()
 
 		// agent hasn't become a leader
 		retry.RunWith(retry.ThirtySeconds(), t, func(r *testretry.R) {
@@ -268,8 +280,11 @@ func TestHTTPHandlers_AgentMetrics_LeaderShipMetrics(t *testing.T) {
 
 		_, err := s2.JoinLAN([]string{s1.Config.SerfBindAddrLAN.String()}, nil)
 		require.NoError(t, err)
+		_, err = s3.JoinLAN([]string{s1.Config.SerfBindAddrLAN.String()}, nil)
+		require.NoError(t, err)
 		testrpc.WaitForLeader(t, s1.RPC, "dc1")
 		testrpc.WaitForLeader(t, s2.RPC, "dc1")
+		testrpc.WaitForLeader(t, s3.RPC, "dc1")
 
 		// Verify agent's isLeader metrics is 1
 		retry.RunWith(retry.ThirtySeconds(), t, func(r *testretry.R) {
@@ -281,7 +296,11 @@ func TestHTTPHandlers_AgentMetrics_LeaderShipMetrics(t *testing.T) {
 			recordPromMetrics(r, s2, respRec2)
 			found2 := strings.Contains(respRec2.Body.String(), metricsPrefix2+"_server_isLeader 1")
 
-			require.True(r, found1 || found2, "leader server should have isLeader 1")
+			respRec3 := httptest.NewRecorder()
+			recordPromMetrics(r, s3, respRec3)
+			found3 := strings.Contains(respRec3.Body.String(), metricsPrefix3+"_server_isLeader 1")
+
+			require.True(r, found1 || found2 || found3, "leader server should have isLeader 1")
 		})
 	})
 }

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -264,10 +264,12 @@ func TestHTTPHandlers_AgentMetrics_LeaderShipMetrics(t *testing.T) {
 		`
 
 		s1 := StartTestAgent(t, TestAgent{Name: "s1", HCL: hcl1, Overrides: overrides})
-		s2 := StartTestAgent(t, TestAgent{Name: "s2", HCL: hcl2, Overrides: overrides})
-		s3 := StartTestAgent(t, TestAgent{Name: "s3", HCL: hcl3, Overrides: overrides})
 		defer s1.Shutdown()
+
+		s2 := StartTestAgent(t, TestAgent{Name: "s2", HCL: hcl2, Overrides: overrides})
 		defer s2.Shutdown()
+
+		s3 := StartTestAgent(t, TestAgent{Name: "s3", HCL: hcl3, Overrides: overrides})
 		defer s3.Shutdown()
 
 		// agent hasn't become a leader
@@ -282,6 +284,7 @@ func TestHTTPHandlers_AgentMetrics_LeaderShipMetrics(t *testing.T) {
 		require.NoError(t, err)
 		_, err = s3.JoinLAN([]string{s1.Config.SerfBindAddrLAN.String()}, nil)
 		require.NoError(t, err)
+
 		testrpc.WaitForLeader(t, s1.RPC, "dc1")
 		testrpc.WaitForLeader(t, s2.RPC, "dc1")
 		testrpc.WaitForLeader(t, s3.RPC, "dc1")


### PR DESCRIPTION
### Description

This is one of our flakiest tests.  When it fails, there are lots of logs related to:
- initial warnings of `A cluster with 2 servers will provide no failure tolerance.`
- leadership not being able to be established
- each of the two servers each trying to start their own election but not being able to get a quorom
- index mismatches when contacting the other server and then stepping down

Basically an endless loop when their indexes get out of sync.  Changing the test to do have 3 servers to align with our recommendations and prevent this 2 server index / election loop.

An example can be seen here: https://github.com/hashicorp/consul-enterprise/actions/runs/9103918643/job/25026885402
You will want to View Raw Logs and search for `TestHTTPHandlers_AgentMetrics_LeaderShipMetrics`
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
