### PR TITLE
[NET-9445] chore: update submodule versions

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -11,8 +11,8 @@ retract v1.28.0 // tag was mutated
 
 require (
 	github.com/google/go-cmp v0.5.9
-	github.com/hashicorp/consul/proto-public v0.5.1
-	github.com/hashicorp/consul/sdk v0.15.0
+	github.com/hashicorp/consul/proto-public v0.6.1
+	github.com/hashicorp/consul/sdk v0.16.1
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/envoyextensions/go.mod
+++ b/envoyextensions/go.mod
@@ -11,8 +11,8 @@ replace (
 require (
 	github.com/envoyproxy/go-control-plane v0.12.0
 	github.com/google/go-cmp v0.5.9
-	github.com/hashicorp/consul/api v1.26.1
-	github.com/hashicorp/consul/sdk v0.15.0
+	github.com/hashicorp/consul/api v1.29.1
+	github.com/hashicorp/consul/sdk v0.16.1
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -43,11 +43,11 @@ require (
 	github.com/hashi-derek/grpc-proxy v0.0.0-20231207191910-191266484d75
 	github.com/hashicorp/consul-awsauth v0.0.0-20220713182709-05ac1c5c2706
 	github.com/hashicorp/consul-net-rpc v0.0.0-20221205195236-156cfab66a69
-	github.com/hashicorp/consul/api v1.26.1
-	github.com/hashicorp/consul/envoyextensions v0.5.1
-	github.com/hashicorp/consul/proto-public v0.5.1
-	github.com/hashicorp/consul/sdk v0.15.0
-	github.com/hashicorp/consul/troubleshoot v0.4.1
+	github.com/hashicorp/consul/api v1.29.1
+	github.com/hashicorp/consul/envoyextensions v0.7.0
+	github.com/hashicorp/consul/proto-public v0.6.1
+	github.com/hashicorp/consul/sdk v0.16.1
+	github.com/hashicorp/consul/troubleshoot v0.6.1
 	github.com/hashicorp/go-bexpr v0.1.2
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/test-integ/go.mod
+++ b/test-integ/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9
-	github.com/hashicorp/consul/api v1.26.1
-	github.com/hashicorp/consul/proto-public v0.5.1
-	github.com/hashicorp/consul/sdk v0.15.0
+	github.com/hashicorp/consul/api v1.29.1
+	github.com/hashicorp/consul/proto-public v0.6.1
+	github.com/hashicorp/consul/sdk v0.16.1
 	github.com/hashicorp/consul/test/integration/consul-container v0.0.0-20230628201853-bdf4fad7c5a5
 	github.com/hashicorp/consul/testing/deployer v0.0.0-20230811171106-4a0afb5d1373
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/test/integration/consul-container/go.mod
+++ b/test/integration/consul-container/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/go-jose/go-jose/v3 v3.0.3
 	github.com/hashicorp/consul v1.16.1
-	github.com/hashicorp/consul/api v1.26.1
-	github.com/hashicorp/consul/envoyextensions v0.5.1
-	github.com/hashicorp/consul/proto-public v0.5.1
-	github.com/hashicorp/consul/sdk v0.15.0
+	github.com/hashicorp/consul/api v1.29.1
+	github.com/hashicorp/consul/envoyextensions v0.7.0
+	github.com/hashicorp/consul/proto-public v0.6.1
+	github.com/hashicorp/consul/sdk v0.16.1
 	github.com/hashicorp/consul/testing/deployer v0.0.0-20230811171106-4a0afb5d1373
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/testing/deployer/go.mod
+++ b/testing/deployer/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/consul-server-connection-manager v0.1.4
 	github.com/hashicorp/consul/api v1.26.1
-	github.com/hashicorp/consul/proto-public v0.5.1
-	github.com/hashicorp/consul/sdk v0.15.0
+	github.com/hashicorp/consul/proto-public v0.6.1
+	github.com/hashicorp/consul/sdk v0.16.1
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/troubleshoot/go.mod
+++ b/troubleshoot/go.mod
@@ -6,6 +6,7 @@ replace (
 	github.com/hashicorp/consul/api => ../api
 	github.com/hashicorp/consul/envoyextensions => ../envoyextensions
 	github.com/hashicorp/consul/proto-public => ../proto-public
+	github.com/hashicorp/consul/sdk => ../sdk
 )
 
 exclude (
@@ -16,9 +17,9 @@ exclude (
 require (
 	github.com/envoyproxy/go-control-plane v0.12.0
 	github.com/envoyproxy/go-control-plane/xdsmatcher v0.0.0-20230524161521-aaaacbfbe53e
-	github.com/hashicorp/consul/api v1.26.1
-	github.com/hashicorp/consul/envoyextensions v0.5.1
-	github.com/hashicorp/consul/sdk v0.15.0
+	github.com/hashicorp/consul/api v1.29.1
+	github.com/hashicorp/consul/envoyextensions v0.7.0
+	github.com/hashicorp/consul/sdk v0.16.1
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/protobuf v1.33.0
 )

--- a/troubleshoot/go.sum
+++ b/troubleshoot/go.sum
@@ -61,8 +61,6 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/hashicorp/consul/sdk v0.15.0 h1:2qK9nDrr4tiJKRoxPGhm6B7xJjLVIQqkjiab2M4aKjU=
-github.com/hashicorp/consul/sdk v0.15.0/go.mod h1:r/OmRRPbHOe0yxNahLw7G9x5WG17E1BIECMtCjcPSNo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
- Update submodule versions that were released
- Add missing replace directive to troubleshoot submodule

### Description

Propagate 1.19.x submodule updates made in https://github.com/hashicorp/consul/pull/21237 to `main`.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
