### PR TITLE
ci: add ENVOY_VERSIONS file for nightly int tests (1.17)

### DIFF
--- a/envoyextensions/xdscommon/ENVOY_VERSIONS
+++ b/envoyextensions/xdscommon/ENVOY_VERSIONS
@@ -1,0 +1,14 @@
+# This file represents the canonical list of supported Envoy versions for this version of Consul.
+#
+# Every line must contain a valid version number in the format "x.y.z" where x, y, and z are integers.
+# All other lines must be comments beginning with a "#", or a blank line.
+#
+# Every prior "minor" version for a given "major" (x.y) version is implicitly supported unless excluded by
+# `xdscommon.UnsupportedEnvoyVersions`. For example, 1.28.3 implies support for 1.28.0, 1.28.1, and 1.28.2.
+#
+# See https://www.consul.io/docs/connect/proxies/envoy#supported-versions for more information on Consul's Envoy
+# version support.
+1.27.6
+1.26.8
+1.25.11
+1.24.12


### PR DESCRIPTION
This file will be sourced by nightly integration tests, so must exist on both CE and Ent regardless of whether CE is actively released.

Enables upgrade tests in https://github.com/hashicorp/consul/pull/21245.

Going forward, this file will already exist in CE versions, and the policy should be to update it in CE s.t. nightly upgrade tests run against the latest Envoy version supported by the earliest active non-LTS version of Consul. Maintaining the file in CE ensures we use the correct version for testing upgrades in all cases, regardless of which release branches are active or which repo the tests are run from.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
