### PR TITLE
ci: fix a few missed Envoy version changes in latest bump

### DIFF
--- a/.github/workflows/nightly-test-integrations-1.19.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.19.x.yml
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        envoy-version: ["1.26.8", "1.27.6", "1.28.5", "1.29.5"]
+        envoy-version: ["1.26.8", "1.27.6", "1.28.4", "1.29.5"]
         xds-target: ["server", "client"]
         test-cases: ${{ fromJSON(needs.generate-envoy-job-matrices.outputs.envoy-matrix) }}
     env:

--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -206,8 +206,8 @@ jobs:
       CONSUL_LATEST_VERSION: ${{ matrix.consul-version }}
       # ENVOY_VERSION should be the latest version upported by all
       # consul versions in the matrix.consul-version, since we are testing upgrade from
-      # an older consul version, e.g., 1.27.5 is supported by both 1.16 and 1.17.
-      ENVOY_VERSION: "1.27.5"
+      # an older consul version, e.g., 1.27.x is supported by both 1.17 and 1.18.
+      ENVOY_VERSION: "1.27.6"
     steps:
       - name: Checkout code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -329,7 +329,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consul-version: [ "1.16", "1.17"]
+        consul-version: [ "1.17", "1.18"]
     env:
       CONSUL_LATEST_VERSION: ${{ matrix.consul-version }}
     steps:


### PR DESCRIPTION
Also update a missed Consul version shift for deployer upgrade tests to match non-deployer tests matrix, and update public docs on `main`.

Follow-up to https://github.com/hashicorp/consul/pull/21277.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
