### PR TITLE
Use text/template instead of html/template for ACL template policy generation

### DIFF
--- a/agent/structs/acl_templated_policy.go
+++ b/agent/structs/acl_templated_policy.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
-	"html/template"
+	"text/template"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/xeipuuv/gojsonschema"


### PR DESCRIPTION
### Description
We've discovered significant performance penalties using `html/template` that are seemingly made worse by the upgrade to Go 1.22. This PR switches to `text/template` instead since we aren't rendering HTML.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
