### PR TITLE
Configure linter to forbid use of html/template

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,7 @@ linters-settings:
   forbidigo:
     # Forbid the following identifiers (list of regexp).
     forbid:
+      - '\bhtml\/template\b(# Use text/template instead)?'
       - '\bioutil\b(# Use io and os packages instead of ioutil)?'
       - '\brequire\.New\b(# Use package-level functions with explicit TestingT)?'
       - '\bassert\.New\b(# Use package-level functions with explicit TestingT)?'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,6 +75,7 @@ linters-settings:
     simplify: true
   forbidigo:
     # Forbid the following identifiers (list of regexp).
+    # Format includes custom message based on https://github.com/ashanbrown/forbidigo/pull/11
     forbid:
       - '\bhtml\/template\b(# Use text/template instead)?'
       - '\bioutil\b(# Use io and os packages instead of ioutil)?'


### PR DESCRIPTION
### Description
We should never use html/template due to the performance penalty and the fact that we are highly unlikely to ever be generating HTML templates. This PR enforces a ban using the linter.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
