### PR TITLE
chore: update versions.hcl for 1.19.0 release

### DIFF
--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -10,12 +10,9 @@ active_versions {
     ce_active = true
   }
   version "1.18" {
-    # This release should remain active until 1.19 GA
-    ce_active = true
     lts       = true
   }
   version "1.17" {}
-  version "1.16" {}
   version "1.15" {
     lts = true
   }


### PR DESCRIPTION
### Description
Remove 1.18 as active for CE and totally remove support for 1.16.
