### PR TITLE
Backport of docs: simplify Envoy version support docs into release/1.18.x

### DIFF
--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -58,9 +58,9 @@ apply to both Consul Enterprise and Consul community edition (CE).
 
 | Consul Version | Compatible Envoy Versions              |
 | -------------- | -------------------------------------- |
-| 1.18.x CE      | 1.28.3, 1.27.5, 1.26.8, 1.25.11        |
-| 1.17.x         | 1.27.5, 1.26.8, 1.25.11, 1.24.12       |
-| 1.16.x         | 1.26.8, 1.25.11, 1.24.12, 1.23.12      |
+| 1.18.x CE      | 1.28.x, 1.27.x, 1.26.x, 1.25.x         |
+| 1.17.x         | 1.27.x, 1.26.x, 1.25.x, 1.24.x         |
+| 1.16.x         | 1.26.x, 1.25.x, 1.24.x, 1.23.x         |
 
 #### Enterprise Long Term Support releases
 
@@ -71,8 +71,8 @@ until the LTS release reaches its end of maintenance.
 
 | Consul Version | Compatible Envoy Versions                                                          |
 | -------------- | -----------------------------------------------------------------------------------|
-| 1.18.x Ent     | 1.29.4, 1.28.3, 1.27.5, 1.26.8, 1.25.11                                            |
-| 1.15.x Ent     | 1.29.4, 1.27.5, 1.26.8, 1.25.11, 1.24.12, 1.23.12, 1.22.11                         |
+| 1.18.x Ent     | 1.29.x, 1.28.x, 1.27.x, 1.26.x, 1.25.x                                             |
+| 1.15.x Ent     | 1.29.x, 1.28.x, 1.27.x, 1.26.x, 1.25.x, 1.24.x, 1.23.x, 1.22.x                     |
 
 ### Envoy and Consul Dataplane
 


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/consul/pull/21295
