### PR TITLE
Backport of docs: simplify Envoy version support docs into release/1.15.x

### DIFF
--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -37,11 +37,13 @@ The following matrix describes Envoy compatibility for the currently supported *
 
 Consul supports **four major Envoy releases** at the beginning of each major Consul release. Consul maintains compatibility with Envoy patch releases for each major version so that users can benefit from bug and security fixes in Envoy. As a policy, Consul will add support for a new major versions of Envoy in a Consul major release. Support for newer versions of Envoy will not be added to existing releases.
 
+_Note: For more on Envoy extended support in Consul Enterprise LTS releases (including 1.15), see the [latest docs](https://developer.hashicorp.com/consul/docs/connect/proxies/envoy)._
+
 | Consul Version      | Compatible Envoy Versions                                                          |
 | ------------------- | -----------------------------------------------------------------------------------|
-| 1.15.x              | 1.29.4, 1.28.3, 1.27.5, 1.26.8, 1.25.11, 1.24.12, 1.23.12, 1.22.11                 |
-| 1.14.x              | 1.24.12, 1.23.12, 1.22.11, 1.21.6                                                  |
-| 1.13.x              | 1.23.1, 1.22.5, 1.21.5, 1.20.7                                                     |
+| 1.15.x              | 1.29.x, 1.28.x, 1.27.x, 1.26.x, 1.25.x, 1.24.x, 1.23.x, 1.22.x                     |
+| 1.14.x              | 1.24.x, 1.23.x, 1.22.x, 1.21.x                                                     |
+| 1.13.x              | 1.23.x, 1.22.x, 1.21.x, 1.20.x                                                     |
 
 ### Envoy and Consul Dataplane
 


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/consul/pull/21295

Also adds a note to check latest docs for LTS details, as the extended version range here somewhat contradicts the statement above it:
> As a policy, Consul will add support for a new major versions of Envoy in a Consul major release. Support for newer versions of Envoy will not be added to existing releases.