### PR TITLE
Use variable for Red Hat project ID

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -324,7 +324,7 @@ jobs:
         run: |
           echo "full_dev_tag=${{ env.version }}"
           echo "full_dev_tag=${{ env.version }}" >> $GITHUB_ENV
-          echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')" 
+          echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')"
           echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')" >> $GITHUB_ENV
 
       - name: Docker Build (Action)
@@ -362,7 +362,7 @@ jobs:
         run: |
           echo "full_dev_tag=${{ env.version }}"
           echo "full_dev_tag=${{ env.version }}" >> $GITHUB_ENV
-          echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')" 
+          echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')"
           echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')" >> $GITHUB_ENV
 
       - uses: hashicorp/actions-docker-build@v2
@@ -379,7 +379,7 @@ jobs:
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor_dev_tag }}-ubi
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor_dev_tag }}-ubi-${{ github.sha }}
           smoke_test: .github/scripts/verify_docker.sh v${{ env.version }}
-          redhat_tag: quay.io/redhat-isv-containers/60f9fdbec3a80eac643abedf:${{env.version}}-ubi
+          redhat_tag: quay.io/redhat-isv-containers/${{ vars.REDHAT_PROJECT_ID }}:${{env.version}}-ubi
 
   verify-linux:
     needs:


### PR DESCRIPTION
### Description

Replacing the hard-coded Red Hat Project ID with a variable. This is to prevent the ENT values from being overwritten during CE-->ENT merges.

See https://hashicorp.atlassian.net/browse/SMRE-317 for more details.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
