### PR TITLE
ci: fix file parsing in conditional-skip script

### DIFF
--- a/.github/scripts/check_skip_ci.sh
+++ b/.github/scripts/check_skip_ci.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # Get the list of changed files
-# Using `git merge-base` ensures that we're always comparing against the correct branch point. 
+# Using `git merge-base` ensures that we're always comparing against the correct branch point.
 #For example, given the commits:
 #
 # A---B---C---D---W---X---Y---Z # origin/main
@@ -16,27 +16,34 @@ set -euo pipefail
 files_to_check=$(git diff --name-only "$(git merge-base origin/$SKIP_CHECK_BRANCH HEAD~)"...HEAD)
 
 # Define the directories to check
-skipped_directories=("docs/" "ui/" "website/" "grafana/")
+skipped_directories=("docs/" "ui/" "website/" "grafana/" ".changelog/")
 
 # Loop through the changed files and find directories/files outside the skipped ones
-for file_to_check in "${files_to_check[@]}"; do
+files_to_check_array=($files_to_check)
+for file_to_check in "${files_to_check_array[@]}"; do
 	file_is_skipped=false
+	echo "checking file: $file_to_check"
+
+	# Allow changes to:
+	# - This script
+	# - Files in the skipped directories
+	# - Markdown files
 	for dir in "${skipped_directories[@]}"; do
-		if [[ "$file_to_check" == "$dir"* ]] || [[ "$file_to_check" == *.md && "$dir" == *"/" ]]; then
+		if [[ "$file_to_check" == */check_skip_ci.sh ]] ||
+		   [[ "$file_to_check" == "$dir"* ]] ||
+		   [[ "$file_to_check" == *.md ]]; then
 			file_is_skipped=true
 			break
 		fi
 	done
+
 	if [ "$file_is_skipped" != "true" ]; then
-		echo -e $file_to_check
-        SKIP_CI=false
-		echo "Changes detected in non-documentation files - skip-ci: $SKIP_CI"
-        echo "skip-ci=$SKIP_CI" >> "$GITHUB_OUTPUT"
+		echo -e "non-skippable file changed: $file_to_check"
+		echo "Changes detected in non-documentation files - will not skip tests and build"
+        echo "skip-ci=false" >> "$GITHUB_OUTPUT"
 		exit 0 ## if file is outside of the skipped_directory exit script
 	fi
 done
 
-echo -e "$files_to_check"
-SKIP_CI=true
-echo "Changes detected in only documentation files - skip-ci: $SKIP_CI"
-echo "skip-ci=$SKIP_CI" >> "$GITHUB_OUTPUT"
+echo "Changes detected in only documentation files - skipping tests and build"
+echo "skip-ci=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -38,10 +38,10 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
-          fetch-depth: 0  
+          fetch-depth: 0
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files_go_test.sh
+        run: ./.github/scripts/check_skip_ci.sh
 
   setup:
     needs: [conditional-skip]

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files_go_test.sh
+        run: ./.github/scripts/check_skip_ci.sh
 
   setup:
     needs: [conditional-skip]

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files_go_test.sh
+        run: ./.github/scripts/check_skip_ci.sh
 
   setup:
     needs: [conditional-skip]


### PR DESCRIPTION
Ensure files are split rather than compared as a single list for accuracy and easier debugging. This was sneaky and it took me a while to notice even after testing some other changes!

Also adopt minor changes and file name from introduction of similar check `consul-dataplane` and `consul-k8s` for clarity.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
