### PR TITLE
ci: skip 1.18 nightly int tests on CE

### DIFF
--- a/.github/workflows/nightly-test-1.18.x.yaml
+++ b/.github/workflows/nightly-test-1.18.x.yaml
@@ -14,8 +14,15 @@ env:
   GOPRIVATE: github.com/hashicorp # Required for enterprise deps
 
 jobs:
+  check-ent:
+    runs-on: ubuntu-latest
+    if: ${{ endsWith(github.repository, '-enterprise') }}
+    steps:
+      - run: echo "Building Enterprise"
+
   frontend-test-workspace-node:
     runs-on: ubuntu-latest
+    needs: [check-ent]
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
@@ -45,6 +52,7 @@ jobs:
 
   frontend-build-ce:
     runs-on: ubuntu-latest
+    needs: [check-ent]
     env:
       JOBS: 2
       CONSUL_NSPACES_ENABLED: 0
@@ -117,6 +125,7 @@ jobs:
 
   frontend-build-ent:
     runs-on: ubuntu-latest
+    needs: [check-ent]
     env:
       JOBS: 2
       CONSUL_NSPACES_ENABLED: 1

--- a/.github/workflows/nightly-test-integrations-1.18.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.18.x.yml
@@ -23,8 +23,15 @@ env:
   BRANCH_NAME: "release-1.18.x"   # Used for naming artifacts
 
 jobs:
+  check-ent:
+    runs-on: ubuntu-latest
+    if: ${{ endsWith(github.repository, '-enterprise') }}
+    steps:
+      - run: echo "Building Enterprise"
+
   setup:
     runs-on: ubuntu-latest
+    needs: [check-ent]
     name: Setup
     outputs:
       compute-small: ${{ steps.runners.outputs.compute-small }}
@@ -41,6 +48,7 @@ jobs:
         run: .github/scripts/get_runner_classes.sh
 
   get-go-version:
+    needs: [check-ent]
     uses: ./.github/workflows/reusable-get-go-version.yml
 
   dev-build:
@@ -418,7 +426,7 @@ jobs:
     - upgrade-integration-test
     - upgrade-integration-test-deployer
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-    if: ${{ always() }}
+    if: ${{ always() && endsWith(github.repository, '-enterprise') }}
     steps:
       - name: evaluate upstream job results
         run: |


### PR DESCRIPTION
This version is no longer active in CE.

c.f. https://github.com/hashicorp/consul/pull/21242/files