### PR TITLE
[NET-10246] use correct enterprise meta for service name for LinkedService

### DIFF
--- a/.changelog/21382.txt
+++ b/.changelog/21382.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+terminating-gateway: **(Enterprise Only)** Fixed issue where enterprise metadata applied to linked services was the terminating-gateways enterprise metadata and not the linked services enterprise metadata.
+```

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -942,7 +942,7 @@ func ensureServiceTxn(tx WriteTxn, idx uint64, node string, preserveIndexes bool
 			}
 			if conf != nil {
 				termGatewayConf := conf.(*structs.TerminatingGatewayConfigEntry)
-				addrs, err := getTermGatewayVirtualIPs(tx, idx, termGatewayConf.Services, &svc.EnterpriseMeta)
+				addrs, err := getTermGatewayVirtualIPs(tx, idx, termGatewayConf.Services)
 				if err != nil {
 					return err
 				}
@@ -3585,11 +3585,10 @@ func getTermGatewayVirtualIPs(
 	tx WriteTxn,
 	idx uint64,
 	services []structs.LinkedService,
-	entMeta *acl.EnterpriseMeta,
 ) (map[string]structs.ServiceAddress, error) {
 	addrs := make(map[string]structs.ServiceAddress, len(services))
 	for _, s := range services {
-		sn := structs.ServiceName{Name: s.Name, EnterpriseMeta: *entMeta}
+		sn := structs.ServiceName{Name: s.Name, EnterpriseMeta: s.EnterpriseMeta}
 		// Terminating Gateways cannot route to services in peered clusters
 		psn := structs.PeeredServiceName{ServiceName: sn, Peer: structs.DefaultPeerKeyword}
 		vip, err := assignServiceVirtualIP(tx, idx, psn)
@@ -3606,7 +3605,7 @@ func getTermGatewayVirtualIPs(
 func updateTerminatingGatewayVirtualIPs(tx WriteTxn, idx uint64, conf *structs.TerminatingGatewayConfigEntry, entMeta *acl.EnterpriseMeta) error {
 	// Build the current map of services with virtual IPs for this gateway
 	services := conf.Services
-	addrs, err := getTermGatewayVirtualIPs(tx, idx, services, entMeta)
+	addrs, err := getTermGatewayVirtualIPs(tx, idx, services)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Previously we were incorrectly using the terminating gateway enterprise meta for linked services when we should be using the linked services ent meta

### Testing & Reproduction steps


### Links


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
