### PR TITLE
security: fix AliasCheck panic (update)

### DIFF
--- a/agent/checks/alias.go
+++ b/agent/checks/alias.go
@@ -164,6 +164,12 @@ RETRY_CALL:
 		}
 		return false, err
 	}
+
+	// Do not proceed for nil returned services.
+	if out.NodeServices == nil {
+		return false, fmt.Errorf("no services found on node")
+	}
+
 	for _, srv := range out.NodeServices.Services {
 		if serviceID.Matches(srv.CompoundServiceID()) {
 			return true, nil


### PR DESCRIPTION
Updated `checkServiceExistsOnRemoteServer` to ensure there are services returned from the specified node before proceeding with the service matcher.

### Description

Resolves the following

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x10370a28c]

goroutine 344 [running]:
[github.com/hashicorp/consul/agent/checks.(*CheckAlias).checkServiceExistsOnRemoteServer(0x140009f37c0](http://github.com/hashicorp/consul/agent/checks.(*CheckAlias).checkServiceExistsOnRemoteServer(0x140009f37c0), 0x140009f37d0)
        [github.com/hashicorp/consul/agent/checks/alias.go:164](http://github.com/hashicorp/consul/agent/checks/alias.go:164) +0x18c
[github.com/hashicorp/consul/agent/checks.(*CheckAlias).runQuery.func1(0x1](http://github.com/hashicorp/consul/agent/checks.(*CheckAlias).runQuery.func1(0x1)?)
        [github.com/hashicorp/consul/agent/checks/alias.go:237](http://github.com/hashicorp/consul/agent/checks/alias.go:237) +0x28
[github.com/hashicorp/consul/agent/checks.(*CheckAlias).processChecks(0x140009f37c0](http://github.com/hashicorp/consul/agent/checks.(*CheckAlias).processChecks(0x140009f37c0), {0x0, 0x0, 0x1057baa22?}, 0x140010dff48)
        [github.com/hashicorp/consul/agent/checks/alias.go:284](http://github.com/hashicorp/consul/agent/checks/alias.go:284) +0x36c
[github.com/hashicorp/consul/agent/checks.(*CheckAlias).runQuery(0x140009f37c0](http://github.com/hashicorp/consul/agent/checks.(*CheckAlias).runQuery(0x140009f37c0), 0x0?)
        [github.com/hashicorp/consul/agent/checks/alias.go:236](http://github.com/hashicorp/consul/agent/checks/alias.go:236) +0x29c
[github.com/hashicorp/consul/agent/checks.(*CheckAlias).run(0x0](http://github.com/hashicorp/consul/agent/checks.(*CheckAlias).run(0x0)?, 0x0?)
        [github.com/hashicorp/consul/agent/checks/alias.go:89](http://github.com/hashicorp/consul/agent/checks/alias.go:89) +0x58
created by [github.com/hashicorp/consul/agent/checks.(*CheckAlias).Start](http://github.com/hashicorp/consul/agent/checks.(*CheckAlias).Start) in goroutine 342
        [github.com/hashicorp/consul/agent/checks/alias.go:64](http://github.com/hashicorp/consul/agent/checks/alias.go:64) +0x15c
```

Fixes #21339

### Testing & Reproduction steps

```
curl --request PUT --data '{"name": "a", "check": {"AliasNode": "doesnotexist"}}' http://127.0.0.1:8500/v1/agent/service/register
```

### Links

https://github.com/hashicorp/consul/pull/21339

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
