### PR TITLE
fix(txn): validate verbs

### DIFF
--- a/.changelog/21519.txt
+++ b/.changelog/21519.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+txn: Fix a bug where mismatched Consul server versions could result in undetected data loss for when using newer Transaction verbs.
+```


### PR DESCRIPTION
### Description
There are two entry points into the state store:
1. Through RPCs
2. Indirectly, through Raft FSM Applies

In the latter case, errors are not acknowledged because the log must be processed by Consul. It is possible in this case that if a future version of Consul is using syntax, such as Txn API Verbs, that the current version does not understand, it will fail to apply successfully, causing a divergence with other servers.

This PR makes two types of changes:
1. Panics are introduced for unknown verb types to prevent state store divergence
1. Validation at the endpoint layer to make sure there is feedback to user for invalid verbs and this cannot be used for a DOS attack.