### PR TITLE
[NET-10290] Update ENVOY_VERSIONS

### DIFF
--- a/.changelog/21524.txt
+++ b/.changelog/21524.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-Upgrade envoy module dependencies to version 1.27.7, 1.28.5 and 1.29.7 or higher to resolve CVE-2024-39305
+Upgrade envoy module dependencies to version 1.27.7, 1.28.5 and 1.29.7 or higher to resolve [CVE-2024-39305](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39305)
 ```

--- a/.changelog/21524.txt
+++ b/.changelog/21524.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Upgrade envoy module dependencies to version 1.27.7, 1.28.5 and 1.29.7 or higher to resolve CVE-2024-39305
+```

--- a/envoyextensions/xdscommon/ENVOY_VERSIONS
+++ b/envoyextensions/xdscommon/ENVOY_VERSIONS
@@ -8,7 +8,7 @@
 #
 # See https://www.consul.io/docs/connect/proxies/envoy#supported-versions for more information on Consul's Envoy
 # version support.
-1.29.5
-1.28.4
-1.27.6
+1.29.7
+1.28.5
+1.27.7
 1.26.8


### PR DESCRIPTION
### Description
Upgrade envoy module dependencies to version 1.27.7, 1.28.5 and 1.29.7 or higher to resolve CVE-2024-39305

### Testing & Reproduction steps
🤖 tests pass

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
