### PR TITLE
Use debian:12 instead of centos:7 for artifact verification

### DIFF
--- a/.github/scripts/verify_artifact.sh
+++ b/.github/scripts/verify_artifact.sh
@@ -70,11 +70,11 @@ function verify_rpm {
   case "${artifact_path}" in
     *.i386.rpm)
       docker_platform="linux/386"
-      docker_image="i386/centos:7"
+      docker_image="debian:12"
       ;;
     *.x86_64.rpm)
       docker_platform="linux/amd64"
-      docker_image="amd64/centos:7"
+      docker_image="debian:12"
       ;;
     *.armv7hl.rpm)
       docker_platform="linux/arm/v7"


### PR DESCRIPTION
### Description
CentOS 7 has entered End of Life as of June 30, 2024. We aren't using CentOS 7 for builds but are using it for verifying artifacts for some architectures. In order for artifact verification to continue working, we must upgrade. I'm switching to `debian:12` which is supported through June 10, 2028.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
