### PR TITLE
Use vault.centos.org instead of mirror.centos.org

### DIFF
--- a/.github/scripts/verify_artifact.sh
+++ b/.github/scripts/verify_artifact.sh
@@ -70,11 +70,11 @@ function verify_rpm {
   case "${artifact_path}" in
     *.i386.rpm)
       docker_platform="linux/386"
-      docker_image="debian:12"
+      docker_image="i386/centos:7"
       ;;
     *.x86_64.rpm)
       docker_platform="linux/amd64"
-      docker_image="debian:12"
+      docker_image="amd64/centos:7"
       ;;
     *.armv7hl.rpm)
       docker_platform="linux/arm/v7"
@@ -102,7 +102,8 @@ function verify_rpm {
     ${docker_image} \
     /scripts/verify_rpm.sh \
     "/workdir/${artifact_path}" \
-    "${expect_version}"
+    "${expect_version}" \
+    "${docker_image}"
 }
 
 # Arguments:

--- a/.github/scripts/verify_rpm.sh
+++ b/.github/scripts/verify_rpm.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 # report why it failed. This is meant to be run as part of the build workflow to verify the built
 # .rpm meets some basic criteria for validity.
 
+# Notably, CentOS 7 is EOL, so we need to point to the vault for updates. It's not clear what alternative
+# we may use in the future that supports linux/386 as the platform was dropped in CentOS 8+9. The docker_image
+# is passed in as the third argument so that the script can determine if it needs to point to the vault for updates.
+
 # set this so we can locate and execute the verify_bin.sh script for verifying version output
 SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
@@ -20,6 +24,7 @@ function usage {
 function main {
   local rpm_path="${1:-}"
   local expect_version="${2:-}"
+  local docker_image="${3:-}"
   local got_version
 
   if [[ -z "${rpm_path}" ]]; then
@@ -34,6 +39,12 @@ function main {
     exit 1
   fi
 
+  if [[ -z "${docker_image}" ]]; then
+    echo "ERROR: docker image argument is required"
+    usage
+    exit 1
+  fi
+
   # expand globs for path names, if this fails, the script will exit
   rpm_path=$(echo ${rpm_path})
 
@@ -41,6 +52,12 @@ function main {
     echo "ERROR: package at ${rpm_path} does not exist."
     usage
     exit 1
+  fi
+
+  # CentOS 7 is EOL, so we need to point to the vault for updates
+  if [[ "$docker_image" == *centos:7 ]]; then
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
   fi
 
   yum -y clean all


### PR DESCRIPTION
### Description
The latter is no longer resolvable since CentOS 7 is EOL. Note that part of this PR is reverting #21527 

### Testing & Reproduction steps
There's no way to fully test the script in the right environment without merging; however, since the verify step is already broken, merging is low risk as we're in no worse shape.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added (will add more once we verify the fix works)
* [x] not a security concern
