### PR TITLE
docs: Clarify cluster peering vs WAN federation comparison

### DIFF
--- a/website/content/docs/connect/cluster-peering/index.mdx
+++ b/website/content/docs/connect/cluster-peering/index.mdx
@@ -45,7 +45,6 @@ Regardless of whether you connect your clusters through WAN federation or cluste
 | Replicates exported services for service discovery |    &#10060;    |    &#9989;      |
 | Gossip protocol: Requires LAN gossip only          |    &#10060;    |    &#9989;      |
 | Forwards service requests for service discovery    |    &#9989;     |    &#10060;     |
-| Shares key/value stores                            |    &#9989;     |    &#10060;     |
 | Can replicate ACL tokens, policies, and roles      |    &#9989;     |    &#10060;     |
 
 ## Guidance


### PR DESCRIPTION
### Description

[KV replication](https://developer.hashicorp.com/consul/tutorials/production-multi-cluster/multi-cluster-reference-architecture#replication) can happen only with third-party tool [consul-replicate](https://github.com/hashicorp/consul-replicate). Clarifying the documentation by removing the entry from the comparison table.

### Testing & Reproduction steps

N/A

### Links

- https://developer.hashicorp.com/consul/tutorials/production-multi-cluster/multi-cluster-reference-architecture#replication
- https://github.com/hashicorp/consul-replicate

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [ ] not a security concern
