### PR TITLE
ci: use workflow-scoped GH PAT for backports

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
-          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN_WORKFLOW }}
           ENABLE_VERSION_MANIFESTS: true
   backport-ent:
     if: github.event.pull_request.merged && contains(join(github.event.pull_request.labels.*.name), 'backport/ent')


### PR DESCRIPTION
This is necessary to allow backporting changes to GHA workflows, and mirrors the [token use in the CE->Ent merge workflow](https://github.com/hashicorp/consul-enterprise/blob/bd059e81e88e1a7a2a3b5d81c2c1c238d24c5a40/.github/workflows/oss-merge.yml#L21).

### Testing & Reproduction steps

Marking this PR for backport should verify the fix, since this PR is itself modifying GHA workflows.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
