### PR TITLE
NET-10610 - stop logging no data as errors in DNS lookups

### DIFF
--- a/agent/dns/router.go
+++ b/agent/dns/router.go
@@ -275,7 +275,6 @@ func (r *Router) handleRequestRecursively(req *dns.Msg, reqCtx Context, configCt
 	}
 	resp, err := messageSerializer{}.serialize(serializedOpts)
 	if err != nil {
-		r.logger.Error("error serializing DNS results", "error", err)
 		return respGenerator.generateResponseFromError(&generateResponseFromErrorOpts{
 			req:            req,
 			err:            err,


### PR DESCRIPTION
### Description

In the DNS subsystem, the router should pass of errors to the response generator.  The response generator already has logic to log things at the right level and for No Data error, this is the debug level.  This PR removes logging that occurs just before the error is passed off to response generator which is logging everything as an error which creates large amount of noise in logs.


### Links

https://github.com/hashicorp/consul/issues/21508
