### PR TITLE
Suppress CVE-2024-7264

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -41,6 +41,7 @@ container {
 				"CVE-2023-46218", # curl@8.4.0-r0
 				"CVE-2023-46219", # curl@8.4.0-r0
 				"CVE-2023-5678",  # openssl@3.1.4-r0
+				"CVE-2024-7264", # curl@8.9.0
 			]
 			paths = [
 				"internal/tools/proto-gen-rpc-glue/e2e/consul/*",


### PR DESCRIPTION
### Description

CVE-2024-7264 is recently reported and is blocking our dev builds from successfully completing. As there is not currently a fix available I am suppressing the CVE until a fix is made available.  

### Testing & Reproduction steps


### Links


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
