### PR TITLE
docs: Update compatibility.mdx for OpenShift

### DIFF
--- a/website/content/docs/k8s/compatibility.mdx
+++ b/website/content/docs/k8s/compatibility.mdx
@@ -27,11 +27,11 @@ compared to non-LTS Enterprise and community edition releases.
 Unless otherwise noted, rows in the following compatibility table
 apply to both Consul Enterprise and Consul community edition (CE).
 
-| Consul version | Compatible `consul-k8s` versions | Compatible Kubernetes versions | Compatible OpenShift versions          |
-| -------------- | -------------------------------- | -------------------------------| -------------------------------------- |
-| 1.19.x         | 1.5.x                            | 1.27.x - 1.29.x                | 4.13.x - 4.15.x (4.16.x not available) |
-| 1.18.x CE      | 1.4.x                            | 1.26.x - 1.29.x                | 4.13.x - 4.15.x (4.16.x not available) |
-| 1.17.x         | 1.3.x                            | 1.25.x - 1.28.x                | 4.12.x - 4.15.x                        |
+| Consul version | Compatible `consul-k8s` versions | Compatible Kubernetes versions | Compatible OpenShift versions |
+| -------------- | -------------------------------- | -------------------------------| ------------------------------|
+| 1.19.x         | 1.5.x                            | 1.27.x - 1.29.x                | 4.13.x - 4.15.x               |
+| 1.18.x CE      | 1.4.x                            | 1.26.x - 1.29.x                | 4.13.x - 4.15.x               |
+| 1.17.x         | 1.3.x                            | 1.25.x - 1.28.x                | 4.12.x - 4.15.x               |
 
 #### Enterprise Long Term Support releases
 
@@ -40,10 +40,10 @@ Active Consul Enterprise
 releases expand their Kubernetes version compatibility window
 until the LTS release reaches its end of maintenance.
 
-| Consul version | Compatible `consul-k8s` versions | Compatible Kubernetes versions | Compatible OpenShift versions          |
-| -------------- | -------------------------------- | -------------------------------| -------------------------------------- |
-| 1.18.x Ent     | 1.4.x                            | 1.26.x - 1.29.x                | 4.13.x - 4.15.x (4.16.x not available) |
-| 1.15.x Ent     | 1.1.x                            | 1.23.x - 1.28.x                | 4.10.x - 4.15.x                        |
+| Consul version | Compatible `consul-k8s` versions | Compatible Kubernetes versions | Compatible OpenShift versions |
+| -------------- | -------------------------------- | -------------------------------| ------------------------------|
+| 1.18.x Ent     | 1.4.x                            | 1.26.x - 1.29.x                | 4.13.x - 4.15.x               |
+| 1.15.x Ent     | 1.1.x                            | 1.23.x - 1.28.x                | 4.10.x - 4.15.x               |
 
 ### Version-specific upgrade requirements
 


### PR DESCRIPTION
Remove note that OpenShift 4.16 is not yet available, now that it's been released.

It will be added to the matrix in a future update once we've tested compatibility across eligible `consul-k8s` versions.

1.18 PR: https://github.com/hashicorp/consul/pull/21601
