### PR TITLE
[NET-10719] Fix cluster generation for jwt clusters for external jwt providers

### DIFF
--- a/.changelog/21604.txt
+++ b/.changelog/21604.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: **(Enterprise only)** ensure clusters are properly created for JWT providers with a remote URI for the JWKS endpoint
+```

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -148,7 +148,7 @@ func (s *ResourceGenerator) clustersFromSnapshotConnectProxy(cfgSnap *proxycfg.C
 
 	// add clusters for jwt-providers
 	for _, prov := range cfgSnap.JWTProviders {
-		//skip cluster creation for local providers
+		// skip cluster creation for local providers
 		if prov.JSONWebKeySet == nil || prov.JSONWebKeySet.Remote == nil {
 			continue
 		}
@@ -923,7 +923,6 @@ func (s *ResourceGenerator) injectGatewayDestinationAddons(cfgSnap *proxycfg.Con
 			}
 			c.TransportSocket = transportSocket
 		}
-
 	}
 	return nil
 }
@@ -1004,6 +1003,8 @@ func (s *ResourceGenerator) clustersFromSnapshotAPIGateway(cfgSnap *proxycfg.Con
 
 			createdClusters[uid] = true
 		}
+
+		clusters = append(clusters, makeAPIGatewayJWKClusters(s.Logger, cfgSnap)...)
 	}
 	return clusters, nil
 }
@@ -1145,7 +1146,6 @@ func (s *ResourceGenerator) makeUpstreamClusterForPeerService(
 	}
 
 	upstreamsSnapshot, err := cfgSnap.ToConfigSnapshotUpstreams()
-
 	if err != nil {
 		return c, err
 	}

--- a/agent/xds/jwt_authn_ce.go
+++ b/agent/xds/jwt_authn_ce.go
@@ -8,8 +8,11 @@ package xds
 import (
 	envoy_http_jwt_authn_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/jwt_authn/v3"
 	envoy_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"google.golang.org/protobuf/proto"
 
+	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/go-hclog"
 )
 
 type GatewayAuthFilterBuilder struct {
@@ -21,4 +24,8 @@ type GatewayAuthFilterBuilder struct {
 
 func (g *GatewayAuthFilterBuilder) makeGatewayAuthFilters() ([]*envoy_http_v3.HttpFilter, error) {
 	return nil, nil
+}
+
+func makeAPIGatewayJWKClusters(_ hclog.Logger, _ *proxycfg.ConfigSnapshot) []proto.Message {
+	return nil
 }


### PR DESCRIPTION
### Description

JWT clusters were previously not being created correctly, this adds the plumbing to handle this in the enterprise fork

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
