### PR TITLE
Fix TestDNS_ServiceLookup_ARecordLimits so that it only creates test agents the minimal amount of time

### DIFF
--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -3117,16 +3117,6 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 		{"udp-edns-5", 5, 5, 5, 5, 30, 30, 8192},
 		{"udp-edns-6", 6, 6, 6, 6, 30, 30, 8192},
 		{"udp-edns-max", 6, 2, 1, 3, 3, 3, 8192},
-		// All UDP without EDNS have a limit of 2 answers due to udpAnswerLimit
-		// Even SRV records are limit to 2 records
-		{"udp-limit-1", 1, 1, 0, 1, 1, 1, 512},
-		{"udp-limit-2", 2, 1, 1, 2, 2, 2, 512},
-		// AAAA results limited by size of payload
-		{"udp-limit-3", 3, 1, 1, 2, 2, 2, 512},
-		{"udp-limit-4", 4, 1, 1, 2, 2, 2, 512},
-		{"udp-limit-5", 5, 1, 1, 2, 2, 2, 512},
-		{"udp-limit-6", 6, 1, 1, 2, 2, 2, 512},
-		{"udp-limit-max", 6, 1, 1, 2, 2, 2, 512},
 		// All UDP without EDNS and no udpAnswerLimit
 		// Size of records is limited by UDP payload
 		{"udp-1", 1, 1, 0, 1, 1, 1, 512},

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -3100,52 +3100,51 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                   string
-		aRecordLimit           int
-		expectedAResults       int
-		expectedAAAAResults    int
-		expectedANYResults     int
-		expectedSRVResults     int
-		numNodesTotal          int
-		udpSize                uint16
-		_unused_udpAnswerLimit int // NOTE: this field is not used
+		name                string
+		aRecordLimit        int
+		expectedAResults    int
+		expectedAAAAResults int
+		expectedANYResults  int
+		expectedSRVResults  int
+		numNodesTotal       int
+		udpSize             uint16
 	}{
 		// UDP + EDNS
-		{"udp-edns-1", 1, 1, 1, 1, 30, 30, 8192, 3},
-		{"udp-edns-2", 2, 2, 2, 2, 30, 30, 8192, 3},
-		{"udp-edns-3", 3, 3, 3, 3, 30, 30, 8192, 3},
-		{"udp-edns-4", 4, 4, 4, 4, 30, 30, 8192, 3},
-		{"udp-edns-5", 5, 5, 5, 5, 30, 30, 8192, 3},
-		{"udp-edns-6", 6, 6, 6, 6, 30, 30, 8192, 3},
-		{"udp-edns-max", 6, 2, 1, 3, 3, 3, 8192, 3},
+		{"udp-edns-1", 1, 1, 1, 1, 30, 30, 8192},
+		{"udp-edns-2", 2, 2, 2, 2, 30, 30, 8192},
+		{"udp-edns-3", 3, 3, 3, 3, 30, 30, 8192},
+		{"udp-edns-4", 4, 4, 4, 4, 30, 30, 8192},
+		{"udp-edns-5", 5, 5, 5, 5, 30, 30, 8192},
+		{"udp-edns-6", 6, 6, 6, 6, 30, 30, 8192},
+		{"udp-edns-max", 6, 2, 1, 3, 3, 3, 8192},
 		// All UDP without EDNS have a limit of 2 answers due to udpAnswerLimit
 		// Even SRV records are limit to 2 records
-		{"udp-limit-1", 1, 1, 0, 1, 1, 1, 512, 2},
-		{"udp-limit-2", 2, 1, 1, 2, 2, 2, 512, 2},
+		{"udp-limit-1", 1, 1, 0, 1, 1, 1, 512},
+		{"udp-limit-2", 2, 1, 1, 2, 2, 2, 512},
 		// AAAA results limited by size of payload
-		{"udp-limit-3", 3, 1, 1, 2, 2, 2, 512, 2},
-		{"udp-limit-4", 4, 1, 1, 2, 2, 2, 512, 2},
-		{"udp-limit-5", 5, 1, 1, 2, 2, 2, 512, 2},
-		{"udp-limit-6", 6, 1, 1, 2, 2, 2, 512, 2},
-		{"udp-limit-max", 6, 1, 1, 2, 2, 2, 512, 2},
+		{"udp-limit-3", 3, 1, 1, 2, 2, 2, 512},
+		{"udp-limit-4", 4, 1, 1, 2, 2, 2, 512},
+		{"udp-limit-5", 5, 1, 1, 2, 2, 2, 512},
+		{"udp-limit-6", 6, 1, 1, 2, 2, 2, 512},
+		{"udp-limit-max", 6, 1, 1, 2, 2, 2, 512},
 		// All UDP without EDNS and no udpAnswerLimit
 		// Size of records is limited by UDP payload
-		{"udp-1", 1, 1, 0, 1, 1, 1, 512, 0},
-		{"udp-2", 2, 1, 1, 2, 2, 2, 512, 0},
-		{"udp-3", 3, 1, 1, 2, 2, 2, 512, 0},
-		{"udp-4", 4, 1, 1, 2, 2, 2, 512, 0},
-		{"udp-5", 5, 1, 1, 2, 2, 2, 512, 0},
-		{"udp-6", 6, 1, 1, 2, 2, 2, 512, 0},
+		{"udp-1", 1, 1, 0, 1, 1, 1, 512},
+		{"udp-2", 2, 1, 1, 2, 2, 2, 512},
+		{"udp-3", 3, 1, 1, 2, 2, 2, 512},
+		{"udp-4", 4, 1, 1, 2, 2, 2, 512},
+		{"udp-5", 5, 1, 1, 2, 2, 2, 512},
+		{"udp-6", 6, 1, 1, 2, 2, 2, 512},
 		// Only 3 A and 3 SRV records on 512 bytes
-		{"udp-max", 6, 1, 1, 2, 2, 2, 512, 0},
+		{"udp-max", 6, 1, 1, 2, 2, 2, 512},
 
-		{"tcp-1", 1, 1, 1, 1, 30, 30, 0, 0},
-		{"tcp-2", 2, 2, 2, 2, 30, 30, 0, 0},
-		{"tcp-3", 3, 3, 3, 3, 30, 30, 0, 0},
-		{"tcp-4", 4, 4, 4, 4, 30, 30, 0, 0},
-		{"tcp-5", 5, 5, 5, 5, 30, 30, 0, 0},
-		{"tcp-6", 6, 6, 6, 6, 30, 30, 0, 0},
-		{"tcp-max", 6, 1, 1, 2, 2, 2, 0, 0},
+		{"tcp-1", 1, 1, 1, 1, 30, 30, 0},
+		{"tcp-2", 2, 2, 2, 2, 30, 30, 0},
+		{"tcp-3", 3, 3, 3, 3, 30, 30, 0},
+		{"tcp-4", 4, 4, 4, 4, 30, 30, 0},
+		{"tcp-5", 5, 5, 5, 5, 30, 30, 0},
+		{"tcp-6", 6, 6, 6, 6, 30, 30, 0},
+		{"tcp-max", 6, 1, 1, 2, 2, 2, 0},
 	}
 	for _, test := range tests {
 		test := test // capture loop var

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -3017,6 +3017,7 @@ func checkDNSService(
 	qType uint16,
 	expectedResultsCount int,
 	udpSize uint16,
+	setEDNS0 bool,
 ) {
 	a := NewTestAgent(t, `
 		node_name = "test-node"
@@ -3076,7 +3077,7 @@ func checkDNSService(
 			m := new(dns.Msg)
 
 			m.SetQuestion(question, qType)
-			if udpSize > 512 {
+			if setEDNS0 {
 				m.SetEdns0(udpSize, true)
 			}
 			c := &dns.Client{Net: protocol, UDPSize: udpSize}
@@ -3110,33 +3111,34 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 		expectedSRVResults  int
 		numNodesTotal       int
 		udpSize             uint16
+		setEDNS0            bool
 	}{
 		// UDP + EDNS
-		{"udp-edns-1", UDP, 1, 1, 1, 1, 30, 30, 8192},
-		{"udp-edns-2", UDP, 2, 2, 2, 2, 30, 30, 8192},
-		{"udp-edns-3", UDP, 3, 3, 3, 3, 30, 30, 8192},
-		{"udp-edns-4", UDP, 4, 4, 4, 4, 30, 30, 8192},
-		{"udp-edns-5", UDP, 5, 5, 5, 5, 30, 30, 8192},
-		{"udp-edns-6", UDP, 6, 6, 6, 6, 30, 30, 8192},
-		{"udp-edns-max", UDP, 6, 2, 1, 3, 3, 3, 8192},
+		{"udp-edns-1", UDP, 1, 1, 1, 1, 30, 30, 8192, true},
+		{"udp-edns-2", UDP, 2, 2, 2, 2, 30, 30, 8192, true},
+		{"udp-edns-3", UDP, 3, 3, 3, 3, 30, 30, 8192, true},
+		{"udp-edns-4", UDP, 4, 4, 4, 4, 30, 30, 8192, true},
+		{"udp-edns-5", UDP, 5, 5, 5, 5, 30, 30, 8192, true},
+		{"udp-edns-6", UDP, 6, 6, 6, 6, 30, 30, 8192, true},
+		{"udp-edns-max", UDP, 6, 2, 1, 3, 3, 3, 8192, true},
 		// All UDP without EDNS and no udpAnswerLimit
 		// Size of records is limited by UDP payload
-		{"udp-1", UDP, 1, 1, 0, 1, 1, 1, 512},
-		{"udp-2", UDP, 2, 1, 1, 2, 2, 2, 512},
-		{"udp-3", UDP, 3, 1, 1, 2, 2, 2, 512},
-		{"udp-4", UDP, 4, 1, 1, 2, 2, 2, 512},
-		{"udp-5", UDP, 5, 1, 1, 2, 2, 2, 512},
-		{"udp-6", UDP, 6, 1, 1, 2, 2, 2, 512},
+		{"udp-1", UDP, 1, 1, 0, 1, 1, 1, 512, false},
+		{"udp-2", UDP, 2, 1, 1, 2, 2, 2, 512, false},
+		{"udp-3", UDP, 3, 1, 1, 2, 2, 2, 512, false},
+		{"udp-4", UDP, 4, 1, 1, 2, 2, 2, 512, false},
+		{"udp-5", UDP, 5, 1, 1, 2, 2, 2, 512, false},
+		{"udp-6", UDP, 6, 1, 1, 2, 2, 2, 512, false},
 		// Only 3 A and 3 SRV records on 512 bytes
-		{"udp-max", UDP, 6, 1, 1, 2, 2, 2, 512},
+		{"udp-max", UDP, 6, 1, 1, 2, 2, 2, 512, false},
 
-		{"tcp-1", TCP, 1, 1, 1, 1, 30, 30, 0},
-		{"tcp-2", TCP, 2, 2, 2, 2, 30, 30, 0},
-		{"tcp-3", TCP, 3, 3, 3, 3, 30, 30, 0},
-		{"tcp-4", TCP, 4, 4, 4, 4, 30, 30, 0},
-		{"tcp-5", TCP, 5, 5, 5, 5, 30, 30, 0},
-		{"tcp-6", TCP, 6, 6, 6, 6, 30, 30, 0},
-		{"tcp-max", TCP, 6, 1, 1, 2, 2, 2, 0},
+		{"tcp-1", TCP, 1, 1, 1, 1, 30, 30, 0, false},
+		{"tcp-2", TCP, 2, 2, 2, 2, 30, 30, 0, false},
+		{"tcp-3", TCP, 3, 3, 3, 3, 30, 30, 0, false},
+		{"tcp-4", TCP, 4, 4, 4, 4, 30, 30, 0, false},
+		{"tcp-5", TCP, 5, 5, 5, 5, 30, 30, 0, false},
+		{"tcp-6", TCP, 6, 6, 6, 6, 30, 30, 0, false},
+		{"tcp-max", TCP, 6, 1, 1, 2, 2, 2, 0, false},
 	}
 	for _, test := range tests {
 		test := test // capture loop var
@@ -3146,20 +3148,20 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 			// All those queries should have at max queriesLimited elements
 
 			t.Run("A", func(t *testing.T) {
-				checkDNSService(t, test.protocol, test.numNodesTotal, test.aRecordLimit, dns.TypeA, test.expectedAResults, test.udpSize)
+				checkDNSService(t, test.protocol, test.numNodesTotal, test.aRecordLimit, dns.TypeA, test.expectedAResults, test.udpSize, test.setEDNS0)
 			})
 
 			t.Run("AAAA", func(t *testing.T) {
-				checkDNSService(t, test.protocol, test.numNodesTotal, test.aRecordLimit, dns.TypeAAAA, test.expectedAAAAResults, test.udpSize)
+				checkDNSService(t, test.protocol, test.numNodesTotal, test.aRecordLimit, dns.TypeAAAA, test.expectedAAAAResults, test.udpSize, test.setEDNS0)
 			})
 
 			t.Run("ANY", func(t *testing.T) {
-				checkDNSService(t, test.protocol, test.numNodesTotal, test.aRecordLimit, dns.TypeANY, test.expectedANYResults, test.udpSize)
+				checkDNSService(t, test.protocol, test.numNodesTotal, test.aRecordLimit, dns.TypeANY, test.expectedANYResults, test.udpSize, test.setEDNS0)
 			})
 
 			// No limits but the size of records for SRV records, since not subject to randomization issues
 			t.Run("SRV", func(t *testing.T) {
-				checkDNSService(t, test.protocol, test.expectedSRVResults, test.aRecordLimit, dns.TypeSRV, test.numNodesTotal, test.udpSize)
+				checkDNSService(t, test.protocol, test.expectedSRVResults, test.aRecordLimit, dns.TypeSRV, test.numNodesTotal, test.udpSize, test.setEDNS0)
 			})
 		})
 	}


### PR DESCRIPTION
### Description
`TestDNS_ServiceLookup_ARecordLimits` is one of our longest running tests.  

It's average runtime in CI over the last 3 months is 1min 45 secs.

Locally on a mac M1, it performs in 1 min 11 seconds:
<img width="301" alt="Screenshot 2024-08-15 at 7 04 21 AM" src="https://github.com/user-attachments/assets/1cefd7fc-2549-4244-840a-787f156a7c71">

The reason why is that for every test case it spawns a new TestAgent.  This is **112 test agents** getting spawned, taking up ports, file descriptors, etc.  

Re-arranging this test so that test agents are only created when the agent config changes, reduces it to 7 Test Agents getting created.  (There was also a category of tests that could be removed as duplicates that removed 28 of the test agent).

This is the test results locally now that finish in 10 secs:
<img width="328" alt="Screenshot 2024-08-15 at 9 20 19 AM" src="https://github.com/user-attachments/assets/9f090e57-e0ff-4e06-a368-24ec79a9930d">

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
