### PR TITLE
[NET-10774] Fix Group Reference in GatewayPolcy Docs

### DIFF
--- a/website/content/docs/connect/gateways/api-gateway/configuration/gatewaypolicy.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/configuration/gatewaypolicy.mdx
@@ -53,7 +53,7 @@ spec:
   targetRef:
     name: gateway
     kind: Gateway
-    group: gateway.networking.kubernetes.io
+    group: gateway.networking.k8s.io/v1beta1
     sectionName: <name of a specific listener the policy applies>
   override:
     jwt:
@@ -153,7 +153,7 @@ The following table describes the members of the `targetRef` map:
 | `namespace` | Specifies the namespace that the target reference is a member of. | String | `default` |
 | `name` | Specifies the name of the API gateway that the policy attaches to. | String | None |
 | `kind` | Specifies the type of resource that the policy attaches to. Must be set to `Gateway`. | String | None |
-| `group` | Specifies the resource group. Must be set to `gateway.networking.kubernetes.io`. | String | None |
+| `group` | Specifies the resource group. Must be set to `gateway.networking.k8s.io/v1beta1`. | String | None |
 | `sectionName` | Specifies a part of the gateway that the policy applies to. | String | None |
 
 ### `spec.override`
@@ -237,7 +237,7 @@ spec:
   targetRef:
     name: gateway
     kind: Gateway
-    group: gateway.networking.kubernetes.io
+    group: gateway.networking.k8s.io/v1beta1
     sectionName: to-server
   override:
     jwt:

--- a/website/content/docs/connect/gateways/api-gateway/secure-traffic/verify-jwts-k8s.mdx
+++ b/website/content/docs/connect/gateways/api-gateway/secure-traffic/verify-jwts-k8s.mdx
@@ -67,7 +67,7 @@ Create a `GatewayPolicy` CRD that defines default and override settings for JWT 
 - `metadata.name`: Specifies a name for the policy.
 - `spec.targetRef.name`: Specifies the name of the API gateway to attach the policy to.
 - `spec.targetRef.kind`: Specifies the kind of resource to attach to the policy to. Must be set to `Gateway`.
-- `spec.targetRef.group`: Specifies the resource group. Unless you have created a custom group, this should be set to `gateway.networking.kubernetes.io`.
+- `spec.targetRef.group`: Specifies the resource group. Unless you have created a custom group, this should be set to `gateway.networking.k8s.io/v1beta1`.
 - `spec.targetRef.sectionName`: Specifies a part of the gateway that the policy applies to.
 - `spec.targetRef.override.jwt.providers`: Specifies a list of providers and claims used to verify requests to the gateway. The override settings take precedence over the default and route-specific JWT verification settings.
 - `spec.targetRef.default.jwt.providers`: Specifies a list of default providers and claims used to verify requests to the gateway.
@@ -176,7 +176,7 @@ For more information about the fields you can configure, refer to [`RouteAuthFil
 In the `filters` field of your HTTPRoute configuration, define the filter behavior that results from JWT verification.
 
 - `type: extensionRef`: Declare list of extension references.
-- `extensionRef.group`: Specifies the resource group. Unless you have created a custom group, this should be set to `gateway.networking.kubernetes.io`.
+- `extensionRef.group`: Specifies the resource group. Unless you have created a custom group, this should be set to `gateway.networking.k8s.io/v1beta1`.
 - `extensionRef.kind`: Specifies the type of extension reference to attach to the route. Must be `RouteAuthFilter`
 - `extensionRef.name`: Specifies the name of the auth filter.
 


### PR DESCRIPTION
### Description

Gateway policy docs incorrectly specify the group for the target ref to be `gateway.networking.kubernetes.io` it should be `gateway.networking.k8s.io/v1beta1`

### Testing & Reproduction steps



### Links



### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
