### PR TITLE
Backport of add build support script to print out the submodule versions required in other submodules into release/1.15.x

### DIFF
--- a/build-support/functions/10-util.sh
+++ b/build-support/functions/10-util.sh
@@ -667,3 +667,21 @@ function go_mod_assert {
    fi
    return 0
 }
+
+function get_consul_module_versions {
+  local module_directories
+  module_directories=( "." "api" "envoyextensions" "proto-public" "sdk" "troubleshoot")
+  for module_dir in "${module_directories[@]}"; do
+    echo "Module versions for directory: '$module_dir':"
+    echo "--------------"
+    (cd "$module_dir" && go list -m all | grep -e github.com/hashicorp/consul/api \
+    -e github.com/hashicorp/consul/envoyextensions \
+    -e github.com/hashicorp/consul/proto-public \
+    -e github.com/hashicorp/consul/sdk \
+    -e github.com/hashicorp/consul/troubleshoot \
+    | if [ "$module_dir" != "." ]; then grep -v "consul/$module_dir"; else cat; fi)
+    echo "--------------"
+    echo ""
+  done
+  return 0
+}

--- a/build-support/scripts/consul-module-versions-in-consul.sh
+++ b/build-support/scripts/consul-module-versions-in-consul.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+
+readonly SCRIPT_NAME="$(basename ${BASH_SOURCE[0]})"
+readonly SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+readonly SOURCE_DIR="$(dirname "$(dirname "${SCRIPT_DIR}")")"
+readonly FN_DIR="$(dirname "${SCRIPT_DIR}")/functions"
+
+source "${SCRIPT_DIR}/functions.sh"
+
+function usage {
+cat <<-EOF
+Usage: ${SCRIPT_NAME}  [<options ...>]
+
+Description:
+
+   This script reports the consul module versions in each of the go.mod files in the Consul repository.
+
+Options:                       
+   -h | --help                   Print this help text.
+EOF
+}
+
+function err_usage {
+   err "$1"
+   err ""
+   err "$(usage)"
+}
+
+function main {
+   while test $# -gt 0
+   do
+      case "$1" in
+         -h | --help )
+            usage
+            return 0
+            ;;
+         *)
+            err_usage "ERROR: Unknown argument: '$1'"
+            return 1
+            ;;
+      esac
+   done
+   
+   get_consul_module_versions || return 1
+   
+   return 0
+}
+
+main "$@"
+exit $?
+   


### PR DESCRIPTION
## Backport

This PR is manual from #21635.



The below text is copied from the body of the original PR.

---


### Description
This is used during releases to know which bumps need to be made.  Will manually backport to 1.15, 1.17, and 1.18.

Usage: 
```
$ ./build-support/scripts/consul-module-versions-in-consul.sh
Module versions for directory: '.':
--------------
github.com/hashicorp/consul/api v1.29.1 => ./api
add build support script to print out the submodule versions required in other submodules
github.com/hashicorp/consul/envoyextensions v0.7.0 => ./envoyextensions
github.com/hashicorp/consul/proto-public v0.6.1 => ./proto-public
github.com/hashicorp/consul/sdk v0.16.1 => ./sdk
github.com/hashicorp/consul/troubleshoot v0.6.1 => ./troubleshoot
--------------

Module versions for directory: 'api':
--------------
github.com/hashicorp/consul/api
github.com/hashicorp/consul/proto-public v0.6.1 => ../proto-public
github.com/hashicorp/consul/sdk v0.16.1 => ../sdk
--------------

Module versions for directory: 'envoyextensions':
--------------
github.com/hashicorp/consul/envoyextensions
github.com/hashicorp/consul/api v1.29.1 => ../api
github.com/hashicorp/consul/proto-public v0.6.1 => ../proto-public
github.com/hashicorp/consul/sdk v0.16.1 => ../sdk
--------------

Module versions for directory: 'proto-public':
--------------
github.com/hashicorp/consul/proto-public
--------------

Module versions for directory: 'sdk':
--------------
github.com/hashicorp/consul/sdk
--------------

Module versions for directory: 'troubleshoot':
--------------
github.com/hashicorp/consul/troubleshoot
github.com/hashicorp/consul/api v1.29.1 => ../api
github.com/hashicorp/consul/envoyextensions v0.7.0 => ../envoyextensions
github.com/hashicorp/consul/proto-public v0.6.1 => ../proto-public
github.com/hashicorp/consul/sdk v0.16.1 => ../sdk
--------------
```


---

<details>
<summary> Overview of commits </summary>

  - 7a0d3ca36dbb364f6b8a8d6fa3a5008ba83c3095  - 2ae80130911529a8d7c7258027d690a00f720198 

</details>


