### PR TITLE
ci: fix workflow graph for 1.18 Envoy int tests

### DIFF
--- a/.github/workflows/nightly-test-integrations-1.18.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.18.x.yml
@@ -54,6 +54,7 @@ jobs:
       ref: release/1.18.x
 
   get-envoy-versions:
+    needs: [check-ent]
     uses: ./.github/workflows/reusable-get-envoy-versions.yml
     with:
       ref: release/1.18.x


### PR DESCRIPTION
This branch is no longer active on CE, so its jobs should all be skipped via check-ent. One job was missed so it fails nightly right now.
