### PR TITLE
revert change to website/content/docs/connect/config-entries/mesh.mdx

### DIFF
--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -343,17 +343,6 @@ Note that the Kubernetes example does not include a `partition` field. Configura
         'Controls whether `MutualTLSMode=permissive` can be set in the `proxy-defaults` and `service-defaults` configuration entries. '
     },
     {
-      name: 'ValidateClusters',
-      type: 'bool: false',
-      description:
-        `Controls whether the clusters the route table refers to are validated. The default value is false. When set to
-         false and a route refers to a cluster that does not exist, the route table loads and routing to a non-existent
-         cluster results in a 404. When set to true and the route is set to a cluster that do not exist, the route table
-         will not load.  For more information, refer to
-         [HTTP route configuration in the Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto#envoy-v3-api-field-config-route-v3-routeconfiguration-validate-clusters)
-         for more details. `,
-    },
-    {
       name: 'TLS',
       type: 'TLSConfig: <optional>',
       description: 'TLS configuration for the service mesh.',


### PR DESCRIPTION
### Description
In backporting the ValidateClusters change to api and protos a docs change also inadvertently got pulled back.
