### PR TITLE
test: update pause Docker image in Envoy int tests

### DIFF
--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -553,8 +553,7 @@ function suite_setup {
     docker run --sysctl net.ipv6.conf.all.disable_ipv6=1 -d --name envoy_workdir_1 \
         $WORKDIR_SNIPPET \
         --net=none \
-        k8s.gcr.io/pause &>/dev/null
-    # TODO(rb): switch back to "${HASHICORP_DOCKER_PROXY}/google/pause" once that is cached
+        registry.k8s.io/pause &>/dev/null
 
     # pre-build the verify container
     echo "Rebuilding 'bats-verify' image..."


### PR DESCRIPTION
k8s.gcr.io has been migrated to registry.k8s.io for several years now, and the old registry is being shut down, causing image pull failures.

Update to target the new registry when pulling the pause image used in Envoy integration tests.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
