### PR TITLE
Update 1.18.x after re-publishing modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,8 +43,8 @@ require (
 	github.com/hashi-derek/grpc-proxy v0.0.0-20231207191910-191266484d75
 	github.com/hashicorp/consul-awsauth v0.0.0-20220713182709-05ac1c5c2706
 	github.com/hashicorp/consul-net-rpc v0.0.0-20221205195236-156cfab66a69
-	github.com/hashicorp/consul/api v1.29.1
-	github.com/hashicorp/consul/envoyextensions v0.7.0
+	github.com/hashicorp/consul/api v1.28.4
+	github.com/hashicorp/consul/envoyextensions v0.6.2
 	github.com/hashicorp/consul/proto-public v0.6.1
 	github.com/hashicorp/consul/sdk v0.16.0
 	github.com/hashicorp/consul/troubleshoot v0.6.1

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/hashicorp/consul/envoyextensions v0.6.2
 	github.com/hashicorp/consul/proto-public v0.6.1
 	github.com/hashicorp/consul/sdk v0.16.0
-	github.com/hashicorp/consul/troubleshoot v0.6.1
+	github.com/hashicorp/consul/troubleshoot v0.6.5
 	github.com/hashicorp/go-bexpr v0.1.2
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/test-integ/go.mod
+++ b/test-integ/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9
-	github.com/hashicorp/consul/api v1.29.1
+	github.com/hashicorp/consul/api v1.28.4
 	github.com/hashicorp/consul/proto-public v0.6.1
 	github.com/hashicorp/consul/sdk v0.16.0
 	github.com/hashicorp/consul/test/integration/consul-container v0.0.0-20230628201853-bdf4fad7c5a5

--- a/test/integration/consul-container/go.mod
+++ b/test/integration/consul-container/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/go-jose/go-jose/v3 v3.0.3
 	github.com/hashicorp/consul v1.16.1
-	github.com/hashicorp/consul/api v1.29.1
-	github.com/hashicorp/consul/envoyextensions v0.7.0
+	github.com/hashicorp/consul/api v1.28.4
+	github.com/hashicorp/consul/envoyextensions v0.6.2
 	github.com/hashicorp/consul/proto-public v0.6.1
 	github.com/hashicorp/consul/sdk v0.16.0
 	github.com/hashicorp/consul/testing/deployer v0.0.0-20230811171106-4a0afb5d1373

--- a/troubleshoot/go.mod
+++ b/troubleshoot/go.mod
@@ -13,11 +13,6 @@ exclude (
 	github.com/hashicorp/go-msgpack v1.1.6 // contains retractions but same as v1.1.5
 )
 
-retract (
-	v0.6.2 // tag has incorrect line of deps
-	v0.6.1 // tag has incorrect line of deps
-)
-
 require (
 	github.com/envoyproxy/go-control-plane v0.11.1
 	github.com/envoyproxy/go-control-plane/xdsmatcher v0.0.0-20230524161521-aaaacbfbe53e

--- a/troubleshoot/go.mod
+++ b/troubleshoot/go.mod
@@ -13,6 +13,11 @@ exclude (
 	github.com/hashicorp/go-msgpack v1.1.6 // contains retractions but same as v1.1.5
 )
 
+retract (
+	v0.6.2 // tag has incorrect line of deps
+	v0.6.1 // tag has incorrect line of deps
+)
+
 require (
 	github.com/envoyproxy/go-control-plane v0.11.1
 	github.com/envoyproxy/go-control-plane/xdsmatcher v0.0.0-20230524161521-aaaacbfbe53e


### PR DESCRIPTION
### Description

The following tags have been released and this PR updates 1.18.x with the recent versions:
- [api/v1.28.4](https://github.com/hashicorp/consul/releases/tag/api%2Fv1.28.4)
- [envoyextensions/v0.6.2](https://github.com/hashicorp/consul/releases/tag/envoyextensions%2Fv0.6.2)
- [troubleshoot/v0.6.5](https://github.com/hashicorp/consul/releases/tag/troubleshoot%2Fv0.6.5)