### PR TITLE
run integration tests on push in main and release/*

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -13,7 +13,11 @@ on:
       - 'backport/docs/**'
       - 'backport/ui/**'
       - 'backport/mktg-**'
-
+  push:
+    branches:
+      # Push events on the main branch
+      - main
+      - release/**
 env:
   TEST_RESULTS_DIR: /tmp/test-results
   TEST_RESULTS_ARTIFACT_NAME: test-results

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -18,6 +18,7 @@ on:
       # Push events on the main branch
       - main
       - release/**
+
 env:
   TEST_RESULTS_DIR: /tmp/test-results
   TEST_RESULTS_ARTIFACT_NAME: test-results


### PR DESCRIPTION
### Description

Our branch protection rules expect this...and we have no reason not to run these in release branches and on main.

Will manually backport to 1.15, 1.17, and 1.18.