### PR TITLE
Backport of run integration tests on push in main and release/* into release/1.17.x

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -13,6 +13,11 @@ on:
       - 'backport/docs/**'
       - 'backport/ui/**'
       - 'backport/mktg-**'
+  push:
+    branches:
+      # Push events on the main branch
+      - main
+      - release/**
 
 env:
   TEST_RESULTS_DIR: /tmp/test-results


### PR DESCRIPTION
## Backport

This PR is manually generated from #21666.



The below text is copied from the body of the original PR.

---

### Description

Our branch protection rules expect this...and we have no reason not to run these in release branches and on main.

Will manually backport to 1.15, 1.17, and 1.18.

---

<details>
<summary> Overview of commits </summary>

  - cb63abf7a7f1597fdd00a55af0d49ecb04ff4d31  - 40a95ae7599fffb29dd64b05f80defbdaae0f6e7 

</details>


