### PR TITLE
test: fix Envoy int tests and add container logs

### DIFF
--- a/.github/workflows/nightly-test-integrations-1.15.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.15.x.yml
@@ -146,11 +146,15 @@ jobs:
           path: ./bin
       - name: restore mode+x
         run: chmod +x ./bin/consul
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
       - name: Docker build
         run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile ./bin
+
       - name: Envoy Integration Tests
+        id: envoy-integration-tests
         env:
           GOTESTSUM_JUNITFILE: ${{ env.TEST_RESULTS_DIR }}/results.xml
           GOTESTSUM_FORMAT: standard-verbose
@@ -170,6 +174,23 @@ jobs:
               --jsonfile /tmp/jsonfile/go-test.log \
               --packages=./test/integration/connect/envoy \
               -- -timeout=30m -tags integration -run="TestEnvoy/(${{ matrix.test-cases }})"
+
+      # See https://github.com/orgs/community/discussions/8945#discussioncomment-9897011
+      # and overall topic discussion for why this is necessary.
+      - name: Generate artifact ID
+        id: generate-artifact-id
+        if: ${{ failure() && steps.envoy-integration-tests.conclusion == 'failure' }}
+        run: |
+          ARTIFACT_ID=$(uuidgen)
+          echo "Artifact ID: $ARTIFACT_ID (search this in job summary for download link)"
+          echo "artifact_id=$ARTIFACT_ID" >> "$GITHUB_ENV"
+
+      - name: Upload failure logs
+        if: ${{ failure() && steps.envoy-integration-tests.conclusion == 'failure' }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: envoy-${{ matrix.envoy-version }}-logs-${{ env.artifact_id }}
+          path: test/integration/connect/envoy/workdir/logs/
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault

--- a/.github/workflows/nightly-test-integrations-1.17.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.17.x.yml
@@ -154,6 +154,7 @@ jobs:
         run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile ./bin
 
       - name: Envoy Integration Tests
+        id: envoy-integration-tests
         env:
           GOTESTSUM_JUNITFILE: ${{ env.TEST_RESULTS_DIR }}/results.xml
           GOTESTSUM_FORMAT: standard-verbose
@@ -173,6 +174,23 @@ jobs:
               --jsonfile /tmp/jsonfile/go-test.log \
               --packages=./test/integration/connect/envoy \
               -- -timeout=30m -tags integration -run="TestEnvoy/(${{ matrix.test-cases }})"
+
+      # See https://github.com/orgs/community/discussions/8945#discussioncomment-9897011
+      # and overall topic discussion for why this is necessary.
+      - name: Generate artifact ID
+        id: generate-artifact-id
+        if: ${{ failure() && steps.envoy-integration-tests.conclusion == 'failure' }}
+        run: |
+          ARTIFACT_ID=$(uuidgen)
+          echo "Artifact ID: $ARTIFACT_ID (search this in job summary for download link)"
+          echo "artifact_id=$ARTIFACT_ID" >> "$GITHUB_ENV"
+
+      - name: Upload failure logs
+        if: ${{ failure() && steps.envoy-integration-tests.conclusion == 'failure' }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: envoy-${{ matrix.envoy-version }}-logs-${{ env.artifact_id }}
+          path: test/integration/connect/envoy/workdir/logs/
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault

--- a/.github/workflows/nightly-test-integrations-1.18.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.18.x.yml
@@ -68,7 +68,7 @@ jobs:
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       uploaded-binary-name: 'consul-bin'
-      branch-name: "release/1.17.x"
+      branch-name: "release/1.18.x"
       go-version: ${{ needs.get-go-version.outputs.go-version }}
     secrets:
       elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
@@ -154,6 +154,7 @@ jobs:
         run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile ./bin
 
       - name: Envoy Integration Tests
+        id: envoy-integration-tests
         env:
           GOTESTSUM_JUNITFILE: ${{ env.TEST_RESULTS_DIR }}/results.xml
           GOTESTSUM_FORMAT: standard-verbose
@@ -173,6 +174,23 @@ jobs:
               --jsonfile /tmp/jsonfile/go-test.log \
               --packages=./test/integration/connect/envoy \
               -- -timeout=30m -tags integration -run="TestEnvoy/(${{ matrix.test-cases }})"
+
+      # See https://github.com/orgs/community/discussions/8945#discussioncomment-9897011
+      # and overall topic discussion for why this is necessary.
+      - name: Generate artifact ID
+        id: generate-artifact-id
+        if: ${{ failure() && steps.envoy-integration-tests.conclusion == 'failure' }}
+        run: |
+          ARTIFACT_ID=$(uuidgen)
+          echo "Artifact ID: $ARTIFACT_ID (search this in job summary for download link)"
+          echo "artifact_id=$ARTIFACT_ID" >> "$GITHUB_ENV"
+
+      - name: Upload failure logs
+        if: ${{ failure() && steps.envoy-integration-tests.conclusion == 'failure' }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: envoy-${{ matrix.envoy-version }}-logs-${{ env.artifact_id }}
+          path: test/integration/connect/envoy/workdir/logs/
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault

--- a/.github/workflows/nightly-test-integrations-1.19.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.19.x.yml
@@ -59,7 +59,7 @@ jobs:
       runs-on: ${{ needs.setup.outputs.compute-large }}
       repository-name: ${{ github.repository }}
       uploaded-binary-name: 'consul-bin'
-      branch-name: "release/1.17.x"
+      branch-name: "release/1.19.x"
       go-version: ${{ needs.get-go-version.outputs.go-version }}
     secrets:
       elevated-github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
@@ -145,6 +145,7 @@ jobs:
         run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile ./bin
 
       - name: Envoy Integration Tests
+        id: envoy-integration-tests
         env:
           GOTESTSUM_JUNITFILE: ${{ env.TEST_RESULTS_DIR }}/results.xml
           GOTESTSUM_FORMAT: standard-verbose
@@ -164,6 +165,23 @@ jobs:
               --jsonfile /tmp/jsonfile/go-test.log \
               --packages=./test/integration/connect/envoy \
               -- -timeout=30m -tags integration -run="TestEnvoy/(${{ matrix.test-cases }})"
+
+      # See https://github.com/orgs/community/discussions/8945#discussioncomment-9897011
+      # and overall topic discussion for why this is necessary.
+      - name: Generate artifact ID
+        id: generate-artifact-id
+        if: ${{ failure() && steps.envoy-integration-tests.conclusion == 'failure' }}
+        run: |
+          ARTIFACT_ID=$(uuidgen)
+          echo "Artifact ID: $ARTIFACT_ID (search this in job summary for download link)"
+          echo "artifact_id=$ARTIFACT_ID" >> "$GITHUB_ENV"
+
+      - name: Upload failure logs
+        if: ${{ failure() && steps.envoy-integration-tests.conclusion == 'failure' }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: envoy-${{ matrix.envoy-version }}-logs-${{ env.artifact_id }}
+          path: test/integration/connect/envoy/workdir/logs/
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -340,6 +340,7 @@ jobs:
         run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile ./bin
 
       - name: Envoy Integration Tests
+        id: envoy-integration-tests
         env:
           GOTESTSUM_JUNITFILE: ${{ env.TEST_RESULTS_DIR }}/results.xml
           GOTESTSUM_FORMAT: standard-verbose
@@ -359,6 +360,23 @@ jobs:
               --jsonfile /tmp/jsonfile/go-test.log \
               --packages=./test/integration/connect/envoy \
               -- -timeout=30m -tags integration -run="TestEnvoy/(${{ matrix.test-cases }})"
+
+      # See https://github.com/orgs/community/discussions/8945#discussioncomment-9897011
+      # and overall topic discussion for why this is necessary.
+      - name: Generate artifact ID
+        id: generate-artifact-id
+        if: ${{ failure() && steps.envoy-integration-tests.conclusion == 'failure' }}
+        run: |
+          ARTIFACT_ID=$(uuidgen)
+          echo "Artifact ID: $ARTIFACT_ID (search this in job summary for download link)"
+          echo "artifact_id=$ARTIFACT_ID" >> "$GITHUB_ENV"
+
+      - name: Upload failure logs
+        if: ${{ failure() && steps.envoy-integration-tests.conclusion == 'failure' }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: envoy-${{ matrix.envoy-version }}-logs-${{ env.artifact_id }}
+          path: test/integration/connect/envoy/workdir/logs/
 
       # NOTE: ENT specific step as we store secrets in Vault.
       - name: Authenticate to Vault


### PR DESCRIPTION
Correctly set the the version of Consul built by the `dev-build` job, which is then copied into the Consul dev image used in integration tests.

This was causing failures starting sidecar proxies via `consul connect envoy` due to a mismatch between the (incorrect) Consul binary's supported Envoy versions and the (correct) Envoy version under test.

Also add debug log uploads to each int test so we can more easily diagnose this sort of failure in the future, as it was entirely hidden in test output.

What's most unintuitive about this, is that the Consul Docker image used as a base for the tests was correct - it was only the _replaced binary_ in that image that was wrong.

This change does not need to be backported since it's made within scheduled workflows run from `main`. Note that only 1.19 tests run on CE; the rest will exclusively affect Ent.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
