### PR TITLE
exclude release branches for 1.15 thru 1.18

### DIFF
--- a/.github/workflows/ce-merge-trigger.yml
+++ b/.github/workflows/ce-merge-trigger.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
       - release/**
+      - '!release/1.18**'
+      - '!release/1.17**'
+      - '!release/1.16**'
+      - '!release/1.15**'
+
 
 jobs:
   trigger-ce-merge:


### PR DESCRIPTION
### Description
Sync needs to be disabled for release branches that are not supported in CE.  This causes PRs with large merge conflicts for dependencies.  We can come up with a more elegant solution later that possibly reads `.releases/version.hcl` but for now this will stop the syncs.