### PR TITLE
Backport of Docs CE-709: Remove circular links (#21685) into release/1.15.x

### DIFF
--- a/website/content/docs/security/acl/index.mdx
+++ b/website/content/docs/security/acl/index.mdx
@@ -9,15 +9,6 @@ description: >-
 
 This topic describes core concepts associated with the optional access control list (ACL) system shipped with Consul. ACLs authenticate requests and authorize access to resources. They also control access to the Consul UI, API, and CLI, as well as secure service-to-service and agent-to-agent communication.
 
-Refer to the following tutorials for step-by-step instructions on how to get started using ACLs:
-
-- [Bootstrap and Explore ACLs]
-- [Secure Consul with ACLs]
-- [Troubleshoot the ACL System](/consul/tutorials/security/access-control-troubleshoot)
-
-[bootstrap and explore acls]: /consul/tutorials/security/access-control-setup-production?utm_source=docs
-[secure consul with acls]: /consul/tutorials/security/access-control-setup-production
-
 Refer to the [ACL API reference](/consul/api-docs/acl) and [ACL CLI reference](/consul/commands/acl) for additional usage information.
 
 ## Workflow Overview


### PR DESCRIPTION
Manual backport of Docs CE-70: Remove circular links

Remove links to tutorials that no longer exist and redirect back to the ACL overview page.

