### PR TITLE
[NET-10952] fix cluster dns lookup family to gracefully handle ipv6

### DIFF
--- a/.changelog/21703.txt
+++ b/.changelog/21703.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+jwt-provider: change dns lookup family from the default of AUTO which would prefer ipv6 to ALL if LOGICAL_DNS is used or PREFER_IPV4 if STRICT_DNS is used to gracefully handle transitions to ipv6.
+```

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -380,6 +380,56 @@ func TestMakeJWKSDiscoveryClusterType(t *testing.T) {
 	}
 }
 
+func TestMakeJWKSClusterDNSLookupFamilyType(t *testing.T) {
+	tests := map[string]struct {
+		clusterType             *envoy_cluster_v3.Cluster_Type
+		expectedDNSLookupFamily envoy_cluster_v3.Cluster_DnsLookupFamily
+	}{
+		// strict dns and logical dns are the only ones that are different
+		"jwks with strict dns": {
+			clusterType: &envoy_cluster_v3.Cluster_Type{
+				Type: envoy_cluster_v3.Cluster_STRICT_DNS,
+			},
+			expectedDNSLookupFamily: envoy_cluster_v3.Cluster_V4_PREFERRED,
+		},
+		"jwks with logical dns": {
+			clusterType: &envoy_cluster_v3.Cluster_Type{
+				Type: envoy_cluster_v3.Cluster_LOGICAL_DNS,
+			},
+			expectedDNSLookupFamily: envoy_cluster_v3.Cluster_ALL,
+		},
+		// all should be auto from here down
+		"jwks with cluster EDS": {
+			clusterType: &envoy_cluster_v3.Cluster_Type{
+				Type: envoy_cluster_v3.Cluster_EDS,
+			},
+			expectedDNSLookupFamily: envoy_cluster_v3.Cluster_AUTO,
+		},
+		"jwks with static dns": {
+			clusterType: &envoy_cluster_v3.Cluster_Type{
+				Type: envoy_cluster_v3.Cluster_STATIC,
+			},
+			expectedDNSLookupFamily: envoy_cluster_v3.Cluster_AUTO,
+		},
+
+		"jwks with original dst": {
+			clusterType: &envoy_cluster_v3.Cluster_Type{
+				Type: envoy_cluster_v3.Cluster_ORIGINAL_DST,
+			},
+			expectedDNSLookupFamily: envoy_cluster_v3.Cluster_AUTO,
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			actualDNSLookupFamily := makeJWKSClusterDNSLookupFamilyType(tt.clusterType)
+
+			require.Equal(t, tt.expectedDNSLookupFamily, actualDNSLookupFamily)
+		})
+	}
+}
+
 func TestParseJWTRemoteURL(t *testing.T) {
 	tests := map[string]struct {
 		uri            string


### PR DESCRIPTION
### Description

When creating an envoy cluster the default [DNS Lookup Family](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-dns-lookup-family) defaults to [AUTO](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-dnslookupfamily), for inter-cluster communication this is not an issue but when creating a cluster that access external sources (like we do for `JWTProviders`) this can cause an issue. The `AUTO` setting prefers using `ipv6`, so if a user has a cluster that is not setup to handle ipv6 they will get an ipv6 address back for the external source and will be unable to connect.

 To handle this we will be using the `V4_PREFERRED` lookup family when [STRICT_DNS](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/service_discovery#arch-overview-service-discovery-types-strict-dns) is enabled (`STRICT_DNS` will grab all addresses for the target and attempt to make a host for each and load balance between them).

 When 
[LOGICAL_DNS](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/service_discovery#logical-dns) is enabled (`LOGICAL_DNS` will grab all the addresses and only use the first when a new connection is needed) we will use the `ALL` lookup family, which fetches all the ip addresses for a given hostname and cycles through them to find the first one that is reachable using [happy eyeballs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling#arch-overview-happy-eyeballs)

If any other DNS Discovery Type is used we fallback to the default of `AUTO` because envoy ignores the Lookup Family for all other cluster types.

### Testing & Reproduction 

### Links



### PR Checklist

* [X] updated test coverage
* [ ] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
