### PR TITLE
Hard update all 1.3 dataplane to 1.6

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -535,7 +535,8 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      DEPLOYER_CONSUL_DATAPLANE_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.3-dev"
+      # TODO @sarah.alsmiller Don't hardcode this version value
+      DEPLOYER_CONSUL_DATAPLANE_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.6-dev"
     steps:
       - name: Checkout code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -422,7 +422,8 @@ jobs:
       contents: read
     env:
       ENVOY_VERSION: ${{ needs.get-envoy-versions.outputs.max-envoy-version }}
-      CONSUL_DATAPLANE_IMAGE: "docker.io/hashicorppreview/consul-dataplane:1.5-dev-ubi"
+      #TODO don't harcode this image name
+      CONSUL_DATAPLANE_IMAGE: "docker.io/hashicorppreview/consul-dataplane:1.6-dev-ubi"
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,8 @@ CONSUL_IMAGE_VERSION?=latest
 GOLANG_VERSION?=$(shell head -n 1 .go-version)
 # Takes the highest version from the ENVOY_VERSIONS file.
 ENVOY_VERSION?=$(shell cat envoyextensions/xdscommon/ENVOY_VERSIONS | grep '^[[:digit:]]' | sort -nr | head -n 1)
-CONSUL_DATAPLANE_IMAGE := $(or $(CONSUL_DATAPLANE_IMAGE),"docker.io/hashicorppreview/consul-dataplane:1.3-dev-ubi")
-DEPLOYER_CONSUL_DATAPLANE_IMAGE := $(or $(DEPLOYER_CONSUL_DATAPLANE_IMAGE), "docker.io/hashicorppreview/consul-dataplane:1.3-dev")
+CONSUL_DATAPLANE_IMAGE := $(or $(CONSUL_DATAPLANE_IMAGE),"docker.io/hashicorppreview/consul-dataplane:1.6-dev-ubi")
+DEPLOYER_CONSUL_DATAPLANE_IMAGE := $(or $(DEPLOYER_CONSUL_DATAPLANE_IMAGE), "docker.io/hashicorppreview/consul-dataplane:1.6-dev")
 
 CONSUL_VERSION?=$(shell cat version/VERSION)
 

--- a/test-integ/connect/snapshot_test.go
+++ b/test-integ/connect/snapshot_test.go
@@ -155,7 +155,7 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 	)
 	asserter.FortioFetch2HeaderEcho(t, staticClient, &topology.Upstream{
 		ID:        staticServerSID,
-		LocalPort: 8080,
+		LocalPort: 5000,
 	})
 	staticServer := sp.Topology().Clusters["dc1"].WorkloadByID(
 		topology.NewNodeID("dc1-client1", "default"),
@@ -184,6 +184,6 @@ func Test_Snapshot_Restore_Agentless(t *testing.T) {
 	// Ensure the static-client connected to the new static-server
 	asserter.FortioFetch2HeaderEcho(t, staticClient, &topology.Upstream{
 		ID:        staticServerSID,
-		LocalPort: 8080,
+		LocalPort: 5000,
 	})
 }

--- a/testing/deployer/sprawl/sprawltest/test_test.go
+++ b/testing/deployer/sprawl/sprawltest/test_test.go
@@ -22,10 +22,11 @@ func TestSprawl(t *testing.T) {
 
 	cfg := &topology.Config{
 		Images: topology.Images{
+			// TODO NOT HARDCODE
 			// ConsulEnterprise: "consul-dev:latest",
-			ConsulCE:         "hashicorppreview/consul:1.17-dev",
-			ConsulEnterprise: "hashicorppreview/consul-enterprise:1.17-dev",
-			Dataplane:        "hashicorppreview/consul-dataplane:1.3-dev",
+			ConsulCE:         "hashicorppreview/consul:1.20-dev",
+			ConsulEnterprise: "hashicorppreview/consul-enterprise:1.20-dev",
+			Dataplane:        "hashicorppreview/consul-dataplane:1.6-dev",
 		},
 		Networks: []*topology.Network{
 			{Name: "dc1"},

--- a/testing/deployer/topology/default_versions.go
+++ b/testing/deployer/topology/default_versions.go
@@ -5,9 +5,10 @@
 
 package topology
 
+//TODO @sarah.alsmiller figure out if we can delete this
 const (
-	DefaultConsulCEImage         = "hashicorp/consul:1.17.0"
-	DefaultConsulEnterpriseImage = "hashicorp/consul-enterprise:1.17.0-ent"
-	DefaultEnvoyImage            = "envoyproxy/envoy:v1.27.2"
-	DefaultDataplaneImage        = "hashicorp/consul-dataplane:1.3.0"
+	DefaultConsulCEImage         = "hashicorp/consul:1.19.0"
+	DefaultConsulEnterpriseImage = "hashicorp/consul-enterprise:1.19.0-ent"
+	DefaultEnvoyImage            = "envoyproxy/envoy:v1.28.5"
+	DefaultDataplaneImage        = "hashicorp/consul-dataplane:1.5.0"
 )


### PR DESCRIPTION
### Description

Found several isntances of dataplane 1.3 hardcoded. Updating all of them to 1.6 and adding todos to remove hardcoding. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
