### PR TITLE
security: update alpine base image to 3.20

### DIFF
--- a/.changelog/21729.txt
+++ b/.changelog/21729.txt
@@ -1,0 +1,4 @@
+```release-notes:security
+Bump Dockerfile base image to `alpine:3.20`.
+This resolves CVE-2024-7264 and CVE-2024-8096 (curl).
+```

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -38,11 +38,6 @@ container {
 		suppress {
 			# N.b. `vulnerabilites` is the correct spelling for this tool.
 			vulnerabilites = [
-				"CVE-2023-46218", # curl@8.4.0-r0
-				"CVE-2023-46219", # curl@8.4.0-r0
-				"CVE-2023-5678",  # openssl@3.1.4-r0
-				"CVE-2024-7264", # curl@8.9.0
-				"CVE-2024-8096", # curl@8.9.1-r0
 			]
 			paths = [
 				"internal/tools/proto-gen-rpc-glue/e2e/consul/*",

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # Official docker image that includes binaries from releases.hashicorp.com. This
 # downloads the release from releases.hashicorp.com and therefore requires that
 # the release is published before building the Docker image.
-FROM docker.mirror.hashicorp.services/alpine:3.19 as official
+FROM docker.mirror.hashicorp.services/alpine:3.20 as official
 
 # This is the release of Consul to pull in.
 ARG VERSION
@@ -112,7 +112,7 @@ CMD ["agent", "-dev", "-client", "0.0.0.0"]
 
 # Production docker image that uses CI built binaries.
 # Remember, this image cannot be built locally.
-FROM docker.mirror.hashicorp.services/alpine:3.19 as default
+FROM docker.mirror.hashicorp.services/alpine:3.20 as default
 
 ARG PRODUCT_VERSION
 ARG BIN_NAME

--- a/test/integration/connect/envoy/Dockerfile-tcpdump
+++ b/test/integration/connect/envoy/Dockerfile-tcpdump
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.20
 
 RUN apk add --no-cache tcpdump
 VOLUME  [ "/data" ]

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -652,7 +652,7 @@ function docker_consul_for_proxy_bootstrap {
 function docker_wget {
   local DC=$1
   shift 1
-  docker run --rm --network container:envoy_consul-${DC}_1 docker.mirror.hashicorp.services/alpine:3.17 wget "$@"
+  docker run --rm --network container:envoy_consul-${DC}_1 docker.mirror.hashicorp.services/alpine:3.20 wget "$@"
 }
 
 function docker_curl {


### PR DESCRIPTION
### Description

Fixes several CVEs by upgrading dependencies via base image upgrade.

### Testing & Reproduction steps

Tested locally from [one-off Docker CI build](https://github.com/hashicorp/consul/actions/runs/10854208959/job/30124439601):
```shell
❯ scan container ./consul_default_linux_arm64_1.19.3-dev_c5ca319b156ce0bbb67d79eaa1bbc80113ae3557.docker.tar
✓ Scanned file:{path:"/Users/michael.zalimeni/workspace/security-scanner/consul_default_linux_arm64_1.19.3-dev_c5ca319b156ce0bbb67d79eaa1bbc80113ae3557.docker.tar"} in 59.8s - no results found
```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
