### PR TITLE
ci: fix CI skip script hole

### DIFF
--- a/.github/scripts/check_skip_ci.sh
+++ b/.github/scripts/check_skip_ci.sh
@@ -13,7 +13,8 @@ set -euo pipefail
 #
 # ... `git merge-base origin/$SKIP_CHECK_BRANCH HEAD` would return commit `D`
 # `...HEAD` specifies from the common ancestor to the latest commit on the current branch (HEAD)..
-files_to_check=$(git diff --name-only "$(git merge-base origin/$SKIP_CHECK_BRANCH HEAD~)"...HEAD)
+skip_check_branch=${SKIP_CHECK_BRANCH:?SKIP_CHECK_BRANCH is required}
+files_to_check=$(git diff --name-only "$(git merge-base origin/$skip_check_branch HEAD~)"...HEAD)
 
 # Define the directories to check
 skipped_directories=("docs/" "ui/" "website/" "grafana/" ".changelog/")


### PR DESCRIPTION
In some environments, the script will not fail despite `SKIP_CHECK_BRANCH` being unset, leading to the script explicitly skipping CI when it should fail fast.

**Meta-comment: we should consider transitioning to [paths-ignore](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore). Even though it'd be a bit more copypasta, the upside is we can't silently skip and pass tests + security scans by accident if a future bug or misconfiguration occurs.**

### Description

Example script failure -> skipped CI: https://github.com/hashicorp/consul/actions/runs/10851790913/job/30116333377#step:3:5 (this workflow no longer uses the script, and relies on `paths-ignore` instead).

### Testing

```shell
❯ .github/scripts/check_skip_ci.sh; echo $?
.github/scripts/check_skip_ci.sh: line 16: SKIP_CHECK_BRANCH: SKIP_CHECK_BRANCH is required
1
```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
