### PR TITLE
ci: update the security-scanner gha token

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: hashicorp/security-scanner
-          token: ${{ secrets.HASHIBOT_PRODSEC_GITHUB_TOKEN }}
+          token: ${{ secrets.PRODSEC_SCANNER_READ_ONLY }}
           path: security-scanner
           ref: main
 


### PR DESCRIPTION
### Description

Using the org level secret instead of the repository one.

### Testing & Reproduction steps

If the security scan passes, we are good.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
