### PR TITLE
Update test-integrations.yml to capture latest versions of Nomad and Vault

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -94,7 +94,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        nomad-version: ['v1.8.3', 'v1.7.11', 'v1.6.15']
+        nomad-version: ['v1.8.3', 'v1.7.7', 'v1.6.10']
     steps:
       - name: Checkout Nomad
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -177,7 +177,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        vault-version: ["1.17.5", "1.16.9", "1.15.14"]
+        vault-version: ["1.17.5", "1.16.3", "1.15.6"]
     env:
       VAULT_BINARY_VERSION: ${{ matrix.vault-version }}
     steps:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -94,7 +94,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        nomad-version: ['v1.7.7', 'v1.6.10', 'v1.5.17']
+        nomad-version: ['v1.8.3', 'v1.7.11', 'v1.6.15']
     steps:
       - name: Checkout Nomad
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -177,7 +177,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        vault-version: ["1.16.2", "1.15.6", "1.14.10"]
+        vault-version: ["1.17.5", "1.16.9", "1.15.14"]
     env:
       VAULT_BINARY_VERSION: ${{ matrix.vault-version }}
     steps:


### PR DESCRIPTION
Update Vault/Nomad versions to ensure we're testing the latest versions .

### Description

Nomad's latest supported nomad-version: nomad-version: ['v1.8.3', 'v1.7.11', 'v1.6.15']
 [Releases · hashicorp/nomad](https://github.com/hashicorp/nomad/releases) 

Vault's latest supported vault-version: [] Grabbed the latest from the changelog- [vault/CHANGELOG.md at main · hashicorp/vault](https://github.com/hashicorp/vault/blob/main/CHANGELOG.md)

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
