### PR TITLE
ci: fix versions.hcl parsing by removing extraneous comma

### DIFF
--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -8,7 +8,7 @@ schema = 1
 active_versions {
   version "1.20" {
     ce_active = true
-  },
+  }
   version "1.19" {
     ce_active = true
   }


### PR DESCRIPTION
Commas are not expected after HCL blocks. This is causing parsing in BPA to fail and may interfere w/ other release-related workflows.
