### PR TITLE
default log store backend to WAL raft

### DIFF
--- a/.changelog/21759.txt
+++ b/.changelog/21759.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+raft: use raft-wal as the default raft log store.
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -2840,7 +2840,7 @@ func (b *builder) raftLogStoreConfigVal(raw *RaftLogStoreRaw) consul.RaftLogStor
 		cfg.Backend = stringValWithDefault(raw.Backend, consul.LogStoreBackendDefault)
 		cfg.DisableLogCache = boolVal(raw.DisableLogCache)
 
-		cfg.Verification.Enabled = boolVal(raw.Verification.Enabled)
+		cfg.Verification.Enabled = boolValWithDefault(raw.Verification.Enabled, true)
 		cfg.Verification.Interval = b.durationVal("raft_logstore.verification.interval", raw.Verification.Interval)
 
 		cfg.BoltDB.NoFreelistSync = boolVal(raw.BoltDBConfig.NoFreelistSync)


### PR DESCRIPTION
### Description

This PR change the default log store config to use WAL when starting with a fresh database. If a bolt db already exist bolt db will be used as a backend and a warning will be logged.

It also allow the log verifier, enabled by default, to be disabled. 

### Testing & Reproduction steps

Added tests to verify combination of configs.


### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
