### PR TITLE
Adds initial sg documentation

### DIFF
--- a/website/content/api-docs/health.mdx
+++ b/website/content/api-docs/health.mdx
@@ -273,6 +273,9 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace of the service.
   You can also [specify the namespace through other methods](#methods-to-specify-namespace).
 
+- `sg` `(string: "")` <EnterpriseAlert inline /> - Specifies the sameness group the service is a member of to
+  facilitate requests to identical services in other peers or partitions. 
+
 ### Sample Request
 
 ```shell-session


### PR DESCRIPTION
### Description

The Health API documentation is lacking the `sg` entry for sameness groups. 

