### PR TITLE
chore: remove unintentionally committed consul-k8s submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ terraform.rc
 /go.work
 /go.work.sum
 .docker
+
+# Avoid accidental commits of consul-k8s submodule used by some dev environments
+consul-k8s/


### PR DESCRIPTION
Also prevent future re-commits of this submodule path by adding to .gitignore.

### Description

Removes submodule added in #21802.