### PR TITLE
Allow customizing the test server's API timeout

### DIFF
--- a/sdk/testutil/retry/retryer.go
+++ b/sdk/testutil/retry/retryer.go
@@ -34,3 +34,8 @@ func TwoSeconds() *Timer {
 func ThreeTimes() *Counter {
 	return &Counter{Count: 3, Wait: 25 * time.Millisecond}
 }
+
+// Seconds repeats an operation for the number of input seconds and waits 25ms in between.
+func Seconds(secs time.Duration) *Timer {
+	return &Timer{Timeout: secs * time.Second, Wait: 25 * time.Millisecond}
+}


### PR DESCRIPTION
### Description

Allow the test code to customize the time-out for waiting the REST APIs to be available.
It is required in case of a very slow server.
