### PR TITLE
Suppress CVE-2024-9143

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -39,6 +39,7 @@ container {
 			# N.b. `vulnerabilites` is the correct spelling for this tool.
 			vulnerabilites = [
 				"CVE-2024-8096", # curl@8.9.1-r2,
+				"CVE-2024-9143", # openssl@3.3.2-r0,
 			]
 			paths = [
 				"internal/tools/proto-gen-rpc-glue/e2e/consul/*",


### PR DESCRIPTION
### Description

Suppressing CVE-2024-9143 because the fix is listed as deferred and to unblock our builds. 
