### PR TITLE
Update compatibility.mdx

### DIFF
--- a/website/content/docs/ecs/reference/compatibility.mdx
+++ b/website/content/docs/ecs/reference/compatibility.mdx
@@ -14,8 +14,8 @@ For every release of Consul on ECS, the `consul-ecs` binary and `consul-ecs` Ter
 | `consul` version         | Compatible `consul-ecs` version |
 |----------------------- | ----------------------------- |
 | 1.18.x                 | 0.8.x                         |
-| 1.16.x 1.17.x          | 0.7.x                         |
-| 1.15.x, 1.14.x, 1.13.x | 0.6.x                         |
+| 1.17.x          | 0.7.x                         |
+| 1.16.x, 1.15.x, 1.14.x, 1.13.x | 0.6.x                         |
 | 1.14.x, 1.13.x, 1.12.x | 0.5.2+                        |
 | 1.11.x                 | 0.3.0, 0.4.x                  |
 | 1.10.x                 | 0.2.x                         |


### PR DESCRIPTION
While 1.16 documentation suggests traditional Consul architecture with clients present: https://developer.hashicorp.com/consul/docs/v1.16.x/ecs/architecture

compatibility matrix points to 0.7.x consul-ecs version: https://developer.hashicorp.com/consul/docs/ecs/reference/compatibility

And 0.7.x release notes say that only dataplane architecture is supported: https://developer.hashicorp.com/consul/docs/release-notes/consul-ecs/v0_7_x

So, fixing the matrix

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
