### PR TITLE
Upgrade envoy version in nightly integration tests

### DIFF
--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -217,7 +217,7 @@ jobs:
       # matrix.consul-version (i.e. whenever the highest common Envoy version across active
       # Consul versions changes). The minor Envoy version does not necessarily need to be
       # kept current for the purpose of these tests, but the major (1.N) version should be.
-      ENVOY_VERSION: 1.27.6
+      ENVOY_VERSION: 1.28.7
     steps:
       - name: Checkout code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4


### PR DESCRIPTION
### Description

Nightly integrations tests are currently failing presumably due to unsupported envoy version in the test. 

### Testing & Reproduction steps
- CI passes

### Links


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
