### PR TITLE
Fix PeerUpstreamEndpoints and UpstreamPeerTrustBundles to only Cancel watch when needed, otherwise keep the watch active

### DIFF
--- a/.changelog/21871.txt
+++ b/.changelog/21871.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+proxycfg: fix a bug where peered upstreams watches is cancels even when another target need it.
+```

--- a/.changelog/21871.txt
+++ b/.changelog/21871.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-proxycfg: fix a bug where peered upstreams watches is cancels even when another target need it.
+proxycfg: fix a bug where peered upstreams watches are canceled even when another target needs it.
 ```

--- a/agent/proxycfg/api_gateway.go
+++ b/agent/proxycfg/api_gateway.go
@@ -476,16 +476,17 @@ func (h *handlerAPIGateway) handleRouteConfigUpdate(ctx context.Context, u Updat
 			cancelUpstream()
 			delete(snap.APIGateway.WatchedUpstreams[upstreamID], targetID)
 			delete(snap.APIGateway.WatchedUpstreamEndpoints[upstreamID], targetID)
-
-			if targetUID := NewUpstreamIDFromTargetID(targetID); targetUID.Peer != "" {
-				snap.APIGateway.PeerUpstreamEndpoints.CancelWatch(targetUID)
-				snap.APIGateway.UpstreamPeerTrustBundles.CancelWatch(targetUID.Peer)
-			}
 		}
 
 		cancelDiscoChain()
 		delete(snap.APIGateway.WatchedDiscoveryChains, upstreamID)
 	}
+	reconcilePeeringWatches(snap.APIGateway.DiscoveryChain,
+		snap.APIGateway.UpstreamConfig,
+		snap.APIGateway.PeeredUpstreams,
+		snap.APIGateway.PeerUpstreamEndpoints,
+		snap.APIGateway.UpstreamPeerTrustBundles,
+		h.logger)
 
 	return nil
 }

--- a/agent/proxycfg/api_gateway.go
+++ b/agent/proxycfg/api_gateway.go
@@ -481,12 +481,7 @@ func (h *handlerAPIGateway) handleRouteConfigUpdate(ctx context.Context, u Updat
 		cancelDiscoChain()
 		delete(snap.APIGateway.WatchedDiscoveryChains, upstreamID)
 	}
-	reconcilePeeringWatches(snap.APIGateway.DiscoveryChain,
-		snap.APIGateway.UpstreamConfig,
-		snap.APIGateway.PeeredUpstreams,
-		snap.APIGateway.PeerUpstreamEndpoints,
-		snap.APIGateway.UpstreamPeerTrustBundles,
-		h.logger)
+	reconcilePeeringWatches(snap.APIGateway.DiscoveryChain, snap.APIGateway.UpstreamConfig, snap.APIGateway.PeeredUpstreams, snap.APIGateway.PeerUpstreamEndpoints, snap.APIGateway.UpstreamPeerTrustBundles)
 
 	return nil
 }

--- a/agent/proxycfg/connect_proxy.go
+++ b/agent/proxycfg/connect_proxy.go
@@ -380,12 +380,7 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u UpdateEvent, s
 		//
 		// Clean up data
 		//
-		reconcilePeeringWatches(snap.ConnectProxy.DiscoveryChain,
-			snap.ConnectProxy.UpstreamConfig,
-			snap.ConnectProxy.PeeredUpstreams,
-			snap.ConnectProxy.PeerUpstreamEndpoints,
-			snap.ConnectProxy.UpstreamPeerTrustBundles,
-			s.logger)
+		reconcilePeeringWatches(snap.ConnectProxy.DiscoveryChain, snap.ConnectProxy.UpstreamConfig, snap.ConnectProxy.PeeredUpstreams, snap.ConnectProxy.PeerUpstreamEndpoints, snap.ConnectProxy.UpstreamPeerTrustBundles)
 	case u.CorrelationID == intentionUpstreamsID:
 		resp, ok := u.Result.(*structs.IndexedServiceList)
 		if !ok {
@@ -459,12 +454,7 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u UpdateEvent, s
 				delete(snap.ConnectProxy.WatchedUpstreams, uid)
 			}
 		}
-		reconcilePeeringWatches(snap.ConnectProxy.DiscoveryChain,
-			snap.ConnectProxy.UpstreamConfig,
-			snap.ConnectProxy.PeeredUpstreams,
-			snap.ConnectProxy.PeerUpstreamEndpoints,
-			snap.ConnectProxy.UpstreamPeerTrustBundles,
-			s.logger)
+		reconcilePeeringWatches(snap.ConnectProxy.DiscoveryChain, snap.ConnectProxy.UpstreamConfig, snap.ConnectProxy.PeeredUpstreams, snap.ConnectProxy.PeerUpstreamEndpoints, snap.ConnectProxy.UpstreamPeerTrustBundles)
 		for uid := range snap.ConnectProxy.WatchedUpstreamEndpoints {
 			if upstream, ok := snap.ConnectProxy.UpstreamConfig[uid]; ok && !upstream.CentrallyConfigured {
 				continue

--- a/agent/proxycfg/connect_proxy.go
+++ b/agent/proxycfg/connect_proxy.go
@@ -380,49 +380,12 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u UpdateEvent, s
 		//
 		// Clean up data
 		//
-
-		peeredChainTargets := make(map[UpstreamID]struct{})
-		for _, discoChain := range snap.ConnectProxy.DiscoveryChain {
-			for _, target := range discoChain.Targets {
-				if target.Peer == "" {
-					continue
-				}
-				uid := NewUpstreamIDFromTargetID(target.ID)
-				peeredChainTargets[uid] = struct{}{}
-			}
-		}
-
-		validPeerNames := make(map[string]struct{})
-
-		// Iterate through all known endpoints and remove references to upstream IDs that weren't in the update
-		snap.ConnectProxy.PeerUpstreamEndpoints.ForEachKey(func(uid UpstreamID) bool {
-			// Peered upstream is explicitly defined in upstream config
-			if _, ok := snap.ConnectProxy.UpstreamConfig[uid]; ok {
-				validPeerNames[uid.Peer] = struct{}{}
-				return true
-			}
-			// Peered upstream came from dynamic source of imported services
-			if _, ok := seenUpstreams[uid]; ok {
-				validPeerNames[uid.Peer] = struct{}{}
-				return true
-			}
-			// Peered upstream came from a discovery chain target
-			if _, ok := peeredChainTargets[uid]; ok {
-				validPeerNames[uid.Peer] = struct{}{}
-				return true
-			}
-			snap.ConnectProxy.PeerUpstreamEndpoints.CancelWatch(uid)
-			return true
-		})
-
-		// Iterate through all known trust bundles and remove references to any unseen peer names
-		snap.ConnectProxy.UpstreamPeerTrustBundles.ForEachKey(func(peerName PeerName) bool {
-			if _, ok := validPeerNames[peerName]; !ok {
-				snap.ConnectProxy.UpstreamPeerTrustBundles.CancelWatch(peerName)
-			}
-			return true
-		})
-
+		reconcilePeeringWatches(snap.ConnectProxy.DiscoveryChain,
+			snap.ConnectProxy.UpstreamConfig,
+			snap.ConnectProxy.PeeredUpstreams,
+			snap.ConnectProxy.PeerUpstreamEndpoints,
+			snap.ConnectProxy.UpstreamPeerTrustBundles,
+			s.logger)
 	case u.CorrelationID == intentionUpstreamsID:
 		resp, ok := u.Result.(*structs.IndexedServiceList)
 		if !ok {
@@ -490,18 +453,18 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u UpdateEvent, s
 				continue
 			}
 			if _, ok := seenUpstreams[uid]; !ok {
-				for targetID, cancelFn := range targets {
+				for _, cancelFn := range targets {
 					cancelFn()
-
-					targetUID := NewUpstreamIDFromTargetID(targetID)
-					if targetUID.Peer != "" {
-						snap.ConnectProxy.PeerUpstreamEndpoints.CancelWatch(targetUID)
-						snap.ConnectProxy.UpstreamPeerTrustBundles.CancelWatch(targetUID.Peer)
-					}
 				}
 				delete(snap.ConnectProxy.WatchedUpstreams, uid)
 			}
 		}
+		reconcilePeeringWatches(snap.ConnectProxy.DiscoveryChain,
+			snap.ConnectProxy.UpstreamConfig,
+			snap.ConnectProxy.PeeredUpstreams,
+			snap.ConnectProxy.PeerUpstreamEndpoints,
+			snap.ConnectProxy.UpstreamPeerTrustBundles,
+			s.logger)
 		for uid := range snap.ConnectProxy.WatchedUpstreamEndpoints {
 			if upstream, ok := snap.ConnectProxy.UpstreamConfig[uid]; ok && !upstream.CentrallyConfigured {
 				continue

--- a/agent/proxycfg/ingress_gateway.go
+++ b/agent/proxycfg/ingress_gateway.go
@@ -171,18 +171,18 @@ func (s *handlerIngressGateway) handleUpdate(ctx context.Context, u UpdateEvent,
 					delete(snap.IngressGateway.WatchedUpstreams[uid], targetID)
 					delete(snap.IngressGateway.WatchedUpstreamEndpoints[uid], targetID)
 					cancelUpstreamFn()
-
-					targetUID := NewUpstreamIDFromTargetID(targetID)
-					if targetUID.Peer != "" {
-						snap.IngressGateway.PeerUpstreamEndpoints.CancelWatch(targetUID)
-						snap.IngressGateway.UpstreamPeerTrustBundles.CancelWatch(targetUID.Peer)
-					}
 				}
 
 				cancelFn()
 				delete(snap.IngressGateway.WatchedDiscoveryChains, uid)
 			}
 		}
+		reconcilePeeringWatches(snap.IngressGateway.DiscoveryChain,
+			snap.IngressGateway.UpstreamConfig,
+			snap.IngressGateway.PeeredUpstreams,
+			snap.IngressGateway.PeerUpstreamEndpoints,
+			snap.IngressGateway.UpstreamPeerTrustBundles,
+			s.logger)
 
 		if err := s.watchIngressLeafCert(ctx, snap); err != nil {
 			return err

--- a/agent/proxycfg/ingress_gateway.go
+++ b/agent/proxycfg/ingress_gateway.go
@@ -177,12 +177,7 @@ func (s *handlerIngressGateway) handleUpdate(ctx context.Context, u UpdateEvent,
 				delete(snap.IngressGateway.WatchedDiscoveryChains, uid)
 			}
 		}
-		reconcilePeeringWatches(snap.IngressGateway.DiscoveryChain,
-			snap.IngressGateway.UpstreamConfig,
-			snap.IngressGateway.PeeredUpstreams,
-			snap.IngressGateway.PeerUpstreamEndpoints,
-			snap.IngressGateway.UpstreamPeerTrustBundles,
-			s.logger)
+		reconcilePeeringWatches(snap.IngressGateway.DiscoveryChain, snap.IngressGateway.UpstreamConfig, snap.IngressGateway.PeeredUpstreams, snap.IngressGateway.PeerUpstreamEndpoints, snap.IngressGateway.UpstreamPeerTrustBundles)
 
 		if err := s.watchIngressLeafCert(ctx, snap); err != nil {
 			return err

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -555,13 +555,8 @@ func watchMeshGateway(ctx context.Context, opts gatewayWatchOpts) error {
 	}, correlationId, opts.notifyCh)
 }
 
-func reconcilePeeringWatches(
-	compiledDiscoveryChains map[UpstreamID]*structs.CompiledDiscoveryChain,
-	upstreams map[UpstreamID]*structs.Upstream,
-	peeredUpstreams map[UpstreamID]struct{},
-	peerUpstreamEndpoints watch.Map[UpstreamID, structs.CheckServiceNodes],
-	upstreamPeerTrustBundles watch.Map[PeerName, *pbpeering.PeeringTrustBundle],
-	logger hclog.Logger) {
+func reconcilePeeringWatches(compiledDiscoveryChains map[UpstreamID]*structs.CompiledDiscoveryChain, upstreams map[UpstreamID]*structs.Upstream, peeredUpstreams map[UpstreamID]struct{}, peerUpstreamEndpoints watch.Map[UpstreamID, structs.CheckServiceNodes], upstreamPeerTrustBundles watch.Map[PeerName, *pbpeering.PeeringTrustBundle]) {
+
 	peeredChainTargets := make(map[UpstreamID]struct{})
 	for _, discoChain := range compiledDiscoveryChains {
 		for _, target := range discoChain.Targets {

--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -102,12 +102,7 @@ func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u UpdateEv
 		if err := s.resetWatchesFromChain(ctx, uid, resp.Chain, upstreamsSnapshot); err != nil {
 			return err
 		}
-		reconcilePeeringWatches(upstreamsSnapshot.DiscoveryChain,
-			upstreamsSnapshot.UpstreamConfig,
-			upstreamsSnapshot.PeeredUpstreams,
-			upstreamsSnapshot.PeerUpstreamEndpoints,
-			upstreamsSnapshot.UpstreamPeerTrustBundles,
-			s.logger)
+		reconcilePeeringWatches(upstreamsSnapshot.DiscoveryChain, upstreamsSnapshot.UpstreamConfig, upstreamsSnapshot.PeeredUpstreams, upstreamsSnapshot.PeerUpstreamEndpoints, upstreamsSnapshot.UpstreamPeerTrustBundles)
 
 	case strings.HasPrefix(u.CorrelationID, upstreamPeerWatchIDPrefix):
 		resp, ok := u.Result.(*structs.IndexedCheckServiceNodes)

--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -102,6 +102,12 @@ func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u UpdateEv
 		if err := s.resetWatchesFromChain(ctx, uid, resp.Chain, upstreamsSnapshot); err != nil {
 			return err
 		}
+		reconcilePeeringWatches(upstreamsSnapshot.DiscoveryChain,
+			upstreamsSnapshot.UpstreamConfig,
+			upstreamsSnapshot.PeeredUpstreams,
+			upstreamsSnapshot.PeerUpstreamEndpoints,
+			upstreamsSnapshot.UpstreamPeerTrustBundles,
+			s.logger)
 
 	case strings.HasPrefix(u.CorrelationID, upstreamPeerWatchIDPrefix):
 		resp, ok := u.Result.(*structs.IndexedCheckServiceNodes)
@@ -301,12 +307,6 @@ func (s *handlerUpstreams) resetWatchesFromChain(
 		delete(snap.WatchedUpstreams[uid], targetID)
 		delete(snap.WatchedUpstreamEndpoints[uid], targetID)
 		cancelFn()
-
-		targetUID := NewUpstreamIDFromTargetID(targetID)
-		if targetUID.Peer != "" {
-			snap.PeerUpstreamEndpoints.CancelWatch(targetUID)
-			snap.UpstreamPeerTrustBundles.CancelWatch(targetUID.Peer)
-		}
 	}
 
 	var (
@@ -479,8 +479,8 @@ func (s *handlerUpstreams) watchUpstreamTarget(ctx context.Context, snap *Config
 	var entMeta acl.EnterpriseMeta
 	entMeta.Merge(opts.entMeta)
 
-	ctx, cancel := context.WithCancel(ctx)
-	err := s.dataSources.Health.Notify(ctx, &structs.ServiceSpecificRequest{
+	peerCtx, cancel := context.WithCancel(ctx)
+	err := s.dataSources.Health.Notify(peerCtx, &structs.ServiceSpecificRequest{
 		PeerName:   opts.peer,
 		Datacenter: opts.datacenter,
 		QueryOptions: structs.QueryOptions{
@@ -506,25 +506,25 @@ func (s *handlerUpstreams) watchUpstreamTarget(ctx context.Context, snap *Config
 		return nil
 	}
 
-	if ok := snap.PeerUpstreamEndpoints.IsWatched(uid); !ok {
+	if !snap.PeerUpstreamEndpoints.IsWatched(uid) {
 		snap.PeerUpstreamEndpoints.InitWatch(uid, cancel)
 	}
-
 	// Check whether a watch for this peer exists to avoid duplicates.
-	if ok := snap.UpstreamPeerTrustBundles.IsWatched(uid.Peer); !ok {
-		peerCtx, cancel := context.WithCancel(ctx)
-		if err := s.dataSources.TrustBundle.Notify(peerCtx, &cachetype.TrustBundleReadRequest{
+
+	if !snap.UpstreamPeerTrustBundles.IsWatched(uid.Peer) {
+		peerCtx2, cancel2 := context.WithCancel(ctx)
+		if err := s.dataSources.TrustBundle.Notify(peerCtx2, &cachetype.TrustBundleReadRequest{
 			Request: &pbpeering.TrustBundleReadRequest{
 				Name:      uid.Peer,
 				Partition: uid.PartitionOrDefault(),
 			},
 			QueryOptions: structs.QueryOptions{Token: s.token},
 		}, peerTrustBundleIDPrefix+uid.Peer, s.ch); err != nil {
-			cancel()
+			cancel2()
 			return fmt.Errorf("error while watching trust bundle for peer %q: %w", uid.Peer, err)
 		}
 
-		snap.UpstreamPeerTrustBundles.InitWatch(uid.Peer, cancel)
+		snap.UpstreamPeerTrustBundles.InitWatch(uid.Peer, cancel2)
 	}
 
 	return nil


### PR DESCRIPTION
### Description

This PR unify the way we cancel `PeerUpstreamEndpoints` and `UpstreamPeerTrustBundles` and add more safeguards to only cancel those watches when no other data needs them. 

This is important because those watches could be shared by different upstreams in the scenario where multiple upstreams have the same target for `PeerUpstreamEndpoints` and in the case where multiple targets belong to the same Peer for `UpstreamPeerTrustBundles`. To avoid canceling a watch for those data sources while another upstream need them, we loop through all the upstreams and determine which watch is still needed and only cancel those which are not.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
