### PR TITLE
docs: add missing slash in redirect

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -238,7 +238,7 @@ module.exports = [
     permanent: true,
   },
   {
-    source: 'consul/docs/architecture/v2/:slug*',
+    source: '/consul/docs/architecture/v2/:slug*',
     destination: '/consul/docs/architecture/catalog#v2-catalog',
     permanent: true,
   },


### PR DESCRIPTION
### Description

Vercel builds are showing an error in the Consul redirects due to a missing slash in one of the paths.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
