### PR TITLE
backport to 1.18.5 - centos logic to point to vault.centos.org for centos:7 since it is EOL

### DIFF
--- a/.github/scripts/verify_rpm.sh
+++ b/.github/scripts/verify_rpm.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 # report why it failed. This is meant to be run as part of the build workflow to verify the built
 # .rpm meets some basic criteria for validity.
 
+# Notably, CentOS 7 is EOL, so we need to point to the vault for updates. It's not clear what alternative
+# we may use in the future that supports linux/386 as the platform was dropped in CentOS 8+9. The docker_image
+# is passed in as the third argument so that the script can determine if it needs to point to the vault for updates.
+
 # set this so we can locate and execute the verify_bin.sh script for verifying version output
 SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
@@ -20,6 +24,7 @@ function usage {
 function main {
   local rpm_path="${1:-}"
   local expect_version="${2:-}"
+  local docker_image="${3:-}"
   local got_version
 
   if [[ -z "${rpm_path}" ]]; then
@@ -34,6 +39,12 @@ function main {
     exit 1
   fi
 
+  if [[ -z "${docker_image}" ]]; then
+    echo "ERROR: docker image argument is required"
+    usage
+    exit 1
+  fi
+
   # expand globs for path names, if this fails, the script will exit
   rpm_path=$(echo ${rpm_path})
 
@@ -41,6 +52,12 @@ function main {
     echo "ERROR: package at ${rpm_path} does not exist."
     usage
     exit 1
+  fi
+
+  # CentOS 7 is EOL, so we need to point to the vault for updates
+  if [[ "$docker_image" == *centos:7 ]]; then
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
   fi
 
   yum -y clean all


### PR DESCRIPTION


### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
