### PR TITLE
ci(security-scanner): add support for Red Hat UBI images and fix typo

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -36,7 +36,6 @@ container {
 	# periodically cleaned up to remove items that are no longer found by the scanner.
 	triage {
 		suppress {
-			# N.b. `vulnerabilities` is the correct spelling for this tool.
 			vulnerabilities = [
 				"CVE-2024-8096", # curl@8.9.1-r2,
 				"CVE-2024-9143", # openssl@3.3.2-r0,
@@ -79,7 +78,6 @@ binary {
 	# periodically cleaned up to remove items that are no longer found by the scanner.
 	triage {
 		suppress {
-			# N.b. `vulnerabilities` is the correct spelling for this tool.
 			vulnerabilities = [
 			]
 			paths = [

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -14,7 +14,7 @@
 
 container {
 	dependencies = true
-	osv 		 = true
+	osv          = true
 
 	secrets {
 		matchers {

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -14,7 +14,7 @@
 
 container {
 	dependencies = true
-	alpine_secdb = true
+	osv 		 = true
 
 	secrets {
 		matchers {
@@ -36,8 +36,8 @@ container {
 	# periodically cleaned up to remove items that are no longer found by the scanner.
 	triage {
 		suppress {
-			# N.b. `vulnerabilites` is the correct spelling for this tool.
-			vulnerabilites = [
+			# N.b. `vulnerabilities` is the correct spelling for this tool.
+			vulnerabilities = [
 				"CVE-2024-8096", # curl@8.9.1-r2,
 				"CVE-2024-9143", # openssl@3.3.2-r0,
 			]
@@ -79,8 +79,8 @@ binary {
 	# periodically cleaned up to remove items that are no longer found by the scanner.
 	triage {
 		suppress {
-			# N.b. `vulnerabilites` is the correct spelling for this tool.
-			vulnerabilites = [
+			# N.b. `vulnerabilities` is the correct spelling for this tool.
+			vulnerabilities = [
 			]
 			paths = [
 				"internal/tools/proto-gen-rpc-glue/e2e/consul/*",

--- a/scan.hcl
+++ b/scan.hcl
@@ -28,7 +28,6 @@ repository {
   # periodically cleaned up to remove items that are no longer found by the scanner.
   triage {
     suppress {
-      # N.b. `vulnerabilities` is the correct spelling for this tool.
       vulnerabilities = [
       ]
       paths = [

--- a/scan.hcl
+++ b/scan.hcl
@@ -28,8 +28,8 @@ repository {
   # periodically cleaned up to remove items that are no longer found by the scanner.
   triage {
     suppress {
-      # N.b. `vulnerabilites` is the correct spelling for this tool.
-      vulnerabilites = [
+      # N.b. `vulnerabilities` is the correct spelling for this tool.
+      vulnerabilities = [
       ]
       paths = [
         "internal/tools/proto-gen-rpc-glue/e2e/consul/*",


### PR DESCRIPTION
### Description
Adding support for RedHat UBI images scans to cover more type of container images and fixing a typo.

Ref: [PSP-2287](https://hashicorp.atlassian.net/browse/PSP-2287)

### Testing & Reproduction steps
https://github.com/hashicorp/security-scanner/pull/918

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern


[PSP-2287]: https://hashicorp.atlassian.net/browse/PSP-2287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ