### PR TITLE
[Security] SECVULN-8621: Fix XSS Vulnerability where content-type header wasn't explicitly set in API requests

### DIFF
--- a/.changelog/21930.txt
+++ b/.changelog/21930.txt
@@ -1,0 +1,3 @@
+```release-note:security
+api: Enforces strict content-type header validation to protect against XSS vulnerability.
+```

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -617,7 +617,6 @@ func TestHTTPAPI_DefaultACLPolicy(t *testing.T) {
 		})
 	}
 }
-
 func TestHTTPAPIResponseHeaders(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -646,6 +645,87 @@ func TestHTTPAPIResponseHeaders(t *testing.T) {
 	requireHasHeadersSet(t, a, "/", "text/plain; charset=utf-8")
 }
 
+func TestHTTPAPIValidateContentTypeHeaders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	type testcase struct {
+		name                string
+		endpoint            string
+		method              string
+		requestBody         io.Reader
+		expectedContentType string
+	}
+
+	cases := []testcase{
+		{
+			name:                "snapshot endpoint expect non-default content type",
+			method:              http.MethodPut,
+			endpoint:            "/v1/snapshot",
+			requestBody:         bytes.NewBuffer([]byte("test")),
+			expectedContentType: "application/octet-stream",
+		},
+		{
+			name:                "kv endpoint expect non-default content type",
+			method:              http.MethodPut,
+			endpoint:            "/v1/kv",
+			requestBody:         bytes.NewBuffer([]byte("test")),
+			expectedContentType: "application/octet-stream",
+		},
+		{
+			name:                "event/fire endpoint expect default content type",
+			method:              http.MethodPut,
+			endpoint:            "/v1/event/fire",
+			requestBody:         bytes.NewBuffer([]byte("test")),
+			expectedContentType: "application/octet-stream",
+		},
+		{
+			name:                "peering/token endpoint expect default content type",
+			method:              http.MethodPost,
+			endpoint:            "/v1/peering/token",
+			requestBody:         bytes.NewBuffer([]byte("test")),
+			expectedContentType: "application/json",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := NewTestAgent(t, "")
+			defer a.Shutdown()
+
+			requireContentTypeHeadersSet(t, a, tc.method, tc.endpoint, tc.requestBody, tc.expectedContentType)
+		})
+	}
+}
+
+func requireContentTypeHeadersSet(t *testing.T, a *TestAgent, method, path string, body io.Reader, contentType string) {
+	t.Helper()
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest(method, path, body)
+	a.enableDebug.Store(true)
+
+	a.srv.handler().ServeHTTP(resp, req)
+
+	reqHdrs := req.Header
+	respHdrs := resp.Header()
+
+	// require request content-type
+	require.NotEmpty(t, reqHdrs.Get("Content-Type"))
+	require.Equal(t, contentType, reqHdrs.Get("Content-Type"),
+		"Request Header Content-Type value incorrect")
+
+	// require response content-type
+	require.NotEmpty(t, respHdrs.Get("Content-Type"))
+	require.Equal(t, contentType, respHdrs.Get("Content-Type"),
+		"Response Header Content-Type value incorrect")
+}
+
 func requireHasHeadersSet(t *testing.T, a *TestAgent, path string, contentType string) {
 	t.Helper()
 
@@ -663,7 +743,7 @@ func requireHasHeadersSet(t *testing.T, a *TestAgent, path string, contentType s
 		"X-XSS-Protection header value incorrect")
 
 	require.Equal(t, contentType, hdrs.Get("Content-Type"),
-		"")
+		"Reponse Content-Type header value incorrect")
 }
 
 func TestUIResponseHeaders(t *testing.T) {
@@ -704,7 +784,7 @@ func TestErrorContentTypeHeaderSet(t *testing.T) {
 	`)
 	defer a.Shutdown()
 
-	requireHasHeadersSet(t, a, "/fake-path-doesn't-exist", "text/plain; charset=utf-8")
+	requireHasHeadersSet(t, a, "/fake-path-doesn't-exist", "application/json")
 }
 
 func TestAcceptEncodingGzip(t *testing.T) {

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -743,7 +743,7 @@ func requireHasHeadersSet(t *testing.T, a *TestAgent, path string, contentType s
 		"X-XSS-Protection header value incorrect")
 
 	require.Equal(t, contentType, hdrs.Get("Content-Type"),
-		"Reponse Content-Type header value incorrect")
+		"Response Content-Type header value incorrect")
 }
 
 func TestUIResponseHeaders(t *testing.T) {

--- a/api/api.go
+++ b/api/api.go
@@ -1087,8 +1087,23 @@ func (c *Client) doRequest(r *request) (time.Duration, *http.Response, error) {
 	if err != nil {
 		return 0, nil, err
 	}
+
+	contentType := GetContentType(req)
+
+	if req != nil {
+		req.Header.Set(contentTypeHeader, contentType)
+	}
+
 	start := time.Now()
 	resp, err := c.config.HttpClient.Do(req)
+
+	if resp != nil {
+		respContentType := resp.Header.Get(contentTypeHeader)
+		if respContentType == "" || respContentType != contentType {
+			resp.Header.Set(contentTypeHeader, contentType)
+		}
+	}
+
 	diff := time.Since(start)
 	return diff, resp, err
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -935,11 +935,11 @@ func TestAPI_Headers(t *testing.T) {
 
 	_, _, err = kv.Get("test-headers", nil)
 	require.NoError(t, err)
-	require.Equal(t, "", request.Header.Get("Content-Type"))
+	require.Equal(t, "application/json", request.Header.Get("Content-Type"))
 
 	_, err = kv.Delete("test-headers", nil)
 	require.NoError(t, err)
-	require.Equal(t, "", request.Header.Get("Content-Type"))
+	require.Equal(t, "application/json", request.Header.Get("Content-Type"))
 
 	err = c.Snapshot().Restore(nil, strings.NewReader("foo"))
 	require.Error(t, err)

--- a/api/content_type.go
+++ b/api/content_type.go
@@ -1,0 +1,81 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	contentTypeHeader = "Content-Type"
+	plainContentType  = "text/plain; charset=utf-8"
+	octetStream       = "application/octet-stream"
+	jsonContentType   = "application/json" // Default content type
+)
+
+// ContentTypeRule defines a rule for determining the content type of an HTTP request.
+// This rule is based on the combination of the HTTP path, method, and the desired content type.
+type ContentTypeRule struct {
+	path        string
+	httpMethod  string
+	contentType string
+}
+
+var ContentTypeRules = []ContentTypeRule{
+	{
+		path:        "/v1/snapshot",
+		httpMethod:  http.MethodPut,
+		contentType: octetStream,
+	},
+	{
+		path:        "/v1/kv",
+		httpMethod:  http.MethodPut,
+		contentType: octetStream,
+	},
+	{
+		path:        "/v1/event/fire",
+		httpMethod:  http.MethodPut,
+		contentType: octetStream,
+	},
+}
+
+// GetContentType returns the content type for a request
+// This function isused as routing logic or middleware to determine and enforce
+// the appropriate content type for HTTP requests.
+func GetContentType(req *http.Request) string {
+	reqContentType := req.Header.Get(contentTypeHeader)
+
+	if isIndexPage(req) {
+		return plainContentType
+	}
+
+	// For GET, DELETE, or internal API paths, ensure a valid Content-Type is returned.
+	if req.Method == http.MethodGet || req.Method == http.MethodDelete || strings.HasPrefix(req.URL.Path, "/v1/internal") {
+		if reqContentType == "" {
+			// Default to JSON Content-Type if no Content-Type is provided.
+			return jsonContentType
+		}
+		// Return the provided Content-Type if it exists.
+		return reqContentType
+	}
+
+	for _, rule := range ContentTypeRules {
+		if matchesRule(req, rule) {
+			return rule.contentType
+		}
+	}
+	return jsonContentType
+}
+
+// matchesRule checks if a request matches a content type rule
+func matchesRule(req *http.Request, rule ContentTypeRule) bool {
+	return strings.HasPrefix(req.URL.Path, rule.path) &&
+		(rule.httpMethod == "" || req.Method == rule.httpMethod)
+}
+
+// isIndexPage checks if the request is for the index page
+func isIndexPage(req *http.Request) bool {
+	return req.URL.Path == "/" || req.URL.Path == "/ui"
+}


### PR DESCRIPTION
### Description
- Modified existing `ensureContentTypeHeader` middleware to set the response `Content-Type` to match the type of content that the server will process.

### SOLUTION
`ensureContentTypeHeader` middleware is used to determine if the content-type set in the API request is the expected content type. If it's not a match:
- A warning is logged in Consul 
- The appropriate contentType Header set before processing the request.
- The same action is carried out for API response. 
**NOTE**: The same function is used in `doRequest` function which is used in processing CLI requests to the Consul API.  

### Testing & Reproduction steps
Updated unit tests to add additional checks for content-type header
Vercel should deploy UI with no errors

## MANUAL TESTING
Before Changes
<details>
<summary>
</summary>

![Screenshot 2024-11-26 at 1 32 11 PM](https://github.com/user-attachments/assets/1b3292f5-b4d5-471e-a185-c34acda0cc99)

</details>

After Changes
<details>
<summary>
</summary>

![Screenshot 2024-11-26 at 1 33 02 PM](https://github.com/user-attachments/assets/933725f2-3480-483b-94f5-93d7f6ce09bc)

</details>

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [ ] not a security concern
