### PR TITLE
Backport of docs: Adds initial sg documentation for the health API into release 1.20.x

### DIFF
--- a/website/content/api-docs/health.mdx
+++ b/website/content/api-docs/health.mdx
@@ -273,6 +273,9 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace of the service.
   You can also [specify the namespace through other methods](#methods-to-specify-namespace).
 
+- `sg` `(string: "")` <EnterpriseAlert inline /> - Specifies the sameness group the service is a member of to
+  facilitate requests to identical services in other peers or partitions. 
+
 ### Sample Request
 
 ```shell-session

--- a/website/content/api-docs/health.mdx
+++ b/website/content/api-docs/health.mdx
@@ -222,7 +222,7 @@ The table below shows this endpoint's support for
 | `YES` <sup>1</sup>   | `all`             | `background refresh` | `node:read,service:read` |
 
 <p>
- <sup>1</sup>some query parameters will use the <a href="/consul/api-docs/features/blocking#streaming-backend">streaming backend</a> for blocking queries. 
+ <sup>1</sup>some query parameters will use the <a href="/consul/api-docs/features/blocking#streaming-backend">streaming backend</a> for blocking queries.
 </p>
 
 ### Path Parameters
@@ -265,16 +265,16 @@ The table below shows this endpoint's support for
 
 - `merge-central-config` - Include this flag in a request for `connect-proxy` kind or `*-gateway` kind
   services to return a fully resolved service definition that includes merged values from the
-  [proxy-defaults/global](/consul/docs/connect/config-entries/proxy-defaults) and 
+  [proxy-defaults/global](/consul/docs/connect/config-entries/proxy-defaults) and
   [service-defaults/:service](/consul/docs/connect/config-entries/service-defaults) config entries.
-  Returning a fully resolved service definition is useful when a service was registered using the 
+  Returning a fully resolved service definition is useful when a service was registered using the
   [/catalog/register](/consul/api-docs/catalog#register_entity) endpoint, which does not automatically merge config entries.
 
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace of the service.
   You can also [specify the namespace through other methods](#methods-to-specify-namespace).
 
 - `sg` `(string: "")` <EnterpriseAlert inline /> - Specifies the sameness group the service is a member of to
-  facilitate requests to identical services in other peers or partitions. 
+  facilitate requests to identical services in other peers or partitions.
 
 ### Sample Request
 


### PR DESCRIPTION
### Description

Manual cherry-pick. The original PR was merged on Sept 18 into main and release/1.19.x. @nickwales noticed that his `sg` [commit](https://github.com/hashicorp/consul/commit/ac9e694b98c4ccef4f2e6fc8803dc598bfcf18c5) was not in release/1.20.x, so I manually cherry picked into release/1.20.x

### Links

Jira: [CE-767]
[Deploy preview](https://consul-a5149qm4i-hashicorp.vercel.app/consul/api-docs/health#query-parameters-2) `sg` is the last parameter in the Query parameters list.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern


[CE-767]: https://hashicorp.atlassian.net/browse/CE-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ