### PR TITLE
Suppress redhat linux CVEs

### DIFF
--- a/.changelog/22011.txt
+++ b/.changelog/22011.txt
@@ -1,4 +1,4 @@
 ```release-note:security
-Update `registry.access.redhat.com/ubi9-minimal` image to 9.5 to address [CVE-2019-12900](https://nvd.nist.gov/vuln/detail/cve-2019-12900),[CVE-2024-3596](https://nvd.nist.gov/vuln/detail/CVE-2024-3596),[CVE-2024-2511](https://nvd.nist.gov/vuln/detail/CVE-2024-2511),[CVE-2024-26458](https://nvd.nist.gov/vuln/detail/CVE-2024-26458),[CVE-2024-4067](https://nvd.nist.gov/vuln/detail/CVE-2024-4067).
+Update `registry.access.redhat.com/ubi9-minimal` image to 9.5 to address [CVE-2024-3596](https://nvd.nist.gov/vuln/detail/CVE-2024-3596),[CVE-2024-2511](https://nvd.nist.gov/vuln/detail/CVE-2024-2511),[CVE-2024-26458](https://nvd.nist.gov/vuln/detail/CVE-2024-26458).
 ```
 

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -37,6 +37,8 @@ container {
 	triage {
 		suppress {
 			vulnerabilities = [
+				"CVE-2024-4067", # libsolv@0:0.7.24-3.el9
+				"CVE-2019-12900" # bzip2-libs@0:1.0.8-8.el9
 			]
 			paths = [
 				"internal/tools/proto-gen-rpc-glue/e2e/consul/*",


### PR DESCRIPTION
### Description
Previous PR https://github.com/hashicorp/consul/pull/22011 attempted to resolve these CVEs by updating the redhat ubi image, however these CVEs are still being reported in the scanner. Suppressing for now as we do not use these packages.

### Testing & Reproduction steps
- CI passes

### Links
[Original PR 
](https://github.com/hashicorp/consul/pull/22011)
### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
