### PR TITLE
chore: remove staff codeowners now that it requires mandatory review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,34 +10,3 @@
 # release configuration
 /.release/                              @hashicorp/team-selfmanaged-releng @hashicorp/consul-selfmanage-maintainers
 /.github/workflows/build.yml            @hashicorp/team-selfmanaged-releng @hashicorp/consul-selfmanage-maintainers
-
-
-# Staff Engineer Review (protocol buffer definitions)
-/proto-public/   @hashicorp/consul-core-staff
-/proto/          @hashicorp/consul-core-staff
-
-# Staff Engineer Review (v1 architecture shared components)
-/agent/cache/                  @hashicorp/consul-core-staff
-/agent/consul/fsm/             @hashicorp/consul-core-staff
-/agent/consul/leader*.go       @hashicorp/consul-core-staff
-/agent/consul/server*.go       @hashicorp/consul-core-staff
-/agent/consul/state/           @hashicorp/consul-core-staff
-/agent/consul/stream/          @hashicorp/consul-core-staff
-/agent/submatview/             @hashicorp/consul-core-staff
-/agent/blockingquery/          @hashicorp/consul-core-staff
-
-# Staff Engineer Review (raft/autopilot)
-/agent/consul/autopilotevents/  @hashicorp/consul-core-staff
-/agent/consul/autopilot*.go     @hashicorp/consul-core-staff
-
-# Staff Engineer Review (v2 architecture shared components)
-/internal/controller/                   @hashicorp/consul-core-staff
-/internal/resource/                     @hashicorp/consul-core-staff
-/internal/storage/                      @hashicorp/consul-core-staff
-/agent/consul/controller/               @hashicorp/consul-core-staff
-/agent/grpc-external/services/resource/ @hashicorp/consul-core-staff
-
-# Staff Engineer Review (v1 security)
-/acl/                   @hashicorp/consul-core-staff
-/agent/xds/rbac*.go     @hashicorp/consul-core-staff
-/agent/xds/jwt*.go      @hashicorp/consul-core-staff


### PR DESCRIPTION
### Description

The staff codeowners line items were added when the codeowners files were non-mandatory, to be used as a notification only. Now that the codeowners file requires mandatory review the spirit of the original change isn't correct anymore.
