### PR TITLE
Manual backport of Added labels for redhat validation into release/1.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,13 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
       org.opencontainers.image.vendor="HashiCorp" \
       org.opencontainers.image.title="consul" \
       org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration." \
+      name="Consul" \
+      maintainer="Consul Team <consul@hashicorp.com>" \
+      vendor="HashiCorp" \
+      release=${PRODUCT_REVISION} \
+      revision=${PRODUCT_REVISION} \
+      summary="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration." \
+      description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration." \
       version=${VERSION}
 
 # This is the location of the releases.
@@ -137,6 +144,13 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
       org.opencontainers.image.title="consul" \
       org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration." \
       org.opencontainers.image.licenses="BSL-1.1" \
+      name="Consul" \
+      maintainer="Consul Team <consul@hashicorp.com>" \
+      vendor="HashiCorp" \
+      release=${PRODUCT_REVISION} \
+      revision=${PRODUCT_REVISION} \
+      summary="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration." \
+      description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration." \
       version=${PRODUCT_VERSION}
 
 COPY LICENSE /usr/share/doc/$PRODUCT_NAME/LICENSE.txt
@@ -227,6 +241,13 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
       org.opencontainers.image.title="consul" \
       org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration." \
       org.opencontainers.image.licenses="BSL-1.1" \
+      name="Consul" \
+      maintainer="Consul Team <consul@hashicorp.com>" \
+      vendor="HashiCorp" \
+      release=${PRODUCT_REVISION} \
+      revision=${PRODUCT_REVISION} \
+      summary="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration." \
+      description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration." \
       version=${PRODUCT_VERSION}
 
 COPY LICENSE /usr/share/doc/$PRODUCT_NAME/LICENSE.txt


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Manual Backport of [PR](https://github.com/hashicorp/consul/pull/22048) which Added labels for redhat validation into release/1.20.2

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
