### PR TITLE
fix: security scanner gh token 

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           repository: hashicorp/security-scanner
-          token: ${{ secrets.HASHIBOT_PRODSEC_GITHUB_TOKEN }}
+          token: ${{ secrets.PRODSEC_SCANNER_READ_ONLY }}
           path: security-scanner
           ref: main
 


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
The security scan check is failing due to expired gh token. Using the org level GH token which rotates and is maintained 
Failed scan: https://github.com/hashicorp/consul/actions/runs/12657118157?pr=22055
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
