### PR TITLE
Update datadog.mdx

### DIFF
--- a/website/content/docs/k8s/deployment-configurations/datadog.mdx
+++ b/website/content/docs/k8s/deployment-configurations/datadog.mdx
@@ -293,10 +293,7 @@ during normal operation beyond that of Consul's available metrics.
 See the below [table](#additional-integration-checks-performed) for an outline of the features added by the official integration.
 
 <Note>
-  Currently, the annotations configured by the Helm overrides, when Consul RPC TLS is enabled,
-  presume the user has shared the server and ca certificate secrets with the Datadog agent's Kubernetes namespace and 
-  mount the valid <code>tls.crt</code>, <code>tls.key</code>, and <code>ca.crt</code> secret volumes at the <code>/etc/datadog-agent/conf.d/consul.d/certs</code> 
-  path within the Datadog Agent pod's <code>agent</code> container.
+  When Consul RPC TLS is enabled, the annotations configured by the Helm overrides assume that the user already shared the server and CA certificate secrets with the Datadog agent's Kubernetes namespace. As a result, it mounts `tls.crt`, `tls.key`, and `ca.crt` secret volumes at the `/etc/datadog-agent/conf.d/consul.d/certs` path in the `agent` container of the Datadog agent's Pod.
 </Note>
 
 ### Helm Chart Configuration

--- a/website/content/docs/k8s/deployment-configurations/datadog.mdx
+++ b/website/content/docs/k8s/deployment-configurations/datadog.mdx
@@ -293,9 +293,10 @@ during normal operation beyond that of Consul's available metrics.
 See the below [table](#additional-integration-checks-performed) for an outline of the features added by the official integration.
 
 <Note>
-  Currently, the annotations configured by the Helm overrides with Consul RPC TLS enabled
-  assume server and ca certificate secrets are shared with the Datadog agent release namespace and mount the valid <code>tls.crt</code>, <code>tls.key</code>,
-  and <code>ca.crt</code> secret volumes at the <code>/etc/datadog-agent/conf.d/consul.d/certs</code> path on the Datadog Agent, agent container.
+  Currently, the annotations configured by the Helm overrides, when Consul RPC TLS is enabled,
+  presume the user has shared the server and ca certificate secrets with the Datadog agent's Kubernetes namespace and 
+  mount the valid <code>tls.crt</code>, <code>tls.key</code>, and <code>ca.crt</code> secret volumes at the <code>/etc/datadog-agent/conf.d/consul.d/certs</code> 
+  path within the Datadog Agent pod's <code>agent</code> container.
 </Note>
 
 ### Helm Chart Configuration


### PR DESCRIPTION
### Description

Reword the end user note to be in an English-understandable format.

_**Original**_
> Currently, the annotations configured by the Helm overrides with Consul RPC TLS enabled assume server and ca certificate secrets are shared with the Datadog agent release namespace and mount the valid tls.crt, tls.key, and ca.crt secret volumes at the /etc/datadog-agent/conf.d/consul.d/certs path on the Datadog Agent, agent container.

_**Update**_
> Currently, the annotations configured by the Helm overrides, when Consul RPC TLS is enabled, presume the user has shared the server and ca certificate secrets with the Datadog agent's Kubernetes namespace and mount the valid tls.crt, tls.key, and ca.crt secret volumes at the /etc/datadog-agent/conf.d/consul.d/certs path within the Datadog Agent pod's agent container.


### Testing & Reproduction steps
* N/A

### Links

* N/A

### PR Checklist
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
