### PR TITLE
Add UpdatesOnly query option to fetch data for only changed keys

### DIFF
--- a/agent/consul/fsm/commands_ce_test.go
+++ b/agent/consul/fsm/commands_ce_test.go
@@ -968,7 +968,7 @@ func TestFSM_TombstoneReap(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	idx, _, err := fsm.state.KVSList(nil, "/remove", nil)
+	idx, _, err := fsm.state.KVSList(nil, "/remove", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/fsm/snapshot_test.go
+++ b/agent/consul/fsm/snapshot_test.go
@@ -172,7 +172,7 @@ func TestFSM_SnapshotRestore_CE(t *testing.T) {
 		Value: []byte("foo"),
 	})
 	fsm.state.KVSDelete(12, "/remove", nil)
-	idx, _, err := fsm.state.KVSList(nil, "/remove", nil)
+	idx, _, err := fsm.state.KVSList(nil, "/remove", nil, 0)
 	require.NoError(t, err)
 	require.EqualValues(t, 12, idx, "bad index")
 

--- a/agent/consul/kvs_endpoint.go
+++ b/agent/consul/kvs_endpoint.go
@@ -204,16 +204,16 @@ func (k *KVS) List(args *structs.KeyRequest, reply *structs.IndexedDirEntries) e
 		&args.QueryOptions,
 		&reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
-			index, ent, err := state.KVSList(ws, args.Key, &args.EnterpriseMeta)
+			index, entries, err := FilterKVList(state, ws, args.Key, &args.EnterpriseMeta, &reply.QueryMeta, args.QueryOptions)
 			if err != nil {
 				return err
 			}
 
-			total := len(ent)
-			ent = FilterDirEnt(authz, ent)
-			reply.QueryMeta.ResultsFilteredByACLs = total != len(ent)
+			total := len(entries)
+			entries = FilterDirEnt(authz, entries)
+			reply.QueryMeta.ResultsFilteredByACLs = total != len(entries)
 
-			if len(ent) == 0 {
+			if len(entries) == 0 {
 				// Must provide non-zero index to prevent blocking
 				// Index 1 is impossible anyways (due to Raft internals)
 				if index == 0 {
@@ -224,7 +224,7 @@ func (k *KVS) List(args *structs.KeyRequest, reply *structs.IndexedDirEntries) e
 				reply.Entries = nil
 			} else {
 				reply.Index = index
-				reply.Entries = ent
+				reply.Entries = entries
 			}
 			return nil
 		})
@@ -259,7 +259,7 @@ func (k *KVS) ListKeys(args *structs.KeyListRequest, reply *structs.IndexedKeyLi
 		&args.QueryOptions,
 		&reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
-			index, entries, err := state.KVSList(ws, args.Prefix, &args.EnterpriseMeta)
+			index, entries, err := FilterKVList(state, ws, args.Prefix, &args.EnterpriseMeta, &reply.QueryMeta, args.QueryOptions)
 			if err != nil {
 				return err
 			}

--- a/agent/consul/state/kvs.go
+++ b/agent/consul/state/kvs.go
@@ -211,7 +211,7 @@ func kvsGetTxn(tx ReadTxn,
 // is the max index of the returned kvs entries or applicable tombstones, or
 // else it's the full table indexes for kvs and tombstones.
 func (s *Store) KVSList(ws memdb.WatchSet,
-	prefix string, entMeta *acl.EnterpriseMeta) (uint64, structs.DirEntries, error) {
+	prefix string, entMeta *acl.EnterpriseMeta, minQueryIndex uint64) (uint64, structs.DirEntries, error) {
 
 	tx := s.db.Txn(false)
 	defer tx.Abort()
@@ -221,18 +221,18 @@ func (s *Store) KVSList(ws memdb.WatchSet,
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
 
-	return s.kvsListTxn(tx, ws, prefix, *entMeta)
+	return s.kvsListTxn(tx, ws, prefix, *entMeta, minQueryIndex)
 }
 
 // kvsListTxn is the inner method that gets a list of KVS entries matching a
 // prefix.
 func (s *Store) kvsListTxn(tx ReadTxn,
-	ws memdb.WatchSet, prefix string, entMeta acl.EnterpriseMeta) (uint64, structs.DirEntries, error) {
+	ws memdb.WatchSet, prefix string, entMeta acl.EnterpriseMeta, minQueryIndex uint64) (uint64, structs.DirEntries, error) {
 
 	// Get the table indexes.
 	idx := kvsMaxIndex(tx, entMeta)
 
-	lindex, entries, err := kvsListEntriesTxn(tx, ws, prefix, entMeta)
+	lindex, entries, err := kvsListEntriesTxn(tx, ws, prefix, entMeta, minQueryIndex)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed kvs lookup: %s", err)
 	}

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -415,7 +415,7 @@ func TestStateStore_Restore_Abort(t *testing.T) {
 	}
 	restore.Abort()
 
-	idx, entries, err := s.KVSList(nil, "", nil)
+	idx, entries, err := s.KVSList(nil, "", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/txn.go
+++ b/agent/consul/state/txn.go
@@ -86,7 +86,7 @@ func (s *Store) txnKVS(tx WriteTxn, idx uint64, op *structs.TxnKVOp) (structs.Tx
 
 	case api.KVGetTree:
 		var entries structs.DirEntries
-		_, entries, err = s.kvsListTxn(tx, nil, op.DirEnt.Key, op.DirEnt.EnterpriseMeta)
+		_, entries, err = s.kvsListTxn(tx, nil, op.DirEnt.Key, op.DirEnt.EnterpriseMeta, 0)
 		if err == nil {
 			results := make(structs.TxnResults, 0, len(entries))
 			for _, e := range entries {

--- a/agent/consul/state/txn_test.go
+++ b/agent/consul/state/txn_test.go
@@ -837,7 +837,7 @@ func TestStateStore_Txn_KVS(t *testing.T) {
 	}
 
 	// Pull the resulting state store contents.
-	idx, actual, err := s.KVSList(nil, "", nil)
+	idx, actual, err := s.KVSList(nil, "", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -918,7 +918,7 @@ func TestStateStore_Txn_KVS_Rollback(t *testing.T) {
 
 	// This function verifies that the state store wasn't changed.
 	verifyStateStore := func(desc string) {
-		idx, actual, err := s.KVSList(nil, "", nil)
+		idx, actual, err := s.KVSList(nil, "", nil, 0)
 		if err != nil {
 			t.Fatalf("err (%s): %s", desc, err)
 		}
@@ -1358,7 +1358,7 @@ func TestStateStore_Txn_KVS_ModifyIndexes(t *testing.T) {
 	}
 
 	// Pull the resulting state store contents.
-	idx, actual, err := s.KVSList(nil, "", nil)
+	idx, actual, err := s.KVSList(nil, "", nil, 0)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -328,6 +328,10 @@ type QueryOptions struct {
 	// QueryMeta.Index, the response can be left empty and QueryMeta.NotModified
 	// will be set to true to indicate the result of the query has not changed.
 	AllowNotModifiedResponse bool `mapstructure:"allow-not-modified-response,omitempty"`
+
+	// UpdatesOnly is used to filter out K/V entries or keys with an old
+	// ModifyIndex in the state layer, before data is returned.
+	UpdatesOnly bool `mapstructure:"updates-only,omitempty"`
 }
 
 // IsRead is always true for QueryOption.

--- a/api/api.go
+++ b/api/api.go
@@ -221,6 +221,10 @@ type QueryOptions struct {
 	// Global is used to request information from all datacenters. Currently only
 	// used for operator usage requests.
 	Global bool
+
+	// UpdatesOnly is used to filter out K/V entries or keys with an old
+	// ModifyIndex in the state layer, before data is returned.
+	UpdatesOnly bool
 }
 
 func (o *QueryOptions) Context() context.Context {
@@ -927,6 +931,9 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	}
 	if q.Global {
 		r.params.Set("global", "")
+	}
+	if q.UpdatesOnly {
+		r.params.Set("updates-only", "true")
 	}
 
 	r.ctx = q.ctx


### PR DESCRIPTION
### Description

As mentioned long ago (and roughly outlined) in https://github.com/hashicorp/consul/issues/2791, a limitation on blocking queries is that all K/V entries matching that prefix are returned, even though only 1 key may have changed. This diff adds a new `UpdatesOnly` option, that when set, introduces server-side filtering to remove all keys/entries (from a `Keys()` or `List()` query) that have an old `ModifyIndex`.

It uses `MinQueryIndex` as the threshold here, which follows the effective serialization/deserialization chain: `WaitIndex` --> `index` --> `MinQueryIndex`.
- `WaitIndex` being the client-side parameter, determining the index the "client" waits for on a blocking query
- `index` being the serialized HTTP query parameter representing the `WaitIndex`
- `MinQueryIndex` being the server-side struct (deserialized result of `index`)

While we (potentially?) wait for the streaming backend: https://developer.hashicorp.com/consul/api-docs/features/blocking#streaming-backend to be implemented for KV endpoints, this can be a good stop-gap solution to enable in-memory, incremental scans or queries over a prefix.

### Testing & Reproduction steps

- Updated unit tests to default `minQueryIndex` passed down the state layer to be 0 (no filtering)
- Added a test in `state/kvs_test.go` to illustrate the filtering based on `ModifyIndex`

### Links

Original GH issue: https://github.com/hashicorp/consul/issues/2791

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
