### PR TITLE
metadata: memoize the parsed build versions

### DIFF
--- a/.changelog/22113.txt
+++ b/.changelog/22113.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+metadata: memoize the parsed build versions
+```

--- a/agent/metadata/build.go
+++ b/agent/metadata/build.go
@@ -4,12 +4,51 @@
 package metadata
 
 import (
+	"sync"
+
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/serf/serf"
 )
 
+type versionTuple struct {
+	Value *version.Version
+	Err   error
+}
+
+var versionCache sync.Map // string->versionTuple
+
 // Build extracts the Consul version info for a member.
 func Build(m *serf.Member) (*version.Version, error) {
-	str := versionFormat.FindString(m.Tags["build"])
+	build := m.Tags["build"]
+
+	ok, v, err := getMemoizedBuildVersion(build)
+	if ok {
+		return v, err
+	}
+
+	v, err = parseBuildAsVersion(build)
+
+	versionCache.Store(build, versionTuple{Value: v, Err: err})
+
+	return v, err
+}
+
+func getMemoizedBuildVersion(build string) (bool, *version.Version, error) {
+	rawTuple, ok := versionCache.Load(build)
+	if !ok {
+		return false, nil, nil
+	}
+	tuple, ok := rawTuple.(versionTuple)
+	if !ok {
+		return false, nil, nil
+	}
+	if tuple.Err != nil {
+		return true, nil, tuple.Err
+	}
+	return true, tuple.Value, nil
+}
+
+func parseBuildAsVersion(build string) (*version.Version, error) {
+	str := versionFormat.FindString(build)
 	return version.NewVersion(str)
 }

--- a/agent/metadata/build.go
+++ b/agent/metadata/build.go
@@ -42,10 +42,7 @@ func getMemoizedBuildVersion(build string) (bool, *version.Version, error) {
 	if !ok {
 		return false, nil, nil
 	}
-	if tuple.Err != nil {
-		return true, nil, tuple.Err
-	}
-	return true, tuple.Value, nil
+	return true, tuple.Value, tuple.Err
 }
 
 func parseBuildAsVersion(build string) (*version.Version, error) {

--- a/agent/metadata/server.go
+++ b/agent/metadata/server.go
@@ -127,11 +127,6 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 		}
 	}
 
-	buildVersion, err := Build(&m)
-	if err != nil {
-		return false, nil
-	}
-
 	wanJoinPort := 0
 	wanJoinPortStr, ok := m.Tags["wan_join_port"]
 	if ok {
@@ -179,6 +174,11 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 	_, readReplica := m.Tags["read_replica"]
 
 	addr := &net.TCPAddr{IP: m.Addr, Port: port}
+
+	buildVersion, err := Build(&m)
+	if err != nil {
+		return false, nil
+	}
 
 	parts := &Server{
 		Name:                m.Name,


### PR DESCRIPTION
### Description

There will only be a small set of consul build versions that a single consul server will witness. Inside of `metadata.IsConsulServer` we use a very expensive function in the `hashicorp/go-version` library to parse these into read-only `*version.Version` structs all over Consul.

Memoize these in a package cache map. Likely the thing will only have like 2 keys in it ever over the life of the process.
