### PR TITLE
Fix CI: Updated upload-artifact and download-artifact to v4 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,8 @@
 # Techical Writer Review
 
 /website/content/docs/ @hashicorp/consul-docs
-	@@ -6,36 +8,5 @@
+/website/content/commands/ @hashicorp/consul-docs
+/website/content/api-docs/ @hashicorp/consul-docs
 
 
 # release configuration

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,41 +1,11 @@
+* @hashicorp/consul-selfmanage-maintainers
+
 # Techical Writer Review
 
 /website/content/docs/ @hashicorp/consul-docs
-/website/content/commands/ @hashicorp/consul-docs
-/website/content/api-docs/ @hashicorp/consul-docs
+	@@ -6,36 +8,5 @@
 
 
 # release configuration
-/.release/                              @hashicorp/release-engineering @hashicorp/github-consul-core
-/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-consul-core
-
-
-# Staff Engineer Review (protocol buffer definitions)
-/proto-public/   @hashicorp/consul-core-staff
-/proto/          @hashicorp/consul-core-staff
-
-# Staff Engineer Review (v1 architecture shared components)
-/agent/cache/                  @hashicorp/consul-core-staff
-/agent/consul/fsm/             @hashicorp/consul-core-staff
-/agent/consul/leader*.go       @hashicorp/consul-core-staff
-/agent/consul/server*.go       @hashicorp/consul-core-staff
-/agent/consul/state/           @hashicorp/consul-core-staff
-/agent/consul/stream/          @hashicorp/consul-core-staff
-/agent/submatview/             @hashicorp/consul-core-staff
-/agent/blockingquery/          @hashicorp/consul-core-staff
-
-# Staff Engineer Review (raft/autopilot)
-/agent/consul/autopilotevents/  @hashicorp/consul-core-staff
-/agent/consul/autopilot*.go     @hashicorp/consul-core-staff
-
-# Staff Engineer Review (v2 architecture shared components)
-/internal/controller/                   @hashicorp/consul-core-staff
-/internal/resource/                     @hashicorp/consul-core-staff
-/internal/storage/                      @hashicorp/consul-core-staff
-/agent/consul/controller/               @hashicorp/consul-core-staff
-/agent/grpc-external/services/resource/ @hashicorp/consul-core-staff
-
-# Staff Engineer Review (v1 security)
-/acl/                   @hashicorp/consul-core-staff
-/agent/xds/rbac*.go     @hashicorp/consul-core-staff
-/agent/xds/jwt*.go      @hashicorp/consul-core-staff
+/.release/                              @hashicorp/team-selfmanaged-releng @hashicorp/consul-selfmanage-maintainers
+/.github/workflows/build.yml            @hashicorp/team-selfmanaged-releng @hashicorp/consul-selfmanage-maintainers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,7 +417,7 @@ jobs:
 
       - name: Download ${{ matrix.arch  }} zip
         if: ${{ endsWith(github.repository, '-enterprise') || matrix.arch != 's390x' }}
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{ env.zip_name }}
 
@@ -448,7 +448,7 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Download amd64 darwin zip
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{ env.zip_name }}
 
@@ -483,7 +483,7 @@ jobs:
           echo "pkg_name=consul_${{ env.pkg_version }}-1_${{ matrix.arch }}.deb" >> $GITHUB_ENV
 
       - name: Download workflow artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{ env.pkg_name }}
 
@@ -520,7 +520,7 @@ jobs:
           echo "pkg_name=consul-${{ env.pkg_version }}-1.${{ matrix.arch }}.rpm" >> $GITHUB_ENV
 
       - name: Download workflow artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{ env.pkg_name }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           version: ${{ needs.set-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
 
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
@@ -182,13 +182,13 @@ jobs:
           echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
           echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
 
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ matrix.goos == 'linux' }}
         with:
           name: ${{ env.RPM_PACKAGE }}
           path: out/${{ env.RPM_PACKAGE }}
 
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ matrix.goos == 'linux' }}
         with:
           name: ${{ env.DEB_PACKAGE }}

--- a/.github/workflows/nightly-test-integrations-1.15.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.15.x.yml
@@ -126,7 +126,7 @@ jobs:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
 
       - name: fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ./bin
@@ -221,7 +221,7 @@ jobs:
 
       # Get go binary from workspace
       - name: fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: .

--- a/.github/workflows/nightly-test-integrations-1.16.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.16.x.yml
@@ -126,7 +126,7 @@ jobs:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
 
       - name: fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ./bin
@@ -224,7 +224,7 @@ jobs:
 
       # Get go binary from workspace
       - name: fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: .

--- a/.github/workflows/nightly-test-integrations-1.17.x.yml
+++ b/.github/workflows/nightly-test-integrations-1.17.x.yml
@@ -126,7 +126,7 @@ jobs:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
 
       - name: fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ./bin
@@ -224,7 +224,7 @@ jobs:
 
       # Get go binary from workspace
       - name: fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: .

--- a/.github/workflows/nightly-test-integrations.yml
+++ b/.github/workflows/nightly-test-integrations.yml
@@ -123,7 +123,7 @@ jobs:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
 
       - name: fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ./bin
@@ -221,7 +221,7 @@ jobs:
 
       # Get go binary from workspace
       - name: fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: .

--- a/.github/workflows/reusable-dev-build-windows.yml
+++ b/.github/workflows/reusable-dev-build-windows.yml
@@ -41,7 +41,7 @@ jobs:
           GOARCH: ${{ inputs.goarch }}
         run: go build .
       # save dev build to pass to downstream jobs
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: ${{inputs.uploaded-binary-name}}
           path: consul.exe

--- a/.github/workflows/reusable-dev-build.yml
+++ b/.github/workflows/reusable-dev-build.yml
@@ -41,7 +41,7 @@ jobs:
           GOARCH: ${{ inputs.goarch }}
         run: make dev
       # save dev build to pass to downstream jobs
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: ${{inputs.uploaded-binary-name}}
           path: ./bin/consul

--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -85,6 +85,14 @@ jobs:
           ulimit -Sa
           echo "Hard limits"
           ulimit -Ha   
+      # upload-artifact requires a unique ID per run. These steps will be repeated with the matrix run, and other unit tests
+      # will also overlap with the names here. We use a random string rather than trying to do trickery
+      # with the package matrix.
+      - id: generate-matrix-id
+        run: |
+          MATRIX_RUN_ID=$(head /dev/urandom | tr -dc A-Z | head -c8)
+          echo "The matrix run ID is $MATRIX_RUN_ID"
+          echo "matrix-run-id=$MATRIX_RUN_ID" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
       # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
       - name: Setup Git
@@ -169,12 +177,12 @@ jobs:
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !cancelled() }}
         with:
-          name: test-results
+          name: ${{ steps.generate-matrix-id.outputs.matrix-run-id }}-test-results
           path: ${{env.TEST_RESULTS}}
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !cancelled() }}
         with:
-          name: jsonfile
+          name: ${{ steps.generate-matrix-id.outputs.matrix-run-id }}-jsonfile
           path: /tmp/jsonfile
       - name: "Re-run fails report"
         if: ${{ !cancelled() }}

--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -166,12 +166,12 @@ jobs:
           DD_ENV: ci
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" ${{env.TEST_RESULTS}}/gotestsum-report.xml
 
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !cancelled() }}
         with:
           name: test-results
           path: ${{env.TEST_RESULTS}}
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !cancelled() }}
         with:
           name: jsonfile

--- a/.github/workflows/reusable-unit-split.yml
+++ b/.github/workflows/reusable-unit-split.yml
@@ -98,7 +98,7 @@ jobs:
         working-directory: ${{inputs.directory}}
         run: go mod download
       - name: Download consul
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{inputs.uploaded-binary-name}}
           path: ${{inputs.directory}} 

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -134,12 +134,12 @@ jobs:
           DD_ENV: ci
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" ${{env.TEST_RESULTS}}/gotestsum-report.xml
 
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !cancelled() }}
         with:
           name: test-results
           path: ${{env.TEST_RESULTS}}
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !cancelled() }}
         with:
           name: jsonfile

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -68,7 +68,7 @@ jobs:
         working-directory: ${{inputs.directory}}
         run: go mod download
       - name: Download consul
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{inputs.uploaded-binary-name}}
           path: ${{inputs.directory}}

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -133,16 +133,22 @@ jobs:
         env:
           DD_ENV: ci
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" ${{env.TEST_RESULTS}}/gotestsum-report.xml
-
+      # upload-artifact requires a unique ID per run. These steps will overlap with other users of the reusable workflow.
+      # We use a random string rather than trying to pass in some identifying information.
+      - id: generate-run-id
+        run: |
+          RUN_ID=$(head /dev/urandom | tr -dc A-Z | head -c8)
+          echo "The run ID is $RUN_ID"
+          echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !cancelled() }}
         with:
-          name: test-results
+          name: ${{ steps.generate-run-id.outputs.run-id }}-test-results
           path: ${{env.TEST_RESULTS}}
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !cancelled() }}
         with:
-          name: jsonfile
+          name: ${{ steps.generate-run-id.outputs.run-id }}-jsonfile
           path: /tmp/jsonfile
       - name: "Re-run fails report"
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-integrations-windows.yml
+++ b/.github/workflows/test-integrations-windows.yml
@@ -75,7 +75,7 @@ jobs:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
 
       - name: Fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ${{ github.workspace }}

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -106,7 +106,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Fetch Consul binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ./bin
@@ -324,7 +324,7 @@ jobs:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
 
       - name: fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: ./bin
@@ -412,7 +412,7 @@ jobs:
           docker version
           docker info
       - name: fetch binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: '${{ env.CONSUL_BINARY_UPLOAD_NAME }}'
           path: .


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
The current CI is failing due to the error `This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: 0b7f8abb1508181956e8e162db84b466c27e18ce`.`

Updated to v4 version now. 

[Deprecation Link](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links
Failed CI [run](https://github.com/hashicorp/consul/actions/runs/13236305622/job/36941822483?pr=22125)
<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
