### PR TITLE
Update golangci-lint to 1.56.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GO_MODULES := $(shell find . -name go.mod -exec dirname {} \; | grep -v "proto-g
 # These version variables can either be a valid string for "go install <module>@<version>"
 # or the string @DEV to imply use what is currently installed locally.
 ###
-GOLANGCI_LINT_VERSION='v1.55.2'
+GOLANGCI_LINT_VERSION='v1.56.1'
 MOCKERY_VERSION='v2.41.0'
 BUF_VERSION='v1.26.0'
 


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Lint is failing after upgrade to go 1.22.12 and hence updating the golangci-lint to 1.56.1 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
