### PR TITLE
[Manual] Backport of bugfix(logging): add Darwin-specific log file creation time handling to 1.19.x

### DIFF
--- a/.changelog/22143.txt
+++ b/.changelog/22143.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed logging error while building for OpenBSD OS [[GH-22120](https://github.com/hashicorp/consul/pull/22120)]
+```

--- a/logging/logfile_darwin.go
+++ b/logging/logfile_darwin.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-//go:build freebsd || netbsd || openbsd
+//go:build darwin
 
 package logging
 
@@ -14,5 +14,6 @@ import (
 func (l *LogFile) createTime(stat os.FileInfo) time.Time {
 	stat_t := stat.Sys().(*syscall.Stat_t)
 	createTime := stat_t.Ctimespec
+	// Sec and Nsec are int32 in 32-bit architectures.
 	return time.Unix(int64(createTime.Sec), int64(createTime.Nsec)) //nolint:unconvert
 }

--- a/logging/logfile_linux.go
+++ b/logging/logfile_linux.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-//go:build dragonfly || linux
+//go:build dragonfly || linux || darwin
 
 package logging
 


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
This is needed to fix compiling software dependent on Consul with OS=freebsd and ARCH=386 

Manual Backport of https://github.com/hashicorp/consul/pull/22120 
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
