### PR TITLE
security: Suppress redhat linux CVEs

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -38,7 +38,8 @@ container {
 		suppress {
 			vulnerabilities = [
 				"CVE-2024-4067", # libsolv@0:0.7.24-3.el9
-				"CVE-2019-12900" # bzip2-libs@0:1.0.8-8.el9
+				"CVE-2019-12900", # bzip2-libs@0:1.0.8-8.el9
+				"CVE-2024-12797" # openssl-libs@1:3.2.2-6.el9_5
 			]
 			paths = [
 				"internal/tools/proto-gen-rpc-glue/e2e/consul/*",


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Suppressing the [CVE-2024-12797](https://nvd.nist.gov/vuln/detail/CVE-2024-12797) as the fix isn't available and the base image will update once the fix is released by redhat 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
