### PR TITLE
docs: namespace ACL config typo fix

### DIFF
--- a/website/content/docs/connect/config-entries/exported-services.mdx
+++ b/website/content/docs/connect/config-entries/exported-services.mdx
@@ -788,7 +788,7 @@ partition "default" {
 }
 
 partition_prefix "" {
-  namespace_prefix "" {S
+  namespace_prefix "" {
     node_prefix "" {
       policy = "read"
     }


### PR DESCRIPTION
### Description

Corrects a typo when the namespace prefix configuration was added in https://github.com/hashicorp/consul/pull/22162.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
