### PR TITLE
Send TLS SNI in JWT auth provider

### DIFF
--- a/.changelog/22168.txt
+++ b/.changelog/22168.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: send TLS SNI in JWT auth provider
+```

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -242,6 +242,7 @@ func makeJWTProviderCluster(p *structs.JWTProviderConfigEntry) (*envoy_cluster_v
 	if scheme == "https" {
 		jwksTLSContext, err := makeUpstreamTLSTransportSocket(
 			&envoy_tls_v3.UpstreamTlsContext{
+				Sni: hostname,
 				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
 					ValidationContextType: &envoy_tls_v3.CommonTlsContext_ValidationContext{
 						ValidationContext: makeJWTCertValidationContext(p.JSONWebKeySet.Remote.JWKSCluster),

--- a/agent/xds/testdata/clusters/connect-proxy-with-jwt-config-entry-with-remote-jwks.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-jwt-config-entry-with-remote-jwks.latest.golden
@@ -138,7 +138,8 @@
                 "filename": "mycert.crt"
               }
             }
-          }
+          },
+          "sni": "test.test.com"
         }
       },
       "type": "STATIC"

--- a/agent/xds/testdata/jwt_authn_clusters/https-provider-with-hostname-and-port.golden
+++ b/agent/xds/testdata/jwt_authn_clusters/https-provider-with-hostname-and-port.golden
@@ -30,7 +30,8 @@
             "filename": "mycert.crt"
           }
         }
-      }
+      },
+      "sni": "example-okta.com"
     }
   },
   "type": "STATIC"

--- a/agent/xds/testdata/jwt_authn_clusters/https-provider-with-hostname-no-port.golden
+++ b/agent/xds/testdata/jwt_authn_clusters/https-provider-with-hostname-no-port.golden
@@ -30,7 +30,8 @@
             "filename": "mycert.crt"
           }
         }
-      }
+      },
+      "sni": "example-okta.com"
     }
   },
   "type": "STATIC"

--- a/agent/xds/testdata/jwt_authn_clusters/https-provider-with-ip-and-port.golden
+++ b/agent/xds/testdata/jwt_authn_clusters/https-provider-with-ip-and-port.golden
@@ -30,7 +30,8 @@
             "filename": "mycert.crt"
           }
         }
-      }
+      },
+      "sni": "127.0.0.1"
     }
   },
   "type": "STATIC"

--- a/agent/xds/testdata/jwt_authn_clusters/https-provider-with-ip-no-port.golden
+++ b/agent/xds/testdata/jwt_authn_clusters/https-provider-with-ip-no-port.golden
@@ -30,7 +30,8 @@
             "filename": "mycert.crt"
           }
         }
-      }
+      },
+      "sni": "127.0.0.1"
     }
   },
   "type": "STATIC"


### PR DESCRIPTION
### Description
Send hostname in SNI while initiating a TLS connection for JWTProvider. This is required by certain JWT providers such as Auth0 and not having it leads to a handshake error immediately after CLIENT_HELLO.

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--


* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
