### PR TITLE
Update cert.mdx

### DIFF
--- a/website/content/commands/tls/cert.mdx
+++ b/website/content/commands/tls/cert.mdx
@@ -71,8 +71,7 @@ Usage: `consul tls cert create [filename-prefix] [options]`
 - `-dc=<string>` - Provide the datacenter. Matters only for `-server`
   certificates. Defaults to `dc1`.
 
-- `-domain=<string>` - Provide the domain. Matters only for `-server`
-  certificates.
+- `-domain=<string>` - Provide the domain. Matters only if you set such option before `ca create` execution
 
 - `-key=<string>` - Provide path to the key. Defaults to
   `#DOMAIN#-agent-ca-key.pem`.


### PR DESCRIPTION
### Description
-domain flag is required not only for server certificate creation

### Testing & Reproduction steps
```

consul tls ca create -name-constraint -domain consul.local
consul tls cert create  -domain consul.local -ca consul.local-agent-ca.pem  -key consul.local-agent-ca-key.pem -server
consul tls cert create  -domain consul.local -ca consul.local-agent-ca.pem  -key consul.local-agent-ca-key.pem -server
consul tls cert create  -domain consul.local -ca consul.local-agent-ca.pem  -key consul.local-agent-ca-key.pem -server


consul tls cert create   -ca consul.local-agent-ca.pem  -key consul.local-agent-ca-key.pem -client

consul tls cert create  -domain consul.local -ca consul.local-agent-ca.pem  -key consul.local-agent-ca-key.pem -client

```

### Links
![image](https://github.com/user-attachments/assets/de43b046-323f-4d45-a6fb-398055aeedeb)


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
