### PR TITLE
Add the missing Service TaggedAddresses and Check Type fields to Txn API

### DIFF
--- a/.changelog/22220.txt
+++ b/.changelog/22220.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Add the missing Service TaggedAddresses and Check Type fields to Txn API.
+```

--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -231,6 +231,16 @@ func (s *HTTPHandlers) convertOps(resp http.ResponseWriter, req *http.Request) (
 					},
 				},
 			}
+			if len(in.Service.Service.TaggedAddresses) > 0 {
+				taggedAddresses := make(map[string]structs.ServiceAddress)
+				for name, addr := range in.Service.Service.TaggedAddresses {
+					taggedAddresses[name] = structs.ServiceAddress{
+						Address: addr.Address,
+						Port:    addr.Port,
+					}
+				}
+				out.Service.Service.TaggedAddresses = taggedAddresses
+			}
 
 			if svc.Proxy != nil {
 				out.Service.Service.Proxy = structs.ConnectProxyConfig{}
@@ -300,6 +310,7 @@ func (s *HTTPHandlers) convertOps(resp http.ResponseWriter, req *http.Request) (
 						Status:      check.Status,
 						Notes:       check.Notes,
 						Output:      check.Output,
+						Type:        check.Type,
 						ServiceID:   check.ServiceID,
 						ServiceName: check.ServiceName,
 						ServiceTags: check.ServiceTags,


### PR DESCRIPTION
### Description

**Update**: looks like there is an issue with API package unable to unmarshall [TxnResult](https://github.com/hashicorp/consul/blob/v1.20.3/api/txn.go#L237) when the service has `TaggedAddresses` set. This issue should be resolved first before this PR. 

Consul Transaction API Service Operation does not register the `TaggedAddresses` field in the `AgentService` struct that is sent from the client. Same with the `Type` field in the `HealthCheck` struct.

### Testing & Reproduction steps

1. Create a Transaction API input file `txn.json`
```
[
{
    "Node": {
        "Verb": "set",
        "Node": {
            "Node": "n1",
            "Address": "192.168.0.10"
        }
    }
},
{
    "Service": {
        "Verb": "set",
        "Node": "n1",
        "Service": {
            "ID": "s1",
            "Service": "s1",
            "Address": "192.168.0.10",
            "TaggedAddresses": {
                "lan": {
                    "Address": "192.168.0.10",
                    "Port": 8080
                }
            },
            "Port": 8080
        }
        }
},
{
    "Check": {
        "Verb": "set",
        "Check": {
            "Node": "n1",
            "CheckID": "healthcheck",
            "Name": "healthcheck",
            "Status": "passing",
            "ServiceID": "s1",
            "ServiceName": "s1",
            "Definition": {
                "HTTP": "http://localhost:8080",
                "Interval": "10s"
            },
            "Type": "http"
        }
    }
}
]
```

2. Start Consul in Agent mode.
```
docker run -p 8500:8500 hashicorp/consul:1.20
```

3. Submit the transaction, returns success but Service `TaggedAddresses` and Check `Type` are not registered.
```
curl --request PUT --data @txn2.json http://127.0.0.1:8500/v1/txn

{
    "Results": [
        {
            "Node": {
                "ID": "",
                "Node": "n1",
                "Address": "192.168.0.10",
                "Datacenter": "dc1",
                "TaggedAddresses": null,
                "Meta": null,
                "CreateIndex": 18,
                "ModifyIndex": 18
            }
        },
        {
            "Service": {
                "ID": "s1",
                "Service": "s1",
                "Tags": null,
                "Address": "192.168.0.10",
                "Meta": null,
                "Port": 8080,
                "Weights": {
                    "Passing": 1,
                    "Warning": 1
                },
                "EnableTagOverride": false,
                "Proxy": {
                    "Mode": "",
                    "MeshGateway": {},
                    "Expose": {}
                },
                "Connect": {},
                "PeerName": "",
                "CreateIndex": 18,
                "ModifyIndex": 18
            }
        },
        {
            "Check": {
                "Node": "n1",
                "CheckID": "healthcheck",
                "Name": "healthcheck",
                "Status": "passing",
                "Notes": "",
                "Output": "",
                "ServiceID": "s1",
                "ServiceName": "s1",
                "ServiceTags": null,
                "Type": "",
                "Interval": "",
                "Timeout": "",
                "ExposedPort": 0,
                "Definition": {
                    "Interval": "10s",
                    "HTTP": "http://localhost:8080"
                },
                "CreateIndex": 18,
                "ModifyIndex": 18
            }
        }
    ],
    "Errors": null
```

Relevant Unit Test:
https://github.com/jzou-rbx/consul/blob/4d76a43dc6d0ad9dacd6079c7b34d128baad12c7/agent/txn_endpoint_test.go#L533
does not test for the `Type` field in a check.

https://github.com/jzou-rbx/consul/blob/4d76a43dc6d0ad9dacd6079c7b34d128baad12c7/agent/txn_endpoint_test.go#L703 does not test for the `TaggedAddresses` field in a regular service.

The test build after the PR now work properly to include these fields when submitting the same input above to the Transaction API.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
