### PR TITLE
Fix IPv6 address handling in LAN <-> WAN join flooder

### DIFF
--- a/.changelog/22226.txt
+++ b/.changelog/22226.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+wan-federation: Fixed an issue where advertised IPv6 addresses were causing WAN federation to fail.
+```

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -781,7 +781,7 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 			if err != nil {
 				return "", err
 			}
-			return fmt.Sprintf("%s:%d", addr, s.WanJoinPort), nil
+			return net.JoinHostPort(addr, strconv.Itoa(s.WanJoinPort)), nil
 		}
 		go s.Flood(addrFn, s.serfWAN)
 	}


### PR DESCRIPTION
When `advertise_addr` is an IPv6 address, Consul WAN federation breaks and we get a constant stream of warnings:
```
[WARN]  agent.server.memberlist.wan: memberlist: Failed to resolve
i-02a3c94b46768b01f.aws-eu-west-1/2a05:d018:18a3:f202:64d9:1621:ab22:df45:8302:
lookup 2a05:d018:18a3:f202:64d9:1621:ab22:df45:8302: no such host
```

The LAN <-> WAN join flooder creates IPv6 addresses without square brackets with `fmt.Sprintf("%s:%d", addr, s.WanJoinPort)`, which confuses `net.SplitHostPort` in `memberlist.resolveAddr`.

Fixes hashicorp/consul#22225
<!-- Please describe why you're making this change, in plain English. -->
<!--
### Description

### Testing & Reproduction steps

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->
<!--

### Links

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
-->