### PR TITLE
Update lock.mdx (Node Health Check and TTL)

### DIFF
--- a/website/content/commands/lock.mdx
+++ b/website/content/commands/lock.mdx
@@ -84,22 +84,22 @@ Windows has no POSIX compatible notion for `SIGTERM`.
 
 @include 'http_api_options_server.mdx'
 
-## Node Health Checks and TTL Behavior
+## Node health checks and TTL behavior
 
-When you run `consul lock`, Consul automatically creates an **ephemeral session** that attaches one or more node checks by default (for example, the `serfHealth` check). Because these checks keep the node considered “healthy” from Consul’s perspective, the session is effectively **auto-renewed** as long as the agent passes these health checks. Even if the session has a TTL (for example, `"TTL": "15s"`), that TTL never reaches zero as long as the node remains healthy to the cluster.
+When you run `consul lock`, Consul automatically creates an _ephemeral session_ that attaches one or more node checks, such as the `serfHealth` check, by default. These checks keep the node “healthy” from Consul’s perspective. This session automatically renews as long as the agent passes these health checks. For sessions with a a TTL configured, that TTL never reaches zero as long as the node remains healthy.
 
-This design ensures the lock is not lost as long as the local Consul agent is up and healthy. However, it can also mean that the session persists indefinitely if:
+This design ensures the lock is not lost as long as the local Consul agent is up and healthy. However, emphemeral sessions run indefinitely when:
 
-1. **The node remains healthy** (including in partial network partitions, where at least one Consul server still sees the node as online).  
-2. **No explicit session destroy** or forced release occurs.
+- **The node remains healthy**, including in partial networks where at least one Consul server still reads the node as online.  
+- **No explicit session destroy** or forced release occurs.
 
-**Note:** If you want the TTL to be strictly enforced and **not** auto-renewed by node checks, you must create or manage your own session separately. In that scenario:
+To strictly enforce the TTL and prevent auto-renewed by node checks, you must create or manage your own session separately. In that scenario:
 
-- **Manually create** a session (via the HTTP API) that either excludes node checks or uses custom service checks.  
-- **Acquire** the lock on that custom session using the raw KV API (`?acquire=<sessionID>`).  
-- **Manage** renewals and releases yourself (if needed).
+1. **Manually create a session** with the HTTP API that either excludes node checks or uses custom service checks.  
+1. **Acquire the lock** on that custom session using the raw KV API (`?acquire=<sessionID>`).  
+1. **Manage renewals** and releases yourself as needed.
 
-By removing node checks, the TTL-based session will genuinely expire after the specified time if you do not renew it, causing Consul to release the lock automatically.
+When you remove node checks, the TTL-based session expires after the specified time if you do not renew it. Consul releases the lock automatically when the session expires.
 
 ## SHELL
 

--- a/website/content/commands/lock.mdx
+++ b/website/content/commands/lock.mdx
@@ -84,6 +84,23 @@ Windows has no POSIX compatible notion for `SIGTERM`.
 
 @include 'http_api_options_server.mdx'
 
+## Node Health Checks and TTL Behavior
+
+When you run `consul lock`, Consul automatically creates an **ephemeral session** that attaches one or more node checks by default (for example, the `serfHealth` check). Because these checks keep the node considered “healthy” from Consul’s perspective, the session is effectively **auto-renewed** as long as the agent passes these health checks. Even if the session has a TTL (for example, `"TTL": "15s"`), that TTL never reaches zero as long as the node remains healthy to the cluster.
+
+This design ensures the lock is not lost as long as the local Consul agent is up and healthy. However, it can also mean that the session persists indefinitely if:
+
+1. **The node remains healthy** (including in partial network partitions, where at least one Consul server still sees the node as online).  
+2. **No explicit session destroy** or forced release occurs.
+
+**Note:** If you want the TTL to be strictly enforced and **not** auto-renewed by node checks, you must create or manage your own session separately. In that scenario:
+
+- **Manually create** a session (via the HTTP API) that either excludes node checks or uses custom service checks.  
+- **Acquire** the lock on that custom session using the raw KV API (`?acquire=<sessionID>`).  
+- **Manage** renewals and releases yourself (if needed).
+
+By removing node checks, the TTL-based session will genuinely expire after the specified time if you do not renew it, causing Consul to release the lock automatically.
+
 ## SHELL
 
 Consul lock launches its children in a shell. By default, Consul will use the shell


### PR DESCRIPTION
**Title**  
Consul lock docs: Clarify node checks & TTL behavior, plus manual session workaround

### Description

This PR updates the `consul lock` command documentation to explain how an ephemeral session is automatically created with node checks (e.g. `serfHealth`), which can cause the lock’s TTL to be effectively auto-renewed as long as the node is healthy. It also outlines a recommended workaround (manually creating and managing a custom session) for users who need strict TTL enforcement without node checks.

### Testing & Reproduction Steps

- **No functional code changes** – this is a documentation-only update.
- **Relevant sections**:
  - A new note/section titled “Node Health Checks and TTL Behavior.”
  - Explains that the default session includes node checks, leading to indefinite lock behavior unless manually overridden.
- **Validation**:
  1. Confirmed that the `agent/session_endpoint.go` sets `NodeChecks` to `[serfHealth]` by default.
  2. Verified that `consul lock` does not expose a built-in flag for removing node checks.
  3. Tested a scenario in which a user removes node checks by manually calling the session create API, verifying the lock expires after TTL if not renewed.

### Links

- GitHub Issue [#5205](https://github.com/hashicorp/consul/issues/5205) (related example of locks not releasing after session deletion)

### PR Checklist

- [x] **updated external-facing docs** to clarify node health check behavior
- [x] test coverage not applicable (no code changes)
- [x] not a security concern