### PR TITLE
suppressing alpine CVEs as there is no fix yet

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -39,7 +39,14 @@ container {
 			vulnerabilities = [
 				"CVE-2024-4067", # libsolv@0:0.7.24-3.el9
 				"CVE-2019-12900", # bzip2-libs@0:1.0.8-8.el9
-				"CVE-2024-12797" # openssl-libs@1:3.2.2-6.el9_5
+				"CVE-2024-12797", # openssl-libs@1:3.2.2-6.el9_5
+				"CVE-2024-53427", # jq@1.7.1-r0
+				"CVE-2025-31498", # c-ares@1.34.3-r0
+				"CVE-2025-30258", # gnupg@2.4.7-r0
+				"CVE-2025-31498", # c-ares@1.34.3-r0
+				"CVE-2025-30258", #  gnupg@2.4.7-r0
+				"CVE-2024-53427", # jq@1.7.1-r0
+				"CVE-2022-49043" # libxml2@0:2.9.13-6.el9_5.2
 			]
 			paths = [
 				"internal/tools/proto-gen-rpc-glue/e2e/consul/*",


### PR DESCRIPTION
### Description
Suppressing  following alpine CVEs as there is no fix yet:

CVE-2024-53427 from Alpine Linux's Security Issue Tracker in jq@1.7.1-r0

CVE-2025-31498 from Alpine Linux's Security Issue Tracker in c-ares@1.34.3-r0

CVE-2025-30258 from Alpine Linux's Security Issue Tracker in gnupg@2.4.7-r0

CVE-2025-31498 from Alpine Linux's Security Issue Tracker in c-ares@1.34.3-r0

CVE-2025-30258 from Alpine Linux's Security Issue Tracker in gnupg@2.4.7-r0

CVE-2024-53427 from Alpine Linux's Security Issue Tracker in jq@1.7.1-r0

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
