### PR TITLE
feat: add LUA script Envoy extension support for API gateway

### DIFF
--- a/.changelog/22291.txt
+++ b/.changelog/22291.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Added Lua script Envoy extension support for API Gateway
+```

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -68,7 +68,7 @@ jobs:
       if: ${{ endsWith(github.repository, '-enterprise') }}
       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
 
-    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version: ${{ needs.get-go-version.outputs.go-version }}
     

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Setup Git
       if: ${{ endsWith(github.repository, '-enterprise') }}
       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version: ${{ needs.get-go-version.outputs.go-version }}
     - run: make proto-tools
@@ -100,7 +100,7 @@ jobs:
      - name: Setup Git
        if: ${{ endsWith(github.repository, '-enterprise') }}
        run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+     - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
        with:
          go-version: ${{ needs.get-go-version.outputs.go-version }}
      - run: make --always-make codegen
@@ -121,7 +121,7 @@ jobs:
     - name: Setup Git
       if: ${{ endsWith(github.repository, '-enterprise') }}
       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version: ${{ needs.get-go-version.outputs.go-version }}
     - run: go install github.com/reillywatson/enumcover/cmd/enumcover@master && enumcover ./...
@@ -136,7 +136,7 @@ jobs:
     # NOTE: This step is specifically needed for ENT. It allows us to access the required private HashiCorp repos.
     - name: Setup Git
       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version: ${{ needs.get-go-version.outputs.go-version }}
     - run: make lint-container-test-deps
@@ -152,7 +152,7 @@ jobs:
     - name: Setup Git
       if: ${{ endsWith(github.repository, '-enterprise') }}
       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version: ${{ needs.get-go-version.outputs.go-version }}
     - run: make lint-consul-retry

--- a/.github/workflows/reusable-check-go-mod.yml
+++ b/.github/workflows/reusable-check-go-mod.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Git
       if: ${{ endsWith(inputs.repository-name, '-enterprise') }}
       run: git config --global url."https://${{ secrets.elevated-github-token }}:@github.com".insteadOf "https://github.com"
-    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version: ${{ inputs.go-version }}
     # Run on all go.mod (include submodules).

--- a/.github/workflows/reusable-dev-build-windows.yml
+++ b/.github/workflows/reusable-dev-build-windows.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Git
         if: ${{ endsWith(inputs.repository-name, '-enterprise') }}
         run: git config --global url."https://${{ secrets.elevated-github-token }}:@github.com".insteadOf "https://github.com"
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ inputs.go-version }}
       - name: Build

--- a/.github/workflows/reusable-dev-build.yml
+++ b/.github/workflows/reusable-dev-build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Git
         if: ${{ endsWith(inputs.repository-name, '-enterprise') }}
         run: git config --global url."https://${{ secrets.elevated-github-token }}:@github.com".insteadOf "https://github.com"
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ inputs.go-version }}
       - name: Build

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Git
         if: ${{ endsWith(inputs.repository-name, '-enterprise') }}
         run: git config --global url."https://${{ secrets.elevated-github-token }}:@github.com".insteadOf "https://github.com"
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ inputs.go-version }}
       - run: go env

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Git
         if: ${{ endsWith(inputs.repository-name, '-enterprise') }}
         run: git config --global url."https://${{ secrets.elevated-github-token }}:@github.com".insteadOf "https://github.com"
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ inputs.go-version }}
       - run: mkdir -p ${{env.TEST_RESULTS}}

--- a/agent/config/config.deepcopy.go
+++ b/agent/config/config.deepcopy.go
@@ -360,6 +360,10 @@ func (o *RuntimeConfig) DeepCopy() *RuntimeConfig {
 						cp.Cloud.TLSConfig.Certificates[i5].Leaf.Policies = make([]x509.OID, len(o.Cloud.TLSConfig.Certificates[i5].Leaf.Policies))
 						copy(cp.Cloud.TLSConfig.Certificates[i5].Leaf.Policies, o.Cloud.TLSConfig.Certificates[i5].Leaf.Policies)
 					}
+					if o.Cloud.TLSConfig.Certificates[i5].Leaf.PolicyMappings != nil {
+						cp.Cloud.TLSConfig.Certificates[i5].Leaf.PolicyMappings = make([]x509.PolicyMapping, len(o.Cloud.TLSConfig.Certificates[i5].Leaf.PolicyMappings))
+						copy(cp.Cloud.TLSConfig.Certificates[i5].Leaf.PolicyMappings, o.Cloud.TLSConfig.Certificates[i5].Leaf.PolicyMappings)
+					}
 				}
 			}
 		}
@@ -703,6 +707,10 @@ func (o *RuntimeConfig) DeepCopy() *RuntimeConfig {
 							cp_Cloud_TLSConfig_NameToCertificate_v5.Leaf.Policies = make([]x509.OID, len(v5.Leaf.Policies))
 							copy(cp_Cloud_TLSConfig_NameToCertificate_v5.Leaf.Policies, v5.Leaf.Policies)
 						}
+						if v5.Leaf.PolicyMappings != nil {
+							cp_Cloud_TLSConfig_NameToCertificate_v5.Leaf.PolicyMappings = make([]x509.PolicyMapping, len(v5.Leaf.PolicyMappings))
+							copy(cp_Cloud_TLSConfig_NameToCertificate_v5.Leaf.PolicyMappings, v5.Leaf.PolicyMappings)
+						}
 					}
 				}
 				cp.Cloud.TLSConfig.NameToCertificate[k5] = cp_Cloud_TLSConfig_NameToCertificate_v5
@@ -731,6 +739,20 @@ func (o *RuntimeConfig) DeepCopy() *RuntimeConfig {
 		if o.Cloud.TLSConfig.EncryptedClientHelloConfigList != nil {
 			cp.Cloud.TLSConfig.EncryptedClientHelloConfigList = make([]byte, len(o.Cloud.TLSConfig.EncryptedClientHelloConfigList))
 			copy(cp.Cloud.TLSConfig.EncryptedClientHelloConfigList, o.Cloud.TLSConfig.EncryptedClientHelloConfigList)
+		}
+		if o.Cloud.TLSConfig.EncryptedClientHelloKeys != nil {
+			cp.Cloud.TLSConfig.EncryptedClientHelloKeys = make([]tls.EncryptedClientHelloKey, len(o.Cloud.TLSConfig.EncryptedClientHelloKeys))
+			copy(cp.Cloud.TLSConfig.EncryptedClientHelloKeys, o.Cloud.TLSConfig.EncryptedClientHelloKeys)
+			for i5 := range o.Cloud.TLSConfig.EncryptedClientHelloKeys {
+				if o.Cloud.TLSConfig.EncryptedClientHelloKeys[i5].Config != nil {
+					cp.Cloud.TLSConfig.EncryptedClientHelloKeys[i5].Config = make([]byte, len(o.Cloud.TLSConfig.EncryptedClientHelloKeys[i5].Config))
+					copy(cp.Cloud.TLSConfig.EncryptedClientHelloKeys[i5].Config, o.Cloud.TLSConfig.EncryptedClientHelloKeys[i5].Config)
+				}
+				if o.Cloud.TLSConfig.EncryptedClientHelloKeys[i5].PrivateKey != nil {
+					cp.Cloud.TLSConfig.EncryptedClientHelloKeys[i5].PrivateKey = make([]byte, len(o.Cloud.TLSConfig.EncryptedClientHelloKeys[i5].PrivateKey))
+					copy(cp.Cloud.TLSConfig.EncryptedClientHelloKeys[i5].PrivateKey, o.Cloud.TLSConfig.EncryptedClientHelloKeys[i5].PrivateKey)
+				}
+			}
 		}
 	}
 	if o.DNSServiceTTL != nil {

--- a/agent/envoyextensions/builtin/lua/lua_test.go
+++ b/agent/envoyextensions/builtin/lua/lua_test.go
@@ -6,10 +6,15 @@ package lua
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_lua_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
+	envoy_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/envoyextensions/extensioncommon"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func TestConstructor(t *testing.T) {
@@ -17,17 +22,15 @@ func TestConstructor(t *testing.T) {
 		m := map[string]interface{}{
 			"ProxyType": "connect-proxy",
 			"Listener":  "inbound",
-			"Script":    "lua-script",
+			"Script":    "function envoy_on_request(request_handle) request_handle:headers():add('test', 'test') end",
 		}
-
 		for k, v := range overrides {
 			m[k] = v
 		}
-
 		return m
 	}
 
-	cases := map[string]struct {
+	tests := map[string]struct {
 		extensionName string
 		arguments     map[string]interface{}
 		expected      lua
@@ -59,7 +62,16 @@ func TestConstructor(t *testing.T) {
 			expected: lua{
 				ProxyType: "connect-proxy",
 				Listener:  "inbound",
-				Script:    "lua-script",
+				Script:    "function envoy_on_request(request_handle) request_handle:headers():add('test', 'test') end",
+			},
+			ok: true,
+		},
+		"api gateway proxy type": {
+			arguments: makeArguments(map[string]interface{}{"ProxyType": "api-gateway"}),
+			expected: lua{
+				ProxyType: "api-gateway",
+				Listener:  "inbound",
+				Script:    "function envoy_on_request(request_handle) request_handle:headers():add('test', 'test') end",
 			},
 			ok: true,
 		},
@@ -68,23 +80,21 @@ func TestConstructor(t *testing.T) {
 			expected: lua{
 				ProxyType: "connect-proxy",
 				Listener:  "inbound",
-				Script:    "lua-script",
+				Script:    "function envoy_on_request(request_handle) request_handle:headers():add('test', 'test') end",
 			},
 			ok: true,
 		},
 	}
 
-	for n, tc := range cases {
-		t.Run(n, func(t *testing.T) {
-
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			extensionName := api.BuiltinLuaExtension
 			if tc.extensionName != "" {
 				extensionName = tc.extensionName
 			}
 
-			svc := api.CompoundServiceName{Name: "svc"}
 			ext := extensioncommon.RuntimeConfig{
-				ServiceName: svc,
+				ServiceName: api.CompoundServiceName{Name: "svc"},
 				EnvoyExtension: api.EnvoyExtension{
 					Name:      extensionName,
 					Arguments: tc.arguments,
@@ -101,4 +111,175 @@ func TestConstructor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLuaExtension_PatchFilter(t *testing.T) {
+	makeFilter := func(filters []*envoy_http_v3.HttpFilter) *envoy_listener_v3.Filter {
+		hcm := &envoy_http_v3.HttpConnectionManager{
+			HttpFilters: filters,
+		}
+		any, err := anypb.New(hcm)
+		require.NoError(t, err)
+		return &envoy_listener_v3.Filter{
+			Name: "envoy.filters.network.http_connection_manager",
+			ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+				TypedConfig: any,
+			},
+		}
+	}
+
+	makeLuaFilter := func(script string) *envoy_http_v3.HttpFilter {
+		luaConfig := &envoy_lua_v3.Lua{
+			DefaultSourceCode: &envoy_core_v3.DataSource{
+				Specifier: &envoy_core_v3.DataSource_InlineString{
+					InlineString: script,
+				},
+			},
+		}
+		return &envoy_http_v3.HttpFilter{
+			Name: "envoy.filters.http.lua",
+			ConfigType: &envoy_http_v3.HttpFilter_TypedConfig{
+				TypedConfig: mustMarshalAny(luaConfig),
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		extension      *lua
+		filter         *envoy_listener_v3.Filter
+		isInbound      bool
+		expectedFilter *envoy_listener_v3.Filter
+		expectPatched  bool
+		expectError    string
+	}{
+		"non-http filter is ignored": {
+			extension: &lua{
+				ProxyType: "connect-proxy",
+				Listener:  "inbound",
+				Script:    "function envoy_on_request(request_handle) end",
+			},
+			filter: &envoy_listener_v3.Filter{
+				Name: "envoy.filters.network.tcp_proxy",
+			},
+			expectedFilter: &envoy_listener_v3.Filter{
+				Name: "envoy.filters.network.tcp_proxy",
+			},
+			expectPatched: false,
+		},
+		"listener direction mismatch": {
+			extension: &lua{
+				ProxyType: "connect-proxy",
+				Listener:  "inbound",
+				Script:    "function envoy_on_request(request_handle) end",
+			},
+			filter: makeFilter([]*envoy_http_v3.HttpFilter{
+				{Name: "envoy.filters.http.router"},
+			}),
+			isInbound:      false,
+			expectedFilter: makeFilter([]*envoy_http_v3.HttpFilter{{Name: "envoy.filters.http.router"}}),
+			expectPatched:  false,
+		},
+		"no router filter": {
+			extension: &lua{
+				ProxyType: "connect-proxy",
+				Listener:  "inbound",
+				Script:    "function envoy_on_request(request_handle) end",
+			},
+			filter: makeFilter([]*envoy_http_v3.HttpFilter{
+				{Name: "envoy.filters.http.other"},
+			}),
+			isInbound:      true,
+			expectedFilter: makeFilter([]*envoy_http_v3.HttpFilter{{Name: "envoy.filters.http.other"}}),
+			expectPatched:  false,
+		},
+		"successful patch with router filter": {
+			extension: &lua{
+				ProxyType: "connect-proxy",
+				Listener:  "inbound",
+				Script:    "function envoy_on_request(request_handle) end",
+			},
+			filter: makeFilter([]*envoy_http_v3.HttpFilter{
+				{Name: "envoy.filters.http.router"},
+			}),
+			isInbound: true,
+			expectedFilter: makeFilter([]*envoy_http_v3.HttpFilter{
+				makeLuaFilter("function envoy_on_request(request_handle) end"),
+				{Name: "envoy.filters.http.router"},
+			}),
+			expectPatched: true,
+		},
+		"successful patch with multiple filters": {
+			extension: &lua{
+				ProxyType: "connect-proxy",
+				Listener:  "inbound",
+				Script:    "function envoy_on_request(request_handle) end",
+			},
+			filter: makeFilter([]*envoy_http_v3.HttpFilter{
+				{Name: "envoy.filters.http.other1"},
+				{Name: "envoy.filters.http.router"},
+				{Name: "envoy.filters.http.other2"},
+			}),
+			isInbound: true,
+			expectedFilter: makeFilter([]*envoy_http_v3.HttpFilter{
+				{Name: "envoy.filters.http.other1"},
+				makeLuaFilter("function envoy_on_request(request_handle) end"),
+				{Name: "envoy.filters.http.router"},
+				{Name: "envoy.filters.http.other2"},
+			}),
+			expectPatched: true,
+		},
+		"invalid filter config": {
+			extension: &lua{
+				ProxyType: "connect-proxy",
+				Listener:  "inbound",
+				Script:    "function envoy_on_request(request_handle) end",
+			},
+			filter: &envoy_listener_v3.Filter{
+				Name: "envoy.filters.network.http_connection_manager",
+				ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+					TypedConfig: &anypb.Any{},
+				},
+			},
+			isInbound:      true,
+			expectedFilter: nil,
+			expectPatched:  false,
+			expectError:    "error unmarshalling filter",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			direction := extensioncommon.TrafficDirectionOutbound
+			if tc.isInbound {
+				direction = extensioncommon.TrafficDirectionInbound
+			}
+
+			payload := extensioncommon.FilterPayload{
+				Message:          tc.filter,
+				TrafficDirection: direction,
+			}
+
+			filter, patched, err := tc.extension.PatchFilter(payload)
+
+			if tc.expectError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectPatched, patched)
+			if tc.expectedFilter != nil {
+				require.Equal(t, tc.expectedFilter, filter)
+			}
+		})
+	}
+}
+
+func mustMarshalAny(m proto.Message) *anypb.Any {
+	a, err := anypb.New(m)
+	if err != nil {
+		panic(err)
+	}
+	return a
 }

--- a/agent/xds/extensionruntime/runtime_config_test.go
+++ b/agent/xds/extensionruntime/runtime_config_test.go
@@ -1,0 +1,90 @@
+package extensionruntime
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/envoyextensions/extensioncommon"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRuntimeConfigurations_APIGateway(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfgSnap        *proxycfg.ConfigSnapshot
+		expectedConfig map[api.CompoundServiceName][]extensioncommon.RuntimeConfig
+	}{
+		{
+			name: "API Gateway with no extensions",
+			cfgSnap: &proxycfg.ConfigSnapshot{
+				Kind:    structs.ServiceKindAPIGateway,
+				Proxy:   structs.ConnectProxyConfig{},
+				Service: "api-gateway",
+				ProxyID: proxycfg.ProxyID{
+					ServiceID: structs.ServiceID{
+						ID: "api-gateway",
+					},
+				},
+			},
+			expectedConfig: map[api.CompoundServiceName][]extensioncommon.RuntimeConfig{
+				api.CompoundServiceName{
+					Name:      "api-gateway",
+					Namespace: "default",
+				}: {},
+			},
+		},
+		{
+			name: "API Gateway with extensions",
+			cfgSnap: &proxycfg.ConfigSnapshot{
+				Kind: structs.ServiceKindAPIGateway,
+				Proxy: structs.ConnectProxyConfig{
+					EnvoyExtensions: []structs.EnvoyExtension{
+						{
+							Name: "builtin/lua",
+							Arguments: map[string]interface{}{
+								"Script": "function envoy_on_response(response_handle) response_handle:headers():add('x-test', 'test') end",
+							},
+						},
+					},
+				},
+				Service: "api-gateway",
+				ProxyID: proxycfg.ProxyID{
+					ServiceID: structs.ServiceID{
+						ID: "api-gateway",
+					},
+				},
+			},
+			expectedConfig: map[api.CompoundServiceName][]extensioncommon.RuntimeConfig{
+				api.CompoundServiceName{
+					Name:      "api-gateway",
+					Namespace: "default",
+				}: {
+					{
+						EnvoyExtension: api.EnvoyExtension{
+							Name: "builtin/lua",
+							Arguments: map[string]interface{}{
+								"Script": "function envoy_on_response(response_handle) response_handle:headers():add('x-test', 'test') end",
+							},
+						},
+						ServiceName: api.CompoundServiceName{
+							Name:      "api-gateway",
+							Namespace: "default",
+						},
+						Upstreams:             map[api.CompoundServiceName]*extensioncommon.UpstreamData{},
+						IsSourcedFromUpstream: false,
+						Kind:                  api.ServiceKindAPIGateway,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := GetRuntimeConfigurations(tt.cfgSnap)
+			require.Equal(t, tt.expectedConfig, config)
+		})
+	}
+}

--- a/agent/xds/extensionruntime/runtime_config_test.go
+++ b/agent/xds/extensionruntime/runtime_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package extensionruntime
 
 import (
@@ -29,7 +32,7 @@ func TestGetRuntimeConfigurations_APIGateway(t *testing.T) {
 				},
 			},
 			expectedConfig: map[api.CompoundServiceName][]extensioncommon.RuntimeConfig{
-				api.CompoundServiceName{
+				{
 					Name:      "api-gateway",
 					Namespace: "default",
 				}: {},
@@ -57,7 +60,7 @@ func TestGetRuntimeConfigurations_APIGateway(t *testing.T) {
 				},
 			},
 			expectedConfig: map[api.CompoundServiceName][]extensioncommon.RuntimeConfig{
-				api.CompoundServiceName{
+				{
 					Name:      "api-gateway",
 					Namespace: "default",
 				}: {

--- a/envoyextensions/extensioncommon/basic_envoy_extender.go
+++ b/envoyextensions/extensioncommon/basic_envoy_extender.go
@@ -122,7 +122,7 @@ func (b *BasicEnvoyExtender) Extend(resources *xdscommon.IndexedResources, confi
 
 	switch config.Kind {
 	// Currently we only support extensions for terminating gateways and connect proxies.
-	case api.ServiceKindTerminatingGateway, api.ServiceKindConnectProxy:
+	case api.ServiceKindTerminatingGateway, api.ServiceKindConnectProxy, api.ServiceKindAPIGateway:
 	default:
 		return resources, nil
 	}

--- a/envoyextensions/extensioncommon/basic_envoy_extender_test.go
+++ b/envoyextensions/extensioncommon/basic_envoy_extender_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package extensioncommon
 
 import (

--- a/envoyextensions/extensioncommon/basic_envoy_extender_test.go
+++ b/envoyextensions/extensioncommon/basic_envoy_extender_test.go
@@ -1,0 +1,264 @@
+package extensioncommon
+
+import (
+	"fmt"
+	"testing"
+
+	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// TestBasicEnvoyExtender_CanApply tests the CanApply functionality
+func TestBasicEnvoyExtender_CanApply(t *testing.T) {
+	tests := []struct {
+		name     string
+		extender *BasicEnvoyExtender
+		config   *RuntimeConfig
+		expected bool
+	}{
+		{
+			name: "API Gateway with matching proxy type",
+			extender: &BasicEnvoyExtender{
+				Extension: &mockExtension{
+					proxyType: "api-gateway",
+				},
+			},
+			config: &RuntimeConfig{
+				Kind: api.ServiceKindAPIGateway,
+			},
+			expected: true,
+		},
+		{
+			name: "API Gateway with non-matching proxy type",
+			extender: &BasicEnvoyExtender{
+				Extension: &mockExtension{
+					proxyType: "connect-proxy",
+				},
+			},
+			config: &RuntimeConfig{
+				Kind: api.ServiceKindAPIGateway,
+			},
+			expected: false,
+		},
+		{
+			name: "Connect Proxy with matching proxy type",
+			extender: &BasicEnvoyExtender{
+				Extension: &mockExtension{
+					proxyType: "connect-proxy",
+				},
+			},
+			config: &RuntimeConfig{
+				Kind: api.ServiceKindConnectProxy,
+			},
+			expected: true,
+		},
+		{
+			name: "Connect Proxy with non-matching proxy type",
+			extender: &BasicEnvoyExtender{
+				Extension: &mockExtension{
+					proxyType: "api-gateway",
+				},
+			},
+			config: &RuntimeConfig{
+				Kind: api.ServiceKindConnectProxy,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.extender.CanApply(tt.config)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+// TestBasicEnvoyExtender_PatchFilter tests the PatchFilter functionality
+func TestBasicEnvoyExtender_PatchFilter(t *testing.T) {
+	tests := []struct {
+		name           string
+		extender       *BasicEnvoyExtender
+		payload        FilterPayload
+		expectedConfig *envoy_listener_v3.Filter
+		expectedError  string
+	}{
+		{
+			name: "API Gateway successful filter patch",
+			extender: &BasicEnvoyExtender{
+				Extension: &mockExtension{
+					proxyType: "api-gateway",
+					patchFunc: func(payload FilterPayload) (*envoy_listener_v3.Filter, bool, error) {
+						return &envoy_listener_v3.Filter{
+							Name: "test-filter",
+							ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+								TypedConfig: mustMarshalAny(&envoy_core_v3.DataSource{
+									Specifier: &envoy_core_v3.DataSource_InlineString{
+										InlineString: "test-data",
+									},
+								}),
+							},
+						}, true, nil
+					},
+				},
+			},
+			payload: FilterPayload{
+				Message: &envoy_listener_v3.Filter{
+					Name: "test-filter",
+				},
+				RuntimeConfig: &RuntimeConfig{
+					Kind: api.ServiceKindAPIGateway,
+				},
+			},
+			expectedConfig: &envoy_listener_v3.Filter{
+				Name: "test-filter",
+				ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+					TypedConfig: mustMarshalAny(&envoy_core_v3.DataSource{
+						Specifier: &envoy_core_v3.DataSource_InlineString{
+							InlineString: "test-data",
+						},
+					}),
+				},
+			},
+		},
+		{
+			name: "Connect Proxy successful filter patch",
+			extender: &BasicEnvoyExtender{
+				Extension: &mockExtension{
+					proxyType: "connect-proxy",
+					patchFunc: func(payload FilterPayload) (*envoy_listener_v3.Filter, bool, error) {
+						return &envoy_listener_v3.Filter{
+							Name: "connect-proxy-filter",
+							ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+								TypedConfig: mustMarshalAny(&envoy_core_v3.DataSource{
+									Specifier: &envoy_core_v3.DataSource_InlineString{
+										InlineString: "connect-proxy-data",
+									},
+								}),
+							},
+						}, true, nil
+					},
+				},
+			},
+			payload: FilterPayload{
+				Message: &envoy_listener_v3.Filter{
+					Name: "connect-proxy-filter",
+				},
+				RuntimeConfig: &RuntimeConfig{
+					Kind: api.ServiceKindConnectProxy,
+				},
+			},
+			expectedConfig: &envoy_listener_v3.Filter{
+				Name: "connect-proxy-filter",
+				ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+					TypedConfig: mustMarshalAny(&envoy_core_v3.DataSource{
+						Specifier: &envoy_core_v3.DataSource_InlineString{
+							InlineString: "connect-proxy-data",
+						},
+					}),
+				},
+			},
+		},
+		{
+			name: "Connect Proxy filter patch with error",
+			extender: &BasicEnvoyExtender{
+				Extension: &mockExtension{
+					proxyType: "connect-proxy",
+					patchFunc: func(payload FilterPayload) (*envoy_listener_v3.Filter, bool, error) {
+						return nil, false, fmt.Errorf("test error")
+					},
+				},
+			},
+			payload: FilterPayload{
+				Message: &envoy_listener_v3.Filter{
+					Name: "connect-proxy-filter",
+				},
+				RuntimeConfig: &RuntimeConfig{
+					Kind: api.ServiceKindConnectProxy,
+				},
+			},
+			expectedError: "test error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, _, err := tt.extender.Extension.PatchFilter(tt.payload)
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedConfig, actual)
+		})
+	}
+}
+
+// mockExtension implements the Extension interface for testing
+type mockExtension struct {
+	proxyType string
+	patchFunc func(FilterPayload) (*envoy_listener_v3.Filter, bool, error)
+}
+
+func (m *mockExtension) CanApply(config *RuntimeConfig) bool {
+	return config.Kind == api.ServiceKind(m.proxyType)
+}
+
+func (m *mockExtension) Validate(config *RuntimeConfig) error {
+	return nil
+}
+
+func (m *mockExtension) PatchFilter(payload FilterPayload) (*envoy_listener_v3.Filter, bool, error) {
+	if m.patchFunc != nil {
+		return m.patchFunc(payload)
+	}
+	return payload.Message, false, nil
+}
+
+func (m *mockExtension) PatchCluster(payload ClusterPayload) (*envoy_cluster_v3.Cluster, bool, error) {
+	return payload.Message, false, nil
+}
+
+func (m *mockExtension) PatchClusterLoadAssignment(payload ClusterLoadAssignmentPayload) (*envoy_endpoint_v3.ClusterLoadAssignment, bool, error) {
+	return payload.Message, false, nil
+}
+
+func (m *mockExtension) PatchClusters(config *RuntimeConfig, clusters ClusterMap) (ClusterMap, error) {
+	return clusters, nil
+}
+
+func (m *mockExtension) PatchRoutes(config *RuntimeConfig, routes RouteMap) (RouteMap, error) {
+	return routes, nil
+}
+
+func (m *mockExtension) PatchListeners(config *RuntimeConfig, listeners ListenerMap) (ListenerMap, error) {
+	return listeners, nil
+}
+
+func (m *mockExtension) PatchFilters(config *RuntimeConfig, filters []*envoy_listener_v3.Filter, isInboundListener bool) ([]*envoy_listener_v3.Filter, error) {
+	return filters, nil
+}
+
+func (m *mockExtension) PatchRoute(payload RoutePayload) (*envoy_route_v3.RouteConfiguration, bool, error) {
+	return payload.Message, false, nil
+}
+
+func (m *mockExtension) PatchListener(payload ListenerPayload) (*envoy_listener_v3.Listener, bool, error) {
+	return payload.Message, false, nil
+}
+
+func mustMarshalAny(pb proto.Message) *anypb.Any {
+	a, err := anypb.New(pb)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}

--- a/test/integration/connect/envoy/case-api-gateway-lua/setup.sh
+++ b/test/integration/connect/envoy/case-api-gateway-lua/setup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -euo pipefail
+
+# Create proxy defaults
+cat > proxy-defaults.hcl <<EOF
+Kind = "proxy-defaults"
+Name = "global"
+Config {
+  protocol = "http"
+}
+EOF
+
+consul config write proxy-defaults.hcl
+
+# Create service defaults for static-server
+cat > service-defaults.hcl <<EOF
+Kind = "service-defaults"
+Name = "static-server"
+Protocol = "http"
+EOF
+
+consul config write service-defaults.hcl
+
+# Create API Gateway
+cat > api-gateway.hcl <<EOF
+Kind = "api-gateway"
+Name = "api-gateway"
+Listeners = [
+  {
+    Name = "listener"
+    Port = 8080
+    Protocol = "http"
+  }
+]
+EOF
+
+consul config write api-gateway.hcl
+
+# Create HTTP route
+cat > http-route.hcl <<EOF
+Kind = "http-route"
+Name = "http-route"
+Rules = [
+  {
+    Services = [
+      {
+        Name = "static-server"
+      }
+    ]
+  }
+]
+EOF
+
+consul config write http-route.hcl
+
+# Create service defaults for API Gateway with LUA extension
+cat > api-gateway-service-defaults.hcl <<EOF
+Kind = "service-defaults"
+Name = "api-gateway"
+EnvoyExtensions = [
+  {
+    Name = "builtin/lua"
+    Arguments = {
+      Script = "function envoy_on_response(response_handle) response_handle:headers():add('x-test', 'test') end"
+    }
+  }
+]
+EOF
+
+consul config write api-gateway-service-defaults.hcl
+
+# Register services
+consul services register static-server.hcl
+consul services register api-gateway.hcl
+
+# Generate bootstrap configs
+consul connect envoy -bootstrap \
+  -proxy-id api-gateway-sidecar-proxy \
+  > api-gateway-bootstrap.json
+
+consul connect envoy -bootstrap \
+  -proxy-id static-server-sidecar-proxy \
+  > static-server-bootstrap.json 

--- a/test/integration/connect/envoy/case-api-gateway-lua/verify.bats
+++ b/test/integration/connect/envoy/case-api-gateway-lua/verify.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "api-gateway proxy admin is up on :19000" {
+  retry_default curl -f -s localhost:19000/stats -o /dev/null
+}
+
+@test "static-server proxy admin is up on :19001" {
+  retry_default curl -f -s localhost:19001/stats -o /dev/null
+}
+
+@test "api-gateway listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21000 api-gateway
+}
+
+@test "static-server listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21001 static-server
+}
+
+@test "api-gateway should be healthy" {
+  assert_service_has_healthy_instances api-gateway 1
+}
+
+@test "static-server should be healthy" {
+  assert_service_has_healthy_instances static-server 1
+}
+
+@test "api-gateway upstream should have healthy endpoints for static-server" {
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 static-server.default.primary HEALTHY 1
+}
+
+@test "api-gateway should return 200 with custom message for non-existent path" {
+  run retry_default curl -s -d "hello" "localhost:8080/nonexistent"
+  [ "$status" == "0" ]
+  echo "$output" | grep "Please check whether page or URI is configured correctly or not for api gateway"
+}
+
+@test "api-gateway should return 200 for valid path" {
+  run retry_default curl -s -f -d "hello" "localhost:8080/echo"
+  [ "$status" == "0" ]
+  [ "$output" == "hello" ]
+}
+
+@test "api-gateway should have lua filter configured" {
+  FILTERS=$(get_envoy_listener_filters localhost:19000)
+  echo "$FILTERS" | grep "envoy.filters.http.lua"
+}
+
+@test "api-gateway lua extension" {
+  # Wait for services to be registered
+  retry_default curl -s -f localhost:8500/v1/catalog/service/static-server > /dev/null
+  retry_default curl -s -f localhost:8500/v1/catalog/service/api-gateway > /dev/null
+
+  # Wait for API Gateway to be ready
+  retry_default curl -s -f localhost:8080/health > /dev/null
+
+  # Test that the LUA extension adds the x-test header
+  run curl -s -v localhost:8080/health
+  [ "$status" -eq 0 ]
+  echo "$output" | grep "x-test: test"
+} 


### PR DESCRIPTION
### Description

Extended LUA Script Envoy extension support for API Gateway 

### Testing & Reproduction steps

1. Create a cluster with API gateway
2. Inject LUA script to API gateway using either service defaults or proxy defaults. Sample script:
```
{
    name     = "builtin/lua"
    required = true
    arguments = {
      proxyType = "api-gateway"
      listener  = "outbound"
      script    = <<EOT
        function envoy_on_response(response_handle)
          if response_handle:headers():get(":status") == "404" then
              response_handle:headers():replace(":status", "200")
              local json = '{"message":"Modified by Lua script","status":"success"}'
              response_handle:body():setBytes(json)

              response_handle:headers():remove("x-envoy-upstream-service-time")
              response_handle:headers():remove("x-powered-by")
              response_handle:headers():replace("cache-control", "no-store")
              response_handle:headers():remove("content-length")
              response_handle:headers():replace("content-encoding", "identity")
              response_handle:headers():replace("content-type", "application/json")
          end
        end
      EOT
    }
  }
  ```
  3. Request a non-existent page and see that the response is as provided in the LUA script and headers are modified as per the script.

### Links
https://hashicorp.atlassian.net/browse/NET-12465

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
