### PR TITLE
(feat)Adding configurable value to disable XDS Load balancing

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1601,7 +1601,7 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	cfg.Reporting.License.Enabled = runtimeCfg.Reporting.License.Enabled
 
 	cfg.ServerRejoinAgeMax = runtimeCfg.ServerRejoinAgeMax
-
+	cfg.EnableXDSLoadBalancing = runtimeCfg.EnableXDSLoadBalancing
 	enterpriseConsulConfig(cfg, runtimeCfg)
 
 	return cfg, nil

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1033,6 +1033,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		KVMaxValueSize:             uint64Val(c.Limits.KVMaxValueSize),
 		LeaveDrainTime:             b.durationVal("performance.leave_drain_time", c.Performance.LeaveDrainTime),
 		LeaveOnTerm:                leaveOnTerm,
+		EnableXDSLoadBalancing:     boolVal(c.Performance.EnableXDSLoadBalancing),
 		StaticRuntimeConfig: StaticRuntimeConfig{
 			EncryptVerifyIncoming: boolVal(c.EncryptVerifyIncoming),
 			EncryptVerifyOutgoing: boolVal(c.EncryptVerifyOutgoing),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -677,11 +677,12 @@ type HTTPConfig struct {
 }
 
 type Performance struct {
-	LeaveDrainTime        *string `mapstructure:"leave_drain_time"`
-	RaftMultiplier        *int    `mapstructure:"raft_multiplier"` // todo(fs): validate as uint
-	RPCHoldTimeout        *string `mapstructure:"rpc_hold_timeout"`
-	GRPCKeepaliveInterval *string `mapstructure:"grpc_keepalive_interval"`
-	GRPCKeepaliveTimeout  *string `mapstructure:"grpc_keepalive_timeout"`
+	LeaveDrainTime         *string `mapstructure:"leave_drain_time"`
+	RaftMultiplier         *int    `mapstructure:"raft_multiplier"` // todo(fs): validate as uint
+	RPCHoldTimeout         *string `mapstructure:"rpc_hold_timeout"`
+	GRPCKeepaliveInterval  *string `mapstructure:"grpc_keepalive_interval"`
+	GRPCKeepaliveTimeout   *string `mapstructure:"grpc_keepalive_timeout"`
+	EnableXDSLoadBalancing *bool   `mapstructure:"enable_xds_load_balancing"`
 }
 
 type Telemetry struct {

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -120,6 +120,7 @@ func DefaultSource() Source {
 			rpc_hold_timeout = "7s"
 			grpc_keepalive_interval = "30s"
 			grpc_keepalive_timeout = "20s"
+            enable_xds_load_balancing = true
 		}
 		ports = {
 			dns = 8600

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -739,6 +739,12 @@ type RuntimeConfig struct {
 	// time, the connection will be closed by the server.
 	GRPCKeepaliveTimeout time.Duration
 
+	// EnableXDSLoadBalancing controls whether xDS load balancing between servers
+	// is disabled. When enabled (default), xDS clients will be load balanced across
+	// available servers and Consul will make sure that the load is distributed across all the servers with an error margin of 0.1.
+	// When disabled, Consul will not restrict on the number of xDS connections on a server. It is  expected to have an external load balancer in front of the consul servers and distribute the load accordingly.
+	EnableXDSLoadBalancing bool
+
 	// HTTPAddrs contains the list of TCP addresses and UNIX sockets the HTTP
 	// server will bind to. If the HTTP endpoint is disabled (ports.http <= 0)
 	// the list is empty.

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2125,6 +2125,16 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		expectedErr: `performance.raft_multiplier cannot be 20. Must be between 1 and 10`,
 	})
 	run(t, testCase{
+		desc: "disable XDS Load balancing",
+		args: []string{`-data-dir=` + dataDir},
+		json: []string{`{ "performance": { "enable_xds_load_balancing": false} }`},
+		hcl:  []string{`performance = { enable_xds_load_balancing=false }`},
+		expected: func(rt *RuntimeConfig) {
+			rt.EnableXDSLoadBalancing = false
+			rt.DataDir = dataDir
+		},
+	})
+	run(t, testCase{
 		desc: "node_name invalid",
 		args: []string{
 			`-data-dir=` + dataDir,
@@ -7055,6 +7065,7 @@ func TestLoad_FullConfig(t *testing.T) {
 			WAL:    consul.WALConfig{SegmentSize: 15 * 1024 * 1024},
 		},
 		AutoReloadConfigCoalesceInterval: 1 * time.Second,
+		EnableXDSLoadBalancing:           false,
 	}
 	entFullRuntimeConfig(expected)
 
@@ -7371,8 +7382,9 @@ func TestRuntimeConfig_Sanitize(t *testing.T) {
 				},
 			},
 		},
-		Locality:           &Locality{Region: strPtr("us-west-1"), Zone: strPtr("us-west-1a")},
-		ServerRejoinAgeMax: 24 * 7 * time.Hour,
+		Locality:               &Locality{Region: strPtr("us-west-1"), Zone: strPtr("us-west-1a")},
+		ServerRejoinAgeMax:     24 * 7 * time.Hour,
+		EnableXDSLoadBalancing: true,
 	}
 
 	b, err := json.MarshalIndent(rt.Sanitized(), "", "    ")

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -522,5 +522,6 @@
     "VersionMetadata": "",
     "VersionPrerelease": "",
     "Watches": [],
-    "XDSUpdateRateLimit": 0
+    "XDSUpdateRateLimit": 0,
+    "EnableXDSLoadBalancing":true
 }

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -341,6 +341,7 @@ performance {
     rpc_hold_timeout = "15707s"
     grpc_keepalive_interval = "33s"
     grpc_keepalive_timeout = "22s"
+    enable_xds_load_balancing = false
 }
 pid_file = "43xN80Km"
 ports {

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -389,7 +389,8 @@
     "raft_multiplier": 5,
     "rpc_hold_timeout": "15707s",
     "grpc_keepalive_interval": "33s",
-    "grpc_keepalive_timeout": "22s"
+    "grpc_keepalive_timeout": "22s",
+    "enable_xds_load_balancing": false
   },
   "pid_file": "43xN80Km",
   "ports": {

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -463,6 +463,12 @@ type Config struct {
 	// ServerRejoinAgeMax is used to specify the duration of time a server
 	// is allowed to be down/offline before a startup operation is refused.
 	ServerRejoinAgeMax time.Duration
+
+	// EnableXDSLoadBalancing controls whether xDS load balancing between servers
+	// is disabled. When enabled (default), xDS clients will be load balanced across
+	// available servers and Consul will make sure that the load is distributed across all the servers with an error margin of 0.1.
+	// When disabled, Consul will not restrict on the number of xDS connections on a server. It is  expected to have an external load balancer in front of the consul servers and distribute the load accordingly.
+	EnableXDSLoadBalancing bool
 }
 
 func (c *Config) InPrimaryDatacenter() bool {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -857,9 +857,10 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 	go s.trackLeaderChanges()
 
 	s.xdsCapacityController = xdscapacity.NewController(xdscapacity.Config{
-		Logger:         s.logger.Named(logging.XDSCapacityController),
-		GetStore:       func() xdscapacity.Store { return s.fsm.State() },
-		SessionLimiter: flat.XDSStreamLimiter,
+		Logger:                 s.logger.Named(logging.XDSCapacityController),
+		GetStore:               func() xdscapacity.Store { return s.fsm.State() },
+		SessionLimiter:         flat.XDSStreamLimiter,
+		EnableXDSLoadBalancing: s.config.EnableXDSLoadBalancing,
 	})
 	go s.xdsCapacityController.Run(&lib.StopChannelContext{StopCh: s.shutdownCh})
 

--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -614,6 +614,8 @@ Refer to the [formatting specification](https://golang.org/pkg/time/#ParseDurati
 
   - `grpc_keepalive_timeout` - A duration that determines how long a Consul server waits for a reply to a keep-alive message. If the server does not receive a reply before the end of the duration, Consul flags the gRPC connection as unhealthy and forcibly removes it. Defaults to `20s`.
 
+  - 'enable_xds_load_balancing' - Load balancing of xDS Sessions on the server. false to disable consul internal load balancing so that there is no limit on the number of sessions per server.
+
 - `pid_file` Equivalent to the [`-pid-file` command line flag](/consul/docs/agent/config/cli-flags#_pid_file).
 
 - `ports` This is a nested object that allows setting the bind ports for the following keys:


### PR DESCRIPTION
### Description

Consul has a inbuilt load balancing for XDS sessions in order to distribute the load equally among all the servers with an error margin, hard coded to 0.1

We have cases where The consul servers can sit behind a load balancer and the load distribution  is taken care by it. In such cases, it is possible that the external load balancer might not distribute with the load error margin expected by consul. And, in those cases some clients will get stuck in init state as the clients doesn't know any other server and will reach out to the load balancer only, the external load balancer will keep sending to the same server and the consul server will not accept the request. 

One such case is explained is reported in the JIRA specified below

As a solution to that, a configuration parameter,_enable_xds_load_balancing_  under _performance_, is provided to disable XDS Load balancing. Setting it to false will tell Consul not to limit the number of sessions on a server. Load balancing is enabled by default.

Sample config in a helm chart

```
server:
  replicas: 3
  extraConfig: |
    {
      "performance": {
        "enable_xds_load_balancing": false
      },
      "log_level": "debug"
    }
```

### Testing & Reproduction steps

Deployed a setup with 2 AKS clusters, one hosting the consul servers and the other having clients/dataplane pods. Some clients are stuck in init state with the fix and we can see log that _this server has too many xDS streams open, please try another_ . 

With the fix, no pods are stuck and don't see the above error logs
### Links




### PR Checklist

* [] updated test coverage
* [] external facing docs updated
* [] appropriate backport labels added
* [] not a security concern