### PR TITLE
Revert "Backport of (feat)Adding configurable value to disable XDS Load balancing into release/1.21.x (#22301)"

### DIFF
--- a/.changelog/22299.txt
+++ b/.changelog/22299.txt
@@ -1,3 +1,0 @@
-```release-note:feature
-xds: provided a configurable to value to diable XDS session load balancing so that cases where there is a load balancer in front of the consul servers can disable the internal load balancing
-```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1601,7 +1601,7 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	cfg.Reporting.License.Enabled = runtimeCfg.Reporting.License.Enabled
 
 	cfg.ServerRejoinAgeMax = runtimeCfg.ServerRejoinAgeMax
-	cfg.EnableXDSLoadBalancing = runtimeCfg.EnableXDSLoadBalancing
+
 	enterpriseConsulConfig(cfg, runtimeCfg)
 
 	return cfg, nil

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1033,7 +1033,6 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		KVMaxValueSize:             uint64Val(c.Limits.KVMaxValueSize),
 		LeaveDrainTime:             b.durationVal("performance.leave_drain_time", c.Performance.LeaveDrainTime),
 		LeaveOnTerm:                leaveOnTerm,
-		EnableXDSLoadBalancing:     boolVal(c.Performance.EnableXDSLoadBalancing),
 		StaticRuntimeConfig: StaticRuntimeConfig{
 			EncryptVerifyIncoming: boolVal(c.EncryptVerifyIncoming),
 			EncryptVerifyOutgoing: boolVal(c.EncryptVerifyOutgoing),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -677,12 +677,11 @@ type HTTPConfig struct {
 }
 
 type Performance struct {
-	LeaveDrainTime         *string `mapstructure:"leave_drain_time"`
-	RaftMultiplier         *int    `mapstructure:"raft_multiplier"` // todo(fs): validate as uint
-	RPCHoldTimeout         *string `mapstructure:"rpc_hold_timeout"`
-	GRPCKeepaliveInterval  *string `mapstructure:"grpc_keepalive_interval"`
-	GRPCKeepaliveTimeout   *string `mapstructure:"grpc_keepalive_timeout"`
-	EnableXDSLoadBalancing *bool   `mapstructure:"enable_xds_load_balancing"`
+	LeaveDrainTime        *string `mapstructure:"leave_drain_time"`
+	RaftMultiplier        *int    `mapstructure:"raft_multiplier"` // todo(fs): validate as uint
+	RPCHoldTimeout        *string `mapstructure:"rpc_hold_timeout"`
+	GRPCKeepaliveInterval *string `mapstructure:"grpc_keepalive_interval"`
+	GRPCKeepaliveTimeout  *string `mapstructure:"grpc_keepalive_timeout"`
 }
 
 type Telemetry struct {

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -120,7 +120,6 @@ func DefaultSource() Source {
 			rpc_hold_timeout = "7s"
 			grpc_keepalive_interval = "30s"
 			grpc_keepalive_timeout = "20s"
-			enable_xds_load_balancing = true
 		}
 		ports = {
 			dns = 8600

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -739,13 +739,6 @@ type RuntimeConfig struct {
 	// time, the connection will be closed by the server.
 	GRPCKeepaliveTimeout time.Duration
 
-	// EnableXDSLoadBalancing controls xDS load balancing between the servers. Enabled by default.
-	// When enabled, Consul balances loads from xDS clients across available servers equally with an error margin of 0.1.
-	//
-	// When disabled, Consul does not restrict on the number of xDS connections on a server.
-	// In this scenario, you should deploy an external load balancer in front of the consul servers and distribute the load accordingly.
-	EnableXDSLoadBalancing bool
-
 	// HTTPAddrs contains the list of TCP addresses and UNIX sockets the HTTP
 	// server will bind to. If the HTTP endpoint is disabled (ports.http <= 0)
 	// the list is empty.

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2125,16 +2125,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		expectedErr: `performance.raft_multiplier cannot be 20. Must be between 1 and 10`,
 	})
 	run(t, testCase{
-		desc: "disable XDS Load balancing",
-		args: []string{`-data-dir=` + dataDir},
-		json: []string{`{ "performance": { "enable_xds_load_balancing": false} }`},
-		hcl:  []string{`performance = { enable_xds_load_balancing=false }`},
-		expected: func(rt *RuntimeConfig) {
-			rt.EnableXDSLoadBalancing = false
-			rt.DataDir = dataDir
-		},
-	})
-	run(t, testCase{
 		desc: "node_name invalid",
 		args: []string{
 			`-data-dir=` + dataDir,
@@ -7065,7 +7055,6 @@ func TestLoad_FullConfig(t *testing.T) {
 			WAL:    consul.WALConfig{SegmentSize: 15 * 1024 * 1024},
 		},
 		AutoReloadConfigCoalesceInterval: 1 * time.Second,
-		EnableXDSLoadBalancing:           false,
 	}
 	entFullRuntimeConfig(expected)
 
@@ -7382,9 +7371,8 @@ func TestRuntimeConfig_Sanitize(t *testing.T) {
 				},
 			},
 		},
-		Locality:               &Locality{Region: strPtr("us-west-1"), Zone: strPtr("us-west-1a")},
-		ServerRejoinAgeMax:     24 * 7 * time.Hour,
-		EnableXDSLoadBalancing: true,
+		Locality:           &Locality{Region: strPtr("us-west-1"), Zone: strPtr("us-west-1a")},
+		ServerRejoinAgeMax: 24 * 7 * time.Hour,
 	}
 
 	b, err := json.MarshalIndent(rt.Sanitized(), "", "    ")

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -522,6 +522,5 @@
     "VersionMetadata": "",
     "VersionPrerelease": "",
     "Watches": [],
-    "XDSUpdateRateLimit": 0,
-    "EnableXDSLoadBalancing":true
+    "XDSUpdateRateLimit": 0
 }

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -341,7 +341,6 @@ performance {
     rpc_hold_timeout = "15707s"
     grpc_keepalive_interval = "33s"
     grpc_keepalive_timeout = "22s"
-    enable_xds_load_balancing = false
 }
 pid_file = "43xN80Km"
 ports {

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -389,8 +389,7 @@
     "raft_multiplier": 5,
     "rpc_hold_timeout": "15707s",
     "grpc_keepalive_interval": "33s",
-    "grpc_keepalive_timeout": "22s",
-    "enable_xds_load_balancing": false
+    "grpc_keepalive_timeout": "22s"
   },
   "pid_file": "43xN80Km",
   "ports": {

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -463,13 +463,6 @@ type Config struct {
 	// ServerRejoinAgeMax is used to specify the duration of time a server
 	// is allowed to be down/offline before a startup operation is refused.
 	ServerRejoinAgeMax time.Duration
-
-	// EnableXDSLoadBalancing controls xDS load balancing between the servers. Enabled by default.
-	// When enabled, Consul balances loads from xDS clients across available servers equally with an error margin of 0.1.
-	//
-	// When disabled, Consul does not restrict on the number of xDS connections on a server.
-	// In this scenario, you should deploy an external load balancer in front of the consul servers and distribute the load accordingly.
-	EnableXDSLoadBalancing bool
 }
 
 func (c *Config) InPrimaryDatacenter() bool {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -857,10 +857,9 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 	go s.trackLeaderChanges()
 
 	s.xdsCapacityController = xdscapacity.NewController(xdscapacity.Config{
-		Logger:                 s.logger.Named(logging.XDSCapacityController),
-		GetStore:               func() xdscapacity.Store { return s.fsm.State() },
-		SessionLimiter:         flat.XDSStreamLimiter,
-		EnableXDSLoadBalancing: s.config.EnableXDSLoadBalancing,
+		Logger:         s.logger.Named(logging.XDSCapacityController),
+		GetStore:       func() xdscapacity.Store { return s.fsm.State() },
+		SessionLimiter: flat.XDSStreamLimiter,
 	})
 	go s.xdsCapacityController.Run(&lib.StopChannelContext{StopCh: s.shutdownCh})
 

--- a/agent/consul/xdscapacity/capacity_test.go
+++ b/agent/consul/xdscapacity/capacity_test.go
@@ -68,10 +68,9 @@ func TestController(t *testing.T) {
 	})
 
 	adj := NewController(Config{
-		Logger:                 testutil.Logger(t),
-		GetStore:               func() Store { return store },
-		SessionLimiter:         limiter,
-		EnableXDSLoadBalancing: true,
+		Logger:         testutil.Logger(t),
+		GetStore:       func() Store { return store },
+		SessionLimiter: limiter,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Revert "Backport of (feat)Adding configurable value to disable XDS Load balancing into release/1.21.x (#22301)"

This reverts commit ee010ebb6f05947e56d858329f59d90a610d70a9.
