### PR TITLE
fix: updated grpc config for partition endpoint

### DIFF
--- a/agent/grpc-internal/client.go
+++ b/agent/grpc-internal/client.go
@@ -148,7 +148,7 @@ const grpcServiceConfig = `
 					"INTERNAL",
 					"UNAVAILABLE"
 				]
-			}	
+			}
 		}
 	]
 }`

--- a/agent/grpc-internal/client.go
+++ b/agent/grpc-internal/client.go
@@ -101,14 +101,6 @@ const grpcServiceConfig = `
 				{
 					"service": "subscribe.StateChangeSubscription",
 					"method": "Subscribe"
-				},
-				{
-					"service": "partition.PartitionService",
-					"method": "List"
-				},
-				{
-					"service": "partition.PartitionService",
-					"method": "Read"
 				}
 			],
 			"retryPolicy": {
@@ -128,6 +120,35 @@ const grpcServiceConfig = `
 					"UNAVAILABLE"
 				]
 			}
+		},
+		{
+			"name": [
+				{
+					"service": "partition.PartitionService",
+					"method": "List"
+				},
+				{
+					"service": "partition.PartitionService",
+					"method": "Read"
+				}
+			],
+			"retryPolicy": {
+				"MaxAttempts": 3,
+				"BackoffMultiplier": 1.1,
+				"InitialBackoff": "1s",
+				"MaxBackoff": "5s",
+				"RetryableStatusCodes": [
+					"CANCELLED",
+					"UNKNOWN",
+					"DEADLINE_EXCEEDED",
+					"RESOURCE_EXHAUSTED",
+					"FAILED_PRECONDITION",
+					"ABORTED",
+					"OUT_OF_RANGE",
+					"INTERNAL",
+					"UNAVAILABLE"
+				]
+			}	
 		}
 	]
 }`


### PR DESCRIPTION
### Description

This PR enhances the gRPC retry configuration to reduce the total waiting time in case any error that occurs.

**Context**

When an invalid datacenter URL parameter is provided to the /v1/partitions endpoint, the server currently hangs for 30 seconds to one minute before responding with a "resolver error: resolver produced no addresses" error message. This was due to the internal gRPC retry configuration. This change ensures that clients encountering errors will retry with appropriate backoff rather than waiting for the full server timeout.

**Changes**

Update existing retry configuration:

- Initial backoff: 1 second
- Backoff multiplier: 1.1 (each retry waits 10% longer than previous)
- Maximum attempts: 3 (initial + 2 retries)
- Maximum backoff of 5 seconds per attempt

With these changes the max waiting time is reduced from 30s -> ~5s

Removing the UNKNOWN error code from the list of RetryableStatusCodes would have been a viable option. But the gRPC documentation states that UNKNOWN can act as umbrella for any other API error as well, so I've not removed it.

_Note: These changes are currently only implemented for partition services as the impact on other services is unkown, we can update this once we define the appropriate values for retry configuration._

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links
https://hashicorp.atlassian.net/issues/SECVULN-8623

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
