### PR TITLE
(manual) Backport of cmd/tls: set explicit file permissions for generated certs into release/1.20.x

### DIFF
--- a/.changelog/22286.txt
+++ b/.changelog/22286.txt
@@ -1,0 +1,3 @@
+```release-note:security
+cli: update tls ca and cert create to reduce excessive file perms for generated public files
+```

--- a/command/tls/ca/create/tls_ca_create.go
+++ b/command/tls/ca/create/tls_ca_create.go
@@ -82,12 +82,14 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	if err := file.WriteAtomicWithPerms(certFileName, []byte(ca), 0755, 0666); err != nil {
+	// public CA cert file
+	if err := file.WriteAtomicWithPerms(certFileName, []byte(ca), 0755, 0644); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}
 	c.UI.Output("==> Saved " + certFileName)
 
+	// CA private key
 	if err := file.WriteAtomicWithPerms(pkFileName, []byte(pk), 0755, 0600); err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/command/tls/ca/create/tls_ca_create.go
+++ b/command/tls/ca/create/tls_ca_create.go
@@ -21,6 +21,15 @@ func New(ui cli.Ui) *cmd {
 	return c
 }
 
+const (
+	// DirectoryPerms represents read+write+execute for owner, read+execute for group and others (0755)
+	DirectoryPerms = 0755
+	// PublicFilePerms represents read+write for owner, read-only for group and others (0644)
+	PublicFilePerms = 0644
+	// PrivateFilePerms represents read+write for owner only (0600)
+	PrivateFilePerms = 0600
+)
+
 type cmd struct {
 	UI                    cli.Ui
 	flags                 *flag.FlagSet
@@ -83,14 +92,14 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	// public CA cert file
-	if err := file.WriteAtomicWithPerms(certFileName, []byte(ca), 0755, 0644); err != nil {
+	if err := file.WriteAtomicWithPerms(certFileName, []byte(ca), DirectoryPerms, PublicFilePerms); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}
 	c.UI.Output("==> Saved " + certFileName)
 
 	// CA private key
-	if err := file.WriteAtomicWithPerms(pkFileName, []byte(pk), 0755, 0600); err != nil {
+	if err := file.WriteAtomicWithPerms(pkFileName, []byte(pk), DirectoryPerms, PrivateFilePerms); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}

--- a/command/tls/cert/create/tls_cert_create.go
+++ b/command/tls/cert/create/tls_cert_create.go
@@ -193,12 +193,14 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	if err := file.WriteAtomicWithPerms(certFileName, []byte(pub), 0755, 0666); err != nil {
+	// public cert
+	if err := file.WriteAtomicWithPerms(certFileName, []byte(pub), 0755, 0644); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}
 	c.UI.Output("==> Saved " + certFileName)
 
+	// private key
 	if err := file.WriteAtomicWithPerms(pkFileName, []byte(priv), 0755, 0600); err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/command/tls/cert/create/tls_cert_create.go
+++ b/command/tls/cert/create/tls_cert_create.go
@@ -24,6 +24,15 @@ func New(ui cli.Ui) *cmd {
 	return c
 }
 
+const (
+	// DirectoryPerms represents read+write+execute for owner, read+execute for group and others (0755)
+	DirectoryPerms = 0755
+	// PublicFilePerms represents read+write for owner, read-only for group and others (0644)
+	PublicFilePerms = 0644
+	// PrivateFilePerms represents read+write for owner only (0600)
+	PrivateFilePerms = 0600
+)
+
 type cmd struct {
 	UI          cli.Ui
 	flags       *flag.FlagSet
@@ -194,14 +203,14 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	// public cert
-	if err := file.WriteAtomicWithPerms(certFileName, []byte(pub), 0755, 0644); err != nil {
+	if err := file.WriteAtomicWithPerms(certFileName, []byte(pub), DirectoryPerms, PublicFilePerms); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}
 	c.UI.Output("==> Saved " + certFileName)
 
 	// private key
-	if err := file.WriteAtomicWithPerms(pkFileName, []byte(priv), 0755, 0600); err != nil {
+	if err := file.WriteAtomicWithPerms(pkFileName, []byte(priv), DirectoryPerms, PrivateFilePerms); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}


### PR DESCRIPTION
### Description

Consul CLI's tls create command was generating some sensitive files (e.g. consul tls ca create -server) that had excessive permissions at 0666 for public certs created and it should be 0644. Updated the code to use 0644 file perms when creating sensitive files with ca and certs.
NOTE: [disabled Compatibility Integration Tests until pipeline upgrade is in place](https://github.com/hashicorp/consul/pull/22286/commits/dcca5a9ae629b0bb33f65979f4054f85cadf475c)

### Testing & Reproduction steps
1. Update default OS masking to view actual code behaviour: `umask 000`
2. Run `consul tls ca create -domain=example.test` and list the directory to view generated files with `ls -lah` with excessive perms.
3. Run `consul tls cert create -server` to see similar results
4. Revert OS level masking to default: `umask 022`

### Links

https://hashicorp.atlassian.net/browse/SECVULN-8634
PR: https://github.com/hashicorp/consul/pull/22286

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
