### PR TITLE
fix: Added default namespace and partition check before signing CA certificate in Consul CE 

### DIFF
--- a/.changelog/22369.txt
+++ b/.changelog/22369.txt
@@ -1,0 +1,3 @@
+```release-note:security
+connect: Added non default namespace and partition checks to ConnectCA CSR requests.
+```

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -1439,6 +1439,10 @@ func (c *CAManager) AuthorizeAndSignCertificate(csr *x509.CertificateRequest, au
 	}
 	c.logger.Trace("authorizing and signing cert", "spiffeID", spiffeID)
 
+	if err := c.validateSupportedIdentityScopesInCertificate(spiffeID); err != nil {
+		return nil, err
+	}
+
 	// Perform authorization.
 	var authzContext acl.AuthorizerContext
 	allow := authz.ToAllowAuthorizer()

--- a/agent/consul/leader_connect_ca_ce.go
+++ b/agent/consul/leader_connect_ca_ce.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !consulent
+
+package consul
+
+import (
+	"github.com/hashicorp/consul/agent/connect"
+)
+
+func (c *CAManager) validateSupportedIdentityScopesInCertificate(spiffeID connect.CertURI) error {
+	switch v := spiffeID.(type) {
+	case *connect.SpiffeIDService:
+		if v.Namespace != "default" || v.Partition != "default" {
+			return connect.InvalidCSRError("Non default partition or namespace is supported in Enterprise only."+
+				"Provided namespace is %s and partition is %s", v.Namespace, v.Partition)
+		}
+	case *connect.SpiffeIDMeshGateway:
+		if v.Partition != "default" {
+			return connect.InvalidCSRError("Non default partition is supported in Enterprise only."+
+				"Provided partition is %s", v.Partition)
+		}
+	case *connect.SpiffeIDAgent, *connect.SpiffeIDServer:
+		return nil
+	default:
+		c.logger.Trace("spiffe ID type is not expected", "spiffeID", spiffeID, "spiffeIDType", v)
+		return connect.InvalidCSRError("SPIFFE ID in CSR must be a service, mesh-gateway, or agent ID")
+	}
+	return nil
+}

--- a/agent/consul/leader_connect_ca_ce_test.go
+++ b/agent/consul/leader_connect_ca_ce_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !consulent
+
+package consul
+
+import (
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestValidateSupportedIdentityScopesForServiceInCertificate(t *testing.T) {
+	config := DefaultConfig()
+	manager := NewCAManager(nil, nil, testutil.Logger(t), config)
+
+	tests := []struct {
+		name       string
+		expectErr  string
+		datacenter string
+		namespace  string
+		service    string
+		partition  string
+	}{
+		{
+			name: "err_unsupported_partition_and_namespace_for_service",
+			expectErr: "Non default partition or namespace is supported in Enterprise only." +
+				"Provided namespace is test-namespace and partition is test-partition",
+			namespace: "test-namespace",
+			service:   "test-service",
+			partition: "test-partition",
+		},
+		{
+			name: "err_unsupported_namespace_for_service",
+			expectErr: "Non default partition or namespace is supported in Enterprise only." +
+				"Provided namespace is test-namespace and partition is default",
+			namespace: "test-namespace",
+			service:   "test-service",
+			partition: "default",
+		},
+		{
+			name: "err_unsupported_partition_for_service",
+			expectErr: "Non default partition or namespace is supported in Enterprise only." +
+				"Provided namespace is default and partition is test-partition",
+			namespace: "default",
+			service:   "test-service",
+			partition: "test-partition",
+		},
+		{
+			name:      "default_partition_and_namespace_supported_for_service",
+			expectErr: "",
+			namespace: "default",
+			service:   "test-service",
+			partition: "default",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spiffeIDService := &connect.SpiffeIDService{
+				Host:       config.NodeName,
+				Datacenter: tc.datacenter,
+				Namespace:  tc.namespace,
+				Service:    tc.service,
+				Partition:  tc.partition,
+			}
+			err := manager.validateSupportedIdentityScopesInCertificate(spiffeIDService)
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSupportedIdentityScopesForMeshGatewayInCertificate(t *testing.T) {
+	config := DefaultConfig()
+	manager := NewCAManager(nil, nil, testutil.Logger(t), config)
+
+	tests := []struct {
+		name      string
+		expectErr string
+		partition string
+	}{
+		{
+			name: "err_unsupported_partition_for_mesh_gateway",
+			expectErr: "Non default partition is supported in Enterprise only." +
+				"Provided partition is test-partition",
+			partition: "test-partition",
+		},
+		{
+			name:      "default_partition_supported_for_mesh_gateway",
+			expectErr: "",
+			partition: "default",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spiffeIDMeshGateway := &connect.SpiffeIDMeshGateway{
+				Host:       config.NodeName,
+				Datacenter: config.Datacenter,
+				Partition:  tc.partition,
+			}
+			err := manager.validateSupportedIdentityScopesInCertificate(spiffeIDMeshGateway)
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSupportedIdentityScopesForServerInCertificate(t *testing.T) {
+	config := DefaultConfig()
+	manager := NewCAManager(nil, nil, testutil.Logger(t), config)
+	spiffeIDServer := &connect.SpiffeIDServer{
+		Host: config.NodeName, Datacenter: config.Datacenter}
+	err := manager.validateSupportedIdentityScopesInCertificate(spiffeIDServer)
+	require.NoError(t, err)
+}
+
+func TestValidateSupportedIdentityScopesForAgentInCertificate(t *testing.T) {
+	config := DefaultConfig()
+	manager := NewCAManager(nil, nil, testutil.Logger(t), config)
+	spiffeIDAgent := &connect.SpiffeIDAgent{
+		Host: config.NodeName, Datacenter: config.Datacenter, Partition: "test-partition", Agent: "test-agent"}
+	err := manager.validateSupportedIdentityScopesInCertificate(spiffeIDAgent)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### Description
This change adds a check to validate that CSR with default namespace and partition only can be signed in Consul CE. 

Context
In the CSR passed to CA to be signed if the spiffeID contains non default namespace or partition, it was currently being issued by the CA even though non default namespace and partition is not supported in Consul CE. This led to a security vulnerability in case the cluster is upgraded to Enterprise. More details in the Security vulnerability jira attached. 

Changes:
Added changes to check and throw error if non default namespace or partition is passed in the SpiffeID in CSR for Service and Mesh Gateway in consul CE. 


### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
