### PR TITLE
Fix Install Consul on Kubernetes button having localhost:3000 hard coded

### DIFF
--- a/website/content/docs/deploy/server/k8s/helm.mdx
+++ b/website/content/docs/deploy/server/k8s/helm.mdx
@@ -9,7 +9,7 @@ description: >-
 
 This topic describes how to install Consul on Kubernetes using the official Consul Helm chart. We recommend using this method if you are installing Consul on Kubernetes for multi-cluster deployments that involve cross-partition or cross datacenter communication.
 
-For instruction on how to install Consul on Kubernetes using the Consul K8s CLI, refer to [Install Consul on Kubernetes with the Consul K8s CLI](http://localhost:3000/consul/docs/deploy/server/k8s/consul-k8s).
+For instruction on how to install Consul on Kubernetes using the Consul K8s CLI, refer to [Install Consul on Kubernetes with the Consul K8s CLI](/consul/docs/deploy/server/k8s/consul-k8s).
 
 ## Introduction
 


### PR DESCRIPTION
### Description

When moving around on the docs page the _Install Consul on Kubernetes with the Consul K8s CLI_ links you to localhost:3000 no matter what

### Links

https://developer.hashicorp.com/consul/docs/deploy/server/k8s/helm#install-consul-on-kubernetes-with-helm

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
