### PR TITLE
enforce validation for missing service name in registration

### DIFF
--- a/.changelog/22381.txt
+++ b/.changelog/22381.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+http: return a clear error when both Service.Service and Service.ID are missing during catalog registration
+```

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -200,6 +200,10 @@ func servicePreApply(service *structs.NodeService, authz resolver.Result, authzC
 	if err := service.Validate(); err != nil {
 		return err
 	}
+	// Check if service name and service ID are empty.
+	if service.ID == "" && service.Service == "" {
+		return fmt.Errorf("Must provide service name (Service.Service)")
+	}
 
 	// If no service id, but service name, use default
 	if service.ID == "" && service.Service != "" {

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -202,7 +202,7 @@ func servicePreApply(service *structs.NodeService, authz resolver.Result, authzC
 	}
 	// Check if service name and service ID are empty.
 	if service.ID == "" && service.Service == "" {
-		return fmt.Errorf("Must provide service name (Service.Service)")
+		return fmt.Errorf("service name (Service.Service) is required; both Service ID (Service.ID) and Service Name cannot be empty")
 	}
 
 	// If no service id, but service name, use default

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -334,7 +334,7 @@ func TestCatalog_Register_RejectsMissingServiceName(t *testing.T) {
 	var out struct{}
 	err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", &args, &out)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Must provide service name (Service.Service)")
+	require.Contains(t, err.Error(), "service name (Service.Service) is required; both Service ID (Service.ID) and Service Name cannot be empty")
 }
 func TestCatalog_Register_ForwardLeader(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
### Description

Adds validation to the catalog register endpoint to ensure that a service name (`Service.Service`) is provided when registering a service. This prevents registrations with empty service names, which resulted in the Services page in the Consul UI being broken.

If both `Service.ID` and `Service.Service` are empty, the API now returns an error message.


### Testing & Reproduction steps

* Added unit test `TestCatalog_Register_RejectsMissingServiceName` in `catalog_endpoint_test.go`
* Manually validated behavior using:

```bash
curl -X PUT http://localhost:8500/v1/catalog/register \
  -H "Content-Type: application/json" \
  --data-raw '{
    "Datacenter": "dc1",
    "Node": "my_node",
    "Address": "123.456.78.9",
    "Service": {
      "ID": "",
      "Service": "",
      "Port": 9001
    }
  }'

service name (Service.Service) is required; both Service ID (Service.ID) and Service Name cannot be empty
```
### Links

### PR Checklist

* [x ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x ] not a security concern
