### PR TITLE
fix(config): Warn on invalid characters in `datacenter` property leading to incompatible DNS names

### DIFF
--- a/.changelog/22382.txt
+++ b/.changelog/22382.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+config: Warn about invalid characters in `datacenter` resulting in non-generation of X.509 certificates when using external CA for agent TLS communication.
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1190,9 +1190,6 @@ func advertiseAddrFunc(opts LoadOpts, advertiseAddr *net.IPAddr) (string, func()
 	}
 }
 
-// reDNSCompatible ensures that the name is capable to be part of a DNS name.
-var reDNSCompatible = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$`)
-
 // reBasicName validates that a field contains only lower case alphanumerics,
 // underscore and dash and is non-empty.
 var reBasicName = regexp.MustCompile("^[a-z0-9_-]+$")
@@ -1216,6 +1213,8 @@ func (b *builder) validate(rt RuntimeConfig) error {
 	// validContentPath defines a regexp for a valid content path name.
 	validContentPath := regexp.MustCompile(`^[A-Za-z0-9/_-]+$`)
 	hasVersion := regexp.MustCompile(`^/v\d+/$`)
+	// reDNSCompatible ensures that the name is capable to be part of a DNS name.
+	reDNSCompatible := regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$`)
 	// ----------------------------------------------------------------
 	// check required params we cannot recover from first
 	//

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1190,6 +1190,9 @@ func advertiseAddrFunc(opts LoadOpts, advertiseAddr *net.IPAddr) (string, func()
 	}
 }
 
+// reDNSCompatible ensures that the name is capable to be part of a DNS name.
+var reDNSCompatible = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$`)
+
 // reBasicName validates that a field contains only lower case alphanumerics,
 // underscore and dash and is non-empty.
 var reBasicName = regexp.MustCompile("^[a-z0-9_-]+$")
@@ -1223,6 +1226,9 @@ func (b *builder) validate(rt RuntimeConfig) error {
 
 	if err := validateBasicName("datacenter", rt.Datacenter, false); err != nil {
 		return err
+	}
+	if !reDNSCompatible.MatchString(rt.Datacenter) {
+		b.warn("Datacenter : %q will not be PKI X.509 compatible due to invalid characters. Valid characters include lowercase alphanumeric characters with dashes in between.", rt.Datacenter)
 	}
 	if rt.DataDir == "" && !rt.DevMode {
 		return fmt.Errorf("data_dir cannot be empty")

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -761,7 +761,7 @@ func TestBuilder_DatacenterDNSCompatibleWarning(t *testing.T) {
 		require.NoError(t, err)
 
 		warningFound := false
-		expectedWarningSubstr := "will not be PKI X.509 SAN compatible due to invalid characters"
+		expectedWarningSubstr := "will not be PKI X.509 compatible due to invalid characters"
 		for _, warning := range result.Warnings {
 			if strings.Contains(warning, expectedWarningSubstr) {
 				warningFound = true
@@ -785,7 +785,7 @@ func TestBuilder_DatacenterDNSCompatibleWarning(t *testing.T) {
 		},
 		{
 			name:          "invalid excess characters",
-			datacenter:    "asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfadd1",
+			datacenter:    "asdfaasdfasdfasdfsdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfadd1",
 			expectError:   false,
 			expectWarning: true,
 		},

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -731,3 +731,117 @@ func TestBuilder_CloudConfigWithEnvironmentVars(t *testing.T) {
 		})
 	}
 }
+
+func TestBuilder_DatacenterDNSCompatibleWarning(t *testing.T) {
+	type testCase struct {
+		name          string
+		datacenter    string
+		expectError   bool
+		expectWarning bool
+	}
+
+	fn := func(t *testing.T, tc testCase) {
+		opts := LoadOpts{
+			FlagValues: FlagValuesTarget{
+				Config: Config{
+					Datacenter: pString(tc.datacenter),
+					DataDir:    pString("dir"),
+				},
+			},
+		}
+		patchLoadOptsShims(&opts)
+		result, err := Load(opts)
+
+		if tc.expectError {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "datacenter can only contain lowercase alphanumeric, - or _ characters")
+			return
+		}
+
+		require.NoError(t, err)
+
+		warningFound := false
+		expectedWarningSubstr := "will not be PKI X.509 SAN compatible due to invalid characters"
+		for _, warning := range result.Warnings {
+			if strings.Contains(warning, expectedWarningSubstr) {
+				warningFound = true
+				break
+			}
+		}
+
+		if tc.expectWarning {
+			require.True(t, warningFound, "Expected warning about datacenter DNS compatibility but got none")
+		} else {
+			require.False(t, warningFound, "Got unexpected warning about datacenter DNS compatibility")
+		}
+	}
+
+	var testCases = []testCase{
+		{
+			name:          "valid lowercase datacenter",
+			datacenter:    "deecee1",
+			expectError:   false,
+			expectWarning: false,
+		},
+		{
+			name:          "invalid excess characters",
+			datacenter:    "asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfadd1",
+			expectError:   false,
+			expectWarning: true,
+		},
+		{
+			name:          "valid lowercase datacenter",
+			datacenter:    "deecee1",
+			expectError:   false,
+			expectWarning: false,
+		},
+		{
+			name:          "valid with dash",
+			datacenter:    "dc-west-1",
+			expectError:   false,
+			expectWarning: false,
+		},
+		{
+			name:          "valid uppercase letters",
+			datacenter:    "DEECEE1",
+			expectError:   false, // Will not fail because config is lowercased before validation
+			expectWarning: false, // Won't get to warning check
+		},
+		{
+			name:          "invalid underscore",
+			datacenter:    "dc_1",
+			expectError:   false, // Passes basic validation since underscore is allowed
+			expectWarning: true,  // But fails DNS compatibility check
+		},
+		{
+			name:          "invalid starts with dash",
+			datacenter:    "-dc1",
+			expectError:   false, // Basic validation allows leading dash
+			expectWarning: true,  // But DNS compatibility doesn't
+		},
+		{
+			name:          "invalid ends with dash",
+			datacenter:    "dc1-",
+			expectError:   false, // Basic validation allows trailing dash
+			expectWarning: true,  // But DNS compatibility doesn't
+		},
+		{
+			name:          "invalid special characters",
+			datacenter:    "dc@1",
+			expectError:   true,  // Will fail basic validation
+			expectWarning: false, // Won't get to warning check
+		},
+		{
+			name:          "invalid space",
+			datacenter:    "dc 1",
+			expectError:   true,  // Will fail basic validation
+			expectWarning: false, // Won't get to warning check
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn(t, tc)
+		})
+	}
+}

--- a/website/content/commands/agent.mdx
+++ b/website/content/commands/agent.mdx
@@ -81,6 +81,11 @@ information.
   support for multiple datacenters, but it relies on proper configuration. Nodes
   in the same datacenter should be on a single LAN.
 
+~> **Warning:** This `datacenter` string must conform to [RFC 1035 DNS label requirements](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1),
+    consisting solely of letters, digits, and hyphens, with a maximum
+    length of 63 characters, and no hyphens at the beginning or end of the label.
+    Non-compliant names create Consul DNS entries incompatible with PKI X.509 certificate generation.
+
 - `-dev` ((#\_dev)) - Enable development server mode. This is useful for
   quickly starting a Consul agent with all persistence options turned off, enabling
   an in-memory server which can be used for rapid prototyping or developing against
@@ -487,7 +492,7 @@ information.
   - Metadata values must be between 0 and 512 (inclusive) characters in length.
   - Metadata values for keys beginning with `rfc1035-` are encoded verbatim in DNS TXT requests, otherwise
     the metadata kv-pair is encoded according [RFC1464](https://www.ietf.org/rfc/rfc1464.txt).
- 
+
 - `-disable-host-node-id` ((#\_disable_host_node_id)) - Setting this to
   true will prevent Consul from using information from the host to generate a deterministic
   node ID, and will instead generate a random node ID which will be persisted in

--- a/website/content/docs/reference/agent/configuration-file/general.mdx
+++ b/website/content/docs/reference/agent/configuration-file/general.mdx
@@ -103,6 +103,11 @@ The page provides reference information for general parameters in a Consul agent
   support for multiple datacenters, but it relies on proper configuration. Nodes
   in the same datacenter should be on a single LAN.
 
+~> **Warning:** This `datacenter` string must conform to [RFC 1035 DNS label requirements](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1),
+    consisting solely of letters, digits, and hyphens, with a maximum
+    length of 63 characters, and no hyphens at the beginning or end of the label.
+    Non-compliant names create Consul DNS entries incompatible with PKI X.509 certificate generation.
+
 - `data_dir` ((#\_data_dir)) - This parameter provides a data directory for
   the agent to store state. This is required for all agents. The directory should
   be durable across reboots. This is especially critical for agents that are running
@@ -123,7 +128,7 @@ The page provides reference information for general parameters in a Consul agent
   will not be persisted to a file. Any installed keys will be lost on shutdown, and
   only the given encryption key will be available on startup. Defaults to `false`. Equivalent to the
   [`-disable-keyring-file` command-line flag](/consul/commands/agent#_disable_keyring_file).
-  
+
 - `disable_remote_exec` ((#disable_remote_exec)) - Disables support for remote execution. When set to true, the agent will ignore
   any incoming remote exec requests. In versions of Consul prior to 0.8, this defaulted
   to false. In Consul 0.8 the default was changed to true, to make remote exec opt-in


### PR DESCRIPTION
### Description

Non-compliant characters lead to invalid DNS names that are incompatible with externalized PKI Certificate generation.

### Testing & Reproduction steps

- Start consul with invalid characters in `datacenter` property.
- Create tls certificates using [CLI Commands](https://developer.hashicorp.com/consul/commands/tls/cert). Consul does not warn/fail.
- When using other PKI engines to generate certificates with SAN as `<service-name>.service.<datacenter>.consul` PKI generation usually fails because of invalid characters in datacenter field.
- It is not possible to change datacenter name as it is an initial bootstrapping configuration of consul. One has to migrate entire data.

### Links


### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
