### PR TITLE
Update Enterprise Consul Link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Consul provides several key features:
 
 Consul runs on Linux, macOS, FreeBSD, Solaris, and Windows and includes an
 optional [browser based UI](https://demo.consul.io). A commercial version
-called [Consul Enterprise](https://developer.hashicorp.com/docs/enterprise) is also
+called [Consul Enterprise](https://developer.hashicorp.com/consul/docs/enterprise) is also
 available.
 
 **Please note**: We take Consul's security and our users' trust very seriously. If you


### PR DESCRIPTION


### Description

The current link https://developer.hashicorp.com/docs/enterprise to a 404 page.

Based on my Google search, this link was appropriate.

https://developer.hashicorp.com/consul/docs/enterprise

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
