### PR TITLE
update default testing deployer image versions

### DIFF
--- a/testing/deployer/topology/default_versions.go
+++ b/testing/deployer/topology/default_versions.go
@@ -7,8 +7,8 @@ package topology
 
 //TODO @sarah.alsmiller figure out if we can delete this
 const (
-	DefaultConsulCEImage         = "hashicorp/consul:1.19.0"
-	DefaultConsulEnterpriseImage = "hashicorp/consul-enterprise:1.19.0-ent"
-	DefaultEnvoyImage            = "envoyproxy/envoy:v1.28.5"
-	DefaultDataplaneImage        = "hashicorp/consul-dataplane:1.5.0"
+	DefaultConsulCEImage         = "hashicorp/consul:1.21.0"
+	DefaultConsulEnterpriseImage = "hashicorp/consul-enterprise:1.21.0-ent"
+	DefaultEnvoyImage            = "envoyproxy/envoy:v1.33.2"
+	DefaultDataplaneImage        = "hashicorp/consul-dataplane:1.7.0"
 )


### PR DESCRIPTION
### Description

Updated default images for testing framework for consul-ce, consul-ent, consul-dataplane and envoy. Previously ENVOY_VERSION was updated and v1.28.x was depricated. Because of this the test framework no longer worked and `integration-test-with-deployer` started failing in ce-to-ent-sync.

<img width="850" alt="Screenshot 2025-06-08 at 01 15 44" src="https://github.com/user-attachments/assets/72890a46-1cda-4eeb-8e5c-abf30ae01142" />


### Testing & Reproduction steps

- This can be reproduced locally with `make test-deployer` command.
- With this change, the above test run passes
<img width="850" alt="Screenshot 2025-06-08 at 01 18 48" src="https://github.com/user-attachments/assets/5e4e4067-a63f-4498-9e88-3943eb8b10d8" />


### Links

N/A

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
