### PR TITLE
docs: Add HCP Consul Dedicated EoL notice

### DIFF
--- a/website/content/docs/deploy/server/hcp.mdx
+++ b/website/content/docs/deploy/server/hcp.mdx
@@ -7,6 +7,8 @@ description: >-
 
 # Deploy servers on HCP Consul
 
+@include 'alerts/hcp-dedicated-eol.mdx'
+
 This page provides an overview for deploying Consul servers using HCP Consul. You can deploy HashiCorp-managed clusters or you can use guided workflows to create a self-managed cluster and link it to HCP Consul Central.
 
 For more information about HashiCorp-managed clusters and how they differ from self-managed clusters, refer to [cluster management](/hcp/docs/consul/cluster-management) in the HCP Consul documentation.

--- a/website/content/docs/integrate/index.mdx
+++ b/website/content/docs/integrate/index.mdx
@@ -39,6 +39,8 @@ By leveraging Consul's RESTful HTTP API system, prospective partners are able to
 
 **HCP Consul**: HCP Consul is secure by default and offers an out-of-the-box service mesh solution to streamline operations without the hassle of managing Consul servers. [Sign up for a free HCP Consul account](https://cloud.hashicorp.com/products/consul).
 
+@include 'alerts/hcp-dedicated-eol.mdx'
+
 **Consul integration verification badges**: Partners will be issued the Consul Enterprise badge for integrations that work with [Consul Enterprise features](/consul/docs/enterprise) such as namespaces. Partners will be issued the HCP Consul badge for integrations validated to work with [HCP Consul](/hcp/docs/consul#features). Each badge would be displayed on HashiCorp's partner page as well as be available for posting on the partner's own website to provide better visibility and differentiation of the integration for joint customers.
 
 <span style={{display:'block', textAlign:'center'}}>
@@ -172,6 +174,8 @@ The only knowledge necessary to write a plugin is basic command-line skills and 
 HCP Consul is currently only deployed on AWS and Microsoft Azure, so your application can be deployed to or run in AWS or Azure. 
 
 #### HCP Consul Resource Links:
+
+@include 'alerts/hcp-dedicated-eol.mdx'
 
 - [Getting Started with HCP Consul](/consul/tutorials/get-started-hcp/hcp-gs-deploy)
 - [HCP Consul End-to-End Deployment](/consul/tutorials/cloud-deploy-automation/consul-end-to-end-overview)

--- a/website/content/docs/intro.mdx
+++ b/website/content/docs/intro.mdx
@@ -78,11 +78,7 @@ HashiCorp offers core Consul functionality for free in the community edition, wh
 
 ### HCP Consul Dedicated
 
-<Warning>
-
-HCP Consul Dedicated will be retired on November 12, 2025. [Learn more in the HCP documentation](/hcp/docs/consul/migrate).
-
-</Warning>
+@include 'alerts/hcp-dedicated-eol.mdx'
 
 HashiCorp Cloud Platform (HCP) Consul is our SaaS that delivers Consul Enterprise capabilities and shifts the burden of managing the control plane to us. Create an HCP organization and leverage our expertise to simplify control plane maintenance and configuration. Learn more at [HashiCorp Cloud Platform](https://cloud.hashicorp.com/products/consul). 
 

--- a/website/content/docs/manage/scale/index.mdx
+++ b/website/content/docs/manage/scale/index.mdx
@@ -82,6 +82,8 @@ Consul servers can be deployed on a few different runtimes:
 - **Kubernetes (Self-managed)**. To get started with Consul on Kubernetes, refer to the [Deploy Consul on Kubernetes tutorial](/consul/tutorials/get-started-kubernetes/kubernetes-gs-deploy).
 - **Other container environments, including Docker, Rancher, and Mesos (Self-managed)**.
 
+@include 'alerts/hcp-dedicated-eol.mdx'
+
 When operating Consul at scale, self-managed VM or bare metal server deployments offer the most flexibility. Some Consul Enterprise features that can enhance fault tolerance and read scalability, such as [redundancy zones](/consul/docs/manage/scale/redundancy-zone) and [read replicas](/consul/docs/manage/scale/read-replica), are not available to server agents on Kubernetes runtimes. To learn more, refer to [Consul Enterprise feature availability by runtime](/consul/docs/enterprise#feature-availability-by-runtime).
 
 ### Number of Consul servers

--- a/website/content/docs/multi-tenant/sameness-group/vm.mdx
+++ b/website/content/docs/multi-tenant/sameness-group/vm.mdx
@@ -43,8 +43,6 @@ Mesh gateways are required for cluster peering connections and recommended to se
 
 You must establish connections with cluster peers before you can create a sameness group that includes them. A cluster peering connection exists between two admin partitions in different datacenters, and each connection between two partitions must be established separately with each peer. Refer to [establish cluster peering connections](/consul/docs/east-west/cluster-peering/establish/vm) for step-by-step instructions.
 
-You can establish and manage cluster peering relationships between all of your self-managed clusters using [HCP Consul Central](/hcp/docs/consul/concepts/consul-central). For more information, refer to [cluster peering global view](/hcp/docs/consul/monitor/consul-central/global-views#cluster-peering) in the HCP documentation.
-
 To establish cluster peering connections and define a group as part of the same workflow, follow instructions up to [Export services between clusters](/consul/docs/east-west/cluster-peering/establish/vm#export-services-between-clusters). You can use the same exported services and service intention configuration entries to establish the cluster peering connection and create the sameness group.
 
 ## Create a sameness group

--- a/website/content/docs/north-south/api-gateway/k8s/tech-specs.mdx
+++ b/website/content/docs/north-south/api-gateway/k8s/tech-specs.mdx
@@ -125,6 +125,8 @@ Refer to the [Kubernetes `ReferenceGrant` documentation](https://gateway-api.sig
   - Self-Managed
   - HCP Consul Dedicated
 
+@include 'alerts/hcp-dedicated-eol.mdx'
+
 ### Consul feature support
 
 API gateways on Kubernetes support all Consul features, but you can only route traffic between multiple datacenters through peered connections. Refer to [Route Traffic to Peered Services](/consul/docs/north-south/api-gateway/k8s/peer) for additional information. WAN federation is not supported.

--- a/website/content/docs/reference/agent/configuration-file/hcp.mdx
+++ b/website/content/docs/reference/agent/configuration-file/hcp.mdx
@@ -7,11 +7,7 @@ description: >-
 
 # HCP Consul Dedicated parameters for Consul agent configuration files
 
-<Warning>
-
-HCP Consul Dedicated will be retired on November 12, 2025. [Learn more in the HCP documentation](/hcp/docs/consul/migrate).
-
-</Warning>
+@include 'alerts/hcp-dedicated-eol.mdx'
 
 This page provides reference information for HCP Consul Dedicated in a Consul agent configuration file.
 

--- a/website/content/docs/reference/architecture/ports.mdx
+++ b/website/content/docs/reference/architecture/ports.mdx
@@ -18,6 +18,8 @@ There are slight differences between the port requirements for Consul servers an
 
 HashiCorp-managed servers deployed using [HCP Consul](/hcp/docs/consul) have distinct port assignments. For more information, refer to [cluster management in the HCP documentation](/hcp/docs/consul/concepts/cluster-management#hashicorp-managed-clusters).
 
+@include 'alerts/hcp-dedicated-eol.mdx'
+
 ## Consul servers
 
 This table lists port names, their function, their network protocols, their default port numbers, whether they are enabled or disabled by default, port assignments for HashiCorp-managed server clusters, and the direction of traffic from the Consul server's perspective.

--- a/website/content/docs/release-notes/consul-terraform-sync/v0_6_x.mdx
+++ b/website/content/docs/release-notes/consul-terraform-sync/v0_6_x.mdx
@@ -18,6 +18,8 @@ You can now execute Terraform tasks in `remote` or `cloud agent` mode. For more 
 
 ### HCP Consul Dedicated Support <EnterpriseAlert inline /> 
 
+@include 'alerts/hcp-dedicated-eol.mdx'
+
 CTS now supports interoperability with HCP Consul Dedicated. CTS retrieves licenses from HCP Consul Dedicated so that users can keep their HCP Consul Dedicated license or Consul enterprise deployment license in sync.
 
 ### Auto Service-registration with Consul and Health API Endpoint 

--- a/website/content/partials/alerts/hcp-dedicated-eol.mdx
+++ b/website/content/partials/alerts/hcp-dedicated-eol.mdx
@@ -1,0 +1,5 @@
+<Warning>
+
+HCP Consul Dedicated will be retired on November 12, 2025. [Learn more in the HCP documentation](/hcp/docs/consul/migrate).
+
+</Warning>

--- a/website/content/partials/text/descriptions/cluster-peering.mdx
+++ b/website/content/partials/text/descriptions/cluster-peering.mdx
@@ -1,5 +1,5 @@
 Cluster peering connects two or more independent Consul clusters so that services deployed to different datacenters can communicate. The process to establish a connection generates and exchanges peering tokens between admin partitions in each datacenter. 
 
-Peering topologies that include more than one admin partition in a single Consul datacenter require [Consul Enterprise](/consul/docs/enterprise). HCP Consul enables additional support for cluster peering lifecycle operations through [HCP Consul Central](/hcp/docs/consul/concepts/consul-central).
+Peering topologies that include more than one admin partition in a single Consul datacenter require [Consul Enterprise](/consul/docs/enterprise).
 
 Cluster peering in your service mesh enables [sameness groups](/consul/docs/multi-tenant/sameness-group/vm), [service failover](/consul/docs/manage-traffic/failover), and connections between Consul clusters owned by different operators. Refer to the [Cluster peering documentation](/consul/docs/east-west/cluster-peering#guidance) for more information.

--- a/website/content/partials/text/descriptions/telemetry.mdx
+++ b/website/content/partials/text/descriptions/telemetry.mdx
@@ -1,3 +1,3 @@
-Consul agents, dataplanes, gateways, and sidecar proxies emit metrics that you can access and visualize using tools such as Prometheus and Grafana. Consul's UI can display visualizations of service mesh topologies and L7 metrics when they are enabled and configured in Consul. [HCP Consul Central](/hcp/docs/consul/concepts/central) enables additional visualizations of cluster insights using dashboards and configurations managed by HashiCorp.
+Consul agents, dataplanes, gateways, and sidecar proxies emit metrics that you can access and visualize using tools such as Prometheus and Grafana. Consul's UI can display visualizations of service mesh topologies and L7 metrics when they are enabled and configured in Consul.
 
 Refer to [service mesh telemetry on virtual machines (VMs)](/consul/docs/observe/telemetry/vm) or [service mesh telemetry on Kubernetes](/consul/docs/observe/telemetry/k8s) for more information.

--- a/website/content/partials/text/limitations/observe.mdx
+++ b/website/content/partials/text/limitations/observe.mdx
@@ -1,4 +1,4 @@
 If you experience errors when configuring Consul's observability features, refer to the following list of technical constraints.
 
-- Consul's observability features are not enabled by default on Community and Enterprise deployments. A HashiCorp-managed observability service is available through [HCP Consul Central](/hcp/docs/consul/concepts/central).
+- Consul's observability features are not enabled by default on Community and Enterprise deployments. 
 - Consul deploys Envoy proxies by default. Tracing spans that are incompatible with Envoy proxies do not function with Consul.


### PR DESCRIPTION
### Description

HCP Consul Dedicated is EoL in November. Messaging was previously included in the HCP Consul docs and some of the Consul docs. This PR adds an alert and includes it in strategic locations mentioning HCP Consul Dedicated. It also removes stray references to HCP Consul Central.

### Links

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern
