### PR TITLE
upgrade ubi base image to fix CVEs

### DIFF
--- a/.changelog/22409.txt
+++ b/.changelog/22409.txt
@@ -1,0 +1,11 @@
+```release-note:security
+Upgrade UBI base image version to address CVE
+[CVE-2025-4802](https://access.redhat.com/security/cve/cve-2025-4802)
+[CVE-2024-40896](https://access.redhat.com/security/cve/cve-2024-40896)
+[CVE-2024-12243](https://nvd.nist.gov/vuln/detail/CVE-2024-12243)
+[CVE-2025-24528](https://access.redhat.com/security/cve/cve-2025-24528)
+[CVE-2025-3277](https://access.redhat.com/security/cve/cve-2025-3277)
+[CVE-2024-12133](https://access.redhat.com/security/cve/cve-2024-12133)
+[CVE-2024-57970](https://access.redhat.com/security/cve/cve-2024-57970)
+[CVE-2025-31115](https://access.redhat.com/security/cve/cve-2025-31115)
+```

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -88,6 +88,9 @@ binary {
 		suppress {
 			vulnerabilities = [
 				"GO-2022-0635", // github.com/aws/aws-sdk-go@v1.55.5
+				"GO-2025-3751", // https://osv.dev/vulnerability/GO-2025-3751
+				"GO-2025-3750", // https://osv.dev/vulnerability/GO-2025-3750
+				"GO-2025-3749", // https://osv.dev/vulnerability/GO-2025-3749
 			]
 			paths = [
 				"internal/tools/proto-gen-rpc-glue/e2e/consul/*",

--- a/Dockerfile
+++ b/Dockerfile
@@ -217,7 +217,7 @@ CMD ["agent", "-dev", "-client", "0.0.0.0"]
 
 # Red Hat UBI-based image
 # This target is used to build a Consul image for use on OpenShift.
-FROM registry.access.redhat.com/ubi9-minimal:9.5 as ubi
+FROM registry.access.redhat.com/ubi9-minimal:9.6-1749489516 as ubi
 
 ARG PRODUCT_VERSION
 ARG PRODUCT_REVISION


### PR DESCRIPTION
### Description

Upgraded UBI base image from  `9.5` to `9.6-1749489516` to fix following CVEs:

[CVE-2025-4802](https://access.redhat.com/security/cve/cve-2025-4802)
[CVE-2024-40896](https://access.redhat.com/security/cve/cve-2024-40896)
[CVE-2024-12243](https://nvd.nist.gov/vuln/detail/CVE-2024-12243)
[CVE-2025-24528](https://access.redhat.com/security/cve/cve-2025-24528)
[CVE-2025-3277](https://access.redhat.com/security/cve/cve-2025-3277)
[CVE-2024-12133](https://access.redhat.com/security/cve/cve-2024-12133)
[CVE-2024-57970](https://access.redhat.com/security/cve/cve-2024-57970)
[CVE-2025-31115](https://access.redhat.com/security/cve/cve-2025-31115)

> NOTE: Suppressed binary CVEs as it require Go upgrade to 1.24 and internal tool mog is not generating the structs for proto properly and needs further investigation.

### Testing & Reproduction steps

Used `hashicorp/security/scan` tool to scan binaries and containers

### Links

N/A

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
