### PR TITLE
fix(consul-ui): properly format ipv6 addresses

### DIFF
--- a/.changelog/22423.txt
+++ b/.changelog/22423.txt
@@ -1,3 +1,3 @@
-```release-note: bug
+```release-note:bug
 ui: display IPv6 addresses with proper bracketed formatting
 ```

--- a/.changelog/22423.txt
+++ b/.changelog/22423.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+ui: display IPv6 addresses with proper bracketed formatting
+```

--- a/ui/packages/consul-ui/app/components/consul/service-instance/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service-instance/list/index.hbs
@@ -102,9 +102,17 @@ as |proxy|}}
       </dt>
       <dd>
         {{#if (not-eq item.Service.Address '')}}
-          {{item.Service.Address}}:{{item.Service.Port}}
+          {{#if (string-includes item.Service.Address ":")}}
+            [{{item.Service.Address}}]:{{item.Service.Port}}
+          {{else}}
+            {{item.Service.Address}}:{{item.Service.Port}}
+          {{/if}}
         {{else}}
-          {{item.Node.Address}}:{{item.Service.Port}}
+          {{#if (string-includes item.Node.Address ":")}}
+            [{{item.Node.Address}}]:{{item.Service.Port}}
+          {{else}}
+            {{item.Node.Address}}:{{item.Service.Port}}
+          {{/if}}
         {{/if}}
       </dd>
     </dl>


### PR DESCRIPTION
### Description

Updated the rendering logic to handle IPv6 addresses properly. The changes ensure that IPv6 addresses are enclosed in square brackets to conform to standard formatting.

### Testing & Reproduction steps

Tested this manually with the IPv6 setup for minion-chat-advance app.

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

<!-- ### Links -->

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern
