### PR TITLE
Fixed documentation and tutorials link, trimmed trailing whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
 
-* Documentation and Tutorials: [https://developer.hashicopr.com/consul]
+* Documentation and Tutorials: [https://developer.hashicorp.com/consul]
 * Forum: [Discuss](https://discuss.hashicorp.com/c/consul)
 
 Consul provides several key features:
@@ -22,8 +22,8 @@ Consul provides several key features:
   can use sidecar proxies in a service mesh configuration to establish TLS
   connections for inbound and outbound connections with Transparent Proxy.
 
-* **API Gateway** - Consul API Gateway manages access to services within Consul Service Mesh, 
-  allow users to define traffic and authorization policies to services deployed within the mesh.  
+* **API Gateway** - Consul API Gateway manages access to services within Consul Service Mesh,
+  allow users to define traffic and authorization policies to services deployed within the mesh.
 
 * **Service Discovery** - Consul makes it simple for services to register
   themselves and to discover other services via a DNS or HTTP interface.
@@ -54,7 +54,7 @@ A few quick start guides are available on the Consul website:
 * **Minikube install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-minikube
 * **Kind install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-kind
 * **Kubernetes install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-deployment-guide
-* **Deploy HCP Consul:** https://learn.hashicorp.com/tutorials/consul/hcp-gs-deploy 
+* **Deploy HCP Consul:** https://learn.hashicorp.com/tutorials/consul/hcp-gs-deploy
 
 ## Documentation
 


### PR DESCRIPTION
Fixed documentation and tutorials link, trimmed trailing whitespaces.

### Description

Fixed typo in URL. Hashico**pr** -> Hashicorp. Trimmed some trailing whitespaces for consistency.

### Testing & Reproduction steps

Not Applicable.

### Links

Not Applicable.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern
