### PR TITLE
fix: skipping the coverage step for dependabot PRs also

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -148,8 +148,8 @@ jobs:
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
-        # do not run on forks
-        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
+        # do not run on forks and dependabot PRs
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -232,24 +232,24 @@ jobs:
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
-        # do not run on forks
-        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
+        # do not run on forks and dependabot PRs
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" "${{ env.TEST_RESULTS_DIR }}/gotestsum-report.xml"
 
       - name: upload leader coverage
-        # do not run on forks
-        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
+        # do not run on forks and dependabot PRs
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
         run: datadog-ci junit upload --service "$GITHUB_REPOSITORY" "${{ env.TEST_RESULTS_DIR }}/gotestsum-report-leader.xml"
 
       - name: upload agent coverage
-        # do not run on forks
-        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
+        # do not run on forks and dependabot PRs
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -392,8 +392,8 @@ jobs:
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
-        # do not run on forks
-        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
+        # do not run on forks and dependabot PRs
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -510,8 +510,8 @@ jobs:
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
-        # do not run on forks
-        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
+        # do not run on forks and dependabot PRs
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci
@@ -595,8 +595,8 @@ jobs:
           chmod +x /usr/local/bin/datadog-ci
 
       - name: upload coverage
-        # do not run on forks
-        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
+        # do not run on forks and dependabot PRs
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         env:
           DATADOG_API_KEY: "${{ endsWith(github.repository, '-enterprise') && env.DATADOG_API_KEY || secrets.DATADOG_API_KEY }}"
           DD_ENV: ci


### PR DESCRIPTION
Dependabot PRs are failing at upload coverage stage as it is unable to access DATADOG secrets. Disabling that stage for dependabot PRs along with PRs from forks
