### PR TITLE
Making CODEOWNERS consistent with main branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,41 +1,20 @@
-# Techical Writer Review
+* @hashicorp/consul-selfmanage-maintainers
 
-/website/content/docs/ @hashicorp/consul-docs
-/website/content/commands/ @hashicorp/consul-docs
-/website/content/api-docs/ @hashicorp/consul-docs
+
+# engineering and web presence get notified of, and can approve changes to web tooling, but not content.
+
+/website/           @hashicorp/web-presence @hashicorp/consul-selfmanage-maintainers
+/website/data/
+/website/public/
+/website/content/
+
+# education and engineering get notified of, and can approve changes to web content.
+
+/website/data/          @hashicorp/consul-docs @hashicorp/consul-selfmanage-maintainers
+/website/public/        @hashicorp/consul-docs @hashicorp/consul-selfmanage-maintainers
+/website/content/       @hashicorp/consul-docs @hashicorp/consul-selfmanage-maintainers
 
 
 # release configuration
-/.release/                              @hashicorp/release-engineering @hashicorp/github-consul-core
-/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-consul-core
-
-
-# Staff Engineer Review (protocol buffer definitions)
-/proto-public/   @hashicorp/consul-core-staff
-/proto/          @hashicorp/consul-core-staff
-
-# Staff Engineer Review (v1 architecture shared components)
-/agent/cache/                  @hashicorp/consul-core-staff
-/agent/consul/fsm/             @hashicorp/consul-core-staff
-/agent/consul/leader*.go       @hashicorp/consul-core-staff
-/agent/consul/server*.go       @hashicorp/consul-core-staff
-/agent/consul/state/           @hashicorp/consul-core-staff
-/agent/consul/stream/          @hashicorp/consul-core-staff
-/agent/submatview/             @hashicorp/consul-core-staff
-/agent/blockingquery/          @hashicorp/consul-core-staff
-
-# Staff Engineer Review (raft/autopilot)
-/agent/consul/autopilotevents/  @hashicorp/consul-core-staff
-/agent/consul/autopilot*.go     @hashicorp/consul-core-staff
-
-# Staff Engineer Review (v2 architecture shared components)
-/internal/controller/                   @hashicorp/consul-core-staff
-/internal/resource/                     @hashicorp/consul-core-staff
-/internal/storage/                      @hashicorp/consul-core-staff
-/agent/consul/controller/               @hashicorp/consul-core-staff
-/agent/grpc-external/services/resource/ @hashicorp/consul-core-staff
-
-# Staff Engineer Review (v1 security)
-/acl/                   @hashicorp/consul-core-staff
-/agent/xds/rbac*.go     @hashicorp/consul-core-staff
-/agent/xds/jwt*.go      @hashicorp/consul-core-staff
+/.release/                              @hashicorp/team-selfmanaged-releng @hashicorp/consul-selfmanage-maintainers
+/.github/workflows/build.yml            @hashicorp/team-selfmanaged-releng @hashicorp/consul-selfmanage-maintainers


### PR DESCRIPTION
### Description

As the current CODEOWNERS in release/1.18.x is different from main and other release branches, making it consistent for easier review and approval.