### PR TITLE
chore: Targeting dependabot updates for main and release branch separately

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@
 
 version: 2
 updates:
+# --- Updates for main branch ---
+# Go modules (main)
 - package-ecosystem: gomod
   open-pull-requests-limit: 10
   directory: "/"
@@ -10,9 +12,12 @@ updates:
     - "go"
     - "dependencies"
     - "pr/no-changelog"
+    - "pr/no-backport"
   schedule:
     interval: daily
-- package-ecosystem: npm 
+  target-branch: main
+# npm (main)
+- package-ecosystem: npm
   open-pull-requests-limit: 5
   directory: "/website"
   labels:
@@ -20,8 +25,11 @@ updates:
     - "dependencies"
     - "type/docs-cherrypick"
     - "pr/no-changelog"
+    - "pr/no-backport"
   schedule:
     interval: daily
+  target-branch: main
+# GitHub Actions (main)
 - package-ecosystem: github-actions
   open-pull-requests-limit: 5
   directory: /
@@ -29,5 +37,46 @@ updates:
     - "github_actions"
     - "dependencies"
     - "pr/no-changelog"
+    - "pr/no-backport"
   schedule:
     interval: daily
+  target-branch: main
+
+# --- Updates for release/1.21.x branch ---
+# Go modules (release/1.21.x)
+- package-ecosystem: gomod
+  open-pull-requests-limit: 10
+  directory: "/"
+  labels:
+    - "go"
+    - "dependencies"
+    - "pr/no-changelog"
+    - "pr/no-backport"
+  schedule:
+    interval: daily
+  target-branch: release/1.21.x
+# npm (release/1.21.x)
+- package-ecosystem: npm
+  open-pull-requests-limit: 5
+  directory: "/website"
+  labels:
+    - "javascript"
+    - "dependencies"
+    - "type/docs-cherrypick"
+    - "pr/no-changelog"
+    - "pr/no-backport"
+  schedule:
+    interval: daily
+  target-branch: release/1.21.x
+# GitHub Actions (release/1.21.x)
+- package-ecosystem: github-actions
+  open-pull-requests-limit: 5
+  directory: /
+  labels:
+    - "github_actions"
+    - "dependencies"
+    - "pr/no-changelog"
+    - "pr/no-backport"
+  schedule:
+    interval: daily
+  target-branch: release/1.21.x


### PR DESCRIPTION
We can target dependabot for each individual releases.

This helps 
1. We can avoid back porting once the changes are merged
2.  Ideally, dependencies should/need not be back ported as 
   a.   there can be case where the dependencies used in the latest release can be entirely different from the previous releases.
b. We could have a different major version in the latest release from an older release
3. This will be bring us one step closer to automating the dependencies update management with minimal intervention.

One limitation with this approach is that, we still have to hard code the target branch and the updates has to be duplicated for all the target branches. When we release a new version, we will have to update the dependabot yaml also. We can have this as a post release activity for the release of minor versions.