### PR TITLE
Backport: docs/CE-719 Clarify k8s target namespace

### DIFF
--- a/website/content/docs/deploy/server/k8s/consul-k8s.mdx
+++ b/website/content/docs/deploy/server/k8s/consul-k8s.mdx
@@ -66,6 +66,8 @@ You can create a values file and specify parameters to overwrite the default Hel
 $ consul-k8s install -f values.yaml
 ``` 
 
+@include 'alerts/k8s-namespace.mdx'
+
 ### Install Consul on OpenShift clusters
 
 [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) is a security-conscious, opinionated wrapper for Kubernetes. To install Consul on OpenShift-managed Kubernetes, set `global.openshift.enabled=true` in your [custom installation](#custom-installation) values file:

--- a/website/content/docs/deploy/server/k8s/enterprise.mdx
+++ b/website/content/docs/deploy/server/k8s/enterprise.mdx
@@ -99,6 +99,8 @@ Now, install Consul Enterprise on your Kubernetes cluster using the updated Helm
 $ helm install --wait hashicorp hashicorp/consul --values values.yaml
 ```
 
+@include 'alerts/k8s-namespace.mdx'
+
 ## Verify installation
 
 Once the cluster is up, you can verify the nodes are running Consul Enterprise by using the `consul license get` command.

--- a/website/content/docs/deploy/server/k8s/helm.mdx
+++ b/website/content/docs/deploy/server/k8s/helm.mdx
@@ -61,6 +61,8 @@ Using the Helm Chart requires Helm version 3.6+. Visit the [Helm website](https:
     kube-system       Active   18h
     ```
 
+@include 'alerts/k8s-namespace.mdx'
+
 1. Install Consul on Kubernetes using Helm. The Helm chart does everything to set up your deployment: after installation, agents automatically form clusters, elect leaders, and run the necessary agents.
    
     - Run the following command to install the latest version of Consul on Kubernetes with its default configuration.

--- a/website/content/partials/alerts/k8s-namespace.mdx
+++ b/website/content/partials/alerts/k8s-namespace.mdx
@@ -1,0 +1,8 @@
+<Note>
+
+If you experience errors when deploying or upgrading Consul in a K8s namespace different than the default `consul`, refer to the following list of technical constraints.
+
+- Consul cannot automatically detect its target K8s namespace, and needs it explicitly listed with `-namespace` in the parameters of _Helm_ or the _consul-k8s_ tool.
+- Consul needs its target K8s namespace added to the `connectInjector.k8sAllowNamspaces` Helm chart value. For more information, refer to this specific setting in the [Consul Helm chart reference](/consul/docs/reference/k8s/helm#v-connectinject-k8sallownamespaces).
+
+</Note>


### PR DESCRIPTION
### Description

<details>
	<summary> Overview of commits </summary>
		-  `863d6ae` CE-719 Clarify k8s target namespace
</details>

Upgrading or deploying to a non-default K8s namespace, different than `consul`, can lead to broken deployments for practitioners that expect our K8s install methods to automatically detect this K8s namespace.

### Testing & Reproduction steps

Install or upgrade Consul using Helm or consul-k8s, to a K8s namespace different than `consul` and not specifically whitelisted in the `connectInjector.k8sAllowNamspaces` Helm chart setting.

### Links

https://hashicorp.atlassian.net/browse/CE-719
https://hashicorp.atlassian.net/browse/FRB-758

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
