### PR TITLE
fix consul debug cmd not collecting pprof

### DIFF
--- a/.changelog/22538.txt
+++ b/.changelog/22538.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Consul CLI should be able to capture pprof when ACL is enabled and a token with operator:read is used even when enable_debug config is not explicitly set.
+cli: Consul CLI should be able to capture pprof when ACL is enabled and a token with operator:read is used even when enable_debug config is not explicitly set.
 ```

--- a/.changelog/22538.txt
+++ b/.changelog/22538.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-cli: Consul CLI should be able to capture pprof when ACL is enabled and a token with operator:read is used even when enable_debug config is not explicitly set.
+cli: capture pprof when ACL is enabled and a token with operator:read is used, even if enable_debug config is not explicitly set.
 ```

--- a/.changelog/22538.txt
+++ b/.changelog/22538.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Consul CLI should be able to capture pprof when ACL is enabled and a token with operator:read is used even when enable_debug config is not explicitly set.
+```

--- a/agent/http.go
+++ b/agent/http.go
@@ -225,7 +225,10 @@ func (s *HTTPHandlers) handler() http.Handler {
 		wrapper := func(resp http.ResponseWriter, req *http.Request) {
 
 			// If enableDebug register wrapped pprof handlers
-			if !s.agent.enableDebug.Load() && s.checkACLDisabled() {
+			enableDebug := s.agent.enableDebug.Load()
+			aclEnabled := !s.checkACLDisabled()
+			allowPprof := enableDebug || aclEnabled
+			if !allowPprof {
 				resp.WriteHeader(http.StatusNotFound)
 				resp.Header().Set(contentTypeHeader, plainContentType)
 				return

--- a/agent/http.go
+++ b/agent/http.go
@@ -223,12 +223,34 @@ func (s *HTTPHandlers) handler() http.Handler {
 	handlePProf := func(pattern string, handler http.HandlerFunc) {
 
 		wrapper := func(resp http.ResponseWriter, req *http.Request) {
+			logger := s.agent.logger.Named(logging.HTTP)
+
+			// Log incoming pprof request details
+			logger.Info("pprof request received",
+				"method", req.Method,
+				"path", req.URL.Path,
+				"pattern", pattern,
+				"remote_addr", req.RemoteAddr,
+				"user_agent", req.Header.Get("User-Agent"))
 
 			// If enableDebug register wrapped pprof handlers
 			enableDebug := s.agent.enableDebug.Load()
 			aclEnabled := !s.checkACLDisabled()
 			allowPprof := enableDebug || aclEnabled
+
+			// Log authorization decision data
+			logger.Debug("pprof authorization check",
+				"enable_debug", enableDebug,
+				"acl_enabled", aclEnabled,
+				"allow_pprof", allowPprof,
+				"logic", fmt.Sprintf("enableDebug(%t) || aclEnabled(%t) = %t", enableDebug, aclEnabled, allowPprof))
+
 			if !allowPprof {
+				logger.Warn("pprof access denied - insufficient permissions",
+					"reason", "enable_debug is false and ACLs are disabled",
+					"enable_debug", enableDebug,
+					"acl_enabled", aclEnabled,
+					"response_status", http.StatusNotFound)
 				resp.WriteHeader(http.StatusNotFound)
 				resp.Header().Set(contentTypeHeader, plainContentType)
 				return
@@ -237,25 +259,63 @@ func (s *HTTPHandlers) handler() http.Handler {
 			var token string
 			s.parseToken(req, &token)
 
+			// Log token information (redacted)
+			hasToken := token != ""
+			tokenLength := len(token)
+			if hasToken && tokenLength > 8 {
+				// Show first 4 and last 4 characters for debugging while keeping it secure
+				tokenPreview := token[:4] + "..." + token[tokenLength-4:]
+				logger.Debug("pprof token parsed",
+					"has_token", hasToken,
+					"token_length", tokenLength,
+					"token_preview", tokenPreview)
+			} else {
+				logger.Debug("pprof token parsed",
+					"has_token", hasToken,
+					"token_length", tokenLength)
+			}
+
 			authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 			if err != nil {
+				logger.Warn("pprof access denied - token resolution failed",
+					"error", err.Error(),
+					"has_token", hasToken,
+					"response_status", http.StatusForbidden)
 				resp.Header().Set(contentTypeHeader, plainContentType)
 				resp.WriteHeader(http.StatusForbidden)
 				return
 			}
+
+			logger.Debug("pprof token resolved successfully",
+				"has_token", hasToken)
 
 			// If the token provided does not have the necessary permissions,
 			// write a forbidden response
 			// TODO(partitions): should this be possible in a partition?
 			// TODO(acl-error-enhancements): We should return error details somehow here.
-			if authz.OperatorRead(nil) != acl.Allow {
+			operatorReadPermission := authz.OperatorRead(nil)
+			if operatorReadPermission != acl.Allow {
+				logger.Warn("pprof access denied - insufficient operator permissions",
+					"permission_result", operatorReadPermission.String(),
+					"required_permission", "operator:read",
+					"has_token", hasToken,
+					"response_status", http.StatusForbidden)
 				resp.Header().Set(contentTypeHeader, plainContentType)
 				resp.WriteHeader(http.StatusForbidden)
 				return
 			}
 
+			logger.Info("pprof access granted - calling handler",
+				"operator_read_permission", operatorReadPermission.String(),
+				"handler_pattern", pattern)
+
 			// Call the pprof handler
 			handler(resp, req)
+
+			logger.Debug("pprof handler completed",
+				"pattern", pattern,
+				"method", req.Method,
+				"path", req.URL.Path)
 		}
 
 		handleFuncMetrics(pattern, http.HandlerFunc(wrapper))

--- a/command/debug/debug.go
+++ b/command/debug/debug.go
@@ -313,18 +313,7 @@ func (c *cmd) prepare() (version string, err error) {
 	// Allow pprof if:
 	// 1. enableDebug is true (regardless of ACL state), OR
 	// 2. ACLs are enabled AND we have operator:read permission
-	allowPprof := enableDebug
-
-	if !enableDebug && aclEnabled {
-		// Test if we have operator:read permission by trying to access a pprof endpoint
-		// The /debug/pprof/heap endpoint requires operator:read when ACLs are enabled
-		_, err := c.client.Debug().Heap()
-		if err == nil {
-			// We have permission, allow pprof capture
-			c.UI.Info("[INFO] ACLs enabled and token has operator:read permissions, pprof capture allowed")
-			allowPprof = true
-		}
-	}
+	allowPprof := enableDebug || aclEnabled
 
 	if !allowPprof {
 		// Remove pprof from capture

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -552,3 +552,128 @@ func TestDebugCommand_DebugDisabled(t *testing.T) {
 	errOutput := ui.ErrorWriter.String()
 	require.Contains(t, errOutput, "Unable to capture pprof")
 }
+
+// TestDebugCommand_PprofScenarios tests the four specific pprof capture scenarios
+// based on enable_debug and ACL settings
+func TestDebugCommand_PprofScenarios(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	testCases := []struct {
+		name             string
+		enableDebug      bool
+		aclEnabled       bool
+		expectPprofFiles bool
+		expectWarning    bool
+		warningContains  string
+	}{
+		{
+			name:             "enable_debug=true, acl=disabled - pprof captured",
+			enableDebug:      true,
+			aclEnabled:       false,
+			expectPprofFiles: true,
+			expectWarning:    false,
+		},
+		{
+			name:             "enable_debug=true, acl=enabled - pprof captured",
+			enableDebug:      true,
+			aclEnabled:       true,
+			expectPprofFiles: true,
+			expectWarning:    false,
+		},
+		{
+			name:             "enable_debug=false, acl=enabled - pprof captured",
+			enableDebug:      false,
+			aclEnabled:       true,
+			expectPprofFiles: true,
+			expectWarning:    false,
+		},
+		{
+			name:             "enable_debug=false, acl=disabled - pprof NOT captured",
+			enableDebug:      false,
+			aclEnabled:       false,
+			expectPprofFiles: false,
+			expectWarning:    true,
+			warningContains:  "Unable to capture pprof",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Note: Not using t.Parallel() because concurrent pprof generation
+			// can cause conflicts and test failures
+
+			testDir := testutil.TempDir(t, "debug")
+
+			// Configure agent based on test case
+			config := fmt.Sprintf(`
+				enable_debug = %t
+				acl = {
+					enabled = %t
+					default_policy = "allow"
+				}
+			`, tc.enableDebug, tc.aclEnabled)
+
+			a := agent.NewTestAgent(t, config)
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+			ui := cli.NewMockUi()
+			cmd := New(ui)
+			cmd.validateTiming = false
+
+			outputPath := fmt.Sprintf("%s/debug", testDir)
+			args := []string{
+				"-http-addr=" + a.HTTPAddr(),
+				"-output=" + outputPath,
+				"-archive=false",
+				"-duration=1s",
+				"-interval=1s",
+			}
+
+			code := cmd.Run(args)
+			require.Equal(t, 0, code, "debug command should succeed")
+
+			// Check if pprof files were created
+			// Check files in root directory (profile.prof, trace.out)
+			rootProfiles := []string{"profile.prof", "trace.out"}
+			for _, profile := range rootProfiles {
+				profilePath := filepath.Join(outputPath, profile)
+				_, err := os.Stat(profilePath)
+
+				if tc.expectPprofFiles {
+					require.NoError(t, err,
+						"Expected pprof file %s to be created for scenario: %s", profile, tc.name)
+				} else {
+					require.True(t, os.IsNotExist(err),
+						"Expected pprof file %s NOT to be created for scenario: %s", profile, tc.name)
+				}
+			}
+
+			// Check files in timestamped subdirectories (heap.prof, goroutine.prof)
+			subdirProfiles := []string{"heap.prof", "goroutine.prof"}
+			for _, profile := range subdirProfiles {
+				profileFiles, _ := filepath.Glob(filepath.Join(outputPath, "*", profile))
+
+				if tc.expectPprofFiles {
+					require.True(t, len(profileFiles) > 0,
+						"Expected pprof file %s to be created in subdirectories for scenario: %s", profile, tc.name)
+				} else {
+					require.True(t, len(profileFiles) == 0,
+						"Expected pprof file %s NOT to be created in subdirectories for scenario: %s", profile, tc.name)
+				}
+			}
+
+			// Check warning messages
+			errOutput := ui.ErrorWriter.String()
+			if tc.expectWarning {
+				require.Contains(t, errOutput, tc.warningContains,
+					"Expected warning message for scenario: %s", tc.name)
+			} else {
+				require.NotContains(t, errOutput, "Unable to capture pprof",
+					"Did not expect pprof warning for scenario: %s", tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

This pr aims to fix a bug where consul cli would not collect pprof, even though acl were enabled.
Expected behaviour: Consul CLI should be able to capture pprof when ACL is enabled and a token with operator:read is used even when enable_debug config is not explicitly set. 

### Testing & Reproduction steps

I have tested 4 scenarios, 

[I] ACL Disabled, enable_debug not explicitly set

    Output:
    [WARN] Unable to capture pprof. Set enable_debug to true or enable ACLs.
    [WARN] Unable to capture pprof. Set enable_debug to true or enable ACLs.

[II] ACL Disabled, enable_debug set to true

    Output:
    ==> Starting debugger and capturing static information...
         Agent Version: '1.22.0'
              Interval: '30s'
              Duration: '2m0s'
                Output: 'consul-debug-2025-08-05T14-22-23Z.tar.gz'
               Capture: 'pprof'
    ==> Beginning capture interval 2025-08-05 14:22:23.646385703 +0000 UTC (0)
    ==> Capture successful 2025-08-05 14:22:23.663380376 +0000 UTC (0)

[III] ACL Enabled, enable_debug not explicitly set

    Output:
    [INFO] ACLs enabled and token has operator:read permissions, pprof capture allowed
    ==> Starting debugger and capturing static information...
         Agent Version: '1.22.0'
              Interval: '30s'
              Duration: '2m0s'
                Output: 'consul-debug-2025-08-05T14-22-23Z.tar.gz'
               Capture: 'pprof'
    ==> Beginning capture interval 2025-08-05 14:22:23.646385703 +0000 UTC (0)
    ==> Capture successful 2025-08-05 14:22:23.663380376 +0000 UTC (0)

[IV] ACL enabled, enable_debug set to true

    Output:
    ==> Starting debugger and capturing static information...
         Agent Version: '1.22.0'
              Interval: '30s'
              Duration: '2m0s'
                Output: 'consul-debug-2025-08-05T14-22-23Z.tar.gz'
               Capture: 'pprof'
    ==> Beginning capture interval 2025-08-05 14:22:23.646385703 +0000 UTC (0)
    ==> Capture successful 2025-08-05 14:22:23.663380376 +0000 UTC (0)

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
