### PR TITLE
update: fixed the backport-assistant version format

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -19,7 +19,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.5.8
+    container: hashicorpdev/backport-assistant:v0.5.8
     steps:
       - name: Run Backport Assistant for release branches
         run: |


### PR DESCRIPTION
Fixed the backport-assistant version format. Letter "v" needs to be prefixed for the latest versions.
