### PR TITLE
UI - Remove footer landmark

### DIFF
--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -73,7 +73,7 @@
   </:notifications>
 
   <:side-nav>
-    <Hds::SideNav @hasA11yRefocus={{false}} @isResponsive={{false}} class='consul-side-nav' data-test-navigation>
+    <Hds::SideNav @hasA11yRefocus={{false}} @isResponsive={{false}} class='consul-side-nav' role="navigation" data-test-navigation>
       <:header>
         <Hds::SideNav::Header>
           <:logo>
@@ -211,7 +211,7 @@
         </Hds::SideNav::List>
       </:body>
       <:footer>
-        <footer role='contentinfo' data-test-footer>
+        <div data-test-footer>
           <Hds::Text::Display
             class='hds-side-nav-hide-when-minimized'
             @size='100'
@@ -220,7 +220,7 @@
             {{t "components.hashicorp-consul.side-nav.footer" version=this.consulVersion}}
           </Hds::Text::Display>
           {{{concat '<!-- ' (env 'CONSUL_GIT_SHA') '-->'}}}
-        </footer>
+        </div>
       </:footer>
     </Hds::SideNav>
   </:side-nav>

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -211,7 +211,7 @@
         </Hds::SideNav::List>
       </:body>
       <:footer>
-        <div data-test-footer>
+        <div data-test-footer id="contentinfo">
           <Hds::Text::Display
             class='hds-side-nav-hide-when-minimized'
             @size='100'

--- a/ui/packages/consul-ui/app/components/list-collection/index.js
+++ b/ui/packages/consul-ui/app/components/list-collection/index.js
@@ -59,7 +59,7 @@ export default Component.extend(Slotted, {
       // TODO: This top part is very similar to resize in tabular-collection
       // see if it make sense to DRY out
       const dom = this.dom;
-      const $footer = dom.element('footer[role="contentinfo"]');
+      const $footer = dom.element('#contentinfo');
       if ($footer) {
         const border = 1;
         const rect = this.$element.getBoundingClientRect();
@@ -83,7 +83,7 @@ export default Component.extend(Slotted, {
         const groupRect = $group.getBoundingClientRect();
         const groupBottom = groupRect.top + $group.clientHeight;
 
-        const $footer = this.dom.element('footer[role="contentinfo"]');
+        const $footer = this.dom.element('#contentinfo');
         const footerRect = $footer.getBoundingClientRect();
         const footerTop = footerRect.top;
 

--- a/ui/packages/consul-ui/app/components/modal-dialog/index.hbs
+++ b/ui/packages/consul-ui/app/components/modal-dialog/index.hbs
@@ -52,7 +52,7 @@
               )}}
             </YieldSlot>
           </div>
-          <footer class="modal-dialog-footer">
+          <div class="modal-dialog-footer">
             <YieldSlot @name="actions" @params={{block-params (action "close")}}>
               {{yield (hash
                 open=(action "open")
@@ -61,7 +61,7 @@
                 aria=aria
               )}}
             </YieldSlot>
-          </footer>
+          </div>
         </div>
       </div>
     </div>

--- a/ui/packages/consul-ui/app/components/modal-dialog/layout.scss
+++ b/ui/packages/consul-ui/app/components/modal-dialog/layout.scss
@@ -58,7 +58,7 @@
   max-height: 80vh;
   padding: 20px 23px;
 }
-%modal-window > footer,
+%modal-window > .modal-dialog-footer,
 %modal-window > header {
   padding-top: 12px;
   padding-bottom: 10px;

--- a/ui/packages/consul-ui/app/components/modal-dialog/skin.scss
+++ b/ui/packages/consul-ui/app/components/modal-dialog/skin.scss
@@ -29,7 +29,7 @@
   /*%frame-gray-000*/
   background-color: var(--token-color-surface-primary);
 }
-%modal-window > footer,
+%modal-window > .modal-dialog-footer,
 %modal-window > header {
   @extend %frame-gray-800;
 }
@@ -38,7 +38,7 @@
 }
 
 .modal-dialog-body,
-%modal-window > footer,
+%modal-window > .modal-dialog-footer,
 %modal-window > header {
   border-color: var(--token-color-palette-neutral-300);
 }
@@ -47,7 +47,7 @@
   border-left-width: 1px;
   border-right-width: 1px;
 }
-%modal-window > footer,
+%modal-window > .modal-dialog-footer,
 %modal-window > header {
   border-width: 1px;
 }

--- a/ui/packages/consul-ui/app/components/providers/dimension/README.mdx
+++ b/ui/packages/consul-ui/app/components/providers/dimension/README.mdx
@@ -13,7 +13,7 @@ can use this component to make it easy to take up the remaining space.
 ```
 
 By default, this component will take up the remaining viewport space by taking the
-top of itself as the top-boundary and the `footer[role="contentinfo"]` as the
+top of itself as the top-boundary and the `#contentinfo` as the
 bottom-boundary. In terms of Consul-UI this means _take up the entire space but
 stop at the footer that holds the consul version info at the bottom of the screen_.
 

--- a/ui/packages/consul-ui/app/components/providers/dimension/index.js
+++ b/ui/packages/consul-ui/app/components/providers/dimension/index.js
@@ -32,7 +32,7 @@ export default class DimensionsProvider extends Component {
   }
 
   get footer() {
-    return document.querySelector('footer[role="contentinfo"]');
+    return document.querySelector('#contentinfo');
   }
 
   @action measureDimensions(element) {

--- a/ui/packages/consul-ui/app/components/tabular-collection/index.js
+++ b/ui/packages/consul-ui/app/components/tabular-collection/index.js
@@ -107,7 +107,7 @@ export default CollectionComponent.extend(Slotted, {
         const groupRect = $group.getBoundingClientRect();
         const groupBottom = groupRect.top + $group.clientHeight;
 
-        const $footer = this.dom.element('footer[role="contentinfo"]');
+        const $footer = this.dom.element('#contentinfo');
         const footerRect = $footer.getBoundingClientRect();
         const footerTop = footerRect.top;
 


### PR DESCRIPTION
### Description

https://hashicorp.atlassian.net/browse/CSL-11371
Removes footer element from modal and navigation. 

Footer should be representing the footer of the whole page and should be unique. In Consul UI, there is no footer representation hence removing it. 

