### PR TITLE
add: testcase for IPv6 scenarios in peering establish api

### DIFF
--- a/agent/rpc/peering/testing.go
+++ b/agent/rpc/peering/testing.go
@@ -36,6 +36,7 @@ not valid
 
 var validAddress = "1.2.3.4:80"
 var validHostnameAddress = "foo.bar.baz:80"
+var validIPv6Address = "[2001:db8::1]:80"
 
 var validServerName = "server.consul"
 

--- a/agent/rpc/peering/testing.go
+++ b/agent/rpc/peering/testing.go
@@ -37,6 +37,8 @@ not valid
 var validAddress = "1.2.3.4:80"
 var validHostnameAddress = "foo.bar.baz:80"
 var validIPv6Address = "[2001:db8::1]:80"
+var invalidIPv6Address = "[2001:db8::1:80]"
+var ipv6AddressWithoutPort = "2001:db8::1"
 
 var validServerName = "server.consul"
 

--- a/agent/rpc/peering/validate_test.go
+++ b/agent/rpc/peering/validate_test.go
@@ -67,6 +67,36 @@ func TestValidatePeeringToken(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid ipv6 without port",
+			token: &structs.PeeringToken{
+				CA:              []string{validCA},
+				ServerAddresses: []string{"2001:db8::1"},
+			},
+			wantErr: &errPeeringInvalidServerAddress{
+				"2001:db8::1",
+			},
+		},
+		{
+			name: "invalid ipv6 without port - manual",
+			token: &structs.PeeringToken{
+				CA:                    []string{validCA},
+				ManualServerAddresses: []string{"2001:db8::1"},
+			},
+			wantErr: &errPeeringInvalidServerAddress{
+				"2001:db8::1",
+			},
+		},
+		{
+			name: "invalid ipv6 missing brackets - manual",
+			token: &structs.PeeringToken{
+				CA:                    []string{validCA},
+				ManualServerAddresses: []string{"2001:db8::1:80"},
+			},
+			wantErr: &errPeeringInvalidServerAddress{
+				"2001:db8::1:80",
+			},
+		},
+		{
 			name: "invalid server name",
 			token: &structs.PeeringToken{
 				CA:              []string{validCA},
@@ -99,6 +129,24 @@ func TestValidatePeeringToken(t *testing.T) {
 				ServerAddresses: []string{validHostnameAddress},
 				ServerName:      validServerName,
 				PeerID:          validPeerID,
+			},
+		},
+		{
+			name: "valid token with ipv6 address - manual",
+			token: &structs.PeeringToken{
+				CA:                    []string{validCA},
+				ManualServerAddresses: []string{validIPv6Address},
+				ServerName:            validServerName,
+				PeerID:                validPeerID,
+			},
+		},
+		{
+			name: "valid mixed ipv4 and ipv6 addresses - manual",
+			token: &structs.PeeringToken{
+				CA:                    []string{validCA},
+				ManualServerAddresses: []string{validAddress, validIPv6Address},
+				ServerName:            validServerName,
+				PeerID:                validPeerID,
 			},
 		},
 	}

--- a/agent/rpc/peering/validate_test.go
+++ b/agent/rpc/peering/validate_test.go
@@ -70,30 +70,30 @@ func TestValidatePeeringToken(t *testing.T) {
 			name: "invalid ipv6 without port",
 			token: &structs.PeeringToken{
 				CA:              []string{validCA},
-				ServerAddresses: []string{"2001:db8::1"},
+				ServerAddresses: []string{ipv6AddressWithoutPort},
 			},
 			wantErr: &errPeeringInvalidServerAddress{
-				"2001:db8::1",
+				ipv6AddressWithoutPort,
 			},
 		},
 		{
 			name: "invalid ipv6 without port - manual",
 			token: &structs.PeeringToken{
 				CA:                    []string{validCA},
-				ManualServerAddresses: []string{"2001:db8::1"},
+				ManualServerAddresses: []string{ipv6AddressWithoutPort},
 			},
 			wantErr: &errPeeringInvalidServerAddress{
-				"2001:db8::1",
+				ipv6AddressWithoutPort,
 			},
 		},
 		{
 			name: "invalid ipv6 missing brackets - manual",
 			token: &structs.PeeringToken{
 				CA:                    []string{validCA},
-				ManualServerAddresses: []string{"2001:db8::1:80"},
+				ManualServerAddresses: []string{invalidIPv6Address},
 			},
 			wantErr: &errPeeringInvalidServerAddress{
-				"2001:db8::1:80",
+				invalidIPv6Address,
 			},
 		},
 		{


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change, in plain English. -->
This PR adds test coverage for IPv6 address handling in the /peering/establish endpoint.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding
-->
Unit Test: TestValidatePeeringToken in agent/rpc/peering — verifies /peering/establish correctly handles valid and invalid IPv6 addresses during peering setup.
````
go test -timeout 30s -run ^TestValidatePeeringToken$ github.com/hashicorp/consul/agent/rpc/peering
````


### Links
- [CSL-11318](https://hashicorp.atlassian.net/browse/CSL-11318) — [consul-peering-http-api]: Add IPv6 test case in /peering/establish
<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [] external facing docs updated
* [] appropriate backport labels added
* [x] not a security concern



[CSL-11318]: https://hashicorp.atlassian.net/browse/CSL-11318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ