### PR TITLE
ui: CSL-11417 replace foreground-disabled with foreground-faint

### DIFF
--- a/ui/packages/consul-ui/app/components/anchors/index.scss
+++ b/ui/packages/consul-ui/app/components/anchors/index.scss
@@ -9,7 +9,7 @@ a[rel*='external']::after {
   margin-left: 8px;
 }
 %main-content label a[rel*='help'] {
-  color: var(--token-color-foreground-disabled);
+  color: var(--token-color-foreground-faint);
 }
 %main-content a[rel*='help']::after {
   @extend %with-info-circle-outline-icon, %as-pseudo;

--- a/ui/packages/consul-ui/app/components/app-view/skin.scss
+++ b/ui/packages/consul-ui/app/components/app-view/skin.scss
@@ -16,7 +16,7 @@
   color: var(--token-color-hashicorp-brand);
 }
 %app-view-content div > dl > dd {
-  color: var(--token-color-foreground-disabled);
+  color: var(--token-color-foreground-faint);
 }
 %app-view-title,
 %app-view-content form:not(.filter-bar) fieldset {

--- a/ui/packages/consul-ui/app/components/confirmation-dialog/skin.scss
+++ b/ui/packages/consul-ui/app/components/confirmation-dialog/skin.scss
@@ -7,5 +7,5 @@ table div.with-confirmation.confirming {
   background-color: var(--token-color-surface-primary);
 }
 %confirmation-dialog-inline p {
-  color: var(--token-color-foreground-disabled);
+  color: var(--token-color-foreground-faint);
 }

--- a/ui/packages/consul-ui/app/components/consul/health-check/list/skin.scss
+++ b/ui/packages/consul-ui/app/components/consul/health-check/list/skin.scss
@@ -48,7 +48,7 @@
   border-radius: var(--decor-radius-100);
 }
 %healthcheck-output dd:first-of-type {
-  color: var(--token-color-foreground-disabled);
+  color: var(--token-color-foreground-faint);
 }
 %healthcheck-output pre {
   background-color: var(--token-color-surface-strong);

--- a/ui/packages/consul-ui/app/components/form-elements/skin.scss
+++ b/ui/packages/consul-ui/app/components/form-elements/skin.scss
@@ -19,7 +19,7 @@ textarea:disabled + .CodeMirror,
 %form fieldset > p,
 %form-element-note,
 %form-element-text-input::placeholder {
-  color: var(--token-color-foreground-disabled);
+  color: var(--token-color-foreground-faint);
 }
 %form-element-error > input,
 %form-element-error > textarea {

--- a/ui/packages/consul-ui/app/components/freetext-filter/skin.scss
+++ b/ui/packages/consul-ui/app/components/freetext-filter/skin.scss
@@ -10,7 +10,7 @@
 
     background-color: var(--token-color-surface-primary);
     border-color: var(--token-color-surface-interactive-active);
-    color: var(--token-color-foreground-disabled);
+    color: var(--token-color-foreground-faint);
   }
   &:hover,
   &:hover * {

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.scss
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.scss
@@ -13,7 +13,7 @@
       min-height: var(--token-side-nav-body-list-item-height);
       padding: var(--token-side-nav-body-list-item-padding-vertical)
         var(--token-side-nav-body-list-item-padding-horizontal);
-      color: var(--token-color-foreground-disabled);
+      color: var(--token-color-foreground-faint);
     }
 
     li.consul-side-nav__selector {
@@ -21,7 +21,7 @@
         min-width: 15.5rem;
 
         &:disabled {
-          color: var(--token-color-foreground-disabled);
+          color: var(--token-color-foreground-faint);
           border-color: var(--token-color-border-primary);
 
           &:hover {

--- a/ui/packages/consul-ui/app/components/popover-select/index.scss
+++ b/ui/packages/consul-ui/app/components/popover-select/index.scss
@@ -45,7 +45,7 @@
 }
 %popover-select .value-empty button::before {
   @extend %with-minus-square-fill-mask, %as-pseudo;
-  color: var(--token-color-foreground-disabled);
+  color: var(--token-color-foreground-faint);
 }
 %popover-select .value-unknown button::before {
   @extend %with-help-circle-outline-mask, %as-pseudo;

--- a/ui/packages/consul-ui/app/components/topology-metrics/stats/index.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/stats/index.scss
@@ -20,7 +20,7 @@
     line-height: 1.5em !important;
   }
   dd {
-    color: var(--token-color-foreground-disabled) !important;
+    color: var(--token-color-foreground-faint) !important;
   }
   span {
     padding-bottom: 12px;

--- a/ui/packages/consul-ui/app/styles/base/color/ui/frame-placeholders.scss
+++ b/ui/packages/consul-ui/app/styles/base/color/ui/frame-placeholders.scss
@@ -18,7 +18,7 @@
   @extend %frame-border-000;
   background-color: var(--token-color-surface-strong);
   border-color: var(--token-color-palette-neutral-300);
-  color: var(--token-color-foreground-disabled);
+  color: var(--token-color-foreground-faint);
 }
 /* button focus */
 %frame-gray-300 {

--- a/ui/packages/consul-ui/app/styles/debug.scss
+++ b/ui/packages/consul-ui/app/styles/debug.scss
@@ -245,7 +245,7 @@ html.with-route-announcer .route-title {
       }
       figcaption {
         margin-bottom: 0.5rem;
-        color: var(--token-color-foreground-disabled);
+        color: var(--token-color-foreground-faint);
         font-style: italic;
       }
       figcaption code {


### PR DESCRIPTION
### Description

foreground-disabled color was being used for help and sub texts. This color on top of white background doesn't maintain minimum required contrast. foreground-faint seems to be more suitable for such texts which meets accessibility standards. 

PR replaces references of foreground-disabled with foreground-faint on text color property. 