### PR TITLE
update ui server to replace ContentPath variable in js assets as well

### DIFF
--- a/agent/uiserver/uiserver.go
+++ b/agent/uiserver/uiserver.go
@@ -316,5 +316,7 @@ func (h *Handler) serveTransformedJS(w http.ResponseWriter, jsPath string) {
 	js := string(content)
 	js = strings.ReplaceAll(js, "{{.ContentPath}}", contentPath)
 	w.Header().Set("Content-Type", "application/javascript")
-	w.Write([]byte(js))
+	if _, err := w.Write([]byte(js)); err != nil {
+		h.logger.Error("Failed to write JS response: %s", err)
+	}
 }

--- a/agent/uiserver/uiserver.go
+++ b/agent/uiserver/uiserver.go
@@ -310,7 +310,7 @@ func (h *Handler) serveTransformedJS(w http.ResponseWriter, jsPath string) {
 
 	if !isSuccess {
 		http.Error(w, "ContentPath value not found in template data", http.StatusInternalServerError)
-		h.logger.Error("ContentPath value not found in template data: %s", err)
+		h.logger.Error("ContentPath value not found in template data")
 		return
 	}
 	js := string(content)

--- a/agent/uiserver/uiserver.go
+++ b/agent/uiserver/uiserver.go
@@ -269,8 +269,7 @@ func (h *Handler) serveTransformedJS(w http.ResponseWriter, jsPath string) {
 	if cfg.UIConfig.Dir == "" {
 		sub, err := fs.Sub(dist, "dist")
 		if err != nil {
-			http.Error(w, "Failed to open embedded dist", http.StatusInternalServerError)
-			h.logger.Error("Failed to open embedded dist: %s", err)
+			h.logger.Error("Failed to open embedded dist: %v", err)
 			return
 		}
 		fsys = sub
@@ -289,7 +288,7 @@ func (h *Handler) serveTransformedJS(w http.ResponseWriter, jsPath string) {
 	content, err := io.ReadAll(f)
 	if err != nil {
 		http.Error(w, "Failed to read JS file", http.StatusInternalServerError)
-		h.logger.Error("Failed to read JS file: %s", err)
+		h.logger.Error("Failed to read JS file: %v", err)
 		return
 	}
 
@@ -317,6 +316,6 @@ func (h *Handler) serveTransformedJS(w http.ResponseWriter, jsPath string) {
 	js = strings.ReplaceAll(js, "{{.ContentPath}}", contentPath)
 	w.Header().Set("Content-Type", "application/javascript")
 	if _, err := w.Write([]byte(js)); err != nil {
-		h.logger.Error("Failed to write JS response: %s", err)
+		h.logger.Error("Failed to write JS response: %v", err)
 	}
 }

--- a/agent/uiserver/uiserver.go
+++ b/agent/uiserver/uiserver.go
@@ -269,7 +269,7 @@ func (h *Handler) serveTransformedJS(w http.ResponseWriter, jsPath string) {
 	if cfg.UIConfig.Dir == "" {
 		sub, err := fs.Sub(dist, "dist")
 		if err != nil {
-			h.logger.Error("Failed to open embedded dist: %v", err)
+			h.logger.Error("Failed to open embedded dist: %w", err)
 			return
 		}
 		fsys = sub
@@ -280,7 +280,7 @@ func (h *Handler) serveTransformedJS(w http.ResponseWriter, jsPath string) {
 	f, err := fsys.Open(jsPath)
 	if err != nil {
 		http.Error(w, "JS file not found", http.StatusNotFound)
-		h.logger.Error("JS file not found: %s", err)
+		h.logger.Error("JS file not found: %w", err)
 		return
 	}
 	defer f.Close()
@@ -288,20 +288,20 @@ func (h *Handler) serveTransformedJS(w http.ResponseWriter, jsPath string) {
 	content, err := io.ReadAll(f)
 	if err != nil {
 		http.Error(w, "Failed to read JS file", http.StatusInternalServerError)
-		h.logger.Error("Failed to read JS file: %v", err)
+		h.logger.Error("Failed to read JS file: %w", err)
 		return
 	}
 
 	tplDataFull, err := uiTemplateDataFromConfig(cfg)
 	if err != nil {
 		http.Error(w, "Failed to load template data", http.StatusInternalServerError)
-		h.logger.Error("Failed to load template data: %s", err)
+		h.logger.Error("Failed to load template data: %w", err)
 		return
 	}
 	if h.transform != nil {
 		if err := h.transform(tplDataFull); err != nil {
 			http.Error(w, "Failed to run transform", http.StatusInternalServerError)
-			h.logger.Error("Failed to run transform: %s", err)
+			h.logger.Error("Failed to run transform: %w", err)
 			return
 		}
 	}
@@ -316,6 +316,6 @@ func (h *Handler) serveTransformedJS(w http.ResponseWriter, jsPath string) {
 	js = strings.ReplaceAll(js, "{{.ContentPath}}", contentPath)
 	w.Header().Set("Content-Type", "application/javascript")
 	if _, err := w.Write([]byte(js)); err != nil {
-		h.logger.Error("Failed to write JS response: %v", err)
+		h.logger.Error("Failed to write JS response: %w", err)
 	}
 }

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -690,7 +690,7 @@ func TestServeTransformedJS_ErrorCases(t *testing.T) {
 		h := NewHandler(cfg, testutil.Logger(t), nil)
 
 		req := httptest.NewRequest("GET", "/"+jsFile, nil)
-		
+
 		// Use a mock response writer that fails on Write
 		rec := &failingResponseWriter{
 			ResponseRecorder: httptest.NewRecorder(),

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -527,3 +527,211 @@ func TestServeTransformedJS(t *testing.T) {
 	// Other template variables should remain untouched
 	require.Contains(t, rec.Body.String(), "var untouched = \"{{.ACLsEnabled}}\";")
 }
+
+func TestServeTransformedJS_ErrorCases(t *testing.T) {
+	t.Run("JS file not found", func(t *testing.T) {
+		// Prepare a temp dir without the JS file
+		uiDir := testutil.TempDir(t, "consul-uiserver-js-error")
+		defer os.RemoveAll(uiDir)
+
+		cfg := basicUIEnabledConfig()
+		cfg.UIConfig.Dir = uiDir
+		h := NewHandler(cfg, testutil.Logger(t), nil)
+
+		req := httptest.NewRequest("GET", "/assets/chunk-nonexistent.js", nil)
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusNotFound, rec.Code)
+		require.Contains(t, rec.Body.String(), "JS file not found")
+	})
+
+	t.Run("JS file not found - embedded dist", func(t *testing.T) {
+		cfg := basicUIEnabledConfig()
+		// Use embedded dist (Dir is empty)
+		cfg.UIConfig.Dir = ""
+		h := NewHandler(cfg, testutil.Logger(t), nil)
+
+		req := httptest.NewRequest("GET", "/assets/chunk-nonexistent.js", nil)
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusNotFound, rec.Code)
+		require.Contains(t, rec.Body.String(), "JS file not found")
+	})
+
+	t.Run("unreadable JS file", func(t *testing.T) {
+		// Create a directory with the same name as the JS file to cause read error
+		uiDir := testutil.TempDir(t, "consul-uiserver-js-error")
+		defer os.RemoveAll(uiDir)
+
+		jsFile := "assets/chunk-test.js"
+		jsPath := filepath.Join(uiDir, jsFile)
+		require.NoError(t, os.MkdirAll(jsPath, 0755)) // Create directory instead of file
+
+		cfg := basicUIEnabledConfig()
+		cfg.UIConfig.Dir = uiDir
+		h := NewHandler(cfg, testutil.Logger(t), nil)
+
+		req := httptest.NewRequest("GET", "/"+jsFile, nil)
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+		require.Contains(t, rec.Body.String(), "Failed to read JS file")
+	})
+
+	t.Run("transform function error", func(t *testing.T) {
+		// Prepare a temp dir and JS file
+		uiDir := testutil.TempDir(t, "consul-uiserver-js-error")
+		defer os.RemoveAll(uiDir)
+
+		jsFile := "assets/chunk-test.js"
+		jsPath := filepath.Join(uiDir, jsFile)
+		jsContent := `var root = "{{.ContentPath}}";`
+		require.NoError(t, os.MkdirAll(filepath.Dir(jsPath), 0755))
+		require.NoError(t, os.WriteFile(jsPath, []byte(jsContent), 0644))
+
+		cfg := basicUIEnabledConfig()
+		cfg.UIConfig.Dir = uiDir
+
+		// Create a transform function that returns an error
+		transform := func(data map[string]interface{}) error {
+			return &UITransformError{msg: "transform failed"}
+		}
+		h := NewHandler(cfg, testutil.Logger(t), transform)
+
+		req := httptest.NewRequest("GET", "/"+jsFile, nil)
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+		require.Contains(t, rec.Body.String(), "Failed to run transform")
+	})
+
+	t.Run("ContentPath not found in template data", func(t *testing.T) {
+		// Prepare a temp dir and JS file
+		uiDir := testutil.TempDir(t, "consul-uiserver-js-error")
+		defer os.RemoveAll(uiDir)
+
+		jsFile := "assets/chunk-test.js"
+		jsPath := filepath.Join(uiDir, jsFile)
+		jsContent := `var root = "{{.ContentPath}}";`
+		require.NoError(t, os.MkdirAll(filepath.Dir(jsPath), 0755))
+		require.NoError(t, os.WriteFile(jsPath, []byte(jsContent), 0644))
+
+		cfg := basicUIEnabledConfig()
+		cfg.UIConfig.Dir = uiDir
+
+		// Create a transform function that removes ContentPath
+		transform := func(data map[string]interface{}) error {
+			delete(data, "ContentPath")
+			return nil
+		}
+		h := NewHandler(cfg, testutil.Logger(t), transform)
+
+		req := httptest.NewRequest("GET", "/"+jsFile, nil)
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+		require.Contains(t, rec.Body.String(), "ContentPath value not found in template data")
+	})
+
+	t.Run("ContentPath wrong type in template data", func(t *testing.T) {
+		// Prepare a temp dir and JS file
+		uiDir := testutil.TempDir(t, "consul-uiserver-js-error")
+		defer os.RemoveAll(uiDir)
+
+		jsFile := "assets/chunk-test.js"
+		jsPath := filepath.Join(uiDir, jsFile)
+		jsContent := `var root = "{{.ContentPath}}";`
+		require.NoError(t, os.MkdirAll(filepath.Dir(jsPath), 0755))
+		require.NoError(t, os.WriteFile(jsPath, []byte(jsContent), 0644))
+
+		cfg := basicUIEnabledConfig()
+		cfg.UIConfig.Dir = uiDir
+
+		// Create a transform function that changes ContentPath to wrong type
+		transform := func(data map[string]interface{}) error {
+			data["ContentPath"] = 123 // Set to non-string type
+			return nil
+		}
+		h := NewHandler(cfg, testutil.Logger(t), transform)
+
+		req := httptest.NewRequest("GET", "/"+jsFile, nil)
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+		require.Contains(t, rec.Body.String(), "ContentPath value not found in template data")
+	})
+
+	t.Run("response writer error", func(t *testing.T) {
+		// Prepare a temp dir and JS file
+		uiDir := testutil.TempDir(t, "consul-uiserver-js-error")
+		defer os.RemoveAll(uiDir)
+
+		jsFile := "assets/chunk-test.js"
+		jsPath := filepath.Join(uiDir, jsFile)
+		jsContent := `var root = "{{.ContentPath}}";`
+		require.NoError(t, os.MkdirAll(filepath.Dir(jsPath), 0755))
+		require.NoError(t, os.WriteFile(jsPath, []byte(jsContent), 0644))
+
+		cfg := basicUIEnabledConfig()
+		cfg.UIConfig.Dir = uiDir
+		cfg.UIConfig.ContentPath = "/ui/"
+		h := NewHandler(cfg, testutil.Logger(t), nil)
+
+		req := httptest.NewRequest("GET", "/"+jsFile, nil)
+		
+		// Use a mock response writer that fails on Write
+		rec := &failingResponseWriter{
+			ResponseRecorder: httptest.NewRecorder(),
+			failOnWrite:      true,
+		}
+
+		h.ServeHTTP(rec, req)
+
+		// The response should still have the correct content-type header set
+		// but the body write will fail and be logged
+		require.Equal(t, "application/javascript", rec.Header().Get("Content-Type"))
+	})
+}
+
+// UITransformError is a helper error type for testing transform failures
+type UITransformError struct {
+	msg string
+}
+
+func (e *UITransformError) Error() string {
+	return e.msg
+}
+
+// failingResponseWriter is a mock response writer that can simulate write failures
+type failingResponseWriter struct {
+	*httptest.ResponseRecorder
+	failOnWrite bool
+}
+
+func (f *failingResponseWriter) Write(data []byte) (int, error) {
+	if f.failOnWrite {
+		return 0, &writeError{msg: "simulated write failure"}
+	}
+	return f.ResponseRecorder.Write(data)
+}
+
+// writeError is a helper error type for simulating write failures
+type writeError struct {
+	msg string
+}
+
+func (e *writeError) Error() string {
+	return e.msg
+}


### PR DESCRIPTION
### Description

We recently updated code editor to use hds code-editor instead of ivymirror code editor. The hds editor uses dynamic imports, which causes some js assets to include paths to these files. These paths are again dynamic since they depend on the variable `-ui-content-path`. Therefore, these paths in the files are to be transformed before getting served to the client. 

This PR adds a new method which replaces the variable {{.ContentPath}} in these files with the actual value. To limit the blast radius, i've included files which match `assets/chunk` prefix. 

### Testing & Reproduction steps

This [issue](https://github.com/hashicorp/consul/issues/22574) has steps to reproduce.

### Links

https://github.com/hashicorp/consul/issues/22574


### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
