### PR TITLE
max_request_headers_kb param handling in Proxy Defaults for Connect Proxy

### DIFF
--- a/.changelog/22604.txt
+++ b/.changelog/22604.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+config: Add new parameter `max_request_headers_kb` to configure maximum header size for requests from downstream to upstream
+```

--- a/agent/proxycfg/proxycfg.deepcopy.go
+++ b/agent/proxycfg/proxycfg.deepcopy.go
@@ -167,6 +167,10 @@ func (o *ConfigSnapshot) DeepCopy() *ConfigSnapshot {
 			cp.computedFields.proxyConfig.LocalIdleTimeoutMs = new(int)
 			*cp.computedFields.proxyConfig.LocalIdleTimeoutMs = *o.computedFields.proxyConfig.LocalIdleTimeoutMs
 		}
+		if o.computedFields.proxyConfig.MaxRequestHeadersKB != nil {
+			cp.computedFields.proxyConfig.MaxRequestHeadersKB = new(uint32)
+			*cp.computedFields.proxyConfig.MaxRequestHeadersKB = *o.computedFields.proxyConfig.MaxRequestHeadersKB
+		}
 	}
 	if o.computedFields.gatewayConfig != nil {
 		cp.computedFields.gatewayConfig = new(config.GatewayConfig)

--- a/agent/xds/config/config.go
+++ b/agent/xds/config/config.go
@@ -122,6 +122,8 @@ type ProxyConfig struct {
 	// BalanceInboundConnections indicates how the proxy should attempt to distribute
 	// connections across worker threads. Only used by envoy proxies.
 	BalanceInboundConnections string `json:",omitempty" alias:"balance_inbound_connections"`
+
+	MaxRequestHeadersKB *uint32 `json:",omitempty" mapstructure:"max_request_headers_kb"`
 }
 
 // ParseProxyConfig returns the ProxyConfig parsed from the an opaque map. If an
@@ -135,6 +137,7 @@ func ParseProxyConfig(m map[string]interface{}) (ProxyConfig, error) {
 
 	if cfg.Protocol == "" {
 		cfg.Protocol = "tcp"
+		// TODO::: Remove cfg.Protocol = "http"
 	} else {
 		cfg.Protocol = strings.ToLower(cfg.Protocol)
 	}

--- a/agent/xds/config/config.go
+++ b/agent/xds/config/config.go
@@ -123,6 +123,8 @@ type ProxyConfig struct {
 	// connections across worker threads. Only used by envoy proxies.
 	BalanceInboundConnections string `json:",omitempty" alias:"balance_inbound_connections"`
 
+	// MaxRequestHeadersKB configures the maximum size in kilobytes for request headers
+	// sent from downstream clients to upstream services. If not set, uses Envoy's default.
 	MaxRequestHeadersKB *uint32 `json:",omitempty" mapstructure:"max_request_headers_kb"`
 }
 

--- a/agent/xds/config/config.go
+++ b/agent/xds/config/config.go
@@ -137,7 +137,6 @@ func ParseProxyConfig(m map[string]interface{}) (ProxyConfig, error) {
 
 	if cfg.Protocol == "" {
 		cfg.Protocol = "tcp"
-		// TODO::: Remove cfg.Protocol = "http"
 	} else {
 		cfg.Protocol = strings.ToLower(cfg.Protocol)
 	}

--- a/agent/xds/config/config_test.go
+++ b/agent/xds/config/config_test.go
@@ -207,6 +207,73 @@ func TestParseProxyConfig(t *testing.T) {
 				BalanceInboundConnections: "exact_balance",
 			},
 		},
+		{
+			name: "max request headers KB override, int",
+			input: map[string]interface{}{
+				"max_request_headers_kb": 96,
+			},
+			want: ProxyConfig{
+				LocalConnectTimeoutMs: 5000,
+				Protocol:              "tcp",
+				MaxRequestHeadersKB:   uintPointer(96),
+			},
+		},
+		{
+			name: "max request headers KB override, float",
+			input: map[string]interface{}{
+				"max_request_headers_kb": float64(128.0),
+			},
+			want: ProxyConfig{
+				LocalConnectTimeoutMs: 5000,
+				Protocol:              "tcp",
+				MaxRequestHeadersKB:   uintPointer(128),
+			},
+		},
+		{
+			name: "max request headers KB override, string",
+			input: map[string]interface{}{
+				"max_request_headers_kb": "256",
+			},
+			want: ProxyConfig{
+				LocalConnectTimeoutMs: 5000,
+				Protocol:              "tcp",
+				MaxRequestHeadersKB:   uintPointer(256),
+			},
+		},
+		{
+			name: "max request headers KB with zero value",
+			input: map[string]interface{}{
+				"max_request_headers_kb": 0,
+			},
+			want: ProxyConfig{
+				LocalConnectTimeoutMs: 5000,
+				Protocol:              "tcp",
+				MaxRequestHeadersKB:   uintPointer(0),
+			},
+		},
+		{
+			name: "kitchen sink with max request headers",
+			input: map[string]interface{}{
+				"protocol":                    "http",
+				"bind_address":                "127.0.0.2",
+				"bind_port":                   8888,
+				"local_connect_timeout_ms":    1000,
+				"local_request_timeout_ms":    2000,
+				"local_idle_timeout_ms":       3000,
+				"balance_inbound_connections": "exact_balance",
+				"max_request_headers_kb":      96,
+			},
+			want: ProxyConfig{
+				LocalConnectTimeoutMs:     1000,
+				LocalRequestTimeoutMs:     intPointer(2000),
+				LocalIdleTimeoutMs:        intPointer(3000),
+				Protocol:                  "http",
+				BindAddress:               "127.0.0.2",
+				BindPort:                  8888,
+				BalanceInboundConnections: "exact_balance",
+				MaxRequestHeadersKB:       uintPointer(96),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -310,6 +377,10 @@ func TestParseGatewayConfig(t *testing.T) {
 }
 
 func intPointer(i int) *int {
+	return &i
+}
+
+func uintPointer(i uint32) *uint32 {
 	return &i
 }
 

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -198,7 +198,6 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 				upstream:   upstreamCfg,
 			}
 			upstreamListener := makeListener(opts)
-			// [xdscommon.ListenerType].FilterChains.filter.ConfigType.TypedConfig
 			s.injectConnectionBalanceConfig(cfg.BalanceOutboundConnections, upstreamListener)
 			upstreamListener.FilterChains = []*envoy_listener_v3.FilterChain{
 				filterChain,
@@ -212,7 +211,6 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		// The rest of this loop is used exclusively for transparent proxies.
 		// Below we create a filter chain per upstream, rather than a listener per upstream
 		// as we do for explicit upstreams above.
-		// [xdscommon.ListenerType].FilterChains.filter.ConfigType.TypedConfig
 		filterChain, err := s.makeUpstreamFilterChain(filterChainOpts{
 			accessLogs:          &cfgSnap.Proxy.AccessLogs,
 			routeName:           uid.EnvoyID(),
@@ -2546,7 +2544,6 @@ func makeHTTPFilter(opts listenerFilterOpts) (*envoy_listener_v3.Filter, error) 
 
 	// Set max request headers size if configured
 	if opts.maxRequestHeadersKb != nil {
-		// && *opts.maxRequestHeadersKb == 96
 		cfg.MaxRequestHeadersKb = &wrapperspb.UInt32Value{Value: *opts.maxRequestHeadersKb}
 	}
 

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -176,14 +176,15 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		// Generate the upstream listeners for when they are explicitly set with a local bind port or socket path
 		if upstreamCfg != nil && upstreamCfg.HasLocalPortOrSocket() {
 			filterChain, err := s.makeUpstreamFilterChain(filterChainOpts{
-				accessLogs:      &cfgSnap.Proxy.AccessLogs,
-				routeName:       uid.EnvoyID(),
-				clusterName:     clusterName,
-				filterName:      filterName,
-				protocol:        cfg.Protocol,
-				useRDS:          useRDS,
-				fetchTimeoutRDS: cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
-				tracing:         tracing,
+				accessLogs:          &cfgSnap.Proxy.AccessLogs,
+				routeName:           uid.EnvoyID(),
+				clusterName:         clusterName,
+				filterName:          filterName,
+				protocol:            cfg.Protocol,
+				useRDS:              useRDS,
+				fetchTimeoutRDS:     cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
+				tracing:             tracing,
+				maxRequestHeadersKb: proxyCfg.MaxRequestHeadersKB,
 			})
 			if err != nil {
 				return nil, err

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -2548,7 +2548,6 @@ func makeHTTPFilter(opts listenerFilterOpts) (*envoy_listener_v3.Filter, error) 
 		// && *opts.maxRequestHeadersKb == 96
 		cfg.MaxRequestHeadersKb = &wrapperspb.UInt32Value{Value: *opts.maxRequestHeadersKb}
 	}
-	// TODO::: Remove cfg.MaxRequestHeadersKb = &wrapperspb.UInt32Value{Value: 96}
 
 	if opts.useRDS {
 		if opts.cluster != "" {

--- a/agent/xds/listeners_apigateway.go
+++ b/agent/xds/listeners_apigateway.go
@@ -119,15 +119,14 @@ func (s *ResourceGenerator) makeAPIGatewayListeners(address string, cfgSnap *pro
 					cfgSnap,
 					cfgSnap.APIGateway.TLSConfig,
 					listenerKey.Protocol, listenerFilterOpts{
-						useRDS:              useRDS,
-						fetchTimeoutRDS:     cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
-						protocol:            listenerKey.Protocol,
-						routeName:           listenerKey.RouteName(),
-						cluster:             clusterName,
-						statPrefix:          "ingress_upstream_",
-						accessLogs:          &cfgSnap.Proxy.AccessLogs,
-						logger:              s.Logger,
-						maxRequestHeadersKb: nil, // API Gateway uses Envoy defaults
+						useRDS:          useRDS,
+						fetchTimeoutRDS: cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
+						protocol:        listenerKey.Protocol,
+						routeName:       listenerKey.RouteName(),
+						cluster:         clusterName,
+						statPrefix:      "ingress_upstream_",
+						accessLogs:      &cfgSnap.Proxy.AccessLogs,
+						logger:          s.Logger,
 					},
 					certs,
 				)
@@ -210,18 +209,17 @@ func (s *ResourceGenerator) makeAPIGatewayListeners(address string, cfgSnap *pro
 				}
 			}
 			filterOpts := listenerFilterOpts{
-				useRDS:              true,
-				fetchTimeoutRDS:     cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
-				protocol:            listenerKey.Protocol,
-				filterName:          listenerKey.RouteName(),
-				routeName:           listenerKey.RouteName(),
-				cluster:             "",
-				statPrefix:          "ingress_upstream_",
-				routePath:           "",
-				httpAuthzFilters:    authFilters,
-				accessLogs:          &cfgSnap.Proxy.AccessLogs,
-				logger:              s.Logger,
-				maxRequestHeadersKb: nil, // API Gateway uses Envoy defaults
+				useRDS:           true,
+				fetchTimeoutRDS:  cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
+				protocol:         listenerKey.Protocol,
+				filterName:       listenerKey.RouteName(),
+				routeName:        listenerKey.RouteName(),
+				cluster:          "",
+				statPrefix:       "ingress_upstream_",
+				routePath:        "",
+				httpAuthzFilters: authFilters,
+				accessLogs:       &cfgSnap.Proxy.AccessLogs,
+				logger:           s.Logger,
 			}
 
 			// Generate any filter chains needed for services with custom TLS certs

--- a/agent/xds/listeners_apigateway.go
+++ b/agent/xds/listeners_apigateway.go
@@ -118,16 +118,16 @@ func (s *ResourceGenerator) makeAPIGatewayListeners(address string, cfgSnap *pro
 				l.FilterChains, err = s.makeInlineOverrideFilterChains(
 					cfgSnap,
 					cfgSnap.APIGateway.TLSConfig,
-					listenerKey.Protocol,
-					listenerFilterOpts{
-						useRDS:          useRDS,
-						fetchTimeoutRDS: cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
-						protocol:        listenerKey.Protocol,
-						routeName:       listenerKey.RouteName(),
-						cluster:         clusterName,
-						statPrefix:      "ingress_upstream_",
-						accessLogs:      &cfgSnap.Proxy.AccessLogs,
-						logger:          s.Logger,
+					listenerKey.Protocol, listenerFilterOpts{
+						useRDS:              useRDS,
+						fetchTimeoutRDS:     cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
+						protocol:            listenerKey.Protocol,
+						routeName:           listenerKey.RouteName(),
+						cluster:             clusterName,
+						statPrefix:          "ingress_upstream_",
+						accessLogs:          &cfgSnap.Proxy.AccessLogs,
+						logger:              s.Logger,
+						maxRequestHeadersKb: nil, // API Gateway uses Envoy defaults
 					},
 					certs,
 				)
@@ -209,19 +209,19 @@ func (s *ResourceGenerator) makeAPIGatewayListeners(address string, cfgSnap *pro
 					return nil, err
 				}
 			}
-
 			filterOpts := listenerFilterOpts{
-				useRDS:           true,
-				fetchTimeoutRDS:  cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
-				protocol:         listenerKey.Protocol,
-				filterName:       listenerKey.RouteName(),
-				routeName:        listenerKey.RouteName(),
-				cluster:          "",
-				statPrefix:       "ingress_upstream_",
-				routePath:        "",
-				httpAuthzFilters: authFilters,
-				accessLogs:       &cfgSnap.Proxy.AccessLogs,
-				logger:           s.Logger,
+				useRDS:              true,
+				fetchTimeoutRDS:     cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
+				protocol:            listenerKey.Protocol,
+				filterName:          listenerKey.RouteName(),
+				routeName:           listenerKey.RouteName(),
+				cluster:             "",
+				statPrefix:          "ingress_upstream_",
+				routePath:           "",
+				httpAuthzFilters:    authFilters,
+				accessLogs:          &cfgSnap.Proxy.AccessLogs,
+				logger:              s.Logger,
+				maxRequestHeadersKb: nil, // API Gateway uses Envoy defaults
 			}
 
 			// Generate any filter chains needed for services with custom TLS certs

--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -630,6 +630,17 @@ func getConnectProxyDiscoChainTests(enterprise bool) []goldenTestCase {
 				)
 			},
 		},
+		{
+			name: "connect-proxy-with-http-max-request-headers",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				// Create a custom snapshot instead of using ProxyDefaults
+				snap := proxycfg.TestConfigSnapshotDiscoveryChain(t, "simple", enterprise, func(ns *structs.NodeService) {
+					ns.Proxy.Config["protocol"] = "http"
+					ns.Proxy.Config["max_request_headers_kb"] = 96
+				}, nil)
+				return snap
+			},
+		},
 	}
 
 	if enterprise {

--- a/agent/xds/testdata/clusters/connect-proxy-with-http-max-request-headers.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-http-max-request-headers.latest.golden
@@ -1,0 +1,136 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "altStatName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "circuitBreakers": {},
+      "commonLbConfig": {
+        "healthyPanicThreshold": {}
+      },
+      "connectTimeout": "33s",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {},
+          "resourceApiVersion": "V3"
+        }
+      },
+      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "outlierDetection": {},
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsCertificates": [
+              {
+                "certificateChain": {
+                  "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                },
+                "privateKey": {
+                  "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                }
+              }
+            ],
+            "tlsParams": {},
+            "validationContext": {
+              "matchTypedSubjectAltNames": [
+                {
+                  "matcher": {
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/db"
+                  },
+                  "sanType": "URI"
+                }
+              ],
+              "trustedCa": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+              }
+            }
+          },
+          "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+        }
+      },
+      "type": "EDS"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "circuitBreakers": {},
+      "connectTimeout": "5s",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {},
+          "resourceApiVersion": "V3"
+        }
+      },
+      "name": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "outlierDetection": {},
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsCertificates": [
+              {
+                "certificateChain": {
+                  "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                },
+                "privateKey": {
+                  "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                }
+              }
+            ],
+            "tlsParams": {},
+            "validationContext": {
+              "matchTypedSubjectAltNames": [
+                {
+                  "matcher": {
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                  },
+                  "sanType": "URI"
+                },
+                {
+                  "matcher": {
+                    "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
+                  },
+                  "sanType": "URI"
+                }
+              ],
+              "trustedCa": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+              }
+            }
+          },
+          "sni": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+        }
+      },
+      "type": "EDS"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "local_app",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "127.0.0.1",
+                      "portValue": 8080
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "name": "local_app",
+      "type": "STATIC"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/endpoints/connect-proxy-with-http-max-request-headers.latest.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-http-max-request-headers.latest.golden
@@ -1,0 +1,75 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.20.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/listeners/connect-proxy-with-http-max-request-headers.latest.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http-max-request-headers.latest.golden
@@ -1,0 +1,236 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "statPrefix": "upstream.db.default.default.dc1"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "db:127.0.0.1:9191",
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+                "statPrefix": "upstream.prepared_query_geo-cache"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "APPEND_FORWARD",
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.rbac",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                      "rules": {}
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.header_to_metadata",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config",
+                      "requestRules": [
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "trust-domain",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\1"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "partition",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\2"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "namespace",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\3"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "datacenter",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\4"
+                            }
+                          }
+                        },
+                        {
+                          "header": "x-forwarded-client-cert",
+                          "onHeaderPresent": {
+                            "key": "service",
+                            "metadataNamespace": "consul",
+                            "regexValueRewrite": {
+                              "pattern": {
+                                "regex": ".*URI=spiffe://([^/]+.[^/]+)(?:/ap/([^/]+))?/ns/([^/]+)/dc/([^/]+)/svc/([^/;,]+).*"
+                              },
+                              "substitution": "\\5"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "maxRequestHeadersKb": 96,
+                "normalizePath": true,
+                "routeConfig": {
+                  "name": "public_listener",
+                  "virtualHosts": [
+                    {
+                      "domains": [
+                        "*"
+                      ],
+                      "name": "public_listener",
+                      "routes": [
+                        {
+                          "match": {
+                            "prefix": "/"
+                          },
+                          "route": {
+                            "cluster": "local_app"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
+                },
+                "statPrefix": "public_listener",
+                "tracing": {
+                  "randomSampling": {}
+                },
+                "upgradeConfigs": [
+                  {
+                    "upgradeType": "websocket"
+                  }
+                ]
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "alpnProtocols": [
+                  "http/1.1"
+                ],
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "tlsParams": {},
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "name": "public_listener:0.0.0.0:9999",
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/routes/connect-proxy-with-http-max-request-headers.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-http-max-request-headers.latest.golden
@@ -1,0 +1,5 @@
+{
+  "nonce": "00000001",
+  "typeUrl": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/secrets/connect-proxy-with-http-max-request-headers.latest.golden
+++ b/agent/xds/testdata/secrets/connect-proxy-with-http-max-request-headers.latest.golden
@@ -1,0 +1,5 @@
+{
+  "nonce": "00000001",
+  "typeUrl": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+  "versionInfo": "00000001"
+}

--- a/test/integration/connect/envoy/case-max-request-headers/capture.sh
+++ b/test/integration/connect/envoy/case-max-request-headers/capture.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+snapshot_envoy_admin localhost:19000 s1 primary || true
+snapshot_envoy_admin localhost:19001 s2 primary || true

--- a/test/integration/connect/envoy/case-max-request-headers/service_s1.hcl
+++ b/test/integration/connect/envoy/case-max-request-headers/service_s1.hcl
@@ -1,0 +1,10 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+services {
+  name = "s1"
+  port = 8080
+  connect {
+    sidecar_service {}
+  }
+}

--- a/test/integration/connect/envoy/case-max-request-headers/service_s2.hcl
+++ b/test/integration/connect/envoy/case-max-request-headers/service_s2.hcl
@@ -1,0 +1,23 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+services {
+  name = "s2"
+  port = 8181
+  connect {
+    sidecar_service {
+      proxy {
+        upstreams = [
+          {
+            destination_name = "s1"
+            local_bind_port = 5000
+          }
+        ]
+        config {
+          protocol = "http"
+          max_request_headers_kb = 96
+        }
+      }
+    }
+  }
+}

--- a/test/integration/connect/envoy/case-max-request-headers/setup.sh
+++ b/test/integration/connect/envoy/case-max-request-headers/setup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -eEuo pipefail
+
+# Configure proxy-defaults with max_request_headers_kb setting
+upsert_config_entry primary '
+kind = "proxy-defaults"
+name = "global"
+config {
+  max_request_headers_kb = 96
+}
+'
+
+# Configure service defaults for HTTP protocol
+upsert_config_entry primary '
+kind = "service-defaults"
+name = "s1"
+protocol = "http"
+'
+
+upsert_config_entry primary '
+kind = "service-defaults" 
+name = "s2"
+protocol = "http"
+'
+
+# Register services
+register_services primary
+
+# Generate Envoy bootstrap configs
+gen_envoy_bootstrap s1 19000 primary
+gen_envoy_bootstrap s2 19001 primary

--- a/test/integration/connect/envoy/case-max-request-headers/verify.bats
+++ b/test/integration/connect/envoy/case-max-request-headers/verify.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "s1 proxy is running correct version" {
+  assert_envoy_version 19000
+}
+
+@test "s1 proxy admin is up on :19000" {
+  retry_default curl -f -s localhost:19000/stats -o /dev/null
+}
+
+@test "s2 proxy admin is up on :19001" {
+  retry_default curl -f -s localhost:19001/stats -o /dev/null
+}
+
+@test "s1 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21000 s1
+}
+
+@test "s2 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
+
+@test "s1 proxy should have max_request_headers_kb set to 96" {
+  assert_envoy_max_request_headers_kb 127.0.0.1:19000 96
+}
+
+@test "s2 proxy should have max_request_headers_kb set to 96" {
+  assert_envoy_max_request_headers_kb 127.0.0.1:19001 96
+}
+
+@test "s1 upstream should work with normal headers" {
+  run retry_default curl -s -f -d hello 127.0.0.1:5000
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "s2 should accept requests with headers under 96KB limit (95KB test)" {
+  # Create a header with 95KB of data (under the limit)
+  large_header=$(head -c 95000 < /dev/zero | tr '\0' 'a')
+  
+  run retry_default curl -s -f -H "X-Custom-Header: $large_header" -d "test-payload" 127.0.0.1:5000/
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test-payload"* ]]
+}
+
+@test "s2 should reject requests with headers over 96KB limit (99KB test)" {
+  # Create a header with 99KB of data (over the limit)
+  large_header=$(head -c 99000 < /dev/zero | tr '\0' 'a')
+  
+  # Test should return error response for headers exceeding limit
+  run curl -s -w "%{http_code}" -H "X-Custom-Header: $large_header" -d "test-payload" 127.0.0.1:5000/ -o /dev/null
+  [ "$status" -eq 0 ]
+  # Should get HTTP 431 (Request Header Fields Too Large) or similar error code
+  [[ "$output" == *"431"* ]]
+}


### PR DESCRIPTION
### Description

The Connect/ Sidecar Envoy proxy created is not allowing request from downstream to upstream with header > 60KB. To allow the request headers with increased header size envoy provides option in the bootstrap config by setting up a param called max_request_headers_kb and the max limit allowed is 96KB.

### Testing & Reproduction steps

1. Run the local consul server.
2. Register 2 services - serviceA and serviceB
serviceB.json:
```
{
  "service": {
    "name": "ServiceB",
    "port": 8080,
    "connect": {
      "sidecar_service": {
        "proxy": {
          "upstreams": [
            {
              "destination_name": "serviceA",
              "local_bind_port": 9191
            }
          ],
          "Config": {
            "protocol": "http",
            "max_request_headers_kb": 96
          }
        }
      }
    }
  }
}
```
4. Write proxy-defaults config with protocol as http, and max_request_headers as 96.
```
proxy-defaults.json:
{
  "Kind": "proxy-defaults", 
  "Name": "global",
  "Config": {
    "protocol": "http",
    "max_request_headers_kb": 96
  }
}
```
5. Connect to envoy with the mentioned configs from prox-defaults.
6. Once the envoy proxy is up and running then the check the config_dump, the max_request_headers_kb should be set.
7. Trigger the below curl to test with the increased header size
```
curl http://localhost:9191/ \
  -H "X-Custom-Header: $(head -c 95000 < /dev/zero | tr '\0' 'a')"
```
Based on the changes the proxy should allow up to ~=98000(96KB) size of header data. For >=99000(>96KB) it would throw 431 Request Header Fields Too Large status.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
