### PR TITLE
Changing error message to fix mismatch protocol among config entries

### DIFF
--- a/command/config/write/config_write.go
+++ b/command/config/write/config_write.go
@@ -86,7 +86,8 @@ func (c *cmd) Run(args []string) int {
 		written, _, err = entries.Set(entry, nil)
 	}
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error writing config entry %s/%s: %v", entry.GetKind(), entry.GetName(), err))
+		c.UI.Error(fmt.Sprintf("Error writing config entry %s/%s: %v — possible protocol conflict; check upstream configs (routers/gateways) referencing service '%s' with `consul config list` and `consul config read`.",
+			entry.GetKind(), entry.GetName(), err, entry.GetName()))
 		return 1
 	}
 


### PR DESCRIPTION
Changing error message to fix mismatch protocol among config entries, fixing this as part of a jira requirements. 

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
