### PR TITLE
Typo on ACL roles documentation

### DIFF
--- a/website/content/docs/secure/acl/role.mdx
+++ b/website/content/docs/secure/acl/role.mdx
@@ -62,7 +62,7 @@ Roles may contain the following attributes:
 - `Name`: A unique meaningful name for the role. You can specify the role `Name` when linking it to tokens.
 - `Description`: (Optional) A human-readable description of the role.
 - `Policies`: Specifies a the list of policies that are applicable for the role. The object can reference the policy `ID` or `Name` attribute.
-- `TemplatedPolicies`: Specifies a list of templated polcicies that are applicable for the role. See [Templated Policies](#templated-policies) for details.
+- `TemplatedPolicies`: Specifies a list of templated policies that are applicable for the role. See [Templated Policies](#templated-policies) for details.
 - `ServiceIdentities`: Specifies a list of services that are applicable for the role. See [Service Identities](#service-identities) for details.
 - `NodeIdentities`: Specifies a list of nodes that are applicable for the role. See [Node Identities](#node-identities) for details.
 - `Namespace`: <EnterpriseAlert inline /> The namespace that the policy resides in. Roles can only be linked to policies that are defined in the same namespace. See [Namespaces](/consul/docs/multi-tenant/namespace) for additional information. Requires Consul Enterprise 1.7.0+


### PR DESCRIPTION
Fixes spelling

