### PR TITLE
Add troubleshoot ports info in debug bundle

### DIFF
--- a/.changelog/22624.txt
+++ b/.changelog/22624.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: add troubleshoot ports in debug command. A ports.json file is created, which lists the open or closed ports on the host where the command is executed.
+```

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/google/pprof/profile"
 	"github.com/mitchellh/cli"
+	testifyassert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
@@ -78,6 +80,7 @@ func TestDebugCommand(t *testing.T) {
 			fs.WithFile("agent.json", "", fs.MatchFileContent(validJSON)),
 			fs.WithFile("host.json", "", fs.MatchFileContent(validJSON)),
 			fs.WithFile("members.json", "", fs.MatchFileContent(validJSON)),
+			fs.WithFile("ports.json", "", fs.MatchFileContent(validJSON)),
 			fs.WithFile("metrics.json", "", fs.MatchAnyFileContent),
 			fs.WithFile("listpeers.json", "", fs.MatchAnyFileContent),
 			fs.WithFile("consul.log", "", fs.MatchFileContent(validLogFile)),
@@ -225,7 +228,7 @@ func TestDebugCommand_Archive(t *testing.T) {
 		}
 
 		// should only contain this one capture target
-		if h.Name != "debug/agent.json" && h.Name != "debug/index.json" && h.Name != "debug/listpeers.json" {
+		if h.Name != "debug/agent.json" && h.Name != "debug/index.json" && h.Name != "debug/listpeers.json" && h.Name != "debug/ports.json" {
 			t.Fatalf("archive contents do not match: %s", h.Name)
 		}
 	}
@@ -674,6 +677,113 @@ func TestDebugCommand_PprofScenarios(t *testing.T) {
 				require.NotContains(t, errOutput, "Unable to capture pprof",
 					"Did not expect pprof warning for scenario: %s", tc.name)
 			}
+		})
+	}
+}
+
+func startMockTCPServer(t *testing.T, portsList []string) (cleanup func()) {
+	t.Helper()
+	var listeners []net.Listener
+
+	for _, port := range portsList {
+		listener, err := net.Listen("tcp", "127.0.0.1:"+port)
+		if err != nil {
+			for _, l := range listeners {
+				l.Close()
+			}
+			t.Fatalf("Failed to start mock TCP server on port %s: %v", port, err)
+		}
+
+		listeners = append(listeners, listener)
+
+	}
+	cleanup = func() {
+		for _, l := range listeners {
+			l.Close()
+		}
+	}
+
+	return cleanup
+}
+
+func TestDebugCommand_TroubleshootPorts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	emptyStrArr := []string{}
+
+	testCases := []struct {
+		name        string
+		portsOpen   []string
+		portsClosed []string
+	}{
+		{
+			name:        "All ports closed",
+			portsOpen:   emptyStrArr,
+			portsClosed: default_ports,
+		},
+		{
+			name:        "All ports opened",
+			portsOpen:   default_ports,
+			portsClosed: emptyStrArr,
+		},
+		{
+			name:        "Ports 8500, 8501, 8502, 8503 Open",
+			portsOpen:   []string{"8500", "8501", "8502", "8503"},
+			portsClosed: []string{"8600", "8301", "8302", "8300"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanup := startMockTCPServer(t, tc.portsOpen)
+			defer cleanup()
+
+			testDir := t.TempDir()
+
+			a := agent.NewTestAgent(t, `
+			enable_debug = true
+			`)
+
+			defer a.Shutdown()
+			testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+			ui := cli.NewMockUi()
+			cmd := New(ui)
+			cmd.validateTiming = false
+
+			outputPath := fmt.Sprintf("%s/debug", testDir)
+			args := []string{
+				"-http-addr=" + a.HTTPAddr(),
+				"-output=" + outputPath,
+				"-duration=2s",
+				"-interval=1s",
+				"-archive=false",
+			}
+
+			code := cmd.Run(args)
+			require.Equal(t, 0, code)
+			require.Equal(t, "", ui.ErrorWriter.String())
+
+			expected := PortStatus{
+				Open:   tc.portsOpen,
+				Closed: tc.portsClosed,
+			}
+
+			fileBytes, err := os.ReadFile(outputPath + "/ports.json")
+			if err != nil {
+				t.Fatalf("Failed to read output file %q: %v", outputPath, err)
+			}
+
+			// Parse JSON into struct
+			var actual PortStatus
+			if err := json.Unmarshal(fileBytes, &actual); err != nil {
+				t.Fatalf("Failed to unmarshal JSON from file: %v", err)
+			}
+
+			testifyassert.ElementsMatch(t, expected.Open, actual.Open, "Mismatch in open ports")
+			testifyassert.ElementsMatch(t, expected.Closed, actual.Closed, "Mismatch in closed ports")
 		})
 	}
 }


### PR DESCRIPTION
### Description

This change is to add functionality to the debug command to include port verification results in the debug bundle. This checks if the required ports(8500, 8501, 8502, 8503, 8301, 8302, 8300, 8600) are open and listening on the node where debug command is executed. A file ports.json is created in the debug bundle which has two lists for ports open and closed. This helps during troubleshooting issues so that support engineers can diagnose network-related issues without requiring direct access to the environment.
<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

Built consul binary on local and started a local single node consul server without enabling TLS so that ports 8501, 8502 are closed. Then validated the debug command that it creates a file ports.json and it has ports 8501, 8502 in closed ports list and remaining in the list of open ports.
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
