### PR TITLE
update group permission to auto-config.json

### DIFF
--- a/agent/auto-config/persist.go
+++ b/agent/auto-config/persist.go
@@ -74,7 +74,7 @@ func (ac *AutoConfig) persistAutoConfig(resp *pbautoconf.AutoConfigResponse) err
 
 	path := filepath.Join(ac.config.DataDir, autoConfigFileName)
 
-	err = os.WriteFile(path, serialized, 0660)
+	err = os.WriteFile(path, serialized, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write auto-config configurations: %w", err)
 	}


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
Auto configuration file is being written to disk with 0660 permissions.

If an attacker gains the ability to read an arbitrary file from the Consul agent’s filesystem using the group ID that the Consul agent runs as. The attacker can then read the agent’s TLS certificate and private key, giving them the ability to impersonate the Consul agent and further attack the cluster. To mitigate this in short term, in this PR the permissions of the persisted auto configuration file to 0600 to prevent any user except the Consul agent’s user from reading this file.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
