### PR TITLE
Add H2PING to api.HealthCheckDefinition

### DIFF
--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -323,6 +323,8 @@ func (s *HTTPHandlers) convertOps(resp http.ResponseWriter, req *http.Request) (
 							Header:                         check.Definition.Header,
 							Method:                         check.Definition.Method,
 							Body:                           check.Definition.Body,
+							H2PING:                         check.Definition.H2PING,
+							H2PingUseTLS:                   check.Definition.H2PingUseTLS,
 							TCP:                            check.Definition.TCP,
 							TCPUseTLS:                      check.Definition.TCPUseTLS,
 							GRPC:                           check.Definition.GRPC,

--- a/api/health.go
+++ b/api/health.go
@@ -66,6 +66,8 @@ type HealthCheckDefinition struct {
 	Body                                   string
 	TLSServerName                          string
 	TLSSkipVerify                          bool
+	H2PING                                 string
+	H2PingUseTLS                           bool
 	TCP                                    string
 	TCPUseTLS                              bool
 	UDP                                    string


### PR DESCRIPTION
### Description

This PR adds H2Ping to HealthCheckDefinition. Consul-ESM needs these fields to support H2Ping health checks.