### PR TITLE
Adds disable_gossip to create admin partition API

### DIFF
--- a/website/content/api-docs/admin-partitions.mdx
+++ b/website/content/api-docs/admin-partitions.mdx
@@ -35,6 +35,8 @@ This endpoint creates a new partition and has the following characteristics:
 
 - `Description` `(string: "")` - Free form partition description.
 
+- `DisableGossip` `(bool: false)` - Disable gossip support for this partition. When set to `true` this will save on CPU and network resources on the servers but client agents will be unable to join the partition.
+
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
### Description

This parameter is missing from the API documentation for create admin partition.

### Testing & Reproduction steps

The parameter has been tested as working in the create admin partition.

