### PR TITLE
max_request_headers_kb param handling in Service Defaults for Terminating Gateway

### DIFF
--- a/agent/configentry/resolve.go
+++ b/agent/configentry/resolve.go
@@ -141,6 +141,12 @@ func ComputeResolvedServiceConfig(
 		if serviceConf.LocalRequestTimeoutMs > 0 {
 			proxyConf["local_request_timeout_ms"] = serviceConf.LocalRequestTimeoutMs
 		}
+
+		// TODO::: CSL-11115 Changes : Add comments
+		if serviceConf.MaxRequestHeadersKB != nil {
+			proxyConf["max_request_headers_kb"] = *serviceConf.MaxRequestHeadersKB
+		}
+
 		// Add the proxy conf to the response if any fields were populated
 		if len(proxyConf) > 0 {
 			thisReply.ProxyConfig = proxyConf

--- a/agent/configentry/resolve.go
+++ b/agent/configentry/resolve.go
@@ -142,7 +142,7 @@ func ComputeResolvedServiceConfig(
 			proxyConf["local_request_timeout_ms"] = serviceConf.LocalRequestTimeoutMs
 		}
 
-		// TODO::: CSL-11115 Changes : Add comments
+		// Populate the max_request_headers_kb from the service defaults to terminating gateway proxy config
 		if serviceConf.MaxRequestHeadersKB != nil {
 			proxyConf["max_request_headers_kb"] = *serviceConf.MaxRequestHeadersKB
 		}

--- a/agent/configentry/resolve_test.go
+++ b/agent/configentry/resolve_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
+// uintPointer returns a pointer to a uint32 value
+func uintPointer(u uint32) *uint32 {
+	return &u
+}
+
 func Test_ComputeResolvedServiceConfig(t *testing.T) {
 	type args struct {
 		scReq   *structs.ServiceConfigRequest
@@ -103,6 +108,26 @@ func Test_ComputeResolvedServiceConfig(t *testing.T) {
 					"max_inbound_connections":  20,
 					"local_connect_timeout_ms": 20000,
 					"local_request_timeout_ms": 30000,
+				},
+			},
+		},
+		{
+			name: "proxy with MaxRequestHeadersKB",
+			args: args{
+				scReq: &structs.ServiceConfigRequest{
+					Name: "sid",
+				},
+				entries: &ResolvedServiceConfigSet{
+					ServiceDefaults: map[structs.ServiceID]*structs.ServiceConfigEntry{
+						sid: {
+							MaxRequestHeadersKB: uintPointer(96),
+						},
+					},
+				},
+			},
+			want: &structs.ServiceConfigResponse{
+				ProxyConfig: map[string]interface{}{
+					"max_request_headers_kb": uint32(96),
 				},
 			},
 		},

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -183,8 +183,8 @@ type ServiceConfigEntry struct {
 	Hash               uint64            `json:",omitempty" hash:"ignore"`
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 	RaftIndex          `hash:"ignore"`
-	// TODO::: Valid Comments
-	// TODO::: CSL-11115 Check
+	// MaxRequestHeadersKB configures the maximum size in kilobytes for request headers
+	// sent from downstream clients to upstream services. If not set, uses Envoy's default.
 	MaxRequestHeadersKB *uint32 `json:",omitempty"`
 }
 

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -183,6 +183,9 @@ type ServiceConfigEntry struct {
 	Hash               uint64            `json:",omitempty" hash:"ignore"`
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 	RaftIndex          `hash:"ignore"`
+	// TODO::: Valid Comments
+	// TODO::: CSL-11115 Check
+	MaxRequestHeadersKB *uint32 `json:",omitempty"`
 }
 
 func (e *ServiceConfigEntry) SetHash(h uint64) {

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -3287,6 +3287,30 @@ func TestServiceConfigEntry(t *testing.T) {
 			},
 			validateErr: `invalid value for protocol: blah`,
 		},
+		"validate: valid MaxRequestHeadersKB in service-defaults": {
+			entry: &ServiceConfigEntry{
+				Kind:                ServiceDefaults,
+				Name:                "web",
+				Protocol:            "http",
+				MaxRequestHeadersKB: uintPointer(96),
+			},
+		},
+		"validate: zero MaxRequestHeadersKB in service-defaults": {
+			entry: &ServiceConfigEntry{
+				Kind:                ServiceDefaults,
+				Name:                "web",
+				Protocol:            "http",
+				MaxRequestHeadersKB: uintPointer(0),
+			},
+		},
+		"validate: MaxRequestHeadersKB with TCP protocol": {
+			entry: &ServiceConfigEntry{
+				Kind:                ServiceDefaults,
+				Name:                "web",
+				Protocol:            "tcp",
+				MaxRequestHeadersKB: uintPointer(96),
+			},
+		},
 	}
 	testConfigEntryNormalizeAndValidate(t, cases)
 }

--- a/agent/xds/config/config.go
+++ b/agent/xds/config/config.go
@@ -139,6 +139,7 @@ func ParseProxyConfig(m map[string]interface{}) (ProxyConfig, error) {
 
 	if cfg.Protocol == "" {
 		cfg.Protocol = "tcp"
+		// TODO::: Remove cfg.Protocol = "http"
 	} else {
 		cfg.Protocol = strings.ToLower(cfg.Protocol)
 	}

--- a/agent/xds/config/config.go
+++ b/agent/xds/config/config.go
@@ -139,7 +139,6 @@ func ParseProxyConfig(m map[string]interface{}) (ProxyConfig, error) {
 
 	if cfg.Protocol == "" {
 		cfg.Protocol = "tcp"
-		// TODO::: Remove cfg.Protocol = "http"
 	} else {
 		cfg.Protocol = strings.ToLower(cfg.Protocol)
 	}

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -198,6 +198,7 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 				upstream:   upstreamCfg,
 			}
 			upstreamListener := makeListener(opts)
+			// [xdscommon.ListenerType].FilterChains.filter.ConfigType.TypedConfig
 			s.injectConnectionBalanceConfig(cfg.BalanceOutboundConnections, upstreamListener)
 			upstreamListener.FilterChains = []*envoy_listener_v3.FilterChain{
 				filterChain,

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1859,7 +1859,8 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(cfgSnap *proxycfg.
 		}
 	}
 
-	// TODO::: CSL-11115 Changes : Add Comments
+	// The priority order is service defaults and then the proxy config
+	// the value set in the proxy defaults is considered to be a default, that can be updated by the value from the service-default
 	maxRequestHeadersKb := proxyCfg.MaxRequestHeadersKB
 	serviceProxyConfig, found := cfgSnap.TerminatingGateway.ServiceConfigs[tgtwyOpts.service]
 	if found {

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1859,6 +1859,19 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(cfgSnap *proxycfg.
 		}
 	}
 
+	// TODO::: CSL-11115 Changes : Add Comments
+	maxRequestHeadersKb := proxyCfg.MaxRequestHeadersKB
+	serviceProxyConfig, found := cfgSnap.TerminatingGateway.ServiceConfigs[tgtwyOpts.service]
+	if found {
+		val, found := serviceProxyConfig.ProxyConfig["max_request_headers_kb"]
+		if found {
+			value, done := val.(uint32)
+			if done {
+				maxRequestHeadersKb = &value
+			}
+		}
+	}
+
 	// Lastly we setup the actual proxying component. For L4 this is a straight
 	// tcp proxy. For L7 this is a very hands-off HTTP proxy just to inject an
 	// HTTP filter to do intention checks here instead.
@@ -1872,7 +1885,7 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(cfgSnap *proxycfg.
 		tracing:             tracing,
 		accessLogs:          &cfgSnap.Proxy.AccessLogs,
 		logger:              s.Logger,
-		maxRequestHeadersKb: proxyCfg.MaxRequestHeadersKB,
+		maxRequestHeadersKb: maxRequestHeadersKb,
 	}
 
 	if useHTTPFilter {

--- a/agent/xds/listeners_apigateway.go
+++ b/agent/xds/listeners_apigateway.go
@@ -209,17 +209,18 @@ func (s *ResourceGenerator) makeAPIGatewayListeners(address string, cfgSnap *pro
 				}
 			}
 			filterOpts := listenerFilterOpts{
-				useRDS:           true,
-				fetchTimeoutRDS:  cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
-				protocol:         listenerKey.Protocol,
-				filterName:       listenerKey.RouteName(),
-				routeName:        listenerKey.RouteName(),
-				cluster:          "",
-				statPrefix:       "ingress_upstream_",
-				routePath:        "",
-				httpAuthzFilters: authFilters,
-				accessLogs:       &cfgSnap.Proxy.AccessLogs,
-				logger:           s.Logger,
+				useRDS:              true,
+				fetchTimeoutRDS:     cfgSnap.GetXDSCommonConfig(s.Logger).GetXDSFetchTimeout(),
+				protocol:            listenerKey.Protocol,
+				filterName:          listenerKey.RouteName(),
+				routeName:           listenerKey.RouteName(),
+				cluster:             "",
+				statPrefix:          "ingress_upstream_",
+				routePath:           "",
+				httpAuthzFilters:    authFilters,
+				accessLogs:          &cfgSnap.Proxy.AccessLogs,
+				logger:              s.Logger,
+				maxRequestHeadersKb: nil, // API Gateway uses Envoy defaults
 			}
 
 			// Generate any filter chains needed for services with custom TLS certs

--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -2324,6 +2324,27 @@ func getTerminatingGatewayPeeringGoldenTestCases() []goldenTestCase {
 			name:   "terminating-gateway-default-service-subset",
 			create: proxycfg.TestConfigSnapshotTerminatingGatewayDefaultServiceSubset,
 		},
+		{
+			name: "terminating-gateway-service-max-request-headers",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				// Use the HTTP2 test as base and modify it for our needs
+				snap := proxycfg.TestConfigSnapshotTerminatingGatewayHTTP2(t)
+
+				// Add service-specific max_request_headers_kb configuration for the web service
+				webService := structs.NewServiceName("web", nil)
+				if snap.TerminatingGateway.ServiceConfigs == nil {
+					snap.TerminatingGateway.ServiceConfigs = make(map[structs.ServiceName]*structs.ServiceConfigResponse)
+				}
+				snap.TerminatingGateway.ServiceConfigs[webService] = &structs.ServiceConfigResponse{
+					ProxyConfig: map[string]interface{}{
+						"max_request_headers_kb": uint32(96),
+						"protocol":               "http",
+					},
+				}
+
+				return snap
+			},
+		},
 	}
 }
 

--- a/agent/xds/testdata/clusters/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-service-max-request-headers.latest.golden
@@ -1,0 +1,51 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "connectTimeout": "5s",
+      "dnsLookupFamily": "V4_ONLY",
+      "dnsRefreshRate": "10s",
+      "loadAssignment": {
+        "clusterName": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "web.external.service",
+                      "portValue": 9090
+                    }
+                  }
+                },
+                "healthStatus": "HEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "outlierDetection": {},
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsParams": {},
+            "validationContext": {
+              "trustedCa": {
+                "filename": "ca.cert.pem"
+              }
+            }
+          }
+        }
+      },
+      "type": "LOGICAL_DNS"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/endpoints/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/endpoints/terminating-gateway-service-max-request-headers.latest.golden
@@ -1,0 +1,5 @@
+{
+  "nonce": "00000001",
+  "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/listeners/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-max-request-headers.latest.golden
@@ -1,0 +1,46 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8443
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.sni_cluster",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.sni_cluster.v3.SniCluster"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "",
+                "statPrefix": "terminating_gateway.default"
+              }
+            }
+          ]
+        }
+      ],
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.tls_inspector",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+          }
+        }
+      ],
+      "name": "default:1.2.3.4:8443",
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/routes/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/routes/terminating-gateway-service-max-request-headers.latest.golden
@@ -1,0 +1,5 @@
+{
+  "nonce": "00000001",
+  "typeUrl": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/secrets/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/secrets/terminating-gateway-service-max-request-headers.latest.golden
@@ -1,0 +1,5 @@
+{
+  "nonce": "00000001",
+  "typeUrl": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+  "versionInfo": "00000001"
+}

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -381,6 +381,7 @@ type ServiceConfigEntry struct {
 	Meta                      map[string]string       `json:",omitempty"`
 	CreateIndex               uint64
 	ModifyIndex               uint64
+	MaxRequestHeadersKB       *uint32 `json:",omitempty"`
 }
 
 func (s *ServiceConfigEntry) GetKind() string            { return s.Kind }

--- a/proto/private/pbconfigentry/config_entry.gen.go
+++ b/proto/private/pbconfigentry/config_entry.gen.go
@@ -2127,6 +2127,7 @@ func ServiceDefaultsToStructs(s *ServiceDefaults, t *structs.ServiceConfigEntry)
 	t.EnvoyExtensions = EnvoyExtensionsToStructs(s.EnvoyExtensions)
 	t.Meta = s.Meta
 	t.Hash = s.Hash
+	t.MaxRequestHeadersKB = s.MaxRequestHeadersKB
 }
 func ServiceDefaultsFromStructs(t *structs.ServiceConfigEntry, s *ServiceDefaults) {
 	if s == nil {
@@ -2173,6 +2174,7 @@ func ServiceDefaultsFromStructs(t *structs.ServiceConfigEntry, s *ServiceDefault
 	s.EnvoyExtensions = EnvoyExtensionsFromStructs(t.EnvoyExtensions)
 	s.Meta = t.Meta
 	s.Hash = t.Hash
+	s.MaxRequestHeadersKB = t.MaxRequestHeadersKB
 }
 func ServiceIntentionsToStructs(s *ServiceIntentions, t *structs.ServiceIntentionsConfigEntry) {
 	if s == nil {

--- a/proto/private/pbconfigentry/config_entry.pb.go
+++ b/proto/private/pbconfigentry/config_entry.pb.go
@@ -4083,6 +4083,13 @@ func (x *ServiceDefaults) GetHash() uint64 {
 	return 0
 }
 
+func (x *ServiceDefaults) GetMaxRequestHeadersKB() uint32 {
+	if x != nil && x.MaxRequestHeadersKB != nil {
+		return *x.MaxRequestHeadersKB
+	}
+	return 0
+}
+
 // mog annotation:
 //
 // target=github.com/hashicorp/consul/agent/structs.TransparentProxyConfig
@@ -9490,6 +9497,7 @@ func file_private_pbconfigentry_config_entry_proto_init() {
 		(*ConfigEntry_ExportedServices)(nil),
 		(*ConfigEntry_FileSystemCertificate)(nil),
 	}
+	file_private_pbconfigentry_config_entry_proto_msgTypes[41].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/proto/private/pbconfigentry/config_entry.pb.go
+++ b/proto/private/pbconfigentry/config_entry.pb.go
@@ -3930,8 +3930,9 @@ type ServiceDefaults struct {
 	// mog: func-to=mutualTLSModeToStructs func-from=mutualTLSModeFromStructs
 	MutualTLSMode MutualTLSMode `protobuf:"varint,15,opt,name=MutualTLSMode,proto3,enum=hashicorp.consul.internal.configentry.MutualTLSMode" json:"MutualTLSMode,omitempty"`
 	Hash          uint64        `protobuf:"varint,17,opt,name=Hash,proto3" json:"Hash,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	MaxRequestHeadersKB *uint32 `protobuf:"varint,18,opt,name=MaxRequestHeadersKB,proto3,oneof" json:"MaxRequestHeadersKB,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ServiceDefaults) Reset() {
@@ -8674,7 +8675,8 @@ const file_private_pbconfigentry_config_entry_proto_rawDesc = "" +
 	"\bContains\x18\b \x01(\tR\bContains\x12\x1e\n" +
 	"\n" +
 	"IgnoreCase\x18\t \x01(\bR\n" +
-	"IgnoreCase\"\xf9\t\n" +
+	"IgnoreCase\"\xc8\n" +
+	"\n" +
 	"\x0fServiceDefaults\x12\x1a\n" +
 	"\bProtocol\x18\x01 \x01(\tR\bProtocol\x12D\n" +
 	"\x04Mode\x18\x02 \x01(\x0e20.hashicorp.consul.internal.configentry.ProxyModeR\x04Mode\x12i\n" +
@@ -8695,10 +8697,12 @@ const file_private_pbconfigentry_config_entry_proto_rawDesc = "" +
 	"\x04Meta\x18\r \x03(\v2@.hashicorp.consul.internal.configentry.ServiceDefaults.MetaEntryR\x04Meta\x12Z\n" +
 	"\x0fEnvoyExtensions\x18\x0e \x03(\v20.hashicorp.consul.internal.common.EnvoyExtensionR\x0fEnvoyExtensions\x12Z\n" +
 	"\rMutualTLSMode\x18\x0f \x01(\x0e24.hashicorp.consul.internal.configentry.MutualTLSModeR\rMutualTLSMode\x12\x12\n" +
-	"\x04Hash\x18\x11 \x01(\x04R\x04Hash\x1a7\n" +
+	"\x04Hash\x18\x11 \x01(\x04R\x04Hash\x125\n" +
+	"\x13MaxRequestHeadersKB\x18\x12 \x01(\rH\x00R\x13MaxRequestHeadersKB\x88\x01\x01\x1a7\n" +
 	"\tMetaEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"t\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x16\n" +
+	"\x14_MaxRequestHeadersKB\"t\n" +
 	"\x16TransparentProxyConfig\x122\n" +
 	"\x14OutboundListenerPort\x18\x01 \x01(\x05R\x14OutboundListenerPort\x12&\n" +
 	"\x0eDialedDirectly\x18\x02 \x01(\bR\x0eDialedDirectly\"_\n" +

--- a/proto/private/pbconfigentry/config_entry.proto
+++ b/proto/private/pbconfigentry/config_entry.proto
@@ -593,6 +593,9 @@ message ServiceDefaults {
   // mog: func-to=mutualTLSModeToStructs func-from=mutualTLSModeFromStructs
   MutualTLSMode MutualTLSMode = 15;
   uint64 Hash = 17;
+
+  // TODO::: CSL-11115 changes
+  optional uint32 MaxRequestHeadersKB = 18;
 }
 
 enum ProxyMode {

--- a/proto/private/pbconfigentry/config_entry.proto
+++ b/proto/private/pbconfigentry/config_entry.proto
@@ -594,7 +594,6 @@ message ServiceDefaults {
   MutualTLSMode MutualTLSMode = 15;
   uint64 Hash = 17;
 
-  // TODO::: CSL-11115 changes
   optional uint32 MaxRequestHeadersKB = 18;
 }
 


### PR DESCRIPTION
### Description
The Connect/ Sidecar Envoy proxy created is not allowing request from downstream to upstream with header > 60KB. To allow the request headers with increased header size envoy provides option in the bootstrap config by setting up a param called max_request_headers_kb and the max limit allowed is 96KB.

### Testing & Reproduction steps


### Links
1. Register 2 services to be considered as external services
2. Register terminating gateway services
```
{
  "service": {
    "name": "terminating-gateway",
    "kind": "terminating-gateway",
    "port": 8443,
    "checks": [
      {
        "name": "terminating gateway health",
        "tcp": "localhost:8443",
        "interval": "10s",
        "timeout": "3s"
      }
    ]
  }
}
```
3. Write the service-defaults for the registered external services
service-defaults-externalA.json:
```
{
  "Kind": "service-defaults", 
  "Name": "external-A",
  "Protocol": "http",
  "MaxRequestHeadersKB": 96,
  "ExternalSNI": "api.example.com",
  "MeshGateway": {
    "Mode": "none"
  }
}
```
service-defaults-externalB.json:
```
{
  "Kind": "service-defaults",
  "Name": "external-B",
  "ExternalSNI": "db.example.com",
  "MeshGateway": {
    "Mode": "none"
  }
}
```
4. Connect to envoy as terminating gateway to connect to the external external services.
5.  Once the envoy proxy is up and running then the check the config_dump, the max_request_headers_kb should be set.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
