### PR TITLE
power select to super select from HDS

### DIFF
--- a/ui/packages/consul-ui/app/components/child-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/child-selector/index.hbs
@@ -34,19 +34,6 @@
       }}
       @items={{options}}
     as |collection|>
-      {{!-- <PowerSelect
-        @searchEnabled={{true}}
-        @search={{action collection.search}}
-        @options={{sort-by 'Name:asc' options}}
-        @loadingMessage="Loading..."
-        @searchMessage="No possible options"
-        @searchPlaceholder={{placeholder}}
-        @onOpen={{action (mut isOpen) true}}
-        @onClose={{action (mut isOpen) false}}
-        @onChange={{action "change" "items[]" items}}
-      as |item|>
-        <YieldSlot @name="option" @params={{block-params item}}>{{yield}}</YieldSlot>
-      </PowerSelect> --}}
       <Hds::Form::SuperSelect::Single::Field
         @searchEnabled={{true}}
         @onFilter={{action collection.search}}


### PR DESCRIPTION
### Description

ember-power-select is being used at policy form to select a role. This select component has multiple issues which are not in our control. It would be better if we replace it with hds super-select component. 

Change the component being used from Ember Power Select to HDS Super Select.

### Testing & Reproduction steps

<!--

* Run Axe Developer Tools in Chrome Dev Tools. 
* Scan the page. It will show a list of Accessibility issues.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
