### PR TITLE
fix path cleaning of proxied urls

### DIFF
--- a/.changelog/22671.txt
+++ b/.changelog/22671.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-security: Fix path cleaning of proxied urls.
+security: Fixed proxied URL path validation to prevent path traversal.
 ```

--- a/.changelog/22671.txt
+++ b/.changelog/22671.txt
@@ -1,0 +1,3 @@
+```release-note:security
+security: Fix path cleaning of proxied urls.
+```

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -2744,6 +2744,40 @@ func TestUIEndpoint_MetricsProxy(t *testing.T) {
 			wantCode:     http.StatusOK,
 			wantContains: "RawQuery: foo=bar&encoded=test%5B0%5D%26%26test%5B1%5D%3D%3D%21%40%C2%A3%24%25%5E",
 		},
+		{
+			name: "targetURL exactly matches BaseURL without trailing slash",
+			config: config.UIMetricsProxy{
+				BaseURL: strings.TrimSuffix(backendURL, "/some/prefix"),
+			},
+			path:         endpointPath + "/",
+			wantCode:     http.StatusNotFound,
+			wantContains: "not found on backend",
+		},
+		{
+			name: "targetURL matches BaseURL prefix with trailing slash",
+			config: config.UIMetricsProxy{
+				BaseURL: backendURL,
+			},
+			path:         endpointPath + "/ok",
+			wantCode:     http.StatusOK,
+			wantContains: "OK",
+		},
+		{
+			name: "targetURL fails prefix check - different domain",
+			config: config.UIMetricsProxy{
+				BaseURL: "http://localhost:9999/metrics",
+			},
+			path:     endpointPath + "/../../evil.com/attack",
+			wantCode: http.StatusMovedPermanently,
+		},
+		{
+			name: "targetURL fails prefix check - sibling path escape",
+			config: config.UIMetricsProxy{
+				BaseURL: backend.URL + "/secure/metrics",
+			},
+			path:     endpointPath + "/../../../public/data",
+			wantCode: http.StatusMovedPermanently,
+		},
 	}
 
 	for _, tc := range cases {
@@ -2784,6 +2818,130 @@ func TestUIEndpoint_MetricsProxy(t *testing.T) {
 					require.Contains(t, headersSent[k], v,
 						"header %s doesn't have the right value set", k)
 				}
+			}
+		})
+	}
+}
+
+func TestUIEndpoint_MetricsProxy_TargetURLValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	// Create a test backend server
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+	defer backend.Close()
+
+	a := NewTestAgent(t, `
+		ui_config {
+			enabled = true
+		}
+	`)
+	defer a.Shutdown()
+
+	endpointPath := "/v1/internal/ui/metrics-proxy"
+
+	cases := []struct {
+		name         string
+		baseURL      string
+		requestPath  string
+		wantCode     int
+		wantContains string
+	}{
+		{
+			name:         "exact BaseURL match - allowed",
+			baseURL:      backend.URL + "/metrics",
+			requestPath:  endpointPath + "/",
+			wantCode:     http.StatusOK,
+			wantContains: "OK",
+		},
+		{
+			name:         "proper prefix match with trailing slash - allowed",
+			baseURL:      backend.URL + "/metrics",
+			requestPath:  endpointPath + "/dashboard",
+			wantCode:     http.StatusOK,
+			wantContains: "OK",
+		},
+		{
+			name:         "baseURL without trailing slash, targetURL with prefix - allowed",
+			baseURL:      strings.TrimSuffix(backend.URL, "/") + "/metrics",
+			requestPath:  endpointPath + "/dashboard",
+			wantCode:     http.StatusOK,
+			wantContains: "OK",
+		},
+		{
+			name:         "baseURL with trailing slash, targetURL matches prefix - allowed",
+			baseURL:      backend.URL + "/metrics/",
+			requestPath:  endpointPath + "/dashboard",
+			wantCode:     http.StatusOK,
+			wantContains: "OK",
+		},
+		{
+			name:         "targetURL escapes from baseURL prefix - blocked",
+			baseURL:      backend.URL + "/secure/metrics",
+			requestPath:  endpointPath + "/../../public/data",
+			wantCode:     http.StatusMovedPermanently,
+			wantContains: "Moved Permanently",
+		},
+		{
+			name:         "targetURL attempts sibling directory access - blocked",
+			baseURL:      backend.URL + "/app/metrics",
+			requestPath:  endpointPath + "/../admin/config",
+			wantCode:     http.StatusMovedPermanently,
+			wantContains: "Moved Permanently",
+		},
+		{
+			name:         "targetURL with encoded dots - path.Clean prevents traversal",
+			baseURL:      backend.URL + "/app/metrics",
+			requestPath:  endpointPath + "/%2e%2e/admin/config",
+			wantCode:     http.StatusOK,
+			wantContains: "OK",
+		},
+		{
+			name:         "baseURL validation - exact match is allowed",
+			baseURL:      backend.URL,
+			requestPath:  endpointPath + "/",
+			wantCode:     http.StatusOK,
+			wantContains: "OK",
+		},
+		{
+			name:         "baseURL validation - proper prefix is allowed",
+			baseURL:      backend.URL + "/secure",
+			requestPath:  endpointPath + "/dashboard",
+			wantCode:     http.StatusOK,
+			wantContains: "OK",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Configure the metrics proxy with the specific BaseURL
+			cfg := *a.config
+			cfg.UIConfig.MetricsProxy = config.UIMetricsProxy{
+				BaseURL: tc.baseURL,
+			}
+
+			require.NoError(t, a.reloadConfigInternal(&cfg))
+
+			// Make the request
+			h := a.srv.handler()
+			req := httptest.NewRequest("GET", tc.requestPath, nil)
+			rec := httptest.NewRecorder()
+
+			h.ServeHTTP(rec, req)
+
+			require.Equal(t, tc.wantCode, rec.Code,
+				"Wrong status code for %s. Body = %s", tc.name, rec.Body.String())
+
+			if tc.wantContains != "" {
+				require.Contains(t, rec.Body.String(), tc.wantContains,
+					"Response body should contain expected text for %s", tc.name)
 			}
 		})
 	}


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

This pull request addresses a security issue in the `UIMetricsProxy` handler by improving how proxied URL paths are cleaned and validated to prevent path traversal attacks. The main focus is on ensuring that user-supplied paths cannot escape the intended base URL, even in edge cases.

**Security improvements to URL path handling:**

* Paths are now cleaned using `path.Clean` with a leading slash to ensure that any `../` segments are properly removed, preventing path traversal attacks. (`agent/ui_endpoint.go`)
* The previous redundant cleaning of the parsed URL path after construction has been removed, as the cleaning is now handled earlier and more securely. (`agent/ui_endpoint.go`)

**Base URL validation enhancements:**

* The check for whether the target URL is within the base URL now ensures the base URL has a trailing slash for proper prefix matching, and allows an exact match of the base URL without the trailing slash. This prevents attackers from escaping the base path by manipulating the URL. (`agent/ui_endpoint.go`)

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
