### PR TITLE
Manual backport of update group permission to auto-config.json into release/1.21.x

### DIFF
--- a/.changelog/22626.txt
+++ b/.changelog/22626.txt
@@ -1,0 +1,3 @@
+```release-note:security
+agent: Fix a security vulnerability where the attacker could read agent’s TLS certificate and private key by using the group ID that the Consul agent runs as.
+```

--- a/agent/auto-config/persist.go
+++ b/agent/auto-config/persist.go
@@ -16,6 +16,9 @@ const (
 	// autoConfigFileName is the name of the file that the agent auto-config settings are
 	// stored in within the data directory
 	autoConfigFileName = "auto-config.json"
+	// PermOwnerReadWrite is the file permission used when writing the auto-config
+	// settings to disk
+	PermOwnerReadWrite = 0600
 )
 
 var (
@@ -74,7 +77,7 @@ func (ac *AutoConfig) persistAutoConfig(resp *pbautoconf.AutoConfigResponse) err
 
 	path := filepath.Join(ac.config.DataDir, autoConfigFileName)
 
-	err = os.WriteFile(path, serialized, 0660)
+	err = os.WriteFile(path, serialized, PermOwnerReadWrite)
 	if err != nil {
 		return fmt.Errorf("failed to write auto-config configurations: %w", err)
 	}


### PR DESCRIPTION
## Backport

This PR is manually generated from #22626 to be assessed for backporting. 


The below text is copied from the body of the original PR.

---

### Description

<!-- Please describe why you're making this change, in plain English. -->
Currently the auto configuration file is being written to disk with 0660 permissions. If an attacker gains the ability to read an arbitrary file from the Consul agent’s filesystem using the group ID that the Consul agent runs as. The attacker can then read the agent’s TLS certificate and private key, giving them the ability to impersonate the Consul agent and further attack the cluster. To mitigate this in short term, in this PR the permissions of the persisted auto configuration file are updated to 0600 to prevent any user except the Consul agent’s user from reading this file.

In the long term, review the Consul agent’s data persistence mechanisms that operate outside the Raft consensus protocol. Minimize the permissions for each configuration or data file written to disk.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


---

<details>
<summary> Overview of commits </summary>

 
  - 2627f19f04fe0107353e3fd4e5c5917f79a0873d
 
  - 2f53b7654bb41071e57cb9793c9998860036c76b
 
  - 3c950a3c7f8e9ee05959c055a948f9b370909624
 
  - dbd1ac9900df95e3c16f4bfabcbb931a08b3f275
 
  - 29c85d44e806480ccb538afa7723bf48add2010e
 

</details>


