### PR TITLE
chore: updated backport assistant to use squash merge commit for cherry picking

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
+          BACKPORT_MERGE_COMMIT: true
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN_WORKFLOW }}
           ENABLE_VERSION_MANIFESTS: true
   backport-ent:


### PR DESCRIPTION
The current backporting agent cherry-picks each commit in the PR. This is error prone and a lot of times there are merge conflicts and only some commits are picked. Cherry picking the squashed commit will avoid that. 

While there could be cases with empty commit, which needs to be addressed separately, this change will help in having all the changes instead of engineer cherry-picking the commits again.