### PR TITLE
max_request_headers_kb param handling in Service Defaults for Termina…

### DIFF
--- a/.changelog/22680.txt
+++ b/.changelog/22680.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+config: Handle a new parameter `max_request_headers_kb` to configure maximum header size for requests from downstream to upstream in Terminating Gateway service-defaults and proxy-defaults
+```

--- a/agent/configentry/resolve.go
+++ b/agent/configentry/resolve.go
@@ -141,6 +141,12 @@ func ComputeResolvedServiceConfig(
 		if serviceConf.LocalRequestTimeoutMs > 0 {
 			proxyConf["local_request_timeout_ms"] = serviceConf.LocalRequestTimeoutMs
 		}
+
+		// Populate the max_request_headers_kb from the service defaults to terminating gateway proxy config
+		if serviceConf.MaxRequestHeadersKB != nil {
+			proxyConf["max_request_headers_kb"] = *serviceConf.MaxRequestHeadersKB
+		}
+
 		// Add the proxy conf to the response if any fields were populated
 		if len(proxyConf) > 0 {
 			thisReply.ProxyConfig = proxyConf

--- a/agent/configentry/resolve_test.go
+++ b/agent/configentry/resolve_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
+// uintPointer returns a pointer to a uint32 value
+func uintPointer(u uint32) *uint32 {
+	return &u
+}
+
 func Test_ComputeResolvedServiceConfig(t *testing.T) {
 	type args struct {
 		scReq   *structs.ServiceConfigRequest
@@ -103,6 +108,26 @@ func Test_ComputeResolvedServiceConfig(t *testing.T) {
 					"max_inbound_connections":  20,
 					"local_connect_timeout_ms": 20000,
 					"local_request_timeout_ms": 30000,
+				},
+			},
+		},
+		{
+			name: "proxy with MaxRequestHeadersKB",
+			args: args{
+				scReq: &structs.ServiceConfigRequest{
+					Name: "sid",
+				},
+				entries: &ResolvedServiceConfigSet{
+					ServiceDefaults: map[structs.ServiceID]*structs.ServiceConfigEntry{
+						sid: {
+							MaxRequestHeadersKB: uintPointer(96),
+						},
+					},
+				},
+			},
+			want: &structs.ServiceConfigResponse{
+				ProxyConfig: map[string]interface{}{
+					"max_request_headers_kb": uint32(96),
 				},
 			},
 		},

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -183,6 +183,9 @@ type ServiceConfigEntry struct {
 	Hash               uint64            `json:",omitempty" hash:"ignore"`
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 	RaftIndex          `hash:"ignore"`
+	// MaxRequestHeadersKB configures the maximum size in kilobytes for request headers
+	// sent from downstream clients to upstream services. If not set, uses Envoy's default.
+	MaxRequestHeadersKB *uint32 `json:",omitempty"`
 }
 
 func (e *ServiceConfigEntry) SetHash(h uint64) {

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -3287,6 +3287,30 @@ func TestServiceConfigEntry(t *testing.T) {
 			},
 			validateErr: `invalid value for protocol: blah`,
 		},
+		"validate: valid MaxRequestHeadersKB in service-defaults": {
+			entry: &ServiceConfigEntry{
+				Kind:                ServiceDefaults,
+				Name:                "web",
+				Protocol:            "http",
+				MaxRequestHeadersKB: uintPointer(96),
+			},
+		},
+		"validate: zero MaxRequestHeadersKB in service-defaults": {
+			entry: &ServiceConfigEntry{
+				Kind:                ServiceDefaults,
+				Name:                "web",
+				Protocol:            "http",
+				MaxRequestHeadersKB: uintPointer(0),
+			},
+		},
+		"validate: MaxRequestHeadersKB with TCP protocol": {
+			entry: &ServiceConfigEntry{
+				Kind:                ServiceDefaults,
+				Name:                "web",
+				Protocol:            "tcp",
+				MaxRequestHeadersKB: uintPointer(96),
+			},
+		},
 	}
 	testConfigEntryNormalizeAndValidate(t, cases)
 }

--- a/agent/structs/structs.deepcopy.go
+++ b/agent/structs/structs.deepcopy.go
@@ -975,6 +975,10 @@ func (o *ServiceConfigEntry) DeepCopy() *ServiceConfigEntry {
 			cp.Meta[k2] = v2
 		}
 	}
+	if o.MaxRequestHeadersKB != nil {
+		cp.MaxRequestHeadersKB = new(uint32)
+		*cp.MaxRequestHeadersKB = *o.MaxRequestHeadersKB
+	}
 	return &cp
 }
 

--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -2363,6 +2363,27 @@ func getTerminatingGatewayPeeringGoldenTestCases() []goldenTestCase {
 			name:   "terminating-gateway-default-service-subset",
 			create: proxycfg.TestConfigSnapshotTerminatingGatewayDefaultServiceSubset,
 		},
+		{
+			name: "terminating-gateway-service-max-request-headers",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				// Use the HTTP2 test as base and modify it for our needs
+				snap := proxycfg.TestConfigSnapshotTerminatingGatewayHTTP2(t)
+
+				// Add service-specific max_request_headers_kb configuration for the web service
+				webService := structs.NewServiceName("web", nil)
+				if snap.TerminatingGateway.ServiceConfigs == nil {
+					snap.TerminatingGateway.ServiceConfigs = make(map[structs.ServiceName]*structs.ServiceConfigResponse)
+				}
+				snap.TerminatingGateway.ServiceConfigs[webService] = &structs.ServiceConfigResponse{
+					ProxyConfig: map[string]interface{}{
+						"max_request_headers_kb": uint32(96),
+						"protocol":               "http",
+					},
+				}
+
+				return snap
+			},
+		},
 	}
 }
 

--- a/agent/xds/testdata/clusters/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-service-max-request-headers.latest.golden
@@ -1,0 +1,51 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "connectTimeout": "5s",
+      "dnsLookupFamily": "V4_ONLY",
+      "dnsRefreshRate": "10s",
+      "loadAssignment": {
+        "clusterName": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "web.external.service",
+                      "portValue": 9090
+                    }
+                  }
+                },
+                "healthStatus": "HEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "outlierDetection": {},
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsParams": {},
+            "validationContext": {
+              "trustedCa": {
+                "filename": "ca.cert.pem"
+              }
+            }
+          }
+        }
+      },
+      "type": "LOGICAL_DNS"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/endpoints/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/endpoints/terminating-gateway-service-max-request-headers.latest.golden
@@ -1,0 +1,5 @@
+{
+  "nonce": "00000001",
+  "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/listeners/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-max-request-headers.latest.golden
@@ -1,0 +1,46 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8443
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.sni_cluster",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.sni_cluster.v3.SniCluster"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "cluster": "",
+                "statPrefix": "terminating_gateway.default"
+              }
+            }
+          ]
+        }
+      ],
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.tls_inspector",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+          }
+        }
+      ],
+      "name": "default:1.2.3.4:8443",
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/routes/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/routes/terminating-gateway-service-max-request-headers.latest.golden
@@ -1,0 +1,5 @@
+{
+  "nonce": "00000001",
+  "typeUrl": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/secrets/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/secrets/terminating-gateway-service-max-request-headers.latest.golden
@@ -1,0 +1,5 @@
+{
+  "nonce": "00000001",
+  "typeUrl": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+  "versionInfo": "00000001"
+}

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -381,6 +381,7 @@ type ServiceConfigEntry struct {
 	Meta                      map[string]string       `json:",omitempty"`
 	CreateIndex               uint64
 	ModifyIndex               uint64
+	MaxRequestHeadersKB       *uint32 `json:",omitempty"`
 }
 
 func (s *ServiceConfigEntry) GetKind() string            { return s.Kind }

--- a/proto/private/pbconfigentry/config_entry.gen.go
+++ b/proto/private/pbconfigentry/config_entry.gen.go
@@ -2129,6 +2129,7 @@ func ServiceDefaultsToStructs(s *ServiceDefaults, t *structs.ServiceConfigEntry)
 	t.EnvoyExtensions = EnvoyExtensionsToStructs(s.EnvoyExtensions)
 	t.Meta = s.Meta
 	t.Hash = s.Hash
+	t.MaxRequestHeadersKB = s.MaxRequestHeadersKB
 }
 func ServiceDefaultsFromStructs(t *structs.ServiceConfigEntry, s *ServiceDefaults) {
 	if s == nil {
@@ -2175,6 +2176,7 @@ func ServiceDefaultsFromStructs(t *structs.ServiceConfigEntry, s *ServiceDefault
 	s.EnvoyExtensions = EnvoyExtensionsFromStructs(t.EnvoyExtensions)
 	s.Meta = t.Meta
 	s.Hash = t.Hash
+	s.MaxRequestHeadersKB = t.MaxRequestHeadersKB
 }
 func ServiceIntentionsToStructs(s *ServiceIntentions, t *structs.ServiceIntentionsConfigEntry) {
 	if s == nil {

--- a/proto/private/pbconfigentry/config_entry.pb.go
+++ b/proto/private/pbconfigentry/config_entry.pb.go
@@ -3928,10 +3928,11 @@ type ServiceDefaults struct {
 	// mog: func-to=EnvoyExtensionsToStructs func-from=EnvoyExtensionsFromStructs
 	EnvoyExtensions []*pbcommon.EnvoyExtension `protobuf:"bytes,14,rep,name=EnvoyExtensions,proto3" json:"EnvoyExtensions,omitempty"`
 	// mog: func-to=mutualTLSModeToStructs func-from=mutualTLSModeFromStructs
-	MutualTLSMode MutualTLSMode `protobuf:"varint,15,opt,name=MutualTLSMode,proto3,enum=hashicorp.consul.internal.configentry.MutualTLSMode" json:"MutualTLSMode,omitempty"`
-	Hash          uint64        `protobuf:"varint,17,opt,name=Hash,proto3" json:"Hash,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	MutualTLSMode       MutualTLSMode `protobuf:"varint,15,opt,name=MutualTLSMode,proto3,enum=hashicorp.consul.internal.configentry.MutualTLSMode" json:"MutualTLSMode,omitempty"`
+	Hash                uint64        `protobuf:"varint,17,opt,name=Hash,proto3" json:"Hash,omitempty"`
+	MaxRequestHeadersKB *uint32       `protobuf:"varint,18,opt,name=MaxRequestHeadersKB,proto3,oneof" json:"MaxRequestHeadersKB,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ServiceDefaults) Reset() {
@@ -4079,6 +4080,13 @@ func (x *ServiceDefaults) GetMutualTLSMode() MutualTLSMode {
 func (x *ServiceDefaults) GetHash() uint64 {
 	if x != nil {
 		return x.Hash
+	}
+	return 0
+}
+
+func (x *ServiceDefaults) GetMaxRequestHeadersKB() uint32 {
+	if x != nil && x.MaxRequestHeadersKB != nil {
+		return *x.MaxRequestHeadersKB
 	}
 	return 0
 }
@@ -8675,7 +8683,8 @@ const file_private_pbconfigentry_config_entry_proto_rawDesc = "" +
 	"\bContains\x18\b \x01(\tR\bContains\x12\x1e\n" +
 	"\n" +
 	"IgnoreCase\x18\t \x01(\bR\n" +
-	"IgnoreCase\"\xf9\t\n" +
+	"IgnoreCase\"\xc8\n" +
+	"\n" +
 	"\x0fServiceDefaults\x12\x1a\n" +
 	"\bProtocol\x18\x01 \x01(\tR\bProtocol\x12D\n" +
 	"\x04Mode\x18\x02 \x01(\x0e20.hashicorp.consul.internal.configentry.ProxyModeR\x04Mode\x12i\n" +
@@ -8696,10 +8705,12 @@ const file_private_pbconfigentry_config_entry_proto_rawDesc = "" +
 	"\x04Meta\x18\r \x03(\v2@.hashicorp.consul.internal.configentry.ServiceDefaults.MetaEntryR\x04Meta\x12Z\n" +
 	"\x0fEnvoyExtensions\x18\x0e \x03(\v20.hashicorp.consul.internal.common.EnvoyExtensionR\x0fEnvoyExtensions\x12Z\n" +
 	"\rMutualTLSMode\x18\x0f \x01(\x0e24.hashicorp.consul.internal.configentry.MutualTLSModeR\rMutualTLSMode\x12\x12\n" +
-	"\x04Hash\x18\x11 \x01(\x04R\x04Hash\x1a7\n" +
+	"\x04Hash\x18\x11 \x01(\x04R\x04Hash\x125\n" +
+	"\x13MaxRequestHeadersKB\x18\x12 \x01(\rH\x00R\x13MaxRequestHeadersKB\x88\x01\x01\x1a7\n" +
 	"\tMetaEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"t\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x16\n" +
+	"\x14_MaxRequestHeadersKB\"t\n" +
 	"\x16TransparentProxyConfig\x122\n" +
 	"\x14OutboundListenerPort\x18\x01 \x01(\x05R\x14OutboundListenerPort\x12&\n" +
 	"\x0eDialedDirectly\x18\x02 \x01(\bR\x0eDialedDirectly\"_\n" +
@@ -9500,6 +9511,7 @@ func file_private_pbconfigentry_config_entry_proto_init() {
 		(*ConfigEntry_ExportedServices)(nil),
 		(*ConfigEntry_FileSystemCertificate)(nil),
 	}
+	file_private_pbconfigentry_config_entry_proto_msgTypes[41].OneofWrappers = []any{}
 	file_private_pbconfigentry_config_entry_proto_msgTypes[57].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/proto/private/pbconfigentry/config_entry.proto
+++ b/proto/private/pbconfigentry/config_entry.proto
@@ -593,6 +593,8 @@ message ServiceDefaults {
   // mog: func-to=mutualTLSModeToStructs func-from=mutualTLSModeFromStructs
   MutualTLSMode MutualTLSMode = 15;
   uint64 Hash = 17;
+
+  optional uint32 MaxRequestHeadersKB = 18;
 }
 
 enum ProxyMode {

--- a/test/integration/connect/envoy/case-terminating-gateway-max-request-headers/capture.sh
+++ b/test/integration/connect/envoy/case-terminating-gateway-max-request-headers/capture.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+snapshot_envoy_admin localhost:20000 terminating-gateway primary || true
+snapshot_envoy_admin localhost:19000 s1 primary || true

--- a/test/integration/connect/envoy/case-terminating-gateway-max-request-headers/service-gateway.hcl
+++ b/test/integration/connect/envoy/case-terminating-gateway-max-request-headers/service-gateway.hcl
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+service {
+  name = "terminating-gateway"
+  kind = "terminating-gateway"
+  port = 8443
+}

--- a/test/integration/connect/envoy/case-terminating-gateway-max-request-headers/vars.sh
+++ b/test/integration/connect/envoy/case-terminating-gateway-max-request-headers/vars.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+
+# There is no sidecar proxy for s2, since the terminating gateway acts as the proxy
+export REQUIRED_SERVICES="s1 s1-sidecar-proxy s2 terminating-gateway-primary"

--- a/test/integration/connect/envoy/case-terminating-gateway-max-request-headers/verify.bats
+++ b/test/integration/connect/envoy/case-terminating-gateway-max-request-headers/verify.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "terminating proxy admin is up on :20000" {
+  retry_default curl -f -s localhost:20000/stats -o /dev/null
+}
+
+@test "s1 proxy admin is up on :19000" {
+  retry_default curl -f -s localhost:19000/stats -o /dev/null
+}
+
+@test "terminating-gateway-primary listener is up on :8443" {
+  retry_default nc -z localhost:8443
+}
+
+@test "terminating-gateway should have healthy endpoints for s2" {
+  assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s2 HEALTHY 1
+}
+
+@test "s1 upstream should be able to connect to s2 with normal headers" {
+  run retry_default curl -s -f -d hello localhost:5000
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "s2 accepts requests with normal headers" {
+  # Test with normal-sized headers to ensure basic functionality works
+  run retry_default curl -s -f -H "X-Test-Header: normal-value" -d hello localhost:5000
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "s2 rejects requests with headers over 96KB limit (99KB test)" {
+  # Generate large header (99KB = 101376 bytes)
+  large_header=$(printf 'x%.0s' {1..101376})
+  run curl -s -f -H "X-Large-Header: $large_header" -d hello localhost:5000
+  [ "$status" -ne 0 ]
+}
+
+@test "terminating-gateway is used for the upstream connection" {
+  assert_envoy_metric_at_least 127.0.0.1:20000 "s2.default.primary.*cx_total" 1
+}


### PR DESCRIPTION
Backport of [#22680](https://github.com/hashicorp/consul/pull/22680)

### Description
The Connect/ Sidecar Envoy proxy created is not allowing request from downstream to upstream with header > 60KB. To allow the request headers with increased header size envoy provides option in the bootstrap config by setting up a param called max_request_headers_kb and the max limit allowed is 96KB.

### Testing & Reproduction steps


### Links
1. Register 2 services to be considered as external services
2. Register terminating gateway services
```
{
  "service": {
    "name": "terminating-gateway",
    "kind": "terminating-gateway",
    "port": 8443,
    "checks": [
      {
        "name": "terminating gateway health",
        "tcp": "localhost:8443",
        "interval": "10s",
        "timeout": "3s"
      }
    ]
  }
}
```
3. Write the service-defaults for the registered external services
service-defaults-externalA.json:
```
{
  "Kind": "service-defaults", 
  "Name": "external-A",
  "Protocol": "http",
  "MaxRequestHeadersKB": 96,
  "ExternalSNI": "api.example.com",
  "MeshGateway": {
    "Mode": "none"
  }
}
```
service-defaults-externalB.json:
```
{
  "Kind": "service-defaults",
  "Name": "external-B",
  "ExternalSNI": "db.example.com",
  "MeshGateway": {
    "Mode": "none"
  }
}
```
4. Connect to envoy as terminating gateway to connect to the external external services.
5.  Once the envoy proxy is up and running then the check the config_dump, the max_request_headers_kb should be set.
6. Trigger the below curl to test with the increased header size
```
curl -v http://localhost:5001 \
  -H "X-Test-Header: $(printf '%*s' 95000 | tr ' ' 'a')"
```
Based on the changes the API Gateway Proxy should allow up to ~=98000(96KB) size of header data. For >=99000(>96KB) it would throw 431 Request Header Fields Too Large status code and message.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
