### PR TITLE
Backport: Added max_request_headers_kb documentation (#22728)

### DIFF
--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -2575,7 +2575,7 @@ func makeHTTPFilter(opts listenerFilterOpts) (*envoy_listener_v3.Filter, error) 
 	}
 
 	// Set max request headers size if configured
-	if opts.maxRequestHeadersKb != nil {
+	if opts.maxRequestHeadersKb != nil && *opts.maxRequestHeadersKb > 0 {
 		cfg.MaxRequestHeadersKb = &wrapperspb.UInt32Value{Value: *opts.maxRequestHeadersKb}
 	}
 

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -590,8 +590,7 @@ func Test_makeAPIGatewayListeners_maxRequestHeadersKb(t *testing.T) {
 		"http listener with zero value": {
 			maxRequestHeadersKb: uintPointer(0),
 			protocol:            "http",
-			wantPresent:         true,
-			wantValue:           0,
+			wantPresent:         false, // Default value would be use for <= 0
 		},
 	}
 

--- a/website/content/docs/reference/config-entry/api-gateway.mdx
+++ b/website/content/docs/reference/config-entry/api-gateway.mdx
@@ -26,6 +26,7 @@ The following list outlines field hierarchy, language-specific data types, and r
   - [`Port`](#listeners-port): number | no default
   - [`Hostname`](#listeners-hostname): string | `"*"`
   - [`Protocol`](#listeners-protocol): string | `"tcp"`
+  - [`MaxRequestHeadersKB`](#listeners-maxrequestheaderskb): number | `60`
   - [`TLS`](#listeners-tls): map | none
     - [`MinVersion`](#listeners-tls-minversion): string | no default
     - [`MaxVersion`](#listeners-tls-maxversion): string | no default
@@ -73,6 +74,7 @@ Listeners = [
     Port = <external service port>
     Name = "<unique name for this listener>"
     Protocol = "<protocol used by external service>"
+    MaxRequestHeadersKB = <maximum header size in kilobytes>
     TLS = {
       MaxVersion = "<version of TLS>"
       MinVersion = "<version of TLS>"
@@ -290,6 +292,18 @@ Specifies the protocol associated with the listener.
 - Default: none
 - This field is required.
 - The data type is one of the following string values: `"tcp"` or `"http"`.
+
+### `Listeners[].MaxRequestHeadersKB`
+
+Specifies the maximum size in kilobytes for request headers sent from downstream clients to upstream services. This setting applies to HTTP-based protocols only (HTTP, HTTP/2, gRPC). When requests exceed this limit, the gateway returns an HTTP 431 (Request Header Fields Too Large) error. If not specified, uses Envoy's default limit(60KB).
+
+**Note**: This setting only takes effect when the listener protocol is set to `http`, `http2`, or `grpc` protocols. It has no effect on TCP listeners.
+
+#### Values
+
+- Default: `60` (Envoy's default value)
+- Data type: Integer
+- Valid values: `96` or unset (which uses the default of `60`)
 
 ### `Listeners[].TLS`
 

--- a/website/content/docs/reference/config-entry/proxy-defaults.mdx
+++ b/website/content/docs/reference/config-entry/proxy-defaults.mdx
@@ -931,6 +931,7 @@ Name      = "global"
 Config {
   local_connect_timeout_ms = 1000
   handshake_timeout_ms     = 10000
+  max_request_headers_kb   = 96
 }
 ```
 
@@ -947,6 +948,7 @@ spec:
   config:
     local_connect_timeout_ms: 1000
     handshake_timeout_ms: 10000
+    max_request_headers_kb: 96
 ```
 
 </Tab>
@@ -959,7 +961,58 @@ spec:
   "Name": "global",
   "Config": {
     "local_connect_timeout_ms": 1000,
-    "handshake_timeout_ms": 10000
+    "handshake_timeout_ms": 10000,
+    "max_request_headers_kb": 96
+  }
+}
+```
+
+</Tab>
+
+</Tabs>
+
+### HTTP Request Header Size Limits
+
+The following example configures a global limit of 96 KB for HTTP request headers to help protect services from oversized headers. Note that `max_request_headers_kb` only applies when the protocol is set to an HTTP-based protocol (`http`, `http2`, or `grpc`).
+
+<Tabs>
+<Tab heading="HCL" group="hcl">
+
+```hcl
+Kind      = "proxy-defaults"
+Name      = "global"
+Config {
+  protocol               = "http"
+  max_request_headers_kb = 96
+}
+```
+
+</Tab>
+
+<Tab heading="YAML" group="yaml">
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ProxyDefaults
+metadata:
+  name: global
+spec:
+  config:
+    protocol: http
+    max_request_headers_kb: 96
+```
+
+</Tab>
+
+<Tab heading="JSON" group="json">
+
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "Config": {
+    "protocol": "http",
+    "max_request_headers_kb": 96
   }
 }
 ```

--- a/website/content/docs/reference/config-entry/service-defaults.mdx
+++ b/website/content/docs/reference/config-entry/service-defaults.mdx
@@ -84,6 +84,7 @@ The following list outlines field hierarchy, language-specific data types, requi
   - [`Addresses`](#destination): list
   - [`Port`](#destination): integer | `0`
 - [`MaxInboundConnections`](#maxinboundconnections): number | `0`
+- [`MaxRequestHeadersKB`](#maxrequestheaderskb): number | `60`
 - [`LocalConnectTimeoutMs`](#localconnecttimeoutms): number | `0`
 - [`LocalRequestTimeoutMs`](#localrequesttimeoutms): number | `0`
 - [`MeshGateway`](#meshgateway): map
@@ -169,6 +170,7 @@ The following list outlines field hierarchy, language-specific data types, requi
     - [`addresses`](#destination): list
     - [`port`](#destination): number | `0`
   - [`maxInboundConnections`](#maxinboundconnections): number | `0`
+  - [`maxRequestHeadersKB`](#maxrequestheaderskb): number | `60`
   - [`localConnectTimeoutMs`](#localconnecttimeoutms): number | `0`
   - [`localRequestTimeoutMs`](#localrequesttimeoutms): number | `0`
   - [`meshGateway`](#meshgateway): map
@@ -284,6 +286,7 @@ Destination = {
   Port = 0
 }
 MaxInboundConnections = 0
+MaxRequestHeadersKB = 96
 LocalConnectTimeoutMs = 5000
 LocalRequestTimeoutMs = "15s"
 MeshGateway = {
@@ -379,6 +382,7 @@ spec:
       <second hostname or IP address>
     port:  0
   maxInboundConnections: 0
+  maxRequestHeadersKB: 96
   meshGateway:
     mode: <default mode for mesh gateway services>
   externalSNI: <name of TLS SNI outside o f the mesh>
@@ -489,6 +493,7 @@ spec:
 		"Port": 0
 	},
 	"MaxInboundConnections": 0,
+	"MaxRequestHeadersKB": 96,
 	"MeshGateway": {
 		"Mode": "<mode for mesh gateway services>"
 	},
@@ -915,6 +920,18 @@ Specifies the maximum number of concurrent inbound connections to each service i
 
 - Default: `0`
 - Data type: Integer
+
+### `MaxRequestHeadersKB`
+
+Specifies the maximum size in kilobytes for request headers sent from downstream clients to upstream services. This setting applies to HTTP-based protocols only (HTTP, HTTP/2, gRPC). When requests exceed this limit, the proxy returns an HTTP 431 (Request Header Fields Too Large) error.
+
+**Note**: This setting only takes effect when the service protocol is configured as `http`, `http2`, or `grpc` in the service-defaults configuration entry.
+
+#### Values
+
+- Default: `60` (Envoy's default value)
+- Data type: Integer
+- Valid values: `96` or unset (which uses the default of `60`)
 
 ### `LocalConnectTimeoutMs`
 
@@ -1397,6 +1414,18 @@ Specifies the maximum number of concurrent inbound connections to each service i
 
 - Default: `0`
 - Data type: Integer
+
+### `spec.maxRequestHeadersKB`
+
+Specifies the maximum size in kilobytes for request headers sent from downstream clients to upstream services. This setting applies to HTTP-based protocols only (HTTP, HTTP/2, gRPC). When requests exceed this limit, the proxy returns an HTTP 431 (Request Header Fields Too Large) error.
+
+**Note**: This setting only takes effect when the service protocol is configured as `http`, `http2`, or `grpc` in the service-defaults configuration entry.
+
+#### Values
+
+- Default: `60` (Envoy's default value)
+- Data type: Integer
+- Valid values: `96` or unset (which uses the default of `60`)
 
 ### `spec.localConnectTimeoutMs`
 
@@ -1903,6 +1932,40 @@ rateLimit:
       ]
     }
   }
+}
+```
+
+</CodeTabs>
+
+### HTTP Request Header Size Limits
+
+The following example configures a service-specific limit of 96 KB for HTTP request headers for the `web` service.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind = "service-defaults"
+Name = "web"
+Protocol = "http"
+MaxRequestHeadersKB = 96
+```
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: web
+spec:
+  protocol: http
+  maxRequestHeadersKB: 96
+```
+
+```json
+{
+  "Kind": "service-defaults",
+  "Name": "web",
+  "Protocol": "http",
+  "MaxRequestHeadersKB": 96
 }
 ```
 

--- a/website/content/docs/reference/proxy/envoy.mdx
+++ b/website/content/docs/reference/proxy/envoy.mdx
@@ -434,6 +434,11 @@ defaults that are inherited by all services.
   - `exact_balance` - Inbound connections to the service use the
   [Envoy Exact Balance Strategy.](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig-exactbalance)
 
+- `max_request_headers_kb` - The maximum size in kilobytes for request headers 
+  sent from downstream clients to upstream services. Applies to HTTP-based protocols only (HTTP, HTTP/2, gRPC). 
+  If not specified, uses Envoy's default limit(60KB). 
+  **Note**: This setting only takes effect when the service protocol is configured as `http`, `http2`, or `grpc`.
+
 - `xds_fetch_timeout_ms` - In milliseconds, the amount of time for Envoy to wait for EDS and RDS configuration before timing out. If not specified, this field uses Envoy's default value of `15000`, or 15 seconds. When an Envoy instance is configured with a large number of upstreams that take a significant amount of time to populate with data, setting this field to a higher value may prevent temporary disruption caused by unexpected timeouts.
 
 ### Proxy Upstream Config Options


### PR DESCRIPTION
Backport of [#22728](https://github.com/hashicorp/consul/pull/22728)

### Description

Documentation for max_request_headers_kb. 

The documentation is for below mentioned changes,
[#22604](https://github.com/hashicorp/consul/pull/22604)
[#22679](https://github.com/hashicorp/consul/pull/22679)
[#22680](https://github.com/hashicorp/consul/pull/22680)
[#22722](https://github.com/hashicorp/consul/pull/22722)


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
