### PR TITLE
docs: updated annotations for Helm values

### DIFF
--- a/website/content/docs/reference/k8s/annotation-label.mdx
+++ b/website/content/docs/reference/k8s/annotation-label.mdx
@@ -237,6 +237,7 @@ The following Kubernetes resource annotations could be used on a pod to control 
   - `consul.hashicorp.com/consul-sidecar-cpu-request` - Override the default CPU request.
   - `consul.hashicorp.com/consul-sidecar-memory-limit` - Override the default memory limit.
   - `consul.hashicorp.com/consul-sidecar-memory-request` - Override the default memory request.
+  - `consul.hashicorp.com/enable-consul-dataplane-as-sidecar` - If this is set to `true`, then `consul-dataplane` will load as an init container and check the readiness using the startup probe. This will stall the initialisation of the application container until `consul-dataplane` is ready. Default value is `false`.
   - `consul.hashicorp.com/sidecar-initial-probe-check-delay-seconds` - Number of seconds for the initial delay in Kubernetes before the startup probe starts checking the `consul-dataplane sidecar` container. Default value is `1`.
   - `consul.hashicorp.com/sidecar-probe-period-seconds` - Number of seconds for the period between Kubernetes startup probe checks. Default value is `1`.
   - `consul.hashicorp.com/sidecar-probe-failure-threshold` - Number of consecutive failures for the Kubernetes startup probe checks before restarting the `consul-dataplane` sidecar container. Default value is `1`.


### PR DESCRIPTION
### Description

This PR updates the Consul on Kubernetes annotations to include a series of configurable options for running startup probe checks on the consul-dataplane container.

### Links

[Preview link](https://consul-9r0a1vwn3-hashicorp.vercel.app/consul/docs/reference/k8s/annotation-label#consul-hashicorp-com-consul-sidecar)

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] appropriate backport labels added
* [X] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
