### PR TITLE
[Bugfix]: suppress lacks token permission while checking dual stack

### DIFF
--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -401,8 +401,13 @@ func (c *cmd) run(args []string) int {
 	// check dual stack is configured
 	isDualStack, err := c.checkDualStack()
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error checking dual stack: %s", err.Error()))
-		return 1
+		if strings.Contains(err.Error(), "Permission denied") {
+			// Token did not have agent:read. Suppress and proceed with defaults.
+			c.logger.Warn("Permission denied checking for dual stack. Proceeding with default localhost address when unset")
+		} else {
+			c.UI.Error(fmt.Sprintf("Error checking dual stack: %s", err.Error()))
+			return 1
+		}
 	}
 
 	c.logger.Debug("Received", "isDualStack", strconv.FormatBool(isDualStack))


### PR DESCRIPTION
### Description
When we run the `consul connect envoy` its check the dualstack flag for default binding of the admin or grpc address to either IPv4 or IPv6 loopback.

However, netutil.IsDualStack() required agent:read token permission and with an anonymous token is used implicitly its causing the 403 permission error.
`Error checking dual stack: Unexpected response code: 403 (Permission denied: anonymous token lacks permission 'agent:read on "cslc-dc1-client1-d38e00f24f4260b9-pod" in partition "default" in namespace "default". The anonymous token is used implicitly when a request does not specify a token. ' 
`

### Testing & Reproduction steps
1. with ACL enabled in the config start the local agent
`acl {
    enabled = true
}`

2. Run these command to bring up the envoy `consul connect envoy -sidecar-for <service_name>`

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x ] appropriate backport labels added
* [ x] not a security concern

