### PR TITLE
Backport: sec: perform constant time compare for sensitive values (#22537)

### DIFF
--- a/.changelog/22537.txt
+++ b/.changelog/22537.txt
@@ -1,0 +1,3 @@
+```release-note:security
+security: perform constant time compare for sensitive values.
+```

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -5,6 +5,7 @@ package consul
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"sort"
 	"sync"
@@ -969,7 +970,7 @@ func (r *ACLResolver) resolveTokenToIdentityAndPolicies(token string) (structs.A
 		lastErr = err
 
 		if tokenErr, ok := err.(*policyOrRoleTokenError); ok {
-			if acl.IsErrNotFound(err) && tokenErr.token == identity.SecretToken() {
+			if acl.IsErrNotFound(err) && subtle.ConstantTimeCompare([]byte(tokenErr.token), []byte(identity.SecretToken())) == 1 {
 				// token was deleted while resolving policies
 				return nil, nil, acl.ErrNotFound
 			}
@@ -1008,8 +1009,7 @@ func (r *ACLResolver) resolveTokenToIdentityAndRoles(token string) (structs.ACLI
 		lastErr = err
 
 		if tokenErr, ok := err.(*policyOrRoleTokenError); ok {
-			if acl.IsErrNotFound(err) && tokenErr.token == identity.SecretToken() {
-				// token was deleted while resolving roles
+			if acl.IsErrNotFound(err) && subtle.ConstantTimeCompare([]byte(tokenErr.token), []byte(identity.SecretToken())) == 1 { // token was deleted while resolving roles
 				return nil, nil, acl.ErrNotFound
 			}
 

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -5,6 +5,7 @@ package consul
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"os"
@@ -613,7 +614,7 @@ func (a *ACL) TokenDelete(args *structs.ACLTokenDeleteRequest, reply *string) er
 	}
 
 	if token != nil {
-		if args.Token == token.SecretID {
+		if subtle.ConstantTimeCompare([]byte(args.Token), []byte(token.SecretID)) == 1 {
 			return fmt.Errorf("Deletion of the request's authorization token is not permitted")
 		}
 

--- a/agent/consul/auth/token_writer.go
+++ b/agent/consul/auth/token_writer.go
@@ -4,6 +4,7 @@
 package auth
 
 import (
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"time"
@@ -185,7 +186,7 @@ func (w *TokenWriter) Update(token *structs.ACLToken) (*structs.ACLToken, error)
 
 	if token.SecretID == "" {
 		token.SecretID = match.SecretID
-	} else if match.SecretID != token.SecretID {
+	} else if subtle.ConstantTimeCompare([]byte(match.SecretID), []byte(token.SecretID)) != 1 {
 		return nil, errors.New("Changing a token's SecretID is not permitted")
 	}
 


### PR DESCRIPTION
### Description

Backport of [#22537](https://github.com/hashicorp/consul/pull/22537)

[SECVULN-25353](https://hashicorp.atlassian.net/browse/SECVULN-25353)

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[SECVULN-25353]: https://hashicorp.atlassian.net/browse/SECVULN-25353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ