### PR TITLE
Removing dualstack flag from consul redirect and check from consul API

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -1251,8 +1251,7 @@ func addIPOffset(b net.IP) (net.IP, error) {
 // Returns the sum modulo 2^128 as a new IPv6 address.
 func addIPv6Offset(a, b net.IP) (net.IP, error) {
 	a4 := a.To4()
-	b4 := b.To4()
-	if a4 != nil || b4 != nil {
+	if a4 != nil {
 		return nil, errors.New("ip is not valid IPv6")
 	}
 	a16 := a.To16()

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -239,7 +239,8 @@ func TestAddIPv6Offset(t *testing.T) {
 			name:      "IPv4 address for b",
 			a:         net.ParseIP("fd00::1"),
 			b:         net.ParseIP("1.2.3.4"),
-			expectErr: true,
+			expected:  net.ParseIP("fd00::ffff:102:305"),
+			expectErr: false,
 		},
 	}
 

--- a/command/flags/http.go
+++ b/command/flags/http.go
@@ -159,6 +159,13 @@ func (f *HTTPFlags) APIClient() (*api.Client, error) {
 	return api.NewClient(c)
 }
 
+func (f *HTTPFlags) APIConfig() (*api.Config, error) {
+	c := api.DefaultConfig()
+	f.MergeOntoConfig(c)
+
+	return c, nil
+}
+
 func (f *HTTPFlags) MergeOntoConfig(c *api.Config) {
 	f.address.Merge(&c.Address)
 	f.token.Merge(&c.Token)


### PR DESCRIPTION
### Description

Removal of added dualstack flag to redirect-traffic command as it has a http interface available to connect to consul agent
Removing Ipv4 check for b in addIPv6Offset as b passed in code passes check for Ipv4 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
