### PR TITLE
docs: removed duplicate lines

### DIFF
--- a/website/content/docs/east-west/cluster-peering/establish/k8s.mdx
+++ b/website/content/docs/east-west/cluster-peering/establish/k8s.mdx
@@ -16,8 +16,6 @@ The overall process for establishing a cluster peering connection consists of th
 1. Export services between clusters.
 1. Create intentions to authorize services for peers.
 
-Cluster peering between services cannot be established until all four steps are complete.
-
 Cluster peering between services cannot be established until all four steps are complete. If you want to establish cluster peering connections and create sameness groups at the same time, refer to the guidance in [create sameness groups](/consul/docs/multi-tenant/sameness-group/k8s).
 
 For general guidance for establishing cluster peering connections, refer to [Establish cluster peering connections](/consul/docs/east-west/cluster-peering/establish/vm).


### PR DESCRIPTION
### Description

The current documentation had `Cluster peering between services cannot be established until all four steps are complete.` repeated in the peering steps.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [X] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
