### PR TITLE
fix: event endpoint content lenght limit

### DIFF
--- a/agent/event_endpoint_test.go
+++ b/agent/event_endpoint_test.go
@@ -379,6 +379,126 @@ func TestEventList_EventBufOrder(t *testing.T) {
 	})
 }
 
+func TestEventFire_PayloadSizeLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	const maxPayloadSize = 100
+
+	type expectedResponse struct {
+		success      bool
+		statusCode   int
+		errorMessage string
+		eventName    string
+		payloadSize  int
+	}
+
+	testCases := []struct {
+		name             string
+		payloadSize      int
+		expectedResponse *expectedResponse
+		description      string
+	}{
+		{
+			name:        "empty payload",
+			payloadSize: 0,
+			expectedResponse: &expectedResponse{
+				success:     true,
+				eventName:   "test",
+				payloadSize: 0,
+			},
+			description: "empty payload should be accepted",
+		},
+		{
+			name:        "payload within limit",
+			payloadSize: 50,
+			expectedResponse: &expectedResponse{
+				success:     true,
+				eventName:   "test",
+				payloadSize: 50,
+			},
+			description: "small payload should be accepted",
+		},
+		{
+			name:        "payload at exact limit",
+			payloadSize: maxPayloadSize,
+			expectedResponse: &expectedResponse{
+				success:     true,
+				eventName:   "test",
+				payloadSize: maxPayloadSize,
+			},
+			description: "payload at exactly 100 bytes should be accepted",
+		},
+		{
+			name:        "payload exceeds limit by 1 byte",
+			payloadSize: maxPayloadSize + 1,
+			expectedResponse: &expectedResponse{
+				statusCode:   http.StatusRequestEntityTooLarge,
+				errorMessage: "Event payload too large",
+			},
+			description: "payload exceeding limit should be rejected",
+		},
+		{
+			name:        "large payload",
+			payloadSize: 500,
+			expectedResponse: &expectedResponse{
+				statusCode:   http.StatusRequestEntityTooLarge,
+				errorMessage: "Event payload too large",
+			},
+			description: "large payload should be rejected",
+		},
+
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var payload []byte
+			if tc.payloadSize <= 0 {
+				payload = []byte{}
+			} else {
+				payload = bytes.Repeat([]byte("x"), tc.payloadSize)
+			}
+
+			url := "/v1/event/fire/test"
+			req, err := http.NewRequest("PUT", url, bytes.NewBuffer(payload))
+			require.NoError(t, err)
+
+			resp := httptest.NewRecorder()
+			obj, err := a.srv.EventFire(resp, req)
+
+			if tc.expectedResponse.success {
+				require.NoError(t, err, tc.description)
+				require.NotNil(t, obj, "Should return event object on success")
+
+				event, ok := obj.(*UserEvent)
+				require.True(t, ok, "Expected *UserEvent, got %T", obj)
+				require.Equal(t, tc.expectedResponse.eventName, event.Name)
+
+				if tc.expectedResponse.payloadSize == 0 {
+					// Empty payload should result in nil
+					require.Nil(t, event.Payload)
+				} else {
+					expectedPayload := bytes.Repeat([]byte("x"), tc.expectedResponse.payloadSize)
+					require.Equal(t, expectedPayload, event.Payload)
+				}
+			} else {
+				require.Error(t, err, tc.description)
+				httpErr, ok := err.(HTTPError)
+				require.True(t, ok, "Expected HTTPError, got %T", err)
+				require.Equal(t, tc.expectedResponse.statusCode, httpErr.StatusCode)
+				require.Contains(t, httpErr.Reason, tc.expectedResponse.errorMessage)
+				require.Nil(t, obj, "Should not return event object on error")
+			}
+		})
+	}
+}
+
 func TestUUIDToUint64(t *testing.T) {
 	t.Parallel()
 	inp := "cb9a81ad-fff6-52ac-92a7-5f70687805ec"


### PR DESCRIPTION
### Description

Adding a max limit on the Content-Length value for the event endpoint (EventFire function).
Based the max limit of 100 bytes from what we mention in our doc: https://github.com/hashicorp/consul/blob/main/website/content/commands/event.mdx#consul-event

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
