### PR TITLE
Fixed Duplicate Port Validation issues in CLI registration

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2678,6 +2678,8 @@ func (a *Agent) validateService(service *structs.NodeService, chkTypes []*struct
 	for _, port := range service.Ports {
 		if libdns.InvalidNameRe.MatchString(port.Name) {
 			a.logger.Warn("Service Port with name %s will not be discoverable via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes.", port.Name)
+		} else if len(port.Name) > libdns.MaxLabelLength {
+			a.logger.Warn("Service Port with name %s will not be discoverable via DNS due to it being too long. Valid lengths are between 1 and 63 bytes.", "portName", port.Name)
 		}
 	}
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -398,18 +398,6 @@ type ServicePort struct {
 	Default *bool   `mapstructure:"default"`
 }
 
-func (sp ServicePort) Validate() error {
-	if sp.Name == nil {
-		return fmt.Errorf("every port in ports must have a name defined")
-	}
-
-	if sp.Port == nil {
-		return fmt.Errorf("every port in ports must have a port defined")
-	}
-
-	return nil
-}
-
 type ServiceDefinition struct {
 	Kind              *string                   `mapstructure:"kind"`
 	ID                *string                   `mapstructure:"id"`

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -6205,7 +6205,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 				{
 					Name: "test1",
 					ID:   "test1",
-					Ports: []structs.ServicePort{
+					Ports: structs.ServicePorts{
 						{
 							Name:    "http",
 							Port:    8080,

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1322,8 +1322,8 @@ func (sp ServicePorts) Validate() error {
 			return fmt.Errorf("Ports.Name cannot be empty")
 		}
 
-		if p.Port == 0 {
-			return fmt.Errorf("Ports.Port must be non-zero")
+		if p.Port <= 0 {
+			return fmt.Errorf("Ports.Port must be greater than zero")
 		}
 
 		_, ok := seenName[p.Name]

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -3341,7 +3341,16 @@ func TestServicePorts_Validate(t *testing.T) {
 					Port: 0,
 				},
 			},
-			expectedErr: "Ports.Port must be non-zero",
+			expectedErr: "Ports.Port must be greater than zero",
+		},
+		"invalid_negative_port_number": {
+			ports: ServicePorts{
+				{
+					Name: "http",
+					Port: 0,
+				},
+			},
+			expectedErr: "Ports.Port must be greater than zero",
 		},
 		"invalid_no_default": {
 			ports: ServicePorts{

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -775,7 +775,7 @@ func TestStructs_NodeService_ValidateMultiPort(t *testing.T) {
 					},
 				},
 			},
-			Err: "Ports.Port must be non-zero",
+			Err: "ports.port must be greater than zero",
 		},
 	}
 

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -3347,7 +3347,7 @@ func TestServicePorts_Validate(t *testing.T) {
 			ports: ServicePorts{
 				{
 					Name: "http",
-					Port: 0,
+					Port: -8080,
 				},
 			},
 			expectedErr: "Ports.Port must be greater than zero",

--- a/api/agent.go
+++ b/api/agent.go
@@ -169,7 +169,7 @@ type AgentService struct {
 	Locality   *Locality `json:",omitempty" bexpr:"-" hash:"ignore"`
 }
 
-func (a *AgentService) DefaultPort() int {
+func (a AgentService) DefaultPort() int {
 	for _, p := range a.Ports {
 		if p.Default {
 			return p.Port


### PR DESCRIPTION
### Description
Initially, we thought that every port in a service definition has to be unique, but we found out that multiple services expose different protocols in the same port and would want to define them as different ports with different names in consul. This is also backed by the fact that K8s allows multiple ports with duplicate port values as long as the port names are unique.

This PR acknowledges this and modifies the multiport validation to allow duplicate ports.

### Testing & Reproduction steps

1. Start consul agent with the branch
2. Register this service definition ( Note that the port value is same for both the ports )
```hcl
service {
  name = "multiport-service"
  ports = [
    {
      name = "http"
      port = 8080
      default = true
    },
    {
      name = "metrics",
      port = 8080
    }
  ]
}
```
3. Ensure registration goes through. You can `curl localhost:8500/v1/catalog/service/multiport-service`

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
