### PR TITLE
Feature: adding a Dev Container to Consul, enabling us to launch Cons…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+{
+	"name": "Hashicorp - Consul",
+  
+	// Docker image to use
+	"image": "hashicorp/consul",
+	
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "build": {
+	//   // Path is relative to the devcontainer.json file.
+	//   "dockerfile": "../Dockerfile"
+	// }
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "consul info",
+
+	// Use 'postStartCommand' to run commands after the container is created like starting consul.
+	"postStartCommand": "sh -c 'consul agent -dev'",
+
+	"forwardPorts": [8500],
+	"portsAttributes": {
+		"8500": {
+			"label": "Consul UI",
+			"onAutoForward": "notify"
+		}
+	}
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A few quick start guides are available on the Consul website:
 * **Kind install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-kind
 * **Kubernetes install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-deployment-guide
 * **Deploy HCP Consul:** https://learn.hashicorp.com/tutorials/consul/hcp-gs-deploy 
+* **Open in GitHub Codespaces:** https://codespaces.new/hashicorp/consul?quickstart=1
 
 ## Documentation
 


### PR DESCRIPTION
This PR adds a Dev Container to vault repository. Enabling us to run consul in a Github Codespace or locally using a Dev Container

When we create a Github Codespace a new VSCode window will open
<img width="1916" height="1037" alt="image" src="https://github.com/user-attachments/assets/98db992b-23e0-49e2-845e-940443fe51e1" />

The Codespace will display the output of the postStartCommand sh -c 'consul agent -dev'
<img width="1915" height="1040" alt="image" src="https://github.com/user-attachments/assets/1c3351ea-7ae6-4f9f-b274-6d8938c9f549" />

Port 8500 Consul UI will be available in the Ports tab
<img width="1916" height="1037" alt="image" src="https://github.com/user-attachments/assets/56485175-688a-4b9c-852f-00147e7bc90b" />

We can right click on that port and open it ina. new browser window 
<img width="1918" height="1036" alt="image" src="https://github.com/user-attachments/assets/ae7a8dd1-6353-4fb7-aa42-2386ff785d4b" />

And we will be greeted by the Consul UI
<img width="1915" height="1037" alt="image" src="https://github.com/user-attachments/assets/813ba977-c8b5-4930-bf4a-e5c273118124" />

This is to my knowledge the fastest way to launch Consul for demo or evaluation purposes live on the internet.

Thank you for this great project!




