### PR TITLE
Addition of missing IPv6 listeners and envoy dns ipv4 only resolution change

### DIFF
--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -949,6 +949,13 @@ func makeListener(opts makeListenerOpts) *envoy_listener_v3.Listener {
 func makeListenerWithDefault(opts makeListenerOpts) *envoy_listener_v3.Listener {
 	if opts.addr == "" {
 		opts.addr = "127.0.0.1"
+		ds, err := netutil.IsDualStack(nil, true)
+		if err != nil {
+			return nil
+		}
+		if ds {
+			opts.addr = "::1"
+		}
 	}
 	accessLog, err := accesslogs.MakeAccessLogs(&opts.accessLogs, true)
 	if err != nil && opts.logger != nil {
@@ -1342,6 +1349,13 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 	addr := cfgSnap.Address
 	if addr == "" {
 		addr = "0.0.0.0"
+		ds, err := netutil.IsDualStack(nil, true)
+		if err != nil {
+			return nil, err
+		}
+		if ds {
+			addr = "::"
+		}
 	}
 	if cfg.BindAddress != "" {
 		addr = cfg.BindAddress
@@ -1565,6 +1579,13 @@ func (s *ResourceGenerator) makeExposedCheckListener(cfgSnap *proxycfg.ConfigSna
 		addr = cfg.BindAddress
 	} else if addr == "" {
 		addr = "0.0.0.0"
+		ds, err := netutil.IsDualStack(nil, true)
+		if err != nil {
+			return nil, err
+		}
+		if ds {
+			addr = "::"
+		}
 	}
 
 	// Strip any special characters from path to make a valid and hopefully unique name

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -528,6 +528,13 @@ func (c *cmd) proxyRegistration(svcForSidecar *api.AgentService) (*api.AgentServ
 		// fallback to localhost as the gateway has to reside in the same network namespace
 		// as the agent
 		tcpCheckAddr = "127.0.0.1"
+		ds, err := netutil.IsDualStack(nil, false)
+		if err == nil {
+			return nil, err
+		}
+		if ds {
+			tcpCheckAddr = "::1"
+		}
 	}
 
 	var proxyConf *api.AgentServiceConnectProxyConfig


### PR DESCRIPTION
### Description

Adds ::1 check in case of 127.0.0.1  and :: in case of 0.0.0.0 for listeners 
Change default envoy dns resolution to ALL in case of dualstack
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
