### PR TITLE
Fix for WAN federation policy update in secondaryDC to older version when stale reads from lagging follower in primaryDC

### DIFF
--- a/.changelog/22954.txt
+++ b/.changelog/22954.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: fixed a bug where ACL policy replication in WANfed is impacted when primaryDC is inconsistent
+```

--- a/agent/consul/acl_replication.go
+++ b/agent/consul/acl_replication.go
@@ -66,6 +66,11 @@ type aclTypeReplicator interface {
 	// correction phase).
 	FetchUpdated(srv *Server, updates []string) (int, error)
 
+	//ensureUpdatedConsistent compares the updated items with the upsertable remotes
+	//returns consistent update check post stale batch read or other scenarios
+	//[]string of items missing from remote, []string of items updated remote, error if inconsistent
+	ensureUpdatedConsistent(updates []string) ([]string, []string, error)
+
 	// LenPendingUpdates should be the size of the data retrieved in
 	// FetchUpdated.
 	LenPendingUpdates() int
@@ -87,6 +92,7 @@ type aclTypeReplicator interface {
 }
 
 var errContainsRedactedData = errors.New("replication results contain redacted data")
+var errContainsStaleData = errors.New("replication batch read for update items contain stale data")
 
 func (s *Server) fetchACLRolesBatch(roleIDs []string) (*structs.ACLRoleBatchResponse, error) {
 	req := structs.ACLRoleBatchGetRequest{
@@ -436,10 +442,18 @@ func (s *Server) replicateACLType(ctx context.Context, logger hclog.Logger, tr a
 
 	if len(res.LocalUpserts) > 0 {
 		lenUpdated, err := tr.FetchUpdated(s, res.LocalUpserts)
-		if err == errContainsRedactedData {
-			return 0, false, fmt.Errorf("failed to retrieve unredacted %s - replication token in use does not grant acl:write", tr.PluralNoun())
-		} else if err != nil {
+		if err != nil {
+			if err == errContainsRedactedData {
+				return 0, false, fmt.Errorf("failed to retrieve unredacted %s - replication token in use does not grant acl:write", tr.PluralNoun())
+			}
 			return 0, false, fmt.Errorf("failed to retrieve ACL %s updates: %v", tr.SingularNoun(), err)
+		}
+		_, _, err = tr.ensureUpdatedConsistent(res.LocalUpserts)
+		if err != nil {
+			if err == errContainsStaleData {
+				return 0, false, fmt.Errorf("failed to ensure consistent %s replication updates - stale data", tr.PluralNoun())
+			}
+			return 0, false, fmt.Errorf("failed to ensure consistent ACL %s updates: %v", tr.SingularNoun(), err)
 		}
 		logger.Debug(
 			"acl replication - downloaded updates",

--- a/agent/consul/acl_replication_types.go
+++ b/agent/consul/acl_replication_types.go
@@ -204,7 +204,7 @@ func (r *aclPolicyReplicator) ensureRemoteConsistent(updates []string) ([]string
 	}
 
 	//iterate over all updates array which are policy IDs check if the hash match for both
-	var consistent bool = true
+	var consistent = true
 	var remoteNotCreated []string
 	var remoteNotUpdated []string
 	var err error = nil

--- a/agent/consul/acl_replication_types.go
+++ b/agent/consul/acl_replication_types.go
@@ -4,6 +4,7 @@
 package consul
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -84,6 +85,11 @@ func (r *aclTokenReplicator) FetchUpdated(srv *Server, updates []string) (int, e
 	}
 
 	return len(r.updated), nil
+}
+
+func (r *aclTokenReplicator) ensureUpdatedConsistent(updates []string) ([]string, []string, error) {
+	//return true if consistent updates,
+	return []string{}, []string{}, nil
 }
 
 func (r *aclTokenReplicator) DeleteLocalBatch(srv *Server, batch []string) error {
@@ -184,6 +190,43 @@ func (r *aclPolicyReplicator) FetchUpdated(srv *Server, updates []string) (int, 
 	}
 
 	return len(r.updated), nil
+}
+
+func (r *aclPolicyReplicator) ensureUpdatedConsistent(updates []string) ([]string, []string, error) {
+	updatedMap := make(map[string]*structs.ACLPolicy)
+	for _, policy := range r.updated {
+		updatedMap[policy.ID] = policy
+	}
+
+	remoteMap := make(map[string]*structs.ACLPolicyListStub)
+	for _, policyStub := range r.remote {
+		remoteMap[policyStub.ID] = policyStub
+	}
+
+	//iterate over all updates array which are policy IDs check if the hash match for both
+	var consistent bool = true
+	var deleted []string
+	var updated []string
+	var err error = nil
+
+	for _, policyID := range updates {
+		if updatedPolicy, ok := updatedMap[policyID]; ok {
+			if remotePolicy, ok := remoteMap[policyID]; ok {
+				if !bytes.Equal(updatedPolicy.Hash, remotePolicy.Hash) {
+					updated = append(updated, policyID)
+					consistent = false
+				}
+			}
+		} else {
+			deleted = append(deleted, policyID)
+			consistent = false
+		}
+	}
+
+	if !consistent {
+		err = errContainsStaleData
+	}
+	return deleted, updated, err
 }
 
 func (r *aclPolicyReplicator) DeleteLocalBatch(srv *Server, batch []string) error {
@@ -305,6 +348,11 @@ func (r *aclRoleReplicator) FetchUpdated(srv *Server, updates []string) (int, er
 	}
 
 	return len(r.updated), nil
+}
+
+func (r *aclRoleReplicator) ensureUpdatedConsistent(updates []string) ([]string, []string, error) {
+	//return true if consistent updates,
+	return []string{}, []string{}, nil
 }
 
 func (r *aclRoleReplicator) DeleteLocalBatch(srv *Server, batch []string) error {


### PR DESCRIPTION
Ensure retry if policy batch read for updating into raft has stale reads. 
Fixes the wan federation policy replication issue where raft committed older policy

### Description
This issue happens when there is a mismatch in primaryDC state consistency between leader follower 
and WAN federation setup where secondaryDC replicates the policies from primaryDC. 

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps
Tested with a script for 30 mins to see 
 - if any policy replication from primary was delayed (yes , delay happens and sometimes i had to retry once for fetching the policy from dc2 till it gets replicated) 
 - if policy replicated from primary is wrongly set (no, this fixes this) . 
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
