### PR TITLE
[UI] replace direct use of transitionTo with router service's transitionTo…

### DIFF
--- a/ui/packages/consul-ui/app/mixins/with-blocking-actions.js
+++ b/ui/packages/consul-ui/app/mixins/with-blocking-actions.js
@@ -24,6 +24,7 @@ import { singularize } from 'ember-inflector';
  *
  */
 export default Mixin.create({
+  router: service('router'),
   _feedback: service('feedback'),
   settings: service('settings'),
   init: function () {
@@ -50,7 +51,7 @@ export default Mixin.create({
     // e.g. index or edit
     parts.pop();
     // e.g. dc.intentions, essentially go to the listings page
-    return this.transitionTo(parts.join('.'));
+    return this.router.transitionTo(parts.join('.'));
   },
   afterDelete: function (item) {
     // e.g. dc.intentions.index
@@ -63,7 +64,7 @@ export default Mixin.create({
         return this.refresh();
       default:
         // e.g. dc.intentions essentially do to the listings page
-        return this.transitionTo(parts.join('.'));
+        return this.router.transitionTo(parts.join('.'));
     }
   },
   errorCreate: function (type, e) {

--- a/ui/packages/consul-ui/app/routes/dc/kv/folder.js
+++ b/ui/packages/consul-ui/app/routes/dc/kv/folder.js
@@ -4,13 +4,16 @@
  */
 
 import Route from './index';
+import { inject as service } from '@ember/service';
 
 export default class FolderRoute extends Route {
+  @service router;
+
   beforeModel(transition) {
     super.beforeModel(...arguments);
     const params = this.paramsFor('dc.kv.folder');
     if (params.key === '/' || params.key == null) {
-      return this.transitionTo('dc.kv.index');
+      return this.router.transitionTo('dc.kv.index');
     }
   }
 }

--- a/ui/packages/consul-ui/app/routes/dc/kv/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/kv/index.js
@@ -5,9 +5,12 @@
 
 import Route from 'consul-ui/routing/route';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import isFolder from 'consul-ui/utils/isFolder';
 
 export default class IndexRoute extends Route {
+  @service router;
+
   beforeModel() {
     // we are index or folder, so if the key doesn't have a trailing slash
     // add one to force a fake findBySlug
@@ -21,7 +24,7 @@ export default class IndexRoute extends Route {
   @action
   error(e) {
     if (e.errors && e.errors[0] && e.errors[0].status == '404') {
-      return this.transitionTo('dc.kv.index');
+      return this.router.transitionTo('dc.kv.index');
     }
     // let the route above handle the error
     return true;

--- a/ui/packages/consul-ui/tests/unit/mixins/with-blocking-actions-test.js
+++ b/ui/packages/consul-ui/tests/unit/mixins/with-blocking-actions-test.js
@@ -34,11 +34,11 @@ module('Unit | Mixin | with blocking actions', function (hooks) {
     assert.deepEqual(actual, expected);
     assert.ok(afterUpdate.calledOnce);
   });
-  test('afterUpdate calls transitionTo without the last part of the current route name', function (assert) {
+  test('afterUpdate calls router.transitionTo without the last part of the current route name', function (assert) {
     const subject = this.subject();
     const expected = 'dc.kv';
     subject.routeName = expected + '.edit';
-    const transitionTo = sinon.stub(subject, 'transitionTo').returnsArg(0);
+    const transitionTo = sinon.stub(subject.router, 'transitionTo').returnsArg(0);
     const actual = subject.afterUpdate();
     assert.equal(actual, expected);
     assert.ok(transitionTo.calledOnce);
@@ -47,7 +47,7 @@ module('Unit | Mixin | with blocking actions', function (hooks) {
     const subject = this.subject();
     const expected = 'dc.kv';
     subject.routeName = expected + '.edit';
-    const transitionTo = sinon.stub(subject, 'transitionTo').returnsArg(0);
+    const transitionTo = sinon.stub(subject.router, 'transitionTo').returnsArg(0);
     const actual = subject.afterDelete();
     assert.equal(actual, expected);
     assert.ok(transitionTo.calledOnce);


### PR DESCRIPTION
… method

### Description

Replace direct use of transitionTo with router service's transitionTo method.
https://deprecations.emberjs.com/id/routing-transition-methods/