### PR TITLE
DO NOT MERGE - CSL-9309: Fix logger set to info for 'tls.defaults.verify_incoming' in FIPS mode

### DIFF
--- a/.changelog/22987.txt
+++ b/.changelog/22987.txt
@@ -1,0 +1,3 @@
+```release-note:logger
+fips: Fix logger set to info for 'tls.defaults.verify_incoming' in FIPS mode
+```

--- a/agent/agent_ce.go
+++ b/agent/agent_ce.go
@@ -40,8 +40,8 @@ func enterpriseConsulConfig(_ *consul.Config, _ *config.RuntimeConfig) {
 }
 
 // validateFIPSConfig is a noop stub for the func defined in agent_ent.go
-func validateFIPSConfig(_ *config.RuntimeConfig) error {
-	return nil
+func validateFIPSConfig(_ *config.RuntimeConfig) ([]string, error) {
+	return []string{}, nil
 }
 
 // WriteEvent is a noop stub for the func defined agent_ent.go


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/CSL-9309

we decided to set the logger to info for tls.defaults.verfiy_incoming at global level since this requires the mTLS at all levels, which is not a FIPS mandatory requirement, anyhow if there is customer requirement it should come through enhancement request.
But we still have mTLS at other levels.

To have the mTLS enabled at global level we need a feature/enhancement request ticket.