### PR TITLE
doc: website/forwarding: fix contradicting statements

### DIFF
--- a/website/content/docs/manage/dns/forwarding/index.mdx
+++ b/website/content/docs/manage/dns/forwarding/index.mdx
@@ -22,8 +22,8 @@ You deployed a Consul datacenter and want to use Consul DNS interface for name r
 
 When configured with default values, Consul exposes the DNS interface on port
 8600, while the standard port for DNS is 53. On most operating systems,
-binding to port 53 requires elevated privileges. It is also common, for most
-operating systems, to have a local DNS server already running on port 53.
+binding to port 53 requires elevated privileges. It is also common for 
+operating systems to have a local DNS server already running on port 53.
 
 Instead of running Consul with an administrative or root account, you may forward appropriate queries to Consul, running on an unprivileged port, from another DNS server or using port redirect.
 

--- a/website/content/docs/manage/dns/forwarding/index.mdx
+++ b/website/content/docs/manage/dns/forwarding/index.mdx
@@ -21,9 +21,9 @@ You may apply these operations on every node where a Consul agent is running. On
 You deployed a Consul datacenter and want to use Consul DNS interface for name resolution.
 
 When configured with default values, Consul exposes the DNS interface on port
-8600. By default, Consul serves DNS from port 53. On most operating systems,
-this requires elevated privileges. It is also common, for most operating
-systems, to have a local DNS server already running on port 53.
+8600, while the standard port for DNS is 53. On most operating systems,
+binding to port 53 requires elevated privileges. It is also common, for most
+operating systems, to have a local DNS server already running on port 53.
 
 Instead of running Consul with an administrative or root account, you may forward appropriate queries to Consul, running on an unprivileged port, from another DNS server or using port redirect.
 


### PR DESCRIPTION
### Description

The DNS forwarding documentation was first stating (correctly) that Consul DNS binds to port 8600, and just after stating (incorrectly) that it binds to port 53. Maybe this was a merge damage?

### Testing & Reproduction steps

N/A (documentation change)

### Links

The current (pre-PR) rendered page: https://developer.hashicorp.com/consul/docs/manage/dns/forwarding#introduction

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
