### PR TITLE
Skip query failover entirely if it's not configured for a prepared query

### DIFF
--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -481,7 +481,7 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 		// In the happy path where we found some healthy nodes we go with that
 		// and bail out. Otherwise, we fail over and try remote DCs, as allowed
 		// by the query setup.
-		if len(reply.Nodes) == 0 {
+		if len(reply.Nodes) == 0 && !query.Service.Failover.IsEmpty() {
 			wrapper := newQueryServerWrapper(p.srv, p.ExecuteRemote)
 			if err := queryFailover(wrapper, *query, args, reply); err != nil {
 				return err


### PR DESCRIPTION


### Description

This avoids calling GetOtherDatacentersByDistance through queryFailover() method that could be expensive. 

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
