### PR TITLE
fix route-refresh helper invocation deprecation and ember-can deprecation

### DIFF
--- a/ui/packages/consul-lock-sessions/app/templates/dc/nodes/show/sessions.hbs
+++ b/ui/packages/consul-lock-sessions/app/templates/dc/nodes/show/sessions.hbs
@@ -4,7 +4,7 @@
 }}
 
 <Route
-  @name={{routeName}}
+  @name={{this.routeName}}
 as |route|>
   <DataLoader @src={{uri '/${partition}/${nspace}/${dc}/sessions/for-node/${node}'
     (hash
@@ -23,7 +23,7 @@ as |route|>
     </BlockSlot>
 
     <BlockSlot @name="loaded">
-{{#let api.data as |items|}}
+{{#let api.data (refresh-route) as |items refreshRoute|}}
     <div class="tab-section">
       <DataWriter
         @sink={{uri '/${partition}/${dc}/${nspace}/session/'
@@ -35,7 +35,8 @@ as |route|>
         }}
         @type="session"
         @label="Lock Session"
-        @ondelete={{refresh-route}}
+        {{!-- @ondelete={{refresh-route}} --}}
+        @ondelete={{refreshRoute}}
       as |writer|>
 
         <BlockSlot @name="removed" as |after|>

--- a/ui/packages/consul-nspaces/app/templates/dc/nspaces/index.hbs
+++ b/ui/packages/consul-nspaces/app/templates/dc/nspaces/index.hbs
@@ -74,6 +74,7 @@ as |route|>
       {{/if}}
       </BlockSlot>
       <BlockSlot @name="content">
+        {{#let (refresh-route) as |refreshRoute|}}
         <DataWriter
           @sink={{uri '/${partition}/${dc}/${nspace}/nspace/'
             (hash
@@ -84,7 +85,7 @@ as |route|>
           }}
           @type="nspace"
           @label="Namespace"
-          @ondelete={{refresh-route}}
+          @ondelete={{refreshRoute}}
         as |writer|>
           <BlockSlot @name="removed" as |after|>
             <Consul::Nspace::Notifications 
@@ -150,6 +151,7 @@ as |route|>
         </DataCollection>
     </BlockSlot>
   </DataWriter>
+  {{/let}}
       </BlockSlot>
     </AppView>
   {{/let}}

--- a/ui/packages/consul-partitions/app/templates/dc/partitions/index.hbs
+++ b/ui/packages/consul-partitions/app/templates/dc/partitions/index.hbs
@@ -74,6 +74,7 @@ as |route|>
       {{/if}}
       </BlockSlot>
       <BlockSlot @name="content">
+        {{#let (refresh-route) as |refreshRoute|}}
         <DataWriter
           @sink={{uri '/${partition}/${dc}/${nspace}/partition/'
             (hash
@@ -84,7 +85,7 @@ as |route|>
           }}
           @type="partition"
           @label="Partition"
-          @ondelete={{refresh-route}}
+          @ondelete={{refreshRoute}}
         as |writer|>
           <BlockSlot @name="removed" as |after|>
             <Consul::Partition::Notifications 
@@ -140,6 +141,7 @@ as |route|>
         </DataCollection>
     </BlockSlot>
   </DataWriter>
+  {{/let}}
       </BlockSlot>
     </AppView>
   {{/let}}

--- a/ui/packages/consul-ui/.template-lintrc.js
+++ b/ui/packages/consul-ui/.template-lintrc.js
@@ -28,9 +28,7 @@ module.exports = {
     'style-concatenation': false,
     'link-rel-noopener': false,
 
-    'no-implicit-this': {
-      allow: ['refresh-route'],
-    },
+    'no-implicit-this': 'error',
     'no-curly-component-invocation': false,
     'no-action': false,
     'no-negated-condition': false,

--- a/ui/packages/consul-ui/app/services/abilities.js
+++ b/ui/packages/consul-ui/app/services/abilities.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import Service from 'ember-can/services/can';
+import Service from 'ember-can/services/abilities';
 
 export default class AbilitiesService extends Service {
   parse(str) {

--- a/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
@@ -81,6 +81,7 @@ as |route|>
 
       </BlockSlot>
       <BlockSlot @name="content">
+        {{#let (refresh-route) as |refreshRoute|}}
         <DataWriter
           @sink={{uri '/${partition}/${dc}/${nspace}/intention/'
             (hash
@@ -90,8 +91,8 @@ as |route|>
             )
           }}
           @type="intention"
-          @ondelete={{refresh-route}}
-          @onchange={{refresh-route}}
+          @ondelete={{refreshRoute}}
+          @onchange={{refreshRoute}}
         as |writer|>
           <BlockSlot @name="content">
             <DataCollection
@@ -153,6 +154,7 @@ as |route|>
             </DataCollection>
           </BlockSlot>
         </DataWriter>
+        {{/let}}
       </BlockSlot>
     </AppView>
 

--- a/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
@@ -138,6 +138,7 @@ as |sort filters parent items|}}
 {{/if}}
       </BlockSlot>
       <BlockSlot @name="content">
+        {{#let (refresh-route) as |refreshRoute|}}
         <DataWriter
           @sink={{uri '/${partition}/${nspace}/${dc}/kv/'
             (hash
@@ -148,7 +149,7 @@ as |sort filters parent items|}}
           }}
           @type="kv"
           @label="key"
-          @ondelete={{refresh-route}}
+          @ondelete={{refreshRoute}}
           as |writer|>
           <BlockSlot @name="content">
             <DataCollection
@@ -208,6 +209,7 @@ as |sort filters parent items|}}
             </DataCollection>
           </BlockSlot>
         </DataWriter>
+        {{/let}}
       </BlockSlot>
     </AppView>
 {{/let}}

--- a/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
@@ -66,6 +66,7 @@ as |route|>
           @filter={{filters}}
         />
   {{/if}}
+  {{#let (refresh-route) as |refreshRoute|}}
         <DataWriter
           @sink={{uri
             '/${partition}/${dc}/${nspace}/intention/'
@@ -76,7 +77,7 @@ as |route|>
             )
           }}
           @type="intention"
-          @ondelete={{refresh-route}}
+          @ondelete={{refreshRoute}}
         as |writer|>
           <BlockSlot @name="content">
             <DataCollection
@@ -140,6 +141,7 @@ as |route|>
             </DataCollection>
           </BlockSlot>
         </DataWriter>
+        {{/let}}
     </div>
   {{/let}}
     </BlockSlot>


### PR DESCRIPTION
…tion

### Description

<!-- Please describe why you're making this change, in plain English. -->

https://deprecations.emberjs.com/id/argument-less-helper-paren-less-invocation/
Fix this deprecation from ember-can library -  ember-can.can-service

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
