### PR TITLE
monkey patches functions of ember collection library which caused deprecation issue

### DIFF
--- a/ui/packages/consul-ui/app/components/list-collection/index.js
+++ b/ui/packages/consul-ui/app/components/list-collection/index.js
@@ -8,7 +8,7 @@ import { computed, get, set } from '@ember/object';
 import Component from 'ember-collection/components/ember-collection';
 import PercentageColumns from 'ember-collection/layouts/percentage-columns';
 import Slotted from 'block-slots';
-import { A } from '@ember/array'; 
+import { A } from '@ember/array';
 
 const formatItemStyle = PercentageColumns.prototype.formatItemStyle;
 
@@ -65,7 +65,7 @@ export default Component.extend(Slotted, {
     },
   }),
 
-   updateItems() {
+  updateItems() {
     this._cellLayout = this.getAttr('cell-layout');
     const rawItems = this.getAttr('items');
     if (this._rawItems !== rawItems) {
@@ -76,11 +76,22 @@ export default Component.extend(Slotted, {
       if (!items.__patchedMutators) {
         items.__patchedMutators = true;
         const self = this;
-        ['pushObject','popObject','removeObject','insertAt','unshiftObject','shiftObject','splice','setObjects','reverse','sort'].forEach(m => {
+        [
+          'pushObject',
+          'popObject',
+          'removeObject',
+          'insertAt',
+          'unshiftObject',
+          'shiftObject',
+          'splice',
+          'setObjects',
+          'reverse',
+          'sort',
+        ].forEach((m) => {
           if (typeof items[m] === 'function') {
             const orig = items[m];
-            items[m] = function() {
-              const out = orig.apply(this, arguments);
+            items[m] = function (...args) {
+              const out = orig.apply(this, args);
               if (!self.isDestroying && !self.isDestroyed) {
                 self._needsRevalidate();
               }

--- a/ui/packages/consul-ui/app/components/tabular-collection/index.js
+++ b/ui/packages/consul-ui/app/components/tabular-collection/index.js
@@ -9,7 +9,7 @@ import CollectionComponent from 'ember-collection/components/ember-collection';
 import needsRevalidate from 'ember-collection/utils/needs-revalidate';
 import Grid from 'ember-collection/layouts/grid';
 import Slotted from 'block-slots';
-import { A } from '@ember/array'; 
+import { A } from '@ember/array';
 
 const formatItemStyle = Grid.prototype.formatItemStyle;
 
@@ -88,11 +88,22 @@ export default CollectionComponent.extend(Slotted, {
       if (!items.__patchedMutators) {
         items.__patchedMutators = true;
         const self = this;
-        ['pushObject','popObject','removeObject','insertAt','unshiftObject','shiftObject','splice','setObjects','reverse','sort'].forEach(m => {
+        [
+          'pushObject',
+          'popObject',
+          'removeObject',
+          'insertAt',
+          'unshiftObject',
+          'shiftObject',
+          'splice',
+          'setObjects',
+          'reverse',
+          'sort',
+        ].forEach((m) => {
           if (typeof items[m] === 'function') {
             const orig = items[m];
-            items[m] = function() {
-              const out = orig.apply(this, arguments);
+            items[m] = function (...args) {
+              const out = orig.apply(this, args);
               if (!self.isDestroying && !self.isDestroyed) {
                 self._needsRevalidate();
               }


### PR DESCRIPTION
…recation issue

### Description

<!-- Please describe why you're making this change, in plain English. -->

Array observers issue is present in the app due to the ember collection library which is using the deprecated functionality
https://deprecations.emberjs.com/id/array-observers/

This PR monkey patches the core functions which are being used in the app to fix the deprecation.

Must upgrade to a newer version of ember-collection once that is available or shift to a different library with similar feature at a later point of time

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
