### PR TITLE
docs: Update "New issue" flow to point to web-unified-docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,12 +3,12 @@
 
 blank_issues_enabled: false
 contact_links:
+  - name: Issues with content on developer.hashicorp.com
+    url: https://github.com/hashicorp/web-unified-docs/issues
+    about: Report the issue in the web-unified-docs repository
   - name: Consul Community Support
     url: https://discuss.hashicorp.com/c/consul/29
     about: If you have a question, or are looking for advice, please post on our Discuss forum! The community loves to chime in to help. Happy Coding!
   - name: Consul on Kubernetes GitHub Issues
     url: https://github.com/hashicorp/consul-k8s
     about: Are you submitting an issue or feature enhancement for the Consul Helm chart? Please post in the consul-k8s GitHub Issues.
-  - name: Consul Learn Tracks
-    url: https://learn.hashicorp.com/consul?track=getting-started#getting-started
-    about: Please check out our Learn Guides. These hands on guides deal with many of the tasks common to using Consul


### PR DESCRIPTION
### Description

This PR updates the flow to create a new issue in the consul GH repo to include a link to the `web-unified-docs` repo.

Now that Consul docs live in the `web-unified-docs` repo, we would like users to create issues there instead of in the `consul` repo.


### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
