### PR TITLE
Update Fabio LB link to refliect current home.

### DIFF
--- a/website/content/docs/integrate/consul-tools.mdx
+++ b/website/content/docs/integrate/consul-tools.mdx
@@ -49,7 +49,7 @@ These Consul tools are created and managed by the amazing members of the Consul 
 - [docker-consul](https://github.com/gliderlabs/docker-consul) - Dockerized Consul Agent
 - [Dropwizard Consul Bundle](https://github.com/smoketurner/dropwizard-consul) - Service discovery and configuration integration with the [Dropwizard](http://www.dropwizard.io/) framework
 - [Embedded Consul](https://github.com/pszymczyk/embedded-consul) - Library for JVM based applications, provides easy way to run Consul in integration tests
-- [fabio](https://github.com/eBay/fabio) - Fast, zero-conf, consul-aware load-balancing HTTP/HTTPS router
+- [Fabio](https://fabiolb.net) - Fast, zero-conf, consul-aware load-balancing HTTP/HTTPS router
 - [files-to-consul-kv](https://github.com/bitsofinfo/files-to-consul-kv) - Ultra simple, configuration free CLI tool for syncing a directory structure of key-value files to Consul KV using the transactions API. Docker image available. Integrates easily into any CI/CD workflow.
 - [file2consul](https://github.com/joeatbayes/file2consul) - Update Consul values from git or files. Config loader with support for multiple environments. Provides variable expansion, interpolation, inheritance with overrides and ability to update multiple consul servers. Reduces cost of maintaining larger configuration sets between environments by reducing restatement and manual editing of similar or predictably changing config properties. MIT license, Written in GO.
 - [Flightpath](https://docs.flightpath.xyz/) - An xDS server that can configure Envoy to act as an Edge proxy for Consul service mesh enabled services


### PR DESCRIPTION
### Description

This updates the link to Fabio loadbalancer in the 'integrations' - 'consul tools' part of the docs.

### Testing & Reproduction steps

follow the link at https://developer.hashicorp.com/consul/docs/integrate/consul-tools to see where it goes.

### Links

[Fabio on github](https://github.com/fabiolb/fabio)

[Fabio's home page](https://fabiolb.net)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
