### PR TITLE
(configurable VIP) added new config to configure virtual ip CIDRs in t-proxy

### DIFF
--- a/.changelog/23085.txt
+++ b/.changelog/23085.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: added ability to configure Virtual IP range for t-proxy with CIDRs
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1564,6 +1564,8 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 
 		cfg.CAConfig = ca
 	}
+	cfg.ConnectVirtualIPCIDRv4 = runtimeCfg.ConnectVirtualIPCIDRv4
+	cfg.ConnectVirtualIPCIDRv6 = runtimeCfg.ConnectVirtualIPCIDRv6
 
 	// copy over auto runtimeCfg settings
 	cfg.AutoConfigEnabled = runtimeCfg.AutoConfig.Enabled

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -642,6 +642,8 @@ type Connect struct {
 	CAProvider                      *string                `mapstructure:"ca_provider" json:"ca_provider,omitempty"`
 	CAConfig                        map[string]interface{} `mapstructure:"ca_config" json:"ca_config,omitempty"`
 	MeshGatewayWANFederationEnabled *bool                  `mapstructure:"enable_mesh_gateway_wan_federation" json:"enable_mesh_gateway_wan_federation,omitempty"`
+	VirtualIPCIDRv4                 *string                `mapstructure:"virtual_ip_cidr_v4" json:"virtual_ip_cidr_v4,omitempty"`
+	VirtualIPCIDRv6                 *string                `mapstructure:"virtual_ip_cidr_v6" json:"virtual_ip_cidr_v6,omitempty"`
 
 	// TestCALeafRootChangeSpread controls how long after a CA roots change before new leaf certs will be generated.
 	// This is only tuned in tests, generally set to 1ns to make tests deterministic with when to expect updated leaf

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -526,6 +526,12 @@ type RuntimeConfig struct {
 	// datacenters should exclusively traverse mesh gateways.
 	ConnectMeshGatewayWANFederationEnabled bool
 
+	// ConnectVirtualIPCIDRv4 defines the IPv4 CIDR block used for automatic virtual IPs.
+	ConnectVirtualIPCIDRv4 string
+
+	// ConnectVirtualIPCIDRv6 defines the IPv6 CIDR block used for automatic virtual IPs.
+	ConnectVirtualIPCIDRv6 string
+
 	// ConnectTestCALeafRootChangeSpread is used to control how long the CA leaf
 	// cache with spread CSRs over when a root change occurs. For now we don't
 	// expose this in public config intentionally but could later with a rename.

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -6674,6 +6674,8 @@ func TestLoad_FullConfig(t *testing.T) {
 			"CSRMaxPerSecond":     float64(100),
 			"CSRMaxConcurrent":    float64(2),
 		},
+		ConnectVirtualIPCIDRv4:                 "240.0.0.0/4",
+		ConnectVirtualIPCIDRv6:                 "2000::/3",
 		ConnectMeshGatewayWANFederationEnabled: false,
 		Cloud: hcpconfig.CloudConfig{
 			ResourceID:   "N43DsscE",

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -149,6 +149,8 @@
     "ConnectSidecarMaxPort": 0,
     "ConnectSidecarMinPort": 0,
     "ConnectTestCALeafRootChangeSpread": "0s",
+    "ConnectVirtualIPCIDRv4": "",
+    "ConnectVirtualIPCIDRv6": "",
     "ConsulCoordinateUpdateBatchSize": 0,
     "ConsulCoordinateUpdateMaxBatches": 0,
     "ConsulCoordinateUpdatePeriod": "15s",

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -415,6 +415,12 @@ type Config struct {
 	// datacenters should exclusively traverse mesh gateways.
 	ConnectMeshGatewayWANFederationEnabled bool
 
+	// ConnectVirtualIPCIDRv4 defines the IPv4 CIDR block used for auto-allocated virtual IPs.
+	ConnectVirtualIPCIDRv4 string
+
+	// ConnectVirtualIPCIDRv6 defines the IPv6 CIDR block used for auto-allocated virtual IPs.
+	ConnectVirtualIPCIDRv6 string
+
 	// DefaultIntentionPolicy is used to define a default intention action for all
 	// sources and destinations. Possible values are "allow", "deny", or "" (blank).
 	// For compatibility, falls back to ACLResolverSettings.ACLDefaultPolicy (which

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -484,6 +484,9 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 	if err := config.CheckEnumStrings(); err != nil {
 		return nil, err
 	}
+	if err := state.SetVirtualIPConfig(config.ConnectVirtualIPCIDRv4, config.ConnectVirtualIPCIDRv6); err != nil {
+		return nil, fmt.Errorf("failed to configure virtual IP ranges: %w", err)
+	}
 
 	// Create the tombstone GC.
 	gc, err := state.NewTombstoneGC(config.TombstoneTTL, config.TombstoneTTLGranularity)

--- a/agent/consul/state/virtual_ips.go
+++ b/agent/consul/state/virtual_ips.go
@@ -1,0 +1,157 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package state
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+	"sync"
+)
+
+const (
+	// DefaultVirtualIPv4CIDR matches the historical 240.0.0.0/4 range used for auto-assigned
+	// virtual IPs.
+	DefaultVirtualIPv4CIDR = "240.0.0.0/4"
+	// DefaultVirtualIPv6CIDR matches the historical 2000::/3 range used for auto-assigned
+	// virtual IPs when dual-stack is enabled.
+	DefaultVirtualIPv6CIDR = "2000::/3"
+)
+
+type virtualIPAllocatorConfig struct {
+	startingIPv4  net.IP
+	maxOffsetIPv4 net.IP
+	startingIPv6  net.IP
+	maxOffsetIPv6 net.IP
+}
+
+var (
+	virtualIPConfigMu sync.RWMutex
+	virtualIPConfig   = mustBuildVirtualIPConfig(DefaultVirtualIPv4CIDR, DefaultVirtualIPv6CIDR)
+)
+
+func mustBuildVirtualIPConfig(v4CIDR, v6CIDR string) virtualIPAllocatorConfig {
+	cfg, err := buildVirtualIPConfig(v4CIDR, v6CIDR)
+	if err != nil {
+		panic(err)
+	}
+	return cfg
+}
+
+// SetVirtualIPConfig configures the allocator ranges for IPv4 and IPv6 virtual IPs. Empty strings
+// fall back to defaults. It is expected to be called during server startup before any allocations
+// occur.
+func SetVirtualIPConfig(v4CIDR, v6CIDR string) error {
+	cfg, err := buildVirtualIPConfig(v4CIDR, v6CIDR)
+	if err != nil {
+		return err
+	}
+
+	virtualIPConfigMu.Lock()
+	virtualIPConfig = cfg
+	virtualIPConfigMu.Unlock()
+	return nil
+}
+
+// ValidateVirtualIPCIDRs checks that the provided CIDRs can be used for virtual IP allocation.
+// Empty values are treated as defaults.
+func ValidateVirtualIPCIDRs(v4CIDR, v6CIDR string) error {
+	_, err := buildVirtualIPConfig(v4CIDR, v6CIDR)
+	return err
+}
+
+func currentVirtualIPConfig() virtualIPAllocatorConfig {
+	virtualIPConfigMu.RLock()
+	cfg := virtualIPConfig
+	virtualIPConfigMu.RUnlock()
+	return cfg
+}
+
+func buildVirtualIPConfig(v4CIDR, v6CIDR string) (virtualIPAllocatorConfig, error) {
+	cfg := virtualIPAllocatorConfig{}
+
+	if v4CIDR == "" {
+		v4CIDR = DefaultVirtualIPv4CIDR
+	}
+	if v6CIDR == "" {
+		v6CIDR = DefaultVirtualIPv6CIDR
+	}
+
+	startV4, maxOffsetV4, err := parseVirtualIPCIDR(v4CIDR, net.IPv4len)
+	if err != nil {
+		return cfg, fmt.Errorf("invalid virtual_ip_cidr_v4: %w", err)
+	}
+	startV6, maxOffsetV6, err := parseVirtualIPCIDR(v6CIDR, net.IPv6len)
+	if err != nil {
+		return cfg, fmt.Errorf("invalid virtual_ip_cidr_v6: %w", err)
+	}
+
+	cfg.startingIPv4 = startV4
+	cfg.maxOffsetIPv4 = maxOffsetV4
+	cfg.startingIPv6 = startV6
+	cfg.maxOffsetIPv6 = maxOffsetV6
+	return cfg, nil
+}
+
+// parseVirtualIPCIDR returns the base network address and the maximum offset allowed (host space
+// minus the broadcast address) for the given cidr. expectedLen should be net.IPv4len or
+// net.IPv6len to ensure family matches.
+func parseVirtualIPCIDR(cidr string, expectedLen int) (net.IP, net.IP, error) {
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ones, bits := ipNet.Mask.Size()
+	if bits != expectedLen*8 {
+		return nil, nil, fmt.Errorf("cidr %q must be IPv%d", cidr, expectedLen*8)
+	}
+	hostBits := bits - ones
+	// Require at least 4 addresses (hostBits >= 2) to stay consistent with historical range that
+	// reserved the broadcast address but allowed the network address.
+	if hostBits < 2 {
+		return nil, nil, fmt.Errorf("cidr %q must allow at least four addresses", cidr)
+	}
+
+	base := ip.Mask(ipNet.Mask)
+	if expectedLen == net.IPv4len {
+		base = base.To4()
+		if base == nil {
+			return nil, nil, fmt.Errorf("cidr %q must be IPv4", cidr)
+		}
+		hostCount := uint64(1) << uint(hostBits)
+		// Leave room for the broadcast address to mirror prior behavior.
+		maxOffset := hostCount - 2
+		return base, net.IPv4(byte(maxOffset>>24), byte(maxOffset>>16), byte(maxOffset>>8), byte(maxOffset)), nil
+	}
+
+	// IPv6
+	base = base.To16()
+	if base == nil {
+		return nil, nil, fmt.Errorf("cidr %q must be IPv6", cidr)
+	}
+
+	hostCount := big.NewInt(0).Lsh(big.NewInt(1), uint(hostBits))
+	hostCount.Sub(hostCount, big.NewInt(2))
+	maxOffset := hostCount.Bytes()
+
+	// Left-pad to 16 bytes.
+	if len(maxOffset) < net.IPv6len {
+		padded := make([]byte, net.IPv6len)
+		copy(padded[net.IPv6len-len(maxOffset):], maxOffset)
+		maxOffset = padded
+	}
+
+	return base, net.IP(maxOffset), nil
+}
+
+func (cfg virtualIPAllocatorConfig) maxOffsetFor(ip net.IP) net.IP {
+	if ip.To4() != nil {
+		return cfg.maxOffsetIPv4
+	}
+	if ip.To16() != nil {
+		return cfg.maxOffsetIPv6
+	}
+	return nil
+}

--- a/agent/consul/state/virtual_ips_test.go
+++ b/agent/consul/state/virtual_ips_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package state
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseVirtualIPCIDRIPv4(t *testing.T) {
+	base, max, err := parseVirtualIPCIDR("10.0.0.0/29", net.IPv4len)
+	require.NoError(t, err)
+	require.Equal(t, net.IPv4(10, 0, 0, 0).To4(), base)
+	require.Equal(t, net.IPv4(0, 0, 0, 6), max)
+}
+
+func TestParseVirtualIPCIDRIPv6(t *testing.T) {
+	base, max, err := parseVirtualIPCIDR("fd00::/125", net.IPv6len)
+	require.NoError(t, err)
+	require.Equal(t, net.ParseIP("fd00::").To16(), base)
+	require.Equal(t, net.ParseIP("::6").To16(), max)
+}
+
+func TestParseVirtualIPCIDRTooSmall(t *testing.T) {
+	_, _, err := parseVirtualIPCIDR("10.0.0.0/31", net.IPv4len)
+	require.Error(t, err)
+}
+
+func TestSetVirtualIPConfigOverrides(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, SetVirtualIPConfig("", ""))
+	})
+
+	require.NoError(t, SetVirtualIPConfig("10.0.0.0/29", "fd00::/125"))
+	cfg := currentVirtualIPConfig()
+
+	// Validate starting points and max offsets are derived from the new ranges.
+	v4Base, err := addIPv4Offset(cfg.startingIPv4, net.IPv4zero)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.0", v4Base.String())
+	require.Equal(t, net.IPv4(0, 0, 0, 6), cfg.maxOffsetIPv4)
+
+	v6Base, err := addIPv6Offset(cfg.startingIPv6, net.ParseIP("::"))
+	require.NoError(t, err)
+	require.Equal(t, "fd00::", v6Base.String())
+	require.Equal(t, net.ParseIP("::6").To16(), cfg.maxOffsetIPv6)
+}


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

This is to address: https://github.com/hashicorp/consul/issues/22595

### Testing & Reproduction steps

##### Default Config for Service Mesh

```
connect {
  enabled = true
}
```

<img width="638" height="298" alt="Screenshot 2025-12-01 at 03 04 13" src="https://github.com/user-attachments/assets/95f68770-6599-4959-ab66-9eb9e215072f" />

##### Defined IPv4 CIDR for Virtual IP assignment

```
connect {
  enabled = true
  # Override default 240.0.0.0/4 virtual IP range for transparent proxy
  virtual_ip_cidr_v4 = "240.10.0.0/16"
  # virtual_ip_cidr_v6 = "..." # to define IPv6 CIDR
}
```

<img width="674" height="297" alt="Screenshot 2025-12-01 at 14 59 28" src="https://github.com/user-attachments/assets/cc1f6415-89cd-4087-b269-fd6e4a73a1c2" />

### Links

n/a

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
