### PR TITLE
bugfix: Prevent default TCP checks from being re-added on reload/restart

### DIFF
--- a/.changelog/23088.txt
+++ b/.changelog/23088.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: fix bug prevents default TCP checks from being re-added on service reload when they were explicitly disabled or when custom checks were specified during initial registration.
+```


### PR DESCRIPTION
### Description
This PR fixes an issue where default TCP checks were being re-added on service reload or agent restart, even when they were explicitly disabled or replaced with custom checks during the initial service registration.

With this change, the agent now consistently preserves the original sidecar check configuration, ensuring default checks are added only when intended.

### Testing & Reproduction steps
1. Start the consul agent
`consul agent -dev -data-dir=/tmp/consul/data`

2. Register below hello service definition 
`consul services register hello-service.json `
````
{
  "service": {
    "id": "service-hello-1",
    "name": "service-hello",
    "port": 5050,
    "address": "127.0.0.1",
    "connect": {
      "sidecar_service": {
        "checks": [{
          "alias_service": "web",
          "name": "Connect Sidecar Aliasing web"
        }],
        "proxy": {
          "upstreams": [
            {
              "destination_name": "service-response",
              "local_bind_port": 9090
            }
          ]
        }
      }
    },
    "check": {
      "http": "http://127.0.0.1:5050/health",
      "interval": "10s"
    }
  }
}
````
3. As as sidecar service contains the checks, it does not added the default TCP checks
`http://127.0.0.1:8500/v1/health/service/service-hello-sidecar-proxy?dc=dc1`

4. consul reload or restart the agent
`consul reload`

5. After reload, its inconsistence and defaults TCP checks are added
`http://127.0.0.1:8500/v1/health/service/service-hello-sidecar-proxy?dc=dc1`
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### PR Checklist

* [x ] updated test coverage
* [ ] external facing docs updated
* [ x] appropriate backport labels added
* [x ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
