### PR TITLE
bugfix: Prevent default TCP checks from being re-added on reload/restart

### DIFF
--- a/.changelog/23088.txt
+++ b/.changelog/23088.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: fix bug prevents default TCP checks from being re-added on service reload when they were explicitly disabled or when custom checks were specified during initial registration.
+```


### PR DESCRIPTION


* fix(agent): prevents default TCP checks from being re-added on service reload when they were explicitly disabled or when custom checks were specified during initial registration.

### Description

Manual cherry pick this PR from https://github.com/hashicorp/consul/pull/23088 to be added into backport/1.22.
