### PR TITLE
Add DaysRemaining field to CARoot struct and compute expiry metadata

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1630,6 +1630,13 @@ func (s *HTTPHandlers) AgentConnectCARoots(resp http.ResponseWriter, req *http.R
 	}
 	defer setMeta(resp, &reply.QueryMeta)
 
+	// Populate computed DaysRemaining field for each root
+	for _, root := range reply.Roots {
+		if !root.NotAfter.IsZero() {
+			root.DaysRemaining = int(time.Until(root.NotAfter).Hours() / 24)
+		}
+	}
+
 	return *reply, nil
 }
 

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -109,6 +109,12 @@ type CARoot struct {
 	// certificate. This is the time when the certificate will expire.
 	NotAfter time.Time
 
+	// DaysRemaining is the number of days until the certificate expires.
+	// This is a computed field based on NotAfter and the current time.
+	// Negative values indicate the certificate has already expired.
+	// This field is dynamically calculated and not stored.
+	DaysRemaining int `json:",omitempty"`
+
 	// RootCert is the PEM-encoded public certificate for the root CA. The
 	// certificate is the same for all federated clusters.
 	RootCert string

--- a/api/connect_ca.go
+++ b/api/connect_ca.go
@@ -103,6 +103,17 @@ type CARoot struct {
 	// cannot be active.
 	Active bool
 
+	// NotBefore is the certificate's validity start time.
+	NotBefore *time.Time `json:",omitempty"`
+
+	// NotAfter is the certificate's expiry time.
+	NotAfter *time.Time `json:",omitempty"`
+
+	// DaysRemaining is the number of days until the certificate expires.
+	// This is a computed field based on NotAfter and the current time.
+	// Negative values indicate the certificate has already expired.
+	DaysRemaining *int `json:",omitempty"`
+
 	CreateIndex uint64
 	ModifyIndex uint64
 }

--- a/proto/private/pbconnect/connect.gen.go
+++ b/proto/private/pbconnect/connect.gen.go
@@ -15,6 +15,7 @@ func CARootToStructsCARoot(s *CARoot, t *structs.CARoot) {
 	t.ExternalTrustDomain = s.ExternalTrustDomain
 	t.NotBefore = structs.TimeFromProto(s.NotBefore)
 	t.NotAfter = structs.TimeFromProto(s.NotAfter)
+	t.DaysRemaining = int(s.DaysRemaining)
 	t.RootCert = s.RootCert
 	t.IntermediateCerts = s.IntermediateCerts
 	t.SigningCert = s.SigningCert
@@ -36,6 +37,7 @@ func CARootFromStructsCARoot(t *structs.CARoot, s *CARoot) {
 	s.ExternalTrustDomain = t.ExternalTrustDomain
 	s.NotBefore = structs.TimeToProto(t.NotBefore)
 	s.NotAfter = structs.TimeToProto(t.NotAfter)
+	s.DaysRemaining = int32(t.DaysRemaining)
 	s.RootCert = t.RootCert
 	s.IntermediateCerts = t.IntermediateCerts
 	s.SigningCert = t.SigningCert

--- a/proto/private/pbconnect/connect.pb.go
+++ b/proto/private/pbconnect/connect.pb.go
@@ -194,7 +194,12 @@ type CARoot struct {
 	// mog: func-to=int func-from=int32
 	PrivateKeyBits int32 `protobuf:"varint,15,opt,name=PrivateKeyBits,proto3" json:"PrivateKeyBits,omitempty"`
 	// mog: func-to=RaftIndexTo func-from=RaftIndexFrom
-	RaftIndex     *pbcommon.RaftIndex `protobuf:"bytes,16,opt,name=RaftIndex,proto3" json:"RaftIndex,omitempty"`
+	RaftIndex *pbcommon.RaftIndex `protobuf:"bytes,16,opt,name=RaftIndex,proto3" json:"RaftIndex,omitempty"`
+	// DaysRemaining is the number of days until the certificate expires.
+	// This is a computed field based on NotAfter and the current time.
+	// Negative values indicate the certificate has already expired.
+	// mog: func-to=int func-from=int32
+	DaysRemaining int32 `protobuf:"varint,17,opt,name=DaysRemaining,proto3" json:"DaysRemaining,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -339,6 +344,13 @@ func (x *CARoot) GetRaftIndex() *pbcommon.RaftIndex {
 		return x.RaftIndex
 	}
 	return nil
+}
+
+func (x *CARoot) GetDaysRemaining() int32 {
+	if x != nil {
+		return x.DaysRemaining
+	}
+	return 0
 }
 
 // RaftIndex is used to track the index used while creating
@@ -527,7 +539,7 @@ const file_private_pbconnect_connect_proto_rawDesc = "" +
 	"\fActiveRootID\x18\x01 \x01(\tR\fActiveRootID\x12 \n" +
 	"\vTrustDomain\x18\x02 \x01(\tR\vTrustDomain\x12?\n" +
 	"\x05Roots\x18\x03 \x03(\v2).hashicorp.consul.internal.connect.CARootR\x05Roots\x12I\n" +
-	"\tQueryMeta\x18\x04 \x01(\v2+.hashicorp.consul.internal.common.QueryMetaR\tQueryMeta\"\x97\x05\n" +
+	"\tQueryMeta\x18\x04 \x01(\v2+.hashicorp.consul.internal.common.QueryMetaR\tQueryMeta\"\xbd\x05\n" +
 	"\x06CARoot\x12\x0e\n" +
 	"\x02ID\x18\x01 \x01(\tR\x02ID\x12\x12\n" +
 	"\x04Name\x18\x02 \x01(\tR\x04Name\x12\"\n" +
@@ -547,7 +559,8 @@ const file_private_pbconnect_connect_proto_rawDesc = "" +
 	"\fRotatedOutAt\x18\r \x01(\v2\x1a.google.protobuf.TimestampR\fRotatedOutAt\x12&\n" +
 	"\x0ePrivateKeyType\x18\x0e \x01(\tR\x0ePrivateKeyType\x12&\n" +
 	"\x0ePrivateKeyBits\x18\x0f \x01(\x05R\x0ePrivateKeyBits\x12I\n" +
-	"\tRaftIndex\x18\x10 \x01(\v2+.hashicorp.consul.internal.common.RaftIndexR\tRaftIndex\"\xd3\x04\n" +
+	"\tRaftIndex\x18\x10 \x01(\v2+.hashicorp.consul.internal.common.RaftIndexR\tRaftIndex\x12$\n" +
+	"\rDaysRemaining\x18\x11 \x01(\x05R\rDaysRemaining\"\xd3\x04\n" +
 	"\n" +
 	"IssuedCert\x12\"\n" +
 	"\fSerialNumber\x18\x01 \x01(\tR\fSerialNumber\x12\x18\n" +

--- a/proto/private/pbconnect/connect.proto
+++ b/proto/private/pbconnect/connect.proto
@@ -131,6 +131,12 @@ message CARoot {
 
   // mog: func-to=RaftIndexTo func-from=RaftIndexFrom
   common.RaftIndex RaftIndex = 16;
+
+  // DaysRemaining is the number of days until the certificate expires.
+  // This is a computed field based on NotAfter and the current time.
+  // Negative values indicate the certificate has already expired.
+  // mog: func-to=int func-from=int32
+  int32 DaysRemaining = 17;
 }
 
 // RaftIndex is used to track the index used while creating


### PR DESCRIPTION
### Description

This pull request introduces a new computed field, `DaysRemaining`, to the CA root certificate structures and API responses. This field indicates how many days remain until each CA root certificate expires, helping users and systems monitor certificate lifetimes more easily. The value is dynamically calculated based on the certificate's expiry (`NotAfter`) and the current time, and is included in both agent and API responses.

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
