### PR TITLE
Implement certificate telemetry options in configuration and metrics

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1378,6 +1378,11 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	cfg.SerfLANConfig.MemberlistConfig.GossipInterval = runtimeCfg.GossipLANGossipInterval
 	cfg.SerfLANConfig.MemberlistConfig.GossipNodes = runtimeCfg.GossipLANGossipNodes
 	cfg.SerfLANConfig.MemberlistConfig.ProbeInterval = runtimeCfg.GossipLANProbeInterval
+
+	// Certificate telemetry configuration
+	cfg.CertificateTelemetryEnabled = runtimeCfg.Telemetry.CertificateEnabled
+	cfg.CertificateTelemetryCriticalThresholdDays = runtimeCfg.Telemetry.CertificateCriticalThresholdDays
+	cfg.CertificateTelemetryWarningThresholdDays = runtimeCfg.Telemetry.CertificateWarningThresholdDays
 	cfg.SerfLANConfig.MemberlistConfig.ProbeTimeout = runtimeCfg.GossipLANProbeTimeout
 	cfg.SerfLANConfig.MemberlistConfig.SuspicionMult = runtimeCfg.GossipLANSuspicionMult
 	cfg.SerfLANConfig.MemberlistConfig.RetransmitMult = runtimeCfg.GossipLANRetransmitMult

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -891,7 +891,7 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	if a.tlsConfigurator.Cert() != nil {
-		m := tlsCertExpirationMonitor(a.tlsConfigurator, a.logger)
+		m := tlsCertExpirationMonitor(a.tlsConfigurator, a.config.NodeName, a.logger)
 		go m.Monitor(&lib.StopChannelContext{StopCh: a.shutdownCh})
 	}
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -323,6 +323,54 @@ func (a byName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 
 func (a byName) Less(i, j int) bool { return a[i].Name() < a[j].Name() }
 
+// getCertificateEnabled returns the certificate telemetry enabled flag with default true
+func (b *builder) getCertificateEnabled(cert *CertificateTelemetry) bool {
+	if cert == nil {
+		return true
+	}
+	return boolValWithDefault(cert.Enabled, true)
+}
+
+// getCertificateCacheDuration returns the certificate telemetry cache duration with default 5m
+func (b *builder) getCertificateCacheDuration(cert *CertificateTelemetry) time.Duration {
+	if cert == nil {
+		return 5 * time.Minute
+	}
+	return b.durationValWithDefault("telemetry.certificate.cache_duration", cert.CacheDuration, 5*time.Minute)
+}
+
+// getCertificateCriticalThresholdDays returns the certificate critical threshold with default 7
+func (b *builder) getCertificateCriticalThresholdDays(cert *CertificateTelemetry) int {
+	if cert == nil {
+		return 7
+	}
+	return intValWithDefault(cert.CriticalThresholdDays, 7)
+}
+
+// getCertificateWarningThresholdDays returns the certificate warning threshold with default 30
+func (b *builder) getCertificateWarningThresholdDays(cert *CertificateTelemetry) int {
+	if cert == nil {
+		return 30
+	}
+	return intValWithDefault(cert.WarningThresholdDays, 30)
+}
+
+// getCertificateInfoThresholdDays returns the certificate info threshold with default 90
+func (b *builder) getCertificateInfoThresholdDays(cert *CertificateTelemetry) int {
+	if cert == nil {
+		return 90
+	}
+	return intValWithDefault(cert.InfoThresholdDays, 90)
+}
+
+// getCertificateExcludeAutoRenewable returns the certificate exclude auto-renewable flag with default false
+func (b *builder) getCertificateExcludeAutoRenewable(cert *CertificateTelemetry) bool {
+	if cert == nil {
+		return false
+	}
+	return boolValWithDefault(cert.ExcludeAutoRenewable, false)
+}
+
 // build constructs the runtime configuration from the config sources
 // and the command line flags. The config sources are processed in the
 // order they were added with the flags being processed last to give
@@ -974,6 +1022,12 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 				Expiration: b.durationVal("prometheus_retention_time", c.Telemetry.PrometheusRetentionTime),
 				Name:       stringVal(c.Telemetry.MetricsPrefix),
 			},
+			CertificateEnabled:               b.getCertificateEnabled(c.Telemetry.Certificate),
+			CertificateCacheDuration:         b.getCertificateCacheDuration(c.Telemetry.Certificate),
+			CertificateCriticalThresholdDays: b.getCertificateCriticalThresholdDays(c.Telemetry.Certificate),
+			CertificateWarningThresholdDays:  b.getCertificateWarningThresholdDays(c.Telemetry.Certificate),
+			CertificateInfoThresholdDays:     b.getCertificateInfoThresholdDays(c.Telemetry.Certificate),
+			CertificateExcludeAutoRenewable:  b.getCertificateExcludeAutoRenewable(c.Telemetry.Certificate),
 		},
 
 		// Agent

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -698,31 +698,41 @@ type Performance struct {
 }
 
 type Telemetry struct {
-	CirconusAPIApp                     *string  `mapstructure:"circonus_api_app" json:"circonus_api_app,omitempty"`
-	CirconusAPIToken                   *string  `mapstructure:"circonus_api_token" json:"circonus_api_token,omitempty"`
-	CirconusAPIURL                     *string  `mapstructure:"circonus_api_url" json:"circonus_api_url,omitempty"`
-	CirconusBrokerID                   *string  `mapstructure:"circonus_broker_id" json:"circonus_broker_id,omitempty"`
-	CirconusBrokerSelectTag            *string  `mapstructure:"circonus_broker_select_tag" json:"circonus_broker_select_tag,omitempty"`
-	CirconusCheckDisplayName           *string  `mapstructure:"circonus_check_display_name" json:"circonus_check_display_name,omitempty"`
-	CirconusCheckForceMetricActivation *string  `mapstructure:"circonus_check_force_metric_activation" json:"circonus_check_force_metric_activation,omitempty"`
-	CirconusCheckID                    *string  `mapstructure:"circonus_check_id" json:"circonus_check_id,omitempty"`
-	CirconusCheckInstanceID            *string  `mapstructure:"circonus_check_instance_id" json:"circonus_check_instance_id,omitempty"`
-	CirconusCheckSearchTag             *string  `mapstructure:"circonus_check_search_tag" json:"circonus_check_search_tag,omitempty"`
-	CirconusCheckTags                  *string  `mapstructure:"circonus_check_tags" json:"circonus_check_tags,omitempty"`
-	CirconusSubmissionInterval         *string  `mapstructure:"circonus_submission_interval" json:"circonus_submission_interval,omitempty"`
-	CirconusSubmissionURL              *string  `mapstructure:"circonus_submission_url" json:"circonus_submission_url,omitempty"`
-	DisableHostname                    *bool    `mapstructure:"disable_hostname" json:"disable_hostname,omitempty"`
-	DisablePerTenancyUsageMetrics      *bool    `mapstructure:"disable_per_tenancy_usage_metrics" json:"disable_per_tenancy_usage_metrics,omitempty"`
-	EnableHostMetrics                  *bool    `mapstructure:"enable_host_metrics" json:"enable_host_metrics,omitempty"`
-	DogstatsdAddr                      *string  `mapstructure:"dogstatsd_addr" json:"dogstatsd_addr,omitempty"`
-	DogstatsdTags                      []string `mapstructure:"dogstatsd_tags" json:"dogstatsd_tags,omitempty"`
-	RetryFailedConfiguration           *bool    `mapstructure:"retry_failed_connection" json:"retry_failed_connection,omitempty"`
-	FilterDefault                      *bool    `mapstructure:"filter_default" json:"filter_default,omitempty"`
-	PrefixFilter                       []string `mapstructure:"prefix_filter" json:"prefix_filter,omitempty"`
-	MetricsPrefix                      *string  `mapstructure:"metrics_prefix" json:"metrics_prefix,omitempty"`
-	PrometheusRetentionTime            *string  `mapstructure:"prometheus_retention_time" json:"prometheus_retention_time,omitempty"`
-	StatsdAddr                         *string  `mapstructure:"statsd_address" json:"statsd_address,omitempty"`
-	StatsiteAddr                       *string  `mapstructure:"statsite_address" json:"statsite_address,omitempty"`
+	CirconusAPIApp                     *string               `mapstructure:"circonus_api_app" json:"circonus_api_app,omitempty"`
+	CirconusAPIToken                   *string               `mapstructure:"circonus_api_token" json:"circonus_api_token,omitempty"`
+	CirconusAPIURL                     *string               `mapstructure:"circonus_api_url" json:"circonus_api_url,omitempty"`
+	CirconusBrokerID                   *string               `mapstructure:"circonus_broker_id" json:"circonus_broker_id,omitempty"`
+	CirconusBrokerSelectTag            *string               `mapstructure:"circonus_broker_select_tag" json:"circonus_broker_select_tag,omitempty"`
+	CirconusCheckDisplayName           *string               `mapstructure:"circonus_check_display_name" json:"circonus_check_display_name,omitempty"`
+	CirconusCheckForceMetricActivation *string               `mapstructure:"circonus_check_force_metric_activation" json:"circonus_check_force_metric_activation,omitempty"`
+	CirconusCheckID                    *string               `mapstructure:"circonus_check_id" json:"circonus_check_id,omitempty"`
+	CirconusCheckInstanceID            *string               `mapstructure:"circonus_check_instance_id" json:"circonus_check_instance_id,omitempty"`
+	CirconusCheckSearchTag             *string               `mapstructure:"circonus_check_search_tag" json:"circonus_check_search_tag,omitempty"`
+	CirconusCheckTags                  *string               `mapstructure:"circonus_check_tags" json:"circonus_check_tags,omitempty"`
+	CirconusSubmissionInterval         *string               `mapstructure:"circonus_submission_interval" json:"circonus_submission_interval,omitempty"`
+	CirconusSubmissionURL              *string               `mapstructure:"circonus_submission_url" json:"circonus_submission_url,omitempty"`
+	DisableHostname                    *bool                 `mapstructure:"disable_hostname" json:"disable_hostname,omitempty"`
+	DisablePerTenancyUsageMetrics      *bool                 `mapstructure:"disable_per_tenancy_usage_metrics" json:"disable_per_tenancy_usage_metrics,omitempty"`
+	EnableHostMetrics                  *bool                 `mapstructure:"enable_host_metrics" json:"enable_host_metrics,omitempty"`
+	DogstatsdAddr                      *string               `mapstructure:"dogstatsd_addr" json:"dogstatsd_addr,omitempty"`
+	DogstatsdTags                      []string              `mapstructure:"dogstatsd_tags" json:"dogstatsd_tags,omitempty"`
+	RetryFailedConfiguration           *bool                 `mapstructure:"retry_failed_connection" json:"retry_failed_connection,omitempty"`
+	FilterDefault                      *bool                 `mapstructure:"filter_default" json:"filter_default,omitempty"`
+	PrefixFilter                       []string              `mapstructure:"prefix_filter" json:"prefix_filter,omitempty"`
+	MetricsPrefix                      *string               `mapstructure:"metrics_prefix" json:"metrics_prefix,omitempty"`
+	PrometheusRetentionTime            *string               `mapstructure:"prometheus_retention_time" json:"prometheus_retention_time,omitempty"`
+	StatsdAddr                         *string               `mapstructure:"statsd_address" json:"statsd_address,omitempty"`
+	StatsiteAddr                       *string               `mapstructure:"statsite_address" json:"statsite_address,omitempty"`
+	Certificate                        *CertificateTelemetry `mapstructure:"certificate" json:"certificate,omitempty"`
+}
+
+type CertificateTelemetry struct {
+	Enabled               *bool   `mapstructure:"enabled" json:"enabled,omitempty"`
+	CacheDuration         *string `mapstructure:"cache_duration" json:"cache_duration,omitempty"`
+	CriticalThresholdDays *int    `mapstructure:"critical_threshold_days" json:"critical_threshold_days,omitempty"`
+	WarningThresholdDays  *int    `mapstructure:"warning_threshold_days" json:"warning_threshold_days,omitempty"`
+	InfoThresholdDays     *int    `mapstructure:"info_threshold_days" json:"info_threshold_days,omitempty"`
+	ExcludeAutoRenewable  *bool   `mapstructure:"exclude_auto_renewable" json:"exclude_auto_renewable,omitempty"`
 }
 
 type Ports struct {

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -474,6 +474,15 @@ type Config struct {
 	// When disabled, Consul does not restrict on the number of xDS connections on a server.
 	// In this scenario, you should deploy an external load balancer in front of the consul servers and distribute the load accordingly.
 	EnableXDSLoadBalancing bool
+
+	// CertificateTelemetryEnabled controls whether certificate expiry metrics are emitted.
+	CertificateTelemetryEnabled bool
+
+	// CertificateTelemetryCriticalThresholdDays is the number of days before expiry to emit critical severity.
+	CertificateTelemetryCriticalThresholdDays int
+
+	// CertificateTelemetryWarningThresholdDays is the number of days before expiry to emit warning severity.
+	CertificateTelemetryWarningThresholdDays int
 }
 
 func (c *Config) InPrimaryDatacenter() bool {

--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -43,6 +43,7 @@ func rootCAExpiryMonitor(s *Server) CertExpirationMonitor {
 		Query: func() (time.Duration, time.Duration, error) {
 			return getRootCAExpiry(s)
 		},
+		Server: s,
 	}
 }
 
@@ -70,6 +71,7 @@ func signingCAExpiryMonitor(s *Server) CertExpirationMonitor {
 			}
 			return getRootCAExpiry(s)
 		},
+		Server: s,
 	}
 }
 
@@ -109,12 +111,18 @@ type CertExpirationMonitor struct {
 	// lifespan of the certificate (NotBefore -> NotAfter) and the duration
 	// until the certificate expires (Now -> NotAfter), or an error if the
 	// query failed.
-	Query func() (time.Duration, time.Duration, error)
+	Query  func() (time.Duration, time.Duration, error)
+	Server *Server
 }
 
 const certExpirationMonitorInterval = time.Hour
 
 func (m CertExpirationMonitor) Monitor(ctx context.Context) error {
+	// Check if certificate telemetry is enabled
+	if !m.Server.config.CertificateTelemetryEnabled {
+		return nil
+	}
+
 	ticker := time.NewTicker(certExpirationMonitorInterval)
 	defer ticker.Stop()
 
@@ -127,51 +135,44 @@ func (m CertExpirationMonitor) Monitor(ctx context.Context) error {
 			return
 		}
 
-		key := strings.Join(m.Key, ":")
 		daysRemaining := int(untilAfter.Hours() / 24)
+		criticalDays := m.Server.config.CertificateTelemetryCriticalThresholdDays
+		warningDays := m.Server.config.CertificateTelemetryWarningThresholdDays
 
-		// Log based on severity thresholds: Error <7 days, Warning <30 days
+		// Determine cert type and suggested action for logging
+		key := strings.Join(m.Key, ":")
 		var certType string
-		var shouldLog bool
-		var logLevel string
-
+		var suggestedAction string
+		
 		switch key {
 		case "mesh:active-root-ca:expiry":
 			certType = "Root"
-			shouldLog = daysRemaining < 30
-			if daysRemaining < 7 {
-				logLevel = "error"
-			} else {
-				logLevel = "warn"
-			}
+			suggestedAction = "manually rotate the root certificate"
 		case "mesh:active-signing-ca:expiry":
 			certType = "Intermediate"
-			// Only log if critically low (auto-renewal may have failed)
-			shouldLog = daysRemaining < 7
-			logLevel = "error"
+			suggestedAction = "check consul logs for rotation issues"
 		case "agent:tls:cert:expiry":
 			certType = "Agent"
-			shouldLog = daysRemaining < 30
-			if daysRemaining < 7 {
-				logLevel = "error"
-			} else {
-				logLevel = "warn"
-			}
+			suggestedAction = "manually rotate this agent's certificate"
 		}
 
-		if shouldLog {
-			logArgs := []interface{}{
+		// Log based on threshold severity with detailed context
+		if daysRemaining < criticalDays {
+			logger.Error("certificate expiring soon",
 				"cert_type", certType,
 				"days_remaining", daysRemaining,
 				"time_to_expiry", untilAfter,
 				"expiration", time.Now().Add(untilAfter),
-			}
-
-			if logLevel == "error" {
-				logger.Error("certificate expiring soon", logArgs...)
-			} else {
-				logger.Warn("certificate expiring soon", logArgs...)
-			}
+				"suggested_action", suggestedAction,
+			)
+		} else if daysRemaining < warningDays {
+			logger.Warn("certificate expiring soon",
+				"cert_type", certType,
+				"days_remaining", daysRemaining,
+				"time_to_expiry", untilAfter,
+				"expiration", time.Now().Add(untilAfter),
+				"suggested_action", suggestedAction,
+			)
 		}
 
 		expiry := untilAfter / time.Second

--- a/agent/leafcert/leafcert.go
+++ b/agent/leafcert/leafcert.go
@@ -71,6 +71,10 @@ type Config struct {
 	// deterministic time delay in order to test the behavior here fully and
 	// determinstically.
 	TestOverrideCAChangeInitialDelay time.Duration
+
+	// Certificate telemetry thresholds for determining log severity
+	CertificateTelemetryCriticalThresholdDays int
+	CertificateTelemetryWarningThresholdDays  int
 }
 
 func (c Config) withDefaults() Config {

--- a/agent/metrics.go
+++ b/agent/metrics.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/consul/agent/consul"
@@ -26,9 +28,10 @@ var metricsKeyAgentTLSCertExpiry = []string{"agent", "tls", "cert", "expiry"}
 
 // tlsCertExpirationMonitor returns a CertExpirationMonitor which will
 // monitor the expiration of the certificate used for agent TLS.
-func tlsCertExpirationMonitor(c *tlsutil.Configurator, logger hclog.Logger) consul.CertExpirationMonitor {
+func tlsCertExpirationMonitor(c *tlsutil.Configurator, nodeName string, logger hclog.Logger) consul.CertExpirationMonitor {
 	return consul.CertExpirationMonitor{
 		Key:    metricsKeyAgentTLSCertExpiry,
+		Labels: []metrics.Label{{Name: "node", Value: nodeName}},
 		Logger: logger,
 		Query: func() (time.Duration, time.Duration, error) {
 			raw := c.Cert()

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -14,10 +14,11 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"google.golang.org/grpc/grpclog"
+
 	"github.com/hashicorp/go-hclog"
 	wal "github.com/hashicorp/raft-wal"
 	"github.com/hashicorp/raft-wal/verifier"
-	"google.golang.org/grpc/grpclog"
 
 	autoconf "github.com/hashicorp/consul/agent/auto-config"
 	"github.com/hashicorp/consul/agent/cache"
@@ -169,7 +170,9 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer, providedLogger hcl
 		CertSigner:  leafcert.NewNetRPCCertSigner(d.NetRPC),
 		RootsReader: leafcert.NewCachedRootsReader(d.Cache, cfg.Datacenter),
 		Config: leafcert.Config{
-			TestOverrideCAChangeInitialDelay: cfg.ConnectTestCALeafRootChangeSpread,
+			TestOverrideCAChangeInitialDelay:          cfg.ConnectTestCALeafRootChangeSpread,
+			CertificateTelemetryCriticalThresholdDays: cfg.Telemetry.CertificateCriticalThresholdDays,
+			CertificateTelemetryWarningThresholdDays:  cfg.Telemetry.CertificateWarningThresholdDays,
 		},
 	})
 	// Set the leaf cert manager in the embedded deps type so it can be used by consul servers.

--- a/lib/telemetry.go
+++ b/lib/telemetry.go
@@ -15,9 +15,10 @@ import (
 	"github.com/armon/go-metrics/circonus"
 	"github.com/armon/go-metrics/datadog"
 	"github.com/armon/go-metrics/prometheus"
+	prometheuscore "github.com/prometheus/client_golang/prometheus"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
-	prometheuscore "github.com/prometheus/client_golang/prometheus"
 
 	"github.com/hashicorp/consul/lib/retry"
 )
@@ -220,6 +221,16 @@ type TelemetryConfig struct {
 	//
 	// hcl: telemetry { prometheus_retention_time = "duration" }
 	PrometheusOpts prometheus.PrometheusOpts
+
+	// Certificate telemetry configuration for certificate expiry monitoring
+	//
+	// hcl: telemetry { certificate { ... } }
+	CertificateEnabled               bool          `json:"certificate_enabled" mapstructure:"certificate_enabled"`
+	CertificateCacheDuration         time.Duration `json:"certificate_cache_duration" mapstructure:"certificate_cache_duration"`
+	CertificateCriticalThresholdDays int           `json:"certificate_critical_threshold_days" mapstructure:"certificate_critical_threshold_days"`
+	CertificateWarningThresholdDays  int           `json:"certificate_warning_threshold_days" mapstructure:"certificate_warning_threshold_days"`
+	CertificateInfoThresholdDays     int           `json:"certificate_info_threshold_days" mapstructure:"certificate_info_threshold_days"`
+	CertificateExcludeAutoRenewable  bool          `json:"certificate_exclude_auto_renewable" mapstructure:"certificate_exclude_auto_renewable"`
 }
 
 // MetricsHandler provides an http.Handler for displaying metrics.


### PR DESCRIPTION
### Description

This pull request introduces configurable certificate telemetry settings to the Consul agent, allowing operators to control thresholds, cache duration, and enable/disable certificate expiry metrics via configuration. It removes hardcoded certificate expiry thresholds and replaces them with user-configurable options, improving flexibility and observability for certificate monitoring.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
