### PR TITLE
Add token name format flag for ACL auth method and implement related functionality

### DIFF
--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+
 	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -2134,12 +2135,7 @@ func (a *ACL) Login(args *structs.ACLLoginRequest, reply *structs.ACLToken) erro
 		return err
 	}
 
-	description, err := auth.BuildTokenDescription("token created via login", args.Auth.Meta)
-	if err != nil {
-		return err
-	}
-
-	token, err := a.srv.aclLogin().TokenForVerifiedIdentity(verifiedIdentity, authMethod, description)
+	token, err := a.srv.aclLogin().TokenForVerifiedIdentityWithMeta(verifiedIdentity, authMethod, args.Auth.Meta)
 	if err == nil {
 		*reply = *token
 	}

--- a/agent/consul/auth/login.go
+++ b/agent/consul/auth/login.go
@@ -4,9 +4,11 @@
 package auth
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"text/template"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/authmethod"
@@ -67,6 +69,18 @@ func (l *Login) TokenForVerifiedIdentity(identity *authmethod.Identity, authMeth
 	return updated, nil
 }
 
+// TokenForVerifiedIdentityWithMeta creates an ACLToken for the given identity verified
+// by an auth method, using the auth method's TokenNameFormat if specified.
+func (l *Login) TokenForVerifiedIdentityWithMeta(identity *authmethod.Identity, authMethod *structs.ACLAuthMethod, meta map[string]string) (*structs.ACLToken, error) {
+	// Format the token description using the auth method's TokenNameFormat
+	description, err := FormatTokenName(authMethod.TokenNameFormat, authMethod.Name, identity, meta)
+	if err != nil {
+		return nil, fmt.Errorf("failed to format token name: %w", err)
+	}
+
+	return l.TokenForVerifiedIdentity(identity, authMethod, description)
+}
+
 // BuildTokenDescription builds a description for an ACLToken by encoding the
 // given meta as JSON and applying the prefix.
 func BuildTokenDescription(prefix string, meta map[string]string) (string, error) {
@@ -79,4 +93,88 @@ func BuildTokenDescription(prefix string, meta map[string]string) (string, error
 		return "", err
 	}
 	return fmt.Sprintf("%s: %s", prefix, d), nil
+}
+
+// FormatTokenName formats the token name using the provided template and identity.
+// The template can use variables like ${auth_method}, ${identity.username}, ${identity.email}, etc.
+// If the template is empty, it returns the default description.
+func FormatTokenName(tokenNameFormat string, authMethodName string, identity *authmethod.Identity, meta map[string]string) (string, error) {
+	if tokenNameFormat == "" {
+		return BuildTokenDescription("token created via login", meta)
+	}
+
+	// Build template data from identity and auth method
+	data := make(map[string]interface{})
+	data["auth_method"] = authMethodName
+
+	// Add identity fields
+	if identity != nil {
+		identityFields := make(map[string]interface{})
+		for k, v := range identity.ProjectedVars {
+			identityFields[k] = v
+		}
+		data["identity"] = identityFields
+	}
+
+	// Add meta fields
+	if len(meta) > 0 {
+		data["meta"] = meta
+	}
+
+	// Convert ${var} syntax to {{.var}} for Go templates
+	// Support patterns like ${auth_method}, ${identity.username}, ${meta.key}
+	templateStr := tokenNameFormat
+
+	// Replace ${auth_method} with {{.auth_method}}
+	templateStr = strings.ReplaceAll(templateStr, "${auth_method}", "{{.auth_method}}")
+
+	// Replace ${identity.xxx} with {{.identity.xxx}}
+	// Use a more robust replacement that handles any field name
+	for strings.Contains(templateStr, "${identity.") {
+		start := strings.Index(templateStr, "${identity.")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(templateStr[start:], "}")
+		if end == -1 {
+			break
+		}
+		end += start
+
+		placeholder := templateStr[start : end+1]
+		fieldName := placeholder[2 : len(placeholder)-1] // Remove ${ and }
+		replacement := "{{." + fieldName + "}}"
+		templateStr = strings.ReplaceAll(templateStr, placeholder, replacement)
+	}
+
+	// Replace ${meta.xxx} with {{.meta.xxx}}
+	for strings.Contains(templateStr, "${meta.") {
+		start := strings.Index(templateStr, "${meta.")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(templateStr[start:], "}")
+		if end == -1 {
+			break
+		}
+		end += start
+
+		placeholder := templateStr[start : end+1]
+		fieldName := placeholder[2 : len(placeholder)-1] // Remove ${ and }
+		replacement := "{{." + fieldName + "}}"
+		templateStr = strings.ReplaceAll(templateStr, placeholder, replacement)
+	}
+
+	// Parse and execute template
+	tmpl, err := template.New("token-name").Option("missingkey=zero").Parse(templateStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse token name format template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute token name format template: %w", err)
+	}
+
+	return buf.String(), nil
 }

--- a/agent/consul/auth/login_test.go
+++ b/agent/consul/auth/login_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/consul/authmethod"
+)
+
+func TestFormatTokenName(t *testing.T) {
+	tests := []struct {
+		name            string
+		tokenNameFormat string
+		authMethodName  string
+		identity        *authmethod.Identity
+		meta            map[string]string
+		expected        string
+	}{
+		{
+			name:            "empty format uses default",
+			tokenNameFormat: "",
+			authMethodName:  "test-method",
+			identity:        nil,
+			meta:            nil,
+			expected:        "token created via login",
+		},
+		{
+			name:            "simple auth method name",
+			tokenNameFormat: "Token from ${auth_method}",
+			authMethodName:  "my-auth-method",
+			identity:        nil,
+			meta:            nil,
+			expected:        "Token from my-auth-method",
+		},
+		{
+			name:            "with identity username",
+			tokenNameFormat: "${auth_method}-${identity.username}",
+			authMethodName:  "kubernetes",
+			identity: &authmethod.Identity{
+				ProjectedVars: map[string]string{
+					"username": "john.doe",
+				},
+			},
+			meta:     nil,
+			expected: "kubernetes-john.doe",
+		},
+		{
+			name:            "with identity email",
+			tokenNameFormat: "User: ${identity.email}",
+			authMethodName:  "oidc",
+			identity: &authmethod.Identity{
+				ProjectedVars: map[string]string{
+					"email": "user@example.com",
+				},
+			},
+			meta:     nil,
+			expected: "User: user@example.com",
+		},
+		{
+			name:            "complex template with multiple variables",
+			tokenNameFormat: "${auth_method}/${identity.username}/${identity.namespace}",
+			authMethodName:  "k8s-prod",
+			identity: &authmethod.Identity{
+				ProjectedVars: map[string]string{
+					"username":  "service-account",
+					"namespace": "default",
+				},
+			},
+			meta:     nil,
+			expected: "k8s-prod/service-account/default",
+		},
+		{
+			name:            "with metadata",
+			tokenNameFormat: "${auth_method} - ${meta.env}",
+			authMethodName:  "ldap",
+			identity:        nil,
+			meta: map[string]string{
+				"env": "production",
+			},
+			expected: "ldap - production",
+		},
+		{
+			name:            "missing variable defaults to empty",
+			tokenNameFormat: "${auth_method}-${identity.missing}",
+			authMethodName:  "test",
+			identity: &authmethod.Identity{
+				ProjectedVars: map[string]string{
+					"username": "user",
+				},
+			},
+			meta:     nil,
+			expected: "test-<no value>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := FormatTokenName(tt.tokenNameFormat, tt.authMethodName, tt.identity, tt.meta)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatTokenName_InvalidTemplate(t *testing.T) {
+	// With the preprocessing we do, ${unclosed won't cause an error as it gets converted
+	// Test with an actually invalid Go template instead
+	_, err := FormatTokenName("{{unclosed", "method", nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse token name format template")
+}

--- a/agent/grpc-external/services/acl/login.go
+++ b/agent/grpc-external/services/acl/login.go
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/agent/consul/auth"
 	external "github.com/hashicorp/consul/agent/grpc-external"
 	"github.com/hashicorp/consul/proto-public/pbacl"
 )
@@ -71,13 +70,7 @@ func (s *Server) Login(ctx context.Context, req *pbacl.LoginRequest) (*pbacl.Log
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	description, err := auth.BuildTokenDescription("token created via login", req.Meta)
-	if err != nil {
-		logger.Error("failed to build token description", "error", err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	token, err := s.NewLogin().TokenForVerifiedIdentity(verifiedIdentity, authMethod, description)
+	token, err := s.NewLogin().TokenForVerifiedIdentityWithMeta(verifiedIdentity, authMethod, req.Meta)
 	switch {
 	case acl.IsErrPermissionDenied(err):
 		return nil, status.Error(codes.PermissionDenied, err.Error())

--- a/agent/grpc-external/services/acl/login_test.go
+++ b/agent/grpc-external/services/acl/login_test.go
@@ -40,7 +40,7 @@ func TestServer_Login_Success(t *testing.T) {
 	}
 
 	login := NewMockLogin(t)
-	login.On("TokenForVerifiedIdentity", identity, authMethod, "token created via login").
+	login.On("TokenForVerifiedIdentityWithMeta", identity, authMethod, map[string]string(nil)).
 		Return(token, nil)
 
 	server := NewServer(Config{
@@ -190,7 +190,7 @@ func TestServer_Login_TokenForVerifiedIdentityErrors(t *testing.T) {
 				Return(&authmethod.Identity{}, nil)
 
 			login := NewMockLogin(t)
-			login.On("TokenForVerifiedIdentity", mock.Anything, mock.Anything, mock.Anything).
+			login.On("TokenForVerifiedIdentityWithMeta", mock.Anything, mock.Anything, mock.Anything).
 				Return(nil, tc.error)
 
 			server := NewServer(Config{
@@ -220,7 +220,7 @@ func TestServer_Login_RPCForwarding(t *testing.T) {
 		Return(&authmethod.Identity{}, nil)
 
 	login := NewMockLogin(t)
-	login.On("TokenForVerifiedIdentity", mock.Anything, mock.Anything, mock.Anything).
+	login.On("TokenForVerifiedIdentityWithMeta", mock.Anything, mock.Anything, mock.Anything).
 		Return(&structs.ACLToken{AccessorID: "leader response"}, nil)
 
 	dc2 := NewServer(Config{

--- a/agent/grpc-external/services/acl/mock_Login.go
+++ b/agent/grpc-external/services/acl/mock_Login.go
@@ -37,6 +37,29 @@ func (_m *MockLogin) TokenForVerifiedIdentity(identity *authmethod.Identity, aut
 	return r0, r1
 }
 
+// TokenForVerifiedIdentityWithMeta provides a mock function with given fields: identity, authMethod, meta
+func (_m *MockLogin) TokenForVerifiedIdentityWithMeta(identity *authmethod.Identity, authMethod *structs.ACLAuthMethod, meta map[string]string) (*structs.ACLToken, error) {
+	ret := _m.Called(identity, authMethod, meta)
+
+	var r0 *structs.ACLToken
+	if rf, ok := ret.Get(0).(func(*authmethod.Identity, *structs.ACLAuthMethod, map[string]string) *structs.ACLToken); ok {
+		r0 = rf(identity, authMethod, meta)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*structs.ACLToken)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*authmethod.Identity, *structs.ACLAuthMethod, map[string]string) error); ok {
+		r1 = rf(identity, authMethod, meta)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type mockConstructorTestingTNewMockLogin interface {
 	mock.TestingT
 	Cleanup(func())

--- a/agent/grpc-external/services/acl/server.go
+++ b/agent/grpc-external/services/acl/server.go
@@ -6,10 +6,11 @@ package acl
 import (
 	"context"
 
-	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/authmethod"
@@ -33,6 +34,7 @@ type Config struct {
 //go:generate mockery --name Login --inpackage
 type Login interface {
 	TokenForVerifiedIdentity(identity *authmethod.Identity, authMethod *structs.ACLAuthMethod, description string) (*structs.ACLToken, error)
+	TokenForVerifiedIdentityWithMeta(identity *authmethod.Identity, authMethod *structs.ACLAuthMethod, meta map[string]string) (*structs.ACLToken, error)
 }
 
 //go:generate mockery --name Validator --inpackage

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1242,6 +1242,11 @@ type ACLAuthMethod struct {
 	// This can be either 'local' or 'global'. If empty 'local' is assumed.
 	TokenLocality string `json:",omitempty"`
 
+	// TokenNameFormat is a template used to generate the Description field for tokens
+	// created via this auth method. Available variables include identity attributes
+	// such as ${auth_method}, ${identity.username}, ${identity.email}, etc.
+	TokenNameFormat string `json:",omitempty"`
+
 	// Configuration is arbitrary configuration for the auth method. This
 	// should only contain primitive values and containers (such as lists and
 	// maps).

--- a/api/acl.go
+++ b/api/acl.go
@@ -294,6 +294,11 @@ type ACLAuthMethod struct {
 	// This can be either 'local' or 'global'. If empty 'local' is assumed.
 	TokenLocality string `json:",omitempty"`
 
+	// TokenNameFormat is a template used to generate the Description field for tokens
+	// created via this auth method. Available variables include identity attributes
+	// such as ${auth_method}, ${identity.username}, ${identity.email}, etc.
+	TokenNameFormat string `json:",omitempty"`
+
 	// Configuration is arbitrary configuration for the auth method. This
 	// should only contain primitive values and containers (such as lists and
 	// maps).

--- a/command/acl/authmethod/create/authmethod_create.go
+++ b/command/acl/authmethod/create/authmethod_create.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/cli"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/acl/authmethod"
 	"github.com/hashicorp/consul/command/flags"
 	"github.com/hashicorp/consul/command/helpers"
-	"github.com/mitchellh/cli"
 )
 
 func New(ui cli.Ui) *cmd {
@@ -30,13 +31,14 @@ type cmd struct {
 	http  *flags.HTTPFlags
 	help  string
 
-	authMethodType string
-	name           string
-	displayName    string
-	description    string
-	maxTokenTTL    time.Duration
-	tokenLocality  string
-	config         string
+	authMethodType  string
+	name            string
+	displayName     string
+	description     string
+	maxTokenTTL     time.Duration
+	tokenLocality   string
+	tokenNameFormat string
+	config          string
 
 	k8sHost              string
 	k8sCACert            string
@@ -97,6 +99,14 @@ func (c *cmd) init() {
 		"",
 		"Defines the kind of token that this auth method should produce. "+
 			"This can be either 'local' or 'global'. If empty the value of 'local' is assumed.",
+	)
+
+	c.flags.StringVar(
+		&c.tokenNameFormat,
+		"token-name-format",
+		"",
+		"Template to use for generating token names/descriptions. Can use variables like "+
+			"${auth_method}, ${identity.username}, ${identity.email}, etc.",
 	)
 
 	c.flags.StringVar(
@@ -168,11 +178,12 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	newAuthMethod := &api.ACLAuthMethod{
-		Type:          c.authMethodType,
-		Name:          c.name,
-		DisplayName:   c.displayName,
-		Description:   c.description,
-		TokenLocality: c.tokenLocality,
+		Type:            c.authMethodType,
+		Name:            c.name,
+		DisplayName:     c.displayName,
+		Description:     c.description,
+		TokenLocality:   c.tokenLocality,
+		TokenNameFormat: c.tokenNameFormat,
 	}
 	if c.maxTokenTTL > 0 {
 		newAuthMethod.MaxTokenTTL = c.maxTokenTTL

--- a/command/acl/authmethod/formatter.go
+++ b/command/acl/authmethod/formatter.go
@@ -70,6 +70,9 @@ func (f *prettyFormatter) FormatAuthMethod(method *api.ACLAuthMethod) (string, e
 	if method.TokenLocality != "" {
 		buffer.WriteString(fmt.Sprintf("TokenLocality: %s\n", method.TokenLocality))
 	}
+	if method.TokenNameFormat != "" {
+		buffer.WriteString(fmt.Sprintf("TokenNameFormat: %s\n", method.TokenNameFormat))
+	}
 	if len(method.NamespaceRules) > 0 {
 		buffer.WriteString(fmt.Sprintln("NamespaceRules:"))
 		for _, rule := range method.NamespaceRules {

--- a/command/acl/authmethod/update/authmethod_update.go
+++ b/command/acl/authmethod/update/authmethod_update.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/cli"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/acl/authmethod"
 	"github.com/hashicorp/consul/command/flags"
 	"github.com/hashicorp/consul/command/helpers"
-	"github.com/mitchellh/cli"
 )
 
 func New(ui cli.Ui) *cmd {
@@ -32,11 +33,12 @@ type cmd struct {
 
 	name string
 
-	displayName   string
-	description   string
-	maxTokenTTL   time.Duration
-	tokenLocality string
-	config        string
+	displayName     string
+	description     string
+	maxTokenTTL     time.Duration
+	tokenLocality   string
+	tokenNameFormat string
+	config          string
 
 	k8sHost              string
 	k8sCACert            string
@@ -95,6 +97,14 @@ func (c *cmd) init() {
 		"",
 		"Defines the kind of token that this auth method should produce. "+
 			"This can be either 'local' or 'global'. If empty the value of 'local' is assumed.",
+	)
+
+	c.flags.StringVar(
+		&c.tokenNameFormat,
+		"token-name-format",
+		"",
+		"Template to use for generating token names/descriptions. Can use variables like "+
+			"${auth_method}, ${identity.username}, ${identity.email}, etc.",
 	)
 
 	c.flags.StringVar(
@@ -190,11 +200,12 @@ func (c *cmd) Run(args []string) int {
 	var method *api.ACLAuthMethod
 	if c.noMerge {
 		method = &api.ACLAuthMethod{
-			Name:          currentAuthMethod.Name,
-			Type:          currentAuthMethod.Type,
-			DisplayName:   c.displayName,
-			Description:   c.description,
-			TokenLocality: c.tokenLocality,
+			Name:            currentAuthMethod.Name,
+			Type:            currentAuthMethod.Type,
+			DisplayName:     c.displayName,
+			Description:     c.description,
+			TokenLocality:   c.tokenLocality,
+			TokenNameFormat: c.tokenNameFormat,
 		}
 		if c.maxTokenTTL > 0 {
 			method.MaxTokenTTL = c.maxTokenTTL
@@ -253,6 +264,9 @@ func (c *cmd) Run(args []string) int {
 		}
 		if c.tokenLocality != "" {
 			method.TokenLocality = c.tokenLocality
+		}
+		if c.tokenNameFormat != "" {
+			method.TokenNameFormat = c.tokenNameFormat
 		}
 		if err := c.enterprisePopulateAuthMethod(method); err != nil {
 			c.UI.Error(err.Error())


### PR DESCRIPTION
### Description

This pull request introduces support for customizable token name/description formatting when creating ACL tokens via auth methods. It adds a new `TokenNameFormat` field to the `ACLAuthMethod` struct, enables users to specify a template for token names, and updates the login/token creation flow to use these templates. CLI commands and tests are updated to support and verify this new functionality.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
