### PR TITLE
Remove unreachable code and redundant nil check in envoyID function

### DIFF
--- a/troubleshoot/proxy/utils.go
+++ b/troubleshoot/proxy/utils.go
@@ -62,12 +62,8 @@ func (t *Troubleshoot) GetEnvoyConfigDump() error {
 }
 
 func envoyID(listenerName string) string {
-
 	parts := strings.Split(listenerName, ":")
-	if parts != nil || len(parts) > 0 {
-		return parts[0]
-	}
-	return ""
+	return parts[0]
 }
 
 func (t *Troubleshoot) parseClusters(clusters *envoy_admin_v3.Clusters) ([]string, error) {


### PR DESCRIPTION
## Summary

The `envoyID` function in `troubleshoot/proxy/utils.go` contained unreachable code due to a logic error in the conditional check.

## Bug Description

The original code was:
```go
func envoyID(listenerName string) string {
    parts := strings.Split(listenerName, ":")
    if parts != nil || len(parts) > 0 {
        return parts[0]
    }
    return ""
}
```

This has two issues:
1. `strings.Split` **never returns nil** - it always returns at least a slice with one element (the original string if no separator is found)
2. Since `parts != nil` is always true, and the condition uses `||`, the entire condition is **always true**
3. The fallback `return ""` is **unreachable code**

## Fix

Simplified the function to directly return `parts[0]`, which maintains the same runtime behavior while removing the dead code:

```go
func envoyID(listenerName string) string {
    parts := strings.Split(listenerName, ":")
    return parts[0]
}
```

## Testing

- Verified the build passes: `go build ./proxy/...`
- Verified tests pass: `go test ./proxy/...`