### PR TITLE
agent: revoke login-derived ACL token during ShutdownAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+BUG FIXES:
+
+* acl: Fix ACL token accumulation by revoking login-derived agent tokens during `ShutdownAgent`. Previously, tokens created via `acl/login` were never revoked on agent shutdown, causing indefinite accumulation in the server state store and degraded Raft performance. [[GH-22613](https://github.com/hashicorp/consul/issues/22613)]
+
 ## 1.22.3 (January 23, 2026)
 
 SECURITY:
@@ -203,6 +209,7 @@ BUG FIXES:
 * ui: fixes the issue where namespaces where disappearing and Welcome to Namespace screen showed up after tab switching [[GH-22789](https://github.com/hashicorp/consul/issues/22789)]
 * ui: fixes the issue where when doing deletes of multiple tokens or policies, the three dots on the right hand side stops responding after the first delete. [[GH-22752](https://github.com/hashicorp/consul/issues/22752)]
 * cmd: Fix `consul operator utilization --help` to show only available options without extra parameters. [[GH-22912](https://github.com/hashicorp/consul/issues/22912)]
+
 
 ## 1.22.0-rc2+ent (October 15, 2025)
 


### PR DESCRIPTION
Consul agents that authenticate via an auth method (e.g. the `consul-k8s` `acl-init` init container) obtain a short-lived ACL
   token at startup via `POST /v1/acl/login`. This token is written to disk and loaded as the agent token. On shutdown, the
  token was never revoked — `ShutdownAgent()` had no logout logic — leaving it as an orphaned entry in the server state store
  indefinitely.

  Over time, across pod restarts and node replacements in Kubernetes environments, this causes thousands of stale tokens to
  accumulate. Each token is an entry in the Raft-backed state store, increasing commit latency and server resource usage
  (reported as 1–4s commit latency with ~20,000 stale tokens in production).

  **This PR fixes the issue by calling `ACL.Logout` inside `ShutdownAgent()` before the delegate is shut down**, ensuring the
  RPC channel is still open when the revocation is sent. The server-side `TokenWriter.Delete` already guards against revoking
  static tokens (`token.AuthMethod == "" && fromLogout` returns `ErrPermissionDenied`), so non-login tokens are left completely
   untouched.

  Testing & Reproduction steps:

  * Added `TestShutdownAgent_RevokesLoginDerivedAgentToken` in `agent/agent_test.go`
    * Sets up an agent with ACLs enabled
    * Creates an auth method and binding rule mirroring the `consul-k8s` component auth method setup
    * Logs in via `ACLLogin` to obtain a login-derived token and sets it as the agent token
    * Calls `ShutdownAgent()` and asserts the token is gone from the state store afterwards
    * Also covers the negative case implicitly: static tokens (no `AuthMethod`) are rejected by `TokenWriter.Delete` with
  `ErrPermissionDenied` and are never deleted

  * To run the regression test:
    go test ./agent/ -run TestShutdownAgent_RevokesLoginDerivedAgentToken -v -count=1


  Links:

  * Fixes #22613
  * Related: hashicorp/consul-k8s#1441 (orphaned ACL tokens from ungraceful shutdowns)

  PR Checklist:

  * [x] updated test coverage — `TestShutdownAgent_RevokesLoginDerivedAgentToken` added
  * [ ] external facing docs updated — no config or API surface changes
  * [x] not a security concern — this reduces token accumulation, no new permissions or attack surface