### PR TITLE
fix: upgrade curl to edge to address CVE-2025 vulnerabilities

### DIFF
--- a/.changelog/23211.txt
+++ b/.changelog/23211.txt
@@ -1,0 +1,4 @@
+```release-note:security
+1: Upgraded to latest curl@edge to fix CVE-2025-14819, CVE-2025-14524, and CVE-2025-14017.
+2: Removed unused gnupg and openssl in default target, resolving CVE-2025-30258 and reducing image footprint.
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,11 @@ RUN addgroup consul && \
 # Set up certificates, base tools, and Consul.
 # libc6-compat is needed to symlink the shared libraries for ARM builds
 RUN set -eux && \
-    apk add --no-cache --upgrade ca-certificates curl dumb-init gnupg libcap openssl su-exec iputils jq libc6-compat iptables tzdata && \
+    echo '@edge https://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories && \
+    apk update && \
+    apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates dumb-init gnupg libcap openssl su-exec iputils jq libc6-compat iptables tzdata && \
+    apk add --no-cache curl@edge && \
     gpg --keyserver keyserver.ubuntu.com --recv-keys C874011F0AB405110D02105534365D9472D7468F && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
@@ -156,19 +160,20 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
 COPY LICENSE /usr/share/doc/$PRODUCT_NAME/LICENSE.txt
 # Set up certificates and base tools.
 # libc6-compat is needed to symlink the shared libraries for ARM builds
-RUN apk add -v --no-cache --upgrade \
+RUN echo '@edge https://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories && \
+    apk update && \
+    apk upgrade --no-cache && \
+    apk add -v --no-cache \
 		dumb-init \
 		libc6-compat \
 		iptables \
 		tzdata \
-		curl \
 		ca-certificates \
-		gnupg \
 		iputils \ 
 		libcap \
-		openssl \
 		su-exec \
-		jq 
+		jq && \
+    apk add --no-cache curl@edge 
 
 # Create a consul user and group first so the IDs get set the same way, even as
 # the rest of this may change over time.


### PR DESCRIPTION
### Description
The issue is that Alpine 3.23 repositories don't have patched curl.
Need to pull curl from the edge repository to get the latest security patches.


I've updated both the official and default stages to:
1. Add the Alpine edge repository
2. Install the latest curl from edge (curl@edge) which should have all the CVE fixes
3. Removed redundant upgrade commands and unnecessary packages (gnupg, openssl) from the default stage