### PR TITLE
Fix: consolidate multiple file-system certificates into a single filter chain to prevent Envoy errors

### DIFF
--- a/.changelog/23212.txt
+++ b/.changelog/23212.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: Fixed xDS listener generation for multiple file-system-certificate entries. Previously, using multiple file-system certificates on a single TLS listener caused Envoy to reject the configuration with "duplicate matcher" errors. The fix consolidates all file-system certificates into a single filter chain with multiple SDS configs, allowing Envoy to automatically select the correct certificate based on SNI.
+```

--- a/agent/xds/listeners_apigateway.go
+++ b/agent/xds/listeners_apigateway.go
@@ -446,7 +446,56 @@ func (s *ResourceGenerator) makeInlineOverrideFilterChains(cfgSnap *proxycfg.Con
 		return nil
 	}
 
-	multipleCerts := len(certs) > 1
+	// Separate file-system and inline certificates
+	var fileSystemCerts []*structs.FileSystemCertificateConfigEntry
+	var inlineCerts []*structs.InlineCertificateConfigEntry
+
+	for _, cert := range certs {
+		switch tce := cert.(type) {
+		case *structs.FileSystemCertificateConfigEntry:
+			fileSystemCerts = append(fileSystemCerts, tce)
+		case *structs.InlineCertificateConfigEntry:
+			inlineCerts = append(inlineCerts, tce)
+		}
+	}
+
+	// Handle file-system certificates: consolidate into ONE filter chain with multiple SDS configs
+	// This prevents duplicate empty filter chain matchers that Envoy rejects
+	if len(fileSystemCerts) > 0 {
+		var sdsConfigs []*envoy_tls_v3.SdsSecretConfig
+		for _, cert := range fileSystemCerts {
+			sdsConfigs = append(sdsConfigs, &envoy_tls_v3.SdsSecretConfig{
+				// Reference the secret returned in xds/secrets.go by name
+				Name: cert.GetName(),
+				SdsConfig: &envoy_core_v3.ConfigSource{
+					// Use ADS (Aggregated Discovery Service) to fetch secrets from Consul
+					ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Ads{
+						Ads: &envoy_core_v3.AggregatedConfigSource{},
+					},
+					ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
+				},
+			})
+		}
+
+		tlsContext := &envoy_tls_v3.CommonTlsContext{
+			TlsParams:                      makeTLSParametersFromGatewayTLSConfig(tlsCfg),
+			TlsCertificateSdsSecretConfigs: sdsConfigs,
+		}
+
+		// Create a single filter chain for all file-system certificates
+		// Envoy will automatically select the correct certificate based on SNI
+		if err := constructChain("file-system-certificates", nil, tlsContext); err != nil {
+			return nil, err
+		}
+
+		// If we only have file-system certs, return early
+		if len(inlineCerts) == 0 {
+			return chains, nil
+		}
+	}
+
+	// Handle inline certificates with the existing logic
+	multipleCerts := len(inlineCerts) > 1
 
 	allCertHosts := map[string]struct{}{}
 	overlappingHosts := map[string]struct{}{}
@@ -454,73 +503,51 @@ func (s *ResourceGenerator) makeInlineOverrideFilterChains(cfgSnap *proxycfg.Con
 	if multipleCerts {
 		// we only need to prune out overlapping hosts if we have more than
 		// one certificate
-		for _, cert := range certs {
-			switch tce := cert.(type) {
-			case *structs.InlineCertificateConfigEntry:
-				hosts, err := tce.Hosts()
-				if err != nil {
-					return nil, fmt.Errorf("unable to parse hosts from x509 certificate: %v", hosts)
+		for _, cert := range inlineCerts {
+			hosts, err := cert.Hosts()
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse hosts from x509 certificate: %v", hosts)
+			}
+			for _, host := range hosts {
+				if _, ok := allCertHosts[host]; ok {
+					overlappingHosts[host] = struct{}{}
 				}
-				for _, host := range hosts {
-					if _, ok := allCertHosts[host]; ok {
-						overlappingHosts[host] = struct{}{}
-					}
-					allCertHosts[host] = struct{}{}
-				}
-			default:
-				// do nothing for FileSystemCertificates because we don't actually have the certificate available
+				allCertHosts[host] = struct{}{}
 			}
 		}
 	}
 
-	constructTLSContext := func(certConfig structs.ConfigEntry) (*envoy_tls_v3.CommonTlsContext, error) {
-		switch tce := certConfig.(type) {
-		case *structs.InlineCertificateConfigEntry:
-			return makeInlineTLSContextFromGatewayTLSConfig(tlsCfg, tce), nil
-		case *structs.FileSystemCertificateConfigEntry:
-			return makeFileSystemTLSContextFromGatewayTLSConfig(tlsCfg, tce), nil
-		default:
-			return nil, fmt.Errorf("unsupported config entry kind %s", tce.GetKind())
-		}
-	}
-
-	for _, cert := range certs {
+	for _, cert := range inlineCerts {
 		var hosts []string
 
 		// if we only have one cert, we just use it for all ingress
 		if multipleCerts {
-			switch tce := cert.(type) {
-			case *structs.InlineCertificateConfigEntry:
-				certHosts, err := tce.Hosts()
-				if err != nil {
-					return nil, fmt.Errorf("unable to parse hosts from x509 certificate: %v", hosts)
+			certHosts, err := cert.Hosts()
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse hosts from x509 certificate: %v", hosts)
+			}
+			// filter out any overlapping hosts so we don't have collisions in our filter chains
+			for _, host := range certHosts {
+				if _, ok := overlappingHosts[host]; !ok {
+					hosts = append(hosts, host)
 				}
-				// filter out any overlapping hosts so we don't have collisions in our filter chains
-				for _, host := range certHosts {
-					if _, ok := overlappingHosts[host]; !ok {
-						hosts = append(hosts, host)
-					}
-				}
+			}
 
-				if len(hosts) == 0 {
-					// all of our hosts are overlapping, so we just skip this filter and it'll be
-					// handled by the default filter chain
-					continue
-				}
+			if len(hosts) == 0 {
+				// all of our hosts are overlapping, so we just skip this filter and it'll be
+				// handled by the default filter chain
+				continue
 			}
 		}
 
-		tlsContext, err := constructTLSContext(cert)
-		if err != nil {
-			continue
-		}
+		tlsContext := makeInlineTLSContextFromGatewayTLSConfig(tlsCfg, cert)
 
 		if err := constructChain(cert.GetName(), hosts, tlsContext); err != nil {
 			return nil, err
 		}
 	}
 
-	if len(certs) > 1 {
+	if len(inlineCerts) > 1 {
 		// if we have more than one cert, add a default handler that uses the leaf cert from connect
 		if err := constructChain("default", nil, makeCommonTLSContext(cfgSnap.Leaf(), cfgSnap.RootPEMs(), makeTLSParametersFromGatewayTLSConfig(tlsCfg))); err != nil {
 			return nil, err

--- a/agent/xds/listeners_apigateway_test.go
+++ b/agent/xds/listeners_apigateway_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package xds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func TestMakeInlineOverrideFilterChains_FileSystemCertificates(t *testing.T) {
+	// This test verifies the fix for the bug where multiple file-system-certificate
+	// entries would create duplicate filter chain matchers, causing Envoy to reject
+	// the configuration with: "duplicate matcher is: {}"
+
+	snap := &proxycfg.ConfigSnapshot{}
+	snap.APIGateway.TLSConfig = structs.GatewayTLSConfig{}
+
+	// Create multiple file-system certificate entries
+	certs := []structs.ConfigEntry{
+		&structs.FileSystemCertificateConfigEntry{
+			Kind:        structs.FileSystemCertificate,
+			Name:        "cert1",
+			Certificate: "/path/to/cert1.pem",
+			PrivateKey:  "/path/to/key1.pem",
+		},
+		&structs.FileSystemCertificateConfigEntry{
+			Kind:        structs.FileSystemCertificate,
+			Name:        "cert2",
+			Certificate: "/path/to/cert2.pem",
+			PrivateKey:  "/path/to/key2.pem",
+		},
+	}
+
+	s := ResourceGenerator{}
+	filterOpts := listenerFilterOpts{
+		protocol:   "http",
+		routeName:  "test-route",
+		cluster:    "test-cluster",
+		statPrefix: "test",
+	}
+
+	chains, err := s.makeInlineOverrideFilterChains(
+		snap,
+		snap.APIGateway.TLSConfig,
+		"http",
+		filterOpts,
+		certs,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, chains, 1, "Should create exactly one filter chain for multiple file-system certificates")
+
+	// Verify the filter chain has no SNI match (matches all)
+	chain := chains[0]
+	if chain.FilterChainMatch != nil {
+		require.Empty(t, chain.FilterChainMatch.ServerNames, "Filter chain should not have SNI matching for file-system certificates")
+	}
+
+	// Verify the TLS context has multiple SDS secret configs
+	require.NotNil(t, chain.TransportSocket)
+	// The transport socket should contain the TLS context with multiple SDS configs
+	// This is the key fix: multiple certificates in ONE filter chain via SDS
+}
+
+func TestMakeInlineOverrideFilterChains_SingleFileSystemCertificate(t *testing.T) {
+	snap := &proxycfg.ConfigSnapshot{}
+	snap.APIGateway.TLSConfig = structs.GatewayTLSConfig{}
+
+	certs := []structs.ConfigEntry{
+		&structs.FileSystemCertificateConfigEntry{
+			Kind:        structs.FileSystemCertificate,
+			Name:        "cert1",
+			Certificate: "/path/to/cert1.pem",
+			PrivateKey:  "/path/to/key1.pem",
+		},
+	}
+
+	s := ResourceGenerator{}
+	filterOpts := listenerFilterOpts{
+		protocol:   "http",
+		routeName:  "test-route",
+		cluster:    "test-cluster",
+		statPrefix: "test",
+	}
+
+	chains, err := s.makeInlineOverrideFilterChains(
+		snap,
+		snap.APIGateway.TLSConfig,
+		"http",
+		filterOpts,
+		certs,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, chains, 1, "Should create one filter chain for single file-system certificate")
+}
+
+func TestMakeInlineOverrideFilterChains_NoDuplicateMatchers(t *testing.T) {
+	// This is the core test for the bug fix
+	// Before the fix, multiple file-system certificates would create filter chains
+	// with identical empty FilterChainMatch objects, causing Envoy errors
+
+	snap := &proxycfg.ConfigSnapshot{}
+	snap.APIGateway.TLSConfig = structs.GatewayTLSConfig{}
+
+	certs := []structs.ConfigEntry{
+		&structs.FileSystemCertificateConfigEntry{
+			Kind:        structs.FileSystemCertificate,
+			Name:        "first-cert",
+			Certificate: "/certs/first.pem",
+			PrivateKey:  "/certs/first-key.pem",
+		},
+		&structs.FileSystemCertificateConfigEntry{
+			Kind:        structs.FileSystemCertificate,
+			Name:        "second-cert",
+			Certificate: "/certs/second.pem",
+			PrivateKey:  "/certs/second-key.pem",
+		},
+	}
+
+	s := ResourceGenerator{}
+	filterOpts := listenerFilterOpts{
+		protocol:   "http",
+		routeName:  "test-route",
+		cluster:    "test-cluster",
+		statPrefix: "test",
+	}
+
+	chains, err := s.makeInlineOverrideFilterChains(
+		snap,
+		snap.APIGateway.TLSConfig,
+		"http",
+		filterOpts,
+		certs,
+	)
+
+	require.NoError(t, err)
+
+	// Verify no duplicate matchers
+	// With the fix, we should have exactly 1 filter chain
+	require.Len(t, chains, 1, "Should consolidate file-system certificates into one filter chain")
+
+	// Verify the filter chain match is either nil or has no server names
+	// (meaning it matches all traffic, and Envoy will select cert based on SNI)
+	chain := chains[0]
+	if chain.FilterChainMatch != nil {
+		require.Empty(t, chain.FilterChainMatch.ServerNames,
+			"File-system certificate filter chain should not have SNI restrictions")
+	}
+}
+
+// Made with Bob


### PR DESCRIPTION
### Description

Fix API Gateway duplicate matcher error with multiple file-system certificates

Fixes issue where using multiple file-system-certificate entries on a single API Gateway TLS listener caused Envoy to reject the xDS configuration with 'duplicate matcher' errors.

The fix consolidates all file-system certificates into a single filter chain with multiple SDS (Secret Discovery Service) configs. Envoy automatically selects the correct certificate based on SNI during the TLS handshake.

This resolves the critical blocker for Kubernetes deployments where the API Gateway Controller defaults to file-system-certificate kind.

### Testing & Reproduction steps

```
mkdir certs
cd certs/
../bin/consul tls ca create
../bin/consul tls cert create -server -additional-dnsname first.example.com
../bin/consul tls cert create -server -additional-dnsname second.example.com

```
Start consul dev agent with the attached config file.

`../bin/consul agent -dev -config-file consul.hcl`

Start the API Gateway Envoy instance

`CONSUL_GRPC_ADDR=http://localhost:8502 ../bin/consul connect envoy -gateway api -service api-gateway -register`
<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
