### PR TITLE
(apigw/httproute) Add support to disable traffic with weight 0 in services

### DIFF
--- a/.changelog/23216.txt
+++ b/.changelog/23216.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: allow http-routes to set `weight: 0` to disable traffic to particular service
+```

--- a/agent/structs/config_entry_routes.go
+++ b/agent/structs/config_entry_routes.go
@@ -123,7 +123,7 @@ func (e *HTTPRouteConfigEntry) Normalize() error {
 func (e *HTTPRouteConfigEntry) normalizeHTTPService(service HTTPService) HTTPService {
 	service.Merge(e.GetEnterpriseMeta())
 	service.Normalize()
-	if service.Weight <= 0 {
+	if service.Weight < 0 {
 		service.Weight = 1
 	}
 	return service

--- a/agent/structs/config_entry_routes_test.go
+++ b/agent/structs/config_entry_routes_test.go
@@ -338,7 +338,7 @@ func TestHTTPRoute(t *testing.T) {
 				}},
 			},
 		},
-		"rule normalizes service weight": {
+		"rule preserves zero service weight and normalizes negative service weight": {
 			entry: &HTTPRouteConfigEntry{
 				Kind: HTTPRoute,
 				Name: "route-one",
@@ -357,8 +357,31 @@ func TestHTTPRoute(t *testing.T) {
 			},
 			check: func(t *testing.T, entry ConfigEntry) {
 				route := entry.(*HTTPRouteConfigEntry)
-				require.Equal(t, 1, route.Rules[0].Services[0].Weight)
+				require.Equal(t, 0, route.Rules[0].Services[0].Weight)
 				require.Equal(t, 1, route.Rules[0].Services[1].Weight)
+			},
+		},
+		"rule preserves all-zero service weights as disabled": {
+			entry: &HTTPRouteConfigEntry{
+				Kind: HTTPRoute,
+				Name: "route-one",
+				Rules: []HTTPRouteRule{{
+					Services: []HTTPService{
+						{
+							Name:   "test",
+							Weight: 0,
+						},
+						{
+							Name:   "test2",
+							Weight: 0,
+						},
+					},
+				}},
+			},
+			check: func(t *testing.T, entry ConfigEntry) {
+				route := entry.(*HTTPRouteConfigEntry)
+				require.Equal(t, 0, route.Rules[0].Services[0].Weight)
+				require.Equal(t, 0, route.Rules[0].Services[1].Weight)
 			},
 		},
 


### PR DESCRIPTION
### Description

This PR fixes Consul API Gateway behavior for Kubernetes `HTTPRoute` backends with `weight: 0`.

Previously, `HTTPRoute` normalization converted all `weight <= 0` values to `1`, which caused explicit `weight: 0` backends to still receive traffic. This conflicted with Gateway API expectations and customer-observed behavior.

This change updates normalization logic to:
- Preserve explicit `weight: 0` (so zero-weight backends can be excluded from traffic).
- Continue normalizing negative weights to 1.

### Links
- Prior related fix: [GH-16512](https://github.com/hashicorp/consul/issues/16512)
- Kubernetes Gateway API backendRefs.weight semantics: [Gateway API HTTPRoute spec](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPBackendRef)

### Tests
- With this fix, the routes support definition of 0 weight services.
- The instance with `weight: 0` does not receive any traffic.

<details>
<summary>
<b>HTTPRoute config output</b>
</summary>

`$ consul config read -kind http-route -name quill-route`

```hcl
{
    "Kind": "http-route",
    "Name": "quill-route",
    "Parents": [
        {
            "Kind": "api-gateway",
            "Name": "api-gateway",
            "SectionName": "http-listener"
        }
    ],
    "Rules": [
        {
            "Filters": {
                "Headers": null,
                "URLRewrite": null,
                "RetryFilter": null,
                "TimeoutFilter": null,
                "JWT": null
            },
            "ResponseFilters": {
                "Headers": null
            },
            "Matches": [
                {
                    "Headers": null,
                    "Method": "",
                    "Path": {
                        "Match": "prefix",
                        "Value": "/"
                    },
                    "Query": null
                }
            ],
            "Services": [
                {
                    "Name": "quill-v1",
                    "Weight": 0,
                    "Filters": {
                        "Headers": null,
                        "URLRewrite": null,
                        "RetryFilter": null,
                        "TimeoutFilter": null,
                        "JWT": null
                    },
                    "ResponseFilters": {
                        "Headers": null
                    }
                },
                {
                    "Name": "quill-v2",
                    "Weight": 100,
                    "Filters": {
                        "Headers": null,
                        "URLRewrite": null,
                        "RetryFilter": null,
                        "TimeoutFilter": null,
                        "JWT": null
                    },
                    "ResponseFilters": {
                        "Headers": null
                    }
                }
            ]
        }
    ],
    "Hostnames": null,
    "CreateIndex": 43,
    "ModifyIndex": 80,
    "Status": {
        "Conditions": [
            {
                "Type": "Accepted",
                "Status": "True",
                "Reason": "Accepted",
                "Message": "route is valid",
                "Resource": {
                    "Kind": "",
                    "Name": "",
                    "SectionName": ""
                },
                "LastTransitionTime": "2026-02-16T08:17:57.943208Z"
            },
            {
                "Type": "Bound",
                "Status": "True",
                "Reason": "Bound",
                "Message": "successfully bound route",
                "Resource": {
                    "Kind": "api-gateway",
                    "Name": "api-gateway",
                    "SectionName": "http-listener"
                },
                "LastTransitionTime": "2026-02-16T08:17:57.943215Z"
            }
        ]
    }
}
```

</details>

##### 


#### Traffic Distribution

##### case 1:
```
Services = [
  {
    Name = "quill-v1"
    Weight = 100
  },
  {
    Name = "quill-v2"
    Weight = 100
  }
]
```

<img width="620" height="331" alt="Screenshot 2026-02-16 at 14 29 59" src="https://github.com/user-attachments/assets/75877709-2ed8-4916-b596-5e5e7482e261" />

##### case 2:
```
Services = [
  {
    Name = "quill-v1"
    Weight = 0
  },
  {
    Name = "quill-v2"
    Weight = 100
  }
]
```

<img width="655" height="283" alt="Screenshot 2026-02-16 at 14 32 55" src="https://github.com/user-attachments/assets/74997a79-d779-45f2-ac67-5fb908951f0f" />

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
