### PR TITLE
Fix xDS listener generation failures when dual-stack detection unavai…

### DIFF
--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -102,13 +102,9 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			return nil, err
 		}
 
-		ds, err := netutil.IsDualStack(nil, true)
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine if dual-stack mode is enabled: %w", err)
-		}
-
 		addr := "127.0.0.1"
-		if ds {
+		ds, err := netutil.IsDualStack(nil, true)
+		if err == nil && ds {
 			addr = "::1"
 		}
 
@@ -823,10 +819,7 @@ func (s *ResourceGenerator) listenersFromSnapshotGateway(cfgSnap *proxycfg.Confi
 			addr = "0.0.0.0"
 
 			ds, err := netutil.IsDualStack(nil, true)
-			if err != nil {
-				return nil, err
-			}
-			if ds {
+			if err == nil && ds {
 				addr = "::"
 			}
 		}
@@ -950,10 +943,7 @@ func makeListenerWithDefault(opts makeListenerOpts) *envoy_listener_v3.Listener 
 	if opts.addr == "" {
 		opts.addr = "127.0.0.1"
 		ds, err := netutil.IsDualStack(nil, true)
-		if err != nil {
-			return nil
-		}
-		if ds {
+		if err == nil && ds {
 			opts.addr = "::1"
 		}
 	}
@@ -1350,10 +1340,7 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 	if addr == "" {
 		addr = "0.0.0.0"
 		ds, err := netutil.IsDualStack(nil, true)
-		if err != nil {
-			return nil, err
-		}
-		if ds {
+		if err == nil && ds {
 			addr = "::"
 		}
 	}
@@ -1580,10 +1567,7 @@ func (s *ResourceGenerator) makeExposedCheckListener(cfgSnap *proxycfg.ConfigSna
 	} else if addr == "" {
 		addr = "0.0.0.0"
 		ds, err := netutil.IsDualStack(nil, true)
-		if err != nil {
-			return nil, err
-		}
-		if ds {
+		if err == nil && ds {
 			addr = "::"
 		}
 	}


### PR DESCRIPTION
### Description
Tests TestServer_DeltaAggregatedResources_v3_ACLEnforcement and TestServer_DeltaAggregatedResources_LicenseEnforcement are failing in CI with errors indicating that xDS resource generation is failing before ACL/license checks can execute.

Failing tests:

TestServer_DeltaAggregatedResources_v3_ACLEnforcement/default_deny,_no_token
TestServer_DeltaAggregatedResources_v3_ACLEnforcement/default_deny,_read_token
TestServer_DeltaAggregatedResources_v3_ACLEnforcement/default_deny,_write_token_on_different_service
TestServer_DeltaAggregatedResources_LicenseEnforcement/Service_Mesh_Disabled

Error symptoms:

Tests expect PermissionDenied errors from ACL/license checks
Instead, tests fail because metrics gauges are not being set
Logs show: Get "http://localhost:8500/v1/agent/self": dial tcp [::1]:8500: connect: connection refused


### Root Cause
The IPv6 dual-stack support added in commit 661fc4129b (October 14, 2025) introduced calls to netutil.IsDualStack(nil, true) in listener generation code. This function attempts to connect to a Consul agent HTTP API at localhost:8500 to determine if dual-stack networking is enabled.

The original implementation had overly strict error handling:
```

ds, err := netutil.IsDualStack(nil, true)
if err != nil {
    return nil  // or return nil, err
}
if ds {
    addr = "::1"
}

```
In test environments where no Consul agent is running, this causes:

Early termination - Functions return nil/errors before ACL/license checks execute
Metrics not recorded - Stream handlers terminate before metrics gauges are set
Test failures - Tests cannot verify expected ACL/license denial behavior

### Mitigation
Changed error handling to gracefully degrade when dual-stack detection fails:
```

addr := "127.0.0.1"  // Set IPv4 default first
ds, err := netutil.IsDualStack(nil, true)
if err == nil && ds {  // Only use IPv6 if check succeeds AND dual-stack enabled
    addr = "::1"
}
// Continue with addr - never fails

```

Testing
All previously failing tests now pass:
`go test -v -run "TestServer_DeltaAggregatedResources_v3_ACLEnforcement|TestServer_DeltaAggregatedResources_LicenseEnforcement" ./agent/xds`