### PR TITLE
Fix Go minimum version

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/api
 
-go 1.26
+go 1.25.0
 
 replace github.com/hashicorp/consul/sdk => ../sdk
 

--- a/envoyextensions/go.mod
+++ b/envoyextensions/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/envoyextensions
 
-go 1.26
+go 1.25.0
 
 replace (
 	github.com/hashicorp/consul/api => ../api

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul
 
-go 1.26
+go 1.25.0
 
 replace (
 	github.com/hashicorp/consul/api => ./api

--- a/internal/tools/proto-gen-rpc-glue/e2e/consul/go.mod
+++ b/internal/tools/proto-gen-rpc-glue/e2e/consul/go.mod
@@ -1,5 +1,5 @@
 module github.com/hashicorp/consul
 
-go 1.26
+go 1.25.0
 
 require google.golang.org/protobuf v1.36.11

--- a/internal/tools/proto-gen-rpc-glue/e2e/go.mod
+++ b/internal/tools/proto-gen-rpc-glue/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/internal/tools/proto-gen-rpc-glue/e2e
 
-go 1.26
+go 1.25.0
 
 replace github.com/hashicorp/consul => ./consul
 

--- a/internal/tools/proto-gen-rpc-glue/go.mod
+++ b/internal/tools/proto-gen-rpc-glue/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/internal/tools/proto-gen-rpc-glue
 
-go 1.26
+go 1.25.0
 
 require github.com/stretchr/testify v1.8.4
 

--- a/internal/tools/protoc-gen-consul-rate-limit/go.mod
+++ b/internal/tools/protoc-gen-consul-rate-limit/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/internal/tools/protoc-gen-consul-rate-limit
 
-go 1.26
+go 1.25.0
 
 replace github.com/hashicorp/consul/proto-public => ../../../proto-public
 

--- a/proto-public/go.mod
+++ b/proto-public/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/proto-public
 
-go 1.26
+go 1.25.0
 
 require (
 	google.golang.org/grpc v1.79.3

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/sdk
 
-go 1.26
+go 1.25.0
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/test-integ/go.mod
+++ b/test-integ/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/test-integ
 
-go 1.26
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/test/integration/connect/envoy/test-sds-server/go.mod
+++ b/test/integration/connect/envoy/test-sds-server/go.mod
@@ -1,6 +1,6 @@
 module test-sds-server
 
-go 1.26
+go 1.25.0
 
 require (
 	github.com/envoyproxy/go-control-plane v0.14.0

--- a/test/integration/consul-container/go.mod
+++ b/test/integration/consul-container/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/test/integration/consul-container
 
-go 1.26
+go 1.25.0
 
 require (
 	fortio.org/fortio v1.54.0

--- a/test/integration/consul-container/test/envoy_extensions/testdata/wasm_test_files/go.mod
+++ b/test/integration/consul-container/test/envoy_extensions/testdata/wasm_test_files/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.26
+go 1.25.0
 
 require github.com/tetratelabs/proxy-wasm-go-sdk v0.21.0
 

--- a/testing/deployer/go.mod
+++ b/testing/deployer/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/testing/deployer
 
-go 1.26
+go 1.25.0
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible

--- a/troubleshoot/go.mod
+++ b/troubleshoot/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul/troubleshoot
 
-go 1.26
+go 1.25.0
 
 replace (
 	github.com/hashicorp/consul/api => ../api


### PR DESCRIPTION
### Description

Fix up the Go minimum version requirement specified by the `go` directive in the Go module files.

To quote:

> The go directive sets the minimum version of Go required to use this module.
### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

See: https://go.dev/ref/mod#go-mod-file-go

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
