### PR TITLE
docs(#22739): update security note with HTTP server timeout defaults and configuration options

### DIFF
--- a/.changelog/22739.txt
+++ b/.changelog/22739.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-security: Configure HTTP server timeouts to prevent Slowloris denial-of-service attacks on agent HTTP endpoints and pprof endpoints
+security: Configure HTTP server timeouts to prevent Slowloris denial-of-service attacks on agent HTTP endpoints and pprof endpoints. Default timeouts are: read_timeout=30s, read_header_timeout=10s, write_timeout=30s, idle_timeout=120s. These can be customized via the `http_config` block in agent configuration if longer timeouts are needed for health checks or other operations.
 ```

--- a/.changelog/22739.txt
+++ b/.changelog/22739.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-security: Configure HTTP server timeouts to prevent Slowloris denial-of-service attacks on agent HTTP endpoints and pprof endpoints. Default timeouts are: read_timeout=30s, read_header_timeout=10s, write_timeout=30s, idle_timeout=120s. These can be customized via the `http_config` block in agent configuration if longer timeouts are needed for health checks or other operations.
+security: breaking change - Configure HTTP server timeouts to prevent Slowloris denial-of-service attacks on agent HTTP endpoints and pprof endpoints. Timeouts can be customized via `read_timeout`, `read_header_timeout`, `write_timeout`, and `idle_timeout` options in the `http_config` block if longer timeouts are needed for health checks or other operations.
 ```

--- a/.changelog/22739.txt
+++ b/.changelog/22739.txt
@@ -1,3 +1,3 @@
-```release-note:security
-security: breaking change - Configure HTTP server timeouts to prevent Slowloris denial-of-service attacks on agent HTTP endpoints and pprof endpoints. Timeouts can be customized via `read_timeout`, `read_header_timeout`, `write_timeout`, and `idle_timeout` options in the `http_config` block if longer timeouts are needed for health checks or other operations.
+```release-note:breaking-change
+security: Configure HTTP server timeouts to prevent Slowloris denial-of-service attacks on agent HTTP endpoints and pprof endpoints. Timeouts can be customized via `read_timeout`, `read_header_timeout`, `write_timeout`, and `idle_timeout` options in the `http_config` block if longer timeouts are needed for health checks or other operations.
 ```

--- a/website/content/docs/reference/agent/configuration-file/general.mdx
+++ b/website/content/docs/reference/agent/configuration-file/general.mdx
@@ -209,6 +209,44 @@ The page provides reference information for general parameters in a Consul agent
 
   - `max_header_bytes` This setting controls the maximum number of bytes the consul http server will read parsing the request header's keys and values, including the request line. It does not limit the size of the request body. If zero, or negative, http.DefaultMaxHeaderBytes is used, which equates to 1 Megabyte.
 
+  - `read_timeout` The maximum duration for reading the entire request, including the body. This timeout prevents slow request body attacks. A zero or negative value disables the timeout. Default: `30s`. Minimum: `1s`. Added in Consul 1.22.4.
+
+  - `read_header_timeout` The amount of time allowed to read request headers. The connection's read deadline is reset after reading the headers. This timeout prevents Slowloris attacks on header parsing. Default: `10s`. Minimum: `1s`. Added in Consul 1.22.4.
+
+  - `write_timeout` The maximum duration before timing out writes of the response. This timeout prevents slow response drain attacks. A zero or negative value disables the timeout. Default: `30s`. Minimum: `1s`. Added in Consul 1.22.4.
+
+  - `idle_timeout` The maximum amount of time to wait for the next request when keep-alives are enabled. This timeout prevents connection exhaustion attacks. Default: `120s`. Minimum: `10s`. Added in Consul 1.22.4.
+
+    <Note>
+    
+    If you have health checks or other operations that take longer than the default timeouts, you should increase these values accordingly. For example, if you have health checks that can take up to 60 seconds, set `read_timeout` and `write_timeout` to at least `60s` or higher.
+    
+    </Note>
+
+    <CodeTabs heading="Example: Configuring HTTP timeouts">
+
+    ```hcl
+    http_config {
+      read_timeout = "60s"
+      read_header_timeout = "20s"
+      write_timeout = "60s"
+      idle_timeout = "300s"
+    }
+    ```
+
+    ```json
+    {
+      "http_config": {
+        "read_timeout": "60s",
+        "read_header_timeout": "20s",
+        "write_timeout": "60s",
+        "idle_timeout": "300s"
+      }
+    }
+    ```
+
+    </CodeTabs>
+
 - `leave_on_terminate` If enabled, when the agent receives a TERM signal, it will send a `Leave` message to the rest of the cluster and gracefully leave. The default behavior for this feature varies based on whether or not the agent is running as a client or a server (prior to Consul 0.7 the default value was unconditionally set to `false`). On agents in client-mode, this defaults to `true` and for agents in server-mode, this defaults to `false`.
 
 - `license_path` <EnterpriseAlert inline /> This specifies the path to a file that contains the Consul Enterprise license. Alternatively the license may also be specified in either the `CONSUL_LICENSE` or `CONSUL_LICENSE_PATH` environment variables. Refer to  the [licensing documentation](/consul/docs/enterprise/license) for more information about Consul Enterprise license management. Added in versions 1.10.0, 1.9.7 and 1.8.13. Prior to version 1.10.0 the value may be set for all agents to facilitate forwards compatibility with 1.10 but will only actually be used by client agents.


### PR DESCRIPTION
### Description

update security note with HTTP server timeout defaults and configuration options

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
