### PR TITLE
Fix for cache context to save cache data in entries on context cancel

### DIFF
--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -676,8 +676,6 @@ func (c *Cache) fetch(ctx context.Context, key string, r getOptions, allowNew bo
 		select {
 		case <-handle.stopCh:
 			return
-		case <-ctx.Done():
-			return
 		default:
 		}
 


### PR DESCRIPTION
### Description

Fix for cache context to save cache data in entries on context cancel.
Not saving both the result and err in r.entries is causing issue in certain edge cases while testing mesh gateway and partitions.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
