### PR TITLE
Update CODEOWNERS to remove consul-docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,9 +10,9 @@
 
 # education and engineering get notified of, and can approve changes to web content.
 
-/website/data/          @hashicorp/consul-docs @hashicorp/consul-selfmanage-maintainers
-/website/public/        @hashicorp/consul-docs @hashicorp/consul-selfmanage-maintainers
-/website/content/       @hashicorp/consul-docs @hashicorp/consul-selfmanage-maintainers
+/website/data/           @hashicorp/consul-selfmanage-maintainers
+/website/public/         @hashicorp/consul-selfmanage-maintainers
+/website/content/        @hashicorp/consul-selfmanage-maintainers
 
 
 # release configuration

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,12 +8,6 @@
 /website/public/
 /website/content/
 
-# education and engineering get notified of, and can approve changes to web content.
-
-/website/data/           @hashicorp/consul-selfmanage-maintainers
-/website/public/         @hashicorp/consul-selfmanage-maintainers
-/website/content/        @hashicorp/consul-selfmanage-maintainers
-
 
 # release configuration
 /.release/                              @hashicorp/team-selfmanaged-releng @hashicorp/consul-selfmanage-maintainers


### PR DESCRIPTION
Removed @hashicorp/consul-docs from CODEOWNERS for specific directories.

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
