### PR TITLE
Use toolchain directive instead of bumping go minimum version

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,8 @@
 module github.com/hashicorp/consul/api
 
-go 1.25.7
+go 1.25.0
+
+toolchain go1.25.7
 
 replace github.com/hashicorp/consul/sdk => ../sdk
 

--- a/envoyextensions/go.mod
+++ b/envoyextensions/go.mod
@@ -1,6 +1,8 @@
 module github.com/hashicorp/consul/envoyextensions
 
-go 1.25.7
+go 1.25.0
+
+toolchain go1.25.7
 
 replace (
 	github.com/hashicorp/consul/api => ../api

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/hashicorp/consul
 
-go 1.25.7
+go 1.25.0
+
+toolchain go1.25.7
 
 replace (
 	github.com/hashicorp/consul/api => ./api

--- a/proto-public/go.mod
+++ b/proto-public/go.mod
@@ -1,6 +1,8 @@
 module github.com/hashicorp/consul/proto-public
 
-go 1.25.7
+go 1.25.0
+
+toolchain go1.25.7
 
 require (
 	google.golang.org/grpc v1.75.0

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,8 @@
 module github.com/hashicorp/consul/sdk
 
-go 1.25.7
+go 1.25.0
+
+toolchain go1.25.7
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/troubleshoot/go.mod
+++ b/troubleshoot/go.mod
@@ -1,6 +1,8 @@
 module github.com/hashicorp/consul/troubleshoot
 
-go 1.25.7
+go 1.25.0
+
+toolchain go1.25.7
 
 replace (
 	github.com/hashicorp/consul/api => ../api


### PR DESCRIPTION

### Description

Replace `go 1.25.7` with `go 1.25.0` and `toolchain go1.25.7` in all module go.mod files. The toolchain directive expresses the preferred development toolchain without forcing downstream consumers to require a specific Go patch version.

### Testing & Reproduction steps

Tried building and compiling code, still works 👍 

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

https://go.dev/doc/toolchain

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [X] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
