### PR TITLE
Use strings params to trigger model hooks

### DIFF
--- a/.changelog/23271.txt
+++ b/.changelog/23271.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes [GH-23238](https://github.com/hashicorp/consul/issues/23238)
+```

--- a/.changelog/23271.txt
+++ b/.changelog/23271.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ui: Fixes [GH-23238](https://github.com/hashicorp/consul/issues/23238)
+ui: Fixes [GH-23082](https://github.com/hashicorp/consul/issues/23082)
 ```

--- a/ui/packages/consul-ui/app/controllers/application.js
+++ b/ui/packages/consul-ui/app/controllers/application.js
@@ -27,7 +27,7 @@ export default class ApplicationController extends Controller {
   gotoDefaultDcServices(dcName) {
     // Preserve prior semantics (was route.replaceWith with a hash)
     // If your router expects a positional segment instead, change to: this.router.replaceWith('dc.services.index', dcName);
-    this.router.replaceWith('dc.services.index', { dc: dcName });
+    this.router.replaceWith('dc.services.index', dcName);
   }
 
   @action

--- a/ui/packages/consul-ui/app/routes/dc.js
+++ b/ui/packages/consul-ui/app/routes/dc.js
@@ -12,10 +12,10 @@ import Route from 'consul-ui/routing/route';
 export default class DcRoute extends Route {
   @service('repository/permission') permissionsRepo;
 
-  async model(params) {
+  async model(dcName) {
     // When disabled nspaces is [], so nspace is undefined
     const permissions = await this.permissionsRepo.findAll({
-      dc: params.dc,
+      dc: dcName,
       ns: this.optionalParams().nspace,
       partition: this.optionalParams().partition,
     });

--- a/ui/packages/consul-ui/app/routes/dc.js
+++ b/ui/packages/consul-ui/app/routes/dc.js
@@ -12,10 +12,10 @@ import Route from 'consul-ui/routing/route';
 export default class DcRoute extends Route {
   @service('repository/permission') permissionsRepo;
 
-  async model(dcName) {
+  async model(params) {
     // When disabled nspaces is [], so nspace is undefined
     const permissions = await this.permissionsRepo.findAll({
-      dc: dcName,
+      dc: params.dc,
       ns: this.optionalParams().nspace,
       partition: this.optionalParams().partition,
     });


### PR DESCRIPTION
### Description

Fix for https://github.com/hashicorp/consul/issues/23082. Since ember upgrade, route's doesn't execute model hook if replaceWith is called with a model/object as parameters. It will be called if param is a string, or path params. 

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
