### PR TITLE
CSL-13511 | updated the git_ref to base branch

### DIFF
--- a/.github/workflows/ce-merge-trigger.yml
+++ b/.github/workflows/ce-merge-trigger.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       active: ${{ steps.active.outputs.active }}
     env:
-      BRANCH: ${{ github.ref_name }}
+      BRANCH: ${{ github.event.pull_request.base.ref }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -104,7 +104,7 @@ jobs:
           echo "Approved reviewers: $reviewers"
       - name: Trigger Merge
         env:
-          GIT_REF: ${{ github.ref_name }}
+          GIT_REF: ${{ github.event.pull_request.base.ref }}
           GIT_SHA: ${{ steps.merge_commit.outputs.merge_sha }}
           GH_PAT: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           GIT_ACTOR: ${{ github.actor }}


### PR DESCRIPTION
updated the git_ref to base branch

pull_request_target + closed is always default-branch scoped which leading to send the branch as main in the ce-merge-trigger workflow
