### PR TITLE
add envoy PR generation support in the dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,38 +3,35 @@
 
 version: 2
 updates:
-  - package-ecosystem: gomod
-    open-pull-requests-limit: 10
-    directory: "/"
-    labels:
-      - "go"
-      - "dependencies"
-      - "pr/no-changelog"
-    # Grouping Envoy together so all related packages update in one PR
-    groups:
-      envoy-dependencies:
-        patterns:
-          - "github.com/envoyproxy/*"
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    open-pull-requests-limit: 5
-    directory: "/website"
-    labels:
-      - "javascript"
-      - "dependencies"
-      - "type/docs-cherrypick"
-      - "pr/no-changelog"
-    schedule:
-      interval: daily
-
-  - package-ecosystem: github-actions
-    open-pull-requests-limit: 5
-    directory: /
-    labels:
-      - "github_actions"
-      - "dependencies"
-      - "pr/no-changelog"
-    schedule:
-      interval: daily
+- package-ecosystem: gomod
+  open-pull-requests-limit: 10
+  directory: "/"
+  labels:
+    - "go"
+    - "dependencies"
+    - "pr/no-changelog"
+  groups:
+    envoy-dependencies:
+      patterns:
+        - "github.com/envoyproxy/*"
+  schedule:
+    interval: daily
+- package-ecosystem: npm
+  open-pull-requests-limit: 5
+  directory: "/website"
+  labels:
+    - "javascript"
+    - "dependencies"
+    - "type/docs-cherrypick"
+    - "pr/no-changelog"
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  open-pull-requests-limit: 5
+  directory: /
+  labels:
+    - "github_actions"
+    - "dependencies"
+    - "pr/no-changelog"
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,31 +3,38 @@
 
 version: 2
 updates:
-- package-ecosystem: gomod
-  open-pull-requests-limit: 10
-  directory: "/"
-  labels:
-    - "go"
-    - "dependencies"
-    - "pr/no-changelog"
-  schedule:
-    interval: daily
-- package-ecosystem: npm 
-  open-pull-requests-limit: 5
-  directory: "/website"
-  labels:
-    - "javascript"
-    - "dependencies"
-    - "type/docs-cherrypick"
-    - "pr/no-changelog"
-  schedule:
-    interval: daily
-- package-ecosystem: github-actions
-  open-pull-requests-limit: 5
-  directory: /
-  labels:
-    - "github_actions"
-    - "dependencies"
-    - "pr/no-changelog"
-  schedule:
-    interval: daily
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 10
+    directory: "/"
+    labels:
+      - "go"
+      - "dependencies"
+      - "pr/no-changelog"
+    # Grouping Envoy together so all related packages update in one PR
+    groups:
+      envoy-dependencies:
+        patterns:
+          - "github.com/envoyproxy/*"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    open-pull-requests-limit: 5
+    directory: "/website"
+    labels:
+      - "javascript"
+      - "dependencies"
+      - "type/docs-cherrypick"
+      - "pr/no-changelog"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    open-pull-requests-limit: 5
+    directory: /
+    labels:
+      - "github_actions"
+      - "dependencies"
+      - "pr/no-changelog"
+    schedule:
+      interval: daily

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/deckarep/golang-set/v2 v2.3.1
 	github.com/docker/go-connections v0.4.0
-	github.com/envoyproxy/go-control-plane v0.13.4
+	github.com/envoyproxy/go-control-plane v0.11.4
 	github.com/envoyproxy/go-control-plane/contrib v1.32.4
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4
 	github.com/envoyproxy/go-control-plane/ratelimit v0.1.0


### PR DESCRIPTION
Currently there is no automation for generating the PR if there is newer version of envoy 