### PR TITLE
fix: map maintenance status to critical in peering flattenChecks

### DIFF
--- a/agent/grpc-external/services/peerstream/subscription_manager.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager.go
@@ -709,7 +709,7 @@ func flattenChecks(
 		for _, chk := range checks {
 			id := chk.CheckID
 			if id == api.NodeMaint || strings.HasPrefix(id, api.ServiceMaintPrefix) {
-				healthStatus = api.HealthMaint
+				healthStatus = api.HealthCritical
 				break // always wins
 			}
 			healthStatus = getMostImportantStatus(healthStatus, chk.Status)

--- a/agent/grpc-external/services/peerstream/subscription_manager_test.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager_test.go
@@ -924,7 +924,7 @@ func TestFlattenChecks(t *testing.T) {
 					Status:  api.HealthPassing,
 				},
 			},
-			expect: api.HealthMaint,
+			expect: api.HealthCritical,
 		},
 		"service_maintenance": {
 			checks: []*pbservice.HealthCheck{
@@ -933,7 +933,7 @@ func TestFlattenChecks(t *testing.T) {
 					Status:  api.HealthPassing,
 				},
 			},
-			expect: api.HealthMaint,
+			expect: api.HealthCritical,
 		},
 		"unknown": {
 			checks: []*pbservice.HealthCheck{
@@ -955,7 +955,7 @@ func TestFlattenChecks(t *testing.T) {
 					Status:  api.HealthCritical,
 				},
 			},
-			expect: api.HealthMaint,
+			expect: api.HealthCritical,
 		},
 		"critical_over_warning": {
 			checks: []*pbservice.HealthCheck{


### PR DESCRIPTION
Services in maintenance don't export the critical status to peered clusters, see #23311

