### PR TITLE
acl: return actionable error when binding rule variables contain uppercase

### DIFF
--- a/agent/consul/auth/binder.go
+++ b/agent/consul/auth/binder.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-memdb"
@@ -217,9 +218,28 @@ func computeBindName(bindName string, projectedVars map[string]string, validate 
 	if err != nil {
 		return "", fmt.Errorf("error interpreting template: %w", err)
 	}
+
 	if validate != nil && !validate(computed) {
 		return "", fmt.Errorf("invalid bind name: %q", computed)
 	}
+
+	// Check if any projected variable values contained uppercase characters
+	// that were silently lowercased during interpolation. This produces a
+	// clearer error than the downstream "permission denied" that would
+	// otherwise occur when the generated policy name doesn't match the
+	// actual resource name.
+	if strings.Contains(bindName, "${") {
+		original, err := template.InterpolateHIL(bindName, projectedVars, false)
+		if err == nil && original != computed {
+			return "", fmt.Errorf(
+				"invalid bind name: the projected variables contain uppercase characters "+
+					"(interpolated as %q before lowercasing), but bind names for this type "+
+					"must be lowercase; ensure the bound service or node name is lowercase",
+				original,
+			)
+		}
+	}
+
 	return computed, nil
 }
 
@@ -265,6 +285,20 @@ func computeBindVars(bindVars *structs.ACLTemplatedPolicyVariables, projectedVar
 		if err != nil {
 			return nil, err
 		}
+
+		// Check if uppercase characters were silently lowercased.
+		if strings.Contains(bindVars.Name, "${") {
+			original, oerr := template.InterpolateHIL(bindVars.Name, projectedVars, false)
+			if oerr == nil && original != nameValue {
+				return nil, fmt.Errorf(
+					"invalid bind variable: the projected variables contain uppercase characters "+
+						"(interpolated as %q before lowercasing), but bind variables for this type "+
+						"must be lowercase; ensure the bound resource name is lowercase",
+					original,
+				)
+			}
+		}
+
 		out.Name = nameValue
 	}
 

--- a/agent/consul/auth/binder_test.go
+++ b/agent/consul/auth/binder_test.go
@@ -285,6 +285,70 @@ func TestBinder_ServiceIdentities_NameValidation(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid bind name")
 }
 
+func TestBinder_ServiceIdentities_UppercaseVarError(t *testing.T) {
+	store := testStateStore(t)
+	binder := &Binder{store: store}
+
+	authMethod := &structs.ACLAuthMethod{
+		Name: "test-auth-method",
+		Type: "testing",
+	}
+	require.NoError(t, store.ACLAuthMethodSet(0, authMethod))
+
+	bindingRules := structs.ACLBindingRules{
+		{
+			ID:         generateID(t),
+			Selector:   "",
+			BindType:   structs.BindingRuleBindTypeService,
+			BindName:   "${service_name}",
+			AuthMethod: authMethod.Name,
+		},
+	}
+	require.NoError(t, store.ACLBindingRuleBatchSet(0, bindingRules))
+
+	// When projected vars contain uppercase characters, the binder should
+	// return an actionable error instead of silently lowercasing.
+	_, err := binder.Bind(&structs.ACLAuthMethod{}, &authmethod.Identity{
+		ProjectedVars: map[string]string{
+			"service_name": "MyService",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "uppercase characters")
+	require.Contains(t, err.Error(), "MyService")
+}
+
+func TestBinder_NodeIdentities_UppercaseVarError(t *testing.T) {
+	store := testStateStore(t)
+	binder := &Binder{store: store, datacenter: "dc1"}
+
+	authMethod := &structs.ACLAuthMethod{
+		Name: "test-auth-method",
+		Type: "testing",
+	}
+	require.NoError(t, store.ACLAuthMethodSet(0, authMethod))
+
+	bindingRules := structs.ACLBindingRules{
+		{
+			ID:         generateID(t),
+			Selector:   "",
+			BindType:   structs.BindingRuleBindTypeNode,
+			BindName:   "node-${name}",
+			AuthMethod: authMethod.Name,
+		},
+	}
+	require.NoError(t, store.ACLBindingRuleBatchSet(0, bindingRules))
+
+	_, err := binder.Bind(&structs.ACLAuthMethod{}, &authmethod.Identity{
+		ProjectedVars: map[string]string{
+			"name": "MyNode",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "uppercase characters")
+	require.Contains(t, err.Error(), "MyNode")
+}
+
 func TestBinder_NodeIdentities_Success(t *testing.T) {
 	store := testStateStore(t)
 	binder := &Binder{store: store, datacenter: "dc1"}


### PR DESCRIPTION
## Description

Addresses #20373

When ACL binding rules interpolate projected variables containing uppercase characters (e.g. a service named `RabbitMq-Watcher`), `computeBindName` silently lowercases them via `InterpolateHIL(..., lowercase=true)`. The generated policy then targets `rabbitmq-watcher` instead of `RabbitMq-Watcher`, causing a downstream "permission denied" error with no hint about what went wrong.

This is particularly painful in Nomad workload identity integrations where service names with mixed case are common — operators end up chasing phantom ACL issues with no breadcrumbs.

### What this PR does

Instead of silently lowercasing and producing a mismatched policy, this change detects when interpolation would alter the bind name due to uppercase characters in the projected variables and returns an explicit, actionable error:

```
invalid bind name: the projected variables contain uppercase characters
(interpolated as "RabbitMq-Watcher" before lowercasing), but bind names
for this type must be lowercase; ensure the bound service or node name is lowercase
```

The same check is applied to `computeBindVars` for templated policy variables.

This approach:
- **Doesn't change validation rules** — service/node identity names still require lowercase
- **Aligns with the lowercase direction** discussed in the earlier PR #20374
- **Fails fast with a clear message** instead of producing a silently broken policy

### Testing & Reproduction steps

Added two new test cases:
- `TestBinder_ServiceIdentities_UppercaseVarError` — verifies that binding a service identity with uppercase projected vars returns the expected error
- `TestBinder_NodeIdentities_UppercaseVarError` — same for node identities

All existing tests continue to pass (`go test ./agent/consul/auth/...`).

### PR Checklist

- [x] updated test coverage
- [ ] external facing docs updated
- [x] not a security concern