### PR TITLE
add uuid pollyfill to work for non-secure ui access

### DIFF
--- a/.changelog/23341.txt
+++ b/.changelog/23341.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes [GH-23287](https://github.com/hashicorp/consul/issues/23287) and [GH-23238](https://github.com/hashicorp/consul/issues/23238)
+```

--- a/ui/packages/consul-ui/ember-cli-build.js
+++ b/ui/packages/consul-ui/ember-cli-build.js
@@ -149,6 +149,13 @@ module.exports = function (defaults, $ = process.env) {
       productionEnvironments: prodlike,
     }),
     {
+      '@embroider/macros': {
+        setConfig: {
+          '@ember-data/store': {
+            polyfillUUID: true,
+          },
+        },
+      },
       trees: trees,
       addons: addons,
       'ember-cli-babel': {


### PR DESCRIPTION
### Description

Fixes [issue](https://github.com/hashicorp/consul/issues/23287) and [issue](https://github.com/hashicorp/consul/issues/23238). 

Consul UI had a upgrade for ember data, which uses a function `crypto.randomUUID` which is only accessible in secure environments and localhosts. Ember data provides a polyfill for it work with non-secure env as well. Since, consul users may use this UI in non-secure environments, this PR enables that polyfill. 

### Testing & Reproduction steps

Run consul 1.22.5 as an agent or client with UI enabled
Access the UI on a non secure domain i.e without https or without localhost/127.0.0.1. 
Notice that node and services page throw error. 

To test local servers, we can map local DNS to a hostname and try to access it. 

### Links

https://github.com/hashicorp/consul/issues/23287
https://github.com/hashicorp/consul/issues/23238

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
