### PR TITLE
fix(xds): correct endpoint config generation for API gateway in peere…

### DIFF
--- a/agent/proxycfg/api_gateway.go
+++ b/agent/proxycfg/api_gateway.go
@@ -360,6 +360,19 @@ func (h *handlerAPIGateway) handleRouteConfigUpdate(ctx context.Context, u Updat
 
 		for _, rule := range route.Rules {
 			for _, service := range rule.Services {
+
+				// Retrieving the meshGatewayConfig from handlerAPIGateway instance.
+				// `handlerAPIGateway` embeds `handlerState`, which exposes `serviceInstance.proxyCfg`.
+				// serviceInstance.proxyCfg.MeshGateway is replicated from NodeService during state setup/update.
+				// and NodeService populated for all gateway's during service resistration `AgentRegisterService`.
+				//
+				// So, Whenever any change happens in NodeService, proxyCfg manager will recreate
+				// the state where it copies NodeService to serviceInstance and
+				// then calls this api_gateway handleUpdates method.
+				// which will update the Mesh-Gateway config to api_gateway upstreams (below).
+				// h.service = <name of api-gateway>
+				meshGatewayConfig := h.proxyCfg.MeshGateway
+
 				for _, listener := range snap.APIGateway.Listeners {
 					shouldBind := false
 					for _, parent := range route.Parents {
@@ -382,6 +395,10 @@ func (h *handlerAPIGateway) handleRouteConfigUpdate(ctx context.Context, u Updat
 						Config: map[string]interface{}{
 							"protocol": "http",
 						},
+						// Propogate the meshGatewayConfig in api gateway upstreams
+						// so that meshGatewayMode can be used in XDS for
+						// endpoints and cluster config generation.
+						MeshGateway: meshGatewayConfig,
 					}
 
 					listenerKey := APIGatewayListenerKeyFromListener(listener)
@@ -410,6 +427,7 @@ func (h *handlerAPIGateway) handleRouteConfigUpdate(ctx context.Context, u Updat
 		snap.APIGateway.TCPRoutes.Set(ref, route)
 
 		for _, service := range route.Services {
+			meshGatewayConfig := h.proxyCfg.MeshGateway
 			upstreamID := NewUpstreamIDFromServiceName(service.ServiceName())
 			seenUpstreamIDs.add(upstreamID)
 
@@ -436,6 +454,7 @@ func (h *handlerAPIGateway) handleRouteConfigUpdate(ctx context.Context, u Updat
 					Config: map[string]interface{}{
 						"protocol": "tcp",
 					},
+					MeshGateway: meshGatewayConfig,
 				}
 
 				listenerKey := APIGatewayListenerKeyFromListener(listener)

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -225,6 +225,7 @@ func newKindHandler(config stateConfig, s serviceInstance, ch chan UpdateEvent) 
 	case structs.ServiceKindIngressGateway:
 		handler = &handlerIngressGateway{handlerState: h}
 	case structs.ServiceKindAPIGateway:
+		h.logger = config.logger.Named(logging.APIGateway)
 		handler = &handlerAPIGateway{handlerState: h}
 	default:
 		return nil, errors.New("not a connect-proxy, terminating-gateway, mesh-gateway, or ingress-gateway")

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil"
 )
 
-func TestStateChanged(t *testing.T) {
+func TestStateChangedConnectProxy(t *testing.T) {
 	tests := []struct {
 		name   string
 		ns     *structs.NodeService
@@ -104,6 +104,131 @@ func TestStateChanged(t *testing.T) {
 			token: "foo",
 			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
 				ns.Proxy.Upstreams = nil
+				return &ns, token
+			},
+			want: true,
+		},
+		{
+			name:  "different proxy mesh gateway mode",
+			ns:    structs.TestNodeServiceAPIGateway(t),
+			token: "foo",
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				ns.Proxy.MeshGateway.Mode = structs.MeshGatewayModeLocal
+				return &ns, token
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxyID := ProxyID{ServiceID: tt.ns.CompoundServiceID()}
+			state, err := newState(proxyID, tt.ns, testSource, tt.token, stateConfig{logger: hclog.New(nil)}, rate.NewLimiter(rate.Inf, 1))
+			require.NoError(t, err)
+			otherNS, otherToken := tt.mutate(*tt.ns, tt.token)
+			require.Equal(t, tt.want, state.Changed(otherNS, otherToken))
+		})
+	}
+}
+
+func TestStateChangedAPIGateway(t *testing.T) {
+	tests := []struct {
+		name   string
+		ns     *structs.NodeService
+		token  string
+		mutate func(ns structs.NodeService, token string) (*structs.NodeService, string)
+		want   bool
+	}{
+		{
+			name: "nil node service",
+			ns:   structs.TestNodeServiceAPIGateway(t),
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				return nil, token
+			},
+			want: true,
+		},
+		{
+			name: "same service",
+			ns:   structs.TestNodeServiceAPIGateway(t),
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				return &ns, token
+			}, want: false,
+		},
+		{
+			name:  "same service, different token",
+			ns:    structs.TestNodeServiceAPIGateway(t),
+			token: "foo",
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				return &ns, "bar"
+			},
+			want: true,
+		},
+		{
+			name:  "different address",
+			ns:    structs.TestNodeServiceAPIGateway(t),
+			token: "foo",
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				ns.Address = "10.10.10.10"
+				return &ns, token
+			},
+			want: true,
+		},
+		{
+			name:  "different port",
+			ns:    structs.TestNodeServiceAPIGateway(t),
+			token: "foo",
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				ns.Port = 12345
+				return &ns, token
+			},
+			want: true,
+		},
+		{
+			name:  "different service kind",
+			ns:    structs.TestNodeServiceAPIGateway(t),
+			token: "foo",
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				ns.Kind = ""
+				return &ns, token
+			},
+			want: true,
+		},
+		{
+			name:  "different proxy target",
+			ns:    structs.TestNodeServiceAPIGateway(t),
+			token: "foo",
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				ns.Proxy.DestinationServiceName = "badger"
+				return &ns, token
+			},
+			want: true,
+		},
+		{
+			name:  "different proxy upstreams",
+			ns:    structs.TestNodeServiceAPIGateway(t),
+			token: "foo",
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				ns.Proxy.Upstreams = nil
+				return &ns, token
+			},
+			want: true,
+		},
+		{
+			name:  "different mesh gateway mode (local)",
+			ns:    structs.TestNodeServiceAPIGateway(t),
+			token: "foo",
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				ns.Proxy.MeshGateway.Mode = structs.MeshGatewayModeLocal
+				return &ns, token
+			},
+			want: true,
+		},
+		{
+			name:  "different mesh gateway mode (remote)",
+			ns:    structs.TestNodeServiceAPIGateway(t),
+			token: "foo",
+			mutate: func(ns structs.NodeService, token string) (*structs.NodeService, string) {
+				ns.Proxy.MeshGateway.Mode = structs.MeshGatewayModeRemote
 				return &ns, token
 			},
 			want: true,

--- a/agent/structs/testing_catalog.go
+++ b/agent/structs/testing_catalog.go
@@ -176,10 +176,35 @@ func TestNodeServiceMeshGateway(t testing.T) *NodeService {
 }
 
 func TestNodeServiceAPIGateway(t testing.T) *NodeService {
+	entMeta := DefaultEnterpriseMetaInPartition("")
 	return &NodeService{
 		Kind:    ServiceKindAPIGateway,
 		Service: "api-gateway",
 		Address: "1.1.1.1",
+
+		// ---------------------------------------
+		// Adding TestConnectProxyConfig to the proxy field here within TestNodeServiceAPIGateway
+		// to test whether APIGateway is able to handle state changes within ConnectProxyConfig (TestStateChangedAPIGateway).
+		// Please note:
+		// The naming may suggest that ConnectProxyConfig should only be used for ConnectProxy,
+		// but "APIGateway state" uses serviceInstance, which embeds ConnectProxyConfig as part of its state,
+		// so any changes to ConnectProxyConfig will also impact APIGateway, such as change in "mesh gateway mode".
+		//
+		// For example, let's say a user updates the mesh gateway mode of an API gateway,
+		// First NodeService.Proxy will be updated and then proxyCfg manager detects change in config
+		// and it recreates the state for api_gateway which would copy the
+		// NodeService.Proxy.MeshGateway to serviceInstance.proxyCfg.MeshGateway in `newServiceInstanceFromNodeService` (serviceInstance is part of state)
+		// and then proxyCfg manager calls the api_gateway handleUpdates method which would
+		// update the api_gateway upstreams with new meshGateway config.
+		//
+		// Now, this serviceInstance.proxyCfg and NodeService.Proxy
+		// refers to same proxy configuration, which is of type ConnectProxyConfig.
+
+		// So, we need to test it as well.
+		// ---------------------------------------
+
+		Proxy:          TestConnectProxyConfig(t),
+		EnterpriseMeta: *entMeta,
 	}
 }
 

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -68,17 +68,12 @@ func (s *ResourceGenerator) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			continue
 		}
 
-		var upstreamConfigMap map[string]interface{}
-		if upstream != nil {
-			upstreamConfigMap = upstream.Config
-		}
-
 		es, err := s.endpointsFromDiscoveryChain(
 			uid,
 			chain,
 			cfgSnap,
 			cfgSnap.Locality,
-			upstreamConfigMap,
+			upstream,
 			cfgSnap.ConnectProxy.WatchedUpstreamEndpoints[uid],
 			cfgSnap.ConnectProxy.WatchedGatewayEndpoints[uid],
 			false,
@@ -527,7 +522,7 @@ func (s *ResourceGenerator) endpointsFromSnapshotIngressGateway(cfgSnap *proxycf
 				cfgSnap.IngressGateway.DiscoveryChain[uid],
 				cfgSnap,
 				proxycfg.GatewayKey{Datacenter: cfgSnap.Datacenter, Partition: u.DestinationPartition},
-				u.Config,
+				&u,
 				cfgSnap.IngressGateway.WatchedUpstreamEndpoints[uid],
 				cfgSnap.IngressGateway.WatchedGatewayEndpoints[uid],
 				false,
@@ -549,8 +544,8 @@ func (s *ResourceGenerator) endpointsFromSnapshotAPIGateway(cfgSnap *proxycfg.Co
 	readyListeners := getReadyListeners(cfgSnap)
 
 	for _, readyListener := range readyListeners {
-		for _, u := range readyListener.upstreams {
-			uid := proxycfg.NewUpstreamID(&u)
+		for _, upstream := range readyListener.upstreams {
+			uid := proxycfg.NewUpstreamID(&upstream)
 
 			// If we've already created endpoints for this upstream, skip it. Multiple listeners may
 			// reference the same upstream, so we don't need to create duplicate endpoints in that case.
@@ -563,8 +558,8 @@ func (s *ResourceGenerator) endpointsFromSnapshotAPIGateway(cfgSnap *proxycfg.Co
 				uid,
 				cfgSnap.APIGateway.DiscoveryChain[uid],
 				cfgSnap,
-				proxycfg.GatewayKey{Datacenter: cfgSnap.Datacenter, Partition: u.DestinationPartition},
-				u.Config,
+				proxycfg.GatewayKey{Datacenter: cfgSnap.Datacenter, Partition: upstream.DestinationPartition},
+				&upstream,
 				cfgSnap.APIGateway.WatchedUpstreamEndpoints[uid],
 				cfgSnap.APIGateway.WatchedGatewayEndpoints[uid],
 				false,
@@ -621,9 +616,25 @@ func (s *ResourceGenerator) makeUpstreamLoadAssignmentForPeerService(
 	// If an upstream is configured with local mesh gw mode, we make a load assignment
 	// from the gateway endpoints instead of those of the upstreams.
 	if upstreamGatewayMode == structs.MeshGatewayModeLocal {
-		localGw, ok := cfgSnap.ConnectProxy.WatchedLocalGWEndpoints.Get(cfgSnap.Locality.String())
-		if !ok {
-			// local GW is not ready; return early
+
+		// This makeUpstreamLoadAssignmentForPeerService is a generic method
+		// and used by both connect-proxy and API-GW.
+		// So, whenever this method is invoked for API Gateway (api gateway peered in local mesh mode),
+		// below, localGw would be nil because the existing statement fetches endpoints from cfg.ConnectProxy.
+		//
+		// Fix: generate endpoints conditionally based on the kind of cfgSnap.
+
+		var localGatewayEndpoint structs.CheckServiceNodes
+		ready := false
+		if cfgSnap.Kind == structs.ServiceKindConnectProxy {
+			localGatewayEndpoint, ready = cfgSnap.ConnectProxy.WatchedLocalGWEndpoints.Get(cfgSnap.Locality.String())
+		}
+		if cfgSnap.Kind == structs.ServiceKindAPIGateway {
+			localGatewayEndpoint, ready = cfgSnap.APIGateway.WatchedLocalGWEndpoints.Get(cfgSnap.Locality.String())
+		}
+		if !ready {
+			// local mesh GW is not ready; skip load assignment; return early
+			s.Logger.Trace("local mesh GW is not ready; skipping load assignment", "cluster", clusterName)
 			return la, nil
 		}
 		la = makeLoadAssignment(
@@ -632,7 +643,7 @@ func (s *ResourceGenerator) makeUpstreamLoadAssignmentForPeerService(
 			clusterName,
 			nil,
 			[]loadAssignmentEndpointGroup{
-				{Endpoints: localGw},
+				{Endpoints: localGatewayEndpoint},
 			},
 			cfgSnap.Locality,
 		)
@@ -647,6 +658,7 @@ func (s *ResourceGenerator) makeUpstreamLoadAssignmentForPeerService(
 
 	endpoints, ok := upstreamsSnapshot.PeerUpstreamEndpoints.Get(uid)
 	if !ok {
+		s.Logger.Trace("skipping load assignment for peer instances with hostname as their address", "upstream", uid, "cluster", clusterName)
 		return nil, nil
 	}
 	la = makeLoadAssignment(
@@ -667,7 +679,7 @@ func (s *ResourceGenerator) endpointsFromDiscoveryChain(
 	chain *structs.CompiledDiscoveryChain,
 	cfgSnap *proxycfg.ConfigSnapshot,
 	gatewayKey proxycfg.GatewayKey,
-	upstreamConfigMap map[string]interface{},
+	upstream *structs.Upstream,
 	upstreamEndpoints map[string]structs.CheckServiceNodes,
 	gatewayEndpoints map[string]structs.CheckServiceNodes,
 	forMeshGateway bool,
@@ -679,8 +691,9 @@ func (s *ResourceGenerator) endpointsFromDiscoveryChain(
 		return nil, nil
 	}
 
-	if upstreamConfigMap == nil {
-		upstreamConfigMap = make(map[string]interface{}) // TODO:needed?
+	upstreamConfigMap := make(map[string]interface{})
+	if upstream != nil {
+		upstreamConfigMap = upstream.Config
 	}
 
 	var resources []proto.Message
@@ -712,8 +725,25 @@ func (s *ResourceGenerator) endpointsFromDiscoveryChain(
 		}
 	}
 
+	// This endpointsFromDiscoveryChain is a generic method
+	// and used by both connect-proxy and API-GW.
+	// So, whenever this method is invoked for API Gateway,
+	// Existing `GetUpstream` method is not defined on cfgSnap.APIGateway,
+	// and would return empty object for upstream,
+	// resulting, upstream.MeshGateway.Mode to be "" and
+	// finally mgwMode will remain to MeshGatewayModeDefault (& Default is always treated as remote mode in peering)
+	// which is incorrect because API GW can be configured in local mesh mode as well.
+	//
+	// Fix: generate mgwMode conditionally based on the kind of cfgSnap.
+
 	mgwMode := structs.MeshGatewayModeDefault
-	if upstream, _ := cfgSnap.ConnectProxy.GetUpstream(uid, &cfgSnap.ProxyID.EnterpriseMeta); upstream != nil {
+	if cfgSnap.Kind == structs.ServiceKindConnectProxy {
+		upstreamConfig, _ := cfgSnap.ConnectProxy.GetUpstream(uid, &cfgSnap.ProxyID.EnterpriseMeta)
+		if upstreamConfig != nil {
+			mgwMode = upstreamConfig.MeshGateway.Mode
+		}
+	}
+	if cfgSnap.Kind == structs.ServiceKindAPIGateway {
 		mgwMode = upstream.MeshGateway.Mode
 	}
 

--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -1748,6 +1748,7 @@ func getAPIGatewayPeeringGoldenTestCases(t *testing.T) []goldenTestCase {
 	t.Helper()
 	const peerTrustDomain = "1c053652-8512-4373-90cf-5a7f6263a994.consul"
 
+	// paymentService is the upstream service in peer DC for gateway.
 	paymentService := structs.NewServiceName("paymentService", nil)
 	paymentServiceUID := proxycfg.NewUpstreamIDFromServiceName(paymentService)
 	paymentServiceUID.Peer = "paymentpeer"
@@ -1758,8 +1759,7 @@ func getAPIGatewayPeeringGoldenTestCases(t *testing.T) []goldenTestCase {
 	// Base entries for paymentService discovery chain.
 	//
 	// Discovery chain is required in case of API Gateway with peering,
-	// because we need service resolver to redirect to peer and
-	// get the endpoints from the peer.
+	// because we need service resolver to redirect request to peer.
 	// If paymentServiceSet is not provided, then api-gateway will work as simple api-gw
 	// without knowledge of peering and service resolver (no redirection to peer)
 	paymentServiceSet := configentry.NewDiscoveryChainSet()
@@ -1787,18 +1787,17 @@ func getAPIGatewayPeeringGoldenTestCases(t *testing.T) []goldenTestCase {
 		// Below discovery chain (re)compile request is sent, so that
 		// we could get the updated localGatewayEndpoint.
 		//
-		// API Gateway does not directly updated WatchedLocalGWEndpoints.
-		//
+		// API Gateway does not directly update WatchedLocalGWEndpoints.
 		// It watches route config entries and upstream chains.
 		// So, after every update, DC recompile happens for API GW.
-		// Within recompile,it synthesize the listeners/routes, etc &
+		// Within recompile, it synthesize the listeners/routes, etc &
 		// then we would be able to get localGatewayEndpoint.
 		//
 		// Also, since we are recompiling the discovery chain,
 		// it prefix the clusterName with customizationHash
 		// while generating the cluster configs.
 		//
-		// Also, Please note that:
+		// Please note that:
 		// API Gateway, do not recomplile when "OverrideMeshGateway" changes.
 		// It do not set "OverrideMeshGateway" in discoveryChainWatchOpts.
 		// This is just to trigger the recompilation.

--- a/agent/xds/testdata/endpoints/api-gateway-with-peers-mesh-mode-local-and-upstream-is-hostname.latest.golden
+++ b/agent/xds/testdata/endpoints/api-gateway-with-peers-mesh-mode-local-and-upstream-is-hostname.latest.golden
@@ -1,5 +1,29 @@
 {
   "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "c225dc1c~paymentService.default.paymentpeer.external.1c053652-8512-4373-90cf-5a7f6263a994.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.45.1.1",
+                    "portValue": 8443
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
   "versionInfo": "00000001"
 }

--- a/agent/xds/testdata/endpoints/api-gateway-with-peers-mesh-mode-local-and-upstream-is-static.latest.golden
+++ b/agent/xds/testdata/endpoints/api-gateway-with-peers-mesh-mode-local-and-upstream-is-static.latest.golden
@@ -11,7 +11,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "172.68.1.1",
+                    "address": "10.45.1.1",
                     "portValue": 8443
                   }
                 }

--- a/logging/names.go
+++ b/logging/names.go
@@ -41,6 +41,7 @@ const (
 	License               string = "license"
 	Manager               string = "manager"
 	Memberlist            string = "memberlist"
+	APIGateway            string = "api_gateway"
 	MeshGateway           string = "mesh_gateway"
 	Namespace             string = "namespace"
 	NetworkAreas          string = "network_areas"


### PR DESCRIPTION
fix(xds): correct endpoint config generation for API gateway in peered setups

- Previously, API gateway XDS endpoint generation incorrectly relied on cfgSnap.ConnectProxy config (instead of cgfSnap.APIGateway), which caused wrong endpoint resolution in peered environments.
- Changes made:
- Updated makeUpstreamLoadAssignmentForPeerService to fetch localGatewayEndpoint based on cfgSnap kind instead of always using cfgSnap.ConnectProxy.
- Updated endpointsFromDiscoveryChain to derive meshGatewayMode based on cfgSnap kind instead of always using cfgSnap.ConnectProxy.
- Fixed handleRouteConfigUpdate to properly propagate meshGatewayConfig to API gateway upstreams, which is required during XDS endpoint generation.
- Added TestStateChangedAPIGateway test cases in state_test.go to validate API gateway update handling.
- Added API gateway-specific logging prefix (similar to mesh gateway) to help in debugging.
- Updated golden test file, according to the fix as well.