### PR TITLE
Addition of cleanConnectServicesList to delete older ConnectServicesL…

### DIFF
--- a/agent/grpc-external/services/peerstream/subscription_manager.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager.go
@@ -141,6 +141,7 @@ func (m *subscriptionManager) handleEvent(ctx context.Context, state *subscripti
 			return fmt.Errorf("invalid type for response: %T", u.Result)
 		}
 
+		oldExportList := state.exportList
 		state.exportList = evt
 
 		pending := &pendingPayload{}
@@ -159,6 +160,9 @@ func (m *subscriptionManager) handleEvent(ctx context.Context, state *subscripti
 		}
 
 		state.sendPendingEvents(ctx, m.logger, pending)
+
+		// cleanup connectServices for older deleted exported services
+		state.cleanConnectServicesList(oldExportList)
 
 		// cleanup event versions too
 		state.cleanupEventVersions(m.logger)

--- a/agent/grpc-external/services/peerstream/subscription_state.go
+++ b/agent/grpc-external/services/peerstream/subscription_state.go
@@ -86,6 +86,24 @@ func (s *subscriptionState) sendPendingEvents(
 	}
 }
 
+func (s *subscriptionState) cleanConnectServicesList(oldExportList *structs.ExportedServiceList) {
+
+	if oldExportList == nil {
+		return
+	}
+
+	newServicesMap := make(map[structs.ServiceName]struct{}, len(s.exportList.Services))
+	for _, m := range s.exportList.Services {
+		newServicesMap[m] = struct{}{}
+	}
+
+	for _, v := range oldExportList.Services {
+		if _, ok := newServicesMap[v]; !ok {
+			delete(s.connectServices, v)
+		}
+	}
+}
+
 func (s *subscriptionState) cleanupEventVersions(logger hclog.Logger) {
 	for id := range s.eventVersions {
 		keep := false


### PR DESCRIPTION
### Description

Addition of cleanConnectServicesList to delete older ConnectServicesList based on export-service-list
This deletes peer state connectServices list when the connect service deleted in the exported services.
This removes the cache and make sure on subsequent scale up, new object is passed.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
