### PR TITLE
Backport go and version upgrade in 1.22.x

### DIFF
--- a/.changelog/23372.txt
+++ b/.changelog/23372.txt
@@ -1,0 +1,4 @@
+```release-note:security
+- security: upgrade go version to 1.25.8
+- security: upgarde supported envoy to latest for 1.22.x
+```

--- a/envoyextensions/xdscommon/ENVOY_VERSIONS
+++ b/envoyextensions/xdscommon/ENVOY_VERSIONS
@@ -8,6 +8,6 @@
 #
 # See https://developer.hashicorp.com/docs/connect/proxies/envoy#supported-versions for more information on Consul's Envoy
 # version support.
-1.35.8
-1.34.12
+1.35.9
+1.34.13
 1.33.14

--- a/test/integration/connect/envoy/test-sds-server/go.mod
+++ b/test/integration/connect/envoy/test-sds-server/go.mod
@@ -1,6 +1,6 @@
 module test-sds-server
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/envoyproxy/go-control-plane v0.13.4


### PR DESCRIPTION
### Description

- backport of https://github.com/hashicorp/consul/pull/23372