### PR TITLE
(api-gateway) preserve PathPrefix when replacePrefixMatch is unset

### DIFF
--- a/.changelog/23390.txt
+++ b/.changelog/23390.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+- api-gateway: fix HTTPRoute PathPrefix routing to preserve the original request path when `replacePrefixMatch` is not configured
+```

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -1358,7 +1358,7 @@ func getRewriteActionForUserLogic(destination *structs.ServiceRouteDestination, 
 		return routeAction
 	}
 	// --- THIS IS THE LOGIC UNDER TEST ---
-	if destination.PrefixRewrite == "" || destination.PrefixRewrite == "/" {
+	if destination.PrefixRewrite == "/" {
 		// Build the basic regex pattern
 		regexPattern := fmt.Sprintf(`^%s(/?)(.*)`, regexp.QuoteMeta(routeMatch.GetPrefix()))
 

--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -347,10 +347,10 @@ func TestUserRewriteLogic(t *testing.T) {
 		assert.Equal(t, `/\2`, action.GetRegexRewrite().GetSubstitution())
 	})
 
-	t.Run("No rewrite (Buggy Case)", func(t *testing.T) {
+	t.Run("No rewrite when unset", func(t *testing.T) {
 		t.Parallel()
 		dest := &structs.ServiceRouteDestination{
-			PrefixRewrite: "", // No rewrite defined
+			PrefixRewrite: "",
 		}
 		match := &envoy_route_v3.RouteMatch{
 			PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{
@@ -360,13 +360,7 @@ func TestUserRewriteLogic(t *testing.T) {
 
 		action := getRewriteActionForUserLogic(dest, match)
 
-		// EXPECT (based on your code): This FAILS.
-		// It enters the `if` block because `destination.PrefixRewrite == ""` is true.
 		assert.Empty(t, action.GetPrefixRewrite())
-		require.NotNil(t, action.GetRegexRewrite(), "This assertion fails because your logic incorrectly creates a RegexRewrite")
-
-		// This test proves the logic is applying a rewrite when it shouldn't be.
-		assert.Equal(t, `^/foo(/?)(.*)`, action.GetRegexRewrite().Pattern.GetRegex())
-		assert.Equal(t, `/\2`, action.GetRegexRewrite().GetSubstitution())
+		assert.Nil(t, action.GetRegexRewrite())
 	})
 }

--- a/agent/xds/testdata/routes/api-gateway-http-listener-with-http-route.latest.golden
+++ b/agent/xds/testdata/routes/api-gateway-http-listener-with-http-route.latest.golden
@@ -17,13 +17,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "http-service.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "http-service.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/api-gateway-tcp-listener-with-tcp-and-http-route.latest.golden
+++ b/agent/xds/testdata/routes/api-gateway-tcp-listener-with-tcp-and-http-route.latest.golden
@@ -17,13 +17,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "http-service.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "http-service.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/api-gateway-with-http-max-request-headers.latest.golden
+++ b/agent/xds/testdata/routes/api-gateway-with-http-max-request-headers.latest.golden
@@ -17,13 +17,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "backend.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "backend.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/api-gateway-with-http-route-timeoutfilter-one-set.latest.golden
+++ b/agent/xds/testdata/routes/api-gateway-with-http-route-timeoutfilter-one-set.latest.golden
@@ -36,13 +36,7 @@
               ],
               "route": {
                 "cluster": "service.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "idleTimeout": "30s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "idleTimeout": "30s"
               }
             }
           ]

--- a/agent/xds/testdata/routes/api-gateway-with-http-route-tls-params-unset.latest.golden
+++ b/agent/xds/testdata/routes/api-gateway-with-http-route-tls-params-unset.latest.golden
@@ -37,12 +37,6 @@
               "route": {
                 "cluster": "service.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                 "idleTimeout": "30s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 3,
                   "retriableStatusCodes": [

--- a/agent/xds/testdata/routes/api-gateway-with-http-route.latest.golden
+++ b/agent/xds/testdata/routes/api-gateway-with-http-route.latest.golden
@@ -37,12 +37,6 @@
               "route": {
                 "cluster": "service.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                 "idleTimeout": "30s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 3,
                   "retriableStatusCodes": [

--- a/agent/xds/testdata/routes/api-gateway-with-multiple-hostnames.latest.golden
+++ b/agent/xds/testdata/routes/api-gateway-with-multiple-hostnames.latest.golden
@@ -17,13 +17,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "frontend.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "frontend.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]
@@ -40,13 +34,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "backend.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "backend.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]
@@ -63,13 +51,7 @@
                 "prefix": "/frontend"
               },
               "route": {
-                "cluster": "frontend.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/frontend(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "frontend.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -77,13 +59,7 @@
                 "prefix": "/backend"
               },
               "route": {
-                "cluster": "backend.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/backend(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "backend.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/connect-proxy-route-to-lb-resolver.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-route-to-lb-resolver.latest.golden
@@ -16,13 +16,7 @@
                 "prefix": "/web"
               },
               "route": {
-                "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/web(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -30,13 +24,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-router.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-router.latest.golden
@@ -16,13 +16,7 @@
                 "prefix": "/prefix"
               },
               "route": {
-                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/prefix(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -30,13 +24,7 @@
                 "path": "/exact"
               },
               "route": {
-                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -46,13 +34,7 @@
                 }
               },
               "route": {
-                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -66,13 +48,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -87,13 +63,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -109,13 +79,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -131,13 +95,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -153,13 +111,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -177,13 +129,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -201,13 +147,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -231,13 +171,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -253,13 +187,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -277,13 +205,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -297,13 +219,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -311,13 +227,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -325,13 +235,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -339,13 +243,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -377,12 +275,6 @@
               },
               "route": {
                 "cluster": "req-timeout.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/timeout(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "timeout": "33s"
               }
             },
@@ -392,13 +284,7 @@
               },
               "route": {
                 "cluster": "idle-timeout.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "idleTimeout": "33s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/idle-timeout(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "idleTimeout": "33s"
               }
             },
             {
@@ -407,12 +293,6 @@
               },
               "route": {
                 "cluster": "retry-connect.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-connect(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retryOn": "connect-failure"
@@ -425,12 +305,6 @@
               },
               "route": {
                 "cluster": "retry-reset.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-reset(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retryOn": "reset"
@@ -443,12 +317,6 @@
               },
               "route": {
                 "cluster": "retry-codes.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-codes(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retriableStatusCodes": [
@@ -466,12 +334,6 @@
               },
               "route": {
                 "cluster": "retry-all.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-all(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "retriableStatusCodes": [
                     401,
@@ -487,12 +349,6 @@
                 "prefix": "/split-3-ways"
               },
               "route": {
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/split-3-ways(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "weightedClusters": {
                   "clusters": [
                     {
@@ -552,13 +408,7 @@
                 "qux"
               ],
               "route": {
-                "cluster": "header-manip.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "header-manip.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -566,13 +416,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-splitter-and-mesh-validate-clusters.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-splitter-and-mesh-validate-clusters.latest.golden
@@ -19,12 +19,6 @@
               "route": {
                 "cluster": "big-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                 "idleTimeout": "0s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/big-side(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "timeout": "10s"
               }
             },
@@ -33,13 +27,7 @@
                 "prefix": "/lil-bit-side"
               },
               "route": {
-                "cluster": "lil-bit-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/lil-bit-side(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "lil-bit-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -47,12 +35,6 @@
                 "prefix": "/"
               },
               "route": {
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "weightedClusters": {
                   "clusters": [
                     {

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-splitter.latest.golden
@@ -18,12 +18,6 @@
               "route": {
                 "cluster": "big-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                 "idleTimeout": "0s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/big-side(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "timeout": "10s"
               }
             },
@@ -32,13 +26,7 @@
                 "prefix": "/lil-bit-side"
               },
               "route": {
-                "cluster": "lil-bit-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/lil-bit-side(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "lil-bit-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -46,12 +34,6 @@
                 "prefix": "/"
               },
               "route": {
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "weightedClusters": {
                   "clusters": [
                     {

--- a/agent/xds/testdata/routes/connect-proxy-with-grpc-router.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-grpc-router.latest.golden
@@ -16,13 +16,7 @@
                 "path": "/fgrpc.PingServer/Ping"
               },
               "route": {
-                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -30,13 +24,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router-header-manip.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router-header-manip.latest.golden
@@ -53,13 +53,7 @@
                 "prefix": "/prefix"
               },
               "route": {
-                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/prefix(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -67,13 +61,7 @@
                 "path": "/exact"
               },
               "route": {
-                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -83,13 +71,7 @@
                 }
               },
               "route": {
-                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -103,13 +85,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -124,13 +100,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -146,13 +116,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -168,13 +132,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -190,13 +148,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -214,13 +166,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -238,13 +184,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -268,13 +208,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -290,13 +224,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -314,13 +242,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -334,13 +256,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -348,13 +264,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -362,13 +272,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -376,13 +280,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -414,12 +312,6 @@
               },
               "route": {
                 "cluster": "req-timeout.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/timeout(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "timeout": "33s"
               }
             },
@@ -429,13 +321,7 @@
               },
               "route": {
                 "cluster": "idle-timeout.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "idleTimeout": "33s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/idle-timeout(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "idleTimeout": "33s"
               }
             },
             {
@@ -444,12 +330,6 @@
               },
               "route": {
                 "cluster": "retry-connect.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-connect(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retryOn": "connect-failure"
@@ -462,12 +342,6 @@
               },
               "route": {
                 "cluster": "retry-reset.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-reset(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retryOn": "reset"
@@ -480,12 +354,6 @@
               },
               "route": {
                 "cluster": "retry-codes.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-codes(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retriableStatusCodes": [
@@ -503,12 +371,6 @@
               },
               "route": {
                 "cluster": "retry-all.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-all(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "retriableStatusCodes": [
                     401,
@@ -524,12 +386,6 @@
                 "prefix": "/split-3-ways"
               },
               "route": {
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/split-3-ways(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "weightedClusters": {
                   "clusters": [
                     {
@@ -589,13 +445,7 @@
                 "qux"
               ],
               "route": {
-                "cluster": "header-manip.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "header-manip.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -603,13 +453,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router.latest.golden
@@ -17,13 +17,7 @@
                 "prefix": "/prefix"
               },
               "route": {
-                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/prefix(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -31,13 +25,7 @@
                 "path": "/exact"
               },
               "route": {
-                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -47,13 +35,7 @@
                 }
               },
               "route": {
-                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -67,13 +49,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -88,13 +64,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -110,13 +80,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -132,13 +96,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -154,13 +112,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -178,13 +130,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -202,13 +148,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -232,13 +172,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -254,13 +188,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -278,13 +206,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -298,13 +220,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -312,13 +228,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -326,13 +236,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -340,13 +244,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -378,12 +276,6 @@
               },
               "route": {
                 "cluster": "req-timeout.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/timeout(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "timeout": "33s"
               }
             },
@@ -393,13 +285,7 @@
               },
               "route": {
                 "cluster": "idle-timeout.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "idleTimeout": "33s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/idle-timeout(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "idleTimeout": "33s"
               }
             },
             {
@@ -408,12 +294,6 @@
               },
               "route": {
                 "cluster": "retry-connect.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-connect(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retryOn": "connect-failure"
@@ -426,12 +306,6 @@
               },
               "route": {
                 "cluster": "retry-reset.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-reset(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retryOn": "reset"
@@ -444,12 +318,6 @@
               },
               "route": {
                 "cluster": "retry-codes.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-codes(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retriableStatusCodes": [
@@ -467,12 +335,6 @@
               },
               "route": {
                 "cluster": "retry-all.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-all(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "retriableStatusCodes": [
                     401,
@@ -488,12 +350,6 @@
                 "prefix": "/split-3-ways"
               },
               "route": {
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/split-3-ways(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "weightedClusters": {
                   "clusters": [
                     {
@@ -553,13 +409,7 @@
                 "qux"
               ],
               "route": {
-                "cluster": "header-manip.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "header-manip.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -567,13 +417,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/ingress-with-chain-and-splitter.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-splitter.latest.golden
@@ -19,12 +19,6 @@
               "route": {
                 "cluster": "big-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                 "idleTimeout": "0s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/big-side(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "timeout": "10s"
               }
             },
@@ -33,13 +27,7 @@
                 "prefix": "/lil-bit-side"
               },
               "route": {
-                "cluster": "lil-bit-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/lil-bit-side(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "lil-bit-side.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -47,12 +35,6 @@
                 "prefix": "/"
               },
               "route": {
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "weightedClusters": {
                   "clusters": [
                     {

--- a/agent/xds/testdata/routes/ingress-with-grpc-router.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-grpc-router.latest.golden
@@ -17,13 +17,7 @@
                 "path": "/fgrpc.PingServer/Ping"
               },
               "route": {
-                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -31,13 +25,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
+++ b/agent/xds/testdata/routes/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
@@ -16,12 +16,6 @@
                 "prefix": "/split"
               },
               "route": {
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/split(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "weightedClusters": {
                   "clusters": [
                     {
@@ -41,13 +35,7 @@
                 "prefix": "/api"
               },
               "route": {
-                "cluster": "exported~v2.api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/api(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "exported~v2.api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -55,13 +43,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "exported~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "exported~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/xds-fetch-timeout-ms-ingress-with-router.latest.golden
+++ b/agent/xds/testdata/routes/xds-fetch-timeout-ms-ingress-with-router.latest.golden
@@ -17,13 +17,7 @@
                 "prefix": "/prefix"
               },
               "route": {
-                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/prefix(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -31,13 +25,7 @@
                 "path": "/exact"
               },
               "route": {
-                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -47,13 +35,7 @@
                 }
               },
               "route": {
-                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -67,13 +49,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -88,13 +64,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -110,13 +80,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -132,13 +96,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -154,13 +112,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -178,13 +130,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -202,13 +148,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -232,13 +172,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -254,13 +188,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -278,13 +206,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -298,13 +220,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -312,13 +228,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -326,13 +236,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -340,13 +244,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -378,12 +276,6 @@
               },
               "route": {
                 "cluster": "req-timeout.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/timeout(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "timeout": "33s"
               }
             },
@@ -393,13 +285,7 @@
               },
               "route": {
                 "cluster": "idle-timeout.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "idleTimeout": "33s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/idle-timeout(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "idleTimeout": "33s"
               }
             },
             {
@@ -408,12 +294,6 @@
               },
               "route": {
                 "cluster": "retry-connect.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-connect(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retryOn": "connect-failure"
@@ -426,12 +306,6 @@
               },
               "route": {
                 "cluster": "retry-reset.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-reset(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retryOn": "reset"
@@ -444,12 +318,6 @@
               },
               "route": {
                 "cluster": "retry-codes.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-codes(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retriableStatusCodes": [
@@ -467,12 +335,6 @@
               },
               "route": {
                 "cluster": "retry-all.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-all(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "retriableStatusCodes": [
                     401,
@@ -488,12 +350,6 @@
                 "prefix": "/split-3-ways"
               },
               "route": {
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/split-3-ways(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "weightedClusters": {
                   "clusters": [
                     {
@@ -553,13 +409,7 @@
                 "qux"
               ],
               "route": {
-                "cluster": "header-manip.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "header-manip.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -567,13 +417,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/testdata/routes/xds-fetch-timeout-ms-sidecar.latest.golden
+++ b/agent/xds/testdata/routes/xds-fetch-timeout-ms-sidecar.latest.golden
@@ -16,13 +16,7 @@
                 "prefix": "/prefix"
               },
               "route": {
-                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/prefix(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -30,13 +24,7 @@
                 "path": "/exact"
               },
               "route": {
-                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -46,13 +34,7 @@
                 }
               },
               "route": {
-                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -66,13 +48,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -87,13 +63,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -109,13 +79,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -131,13 +95,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -153,13 +111,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -177,13 +129,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -201,13 +147,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -231,13 +171,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -253,13 +187,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -277,13 +205,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -297,13 +219,7 @@
                 ]
               },
               "route": {
-                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -311,13 +227,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -325,13 +235,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -339,13 +243,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -377,12 +275,6 @@
               },
               "route": {
                 "cluster": "req-timeout.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/timeout(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "timeout": "33s"
               }
             },
@@ -392,13 +284,7 @@
               },
               "route": {
                 "cluster": "idle-timeout.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "idleTimeout": "33s",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/idle-timeout(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "idleTimeout": "33s"
               }
             },
             {
@@ -407,12 +293,6 @@
               },
               "route": {
                 "cluster": "retry-connect.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-connect(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retryOn": "connect-failure"
@@ -425,12 +305,6 @@
               },
               "route": {
                 "cluster": "retry-reset.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-reset(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retryOn": "reset"
@@ -443,12 +317,6 @@
               },
               "route": {
                 "cluster": "retry-codes.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-codes(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "numRetries": 15,
                   "retriableStatusCodes": [
@@ -466,12 +334,6 @@
               },
               "route": {
                 "cluster": "retry-all.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/retry-all(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "retryPolicy": {
                   "retriableStatusCodes": [
                     401,
@@ -487,12 +349,6 @@
                 "prefix": "/split-3-ways"
               },
               "route": {
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/split-3-ways(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                },
                 "weightedClusters": {
                   "clusters": [
                     {
@@ -552,13 +408,7 @@
                 "qux"
               ],
               "route": {
-                "cluster": "header-manip.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "header-manip.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {
@@ -566,13 +416,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "regexRewrite": {
-                  "pattern": {
-                    "regex": "^/(/?)(.*)"
-                  },
-                  "substitution": "/\\2"
-                }
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/agent/xds/xds_protocol_helpers_test.go
+++ b/agent/xds/xds_protocol_helpers_test.go
@@ -5,8 +5,6 @@ package xds
 
 import (
 	"context"
-	"fmt"
-	"regexp"
 	"sort"
 	"sync"
 	"testing"
@@ -26,7 +24,6 @@ import (
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_upstreams_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	envoy_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/mitchellh/copystructure"
 	"github.com/stretchr/testify/require"
@@ -813,12 +810,6 @@ func makeTestRoute(t *testing.T, fixtureName string) *envoy_route_v3.RouteConfig
 								Route: &envoy_route_v3.RouteAction{
 									ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
 										Cluster: "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-									},
-									RegexRewrite: &envoy_matcher_v3.RegexMatchAndSubstitute{
-										Pattern: &envoy_matcher_v3.RegexMatcher{
-											Regex: fmt.Sprintf(`^%s(/?)(.*)`, regexp.QuoteMeta("/")),
-										},
-										Substitution: `/\2`,
 									},
 								},
 							},


### PR DESCRIPTION
### Description

This change fixes the HTTPRoute `PathPrefix` regression where Envoy strips the matched prefix even when no rewrite is configured.

The regression came from the regex rewrite workaround added for `replacePrefixMatch: "/"`. That logic also treated an empty/unset `PrefixRewrite` as a signal to strip the matched prefix, which changed the default behavior for plain `PathPrefix` routes.

With this change:
- `PrefixRewrite == "/"` still uses the regex workaround introduced for the `//` issue
- `PrefixRewrite == ""` does not emit any rewrite
- other non-empty rewrite values still use normal `PrefixRewrite`

This restores the original behavior for routes that only use `PathPrefix`: the full incoming request path is forwarded upstream unchanged.

### Testing & Reproduction steps

Reproduction:
1. Configure an API Gateway `HTTPRoute` with a `PathPrefix` match such as `/admin`
2. Do not configure `replacePrefixMatch` / `URLRewrite`
3. Send a request like `/admin/master/console`
4. Before this change, the generated route emits `regexRewrite` and the upstream receives `/master/console`
5. After this change, no rewrite is emitted and the upstream receives `/admin/master/console`

Manual/behavior verification:
1. Confirm routes with no rewrite configured no longer emit `regexRewrite`
2. Confirm routes with `PrefixRewrite == "/"` still emit the regex-based rewrite workaround
3. Confirm routes with other non-empty rewrite values still emit standard `PrefixRewrite`

Tests run:
- `GOFLAGS=-mod=mod go test ./agent/xds -count=1 -run TestUserRewriteLogic`
- `GOFLAGS=-mod=mod go test ./agent/xds -count=1 -run TestAllResourcesFromSnapshot`

Relevant test updates:
- updated xDS rewrite logic unit test
- updated route goldens to remove unintended default `regexRewrite` output

### Links

- #23035

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  Revert plan: revert this PR to restore the previous rewrite behavior.

- [x] If applicable, I've documented the impact of any changes to security controls.

  This change does not modify security controls.
