### PR TITLE
Fix typos in comments and error messages

### DIFF
--- a/agent/structs/acl_templated_policy.go
+++ b/agent/structs/acl_templated_policy.go
@@ -259,7 +259,7 @@ func (tp *ACLTemplatedPolicy) aclTemplatedPolicyRules(entMeta *acl.EnterpriseMet
 
 	parsedTpl, err := tpl.Parse(tmplCode.Template)
 	if err != nil {
-		return "", fmt.Errorf("an error occured when parsing template structs: %w", err)
+		return "", fmt.Errorf("an error occurred when parsing template structs: %w", err)
 	}
 	var buf bytes.Buffer
 	err = parsedTpl.Execute(&buf, struct {
@@ -272,7 +272,7 @@ func (tp *ACLTemplatedPolicy) aclTemplatedPolicyRules(entMeta *acl.EnterpriseMet
 		ACLTemplatedPolicyVariables: tp.TemplateVariables,
 	})
 	if err != nil {
-		return "", fmt.Errorf("an error occured when executing on templated policy variables: %w", err)
+		return "", fmt.Errorf("an error occurred when executing on templated policy variables: %w", err)
 	}
 
 	return buf.String(), nil

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -217,11 +217,11 @@ type Backend interface {
 	// # Consistency
 	//
 	// Generally, List only supports EventualConsistency. However, for backward
-	// compatability with our v1 APIs, the Raft backend supports StrongConsistency
+	// compatibility with our v1 APIs, the Raft backend supports StrongConsistency
 	// for list operations.
 	//
 	// When the v1 APIs finally goes away, so will this consistency parameter, so
-	// it should not be depended on outside of the backward compatability layer.
+	// it should not be depended on outside of the backward compatibility layer.
 	List(ctx context.Context, consistency ReadConsistency, resType UnversionedType, tenancy *pbresource.Tenancy, namePrefix string) ([]*pbresource.Resource, error)
 
 	// WatchList watches resources of the given type, tenancy, and optionally


### PR DESCRIPTION

**Repo:** hashicorp/consul (⭐ 28000)
**Type:** docs
**Files changed:** 2
**Lines:** +4/-4

## What
Fixes two recurring misspellings in the codebase: `occured` → `occurred` in two user-facing error messages returned by `ACLTemplatedPolicy.SyntheticPolicy` (agent/structs/acl_templated_policy.go), and `compatability` → `compatibility` in the godoc for the storage backend `List` API (internal/storage/storage.go).

## Why
The `occured` variants appear in error strings that are surfaced to operators when ACL templated-policy parsing or execution fails; correct spelling makes those errors easier to search for and avoids propagating the typo into downstream log/metric dashboards. The `compatability` variants are in godoc describing the backward-compatibility guarantees of the resource storage List API — misspellings in public docs can confuse readers and break grep-based documentation navigation.

## Testing
- `grep -rn --include="*.go" -E "occured|compatability"` now returns no hits.
- Changes are comment/string-only; no behavioral change. Existing unit tests for the touched packages remain valid (no test asserts on the exact misspelled string).

## Risk
Low — comment and error-message spelling fixes only; no code logic, types, or exported API names change.
