### PR TITLE
Addition of json omitempty for ACLToken name field and its related structs

### DIFF
--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -577,7 +577,7 @@ func (t *ACLToken) EstimateSize() int {
 type ACLTokens []*ACLToken
 
 type ACLTokenListStub struct {
-	Name              string
+	Name              string `json:",omitempty"`
 	AccessorID        string
 	SecretID          string
 	Description       string
@@ -1165,7 +1165,7 @@ func (rules ACLBindingRules) Sort() {
 
 // Note: this is a subset of ACLAuthMethod's fields
 type ACLAuthMethodListStub struct {
-	Name            string
+	Name            string `json:",omitempty"`
 	Type            string
 	DisplayName     string        `json:",omitempty"`
 	Description     string        `json:",omitempty"`

--- a/api/acl.go
+++ b/api/acl.go
@@ -41,7 +41,7 @@ type ACLTokenRoleLink = ACLLink
 type ACLToken struct {
 	CreateIndex       uint64
 	ModifyIndex       uint64
-	Name              string
+	Name              string `json:",omitempty"`
 	AccessorID        string
 	SecretID          string
 	Description       string
@@ -89,7 +89,7 @@ type ACLTokenExpanded struct {
 }
 
 type ACLTokenListEntry struct {
-	Name              string
+	Name              string `json:",omitempty"`
 	CreateIndex       uint64
 	ModifyIndex       uint64
 	AccessorID        string

--- a/command/acl/token/testdata/FormatToken/basic.json.golden
+++ b/command/acl/token/testdata/FormatToken/basic.json.golden
@@ -1,7 +1,6 @@
 {
     "CreateIndex": 42,
     "ModifyIndex": 100,
-    "Name": "",
     "AccessorID": "fbd2447f-7479-4329-ad13-b021d74f86ba",
     "SecretID": "869c6e91-4de9-4dab-b56e-87548435f9c6",
     "Description": "test token",

--- a/command/acl/token/testdata/FormatToken/complex.json.golden
+++ b/command/acl/token/testdata/FormatToken/complex.json.golden
@@ -1,7 +1,6 @@
 {
     "CreateIndex": 5,
     "ModifyIndex": 10,
-    "Name": "",
     "AccessorID": "fbd2447f-7479-4329-ad13-b021d74f86ba",
     "SecretID": "869c6e91-4de9-4dab-b56e-87548435f9c6",
     "Description": "test token",

--- a/command/acl/token/testdata/FormatTokenExpanded/ce/basic.json.golden
+++ b/command/acl/token/testdata/FormatTokenExpanded/ce/basic.json.golden
@@ -29,7 +29,6 @@
     "ResolvedByAgent": "leader",
     "CreateIndex": 42,
     "ModifyIndex": 100,
-    "Name": "",
     "AccessorID": "fbd2447f-7479-4329-ad13-b021d74f86ba",
     "SecretID": "869c6e91-4de9-4dab-b56e-87548435f9c6",
     "Description": "test token",

--- a/command/acl/token/testdata/FormatTokenExpanded/ce/complex.json.golden
+++ b/command/acl/token/testdata/FormatTokenExpanded/ce/complex.json.golden
@@ -144,7 +144,6 @@
     "ResolvedByAgent": "server-1",
     "CreateIndex": 5,
     "ModifyIndex": 10,
-    "Name": "",
     "AccessorID": "fbd2447f-7479-4329-ad13-b021d74f86ba",
     "SecretID": "869c6e91-4de9-4dab-b56e-87548435f9c6",
     "Description": "test token",

--- a/command/acl/token/testdata/FormatTokenList/basic.json.golden
+++ b/command/acl/token/testdata/FormatTokenList/basic.json.golden
@@ -1,6 +1,5 @@
 [
     {
-        "Name": "",
         "CreateIndex": 42,
         "ModifyIndex": 100,
         "AccessorID": "fbd2447f-7479-4329-ad13-b021d74f86ba",

--- a/command/acl/token/testdata/FormatTokenList/complex.json.golden
+++ b/command/acl/token/testdata/FormatTokenList/complex.json.golden
@@ -1,6 +1,5 @@
 [
     {
-        "Name": "",
         "CreateIndex": 5,
         "ModifyIndex": 10,
         "AccessorID": "fbd2447f-7479-4329-ad13-b021d74f86ba",


### PR DESCRIPTION
### Description

Addition of json omitempty for ACLToken name field and its related structs

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
