### PR TITLE
test: add integration tests for certificate expiry telemetry

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -896,6 +896,7 @@ func (a *Agent) Start(ctx context.Context) error {
 			a.config.Datacenter,
 			a.config.PartitionOrDefault(),
 			a.config.NodeName,
+			tlsCertRole(a.config.ServerMode),
 			a.config.Telemetry.CertificateCriticalThresholdDays,
 			a.config.Telemetry.CertificateWarningThresholdDays,
 			a.logger,

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -6865,6 +6865,10 @@ func TestAgentConnectCARoots_list(t *testing.T) {
 	for _, r := range value.Roots {
 		assert.Equal(t, "", r.SigningCert)
 		assert.Equal(t, "", r.SigningKey)
+		assert.False(t, r.NotBefore.IsZero())
+		assert.False(t, r.NotAfter.IsZero())
+		assert.True(t, r.NotAfter.After(r.NotBefore))
+		assert.True(t, r.NotAfter.After(time.Now()))
 	}
 
 	assert.Equal(t, "MISS", resp.Header().Get("X-Cache"))

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -11,15 +11,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/hashicorp/consul/testrpc"
-
-	"github.com/stretchr/testify/require"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/testrpc"
 )
 
 func TestConnectCARoots_empty(t *testing.T) {
@@ -69,6 +68,10 @@ func TestConnectCARoots_list(t *testing.T) {
 	for _, r := range value.Roots {
 		assert.Equal(t, "", r.SigningCert)
 		assert.Equal(t, "", r.SigningKey)
+		assert.False(t, r.NotBefore.IsZero())
+		assert.False(t, r.NotAfter.IsZero())
+		assert.True(t, r.NotAfter.After(r.NotBefore))
+		assert.True(t, r.NotAfter.After(time.Now()))
 	}
 }
 

--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -23,6 +23,9 @@ import (
 var (
 	metricsKeyMeshRootCAExpiry          = []string{"mesh", "active-root-ca", "expiry"}
 	metricsKeyMeshActiveSigningCAExpiry = []string{"mesh", "active-signing-ca", "expiry"}
+
+	// TestCertExpirationMonitorInterval overrides the default emission cadence in tests.
+	TestCertExpirationMonitorInterval time.Duration
 )
 
 var LeaderCertExpirationGauges = []prometheus.GaugeDefinition{
@@ -38,9 +41,10 @@ var LeaderCertExpirationGauges = []prometheus.GaugeDefinition{
 
 func rootCAExpiryMonitor(s *Server) CertExpirationMonitor {
 	return CertExpirationMonitor{
-		Key:    metricsKeyMeshRootCAExpiry,
-		Labels: []metrics.Label{{Name: "datacenter", Value: s.config.Datacenter}},
-		Logger: s.logger.Named(logging.Connect),
+		Key:      metricsKeyMeshRootCAExpiry,
+		Labels:   []metrics.Label{{Name: "datacenter", Value: s.config.Datacenter}},
+		Logger:   s.logger.Named(logging.Connect),
+		Interval: TestCertExpirationMonitorInterval,
 		Query: func() (time.Duration, time.Duration, error) {
 			return getRootCAExpiry(s)
 		},
@@ -64,9 +68,10 @@ func getRootCAExpiry(s *Server) (time.Duration, time.Duration, error) {
 
 func signingCAExpiryMonitor(s *Server) CertExpirationMonitor {
 	return CertExpirationMonitor{
-		Key:    metricsKeyMeshActiveSigningCAExpiry,
-		Labels: []metrics.Label{{Name: "datacenter", Value: s.config.Datacenter}},
-		Logger: s.logger.Named(logging.Connect),
+		Key:      metricsKeyMeshActiveSigningCAExpiry,
+		Labels:   []metrics.Label{{Name: "datacenter", Value: s.config.Datacenter}},
+		Logger:   s.logger.Named(logging.Connect),
+		Interval: TestCertExpirationMonitorInterval,
 		Query: func() (time.Duration, time.Duration, error) {
 			if s.caManager.isIntermediateUsedToSignLeaf() {
 				return getActiveIntermediateExpiry(s)
@@ -119,6 +124,9 @@ type CertExpirationMonitor struct {
 	// Optional threshold overrides (used when Server is nil, e.g., for agent TLS)
 	CriticalThresholdDays int
 	WarningThresholdDays  int
+
+	// Interval overrides the default emission cadence. This is intended for tests.
+	Interval time.Duration
 }
 
 const certExpirationMonitorInterval = time.Hour
@@ -130,7 +138,12 @@ func (m CertExpirationMonitor) Monitor(ctx context.Context) error {
 		return nil
 	}
 
-	ticker := time.NewTicker(certExpirationMonitorInterval)
+	interval := certExpirationMonitorInterval
+	if m.Interval > 0 {
+		interval = m.Interval
+	}
+
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	logger := m.Logger.With("metric", strings.Join(m.Key, "."))

--- a/agent/leafcert/leafcert.go
+++ b/agent/leafcert/leafcert.go
@@ -75,6 +75,9 @@ type Config struct {
 	// Certificate telemetry thresholds for determining log severity
 	CertificateTelemetryCriticalThresholdDays int
 	CertificateTelemetryWarningThresholdDays  int
+
+	// TestOverrideMetricEmissionInterval overrides the periodic metric re-emission cadence in tests.
+	TestOverrideMetricEmissionInterval time.Duration
 }
 
 func (c Config) withDefaults() Config {
@@ -576,7 +579,12 @@ func (m *Manager) runExpiryLoop() {
 // emitCertMetrics periodically re-emits certificate expiry and failure metrics
 // This ensures metrics persist across agent restarts and remain visible to Prometheus
 func (m *Manager) emitCertMetrics() {
-	ticker := time.NewTicker(5 * time.Minute)
+	interval := 5 * time.Minute
+	if m.config.TestOverrideMetricEmissionInterval > 0 {
+		interval = m.config.TestOverrideMetricEmissionInterval
+	}
+
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	emitMetrics := func() {

--- a/agent/metrics.go
+++ b/agent/metrics.go
@@ -22,7 +22,14 @@ var metricsKeyAgentTLSCertExpiry = []string{"agent", "tls", "cert", "expiry"}
 
 var testCertExpirationMonitorInterval time.Duration
 
-func certExpirationGauges(datacenter, partition, nodeName string) []prometheus.GaugeDefinition {
+func tlsCertRole(isServer bool) string {
+	if isServer {
+		return "server"
+	}
+	return "client"
+}
+
+func certExpirationGauges(datacenter, partition, nodeName, role string) []prometheus.GaugeDefinition {
 	return []prometheus.GaugeDefinition{
 		{
 			Name: metricsKeyAgentTLSCertExpiry,
@@ -31,6 +38,7 @@ func certExpirationGauges(datacenter, partition, nodeName string) []prometheus.G
 				{Name: "datacenter", Value: datacenter},
 				{Name: "partition", Value: acl.PartitionOrDefault(partition)},
 				{Name: "node", Value: nodeName},
+				{Name: "role", Value: role},
 			},
 		},
 	}
@@ -38,11 +46,12 @@ func certExpirationGauges(datacenter, partition, nodeName string) []prometheus.G
 
 // tlsCertExpirationMonitor returns a CertExpirationMonitor which will
 // monitor the expiration of the certificate used for agent TLS.
-func tlsCertExpirationMonitor(c *tlsutil.Configurator, datacenter, partition, nodeName string, criticalDays int, warningDays int, logger hclog.Logger) consul.CertExpirationMonitor {
+func tlsCertExpirationMonitor(c *tlsutil.Configurator, datacenter, partition, nodeName, role string, criticalDays int, warningDays int, logger hclog.Logger) consul.CertExpirationMonitor {
 	labels := []metrics.Label{
 		{Name: "datacenter", Value: datacenter},
 		{Name: "partition", Value: acl.PartitionOrDefault(partition)},
 		{Name: "node", Value: nodeName},
+		{Name: "role", Value: role},
 	}
 	return consul.CertExpirationMonitor{
 		Key:                   metricsKeyAgentTLSCertExpiry,

--- a/agent/metrics.go
+++ b/agent/metrics.go
@@ -13,25 +13,33 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/tlsutil"
 )
 
-var CertExpirationGauges = []prometheus.GaugeDefinition{
-	{
-		Name: metricsKeyAgentTLSCertExpiry,
-		Help: "Seconds until the agent tls certificate expires. Updated every hour",
-	},
-}
-
 var metricsKeyAgentTLSCertExpiry = []string{"agent", "tls", "cert", "expiry"}
+
+func certExpirationGauges(datacenter, partition, nodeName string) []prometheus.GaugeDefinition {
+	return []prometheus.GaugeDefinition{
+		{
+			Name: metricsKeyAgentTLSCertExpiry,
+			Help: "Seconds until the agent tls certificate expires. Updated every hour",
+			ConstLabels: []metrics.Label{
+				{Name: "datacenter", Value: datacenter},
+				{Name: "partition", Value: acl.PartitionOrDefault(partition)},
+				{Name: "node", Value: nodeName},
+			},
+		},
+	}
+}
 
 // tlsCertExpirationMonitor returns a CertExpirationMonitor which will
 // monitor the expiration of the certificate used for agent TLS.
 func tlsCertExpirationMonitor(c *tlsutil.Configurator, datacenter, partition, nodeName string, criticalDays int, warningDays int, logger hclog.Logger) consul.CertExpirationMonitor {
 	labels := []metrics.Label{
 		{Name: "datacenter", Value: datacenter},
-		{Name: "partition", Value: partition},
+		{Name: "partition", Value: acl.PartitionOrDefault(partition)},
 		{Name: "node", Value: nodeName},
 	}
 	return consul.CertExpirationMonitor{

--- a/agent/metrics.go
+++ b/agent/metrics.go
@@ -20,6 +20,8 @@ import (
 
 var metricsKeyAgentTLSCertExpiry = []string{"agent", "tls", "cert", "expiry"}
 
+var testCertExpirationMonitorInterval time.Duration
+
 func certExpirationGauges(datacenter, partition, nodeName string) []prometheus.GaugeDefinition {
 	return []prometheus.GaugeDefinition{
 		{
@@ -48,6 +50,7 @@ func tlsCertExpirationMonitor(c *tlsutil.Configurator, datacenter, partition, no
 		Logger:                logger,
 		CriticalThresholdDays: criticalDays,
 		WarningThresholdDays:  warningDays,
+		Interval:              testCertExpirationMonitorInterval,
 		Query: func() (time.Duration, time.Duration, error) {
 			raw := c.Cert()
 			if raw == nil {

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -500,6 +500,7 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 			`datacenter="dc1"`,
 			`partition="default"`,
 			`node="`,
+			`role="client"`,
 		)
 		assertMetricValueBetween(
 			r,
@@ -523,6 +524,7 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 			`datacenter="dc1"`,
 			`partition="default"`,
 			`node="`,
+			`role="client"`,
 		)
 		require.Less(r, secondValue, firstValue)
 		require.GreaterOrEqual(r, firstValue-secondValue, 1.0)

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -7,16 +7,21 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/rpc/middleware"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -126,6 +131,44 @@ func assertMetricLineContainsFragments(t require.TestingT, respRec *httptest.Res
 	}
 
 	require.Failf(t, "metric line not found", "Could not find metric %q with fragments %q in the /v1/agent/metrics response. Candidate lines: %q", metric, fragments, candidates)
+}
+
+func metricLineValue(t require.TestingT, respRec *httptest.ResponseRecorder, metric string, fragments ...string) float64 {
+	require.NotEmpty(t, respRec.Body.String(), "Response body is empty.")
+
+	var candidates []string
+	for _, line := range strings.Split(respRec.Body.String(), "\n") {
+		if len(line) < 1 || line[0] == '#' || !strings.Contains(line, metric) {
+			continue
+		}
+		candidates = append(candidates, line)
+
+		matches := true
+		for _, fragment := range fragments {
+			if !strings.Contains(line, fragment) {
+				matches = false
+				break
+			}
+		}
+		if !matches {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		require.NotEmpty(t, fields, "metric line should contain fields")
+
+		value, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		require.NoError(t, err, "metric line should end with a numeric value")
+		return value
+	}
+
+	require.Failf(t, "metric value not found", "Could not find metric %q with fragments %q in the /v1/agent/metrics response. Candidate lines: %q", metric, fragments, candidates)
+	return 0
+}
+
+func assertMetricValueBetween(t require.TestingT, metric string, value float64, min float64, max float64) {
+	require.GreaterOrEqualf(t, value, min, "metric %q should be >= %v, got %v", metric, min, value)
+	require.LessOrEqualf(t, value, max, "metric %q should be <= %v, got %v", metric, max, value)
 }
 
 func assertLabelWithValueForMetricExistsNTime(t *testing.T, respRec *httptest.ResponseRecorder, metric string, label string, labelValue string, occurrences int) {
@@ -389,6 +432,11 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 	skipIfShortTesting(t)
 	// This test cannot use t.Parallel() since we modify global state, ie the global metrics instance
 
+	testCertExpirationMonitorInterval = 2 * time.Second
+	t.Cleanup(func() {
+		testCertExpirationMonitorInterval = 0
+	})
+
 	dir := testutil.TempDir(t, "ca")
 	caPEM, caPK, err := tlsutil.GenerateCA(tlsutil.CAOpts{Days: 20, Domain: "consul"})
 	require.NoError(t, err)
@@ -437,11 +485,15 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 	a := StartTestAgent(t, TestAgent{HCL: hcl})
 	defer a.Shutdown()
 
+	certTTL := 20 * 24 * time.Hour
+	certWindow := 15 * time.Minute
+
+	var firstValue float64
 	retry.Run(t, func(r *retry.R) {
 		respRec := httptest.NewRecorder()
 		recordPromMetrics(r, a, respRec)
 
-		assertMetricLineContainsFragments(
+		firstValue = metricLineValue(
 			r,
 			respRec,
 			metricsPrefix+"_agent_tls_cert_expiry",
@@ -449,15 +501,42 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 			`partition="default"`,
 			`node="`,
 		)
+		assertMetricValueBetween(
+			r,
+			metricsPrefix+"_agent_tls_cert_expiry",
+			firstValue,
+			float64((certTTL - certWindow).Seconds()),
+			float64(certTTL.Seconds()),
+		)
+	})
 
-		body := respRec.Body.String()
-		require.Contains(r, body, "1.7")
+	time.Sleep(3 * time.Second)
+
+	retry.Run(t, func(r *retry.R) {
+		respRec := httptest.NewRecorder()
+		recordPromMetrics(r, a, respRec)
+
+		secondValue := metricLineValue(
+			r,
+			respRec,
+			metricsPrefix+"_agent_tls_cert_expiry",
+			`datacenter="dc1"`,
+			`partition="default"`,
+			`node="`,
+		)
+		require.Less(r, secondValue, firstValue)
+		require.GreaterOrEqual(r, firstValue-secondValue, 1.0)
 	})
 }
 
 func TestHTTPHandlers_AgentMetrics_CACertExpiry_Prometheus(t *testing.T) {
 	skipIfShortTesting(t)
 	// This test cannot use t.Parallel() since we modify global state, ie the global metrics instance
+
+	consul.TestCertExpirationMonitorInterval = 2 * time.Second
+	t.Cleanup(func() {
+		consul.TestCertExpirationMonitorInterval = 0
+	})
 
 	t.Run("non-leader emits NaN", func(t *testing.T) {
 		metricsPrefix := getUniqueMetricsPrefix()
@@ -479,11 +558,22 @@ func TestHTTPHandlers_AgentMetrics_CACertExpiry_Prometheus(t *testing.T) {
 		respRec := httptest.NewRecorder()
 		recordPromMetrics(t, a, respRec)
 
-		require.Contains(t, respRec.Body.String(), metricsPrefix+"_mesh_active_root_ca_expiry NaN")
-		require.Contains(t, respRec.Body.String(), metricsPrefix+"_mesh_active_signing_ca_expiry NaN")
+		rootValue := metricLineValue(t, respRec, metricsPrefix+"_mesh_active_root_ca_expiry", `datacenter="dc1"`)
+		signingValue := metricLineValue(t, respRec, metricsPrefix+"_mesh_active_signing_ca_expiry", `datacenter="dc1"`)
+		require.True(t, math.IsNaN(rootValue))
+		require.True(t, math.IsNaN(signingValue))
 	})
 
 	t.Run("leader emits a value", func(t *testing.T) {
+		const (
+			leafTTL         = time.Hour
+			signingTTL      = 4 * time.Hour
+			rootTTL         = 5 * time.Hour
+			rootWindow      = 15 * time.Minute
+			signingWindow   = 15 * time.Minute
+			certDriftBuffer = time.Minute
+		)
+
 		metricsPrefix := getUniqueMetricsPrefix()
 		hcl := fmt.Sprintf(`
 		telemetry = {
@@ -493,19 +583,78 @@ func TestHTTPHandlers_AgentMetrics_CACertExpiry_Prometheus(t *testing.T) {
 		}
 		connect {
 			enabled = true
+			ca_config {
+				cluster_id = "%s"
+				leaf_cert_ttl = "%s"
+				intermediate_cert_ttl = "%s"
+				root_cert_ttl = "%s"
+			}
 		}
-		`, metricsPrefix)
+		`, metricsPrefix, connect.TestClusterID, leafTTL.String(), signingTTL.String(), rootTTL.String())
 
 		a := StartTestAgent(t, TestAgent{HCL: hcl})
 		defer a.Shutdown()
 		testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-		respRec := httptest.NewRecorder()
-		recordPromMetrics(t, a, respRec)
+		var rootFirst, signingFirst float64
+		retry.Run(t, func(r *retry.R) {
+			respRec := httptest.NewRecorder()
+			recordPromMetrics(r, a, respRec)
 
-		out := respRec.Body.String()
-		require.Contains(t, out, metricsPrefix+`_mesh_active_root_ca_expiry{datacenter="dc1"} 3.15`)
-		require.Contains(t, out, metricsPrefix+`_mesh_active_signing_ca_expiry{datacenter="dc1"} 3.15`)
+			rootFirst = metricLineValue(
+				r,
+				respRec,
+				metricsPrefix+"_mesh_active_root_ca_expiry",
+				`datacenter="dc1"`,
+			)
+			signingFirst = metricLineValue(
+				r,
+				respRec,
+				metricsPrefix+"_mesh_active_signing_ca_expiry",
+				`datacenter="dc1"`,
+			)
+
+			assertMetricValueBetween(
+				r,
+				metricsPrefix+"_mesh_active_root_ca_expiry",
+				rootFirst,
+				float64((rootTTL - rootWindow).Seconds()),
+				float64(rootTTL.Seconds()),
+			)
+			assertMetricValueBetween(
+				r,
+				metricsPrefix+"_mesh_active_signing_ca_expiry",
+				signingFirst,
+				float64((signingTTL - certDriftBuffer - signingWindow).Seconds()),
+				float64((signingTTL - certDriftBuffer).Seconds()),
+			)
+			require.Greater(r, rootFirst, signingFirst)
+		})
+
+		time.Sleep(3 * time.Second)
+
+		retry.Run(t, func(r *retry.R) {
+			respRec := httptest.NewRecorder()
+			recordPromMetrics(r, a, respRec)
+
+			rootSecond := metricLineValue(
+				r,
+				respRec,
+				metricsPrefix+"_mesh_active_root_ca_expiry",
+				`datacenter="dc1"`,
+			)
+			signingSecond := metricLineValue(
+				r,
+				respRec,
+				metricsPrefix+"_mesh_active_signing_ca_expiry",
+				`datacenter="dc1"`,
+			)
+
+			require.Less(r, rootSecond, rootFirst)
+			require.Less(r, signingSecond, signingFirst)
+			require.GreaterOrEqual(r, rootFirst-rootSecond, 1.0)
+			require.GreaterOrEqual(r, signingFirst-signingSecond, 1.0)
+		})
 	})
 
 }
@@ -514,7 +663,20 @@ func TestHTTPHandlers_AgentMetrics_LeafCertExpiry_Prometheus(t *testing.T) {
 	skipIfShortTesting(t)
 	// This test cannot use t.Parallel() since we modify global state, ie the global metrics instance
 
+	testLeafCertMetricEmissionInterval = 2 * time.Second
+	t.Cleanup(func() {
+		testLeafCertMetricEmissionInterval = 0
+	})
+
 	t.Run("leaf metrics are emitted after issuing a leaf cert", func(t *testing.T) {
+		const (
+			leafTTL             = time.Hour
+			signingTTL          = 4 * time.Hour
+			rootTTL             = 5 * time.Hour
+			leafWindow          = 5 * time.Minute
+			leafCertDriftBuffer = time.Minute
+		)
+
 		metricsPrefix := getUniqueMetricsPrefix()
 		hcl := fmt.Sprintf(`
 		telemetry = {
@@ -527,8 +689,14 @@ func TestHTTPHandlers_AgentMetrics_LeafCertExpiry_Prometheus(t *testing.T) {
 		}
 		connect {
 			enabled = true
+			ca_config {
+				cluster_id = "%s"
+				leaf_cert_ttl = "%s"
+				intermediate_cert_ttl = "%s"
+				root_cert_ttl = "%s"
+			}
 		}
-		`, metricsPrefix)
+		`, metricsPrefix, connect.TestClusterID, leafTTL.String(), signingTTL.String(), rootTTL.String())
 
 		a := StartTestAgent(t, TestAgent{HCL: hcl})
 		defer a.Shutdown()
@@ -545,11 +713,12 @@ func TestHTTPHandlers_AgentMetrics_LeafCertExpiry_Prometheus(t *testing.T) {
 		_, _, err = client.Agent().ConnectCALeaf("web", nil)
 		require.NoError(t, err)
 
+		var firstValue float64
 		retry.Run(t, func(r *retry.R) {
 			respRec := httptest.NewRecorder()
 			recordPromMetrics(r, a, respRec)
 
-			assertMetricLineContainsFragments(
+			firstValue = metricLineValue(
 				r,
 				respRec,
 				metricsPrefix+"_leaf_certs_cert_expiry",
@@ -559,7 +728,14 @@ func TestHTTPHandlers_AgentMetrics_LeafCertExpiry_Prometheus(t *testing.T) {
 				`service="web"`,
 				`kind=""`,
 			)
-			assertMetricLineContainsFragments(
+			assertMetricValueBetween(
+				r,
+				metricsPrefix+"_leaf_certs_cert_expiry",
+				firstValue,
+				float64((leafTTL - leafCertDriftBuffer - leafWindow).Seconds()),
+				float64((leafTTL - leafCertDriftBuffer).Seconds()),
+			)
+			require.Equal(r, 0.0, metricLineValue(
 				r,
 				respRec,
 				metricsPrefix+"_leaf_certs_cert_renewal_failure",
@@ -568,12 +744,39 @@ func TestHTTPHandlers_AgentMetrics_LeafCertExpiry_Prometheus(t *testing.T) {
 				`namespace="default"`,
 				`service="web"`,
 				`kind=""`,
-				" 0",
+			))
+		})
+
+		time.Sleep(3 * time.Second)
+
+		retry.Run(t, func(r *retry.R) {
+			respRec := httptest.NewRecorder()
+			recordPromMetrics(r, a, respRec)
+
+			secondValue := metricLineValue(
+				r,
+				respRec,
+				metricsPrefix+"_leaf_certs_cert_expiry",
+				`datacenter="dc1"`,
+				`partition="default"`,
+				`namespace="default"`,
+				`service="web"`,
+				`kind=""`,
 			)
+			require.Less(r, secondValue, firstValue)
+			require.GreaterOrEqual(r, firstValue-secondValue, 1.0)
 		})
 	})
 
 	t.Run("leaf metrics are emitted for multiple services independently", func(t *testing.T) {
+		const (
+			leafTTL             = time.Hour
+			signingTTL          = 4 * time.Hour
+			rootTTL             = 5 * time.Hour
+			leafWindow          = 5 * time.Minute
+			leafCertDriftBuffer = time.Minute
+		)
+
 		metricsPrefix := getUniqueMetricsPrefix()
 		hcl := fmt.Sprintf(`
 		telemetry = {
@@ -586,8 +789,14 @@ func TestHTTPHandlers_AgentMetrics_LeafCertExpiry_Prometheus(t *testing.T) {
 		}
 		connect {
 			enabled = true
+			ca_config {
+				cluster_id = "%s"
+				leaf_cert_ttl = "%s"
+				intermediate_cert_ttl = "%s"
+				root_cert_ttl = "%s"
+			}
 		}
-		`, metricsPrefix)
+		`, metricsPrefix, connect.TestClusterID, leafTTL.String(), signingTTL.String(), rootTTL.String())
 
 		a := StartTestAgent(t, TestAgent{HCL: hcl})
 		defer a.Shutdown()
@@ -617,7 +826,7 @@ func TestHTTPHandlers_AgentMetrics_LeafCertExpiry_Prometheus(t *testing.T) {
 			recordPromMetrics(r, a, respRec)
 
 			for _, serviceName := range []string{"api", "payments"} {
-				assertMetricLineContainsFragments(
+				value := metricLineValue(
 					r,
 					respRec,
 					metricsPrefix+"_leaf_certs_cert_expiry",
@@ -627,7 +836,14 @@ func TestHTTPHandlers_AgentMetrics_LeafCertExpiry_Prometheus(t *testing.T) {
 					fmt.Sprintf(`service="%s"`, serviceName),
 					`kind=""`,
 				)
-				assertMetricLineContainsFragments(
+				assertMetricValueBetween(
+					r,
+					metricsPrefix+"_leaf_certs_cert_expiry",
+					value,
+					float64((leafTTL - leafCertDriftBuffer - leafWindow).Seconds()),
+					float64((leafTTL - leafCertDriftBuffer).Seconds()),
+				)
+				require.Equal(r, 0.0, metricLineValue(
 					r,
 					respRec,
 					metricsPrefix+"_leaf_certs_cert_renewal_failure",
@@ -636,8 +852,7 @@ func TestHTTPHandlers_AgentMetrics_LeafCertExpiry_Prometheus(t *testing.T) {
 					`namespace="default"`,
 					fmt.Sprintf(`service="%s"`, serviceName),
 					`kind=""`,
-					" 0",
-				)
+				))
 			}
 		})
 	})

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -166,6 +166,26 @@ func metricLineValue(t require.TestingT, respRec *httptest.ResponseRecorder, met
 	return 0
 }
 
+func metricAnyLineValue(t require.TestingT, respRec *httptest.ResponseRecorder, metric string) float64 {
+	require.NotEmpty(t, respRec.Body.String(), "Response body is empty.")
+
+	for _, line := range strings.Split(respRec.Body.String(), "\n") {
+		if len(line) < 1 || line[0] == '#' || !strings.Contains(line, metric) {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		require.NotEmpty(t, fields, "metric line should contain fields")
+
+		value, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		require.NoError(t, err, "metric line should end with a numeric value")
+		return value
+	}
+
+	require.Failf(t, "metric value not found", "Could not find metric %q in the /v1/agent/metrics response", metric)
+	return 0
+}
+
 func assertMetricValueBetween(t require.TestingT, metric string, value float64, min float64, max float64) {
 	require.GreaterOrEqualf(t, value, min, "metric %q should be >= %v, got %v", metric, min, value)
 	require.LessOrEqualf(t, value, max, "metric %q should be <= %v, got %v", metric, max, value)
@@ -500,7 +520,7 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 			`datacenter="dc1"`,
 			`partition="default"`,
 			`node="`,
-			`role="client"`,
+			`role="server"`,
 		)
 		assertMetricValueBetween(
 			r,
@@ -524,7 +544,7 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 			`datacenter="dc1"`,
 			`partition="default"`,
 			`node="`,
-			`role="client"`,
+			`role="server"`,
 		)
 		require.Less(r, secondValue, firstValue)
 		require.GreaterOrEqual(r, firstValue-secondValue, 1.0)
@@ -557,23 +577,24 @@ func TestHTTPHandlers_AgentMetrics_CACertExpiry_Prometheus(t *testing.T) {
 		a := StartTestAgent(t, TestAgent{HCL: hcl})
 		defer a.Shutdown()
 
-		respRec := httptest.NewRecorder()
-		recordPromMetrics(t, a, respRec)
+		retry.Run(t, func(r *retry.R) {
+			respRec := httptest.NewRecorder()
+			recordPromMetrics(r, a, respRec)
 
-		rootValue := metricLineValue(t, respRec, metricsPrefix+"_mesh_active_root_ca_expiry", `datacenter="dc1"`)
-		signingValue := metricLineValue(t, respRec, metricsPrefix+"_mesh_active_signing_ca_expiry", `datacenter="dc1"`)
-		require.True(t, math.IsNaN(rootValue))
-		require.True(t, math.IsNaN(signingValue))
+			rootValue := metricAnyLineValue(r, respRec, metricsPrefix+"_mesh_active_root_ca_expiry")
+			signingValue := metricAnyLineValue(r, respRec, metricsPrefix+"_mesh_active_signing_ca_expiry")
+			require.True(r, math.IsNaN(rootValue))
+			require.True(r, math.IsNaN(signingValue))
+		})
 	})
 
 	t.Run("leader emits a value", func(t *testing.T) {
 		const (
-			leafTTL         = time.Hour
-			signingTTL      = 4 * time.Hour
-			rootTTL         = 5 * time.Hour
-			rootWindow      = 15 * time.Minute
-			signingWindow   = 15 * time.Minute
-			certDriftBuffer = time.Minute
+			leafTTL       = time.Hour
+			signingTTL    = 4 * time.Hour
+			rootTTL       = 5 * time.Hour
+			rootWindow    = 15 * time.Minute
+			signingWindow = 15 * time.Minute
 		)
 
 		metricsPrefix := getUniqueMetricsPrefix()
@@ -623,14 +644,26 @@ func TestHTTPHandlers_AgentMetrics_CACertExpiry_Prometheus(t *testing.T) {
 				float64((rootTTL - rootWindow).Seconds()),
 				float64(rootTTL.Seconds()),
 			)
-			assertMetricValueBetween(
+			inSigningRange := signingFirst >= float64((signingTTL-signingWindow).Seconds()) && signingFirst <= float64(signingTTL.Seconds())
+			inRootRange := signingFirst >= float64((rootTTL-rootWindow).Seconds()) && signingFirst <= float64(rootTTL.Seconds())
+			require.Truef(
 				r,
-				metricsPrefix+"_mesh_active_signing_ca_expiry",
+				inSigningRange || inRootRange,
+				"expected signing metric in either intermediate range [%v,%v] or root range [%v,%v], got %v",
+				float64((signingTTL - signingWindow).Seconds()),
+				float64(signingTTL.Seconds()),
+				float64((rootTTL - rootWindow).Seconds()),
+				float64(rootTTL.Seconds()),
 				signingFirst,
-				float64((signingTTL - certDriftBuffer - signingWindow).Seconds()),
-				float64((signingTTL - certDriftBuffer).Seconds()),
 			)
-			require.Greater(r, rootFirst, signingFirst)
+
+			// In a primary DC, some CA providers sign leaf certs directly with root,
+			// so signing expiry can equal root expiry. Others use intermediate certs.
+			if inSigningRange {
+				require.Greater(r, rootFirst, signingFirst)
+			} else {
+				require.GreaterOrEqual(r, rootFirst, signingFirst)
+			}
 		})
 
 		time.Sleep(3 * time.Second)

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -14,11 +14,11 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent/rpc/middleware"
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
@@ -101,6 +101,31 @@ func assertMetricExistsWithLabels(t *testing.T, respRec *httptest.ResponseRecord
 	if !foundAllLabels {
 		t.Fatalf("Could not verify that all named labels \"%s\" exist for the metric \"%s\" in the /v1/agent/metrics response", strings.Join(labelNames, ", "), metric)
 	}
+}
+
+func assertMetricLineContainsFragments(t require.TestingT, respRec *httptest.ResponseRecorder, metric string, fragments ...string) {
+	require.NotEmpty(t, respRec.Body.String(), "Response body is empty.")
+
+	var candidates []string
+	for _, line := range strings.Split(respRec.Body.String(), "\n") {
+		if len(line) < 1 || line[0] == '#' || !strings.Contains(line, metric) {
+			continue
+		}
+		candidates = append(candidates, line)
+
+		matches := true
+		for _, fragment := range fragments {
+			if !strings.Contains(line, fragment) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return
+		}
+	}
+
+	require.Failf(t, "metric line not found", "Could not find metric %q with fragments %q in the /v1/agent/metrics response. Candidate lines: %q", metric, fragments, candidates)
 }
 
 func assertLabelWithValueForMetricExistsNTime(t *testing.T, respRec *httptest.ResponseRecorder, metric string, label string, labelValue string, occurrences int) {
@@ -402,6 +427,8 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 				enabled = true
 			}
 		}
+		verify_incoming = true
+		verify_outgoing = true
 		ca_file = "%s"
 		cert_file = "%s"
 		key_file = "%s"
@@ -410,19 +437,22 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 	a := StartTestAgent(t, TestAgent{HCL: hcl})
 	defer a.Shutdown()
 
-	// Wait a bit for the certificate monitor to emit metrics
-	time.Sleep(100 * time.Millisecond)
+	retry.Run(t, func(r *retry.R) {
+		respRec := httptest.NewRecorder()
+		recordPromMetrics(r, a, respRec)
 
-	respRec := httptest.NewRecorder()
-	recordPromMetrics(t, a, respRec)
+		assertMetricLineContainsFragments(
+			r,
+			respRec,
+			metricsPrefix+"_agent_tls_cert_expiry",
+			`datacenter="dc1"`,
+			`partition="default"`,
+			`node="`,
+		)
 
-	body := respRec.Body.String()
-	// The metric includes datacenter, partition, and node labels
-	require.Contains(t, body, metricsPrefix+"_agent_tls_cert_expiry{datacenter=")
-	require.Contains(t, body, `partition="default"`)
-	require.Contains(t, body, "node=")
-	// Check that the value is approximately 20 days = 1.728e6 seconds
-	require.Contains(t, body, "1.7")
+		body := respRec.Body.String()
+		require.Contains(r, body, "1.7")
+	})
 }
 
 func TestHTTPHandlers_AgentMetrics_CACertExpiry_Prometheus(t *testing.T) {
@@ -478,6 +508,139 @@ func TestHTTPHandlers_AgentMetrics_CACertExpiry_Prometheus(t *testing.T) {
 		require.Contains(t, out, metricsPrefix+`_mesh_active_signing_ca_expiry{datacenter="dc1"} 3.15`)
 	})
 
+}
+
+func TestHTTPHandlers_AgentMetrics_LeafCertExpiry_Prometheus(t *testing.T) {
+	skipIfShortTesting(t)
+	// This test cannot use t.Parallel() since we modify global state, ie the global metrics instance
+
+	t.Run("leaf metrics are emitted after issuing a leaf cert", func(t *testing.T) {
+		metricsPrefix := getUniqueMetricsPrefix()
+		hcl := fmt.Sprintf(`
+		telemetry = {
+			prometheus_retention_time = "5s",
+			disable_hostname = true
+			metrics_prefix = "%s"
+			certificate = {
+				enabled = true
+			}
+		}
+		connect {
+			enabled = true
+		}
+		`, metricsPrefix)
+
+		a := StartTestAgent(t, TestAgent{HCL: hcl})
+		defer a.Shutdown()
+		testrpc.WaitForLeader(t, a.RPC, "dc1")
+		testrpc.WaitForActiveCARoot(t, a.RPC, "dc1", nil)
+
+		client := a.Client()
+		err := client.Agent().ServiceRegister(&api.AgentServiceRegistration{
+			Name: "web",
+			Port: 8080,
+		})
+		require.NoError(t, err)
+
+		_, _, err = client.Agent().ConnectCALeaf("web", nil)
+		require.NoError(t, err)
+
+		retry.Run(t, func(r *retry.R) {
+			respRec := httptest.NewRecorder()
+			recordPromMetrics(r, a, respRec)
+
+			assertMetricLineContainsFragments(
+				r,
+				respRec,
+				metricsPrefix+"_leaf_certs_cert_expiry",
+				`datacenter="dc1"`,
+				`partition="default"`,
+				`namespace="default"`,
+				`service="web"`,
+				`kind=""`,
+			)
+			assertMetricLineContainsFragments(
+				r,
+				respRec,
+				metricsPrefix+"_leaf_certs_cert_renewal_failure",
+				`datacenter="dc1"`,
+				`partition="default"`,
+				`namespace="default"`,
+				`service="web"`,
+				`kind=""`,
+				" 0",
+			)
+		})
+	})
+
+	t.Run("leaf metrics are emitted for multiple services independently", func(t *testing.T) {
+		metricsPrefix := getUniqueMetricsPrefix()
+		hcl := fmt.Sprintf(`
+		telemetry = {
+			prometheus_retention_time = "5s",
+			disable_hostname = true
+			metrics_prefix = "%s"
+			certificate = {
+				enabled = true
+			}
+		}
+		connect {
+			enabled = true
+		}
+		`, metricsPrefix)
+
+		a := StartTestAgent(t, TestAgent{HCL: hcl})
+		defer a.Shutdown()
+		testrpc.WaitForLeader(t, a.RPC, "dc1")
+		testrpc.WaitForActiveCARoot(t, a.RPC, "dc1", nil)
+
+		client := a.Client()
+		for _, svc := range []struct {
+			name string
+			port int
+		}{
+			{name: "api", port: 9090},
+			{name: "payments", port: 9091},
+		} {
+			err := client.Agent().ServiceRegister(&api.AgentServiceRegistration{
+				Name: svc.name,
+				Port: svc.port,
+			})
+			require.NoError(t, err)
+
+			_, _, err = client.Agent().ConnectCALeaf(svc.name, nil)
+			require.NoError(t, err)
+		}
+
+		retry.Run(t, func(r *retry.R) {
+			respRec := httptest.NewRecorder()
+			recordPromMetrics(r, a, respRec)
+
+			for _, serviceName := range []string{"api", "payments"} {
+				assertMetricLineContainsFragments(
+					r,
+					respRec,
+					metricsPrefix+"_leaf_certs_cert_expiry",
+					`datacenter="dc1"`,
+					`partition="default"`,
+					`namespace="default"`,
+					fmt.Sprintf(`service="%s"`, serviceName),
+					`kind=""`,
+				)
+				assertMetricLineContainsFragments(
+					r,
+					respRec,
+					metricsPrefix+"_leaf_certs_cert_renewal_failure",
+					`datacenter="dc1"`,
+					`partition="default"`,
+					`namespace="default"`,
+					fmt.Sprintf(`service="%s"`, serviceName),
+					`kind=""`,
+					" 0",
+				)
+			}
+		})
+	})
 }
 
 func TestHTTPHandlers_AgentMetrics_WAL_Prometheus(t *testing.T) {

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -344,7 +344,7 @@ func getPrometheusDefs(cfg *config.RuntimeConfig, isServer bool) ([]prometheus.G
 		xds.StatsGauges,
 		usagemetrics.Gauges,
 		consul.ReplicationGauges,
-		certExpirationGauges(cfg.Datacenter, cfg.PartitionOrDefault(), cfg.NodeName),
+		certExpirationGauges(cfg.Datacenter, cfg.PartitionOrDefault(), cfg.NodeName, tlsCertRole(isServer)),
 		Gauges,
 		raftGauges,
 		serverGauges,

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -341,7 +341,7 @@ func getPrometheusDefs(cfg *config.RuntimeConfig, isServer bool) ([]prometheus.G
 		xds.StatsGauges,
 		usagemetrics.Gauges,
 		consul.ReplicationGauges,
-		CertExpirationGauges,
+		certExpirationGauges(cfg.Datacenter, cfg.PartitionOrDefault(), cfg.NodeName),
 		Gauges,
 		raftGauges,
 		serverGauges,

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -96,6 +96,8 @@ func (r *LazyNetRPC) RPC(ctx context.Context, method string, args any, reply any
 
 type ConfigLoader func(source config.Source) (config.LoadResult, error)
 
+var testLeafCertMetricEmissionInterval time.Duration
+
 func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer, providedLogger hclog.InterceptLogger) (BaseDeps, error) {
 	d := BaseDeps{}
 	result, err := configLoader(nil)
@@ -172,6 +174,7 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer, providedLogger hcl
 		RootsReader: leafcert.NewCachedRootsReader(d.Cache, cfg.Datacenter),
 		Config: leafcert.Config{
 			TestOverrideCAChangeInitialDelay:          cfg.ConnectTestCALeafRootChangeSpread,
+			TestOverrideMetricEmissionInterval:        testLeafCertMetricEmissionInterval,
 			CertificateTelemetryCriticalThresholdDays: cfg.Telemetry.CertificateCriticalThresholdDays,
 			CertificateTelemetryWarningThresholdDays:  cfg.Telemetry.CertificateWarningThresholdDays,
 		},

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -1849,6 +1849,10 @@ func TestAPI_AgentConnectCARoots_list(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, meta.LastIndex > 0)
 	require.Len(t, list.Roots, 1)
+	require.NotNil(t, list.Roots[0].NotBefore)
+	require.NotNil(t, list.Roots[0].NotAfter)
+	require.True(t, list.Roots[0].NotAfter.After(*list.Roots[0].NotBefore))
+	require.True(t, list.Roots[0].NotAfter.After(time.Now()))
 }
 
 func TestAPI_AgentConnectCALeaf(t *testing.T) {

--- a/api/connect_ca_test.go
+++ b/api/connect_ca_test.go
@@ -55,6 +55,11 @@ func TestAPI_ConnectCARoots_list(t *testing.T) {
 		if list.TrustDomain != "11111111-2222-3333-4444-555555555555.consul" {
 			r.Fatalf("expected fixed trust domain got '%s'", list.TrustDomain)
 		}
+		root := list.Roots[0]
+		require.NotNil(r, root.NotBefore)
+		require.NotNil(r, root.NotAfter)
+		require.True(r, root.NotAfter.After(*root.NotBefore))
+		require.True(r, root.NotAfter.After(time.Now()))
 	})
 
 }

--- a/test-integ/connect/certificate_telemetry_test.go
+++ b/test-integ/connect/certificate_telemetry_test.go
@@ -1,0 +1,307 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package connect
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/test/integration/consul-container/libs/utils"
+	"github.com/hashicorp/consul/testing/deployer/sprawl/sprawltest"
+	"github.com/hashicorp/consul/testing/deployer/topology"
+)
+
+func Test_CertificateTelemetry(t *testing.T) {
+	const (
+		clusterName = "dc1"
+		serviceName = "web"
+		// sprawl bootstraps clusters with this management token.
+		managementToken = "root"
+
+		certMetricTolerance = 30 * time.Second
+	)
+
+	cfg := &topology.Config{
+		Images: utils.TargetImages(),
+		Networks: []*topology.Network{
+			{Name: clusterName},
+		},
+		Clusters: []*topology.Cluster{
+			{
+				Name:       clusterName,
+				Enterprise: utils.IsEnterprise(),
+				Nodes: []*topology.Node{
+					{
+						Kind: topology.NodeKindServer,
+						Name: "dc1-server1",
+						Addresses: []*topology.Address{
+							{Network: clusterName},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sp := sprawltest.Launch(t, cfg)
+	t.Logf("launched sprawl topology for cluster=%s", clusterName)
+
+	leaderNode, err := sp.Leader(clusterName)
+	require.NoError(t, err)
+	t.Logf("leader elected: node_id=%s", leaderNode.ID())
+
+	client, err := sp.APIClientForNode(clusterName, leaderNode.ID(), "")
+	require.NoError(t, err)
+
+	httpClient, err := sp.HTTPClientForCluster(clusterName)
+	require.NoError(t, err)
+
+	leaderAddr, err := sp.LocalAddressForNode(clusterName, leaderNode.ID())
+	require.NoError(t, err)
+	t.Logf("leader local address resolved: %s", leaderAddr)
+
+	serverNode := sp.Topology().Clusters[clusterName].FirstServer()
+	require.NotNil(t, serverNode)
+	t.Logf("server node resolved: name=%s docker=%s", serverNode.Name, serverNode.DockerName())
+
+	err = client.Agent().ServiceRegister(&api.AgentServiceRegistration{
+		ID:   serviceName,
+		Name: serviceName,
+		Port: 8080,
+	})
+	require.NoError(t, err)
+	t.Logf("registered service for leaf issuance: service=%s", serviceName)
+
+	leaf, _, err := client.Agent().ConnectCALeaf(serviceName, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, leaf.CertPEM)
+	require.NotEmpty(t, leaf.PrivateKeyPEM)
+	t.Logf("issued leaf certificate: service=%s valid_after=%s valid_before=%s", serviceName, leaf.ValidAfter.UTC().Format(time.RFC3339), leaf.ValidBefore.UTC().Format(time.RFC3339))
+
+	retry.Run(t, func(r *retry.R) {
+		t.Logf("retry step: collecting CA roots and certificate telemetry metrics")
+
+		agentRoots, _, err := client.Agent().ConnectCARoots(nil)
+		require.NoError(r, err)
+		require.NotEmpty(r, agentRoots.ActiveRootID)
+		require.NotEmpty(r, agentRoots.Roots)
+
+		activeRoot := findActiveRoot(r, agentRoots.Roots, agentRoots.ActiveRootID)
+		require.NotNil(r, activeRoot.NotBefore)
+		require.NotNil(r, activeRoot.NotAfter)
+		require.True(r, activeRoot.NotAfter.After(*activeRoot.NotBefore))
+		require.True(r, activeRoot.NotAfter.After(time.Now()))
+		t.Logf("retry step: agent roots loaded active_root_id=%s not_after=%s", agentRoots.ActiveRootID, activeRoot.NotAfter.UTC().Format(time.RFC3339))
+
+		connectRoots, _, err := client.Connect().CARoots(nil)
+		require.NoError(r, err)
+		require.NotEmpty(r, connectRoots.ActiveRootID)
+		require.NotEmpty(r, connectRoots.Roots)
+
+		connectActiveRoot := findActiveRoot(r, connectRoots.Roots, connectRoots.ActiveRootID)
+		require.NotNil(r, connectActiveRoot.NotBefore)
+		require.NotNil(r, connectActiveRoot.NotAfter)
+		require.True(r, connectActiveRoot.NotAfter.After(*connectActiveRoot.NotBefore))
+		require.True(r, connectActiveRoot.NotAfter.After(time.Now()))
+		t.Logf("retry step: connect roots loaded active_root_id=%s not_after=%s", connectRoots.ActiveRootID, connectActiveRoot.NotAfter.UTC().Format(time.RFC3339))
+
+		leafCerts := parsePEMCertificates(r, leaf.CertPEM)
+		t.Logf("retry step: parsed leaf certificate chain cert_count=%d leaf_not_after=%s", len(leafCerts), leafCerts[0].NotAfter.UTC().Format(time.RFC3339))
+
+		serverCert := copyAndParseServerCert(r, sp, serverNode)
+		t.Logf("retry step: parsed server TLS cert not_after=%s", serverCert.NotAfter.UTC().Format(time.RFC3339))
+
+		metricsBody, err := scrapePrometheusMetrics(httpClient, leaderAddr, managementToken)
+		require.NoError(r, err)
+		t.Logf("retry step: scraped prometheus metrics from leader")
+
+		rootValue := promMetricValue(r, metricsBody, "consul_mesh_active_root_ca_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName))
+		signingValue := promMetricValue(r, metricsBody, "consul_mesh_active_signing_ca_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName))
+		agentTLSValue := promMetricValue(r, metricsBody, "consul_agent_tls_cert_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName), `node="`)
+		leafValue := promMetricValue(r, metricsBody, "consul_leaf_certs_cert_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName), `namespace="default"`, fmt.Sprintf(`service="%s"`, serviceName))
+		renewalFailureValue := promMetricValue(r, metricsBody, "consul_leaf_certs_cert_renewal_failure", fmt.Sprintf(`datacenter="%s"`, clusterName), `namespace="default"`, fmt.Sprintf(`service="%s"`, serviceName))
+		t.Logf("retry step: metric values root=%f signing=%f agent_tls=%f leaf=%f renewal_failure=%f", rootValue, signingValue, agentTLSValue, leafValue, renewalFailureValue)
+
+		expectedSigningNotAfter := *activeRoot.NotAfter
+		if len(leafCerts) >= 2 {
+			expectedSigningNotAfter = leafCerts[len(leafCerts)-1].NotAfter
+		}
+
+		requireGaugeMatchesCertExpiry(r, "consul.mesh.active-root-ca.expiry", rootValue, *activeRoot.NotAfter, certMetricTolerance)
+		requireGaugeMatchesCertExpiry(r, "consul.mesh.active-signing-ca.expiry", signingValue, expectedSigningNotAfter, certMetricTolerance)
+		requireGaugeMatchesCertExpiry(r, "consul.agent.tls.cert.expiry", agentTLSValue, serverCert.NotAfter, certMetricTolerance)
+		requireGaugeMatchesCertExpiry(r, "consul.leaf-certs.cert_expiry", leafValue, leaf.ValidBefore, certMetricTolerance)
+		if len(leafCerts) >= 2 {
+			require.Greater(r, rootValue, signingValue)
+		}
+		require.GreaterOrEqual(r, rootValue, signingValue)
+		require.Greater(r, signingValue, leafValue)
+		require.Equal(r, float64(0), renewalFailureValue)
+		t.Logf("retry step: all certificate telemetry assertions passed")
+	})
+	t.Logf("certificate telemetry e2e validation completed successfully")
+}
+
+func scrapePrometheusMetrics(httpClient *http.Client, nodeAddress string, token string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, "http://"+nodeAddress+":8500/v1/agent/metrics?format=prometheus", nil)
+	if err != nil {
+		return "", err
+	}
+	if token != "" {
+		req.Header.Set("X-Consul-Token", token)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("metrics request failed: status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func promMetricValue(t require.TestingT, body string, metric string, fragments ...string) float64 {
+	if h, ok := t.(interface{ Helper() }); ok {
+		h.Helper()
+	}
+
+	require.NotEmpty(t, body, "Prometheus metrics body is empty")
+
+	var candidates []string
+	for _, line := range strings.Split(body, "\n") {
+		if len(line) < 1 || line[0] == '#' || !strings.Contains(line, metric) {
+			continue
+		}
+		candidates = append(candidates, line)
+
+		matches := true
+		for _, fragment := range fragments {
+			if !strings.Contains(line, fragment) {
+				matches = false
+				break
+			}
+		}
+		if !matches {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		require.NotEmpty(t, fields, "metric line should contain fields")
+
+		value, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		require.NoError(t, err, "metric line should end with a numeric value")
+		return value
+	}
+
+	require.Failf(t, "metric not found", "Could not find metric %q with fragments %q. Candidate lines: %q", metric, fragments, candidates)
+	return 0
+}
+
+func requireGaugeMatchesCertExpiry(t require.TestingT, name string, value float64, notAfter time.Time, tolerance time.Duration) {
+	if h, ok := t.(interface{ Helper() }); ok {
+		h.Helper()
+	}
+
+	expected := time.Until(notAfter).Seconds()
+	diff := expected - value
+	if diff < 0 {
+		diff = -diff
+	}
+	require.LessOrEqualf(
+		t,
+		diff,
+		tolerance.Seconds(),
+		"gauge %q should be within %s of cert expiry, expected about %v seconds, got %v seconds",
+		name,
+		tolerance,
+		expected,
+		value,
+	)
+}
+
+func findActiveRoot(t require.TestingT, roots []*api.CARoot, activeRootID string) *api.CARoot {
+	if h, ok := t.(interface{ Helper() }); ok {
+		h.Helper()
+	}
+
+	for _, root := range roots {
+		if root.ID == activeRootID {
+			return root
+		}
+	}
+
+	require.Failf(t, "active root not found", "Could not find active root %q", activeRootID)
+	return nil
+}
+
+func parsePEMCertificates(t require.TestingT, certPEM string) []*x509.Certificate {
+	if h, ok := t.(interface{ Helper() }); ok {
+		h.Helper()
+	}
+
+	var certs []*x509.Certificate
+	rest := []byte(certPEM)
+	for len(rest) > 0 {
+		block, remaining := pem.Decode(rest)
+		rest = remaining
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		require.NoError(t, err)
+		certs = append(certs, cert)
+	}
+
+	require.NotEmpty(t, certs, "expected at least one certificate in PEM bundle")
+	return certs
+}
+
+func copyAndParseServerCert(t require.TestingT, sp interface {
+	CopyFileFromContainer(context.Context, string, string, string) error
+}, node *topology.Node) *x509.Certificate {
+	if h, ok := t.(interface{ Helper() }); ok {
+		h.Helper()
+	}
+
+	tempDir, err := os.MkdirTemp("", "cert-telemetry-server-cert-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	destPath := filepath.Join(tempDir, "server.pem")
+	sourcePath := fmt.Sprintf("/consul/config/certs/%s.pem", node.TLSCertPrefix)
+	err = sp.CopyFileFromContainer(context.Background(), node.DockerName(), sourcePath, destPath)
+	require.NoError(t, err)
+
+	certPEM, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+
+	certs := parsePEMCertificates(t, string(certPEM))
+	return certs[0]
+}

--- a/test-integ/connect/certificate_telemetry_test.go
+++ b/test-integ/connect/certificate_telemetry_test.go
@@ -132,7 +132,7 @@ func Test_CertificateTelemetry(t *testing.T) {
 
 		rootValue := promMetricValue(r, metricsBody, "consul_mesh_active_root_ca_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName))
 		signingValue := promMetricValue(r, metricsBody, "consul_mesh_active_signing_ca_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName))
-		agentTLSValue := promMetricValue(r, metricsBody, "consul_agent_tls_cert_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName), `node="`)
+		agentTLSValue := promMetricValue(r, metricsBody, "consul_agent_tls_cert_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName), `node="`, `role="server"`)
 		leafValue := promMetricValue(r, metricsBody, "consul_leaf_certs_cert_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName), `namespace="default"`, fmt.Sprintf(`service="%s"`, serviceName))
 		renewalFailureValue := promMetricValue(r, metricsBody, "consul_leaf_certs_cert_renewal_failure", fmt.Sprintf(`datacenter="%s"`, clusterName), `namespace="default"`, fmt.Sprintf(`service="%s"`, serviceName))
 		t.Logf("retry step: metric values root=%f signing=%f agent_tls=%f leaf=%f renewal_failure=%f", rootValue, signingValue, agentTLSValue, leafValue, renewalFailureValue)

--- a/test-integ/connect/certificate_telemetry_test.go
+++ b/test-integ/connect/certificate_telemetry_test.go
@@ -93,8 +93,23 @@ func Test_CertificateTelemetry(t *testing.T) {
 	require.NotEmpty(t, leaf.PrivateKeyPEM)
 	t.Logf("issued leaf certificate: service=%s valid_after=%s valid_before=%s", serviceName, leaf.ValidAfter.UTC().Format(time.RFC3339), leaf.ValidBefore.UTC().Format(time.RFC3339))
 
+	var (
+		lastActiveRootID        string
+		lastActiveRootNotAfter  string
+		lastConnectRootID       string
+		lastConnectRootNotAfter string
+		lastLeafCertCount       int
+		lastLeafNotAfter        string
+		lastServerNotAfter      string
+		lastRootValue           float64
+		lastSigningValue        float64
+		lastAgentTLSValue       float64
+		lastLeafValue           float64
+		lastRenewalFailure      float64
+	)
+
 	retry.Run(t, func(r *retry.R) {
-		t.Logf("retry step: collecting CA roots and certificate telemetry metrics")
+		logRetryStepf(r, "retry step: collecting CA roots and certificate telemetry metrics")
 
 		agentRoots, _, err := client.Agent().ConnectCARoots(nil)
 		require.NoError(r, err)
@@ -106,7 +121,9 @@ func Test_CertificateTelemetry(t *testing.T) {
 		require.NotNil(r, activeRoot.NotAfter)
 		require.True(r, activeRoot.NotAfter.After(*activeRoot.NotBefore))
 		require.True(r, activeRoot.NotAfter.After(time.Now()))
-		t.Logf("retry step: agent roots loaded active_root_id=%s not_after=%s", agentRoots.ActiveRootID, activeRoot.NotAfter.UTC().Format(time.RFC3339))
+		lastActiveRootID = agentRoots.ActiveRootID
+		lastActiveRootNotAfter = activeRoot.NotAfter.UTC().Format(time.RFC3339)
+		logRetryStepf(r, "retry step: agent roots loaded active_root_id=%s not_after=%s", agentRoots.ActiveRootID, activeRoot.NotAfter.UTC().Format(time.RFC3339))
 
 		connectRoots, _, err := client.Connect().CARoots(nil)
 		require.NoError(r, err)
@@ -118,24 +135,34 @@ func Test_CertificateTelemetry(t *testing.T) {
 		require.NotNil(r, connectActiveRoot.NotAfter)
 		require.True(r, connectActiveRoot.NotAfter.After(*connectActiveRoot.NotBefore))
 		require.True(r, connectActiveRoot.NotAfter.After(time.Now()))
-		t.Logf("retry step: connect roots loaded active_root_id=%s not_after=%s", connectRoots.ActiveRootID, connectActiveRoot.NotAfter.UTC().Format(time.RFC3339))
+		lastConnectRootID = connectRoots.ActiveRootID
+		lastConnectRootNotAfter = connectActiveRoot.NotAfter.UTC().Format(time.RFC3339)
+		logRetryStepf(r, "retry step: connect roots loaded active_root_id=%s not_after=%s", connectRoots.ActiveRootID, connectActiveRoot.NotAfter.UTC().Format(time.RFC3339))
 
 		leafCerts := parsePEMCertificates(r, leaf.CertPEM)
-		t.Logf("retry step: parsed leaf certificate chain cert_count=%d leaf_not_after=%s", len(leafCerts), leafCerts[0].NotAfter.UTC().Format(time.RFC3339))
+		lastLeafCertCount = len(leafCerts)
+		lastLeafNotAfter = leafCerts[0].NotAfter.UTC().Format(time.RFC3339)
+		logRetryStepf(r, "retry step: parsed leaf certificate chain cert_count=%d leaf_not_after=%s", len(leafCerts), leafCerts[0].NotAfter.UTC().Format(time.RFC3339))
 
 		serverCert := copyAndParseServerCert(r, sp, serverNode)
-		t.Logf("retry step: parsed server TLS cert not_after=%s", serverCert.NotAfter.UTC().Format(time.RFC3339))
+		lastServerNotAfter = serverCert.NotAfter.UTC().Format(time.RFC3339)
+		logRetryStepf(r, "retry step: parsed server TLS cert not_after=%s", serverCert.NotAfter.UTC().Format(time.RFC3339))
 
 		metricsBody, err := scrapePrometheusMetrics(httpClient, leaderAddr, managementToken)
 		require.NoError(r, err)
-		t.Logf("retry step: scraped prometheus metrics from leader")
+		logRetryStepf(r, "retry step: scraped prometheus metrics from leader")
 
 		rootValue := promMetricValue(r, metricsBody, "consul_mesh_active_root_ca_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName))
 		signingValue := promMetricValue(r, metricsBody, "consul_mesh_active_signing_ca_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName))
 		agentTLSValue := promMetricValue(r, metricsBody, "consul_agent_tls_cert_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName), `node="`, `role="server"`)
 		leafValue := promMetricValue(r, metricsBody, "consul_leaf_certs_cert_expiry", fmt.Sprintf(`datacenter="%s"`, clusterName), `namespace="default"`, fmt.Sprintf(`service="%s"`, serviceName))
 		renewalFailureValue := promMetricValue(r, metricsBody, "consul_leaf_certs_cert_renewal_failure", fmt.Sprintf(`datacenter="%s"`, clusterName), `namespace="default"`, fmt.Sprintf(`service="%s"`, serviceName))
-		t.Logf("retry step: metric values root=%f signing=%f agent_tls=%f leaf=%f renewal_failure=%f", rootValue, signingValue, agentTLSValue, leafValue, renewalFailureValue)
+		lastRootValue = rootValue
+		lastSigningValue = signingValue
+		lastAgentTLSValue = agentTLSValue
+		lastLeafValue = leafValue
+		lastRenewalFailure = renewalFailureValue
+		logRetryStepf(r, "retry step: metric values root=%f signing=%f agent_tls=%f leaf=%f renewal_failure=%f", rootValue, signingValue, agentTLSValue, leafValue, renewalFailureValue)
 
 		expectedSigningNotAfter := *activeRoot.NotAfter
 		if len(leafCerts) >= 2 {
@@ -152,9 +179,17 @@ func Test_CertificateTelemetry(t *testing.T) {
 		require.GreaterOrEqual(r, rootValue, signingValue)
 		require.Greater(r, signingValue, leafValue)
 		require.Equal(r, float64(0), renewalFailureValue)
-		t.Logf("retry step: all certificate telemetry assertions passed")
+		logRetryStepf(r, "retry step: all certificate telemetry assertions passed")
 	})
+	t.Logf("retry summary: active_root_id=%s active_root_not_after=%s connect_root_id=%s connect_root_not_after=%s", lastActiveRootID, lastActiveRootNotAfter, lastConnectRootID, lastConnectRootNotAfter)
+	t.Logf("retry summary: leaf_chain_count=%d leaf_not_after=%s server_tls_not_after=%s", lastLeafCertCount, lastLeafNotAfter, lastServerNotAfter)
+	t.Logf("retry summary: metric values root=%f signing=%f agent_tls=%f leaf=%f renewal_failure=%f", lastRootValue, lastSigningValue, lastAgentTLSValue, lastLeafValue, lastRenewalFailure)
 	t.Logf("certificate telemetry e2e validation completed successfully")
+}
+
+func logRetryStepf(r *retry.R, format string, args ...any) {
+	r.Logf(format, args...)
+	fmt.Printf("[retry] "+format+"\n", args...)
 }
 
 func scrapePrometheusMetrics(httpClient *http.Client, nodeAddress string, token string) (string, error) {

--- a/testing/deployer/sprawl/sprawl.go
+++ b/testing/deployer/sprawl/sprawl.go
@@ -766,6 +766,10 @@ func (s *Sprawl) dumpContainerLogs(ctx context.Context, containerName, outputRoo
 	return nil
 }
 
+func (s *Sprawl) CopyFileFromContainer(ctx context.Context, containerName, sourcePath, destPath string) error {
+	return s.runner.DockerExec(ctx, []string{"cp", containerName + ":" + sourcePath, destPath}, nil, nil)
+}
+
 func (s *Sprawl) GetFileFromContainer(ctx context.Context, containerName string, filePath string) error {
-	return s.runner.DockerExec(ctx, []string{"cp", containerName + ":" + filePath, filePath}, nil, nil)
+	return s.CopyFileFromContainer(ctx, containerName, filePath, filePath)
 }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->
This pull request enhances certificate metrics and strengthens related tests in the Consul agent and API. The main improvements include more comprehensive Prometheus metrics for certificate expiration, improved labeling for metrics, and additional validation of certificate validity periods in both agent and API tests.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
