### PR TITLE
Resetting the conditional-skip check

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -27,13 +27,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  #conditional-skip:
-  #  uses: ./.github/workflows/reusable-conditional-skip.yml
+  conditional-skip:
+    uses: ./.github/workflows/reusable-conditional-skip.yml
 
   setup:
-   # needs: [conditional-skip]
+    needs: [conditional-skip]
     name: Setup
-    #if: needs.conditional-skip.outputs.skip-ci != 'true'
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
     runs-on: ubuntu-latest
     outputs:
       compute-small: ${{ steps.setup-outputs.outputs.compute-small }}
@@ -518,7 +518,7 @@ jobs:
 
   go-tests-success:
     needs:
-    #- conditional-skip
+    - conditional-skip
     - setup
     - check-codegen
     - check-generated-protobuf
@@ -542,7 +542,7 @@ jobs:
     - go-test-testing-deployer
     # - go-test-s390x
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
-   # if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
+    if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
       - name: evaluate upstream job results
         run: |

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -33,14 +33,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  #conditional-skip:
-  #  uses: ./.github/workflows/reusable-conditional-skip.yml
+  conditional-skip:
+    uses: ./.github/workflows/reusable-conditional-skip.yml
 
   setup:
-    #needs: [conditional-skip]
+    needs: [conditional-skip]
     runs-on: ubuntu-latest
     name: Setup
-    #if: needs.conditional-skip.outputs.skip-ci != 'true'
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
     outputs:
       compute-small: ${{ steps.runners.outputs.compute-small }}
       compute-medium: ${{ steps.runners.outputs.compute-medium }}
@@ -603,7 +603,7 @@ jobs:
 
   test-integrations-success:
     needs:
-   # - conditional-skip
+    - conditional-skip
     - setup
     - dev-build
     - nomad-integration-test


### PR DESCRIPTION
Reverting the changes introduced for `conditional-skip check ` due to [copyright header update PR](https://github.com/hashicorp/consul/pull/23509)