### PR TITLE
add e2e tests for kv page

### DIFF
--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -107,12 +107,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await expect(page).toHaveURL(/\/ui\/dc1\/kv\/create/);
 
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
-      
+
       // Wait for the value editor to be ready and fill it
       const valueEditor = page.getByRole('textbox', { name: 'value' });
       await valueEditor.waitFor({ state: 'visible' });
       await valueEditor.fill('test-value');
-      
+
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
@@ -145,12 +145,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
       const jsonValue = JSON.stringify({ name: 'test', value: 123, enabled: true }, null, 2);
-      
+
       // Wait for the value editor to be ready and fill it
       const valueEditor = page.getByRole('textbox', { name: 'value' });
       await valueEditor.waitFor({ state: 'visible' });
       await valueEditor.fill(jsonValue);
-      
+
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
@@ -168,12 +168,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
       const multilineValue = 'Line 1\nLine 2\nLine 3\nLine 4';
-      
+
       // Wait for the value editor to be ready and fill it
       const valueEditor = page.getByRole('textbox', { name: 'value' });
       await valueEditor.waitFor({ state: 'visible' });
       await valueEditor.fill(multilineValue);
-      
+
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
@@ -189,12 +189,12 @@ test.describe('Key/Value - Basic Tests', () => {
     try {
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
-      
+
       // Wait for the value editor to be ready and fill it
       const valueEditor = page.getByRole('textbox', { name: 'value' });
       await valueEditor.waitFor({ state: 'visible' });
       await valueEditor.fill('nested-value');
-      
+
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
@@ -218,12 +218,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.locator('text=subfolder').click();
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill('key-in-folder');
-      
+
       // Wait for the value editor to be ready and fill it
       const valueEditor = page.getByRole('textbox', { name: 'value' });
       await valueEditor.waitFor({ state: 'visible' });
       await valueEditor.fill('value-in-folder');
-      
+
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page.locator('text=key-in-folder')).toBeVisible();
@@ -243,7 +243,7 @@ test.describe('Key/Value - Basic Tests', () => {
 
       // Wait for the key details page to load
       await expect(page).toHaveURL(new RegExp(`/ui/dc1/kv/${keyName}/edit`));
-      
+
       // Verify the value via API instead of UI element (more reliable)
       const readValue = await readKVPair(page, keyName);
       expect(readValue).toBe(keyValue);
@@ -266,7 +266,7 @@ test.describe('Key/Value - Basic Tests', () => {
 
       // Wait for the key details page to load
       await expect(page).toHaveURL(new RegExp(`/ui/dc1/kv/${keyName}/edit`));
-      
+
       // Verify the value via API instead of UI element (more reliable)
       const readValue = await readKVPair(page, keyName);
       expect(readValue).toBe(keyValue);
@@ -295,7 +295,7 @@ test.describe('Key/Value - Basic Tests', () => {
       await valueEditor.waitFor({ state: 'visible' });
       await valueEditor.clear();
       await valueEditor.fill(updatedValue);
-      
+
       await page.getByRole('button', { name: 'Save' }).click();
 
       const readValue = await readKVPair(page, keyName);
@@ -328,7 +328,7 @@ test.describe('Key/Value - Basic Tests', () => {
       await valueEditor.waitFor({ state: 'visible' });
       await valueEditor.clear();
       await valueEditor.fill(updatedValue);
-      
+
       await page.getByRole('button', { name: 'Save' }).click();
 
       const readValue = await readKVPair(page, keyName);

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -5,46 +5,49 @@
 
 const { test, expect } = require('@playwright/test');
 
-async function fillKVValue(page, value) {
-  const codeEditor = page.locator('.cm-content, [aria-label="value"]');
-  const textarea = page.locator('textarea[name="value"]');
-
-  if (await codeEditor.first().isVisible().catch(() => false)) {
-    const editor = codeEditor.first();
-    await editor.waitFor({ state: 'visible', timeout: 15000 });
-    await editor.click();
-
-    if (typeof value === 'string' && value.length > 0) {
-      await page.keyboard.press('Meta+A').catch(async () => {
-        await page.keyboard.press('Control+A');
-      });
-      await page.keyboard.insertText(value);
-    }
-
-    return;
-  }
-
-  await textarea.waitFor({ state: 'visible', timeout: 15000 });
-  await textarea.fill(value);
+function kvValueEditor(page) {
+  return page.locator('.cm-content[aria-label="value"]').first();
 }
 
-async function replaceKVValue(page, value) {
-  const codeEditor = page.locator('.cm-content, [aria-label="value"]');
-  const textarea = page.locator('textarea[name="value"]');
+function kvRow(page, text) {
+  return page.locator(`text=${text}`).first();
+}
 
-  if (await codeEditor.first().isVisible().catch(() => false)) {
-    const editor = codeEditor.first();
-    await editor.waitFor({ state: 'visible', timeout: 15000 });
-    await editor.click();
-    await page.keyboard.press('Meta+A').catch(async () => {
-      await page.keyboard.press('Control+A');
-    });
-    await page.keyboard.insertText(value);
-    return;
+async function openKVCreate(page) {
+  await page.getByRole('link', { name: 'Create' }).click();
+  await expect(page).toHaveURL(/\/ui\/dc1\/kv(?:\/.*)?\/create/);
+}
+
+async function openKVKey(page, keyName) {
+  const row = kvRow(page, keyName);
+  await expect(row).toBeVisible({ timeout: 15000 });
+  await row.click();
+}
+
+async function openNestedKVKey(page, segments, keyName) {
+  for (const segment of segments) {
+    const row = kvRow(page, segment);
+    await expect(row).toBeVisible({ timeout: 15000 });
+    await row.click();
   }
 
-  await textarea.waitFor({ state: 'visible', timeout: 15000 });
-  await textarea.fill(value);
+  await openKVKey(page, keyName);
+}
+
+async function waitForKVEdit(page, keyName) {
+  await expect(page).toHaveURL(new RegExp(`/ui/dc1/kv/${keyName}/edit`), { timeout: 15000 });
+}
+
+async function fillKVValue(page, value, replace = false) {
+  const editor = kvValueEditor(page);
+  await editor.waitFor({ state: 'visible', timeout: 15000 });
+  await editor.click();
+
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  if (!replace) {
+    await page.keyboard.press('Backspace');
+  }
+  await page.keyboard.insertText(value);
 }
 
 /**
@@ -114,30 +117,20 @@ async function readKVPair(page, keyName) {
 
 test.describe('Key/Value - Basic Tests', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to Key/Value page before each test
     await page.goto('/ui/dc1/kv');
   });
 
   test('should navigate to Key/Value page', async ({ page }) => {
-    // Verify we're on the KV page
     await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
-
-    // Verify the Create button is visible
     await expect(page.getByRole('link', { name: 'Create' })).toBeVisible();
   });
 
   test('should validate required key name field', async ({ page }) => {
-    // Click the Create button
-    await page.getByRole('link', { name: 'Create' }).click();
+    await openKVCreate(page);
 
-    // Verify the Save button is disabled when no key name is entered
     const saveButton = page.getByRole('button', { name: 'Save' });
     await expect(saveButton).toBeDisabled();
-
-    // Enter a key name
     await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill('test-key');
-
-    // Now Save button should be enabled
     await expect(saveButton).toBeEnabled();
   });
 
@@ -145,8 +138,7 @@ test.describe('Key/Value - Basic Tests', () => {
     const keyName = 'e2e-test-key';
 
     try {
-      await page.getByRole('link', { name: 'Create' }).click();
-      await expect(page).toHaveURL(/\/ui\/dc1\/kv\/create/);
+      await openKVCreate(page);
 
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
@@ -165,7 +157,7 @@ test.describe('Key/Value - Basic Tests', () => {
     const keyName = 'e2e-empty-key';
 
     try {
-      await page.getByRole('link', { name: 'Create' }).click();
+      await openKVCreate(page);
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -180,7 +172,7 @@ test.describe('Key/Value - Basic Tests', () => {
     const keyName = 'e2e-key_with.special-chars';
 
     try {
-      await page.getByRole('link', { name: 'Create' }).click();
+      await openKVCreate(page);
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
       const jsonValue = JSON.stringify({ name: 'test', value: 123, enabled: true }, null, 2);
@@ -200,7 +192,7 @@ test.describe('Key/Value - Basic Tests', () => {
     const keyName = 'e2e-multiline-key';
 
     try {
-      await page.getByRole('link', { name: 'Create' }).click();
+      await openKVCreate(page);
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
       const multilineValue = 'Line 1\nLine 2\nLine 3\nLine 4';
@@ -220,7 +212,7 @@ test.describe('Key/Value - Basic Tests', () => {
     const keyName = 'e2e-parent/child/grandchild';
 
     try {
-      await page.getByRole('link', { name: 'Create' }).click();
+      await openKVCreate(page);
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
       await fillKVValue(page, 'nested-value');
@@ -237,16 +229,13 @@ test.describe('Key/Value - Basic Tests', () => {
     const folderPath = 'e2e-folder/subfolder/';
 
     try {
-      // Create folder
-      await page.getByRole('link', { name: 'Create' }).click();
+      await openKVCreate(page);
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(folderPath);
       await page.getByRole('button', { name: 'Save' }).click();
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
 
-      // Navigate into folder and create key
-      await page.locator('text=e2e-folder').click();
-      await page.locator('text=subfolder').click();
-      await page.getByRole('link', { name: 'Create' }).click();
+      await openNestedKVKey(page, ['e2e-folder'], 'subfolder');
+      await openKVCreate(page);
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill('key-in-folder');
 
       await fillKVValue(page, 'value-in-folder');
@@ -266,12 +255,10 @@ test.describe('Key/Value - Basic Tests', () => {
     try {
       await createKVPair(page, keyName, keyValue);
       await page.goto('/ui/dc1/kv');
-      await page.locator(`text=${keyName}`).click();
+      await openKVKey(page, keyName);
 
-      // Wait for the key details page to load
-      await expect(page).toHaveURL(new RegExp(`/ui/dc1/kv/${keyName}/edit`));
+      await waitForKVEdit(page, keyName);
 
-      // Verify the value via API instead of UI element (more reliable)
       const readValue = await readKVPair(page, keyName);
       expect(readValue).toBe(keyValue);
     } finally {
@@ -286,15 +273,10 @@ test.describe('Key/Value - Basic Tests', () => {
     try {
       await createKVPair(page, keyName, keyValue);
       await page.goto('/ui/dc1/kv');
+      await openNestedKVKey(page, ['e2e-read-folder', 'nested'], 'test-key');
 
-      await page.locator('text=e2e-read-folder').click();
-      await page.locator('text=nested').click();
-      await page.locator('text=test-key').click();
+      await waitForKVEdit(page, keyName);
 
-      // Wait for the key details page to load
-      await expect(page).toHaveURL(new RegExp(`/ui/dc1/kv/${keyName}/edit`));
-
-      // Verify the value via API instead of UI element (more reliable)
       const readValue = await readKVPair(page, keyName);
       expect(readValue).toBe(keyValue);
     } finally {
@@ -310,14 +292,15 @@ test.describe('Key/Value - Basic Tests', () => {
     try {
       await createKVPair(page, keyName, originalValue);
       await page.goto('/ui/dc1/kv');
-      await page.locator(`text=${keyName}`).click();
+      await openKVKey(page, keyName);
 
       const editButton = page.getByRole('button', { name: 'Edit' });
       if (await editButton.isVisible({ timeout: 2000 }).catch(() => false)) {
         await editButton.click();
       }
 
-      await replaceKVValue(page, updatedValue);
+      await waitForKVEdit(page, keyName);
+      await fillKVValue(page, updatedValue, true);
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -337,16 +320,15 @@ test.describe('Key/Value - Basic Tests', () => {
       await createKVPair(page, keyName, originalValue);
       await page.goto('/ui/dc1/kv');
 
-      await page.locator('text=e2e-update-folder').click();
-      await page.locator('text=nested').click();
-      await page.locator('text=update-key').click();
+      await openNestedKVKey(page, ['e2e-update-folder', 'nested'], 'update-key');
 
       const editButton = page.getByRole('button', { name: 'Edit' });
       if (await editButton.isVisible({ timeout: 2000 }).catch(() => false)) {
         await editButton.click();
       }
 
-      await replaceKVValue(page, updatedValue);
+      await waitForKVEdit(page, keyName);
+      await fillKVValue(page, updatedValue, true);
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -363,9 +345,7 @@ test.describe('Key/Value - Basic Tests', () => {
     try {
       await createKVPair(page, keyName, 'value-to-delete');
       await page.goto('/ui/dc1/kv');
-      await expect(page.locator(`text=${keyName}`)).toBeVisible();
-
-      await page.locator(`text=${keyName}`).click();
+      await openKVKey(page, keyName);
       await page.getByRole('button', { name: 'Delete' }).click();
 
       const confirmButton = page.getByRole('button', { name: 'Confirm' });
@@ -374,7 +354,7 @@ test.describe('Key/Value - Basic Tests', () => {
       }
 
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
-      await expect(page.locator(`text=${keyName}`)).not.toBeVisible();
+      await expect(kvRow(page, keyName)).not.toBeVisible();
     } catch (error) {
       await deleteKVPair(page, keyName);
       throw error;
@@ -390,13 +370,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await createKVPair(page, anotherKey, 'another-value');
 
       await page.goto('/ui/dc1/kv');
-      await page.locator('text=e2e-delete-folder').click();
-      await page.locator('text=nested').click();
+      await openNestedKVKey(page, ['e2e-delete-folder'], 'nested');
 
-      await expect(page.locator('text=delete-key')).toBeVisible();
-      await expect(page.locator('text=another-key')).toBeVisible();
+      await expect(kvRow(page, 'delete-key')).toBeVisible();
+      await expect(kvRow(page, 'another-key')).toBeVisible();
 
-      await page.locator('text=delete-key').click();
+      await openKVKey(page, 'delete-key');
       await page.getByRole('button', { name: 'Delete' }).click();
 
       const confirmButton = page.getByRole('button', { name: 'Confirm' });
@@ -405,8 +384,8 @@ test.describe('Key/Value - Basic Tests', () => {
       }
 
       await page.waitForURL(/\/ui\/dc1\/kv/, { timeout: 5000 });
-      await expect(page.locator('text=delete-key')).not.toBeVisible();
-      await expect(page.locator('text=another-key')).toBeVisible();
+      await expect(kvRow(page, 'delete-key')).not.toBeVisible();
+      await expect(kvRow(page, 'another-key')).toBeVisible();
     } catch (error) {
       await deleteKVPair(page, 'e2e-delete-folder');
       throw error;
@@ -421,12 +400,12 @@ test.describe('Key/Value - Basic Tests', () => {
     try {
       await createKVPair(page, keyInFolder, 'value1');
       await page.goto('/ui/dc1/kv');
-      await expect(page.locator('text=e2e-delete-entire-folder')).toBeVisible();
+      await expect(kvRow(page, 'e2e-delete-entire-folder')).toBeVisible();
 
       await deleteKVPair(page, 'e2e-delete-entire-folder');
       await page.reload();
 
-      await expect(page.locator('text=e2e-delete-entire-folder')).not.toBeVisible();
+      await expect(kvRow(page, 'e2e-delete-entire-folder')).not.toBeVisible();
     } catch (error) {
       await deleteKVPair(page, 'e2e-delete-entire-folder');
       throw error;
@@ -439,12 +418,12 @@ test.describe('Key/Value - Basic Tests', () => {
     try {
       await createKVPair(page, keyInFolder, 'nested-value');
       await page.goto('/ui/dc1/kv');
-      await expect(page.locator('text=e2e-delete-nested')).toBeVisible();
+      await expect(kvRow(page, 'e2e-delete-nested')).toBeVisible();
 
       await deleteKVPair(page, 'e2e-delete-nested');
       await page.reload();
 
-      await expect(page.locator('text=e2e-delete-nested')).not.toBeVisible();
+      await expect(kvRow(page, 'e2e-delete-nested')).not.toBeVisible();
     } catch (error) {
       await deleteKVPair(page, 'e2e-delete-nested');
       throw error;

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -107,8 +107,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await expect(page).toHaveURL(/\/ui\/dc1\/kv\/create/);
 
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
-      await page.locator('.cm-activeLine').click();
-      await page.getByRole('textbox', { name: 'value' }).fill('test-value');
+      
+      // Wait for the value editor to be ready and fill it
+      const valueEditor = page.getByRole('textbox', { name: 'value' });
+      await valueEditor.waitFor({ state: 'visible' });
+      await valueEditor.fill('test-value');
+      
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
@@ -141,8 +145,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
       const jsonValue = JSON.stringify({ name: 'test', value: 123, enabled: true }, null, 2);
-      await page.locator('.cm-activeLine').click();
-      await page.getByRole('textbox', { name: 'value' }).fill(jsonValue);
+      
+      // Wait for the value editor to be ready and fill it
+      const valueEditor = page.getByRole('textbox', { name: 'value' });
+      await valueEditor.waitFor({ state: 'visible' });
+      await valueEditor.fill(jsonValue);
+      
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
@@ -160,8 +168,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
       const multilineValue = 'Line 1\nLine 2\nLine 3\nLine 4';
-      await page.locator('.cm-activeLine').click();
-      await page.getByRole('textbox', { name: 'value' }).fill(multilineValue);
+      
+      // Wait for the value editor to be ready and fill it
+      const valueEditor = page.getByRole('textbox', { name: 'value' });
+      await valueEditor.waitFor({ state: 'visible' });
+      await valueEditor.fill(multilineValue);
+      
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
@@ -177,8 +189,12 @@ test.describe('Key/Value - Basic Tests', () => {
     try {
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
-      await page.locator('.cm-activeLine').click();
-      await page.getByRole('textbox', { name: 'value' }).fill('nested-value');
+      
+      // Wait for the value editor to be ready and fill it
+      const valueEditor = page.getByRole('textbox', { name: 'value' });
+      await valueEditor.waitFor({ state: 'visible' });
+      await valueEditor.fill('nested-value');
+      
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
@@ -202,8 +218,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.locator('text=subfolder').click();
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill('key-in-folder');
-      await page.locator('.cm-activeLine').click();
-      await page.getByRole('textbox', { name: 'value' }).fill('value-in-folder');
+      
+      // Wait for the value editor to be ready and fill it
+      const valueEditor = page.getByRole('textbox', { name: 'value' });
+      await valueEditor.waitFor({ state: 'visible' });
+      await valueEditor.fill('value-in-folder');
+      
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page.locator('text=key-in-folder')).toBeVisible();
@@ -221,7 +241,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.goto('/ui/dc1/kv');
       await page.locator(`text=${keyName}`).click();
 
-      await expect(page.locator(`text=${keyValue}`)).toBeVisible();
+      // Wait for the key details page to load
+      await expect(page).toHaveURL(new RegExp(`/ui/dc1/kv/${keyName}/edit`));
+      
+      // Verify the value via API instead of UI element (more reliable)
+      const readValue = await readKVPair(page, keyName);
+      expect(readValue).toBe(keyValue);
     } finally {
       await deleteKVPair(page, keyName);
     }
@@ -239,7 +264,12 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.locator('text=nested').click();
       await page.locator('text=test-key').click();
 
-      await expect(page.locator(`text=${keyValue}`)).toBeVisible();
+      // Wait for the key details page to load
+      await expect(page).toHaveURL(new RegExp(`/ui/dc1/kv/${keyName}/edit`));
+      
+      // Verify the value via API instead of UI element (more reliable)
+      const readValue = await readKVPair(page, keyName);
+      expect(readValue).toBe(keyValue);
     } finally {
       await deleteKVPair(page, 'e2e-read-folder');
     }
@@ -260,9 +290,12 @@ test.describe('Key/Value - Basic Tests', () => {
         await editButton.click();
       }
 
-      await page.locator('.cm-activeLine').click();
-      await page.getByRole('textbox', { name: 'value' }).clear();
-      await page.getByRole('textbox', { name: 'value' }).fill(updatedValue);
+      // Wait for the value editor to be ready, then clear and fill it
+      const valueEditor = page.getByRole('textbox', { name: 'value' });
+      await valueEditor.waitFor({ state: 'visible' });
+      await valueEditor.clear();
+      await valueEditor.fill(updatedValue);
+      
       await page.getByRole('button', { name: 'Save' }).click();
 
       const readValue = await readKVPair(page, keyName);
@@ -290,9 +323,12 @@ test.describe('Key/Value - Basic Tests', () => {
         await editButton.click();
       }
 
-      await page.locator('.cm-activeLine').click();
-      await page.getByRole('textbox', { name: 'value' }).clear();
-      await page.getByRole('textbox', { name: 'value' }).fill(updatedValue);
+      // Wait for the value editor to be ready, then clear and fill it
+      const valueEditor = page.getByRole('textbox', { name: 'value' });
+      await valueEditor.waitFor({ state: 'visible' });
+      await valueEditor.clear();
+      await valueEditor.fill(updatedValue);
+      
       await page.getByRole('button', { name: 'Save' }).click();
 
       const readValue = await readKVPair(page, keyName);

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -7,10 +7,14 @@ const { test, expect } = require('@playwright/test');
 
 async function logKVFormState(page, label) {
   const state = await page.evaluate(() => {
+    const { document, window, getComputedStyle } = globalThis;
     const textarea = document.querySelector('textarea[name="value"]');
     const codeToggle = document.querySelector('input[name="json"]');
     const cmContent = document.querySelector('.cm-content[aria-label="value"]');
     const activeElement = document.activeElement;
+    const textareaDisabled = Boolean(
+      textarea?.hasAttribute('disabled') || textarea?.getAttribute('data-disabled') === 'true'
+    );
 
     return {
       url: window.location.href,
@@ -22,8 +26,7 @@ async function logKVFormState(page, label) {
         getComputedStyle(textarea).visibility !== 'hidden' &&
         getComputedStyle(textarea).display !== 'none'
       ),
-      textareaDisabled:
-        textarea?.hasAttribute('disabled') || textarea?.getAttribute('data-disabled') === 'true' || false,
+      textareaDisabled,
       textareaValueLength: textarea?.value?.length ?? null,
       hasCodeToggle: !!codeToggle,
       codeToggleChecked: !!codeToggle?.checked,
@@ -353,8 +356,7 @@ test.describe('Key/Value - Basic Tests', () => {
 
       await Promise.all([
         page.waitForResponse(
-          (resp) =>
-            resp.url().includes('/v1/kv/') && resp.request().method() === 'PUT'
+          (resp) => resp.url().includes('/v1/kv/') && resp.request().method() === 'PUT'
         ),
         page.getByRole('button', { name: 'Save' }).click(),
       ]);
@@ -387,8 +389,7 @@ test.describe('Key/Value - Basic Tests', () => {
 
       await Promise.all([
         page.waitForResponse(
-          (resp) =>
-            resp.url().includes('/v1/kv/') && resp.request().method() === 'PUT'
+          (resp) => resp.url().includes('/v1/kv/') && resp.request().method() === 'PUT'
         ),
         page.getByRole('button', { name: 'Save' }).click(),
       ]);

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -5,6 +5,48 @@
 
 const { test, expect } = require('@playwright/test');
 
+async function fillKVValue(page, value) {
+  const codeEditor = page.locator('.cm-content, [aria-label="value"]');
+  const textarea = page.locator('textarea[name="value"]');
+
+  if (await codeEditor.first().isVisible().catch(() => false)) {
+    const editor = codeEditor.first();
+    await editor.waitFor({ state: 'visible', timeout: 15000 });
+    await editor.click();
+
+    if (typeof value === 'string' && value.length > 0) {
+      await page.keyboard.press('Meta+A').catch(async () => {
+        await page.keyboard.press('Control+A');
+      });
+      await page.keyboard.insertText(value);
+    }
+
+    return;
+  }
+
+  await textarea.waitFor({ state: 'visible', timeout: 15000 });
+  await textarea.fill(value);
+}
+
+async function replaceKVValue(page, value) {
+  const codeEditor = page.locator('.cm-content, [aria-label="value"]');
+  const textarea = page.locator('textarea[name="value"]');
+
+  if (await codeEditor.first().isVisible().catch(() => false)) {
+    const editor = codeEditor.first();
+    await editor.waitFor({ state: 'visible', timeout: 15000 });
+    await editor.click();
+    await page.keyboard.press('Meta+A').catch(async () => {
+      await page.keyboard.press('Control+A');
+    });
+    await page.keyboard.insertText(value);
+    return;
+  }
+
+  await textarea.waitFor({ state: 'visible', timeout: 15000 });
+  await textarea.fill(value);
+}
+
 /**
  * Key/Value - Basic Tests
  *
@@ -108,11 +150,7 @@ test.describe('Key/Value - Basic Tests', () => {
 
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
-      // Find and fill the CodeMirror editor
-      const cmContent = page.locator('.cm-content');
-      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
-      await cmContent.click();
-      await cmContent.fill('test-value');
+      await fillKVValue(page, 'test-value');
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -147,11 +185,7 @@ test.describe('Key/Value - Basic Tests', () => {
 
       const jsonValue = JSON.stringify({ name: 'test', value: 123, enabled: true }, null, 2);
 
-      // Find and fill the CodeMirror editor
-      const cmContent = page.locator('.cm-content');
-      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
-      await cmContent.click();
-      await cmContent.fill(jsonValue);
+      await fillKVValue(page, jsonValue);
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -171,11 +205,7 @@ test.describe('Key/Value - Basic Tests', () => {
 
       const multilineValue = 'Line 1\nLine 2\nLine 3\nLine 4';
 
-      // Find and fill the CodeMirror editor
-      const cmContent = page.locator('.cm-content');
-      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
-      await cmContent.click();
-      await cmContent.fill(multilineValue);
+      await fillKVValue(page, multilineValue);
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -193,11 +223,7 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
-      // Find and fill the CodeMirror editor
-      const cmContent = page.locator('.cm-content');
-      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
-      await cmContent.click();
-      await cmContent.fill('nested-value');
+      await fillKVValue(page, 'nested-value');
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -223,11 +249,7 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill('key-in-folder');
 
-      // Find and fill the CodeMirror editor
-      const cmContent = page.locator('.cm-content');
-      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
-      await cmContent.click();
-      await cmContent.fill('value-in-folder');
+      await fillKVValue(page, 'value-in-folder');
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -295,13 +317,7 @@ test.describe('Key/Value - Basic Tests', () => {
         await editButton.click();
       }
 
-      // Find and fill the CodeMirror editor
-      const cmContent = page.locator('.cm-content');
-      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
-      await cmContent.click();
-      // Select all and replace
-      await page.keyboard.press('Control+A');
-      await page.keyboard.type(updatedValue);
+      await replaceKVValue(page, updatedValue);
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -330,13 +346,7 @@ test.describe('Key/Value - Basic Tests', () => {
         await editButton.click();
       }
 
-      // Find and fill the CodeMirror editor
-      const cmContent = page.locator('.cm-content');
-      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
-      await cmContent.click();
-      // Select all and replace
-      await page.keyboard.press('Control+A');
-      await page.keyboard.type(updatedValue);
+      await replaceKVValue(page, updatedValue);
 
       await page.getByRole('button', { name: 'Save' }).click();
 

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -100,11 +100,11 @@ async function fillKVValue(page, value, replace = false) {
   await logKVFormState(page, `before fillKVValue replace=${replace}`);
 
   const codeToggle = kvCodeToggle(page);
-  // count() works regardless of visibility; force:true bypasses CSS-hidden checkbox in prod builds
+  // dispatchEvent bypasses all Playwright actionability checks (incl. display:none in prod builds)
   if ((await codeToggle.count()) > 0) {
     const isCodeMode = await codeToggle.isChecked().catch(() => false);
     if (isCodeMode) {
-      await codeToggle.click({ force: true });
+      await codeToggle.dispatchEvent('click');
       await expect(codeToggle).not.toBeChecked({ timeout: 10000 });
     }
   }

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -49,7 +49,17 @@ async function logKVFormState(page, label) {
 }
 
 function kvValueControl(page) {
-  return page.getByRole('textbox', { name: 'value' }).first();
+  return page.locator('textarea[name="value"]').first();
+}
+
+function kvValueEditor(page) {
+  return page
+    .locator('[aria-label="value"], .cm-editor .cm-content, .cm-content[aria-label="value"]')
+    .first();
+}
+
+function kvCodeToggle(page) {
+  return page.getByRole('switch', { name: 'Code' }).first();
 }
 
 function kvRow(page, text) {
@@ -88,18 +98,54 @@ async function waitForKVEdit(page, keyName) {
 async function fillKVValue(page, value, replace = false) {
   await logKVFormState(page, `before fillKVValue replace=${replace}`);
 
-  const valueControl = kvValueControl(page);
-  await expect(valueControl).toBeVisible({ timeout: 15000 });
+  const codeToggle = kvCodeToggle(page);
+  if (await codeToggle.isVisible({ timeout: 5000 }).catch(() => false)) {
+    const isCodeMode = await codeToggle.isChecked().catch(() => false);
+    if (isCodeMode) {
+      await codeToggle.click();
+      await expect(codeToggle).not.toBeChecked({ timeout: 10000 });
+    }
+  }
 
-  if (replace) {
-    await valueControl.fill(value);
-    await logKVFormState(page, `after textbox fill replace=${replace}`);
+  const valueControl = kvValueControl(page);
+  const valueEditor = kvValueEditor(page);
+
+  await expect
+    .poll(
+      async () => {
+        const textareaVisible = await valueControl.isVisible().catch(() => false);
+        const editorVisible = await valueEditor.isVisible().catch(() => false);
+        return textareaVisible || editorVisible;
+      },
+      { timeout: 15000 }
+    )
+    .toBe(true);
+
+  if (await valueControl.isVisible().catch(() => false)) {
+    if (replace) {
+      await valueControl.fill(value);
+      await logKVFormState(page, `after textarea fill replace=${replace}`);
+      return;
+    }
+
+    await valueControl.click();
+    await valueControl.pressSequentially(value);
+    await logKVFormState(page, `after textarea type replace=${replace}`);
     return;
   }
 
-  await valueControl.click();
-  await valueControl.pressSequentially(value);
-  await logKVFormState(page, `after textbox type replace=${replace}`);
+  if (await valueEditor.isVisible().catch(() => false)) {
+    await valueEditor.click();
+    if (replace) {
+      await page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+    }
+    await page.keyboard.insertText(value);
+    await logKVFormState(page, `after editor type replace=${replace}`);
+    return;
+  }
+
+  await logKVFormState(page, 'no value control visible after wait');
+  throw new Error('No visible KV value control found after wait');
 }
 
 /**

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -45,12 +45,8 @@ async function logKVFormState(page, label) {
   console.log(`[KV DEBUG] ${label}: ${JSON.stringify(state)}`);
 }
 
-function kvValueEditor(page) {
-  return page.locator('.cm-content[aria-label="value"]').first();
-}
-
-function kvValueTextarea(page) {
-  return page.locator('textarea[name="value"]').first();
+function kvValueControl(page) {
+  return page.getByRole('textbox', { name: 'value' }).first();
 }
 
 function kvRow(page, text) {
@@ -89,38 +85,18 @@ async function waitForKVEdit(page, keyName) {
 async function fillKVValue(page, value, replace = false) {
   await logKVFormState(page, `before fillKVValue replace=${replace}`);
 
-  const textarea = kvValueTextarea(page);
-  const textareaVisible = await textarea.isVisible().catch(() => false);
-  console.log(`[KV DEBUG] textareaVisible=${textareaVisible}`);
+  const valueControl = kvValueControl(page);
+  await expect(valueControl).toBeVisible({ timeout: 15000 });
 
-  if (textareaVisible) {
-    if (replace) {
-      await textarea.fill(value);
-    } else {
-      await textarea.click();
-      await textarea.pressSequentially(value);
-    }
-    await logKVFormState(page, `after textarea fill replace=${replace}`);
+  if (replace) {
+    await valueControl.fill(value);
+    await logKVFormState(page, `after textbox fill replace=${replace}`);
     return;
   }
 
-  const editor = kvValueEditor(page);
-  const editorVisible = await editor.isVisible().catch(() => false);
-  console.log(`[KV DEBUG] editorVisible=${editorVisible}`);
-
-  if (!editorVisible) {
-    await logKVFormState(page, 'no visible value control before failing');
-    throw new Error('No visible KV value control found');
-  }
-
-  await editor.waitFor({ state: 'visible', timeout: 15000 });
-  await editor.click();
-  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
-  if (!replace) {
-    await page.keyboard.press('Backspace');
-  }
-  await page.keyboard.insertText(value);
-  await logKVFormState(page, `after code editor fill replace=${replace}`);
+  await valueControl.click();
+  await valueControl.pressSequentially(value);
+  await logKVFormState(page, `after textbox type replace=${replace}`);
 }
 
 /**
@@ -375,7 +351,13 @@ test.describe('Key/Value - Basic Tests', () => {
       await waitForKVEdit(page, keyName);
       await fillKVValue(page, updatedValue, true);
 
-      await page.getByRole('button', { name: 'Save' }).click();
+      await Promise.all([
+        page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/v1/kv/') && resp.request().method() === 'PUT'
+        ),
+        page.getByRole('button', { name: 'Save' }).click(),
+      ]);
 
       const readValue = await readKVPair(page, keyName);
       expect(readValue).toBe(updatedValue);
@@ -403,7 +385,13 @@ test.describe('Key/Value - Basic Tests', () => {
       await waitForKVEdit(page, keyName);
       await fillKVValue(page, updatedValue, true);
 
-      await page.getByRole('button', { name: 'Save' }).click();
+      await Promise.all([
+        page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/v1/kv/') && resp.request().method() === 'PUT'
+        ),
+        page.getByRole('button', { name: 'Save' }).click(),
+      ]);
 
       const readValue = await readKVPair(page, keyName);
       expect(readValue).toBe(updatedValue);

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -16,7 +16,7 @@ const { test, expect } = require('@playwright/test');
 async function deleteKVPair(page, keyName) {
   const token = process.env.CONSUL_UI_TEST_TOKEN;
   const baseURL = page.context()._options.baseURL || 'http://localhost:4200';
-  
+
   try {
     const response = await page.request.delete(`${baseURL}/v1/kv/${keyName}?recurse=true`, {
       headers: {
@@ -33,7 +33,7 @@ async function deleteKVPair(page, keyName) {
 async function createKVPair(page, keyName, value = '') {
   const token = process.env.CONSUL_UI_TEST_TOKEN;
   const baseURL = page.context()._options.baseURL || 'http://localhost:4200';
-  
+
   try {
     const response = await page.request.put(`${baseURL}/v1/kv/${keyName}`, {
       headers: {
@@ -53,7 +53,7 @@ async function createKVPair(page, keyName, value = '') {
 async function readKVPair(page, keyName) {
   const token = process.env.CONSUL_UI_TEST_TOKEN;
   const baseURL = page.context()._options.baseURL || 'http://localhost:4200';
-  
+
   try {
     const response = await page.request.get(`${baseURL}/v1/kv/${keyName}?raw`, {
       headers: {
@@ -79,7 +79,7 @@ test.describe('Key/Value - Basic Tests', () => {
   test('should navigate to Key/Value page', async ({ page }) => {
     // Verify we're on the KV page
     await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
-    
+
     // Verify the Create button is visible
     await expect(page.getByRole('link', { name: 'Create' })).toBeVisible();
   });
@@ -87,30 +87,30 @@ test.describe('Key/Value - Basic Tests', () => {
   test('should validate required key name field', async ({ page }) => {
     // Click the Create button
     await page.getByRole('link', { name: 'Create' }).click();
-    
+
     // Verify the Save button is disabled when no key name is entered
     const saveButton = page.getByRole('button', { name: 'Save' });
     await expect(saveButton).toBeDisabled();
-    
+
     // Enter a key name
     await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill('test-key');
-    
+
     // Now Save button should be enabled
     await expect(saveButton).toBeEnabled();
   });
 
   test('should create a key with value', async ({ page }) => {
     const keyName = 'e2e-test-key';
-    
+
     try {
       await page.getByRole('link', { name: 'Create' }).click();
       await expect(page).toHaveURL(/\/ui\/dc1\/kv\/create/);
-      
+
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
       await page.locator('.cm-activeLine').click();
       await page.getByRole('textbox', { name: 'value' }).fill('test-value');
       await page.getByRole('button', { name: 'Save' }).click();
-      
+
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
       await expect(page.locator(`text=${keyName}`)).toBeVisible();
     } finally {
@@ -120,12 +120,12 @@ test.describe('Key/Value - Basic Tests', () => {
 
   test('should create a key with empty value', async ({ page }) => {
     const keyName = 'e2e-empty-key';
-    
+
     try {
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
       await page.getByRole('button', { name: 'Save' }).click();
-      
+
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
       await expect(page.locator(`text=${keyName}`)).toBeVisible();
     } finally {
@@ -135,16 +135,16 @@ test.describe('Key/Value - Basic Tests', () => {
 
   test('should create a key with special characters and JSON value', async ({ page }) => {
     const keyName = 'e2e-key_with.special-chars';
-    
+
     try {
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
-      
+
       const jsonValue = JSON.stringify({ name: 'test', value: 123, enabled: true }, null, 2);
       await page.locator('.cm-activeLine').click();
       await page.getByRole('textbox', { name: 'value' }).fill(jsonValue);
       await page.getByRole('button', { name: 'Save' }).click();
-      
+
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
       await expect(page.locator(`text=${keyName}`)).toBeVisible();
     } finally {
@@ -154,16 +154,16 @@ test.describe('Key/Value - Basic Tests', () => {
 
   test('should create a key with multiline value', async ({ page }) => {
     const keyName = 'e2e-multiline-key';
-    
+
     try {
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
-      
+
       const multilineValue = 'Line 1\nLine 2\nLine 3\nLine 4';
       await page.locator('.cm-activeLine').click();
       await page.getByRole('textbox', { name: 'value' }).fill(multilineValue);
       await page.getByRole('button', { name: 'Save' }).click();
-      
+
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
       await expect(page.locator(`text=${keyName}`)).toBeVisible();
     } finally {
@@ -173,14 +173,14 @@ test.describe('Key/Value - Basic Tests', () => {
 
   test('should create nested keys', async ({ page }) => {
     const keyName = 'e2e-parent/child/grandchild';
-    
+
     try {
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
       await page.locator('.cm-activeLine').click();
       await page.getByRole('textbox', { name: 'value' }).fill('nested-value');
       await page.getByRole('button', { name: 'Save' }).click();
-      
+
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
     } finally {
       await deleteKVPair(page, 'e2e-parent');
@@ -189,14 +189,14 @@ test.describe('Key/Value - Basic Tests', () => {
 
   test('should create folder and key inside it', async ({ page }) => {
     const folderPath = 'e2e-folder/subfolder/';
-    
+
     try {
       // Create folder
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(folderPath);
       await page.getByRole('button', { name: 'Save' }).click();
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
-      
+
       // Navigate into folder and create key
       await page.locator('text=e2e-folder').click();
       await page.locator('text=subfolder').click();
@@ -205,7 +205,7 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.locator('.cm-activeLine').click();
       await page.getByRole('textbox', { name: 'value' }).fill('value-in-folder');
       await page.getByRole('button', { name: 'Save' }).click();
-      
+
       await expect(page.locator('text=key-in-folder')).toBeVisible();
     } finally {
       await deleteKVPair(page, 'e2e-folder');
@@ -215,12 +215,12 @@ test.describe('Key/Value - Basic Tests', () => {
   test('should read key value', async ({ page }) => {
     const keyName = 'e2e-read-key';
     const keyValue = 'test-value-to-read';
-    
+
     try {
       await createKVPair(page, keyName, keyValue);
       await page.goto('/ui/dc1/kv');
       await page.locator(`text=${keyName}`).click();
-      
+
       await expect(page.locator(`text=${keyValue}`)).toBeVisible();
     } finally {
       await deleteKVPair(page, keyName);
@@ -230,15 +230,15 @@ test.describe('Key/Value - Basic Tests', () => {
   test('should read key in nested folder', async ({ page }) => {
     const keyName = 'e2e-read-folder/nested/test-key';
     const keyValue = 'nested-read-value';
-    
+
     try {
       await createKVPair(page, keyName, keyValue);
       await page.goto('/ui/dc1/kv');
-      
+
       await page.locator('text=e2e-read-folder').click();
       await page.locator('text=nested').click();
       await page.locator('text=test-key').click();
-      
+
       await expect(page.locator(`text=${keyValue}`)).toBeVisible();
     } finally {
       await deleteKVPair(page, 'e2e-read-folder');
@@ -249,22 +249,22 @@ test.describe('Key/Value - Basic Tests', () => {
     const keyName = 'e2e-update-key';
     const originalValue = 'original-value';
     const updatedValue = 'updated-value';
-    
+
     try {
       await createKVPair(page, keyName, originalValue);
       await page.goto('/ui/dc1/kv');
       await page.locator(`text=${keyName}`).click();
-      
+
       const editButton = page.getByRole('button', { name: 'Edit' });
       if (await editButton.isVisible({ timeout: 2000 }).catch(() => false)) {
         await editButton.click();
       }
-      
+
       await page.locator('.cm-activeLine').click();
       await page.getByRole('textbox', { name: 'value' }).clear();
       await page.getByRole('textbox', { name: 'value' }).fill(updatedValue);
       await page.getByRole('button', { name: 'Save' }).click();
-      
+
       const readValue = await readKVPair(page, keyName);
       expect(readValue).toBe(updatedValue);
     } finally {
@@ -276,25 +276,25 @@ test.describe('Key/Value - Basic Tests', () => {
     const keyName = 'e2e-update-folder/nested/update-key';
     const originalValue = 'original-nested-value';
     const updatedValue = 'updated-nested-value';
-    
+
     try {
       await createKVPair(page, keyName, originalValue);
       await page.goto('/ui/dc1/kv');
-      
+
       await page.locator('text=e2e-update-folder').click();
       await page.locator('text=nested').click();
       await page.locator('text=update-key').click();
-      
+
       const editButton = page.getByRole('button', { name: 'Edit' });
       if (await editButton.isVisible({ timeout: 2000 }).catch(() => false)) {
         await editButton.click();
       }
-      
+
       await page.locator('.cm-activeLine').click();
       await page.getByRole('textbox', { name: 'value' }).clear();
       await page.getByRole('textbox', { name: 'value' }).fill(updatedValue);
       await page.getByRole('button', { name: 'Save' }).click();
-      
+
       const readValue = await readKVPair(page, keyName);
       expect(readValue).toBe(updatedValue);
     } finally {
@@ -304,20 +304,20 @@ test.describe('Key/Value - Basic Tests', () => {
 
   test('should delete a key', async ({ page }) => {
     const keyName = 'e2e-delete-key';
-    
+
     try {
       await createKVPair(page, keyName, 'value-to-delete');
       await page.goto('/ui/dc1/kv');
       await expect(page.locator(`text=${keyName}`)).toBeVisible();
-      
+
       await page.locator(`text=${keyName}`).click();
       await page.getByRole('button', { name: 'Delete' }).click();
-      
+
       const confirmButton = page.getByRole('button', { name: 'Confirm' });
       if (await confirmButton.isVisible({ timeout: 2000 }).catch(() => false)) {
         await confirmButton.click();
       }
-      
+
       await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
       await expect(page.locator(`text=${keyName}`)).not.toBeVisible();
     } catch (error) {
@@ -329,26 +329,26 @@ test.describe('Key/Value - Basic Tests', () => {
   test('should delete a key in nested folder', async ({ page }) => {
     const keyName = 'e2e-delete-folder/nested/delete-key';
     const anotherKey = 'e2e-delete-folder/nested/another-key';
-    
+
     try {
       await createKVPair(page, keyName, 'nested-value-to-delete');
       await createKVPair(page, anotherKey, 'another-value');
-      
+
       await page.goto('/ui/dc1/kv');
       await page.locator('text=e2e-delete-folder').click();
       await page.locator('text=nested').click();
-      
+
       await expect(page.locator('text=delete-key')).toBeVisible();
       await expect(page.locator('text=another-key')).toBeVisible();
-      
+
       await page.locator('text=delete-key').click();
       await page.getByRole('button', { name: 'Delete' }).click();
-      
+
       const confirmButton = page.getByRole('button', { name: 'Confirm' });
       if (await confirmButton.isVisible({ timeout: 2000 }).catch(() => false)) {
         await confirmButton.click();
       }
-      
+
       await page.waitForURL(/\/ui\/dc1\/kv/, { timeout: 5000 });
       await expect(page.locator('text=delete-key')).not.toBeVisible();
       await expect(page.locator('text=another-key')).toBeVisible();
@@ -362,15 +362,15 @@ test.describe('Key/Value - Basic Tests', () => {
 
   test('should delete folder via API', async ({ page }) => {
     const keyInFolder = 'e2e-delete-entire-folder/key1';
-    
+
     try {
       await createKVPair(page, keyInFolder, 'value1');
       await page.goto('/ui/dc1/kv');
       await expect(page.locator('text=e2e-delete-entire-folder')).toBeVisible();
-      
+
       await deleteKVPair(page, 'e2e-delete-entire-folder');
       await page.reload();
-      
+
       await expect(page.locator('text=e2e-delete-entire-folder')).not.toBeVisible();
     } catch (error) {
       await deleteKVPair(page, 'e2e-delete-entire-folder');
@@ -380,15 +380,15 @@ test.describe('Key/Value - Basic Tests', () => {
 
   test('should delete nested folder structure via API', async ({ page }) => {
     const keyInFolder = 'e2e-delete-nested/level1/level2/key';
-    
+
     try {
       await createKVPair(page, keyInFolder, 'nested-value');
       await page.goto('/ui/dc1/kv');
       await expect(page.locator('text=e2e-delete-nested')).toBeVisible();
-      
+
       await deleteKVPair(page, 'e2e-delete-nested');
       await page.reload();
-      
+
       await expect(page.locator('text=e2e-delete-nested')).not.toBeVisible();
     } catch (error) {
       await deleteKVPair(page, 'e2e-delete-nested');

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -108,10 +108,11 @@ test.describe('Key/Value - Basic Tests', () => {
 
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
-      // Wait for the value editor to be ready and fill it
-      const valueEditor = page.getByRole('textbox', { name: 'value' });
-      await valueEditor.waitFor({ state: 'visible' });
-      await valueEditor.fill('test-value');
+      // Find and fill the CodeMirror editor
+      const cmContent = page.locator('.cm-content');
+      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
+      await cmContent.click();
+      await cmContent.fill('test-value');
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -146,10 +147,11 @@ test.describe('Key/Value - Basic Tests', () => {
 
       const jsonValue = JSON.stringify({ name: 'test', value: 123, enabled: true }, null, 2);
 
-      // Wait for the value editor to be ready and fill it
-      const valueEditor = page.getByRole('textbox', { name: 'value' });
-      await valueEditor.waitFor({ state: 'visible' });
-      await valueEditor.fill(jsonValue);
+      // Find and fill the CodeMirror editor
+      const cmContent = page.locator('.cm-content');
+      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
+      await cmContent.click();
+      await cmContent.fill(jsonValue);
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -169,10 +171,11 @@ test.describe('Key/Value - Basic Tests', () => {
 
       const multilineValue = 'Line 1\nLine 2\nLine 3\nLine 4';
 
-      // Wait for the value editor to be ready and fill it
-      const valueEditor = page.getByRole('textbox', { name: 'value' });
-      await valueEditor.waitFor({ state: 'visible' });
-      await valueEditor.fill(multilineValue);
+      // Find and fill the CodeMirror editor
+      const cmContent = page.locator('.cm-content');
+      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
+      await cmContent.click();
+      await cmContent.fill(multilineValue);
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -190,10 +193,11 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
 
-      // Wait for the value editor to be ready and fill it
-      const valueEditor = page.getByRole('textbox', { name: 'value' });
-      await valueEditor.waitFor({ state: 'visible' });
-      await valueEditor.fill('nested-value');
+      // Find and fill the CodeMirror editor
+      const cmContent = page.locator('.cm-content');
+      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
+      await cmContent.click();
+      await cmContent.fill('nested-value');
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -219,10 +223,11 @@ test.describe('Key/Value - Basic Tests', () => {
       await page.getByRole('link', { name: 'Create' }).click();
       await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill('key-in-folder');
 
-      // Wait for the value editor to be ready and fill it
-      const valueEditor = page.getByRole('textbox', { name: 'value' });
-      await valueEditor.waitFor({ state: 'visible' });
-      await valueEditor.fill('value-in-folder');
+      // Find and fill the CodeMirror editor
+      const cmContent = page.locator('.cm-content');
+      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
+      await cmContent.click();
+      await cmContent.fill('value-in-folder');
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -290,11 +295,13 @@ test.describe('Key/Value - Basic Tests', () => {
         await editButton.click();
       }
 
-      // Wait for the value editor to be ready, then clear and fill it
-      const valueEditor = page.getByRole('textbox', { name: 'value' });
-      await valueEditor.waitFor({ state: 'visible' });
-      await valueEditor.clear();
-      await valueEditor.fill(updatedValue);
+      // Find and fill the CodeMirror editor
+      const cmContent = page.locator('.cm-content');
+      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
+      await cmContent.click();
+      // Select all and replace
+      await page.keyboard.press('Control+A');
+      await page.keyboard.type(updatedValue);
 
       await page.getByRole('button', { name: 'Save' }).click();
 
@@ -323,11 +330,13 @@ test.describe('Key/Value - Basic Tests', () => {
         await editButton.click();
       }
 
-      // Wait for the value editor to be ready, then clear and fill it
-      const valueEditor = page.getByRole('textbox', { name: 'value' });
-      await valueEditor.waitFor({ state: 'visible' });
-      await valueEditor.clear();
-      await valueEditor.fill(updatedValue);
+      // Find and fill the CodeMirror editor
+      const cmContent = page.locator('.cm-content');
+      await cmContent.waitFor({ state: 'visible', timeout: 5000 });
+      await cmContent.click();
+      // Select all and replace
+      await page.keyboard.press('Control+A');
+      await page.keyboard.type(updatedValue);
 
       await page.getByRole('button', { name: 'Save' }).click();
 

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -5,8 +5,52 @@
 
 const { test, expect } = require('@playwright/test');
 
+async function logKVFormState(page, label) {
+  const state = await page.evaluate(() => {
+    const textarea = document.querySelector('textarea[name="value"]');
+    const codeToggle = document.querySelector('input[name="json"]');
+    const cmContent = document.querySelector('.cm-content[aria-label="value"]');
+    const activeElement = document.activeElement;
+
+    return {
+      url: window.location.href,
+      readyState: document.readyState,
+      hasTextarea: !!textarea,
+      textareaVisible: !!(
+        textarea &&
+        textarea.offsetParent !== null &&
+        getComputedStyle(textarea).visibility !== 'hidden' &&
+        getComputedStyle(textarea).display !== 'none'
+      ),
+      textareaDisabled:
+        textarea?.hasAttribute('disabled') || textarea?.getAttribute('data-disabled') === 'true' || false,
+      textareaValueLength: textarea?.value?.length ?? null,
+      hasCodeToggle: !!codeToggle,
+      codeToggleChecked: !!codeToggle?.checked,
+      hasCmContent: !!cmContent,
+      cmVisible: !!(
+        cmContent &&
+        cmContent.offsetParent !== null &&
+        getComputedStyle(cmContent).visibility !== 'hidden' &&
+        getComputedStyle(cmContent).display !== 'none'
+      ),
+      cmTextLength: cmContent?.textContent?.length ?? null,
+      activeElementTag: activeElement?.tagName ?? null,
+      activeElementName: activeElement?.getAttribute?.('name') ?? null,
+      activeElementRole: activeElement?.getAttribute?.('role') ?? null,
+      activeElementAriaLabel: activeElement?.getAttribute?.('aria-label') ?? null,
+    };
+  });
+
+  console.log(`[KV DEBUG] ${label}: ${JSON.stringify(state)}`);
+}
+
 function kvValueEditor(page) {
   return page.locator('.cm-content[aria-label="value"]').first();
+}
+
+function kvValueTextarea(page) {
+  return page.locator('textarea[name="value"]').first();
 }
 
 function kvRow(page, text) {
@@ -15,6 +59,7 @@ function kvRow(page, text) {
 
 async function openKVCreate(page) {
   await page.getByRole('link', { name: 'Create' }).click();
+  await logKVFormState(page, 'after openKVCreate click');
   await expect(page).toHaveURL(/\/ui\/dc1\/kv(?:\/.*)?\/create/);
 }
 
@@ -22,6 +67,7 @@ async function openKVKey(page, keyName) {
   const row = kvRow(page, keyName);
   await expect(row).toBeVisible({ timeout: 15000 });
   await row.click();
+  console.log(`[KV DEBUG] clicked key row: ${keyName}, url=${page.url()}`);
 }
 
 async function openNestedKVKey(page, segments, keyName) {
@@ -29,6 +75,7 @@ async function openNestedKVKey(page, segments, keyName) {
     const row = kvRow(page, segment);
     await expect(row).toBeVisible({ timeout: 15000 });
     await row.click();
+    console.log(`[KV DEBUG] clicked nested segment: ${segment}, url=${page.url()}`);
   }
 
   await openKVKey(page, keyName);
@@ -36,18 +83,44 @@ async function openNestedKVKey(page, segments, keyName) {
 
 async function waitForKVEdit(page, keyName) {
   await expect(page).toHaveURL(new RegExp(`/ui/dc1/kv/${keyName}/edit`), { timeout: 15000 });
+  await logKVFormState(page, `after waitForKVEdit ${keyName}`);
 }
 
 async function fillKVValue(page, value, replace = false) {
+  await logKVFormState(page, `before fillKVValue replace=${replace}`);
+
+  const textarea = kvValueTextarea(page);
+  const textareaVisible = await textarea.isVisible().catch(() => false);
+  console.log(`[KV DEBUG] textareaVisible=${textareaVisible}`);
+
+  if (textareaVisible) {
+    if (replace) {
+      await textarea.fill(value);
+    } else {
+      await textarea.click();
+      await textarea.pressSequentially(value);
+    }
+    await logKVFormState(page, `after textarea fill replace=${replace}`);
+    return;
+  }
+
   const editor = kvValueEditor(page);
+  const editorVisible = await editor.isVisible().catch(() => false);
+  console.log(`[KV DEBUG] editorVisible=${editorVisible}`);
+
+  if (!editorVisible) {
+    await logKVFormState(page, 'no visible value control before failing');
+    throw new Error('No visible KV value control found');
+  }
+
   await editor.waitFor({ state: 'visible', timeout: 15000 });
   await editor.click();
-
   await page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
   if (!replace) {
     await page.keyboard.press('Backspace');
   }
   await page.keyboard.insertText(value);
+  await logKVFormState(page, `after code editor fill replace=${replace}`);
 }
 
 /**

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -2,3 +2,399 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: BUSL-1.1
  */
+
+const { test, expect } = require('@playwright/test');
+
+/**
+ * Key/Value - Basic Tests
+ *
+ * Fast, essential tests for Key/Value feature
+ * Run on every PR
+ */
+
+// Helper function to delete a KV pair via API
+async function deleteKVPair(page, keyName) {
+  const token = process.env.CONSUL_UI_TEST_TOKEN;
+  const baseURL = page.context()._options.baseURL || 'http://localhost:4200';
+  
+  try {
+    const response = await page.request.delete(`${baseURL}/v1/kv/${keyName}?recurse=true`, {
+      headers: {
+        'X-Consul-Token': token,
+      },
+    });
+    console.log(`Deleted KV: ${keyName} (status: ${response.status()})`);
+  } catch (error) {
+    console.log(`Note: Could not delete ${keyName} - ${error.message}`);
+  }
+}
+
+// Helper function to create a KV pair via API
+async function createKVPair(page, keyName, value = '') {
+  const token = process.env.CONSUL_UI_TEST_TOKEN;
+  const baseURL = page.context()._options.baseURL || 'http://localhost:4200';
+  
+  try {
+    const response = await page.request.put(`${baseURL}/v1/kv/${keyName}`, {
+      headers: {
+        'X-Consul-Token': token,
+      },
+      data: value,
+    });
+    console.log(`Created KV: ${keyName} (status: ${response.status()})`);
+    return response.ok();
+  } catch (error) {
+    console.log(`Note: Could not create ${keyName} - ${error.message}`);
+    return false;
+  }
+}
+
+// Helper function to read a KV pair via API
+async function readKVPair(page, keyName) {
+  const token = process.env.CONSUL_UI_TEST_TOKEN;
+  const baseURL = page.context()._options.baseURL || 'http://localhost:4200';
+  
+  try {
+    const response = await page.request.get(`${baseURL}/v1/kv/${keyName}?raw`, {
+      headers: {
+        'X-Consul-Token': token,
+      },
+    });
+    if (response.ok()) {
+      return await response.text();
+    }
+    return null;
+  } catch (error) {
+    console.log(`Note: Could not read ${keyName} - ${error.message}`);
+    return null;
+  }
+}
+
+test.describe('Key/Value - Basic Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to Key/Value page before each test
+    await page.goto('/ui/dc1/kv');
+  });
+
+  test('should navigate to Key/Value page', async ({ page }) => {
+    // Verify we're on the KV page
+    await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
+    
+    // Verify the Create button is visible
+    await expect(page.getByRole('link', { name: 'Create' })).toBeVisible();
+  });
+
+  test('should validate required key name field', async ({ page }) => {
+    // Click the Create button
+    await page.getByRole('link', { name: 'Create' }).click();
+    
+    // Verify the Save button is disabled when no key name is entered
+    const saveButton = page.getByRole('button', { name: 'Save' });
+    await expect(saveButton).toBeDisabled();
+    
+    // Enter a key name
+    await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill('test-key');
+    
+    // Now Save button should be enabled
+    await expect(saveButton).toBeEnabled();
+  });
+
+  test('should create a key with value', async ({ page }) => {
+    const keyName = 'e2e-test-key';
+    
+    try {
+      await page.getByRole('link', { name: 'Create' }).click();
+      await expect(page).toHaveURL(/\/ui\/dc1\/kv\/create/);
+      
+      await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
+      await page.locator('.cm-activeLine').click();
+      await page.getByRole('textbox', { name: 'value' }).fill('test-value');
+      await page.getByRole('button', { name: 'Save' }).click();
+      
+      await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
+      await expect(page.locator(`text=${keyName}`)).toBeVisible();
+    } finally {
+      await deleteKVPair(page, keyName);
+    }
+  });
+
+  test('should create a key with empty value', async ({ page }) => {
+    const keyName = 'e2e-empty-key';
+    
+    try {
+      await page.getByRole('link', { name: 'Create' }).click();
+      await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
+      await page.getByRole('button', { name: 'Save' }).click();
+      
+      await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
+      await expect(page.locator(`text=${keyName}`)).toBeVisible();
+    } finally {
+      await deleteKVPair(page, keyName);
+    }
+  });
+
+  test('should create a key with special characters and JSON value', async ({ page }) => {
+    const keyName = 'e2e-key_with.special-chars';
+    
+    try {
+      await page.getByRole('link', { name: 'Create' }).click();
+      await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
+      
+      const jsonValue = JSON.stringify({ name: 'test', value: 123, enabled: true }, null, 2);
+      await page.locator('.cm-activeLine').click();
+      await page.getByRole('textbox', { name: 'value' }).fill(jsonValue);
+      await page.getByRole('button', { name: 'Save' }).click();
+      
+      await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
+      await expect(page.locator(`text=${keyName}`)).toBeVisible();
+    } finally {
+      await deleteKVPair(page, keyName);
+    }
+  });
+
+  test('should create a key with multiline value', async ({ page }) => {
+    const keyName = 'e2e-multiline-key';
+    
+    try {
+      await page.getByRole('link', { name: 'Create' }).click();
+      await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
+      
+      const multilineValue = 'Line 1\nLine 2\nLine 3\nLine 4';
+      await page.locator('.cm-activeLine').click();
+      await page.getByRole('textbox', { name: 'value' }).fill(multilineValue);
+      await page.getByRole('button', { name: 'Save' }).click();
+      
+      await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
+      await expect(page.locator(`text=${keyName}`)).toBeVisible();
+    } finally {
+      await deleteKVPair(page, keyName);
+    }
+  });
+
+  test('should create nested keys', async ({ page }) => {
+    const keyName = 'e2e-parent/child/grandchild';
+    
+    try {
+      await page.getByRole('link', { name: 'Create' }).click();
+      await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(keyName);
+      await page.locator('.cm-activeLine').click();
+      await page.getByRole('textbox', { name: 'value' }).fill('nested-value');
+      await page.getByRole('button', { name: 'Save' }).click();
+      
+      await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
+    } finally {
+      await deleteKVPair(page, 'e2e-parent');
+    }
+  });
+
+  test('should create folder and key inside it', async ({ page }) => {
+    const folderPath = 'e2e-folder/subfolder/';
+    
+    try {
+      // Create folder
+      await page.getByRole('link', { name: 'Create' }).click();
+      await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill(folderPath);
+      await page.getByRole('button', { name: 'Save' }).click();
+      await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
+      
+      // Navigate into folder and create key
+      await page.locator('text=e2e-folder').click();
+      await page.locator('text=subfolder').click();
+      await page.getByRole('link', { name: 'Create' }).click();
+      await page.getByRole('textbox', { name: 'Key or folder To create a' }).fill('key-in-folder');
+      await page.locator('.cm-activeLine').click();
+      await page.getByRole('textbox', { name: 'value' }).fill('value-in-folder');
+      await page.getByRole('button', { name: 'Save' }).click();
+      
+      await expect(page.locator('text=key-in-folder')).toBeVisible();
+    } finally {
+      await deleteKVPair(page, 'e2e-folder');
+    }
+  });
+
+  test('should read key value', async ({ page }) => {
+    const keyName = 'e2e-read-key';
+    const keyValue = 'test-value-to-read';
+    
+    try {
+      await createKVPair(page, keyName, keyValue);
+      await page.goto('/ui/dc1/kv');
+      await page.locator(`text=${keyName}`).click();
+      
+      await expect(page.locator(`text=${keyValue}`)).toBeVisible();
+    } finally {
+      await deleteKVPair(page, keyName);
+    }
+  });
+
+  test('should read key in nested folder', async ({ page }) => {
+    const keyName = 'e2e-read-folder/nested/test-key';
+    const keyValue = 'nested-read-value';
+    
+    try {
+      await createKVPair(page, keyName, keyValue);
+      await page.goto('/ui/dc1/kv');
+      
+      await page.locator('text=e2e-read-folder').click();
+      await page.locator('text=nested').click();
+      await page.locator('text=test-key').click();
+      
+      await expect(page.locator(`text=${keyValue}`)).toBeVisible();
+    } finally {
+      await deleteKVPair(page, 'e2e-read-folder');
+    }
+  });
+
+  test('should update key value', async ({ page }) => {
+    const keyName = 'e2e-update-key';
+    const originalValue = 'original-value';
+    const updatedValue = 'updated-value';
+    
+    try {
+      await createKVPair(page, keyName, originalValue);
+      await page.goto('/ui/dc1/kv');
+      await page.locator(`text=${keyName}`).click();
+      
+      const editButton = page.getByRole('button', { name: 'Edit' });
+      if (await editButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await editButton.click();
+      }
+      
+      await page.locator('.cm-activeLine').click();
+      await page.getByRole('textbox', { name: 'value' }).clear();
+      await page.getByRole('textbox', { name: 'value' }).fill(updatedValue);
+      await page.getByRole('button', { name: 'Save' }).click();
+      
+      const readValue = await readKVPair(page, keyName);
+      expect(readValue).toBe(updatedValue);
+    } finally {
+      await deleteKVPair(page, keyName);
+    }
+  });
+
+  test('should update key in nested folder', async ({ page }) => {
+    const keyName = 'e2e-update-folder/nested/update-key';
+    const originalValue = 'original-nested-value';
+    const updatedValue = 'updated-nested-value';
+    
+    try {
+      await createKVPair(page, keyName, originalValue);
+      await page.goto('/ui/dc1/kv');
+      
+      await page.locator('text=e2e-update-folder').click();
+      await page.locator('text=nested').click();
+      await page.locator('text=update-key').click();
+      
+      const editButton = page.getByRole('button', { name: 'Edit' });
+      if (await editButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await editButton.click();
+      }
+      
+      await page.locator('.cm-activeLine').click();
+      await page.getByRole('textbox', { name: 'value' }).clear();
+      await page.getByRole('textbox', { name: 'value' }).fill(updatedValue);
+      await page.getByRole('button', { name: 'Save' }).click();
+      
+      const readValue = await readKVPair(page, keyName);
+      expect(readValue).toBe(updatedValue);
+    } finally {
+      await deleteKVPair(page, 'e2e-update-folder');
+    }
+  });
+
+  test('should delete a key', async ({ page }) => {
+    const keyName = 'e2e-delete-key';
+    
+    try {
+      await createKVPair(page, keyName, 'value-to-delete');
+      await page.goto('/ui/dc1/kv');
+      await expect(page.locator(`text=${keyName}`)).toBeVisible();
+      
+      await page.locator(`text=${keyName}`).click();
+      await page.getByRole('button', { name: 'Delete' }).click();
+      
+      const confirmButton = page.getByRole('button', { name: 'Confirm' });
+      if (await confirmButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await confirmButton.click();
+      }
+      
+      await expect(page).toHaveURL(/\/ui\/dc1\/kv/);
+      await expect(page.locator(`text=${keyName}`)).not.toBeVisible();
+    } catch (error) {
+      await deleteKVPair(page, keyName);
+      throw error;
+    }
+  });
+
+  test('should delete a key in nested folder', async ({ page }) => {
+    const keyName = 'e2e-delete-folder/nested/delete-key';
+    const anotherKey = 'e2e-delete-folder/nested/another-key';
+    
+    try {
+      await createKVPair(page, keyName, 'nested-value-to-delete');
+      await createKVPair(page, anotherKey, 'another-value');
+      
+      await page.goto('/ui/dc1/kv');
+      await page.locator('text=e2e-delete-folder').click();
+      await page.locator('text=nested').click();
+      
+      await expect(page.locator('text=delete-key')).toBeVisible();
+      await expect(page.locator('text=another-key')).toBeVisible();
+      
+      await page.locator('text=delete-key').click();
+      await page.getByRole('button', { name: 'Delete' }).click();
+      
+      const confirmButton = page.getByRole('button', { name: 'Confirm' });
+      if (await confirmButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await confirmButton.click();
+      }
+      
+      await page.waitForURL(/\/ui\/dc1\/kv/, { timeout: 5000 });
+      await expect(page.locator('text=delete-key')).not.toBeVisible();
+      await expect(page.locator('text=another-key')).toBeVisible();
+    } catch (error) {
+      await deleteKVPair(page, 'e2e-delete-folder');
+      throw error;
+    } finally {
+      await deleteKVPair(page, 'e2e-delete-folder');
+    }
+  });
+
+  test('should delete folder via API', async ({ page }) => {
+    const keyInFolder = 'e2e-delete-entire-folder/key1';
+    
+    try {
+      await createKVPair(page, keyInFolder, 'value1');
+      await page.goto('/ui/dc1/kv');
+      await expect(page.locator('text=e2e-delete-entire-folder')).toBeVisible();
+      
+      await deleteKVPair(page, 'e2e-delete-entire-folder');
+      await page.reload();
+      
+      await expect(page.locator('text=e2e-delete-entire-folder')).not.toBeVisible();
+    } catch (error) {
+      await deleteKVPair(page, 'e2e-delete-entire-folder');
+      throw error;
+    }
+  });
+
+  test('should delete nested folder structure via API', async ({ page }) => {
+    const keyInFolder = 'e2e-delete-nested/level1/level2/key';
+    
+    try {
+      await createKVPair(page, keyInFolder, 'nested-value');
+      await page.goto('/ui/dc1/kv');
+      await expect(page.locator('text=e2e-delete-nested')).toBeVisible();
+      
+      await deleteKVPair(page, 'e2e-delete-nested');
+      await page.reload();
+      
+      await expect(page.locator('text=e2e-delete-nested')).not.toBeVisible();
+    } catch (error) {
+      await deleteKVPair(page, 'e2e-delete-nested');
+      throw error;
+    }
+  });
+});
+
+// Made with Bob

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -59,7 +59,8 @@ function kvValueEditor(page) {
 }
 
 function kvCodeToggle(page) {
-  return page.getByRole('switch', { name: 'Code' }).first();
+  // Use the underlying checkbox directly; it may be visually hidden in production builds
+  return page.locator('input[name="json"]').first();
 }
 
 function kvRow(page, text) {
@@ -99,10 +100,11 @@ async function fillKVValue(page, value, replace = false) {
   await logKVFormState(page, `before fillKVValue replace=${replace}`);
 
   const codeToggle = kvCodeToggle(page);
-  if (await codeToggle.isVisible({ timeout: 5000 }).catch(() => false)) {
+  // count() works regardless of visibility; force:true bypasses CSS-hidden checkbox in prod builds
+  if ((await codeToggle.count()) > 0) {
     const isCodeMode = await codeToggle.isChecked().catch(() => false);
     if (isCodeMode) {
-      await codeToggle.click();
+      await codeToggle.click({ force: true });
       await expect(codeToggle).not.toBeChecked({ timeout: 10000 });
     }
   }


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

Add tests for Kv Page CRUD operations:

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
CRUD KV | 1. Navigate to the K/V Tab and create a new K/V folder (end the name with '/')2. Inside of your new folder, create some new K/V pairs3. Edit all of these K/V folders and pairs4. Ensure you can filter by type and search5. Delete these newly created K/V pairs | Key Value Pairs work great!
-- | -- | --




### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
