### PR TITLE
feat: add dumbify github workflow

### DIFF
--- a/.github/workflows/dumbify-upstream.yml
+++ b/.github/workflows/dumbify-upstream.yml
@@ -3,11 +3,18 @@ name: Weekly Upstream Dumbify
 on:
   schedule:
     - cron: '0 0 * * 0' # Midnight on Sundays
-  workflow_dispatch: # Allows you to trigger it manually from the Actions tab
+  workflow_dispatch:
+  pull_request:
+    # Triggers when a PR is opened, updated, or reopened against main
+    branches:
+      - main
 
 jobs:
   dumbify-process:
     runs-on: ubuntu-latest
+    # THE FIX: Run on schedules, dispatches, OR PRs that do NOT come from the 'upstream' branch
+    if: github.event_name != 'pull_request' || github.head_ref != 'upstream'
+    
     steps:
       - name: Checkout Fork
         uses: actions/checkout@v4
@@ -19,18 +26,20 @@ jobs:
           git config user.name "Chief Dumbification Officer"
           git config user.email "bot@dumb-hashicorp.local"
 
-      - name: Fetch and Reset Upstream
+      - name: Fetch, Reset, and Purge Upstream
         run: |
-          # Replace the URL below with the specific original repository you are forking
+          # Replace with the actual Hashicorp repo you are forking
           git remote add upstream https://github.com/hashicorp/terraform.git
           git fetch upstream
           
-          # Force the 'upstream' branch to match the fresh 'smart' code from upstream/main
+          # Force the 'upstream' branch to match the fresh 'smart' code
           git checkout -B upstream upstream/main
+
+          # Delete HashiCorp's CI/CD workflows so they don't hijack our fork
+          rm -rf .github/workflows/*
 
       - name: Dumbify Trademarks
         run: |
-          # A strict list of HashiCorp trademarked products
           declare -A trademarks=(
             ["Terraform"]="Dumb Terraform"
             ["Consul"]="Dumb Consul"
@@ -48,15 +57,12 @@ jobs:
             replacement=${trademarks[$tm]}
             echo "Dumbifying trademark: '$tm' -> '$replacement'"
             
-            # Using \b to match whole words only. 
-            # find ignores the .git directory to prevent repository corruption.
             find . -type f -not -path '*/.*' -exec sed -i "s/\b$tm\b/$replacement/g" {} +
           done
 
       - name: Validate Changes
         id: validate
         run: |
-          # Check if any files were actually modified by the dumbify process
           if [[ -z $(git status -s) ]]; then
             echo "No changes detected. The codebase is already sufficiently dumb."
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -67,7 +73,6 @@ jobs:
           fi
 
       - name: Commit and Force Push
-        # Only run if the validation step detected changes
         if: steps.validate.outputs.has_changes == 'true'
         run: |
           git add .
@@ -75,7 +80,6 @@ jobs:
           git push origin upstream --force
 
       - name: Create Dumbify PR
-        # Only run if the validation step detected changes
         if: steps.validate.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
@@ -88,5 +92,6 @@ jobs:
             
             **Changes included:**
             - Targeted replacement of HashiCorp trademarks with their Dumb™ counterparts.
+            - Purged upstream workflows to prevent CI/CD competence.
           labels: |
             dumbified

--- a/.github/workflows/dumbify-upstream.yml
+++ b/.github/workflows/dumbify-upstream.yml
@@ -1,0 +1,92 @@
+name: Weekly Upstream Dumbify
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Midnight on Sundays
+  workflow_dispatch: # Allows you to trigger it manually from the Actions tab
+
+jobs:
+  dumbify-process:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "Chief Dumbification Officer"
+          git config user.email "bot@dumb-hashicorp.local"
+
+      - name: Fetch and Reset Upstream
+        run: |
+          # Replace the URL below with the specific original repository you are forking
+          git remote add upstream https://github.com/hashicorp/terraform.git
+          git fetch upstream
+          
+          # Force the 'upstream' branch to match the fresh 'smart' code from upstream/main
+          git checkout -B upstream upstream/main
+
+      - name: Dumbify Trademarks
+        run: |
+          # A strict list of HashiCorp trademarked products
+          declare -A trademarks=(
+            ["Terraform"]="Dumb Terraform"
+            ["Consul"]="Dumb Consul"
+            ["Vault"]="Dumb Vault"
+            ["Nomad"]="Dumb Nomad"
+            ["Packer"]="Dumb Packer"
+            ["Vagrant"]="Dumb Vagrant"
+            ["Boundary"]="Dumb Boundary"
+            ["Waypoint"]="Dumb Waypoint"
+            ["HashiCorp"]="Dumb HashiCorp"
+            ["HCP"]="Dumb HCP"
+          )
+
+          for tm in "${!trademarks[@]}"; do
+            replacement=${trademarks[$tm]}
+            echo "Dumbifying trademark: '$tm' -> '$replacement'"
+            
+            # Using \b to match whole words only. 
+            # find ignores the .git directory to prevent repository corruption.
+            find . -type f -not -path '*/.*' -exec sed -i "s/\b$tm\b/$replacement/g" {} +
+          done
+
+      - name: Validate Changes
+        id: validate
+        run: |
+          # Check if any files were actually modified by the dumbify process
+          if [[ -z $(git status -s) ]]; then
+            echo "No changes detected. The codebase is already sufficiently dumb."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected! The following files were dumbified:"
+            git status -s
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and Force Push
+        # Only run if the validation step detected changes
+        if: steps.validate.outputs.has_changes == 'true'
+        run: |
+          git add .
+          git commit -m "chore: successfully dumbified upstream updates"
+          git push origin upstream --force
+
+      - name: Create Dumbify PR
+        # Only run if the validation step detected changes
+        if: steps.validate.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: upstream
+          base: main
+          title: "Weekly Dumbification: Freshly Degraded Code"
+          body: |
+            This PR takes the latest innovations from upstream and properly 
+            dumbifies them for public consumption. 
+            
+            **Changes included:**
+            - Targeted replacement of HashiCorp trademarks with their Dumb™ counterparts.
+          labels: |
+            dumbified


### PR DESCRIPTION
### Description

This change introduces the core **Dumbify** engine. This GitHub Action is designed to monitor the upstream HashiCorp repository, extract their high-quality engineering, and strip away all traces of competence and professional branding. By replacing trademarked terms with "Dumb" variations, we ensure that our fork maintains a consistent level of mediocrity and adheres to the principles of high-effort parody.

### Testing & Reproduction steps

* **Manual Workflow Test:** Triggered the `Weekly Upstream Dumbify` workflow manually from the `feature/add-dumbify-workflow` branch using the `workflow_dispatch` event.
* **Environment Isolation:** Verified that the script correctly force-resets the `upstream` branch without impacting the `main` branch.
* **Competence Purge:** Confirmed that the `rm -rf .github/workflows/*` command successfully prevents the original, high-functioning CI/CD pipelines from running on this fork.
* **Trademark Validation:** Performed a regex check to ensure that only whole-word trademarks (e.g., "Vault", "Terraform") were degraded, leaving functional code paths largely intact.

### Links

* [Nathan Fielder's Dumb Starbucks Legal Precedent](https://en.wikipedia.org/wiki/Dumb_Starbucks)

### PR Checklist

* [ ] updated test coverage (N/A - Tests are an unnecessary sign of competence)
* [x] external facing docs updated (Every README is now sufficiently dumb)
* [ ] appropriate backport labels added
* [x] not a security concern (The code is now so broken it’s arguably un-exploitable)

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request. (Revert plan: Apologize to the lawyers and delete the repo).

- [x] If applicable, I've documented the impact of any changes to security controls. (Security impact: We have replaced "Security" with "False Sense of Confidence").