### PR TITLE
fix: enhance service name handling for per-port VIP allocation

### DIFF
--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -80,6 +80,24 @@ func nodesTableSchema() *memdb.TableSchema {
 	}
 }
 
+func baseServiceNameFromVirtualIPEntry(name string) string {
+	_, serviceName, ok := splitAutoPortServiceVIPName(name)
+	if !ok {
+		return name
+	}
+	return serviceName
+}
+
+// splitAutoPortServiceVIPName parses synthetic service names of the form
+// "<port>.<service>" used for per-port VIP allocation.
+func splitAutoPortServiceVIPName(name string) (portName, serviceName string, ok bool) {
+	i := strings.IndexByte(name, '.')
+	if i <= 0 || i == len(name)-1 {
+		return "", "", false
+	}
+	return name[:i], name[i+1:], true
+}
+
 func indexFromNode(n *structs.Node) ([]byte, error) {
 	if n.Node == "" {
 		return nil, errMissingValueForIndex

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -1111,7 +1111,10 @@ func (s *Store) intentionTopologyTxn(
 				return index, nil, fmt.Errorf("failed to list service virtual IPs: %v", err)
 			}
 			for _, svc := range vipServices {
-				services[svc.Service.ServiceName] = struct{}{}
+				services[structs.ServiceName{
+					Name:           baseServiceNameFromVirtualIPEntry(svc.Service.ServiceName.Name),
+					EnterpriseMeta: svc.Service.ServiceName.EnterpriseMeta,
+				}] = struct{}{}
 			}
 			if vipIndex > index {
 				index = vipIndex

--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-memdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/go-memdb"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/netutil"
@@ -2742,4 +2743,68 @@ func TestStore_IntentionTopology_Watches(t *testing.T) {
 		},
 	}
 	require.Equal(t, expect, got)
+}
+
+// TestStore_IntentionTopology_AutoPortVirtualIPs verifies that virtual-IP
+// table entries with synthetic per-port names of the form "<port>.<service>"
+// are normalized back to their base service name when included in the
+// intention topology. Without normalization, the same logical service would
+// appear multiple times (once per port) and/or under a name that does not
+// match any real service registration.
+func TestStore_IntentionTopology_AutoPortVirtualIPs(t *testing.T) {
+	s := testConfigStateStore(t)
+	s.SystemMetadataSet(10, &structs.SystemMetadataEntry{Key: structs.SystemMetadataVirtualIPsEnabled, Value: "true"})
+
+	defaultMeta := *structs.DefaultEnterpriseMetaInDefaultPartition()
+
+	// Insert VIP table entries directly via Restore: a base service entry plus
+	// two synthetic per-port VIP entries for the same logical service ("api"),
+	// and an additional per-port-only entry ("billing") with no base entry.
+	restore := s.Restore()
+	require.NoError(t, restore.ServiceVirtualIP(ServiceVirtualIP{
+		Service: structs.PeeredServiceName{
+			ServiceName: structs.NewServiceName("api", &defaultMeta),
+		},
+		IP:        []byte{0, 0, 0, 1},
+		RaftIndex: structs.RaftIndex{CreateIndex: 11, ModifyIndex: 11},
+	}))
+	require.NoError(t, restore.ServiceVirtualIP(ServiceVirtualIP{
+		Service: structs.PeeredServiceName{
+			ServiceName: structs.NewServiceName("8080.api", &defaultMeta),
+		},
+		IP:        []byte{0, 0, 0, 2},
+		RaftIndex: structs.RaftIndex{CreateIndex: 12, ModifyIndex: 12},
+	}))
+	require.NoError(t, restore.ServiceVirtualIP(ServiceVirtualIP{
+		Service: structs.PeeredServiceName{
+			ServiceName: structs.NewServiceName("9090.api", &defaultMeta),
+		},
+		IP:        []byte{0, 0, 0, 3},
+		RaftIndex: structs.RaftIndex{CreateIndex: 13, ModifyIndex: 13},
+	}))
+	require.NoError(t, restore.ServiceVirtualIP(ServiceVirtualIP{
+		Service: structs.PeeredServiceName{
+			ServiceName: structs.NewServiceName("7070.billing", &defaultMeta),
+		},
+		IP:        []byte{0, 0, 0, 4},
+		RaftIndex: structs.RaftIndex{CreateIndex: 14, ModifyIndex: 14},
+	}))
+	require.NoError(t, restore.Commit())
+
+	target := structs.NewServiceName("web", &defaultMeta)
+
+	// Querying upstreams for "web" with default-allow should include the
+	// VIP-only services. After normalization, "api" must appear exactly once
+	// (collapsing the base + per-port entries) and "billing" must appear under
+	// its base name (not "7070.billing").
+	_, got, err := s.IntentionTopology(nil, target, false /* downstreams */, true /* defaultAllow */, structs.IntentionTargetService)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(got))
+	for _, sn := range got {
+		names = append(names, sn.Name)
+	}
+	sort.Strings(names)
+
+	require.Equal(t, []string{"api", "billing"}, names)
 }


### PR DESCRIPTION
### Description

This pull request improves the handling of synthetic per-port virtual IP (VIP) service names in the intention topology logic. It ensures that services with VIP entries named in the form "<port>.<service>" are normalized back to their base service name, preventing duplicate or mismatched service entries in the intention topology. The changes also add comprehensive testing for this normalization behavior.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
