### PR TITLE
types: fix 'Explictly' typo in TLSVersionAuto comment

### DIFF
--- a/types/tls.go
+++ b/types/tls.go
@@ -19,7 +19,7 @@ const (
 	// Explicit unspecified zero-value to avoid overwriting parent defaults
 	TLSVersionUnspecified TLSVersion = ""
 
-	// Explictly allow implementation to select TLS version
+	// Explicitly allow implementation to select TLS version
 	// May be useful to supercede defaults specified at a higher layer
 	TLSVersionAuto TLSVersion = "TLS_AUTO"
 


### PR DESCRIPTION
Fix a typo in the comment for `TLSVersionAuto`: `Explictly` -> `Explicitly`.