### PR TITLE
fix remote mesh gw connection in same dc cross-partition on eks

### DIFF
--- a/.changelog/23543.txt
+++ b/.changelog/23543.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+XDS: Fixes issue with mesh-gateway in remote mode on AWS EKS, as DNS hostnames are assigned to AWS NLBs instead of IPs and envoy's EDS endpoint validation expects address to be an IP. Now EDS load assignment is skipped for non-peer remote mesh gateway targets with hostname based gateways keeping CDS/EDS in sync.
+```

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -6,6 +6,7 @@ package xds
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -1528,6 +1529,21 @@ func finalizeUpstreamConfig(cfg structs.UpstreamConfig, chain *structs.CompiledD
 	return cfg
 }
 
+// gatewayHostnameEndpoints returns the subset of gateway nodes whose WAN address
+// is a hostname rather than an IP address. EDS cannot resolve hostnames (Envoy
+// rejects them as "malformed IP address"), so callers must configure those
+// clusters as LOGICAL_DNS/STRICT_DNS via CDS instead.
+func gatewayHostnameEndpoints(nodes structs.CheckServiceNodes) structs.CheckServiceNodes {
+	var result structs.CheckServiceNodes
+	for _, n := range nodes {
+		_, addr, _ := n.BestAddress(true /* wan/remote */)
+		if addr != "" && net.ParseIP(addr) == nil {
+			result = append(result, n)
+		}
+	}
+	return result
+}
+
 func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 	uid proxycfg.UpstreamID,
 	upstream *structs.Upstream,
@@ -1747,6 +1763,23 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 				}
 			}
 
+			// For non-peer targets routed via a remote mesh gateway, check if the
+			// gateway WAN address is a hostname (e.g., AWS NLB on EKS). EDS cannot
+			// resolve hostname addresses, so we must use LOGICAL_DNS instead.
+			if useEDS && targetUID.Peer == "" && upstreamsSnapshot != nil {
+				target := chain.Targets[targetInfo.TargetID]
+				if target != nil &&
+					target.MeshGateway.Mode == structs.MeshGatewayModeRemote &&
+					!cfgSnap.Locality.Matches(target.Datacenter, target.Partition) {
+					gwKey := proxycfg.GatewayKey{Datacenter: target.Datacenter, Partition: target.Partition}
+					if gwMap, ok := upstreamsSnapshot.WatchedGatewayEndpoints[uid]; ok {
+						if len(gatewayHostnameEndpoints(gwMap[gwKey.String()])) > 0 {
+							useEDS = false
+						}
+					}
+				}
+			}
+
 			if useEDS {
 				c.ClusterDiscoveryType = &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_EDS}
 				c.EdsClusterConfig = &envoy_cluster_v3.Cluster_EdsClusterConfig{
@@ -1758,13 +1791,37 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 						},
 					},
 				}
-			} else {
+			} else if targetUID.Peer != "" {
 				hostnameEndpoints, ok := upstreamsSnapshot.PeerUpstreamEndpoints.Get(targetUID)
 				if !ok || len(hostnameEndpoints) == 0 {
 					// The upstream snapshot should deliver hostname endpoints soon; skip this cluster until then.
 					s.Logger.Debug("peer hostname endpoints not ready for discovery chain target",
 						"target", targetInfo.TargetID,
 						"upstream", targetUID,
+						"cluster", groupedTarget.ClusterName,
+					)
+					continue
+				}
+				c.EdsClusterConfig = nil
+				configureClusterWithHostnames(
+					s.Logger,
+					c,
+					"", /*TODO: should make configurable ? */
+					hostnameEndpoints,
+					true,  /*isRemote*/
+					false, /*onlyPassing*/
+				)
+			} else {
+				// Non-peer target with a remote mesh gateway whose WAN address is a
+				// hostname (e.g., AWS NLB on EKS). Configure LOGICAL_DNS so that Envoy
+				// resolves the hostname rather than expecting a raw IP from EDS.
+				target := chain.Targets[targetInfo.TargetID]
+				gwKey := proxycfg.GatewayKey{Datacenter: target.Datacenter, Partition: target.Partition}
+				hostnameEndpoints := gatewayHostnameEndpoints(upstreamsSnapshot.WatchedGatewayEndpoints[uid][gwKey.String()])
+				if len(hostnameEndpoints) == 0 {
+					s.Logger.Debug("gateway hostname endpoints not ready for discovery chain target",
+						"target", targetInfo.TargetID,
+						"upstream", uid,
 						"cluster", groupedTarget.ClusterName,
 					)
 					continue

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -824,6 +824,22 @@ func (s *ResourceGenerator) endpointsFromDiscoveryChain(
 				continue // skip the cluster if we're still populating the snapshot
 			}
 
+			// For non-peer targets routed via a remote mesh gateway whose WAN address
+			// is a hostname (e.g., AWS NLB on EKS), the cluster is configured as
+			// LOGICAL_DNS (via CDS). EDS is not used for such clusters, so skip
+			// generating the load assignment to keep CDS/EDS in sync.
+			if !forMeshGateway {
+				target := chain.Targets[ti.TargetID]
+				if target != nil &&
+					target.MeshGateway.Mode == structs.MeshGatewayModeRemote &&
+					!gatewayKey.Matches(target.Datacenter, target.Partition) {
+					gwKey := proxycfg.GatewayKey{Datacenter: target.Datacenter, Partition: target.Partition}
+					if len(gatewayHostnameEndpoints(gatewayEndpoints[gwKey.String()])) > 0 {
+						continue // cluster uses LOGICAL_DNS; endpoints provided via CDS
+					}
+				}
+			}
+
 			la := makeLoadAssignment(
 				s.Logger,
 				cfgSnap,


### PR DESCRIPTION
### Description

For non-peer cross-partition/cross-DC upstreams routed via a remote mesh gateway, consul is always generating an EDS cluster even when the gateway's WAN address is a hostname (EKS NLB). Envoy's EDS endpoint validation expects the address to be an IP address hence rejects hostnames with "malformed IP address".

On GKE/AKS the mesh gateway WAN address is always an IP (from the load balancer), so this path works. On EKS, the NLB assigns a DNS hostname, triggering the bug.

Skip EDS load assignment generation for non-peer remote mesh gateway targets with hostname-based gateway endpoints keeping CDS/EDS in sync. Since the cluster is now LOGICAL_DNS (not EDS), no ClusterLoadAssignment should be sent for it; this prevents Envoy from receiving and validating (and rejecting) an EDS resource with a hostname address.

This ensures that when the gateway WAN address is a hostname, Consul generates Cluster_LOGICAL_DNS with the hostname embedded in the CDS resource, and skips EDS entirely for that cluster. LOGICAL_DNS clusters never send EDS and Envoy resolves the hostname itself via its internal DNS resolver.

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
