### PR TITLE
Zero value check for api gateway limits

### DIFF
--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -1097,13 +1097,10 @@ func mergedAPIGatewayUpstreamConfig(configMap map[string]interface{}, limits *st
 
 func mergeAPIGatewayUpstreamLimits(existing, incoming *structs.UpstreamLimits) *structs.UpstreamLimits {
 	if existing == nil {
-		if incoming == nil {
-			return nil
-		}
-		return incoming.Clone()
+		return normalizeAPIGatewayUpstreamLimits(incoming)
 	}
 	if incoming == nil {
-		return existing.Clone()
+		return normalizeAPIGatewayUpstreamLimits(existing)
 	}
 
 	return &structs.UpstreamLimits{
@@ -1115,13 +1112,10 @@ func mergeAPIGatewayUpstreamLimits(existing, incoming *structs.UpstreamLimits) *
 
 func mergeAPIGatewayLimitValue(existing, incoming *int) *int {
 	if existing == nil {
-		if incoming == nil {
-			return nil
-		}
-		return intPointerCopy(incoming)
+		return positiveIntPointerCopy(incoming)
 	}
 	if incoming == nil {
-		return intPointerCopy(existing)
+		return positiveIntPointerCopy(existing)
 	}
 
 	e := *existing
@@ -1141,8 +1135,7 @@ func mergeAPIGatewayLimitValue(existing, incoming *int) *int {
 		return intPointerCopy(incoming)
 	}
 
-	zero := 0
-	return &zero
+	return nil
 }
 
 func intPointerCopy(v *int) *int {
@@ -1151,6 +1144,25 @@ func intPointerCopy(v *int) *int {
 	}
 	v2 := *v
 	return &v2
+}
+
+func positiveIntPointerCopy(v *int) *int {
+	if v == nil || *v <= 0 {
+		return nil
+	}
+	return intPointerCopy(v)
+}
+
+func normalizeAPIGatewayUpstreamLimits(limits *structs.UpstreamLimits) *structs.UpstreamLimits {
+	if limits == nil {
+		return nil
+	}
+
+	return &structs.UpstreamLimits{
+		MaxConnections:        positiveIntPointerCopy(limits.MaxConnections),
+		MaxPendingRequests:    positiveIntPointerCopy(limits.MaxPendingRequests),
+		MaxConcurrentRequests: positiveIntPointerCopy(limits.MaxConcurrentRequests),
+	}
 }
 
 func (s *ResourceGenerator) configIngressUpstreamCluster(c *envoy_cluster_v3.Cluster, cfgSnap *proxycfg.ConfigSnapshot, listenerKey proxycfg.IngressListenerKey, u *structs.Upstream) {
@@ -2351,17 +2363,25 @@ func makeThresholdsIfNeeded(limits *structs.UpstreamLimits) []*envoy_cluster_v3.
 	}
 
 	threshold := &envoy_cluster_v3.CircuitBreakers_Thresholds{}
+	hasLimit := false
 
 	// Likewise, make sure to not set any threshold values on the zero-value in
 	// order to rely on Envoy defaults
 	if limits.MaxConnections != nil {
 		threshold.MaxConnections = response.MakeUint32Value(*limits.MaxConnections)
+		hasLimit = true
 	}
 	if limits.MaxPendingRequests != nil {
 		threshold.MaxPendingRequests = response.MakeUint32Value(*limits.MaxPendingRequests)
+		hasLimit = true
 	}
 	if limits.MaxConcurrentRequests != nil {
 		threshold.MaxRequests = response.MakeUint32Value(*limits.MaxConcurrentRequests)
+		hasLimit = true
+	}
+
+	if !hasLimit {
+		return nil
 	}
 
 	return []*envoy_cluster_v3.CircuitBreakers_Thresholds{threshold}

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -963,6 +963,43 @@ func TestMergeAPIGatewayUpstreamLimits(t *testing.T) {
 	require.Equal(t, 50, *merged.MaxConcurrentRequests)
 }
 
+func TestMergeAPIGatewayUpstreamLimits_ZeroValuesOmitted(t *testing.T) {
+	t.Parallel()
+
+	merged := mergeAPIGatewayUpstreamLimits(
+		&structs.UpstreamLimits{
+			MaxConnections:        intPointer(0),
+			MaxPendingRequests:    intPointer(4),
+			MaxConcurrentRequests: intPointer(0),
+		},
+		&structs.UpstreamLimits{
+			MaxPendingRequests:    intPointer(3),
+			MaxConcurrentRequests: intPointer(2),
+		},
+	)
+
+	require.NotNil(t, merged)
+	require.Nil(t, merged.MaxConnections)
+	require.NotNil(t, merged.MaxPendingRequests)
+	require.Equal(t, 3, *merged.MaxPendingRequests)
+	require.NotNil(t, merged.MaxConcurrentRequests)
+	require.Equal(t, 2, *merged.MaxConcurrentRequests)
+
+	merged = mergeAPIGatewayUpstreamLimits(
+		&structs.UpstreamLimits{MaxConnections: intPointer(0)},
+		nil,
+	)
+	require.NotNil(t, merged)
+	require.Nil(t, merged.MaxConnections)
+
+	merged = mergeAPIGatewayUpstreamLimits(
+		nil,
+		&structs.UpstreamLimits{MaxConnections: intPointer(0)},
+	)
+	require.NotNil(t, merged)
+	require.Nil(t, merged.MaxConnections)
+}
+
 func TestMergedAPIGatewayUpstreamConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

Step 1: Create consul server agents
Step 2: Apply proxy-defaults, api-gateway, http-routes as below

1-proxy-defaults.hcl
```
Kind = "proxy-defaults"
Name = "global"

Config {
  protocol = "http"
}
```

2-api-gateway.hcl
```
Kind = "api-gateway"
Name = "api-gw-limits-gateway"

Defaults {
  MaxConnections        = 7
  MaxConcurrentRequests = 9
}

Listeners = [
  {
    Name     = "http"
    Port     = 9600
    Protocol = "http"
  }
]
```

3-http-route-default.hcl
```
Kind = "http-route"
Name = "api-gw-limits-route-default"

Parents = [
  {
    Kind        = "api-gateway"
    Name        = "api-gw-limits-gateway"
    SectionName = "http"
  }
]

Rules = [
  {
    Matches = [
      {
        Path {
          Match = "prefix"
          Value = "/default"
        }
      }
    ]

    Services = [
      {
        Name = "api-gw-limits-default-svc"
      }
    ]
  }
]
```

4-http-route-override.hcl
```
Kind = "http-route"
Name = "api-gw-limits-route-override"

Parents = [
  {
    Kind        = "api-gateway"
    Name        = "api-gw-limits-gateway"
    SectionName = "http"
  }
]

Rules = [
  {
    Matches = [
      {
        Path {
          Match = "prefix"
          Value = "/override"
        }
      }
    ]

    Services = [
      {
        Name = "api-gw-limits-override-svc"
        Limits {
          MaxPendingRequests    = 10
        }
      }
    ]
  }
]
```




Step 3: Register the services and api-gateway
5-default-service-registration.json
```
{
  "service": {
    "name": "api-gw-limits-default-svc",
    "id": "api-gw-limits-default-svc-1",
    "port": 8080,
    "connect": {
      "sidecar_service": {
        "port": 21110
      }
    }
  }
}
```

6-override-service-registration.json
```
{
  "service": {
    "name": "api-gw-limits-override-svc",
    "id": "api-gw-limits-override-svc-1",
    "port": 9062,
    "connect": {
      "sidecar_service": {
        "port": 21111
      }
    }
  }
}
```

7-gateway-registration.json
```
{
  "service": {
    "name": "api-gw-limits-gateway",
    "kind": "api-gateway",
    "port": 9600
  }
}
```


Step 4: Create side-car and api-gateway proxies

```consul connect envoy -sidecar-for api-gw-limits-default-svc-1 -grpc-addr=127.0.0.1:8502 -admin-bind 127.0.0.1:19110```
```consul connect envoy -sidecar-for api-gw-limits-override-svc-1 -grpc-addr=127.0.0.1:8502 -admin-bind 127.0.0.1:19111```
```consul connect envoy -gateway=api -register -service api-gw-limits-gateway -address 127.0.0.1:9600 -grpc-addr=127.0.0.1:8502 -admin-bind 127.0.0.1:19210```

Step 5: Below curl will fetch the envoy config-dump
```
curl -s http://localhost:19210/config_dump
```
Look for max_connections, max_pending_requests, max_requests configs. For over-ride service listener only max_pending_requests will be present. For default-svc max_connections, max_requests will be present.

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
