### PR TITLE
add tests for admin partitions page

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -288,7 +288,7 @@ jobs:
       - name: Run basic E2E tests against port 8500 (CE)
         working-directory: ui/packages/consul-ui
         timeout-minutes: 15
-        run: pnpm run test:e2e:basic
+        run: pnpm run test:e2e:basic:ce
         env:
           CI: true
           PLAYWRIGHT_BASE_URL: http://localhost:8500

--- a/ui/packages/consul-ui/e2e-tests/tests/access-controls/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/access-controls/basic.spec.js
@@ -93,7 +93,7 @@ test.describe('Access Controls - Basic', () => {
 
       // 8. Verify we no longer have permission to create tokens.
       await tokensPage.goto();
-      await expect(page.getByRole('link', { name: 'Create' })).toHaveCount(0);
+      await expect(page.getByRole('link', { name: 'Create' })).toHaveCount(0, { timeout: 15000 });
 
       // 9. Sign out, then sign back in with management token.
       await page.getByLabel('Auth menu').click();

--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/basic.spec.js
@@ -4,6 +4,7 @@
  */
 
 const { test, expect } = require('./fixtures');
+const { isEnterpriseConsul } = require('../../utils/ent-utils');
 
 /**
  * Admin Partitions - Basic Tests
@@ -27,11 +28,11 @@ test.describe('Admin Partitions - Basic', () => {
 
   test('default partition is visible in the list', async ({
     partitionsPage,
-    skipEnt,
     request,
     baseURL,
   }) => {
-    await skipEnt(request, baseURL);
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Partition list rows require Enterprise Consul.');
 
     await partitionsPage.goto();
     await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });
@@ -43,11 +44,11 @@ test.describe('Admin Partitions - Basic', () => {
 
   test('partition edit page loads from list action', async ({
     partitionsPage,
-    skipEnt,
     request,
     baseURL,
   }) => {
-    await skipEnt(request, baseURL);
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Partition edit form requires Enterprise Consul.');
 
     await partitionsPage.goto();
     await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });
@@ -62,11 +63,11 @@ test.describe('Admin Partitions - Basic', () => {
 
   test('partition edit page is directly navigable', async ({
     partitionsPage,
-    skipEnt,
     request,
     baseURL,
   }) => {
-    await skipEnt(request, baseURL);
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Partition edit form requires Enterprise Consul.');
 
     await partitionsPage.gotoEdit('default');
 
@@ -76,11 +77,11 @@ test.describe('Admin Partitions - Basic', () => {
 
   test('"All Admin Partitions" breadcrumb navigates back to list', async ({
     partitionsPage,
-    skipEnt,
     request,
     baseURL,
   }) => {
-    await skipEnt(request, baseURL);
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Partition edit form requires Enterprise Consul.');
 
     await partitionsPage.gotoEdit('default');
     await expect(partitionsPage.page).toHaveURL(/\/partitions\/default/, { timeout: 15000 });

--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/basic.spec.js
@@ -18,7 +18,12 @@ const { isEnterpriseConsul } = require('../../utils/ent-utils');
  */
 
 test.describe('Admin Partitions - Basic', { tag: '@ent' }, () => {
-  test('admin partitions list page loads', async ({ partitionsPage, skipEnt, request, baseURL }) => {
+  test('admin partitions list page loads', async ({
+    partitionsPage,
+    skipEnt,
+    request,
+    baseURL,
+  }) => {
     await skipEnt(request, baseURL);
 
     await partitionsPage.goto();
@@ -26,11 +31,7 @@ test.describe('Admin Partitions - Basic', { tag: '@ent' }, () => {
     await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });
   });
 
-  test('default partition is visible in the list', async ({
-    partitionsPage,
-    request,
-    baseURL,
-  }) => {
+  test('default partition is visible in the list', async ({ partitionsPage, request, baseURL }) => {
     const isEnt = await isEnterpriseConsul(request, baseURL);
     test.skip(!isEnt, 'Partition list rows require Enterprise Consul.');
 

--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/basic.spec.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+const { test, expect } = require('./fixtures');
+
+/**
+ * Admin Partitions - Basic Tests
+ *
+ * Fast, essential tests for the Admin Partitions feature.
+ * Run on every PR.
+ *
+ * NOTE: Admin Partitions is an Enterprise-only feature.
+ * These tests currently run on CE + ENT for development purposes.
+ * To restrict to ENT only: set CONSUL_ENT_ONLY=true in the environment.
+ */
+
+test.describe('Admin Partitions - Basic', () => {
+  test('admin partitions list page loads', async ({ partitionsPage, skipEnt, request, baseURL }) => {
+    await skipEnt(request, baseURL);
+
+    await partitionsPage.goto();
+
+    await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });
+  });
+
+  test('default partition is visible in the list', async ({
+    partitionsPage,
+    skipEnt,
+    request,
+    baseURL,
+  }) => {
+    await skipEnt(request, baseURL);
+
+    await partitionsPage.goto();
+    await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });
+
+    // The built-in "default" partition must always be present.
+    await expect(partitionsPage.partitionRow('default')).toBeVisible({ timeout: 15000 });
+    await expect(partitionsPage.partitionRow('default')).toHaveText('default');
+  });
+
+  test('partition edit page loads from list action', async ({
+    partitionsPage,
+    skipEnt,
+    request,
+    baseURL,
+  }) => {
+    await skipEnt(request, baseURL);
+
+    await partitionsPage.goto();
+    await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });
+
+    await partitionsPage.openEditViaMoreMenu('default');
+
+    // Edit form must contain the description input and action buttons.
+    await expect(partitionsPage.descriptionInput).toBeVisible({ timeout: 10000 });
+    await expect(partitionsPage.saveButton).toBeVisible();
+    await expect(partitionsPage.cancelButton).toBeVisible();
+  });
+
+  test('partition edit page is directly navigable', async ({
+    partitionsPage,
+    skipEnt,
+    request,
+    baseURL,
+  }) => {
+    await skipEnt(request, baseURL);
+
+    await partitionsPage.gotoEdit('default');
+
+    await expect(partitionsPage.page).toHaveURL(/\/partitions\/default/, { timeout: 15000 });
+    await expect(partitionsPage.descriptionInput).toBeVisible({ timeout: 15000 });
+  });
+
+  test('"All Admin Partitions" breadcrumb navigates back to list', async ({
+    partitionsPage,
+    skipEnt,
+    request,
+    baseURL,
+  }) => {
+    await skipEnt(request, baseURL);
+
+    await partitionsPage.gotoEdit('default');
+    await expect(partitionsPage.page).toHaveURL(/\/partitions\/default/, { timeout: 15000 });
+
+    await partitionsPage.allPartitionsBreadcrumb.click();
+
+    await expect(partitionsPage.page).toHaveURL(/\/partitions$/, { timeout: 15000 });
+    await expect(partitionsPage.heading).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/basic.spec.js
@@ -17,7 +17,7 @@ const { isEnterpriseConsul } = require('../../utils/ent-utils');
  * To restrict to ENT only: set CONSUL_ENT_ONLY=true in the environment.
  */
 
-test.describe('Admin Partitions - Basic', () => {
+test.describe('Admin Partitions - Basic', { tag: '@ent' }, () => {
   test('admin partitions list page loads', async ({ partitionsPage, skipEnt, request, baseURL }) => {
     await skipEnt(request, baseURL);
 

--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/fixtures.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/fixtures.js
@@ -1,0 +1,268 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+const { test: base, expect } = require('@playwright/test');
+const { skipIfCommunityEdition } = require('../../utils/ent-utils');
+
+/**
+ * PartitionApiHelper — creates and manages partitions via the Consul HTTP API.
+ *
+ * NOTE: The built-in "default" partition cannot be created or deleted via API.
+ * This helper is used to create/cleanup custom partitions in workflow tests.
+ */
+class PartitionApiHelper {
+  constructor(request, baseURL) {
+    this.request = request;
+    this.baseURL = baseURL;
+    this.token = process.env.CONSUL_UI_TEST_TOKEN;
+    this._createdNames = [];
+  }
+
+  get headers() {
+    return { 'X-Consul-Token': this.token };
+  }
+
+  /**
+   * Creates a partition via the API and tracks it for cleanup.
+   * @param {object} [overrides] - Partial body to merge with defaults.
+   * @returns {Promise<object>} The created partition object.
+   */
+  async create(overrides = {}) {
+    const ts = Date.now();
+    const body = {
+      Name: `e2e-partition-${ts}`,
+      Description: `E2E test partition ${ts}`,
+      ...overrides,
+    };
+
+    const response = await this.request.put(`${this.baseURL}/v1/partition`, {
+      headers: this.headers,
+      data: body,
+    });
+
+    expect(response.ok(), `Partition creation failed: ${response.status()}`).toBeTruthy();
+    const created = await response.json();
+    this._createdNames.push(created.Name);
+    return created;
+  }
+
+  /**
+   * Reads a partition by name via the API.
+   * @param {string} name
+   * @returns {Promise<object>}
+   */
+  async read(name) {
+    const response = await this.request.get(`${this.baseURL}/v1/partition/${name}`, {
+      headers: this.headers,
+    });
+    expect(response.ok(), `Partition read failed: ${response.status()}`).toBeTruthy();
+    return response.json();
+  }
+
+  /**
+   * Updates a partition's description via the API.
+   * @param {string} name
+   * @param {object} updates - Fields to update (e.g. { Description: '...' })
+   * @returns {Promise<object>}
+   */
+  async update(name, updates = {}) {
+    const response = await this.request.put(`${this.baseURL}/v1/partition/${name}`, {
+      headers: this.headers,
+      data: updates,
+    });
+    expect(response.ok(), `Partition update failed: ${response.status()}`).toBeTruthy();
+    return response.json();
+  }
+
+  /**
+   * Deletes a partition by name via the API.
+   * @param {string} name
+   */
+  async delete(name) {
+    const response = await this.request.delete(`${this.baseURL}/v1/partition/${name}`, {
+      headers: this.headers,
+    });
+    // 404 is acceptable — partition may already be gone.
+    if (!response.ok() && response.status() !== 404) {
+      console.warn(`Warning: failed to delete partition ${name} (${response.status()})`);
+    }
+    this._createdNames = this._createdNames.filter((n) => n !== name);
+  }
+
+  /**
+   * Lists all partitions via the API.
+   * @returns {Promise<object[]>}
+   */
+  async list() {
+    const response = await this.request.get(`${this.baseURL}/v1/partitions`, {
+      headers: this.headers,
+    });
+    expect(response.ok(), `Partition list failed: ${response.status()}`).toBeTruthy();
+    return response.json();
+  }
+
+  /**
+   * Deletes all partitions created by this helper instance.
+   */
+  async cleanup() {
+    for (const name of [...this._createdNames]) {
+      await this.delete(name);
+    }
+  }
+}
+
+/**
+ * PartitionsPage — page-object helper for the Admin Partitions list and edit pages.
+ */
+class PartitionsPage {
+  constructor(page, baseURL) {
+    this.page = page;
+    this.baseURL = baseURL;
+  }
+
+  // ── Navigation ─────────────────────────────────────────────────────────────
+
+  async goto(dc = 'dc1') {
+    await this.page.goto(`${this.baseURL}/ui/${dc}/partitions`, {
+      waitUntil: 'domcontentloaded',
+    });
+  }
+
+  async gotoEdit(partitionName, dc = 'dc1') {
+    await this.page.goto(`${this.baseURL}/ui/${dc}/partitions/${partitionName}`, {
+      waitUntil: 'domcontentloaded',
+    });
+  }
+
+  // ── Form helpers ───────────────────────────────────────────────────────────
+
+  get descriptionInput() {
+    return this.page.getByRole('textbox', { name: 'Description (Optional)' });
+  }
+
+  get nameInput() {
+    return this.page.getByRole('textbox', { name: 'Name' });
+  }
+
+  get saveButton() {
+    return this.page.getByRole('button', { name: 'Save' });
+  }
+
+  get cancelButton() {
+    return this.page.getByRole('button', { name: 'Cancel' });
+  }
+
+  get searchInput() {
+    return this.page
+      .getByPlaceholder('Search')
+      .or(this.page.locator('input[type="search"]'))
+      .first();
+  }
+
+  get searchAcrossButton() {
+    return this.page.getByRole('button', { name: 'Search Across' });
+  }
+
+  get heading() {
+    return this.page.getByRole('heading', { name: 'Admin Partitions' });
+  }
+
+  // ── List helpers ───────────────────────────────────────────────────────────
+
+  /**
+   * Returns the link for a named partition row.
+   * @param {string} partitionName
+   */
+  partitionRow(partitionName) {
+    return this.page.locator(`[data-test-partition="${partitionName}"]`);
+  }
+
+  /**
+   * Returns the "More" overflow menu button for a named partition row.
+   * @param {string} partitionName
+   */
+  moreButtonForPartition(partitionName) {
+    return this.page
+      .locator('[data-test-list-row]')
+      .filter({ has: this.page.locator(`[data-test-partition="${partitionName}"]`) })
+      .getByRole('button', { name: 'More' });
+  }
+
+  /**
+   * Waits for a partition row to appear in the list.
+   * @param {string} partitionName
+   */
+  async waitForPartitionInList(partitionName) {
+    await expect(this.partitionRow(partitionName)).toBeVisible({ timeout: 15000 });
+  }
+
+  /**
+   * Opens the "More > Edit" action for a named partition.
+   * @param {string} partitionName
+   */
+  async openEditViaMoreMenu(partitionName) {
+    await this.moreButtonForPartition(partitionName).click();
+    await this.page.getByRole('menuitem', { name: 'Edit' }).click();
+    await expect(this.page).toHaveURL(
+      new RegExp(`/partitions/${partitionName}`),
+      { timeout: 15000 }
+    );
+  }
+
+  /**
+   * Fills description and saves the partition edit form.
+   * @param {string} description
+   */
+  async fillDescriptionAndSave(description) {
+    await this.descriptionInput.waitFor({ state: 'visible', timeout: 10000 });
+    await this.descriptionInput.fill(description);
+    await this.saveButton.click();
+    await expect(this.page).toHaveURL(/\/partitions$/, { timeout: 20000 });
+  }
+
+  /**
+   * Breadcrumb link that navigates back from an edit page to the list.
+   */
+  get allPartitionsBreadcrumb() {
+    return this.page.getByRole('link', { name: 'All Admin Partitions' });
+  }
+}
+
+/**
+ * Extended test object providing `partitionApi` and `partitionsPage` fixtures.
+ *
+ * Usage:
+ *   const { test, expect } = require('./fixtures');
+ *   test('my test', async ({ page, partitionApi, partitionsPage }) => { ... });
+ */
+const test = base.extend({
+  /**
+   * Provides a PartitionApiHelper scoped to the test.
+   * Automatically deletes any partitions created during the test.
+   */
+  partitionApi: async ({ request, baseURL }, use) => {
+    const helper = new PartitionApiHelper(request, baseURL);
+    await use(helper);
+    await helper.cleanup();
+  },
+
+  /**
+   * Provides a PartitionsPage page-object scoped to the test.
+   */
+  partitionsPage: async ({ page, baseURL }, use) => {
+    const partitionsPage = new PartitionsPage(page, baseURL);
+    await use(partitionsPage);
+  },
+
+  /**
+   * Re-exports skipIfCommunityEdition bound to the test context for convenience.
+   * Usage: await skipEnt(request, baseURL)
+   */
+  skipEnt: async ({ request, baseURL }, use) => {
+    await use((req, url) => skipIfCommunityEdition(test, req ?? request, url ?? baseURL));
+  },
+});
+
+module.exports = { test, expect, PartitionApiHelper, PartitionsPage };

--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/fixtures.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/fixtures.js
@@ -205,10 +205,9 @@ class PartitionsPage {
   async openEditViaMoreMenu(partitionName) {
     await this.moreButtonForPartition(partitionName).click();
     await this.page.getByRole('menuitem', { name: 'Edit' }).click();
-    await expect(this.page).toHaveURL(
-      new RegExp(`/partitions/${partitionName}`),
-      { timeout: 15000 }
-    );
+    await expect(this.page).toHaveURL(new RegExp(`/partitions/${partitionName}`), {
+      timeout: 15000,
+    });
   }
 
   /**

--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/workflows.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/workflows.spec.js
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+const { test, expect } = require('./fixtures');
+const { isEnterpriseConsul } = require('../../utils/ent-utils');
+
+/**
+ * Admin Partitions - Workflow Tests
+ *
+ * Complex end-to-end scenarios for the Admin Partitions feature.
+ * Run nightly or before release.
+ *
+ * NOTE: Admin Partitions is an Enterprise-only feature.
+ * These tests currently run on CE + ENT for development purposes.
+ * To restrict to ENT only: set CONSUL_ENT_ONLY=true in the environment.
+ */
+
+test.describe('Admin Partitions - Workflows', () => {
+  /**
+   * Covers the full user journey: start at services → open partition selector
+   * → click "View all partitions" footer link → arrive at the partitions list.
+   *
+   * Mirrors the inspector recording flow.
+   */
+  test('navigate to admin partitions via partition selector', async ({
+    page,
+    partitionsPage,
+    skipEnt,
+    request,
+    baseURL,
+  }) => {
+    await skipEnt(request, baseURL);
+
+    await page.goto(`${baseURL}/ui/dc1/services`, { waitUntil: 'domcontentloaded' });
+
+    // Open the partition selector in the side nav.
+    await page.locator('[data-test-partition-menu]').click();
+
+    // Click the "View all partitions" footer link inside the selector dropdown.
+    await page.getByRole('link', { name: 'View all partitions' }).click();
+
+    await expect(partitionsPage.page).toHaveURL(/\/partitions$/, { timeout: 15000 });
+    await expect(partitionsPage.heading).toBeVisible({ timeout: 10000 });
+  });
+
+  /**
+   * Edit the "default" partition's description via the "More > Edit" action,
+   * save the change, and verify redirection back to the list.
+   *
+   * The description is restored after the test via partitionApi to keep state clean.
+   */
+  test('edit partition description and save', async ({
+    partitionsPage,
+    partitionApi,
+    request,
+    baseURL,
+  }) => {
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Partition updates (PUT /v1/partition/:name) return 403 on CE. Requires Enterprise Consul.');
+
+    const newDescription = `E2E test description – ${Date.now()}`;
+
+    // Retrieve the current description for post-test restore.
+    let originalDescription = '';
+    try {
+      const current = await partitionApi.read('default');
+      originalDescription = current?.Description ?? '';
+    } catch {
+      // Non-fatal — proceed without restore guard.
+    }
+
+    await partitionsPage.goto();
+    await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });
+
+    await partitionsPage.openEditViaMoreMenu('default');
+    await partitionsPage.fillDescriptionAndSave(newDescription);
+
+    // After save the UI redirects back to the partitions list.
+    await expect(partitionsPage.page).toHaveURL(/\/dc1\/partitions$/, { timeout: 20000 });
+
+    // Restore the original description so subsequent test runs start clean.
+    try {
+      await partitionApi.update('default', { Description: originalDescription });
+    } catch {
+      console.warn('[admin-partitions] Could not restore original description after test.');
+    }
+  });
+
+  /**
+   * Navigate to the default partition edit page, make a change, then click
+   * Cancel and verify the UI returns to the list without persisting the change.
+   */
+  test('cancel partition edit discards changes and returns to list', async ({
+    partitionsPage,
+    skipEnt,
+    request,
+    baseURL,
+  }) => {
+    await skipEnt(request, baseURL);
+
+    await partitionsPage.gotoEdit('default');
+    await expect(partitionsPage.page).toHaveURL(/\/partitions\/default/, { timeout: 15000 });
+    await partitionsPage.descriptionInput.waitFor({ state: 'visible', timeout: 10000 });
+
+    // Type something but cancel instead of saving.
+    await partitionsPage.descriptionInput.fill('This should not be saved');
+    await partitionsPage.cancelButton.click();
+
+    // Cancel should navigate back to the list without saving.
+    await expect(partitionsPage.page).toHaveURL(/\/partitions$/, { timeout: 15000 });
+    await expect(partitionsPage.heading).toBeVisible({ timeout: 10000 });
+  });
+
+  /**
+   * Use the search bar on the partitions list to filter by partition name.
+   * Verifies that matching rows remain visible and that clearing the search
+   * restores all results.
+   */
+  test('search bar filters the partition list', async ({
+    partitionsPage,
+    skipEnt,
+    request,
+    baseURL,
+  }) => {
+    await skipEnt(request, baseURL);
+
+    await partitionsPage.goto();
+    await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });
+    await partitionsPage.waitForPartitionInList('default');
+
+    // Type a matching search term — "default" should still be visible.
+    await partitionsPage.searchInput.fill('default');
+    await expect(partitionsPage.partitionRow('default')).toBeVisible({ timeout: 10000 });
+
+    // Type a non-matching term — the default row should disappear.
+    await partitionsPage.searchInput.fill('zzz-nonexistent-zzz');
+    await expect(partitionsPage.partitionRow('default')).toHaveCount(0, { timeout: 10000 });
+
+    // Clear the search — the default row should reappear.
+    await partitionsPage.searchInput.fill('');
+    await partitionsPage.waitForPartitionInList('default');
+  });
+
+  /**
+   * Use the "Search Across" button to switch the search scope, then verify
+   * the partition list still renders correctly.
+   */
+  test('search across scope toggle works on partition list', async ({
+    partitionsPage,
+    skipEnt,
+    request,
+    baseURL,
+  }) => {
+    await skipEnt(request, baseURL);
+
+    await partitionsPage.goto();
+    await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });
+
+    await expect(partitionsPage.searchAcrossButton).toBeVisible({ timeout: 10000 });
+    await partitionsPage.searchAcrossButton.click();
+
+    // After toggling, the list should still be intact.
+    await partitionsPage.waitForPartitionInList('default');
+  });
+});

--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/workflows.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/workflows.spec.js
@@ -17,7 +17,7 @@ const { isEnterpriseConsul } = require('../../utils/ent-utils');
  * To restrict to ENT only: set CONSUL_ENT_ONLY=true in the environment.
  */
 
-test.describe('Admin Partitions - Workflows', () => {
+test.describe('Admin Partitions - Workflows', { tag: '@ent' }, () => {
   /**
    * Covers the full user journey: start at services → open partition selector
    * → click "View all partitions" footer link → arrive at the partitions list.

--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/workflows.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/workflows.spec.js
@@ -58,7 +58,10 @@ test.describe('Admin Partitions - Workflows', { tag: '@ent' }, () => {
     baseURL,
   }) => {
     const isEnt = await isEnterpriseConsul(request, baseURL);
-    test.skip(!isEnt, 'Partition updates (PUT /v1/partition/:name) return 403 on CE. Requires Enterprise Consul.');
+    test.skip(
+      !isEnt,
+      'Partition updates (PUT /v1/partition/:name) return 403 on CE. Requires Enterprise Consul.'
+    );
 
     const newDescription = `E2E test description – ${Date.now()}`;
 

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -70,7 +70,9 @@ function kvRow(page, text) {
 // Returns the [data-test-kv] row whose Key ends with the given segment name.
 // This is more stable than `text=` which can match headings after navigation.
 function kvRowByKey(page, segmentName) {
-  return page.locator(`[data-test-kv$="${segmentName}"], [data-test-kv$="${segmentName}/"]`).first();
+  return page
+    .locator(`[data-test-kv$="${segmentName}"], [data-test-kv$="${segmentName}/"]`)
+    .first();
 }
 
 async function openKVCreate(page) {

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -67,6 +67,12 @@ function kvRow(page, text) {
   return page.locator(`text=${text}`).first();
 }
 
+// Returns the [data-test-kv] row whose Key ends with the given segment name.
+// This is more stable than `text=` which can match headings after navigation.
+function kvRowByKey(page, segmentName) {
+  return page.locator(`[data-test-kv$="${segmentName}"], [data-test-kv$="${segmentName}/"]`).first();
+}
+
 async function openKVCreate(page) {
   await page.getByRole('link', { name: 'Create' }).click();
   await logKVFormState(page, 'after openKVCreate click');
@@ -74,17 +80,19 @@ async function openKVCreate(page) {
 }
 
 async function openKVKey(page, keyName) {
-  const row = kvRow(page, keyName);
+  const row = kvRowByKey(page, keyName);
   await expect(row).toBeVisible({ timeout: 15000 });
-  await row.click();
+  // Use a longer timeout — the KV list re-renders due to blocking queries which
+  // detaches elements mid-click. The locator re-evaluates on each retry attempt.
+  await row.click({ timeout: 15000 });
   console.log(`[KV DEBUG] clicked key row: ${keyName}, url=${page.url()}`);
 }
 
 async function openNestedKVKey(page, segments, keyName) {
   for (const segment of segments) {
-    const row = kvRow(page, segment);
+    const row = kvRowByKey(page, segment);
     await expect(row).toBeVisible({ timeout: 15000 });
-    await row.click();
+    await row.click({ timeout: 15000 });
     console.log(`[KV DEBUG] clicked nested segment: ${segment}, url=${page.url()}`);
   }
 

--- a/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/key-value/basic.spec.js
@@ -67,14 +67,6 @@ function kvRow(page, text) {
   return page.locator(`text=${text}`).first();
 }
 
-// Returns the [data-test-kv] row whose Key ends with the given segment name.
-// This is more stable than `text=` which can match headings after navigation.
-function kvRowByKey(page, segmentName) {
-  return page
-    .locator(`[data-test-kv$="${segmentName}"], [data-test-kv$="${segmentName}/"]`)
-    .first();
-}
-
 async function openKVCreate(page) {
   await page.getByRole('link', { name: 'Create' }).click();
   await logKVFormState(page, 'after openKVCreate click');
@@ -82,19 +74,17 @@ async function openKVCreate(page) {
 }
 
 async function openKVKey(page, keyName) {
-  const row = kvRowByKey(page, keyName);
+  const row = kvRow(page, keyName);
   await expect(row).toBeVisible({ timeout: 15000 });
-  // Use a longer timeout — the KV list re-renders due to blocking queries which
-  // detaches elements mid-click. The locator re-evaluates on each retry attempt.
-  await row.click({ timeout: 15000 });
+  await row.click();
   console.log(`[KV DEBUG] clicked key row: ${keyName}, url=${page.url()}`);
 }
 
 async function openNestedKVKey(page, segments, keyName) {
   for (const segment of segments) {
-    const row = kvRowByKey(page, segment);
+    const row = kvRow(page, segment);
     await expect(row).toBeVisible({ timeout: 15000 });
-    await row.click({ timeout: 15000 });
+    await row.click();
     console.log(`[KV DEBUG] clicked nested segment: ${segment}, url=${page.url()}`);
   }
 

--- a/ui/packages/consul-ui/e2e-tests/utils/ent-utils.js
+++ b/ui/packages/consul-ui/e2e-tests/utils/ent-utils.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/**
+ * Enterprise (ENT) detection utilities for Consul UI E2E tests.
+ *
+ * Admin Partitions and other ENT-only features require Consul Enterprise.
+ *
+ * HOW TO GATE TESTS TO ENT-ONLY:
+ *   Set the environment variable CONSUL_ENT_ONLY=true before running tests.
+ *   When set, any test calling skipIfCommunityEdition() will be skipped
+ *   unless the running Consul instance is Enterprise edition.
+ *
+ *   Currently: CONSUL_ENT_ONLY defaults to false, so tests run on CE + ENT.
+ *   To flip: set CONSUL_ENT_ONLY=true in CI or your local .env file.
+ */
+
+// Flip this to 'true' to restrict ENT-only tests to Enterprise instances only.
+const ENT_ONLY_MODE = process.env.CONSUL_ENT_ONLY === 'true';
+
+/**
+ * Detects if the running Consul instance is Enterprise edition by inspecting
+ * the version string from /v1/agent/self (ENT versions contain "+ent").
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} baseURL
+ * @param {string} [token]
+ * @returns {Promise<boolean>}
+ */
+async function isEnterpriseConsul(request, baseURL, token) {
+  try {
+    const headers = token ? { 'X-Consul-Token': token } : {};
+    const response = await request.get(`${baseURL}/v1/agent/self`, { headers });
+    if (!response.ok()) return false;
+    const data = await response.json();
+    const version = (data?.Config?.Version ?? '').toLowerCase();
+    return version.includes('+ent') || version.includes('-ent');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Skips the current test when CONSUL_ENT_ONLY=true AND the running Consul
+ * instance is Community Edition.
+ *
+ * Call this at the top of any test body that covers an ENT-only feature:
+ *
+ *   test('my test', async ({ page, request, baseURL }) => {
+ *     await skipIfCommunityEdition(test, request, baseURL);
+ *     // ...rest of test
+ *   });
+ *
+ * @param {import('@playwright/test').TestType} test - The Playwright `test` object
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} baseURL
+ * @param {string} [token]
+ */
+async function skipIfCommunityEdition(
+  test,
+  request,
+  baseURL,
+  token = process.env.CONSUL_UI_TEST_TOKEN
+) {
+  if (!ENT_ONLY_MODE) {
+    // Currently running on all editions — no skip.
+    return;
+  }
+  const isEnt = await isEnterpriseConsul(request, baseURL, token);
+  test.skip(
+    !isEnt,
+    'Admin Partitions is an Enterprise-only feature. ' +
+      'Set CONSUL_ENT_ONLY=false to run on CE for development.'
+  );
+}
+
+module.exports = { isEnterpriseConsul, skipIfCommunityEdition, ENT_ONLY_MODE };

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -43,6 +43,7 @@
     "test:view": "ember test --server --test-port=${EMBER_TEST_PORT:-7357}",
     "test:e2e": "playwright test --config=e2e-tests/playwright.config.js",
     "test:e2e:basic": "playwright test --config=e2e-tests/playwright.config.js --project=basic",
+    "test:e2e:basic:ce": "playwright test --config=e2e-tests/playwright.config.js --project=basic --grep-invert @ent",
     "test:e2e:workflows": "playwright test --config=e2e-tests/playwright.config.js --project=workflows",
     "test:e2e:headed": "playwright test --config=e2e-tests/playwright.config.js --headed",
     "test:e2e:ui": "playwright test --config=e2e-tests/playwright.config.js --ui",


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

1. Ensure you're testing against an enterprise consul image
2. In the sidebar, open the Admin Partitions select and select Manage Partitions
3. View the existing partitions

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
