### PR TITLE
fix: fixed 503 errors when adding routes to a busy gateway

### DIFF
--- a/agent/consul/controller/controller.go
+++ b/agent/consul/controller/controller.go
@@ -325,16 +325,19 @@ func (c *controller) AddTrigger(request Request, trigger func(ctx context.Contex
 	c.triggerMutex.Unlock()
 
 	c.group.Go(func() error {
-		if err := trigger(ctx); err != nil {
-			c.logger.Error("error while running trigger, adding re-reconcilation anyway", "error", err)
-		}
+		err := trigger(ctx)
 		select {
 		case <-ctx.Done():
+			// Context was cancelled by a newer AddTrigger call for this request.
+			// The newer goroutine handles re-enqueuing if needed.
 			return nil
 		default:
-			c.work.Add(request)
-			return nil
 		}
+		if err != nil {
+			c.logger.Error("error while running trigger, adding re-reconcilation anyway", "error", err)
+		}
+		c.work.Add(request)
+		return nil
 	})
 }
 

--- a/agent/proxycfg/api_gateway.go
+++ b/agent/proxycfg/api_gateway.go
@@ -193,9 +193,9 @@ func (h *handlerAPIGateway) handleGatewayConfigUpdate(ctx context.Context, u Upd
 				ctx, cancel := context.WithCancel(ctx)
 				switch ref.Kind {
 				case structs.HTTPRoute:
-					snap.APIGateway.HTTPRoutes.InitWatch(ref, cancel)
+					snap.APIGateway.HTTPRoutes.UpdateWatch(ref, cancel)
 				case structs.TCPRoute:
-					snap.APIGateway.TCPRoutes.InitWatch(ref, cancel)
+					snap.APIGateway.TCPRoutes.UpdateWatch(ref, cancel)
 				default:
 					cancel()
 					return fmt.Errorf("unexpected route kind on gateway: %s", ref.Kind)

--- a/agent/proxycfg/internal/watch/watchmap.go
+++ b/agent/proxycfg/internal/watch/watchmap.go
@@ -65,6 +65,21 @@ func (m Map[K, V]) InitWatch(key K, cancel func()) {
 	}
 }
 
+// UpdateWatch replaces the cancel function for an existing key, canceling the
+// old context if present, while preserving any stored value. If the key does
+// not exist, it initializes a new entry with the provided cancel function.
+func (m Map[K, V]) UpdateWatch(key K, cancel func()) {
+	if entry, ok := m.M[key]; ok {
+		if entry.cancel != nil {
+			entry.cancel() // cancel the old context
+		}
+		entry.cancel = cancel // swap in new cancel
+		m.M[key] = entry      // stored Val PRESERVED
+	} else {
+		m.M[key] = watchedVal[V]{cancel: cancel}
+	}
+}
+
 // CancelWatch first calls the cancel function
 // associated with the key then deletes the key
 // from the map. No-op if key is not present.

--- a/agent/proxycfg/internal/watch/watchmap_test.go
+++ b/agent/proxycfg/internal/watch/watchmap_test.go
@@ -78,6 +78,98 @@ func TestMap(t *testing.T) {
 	}
 }
 
+func TestMap_UpdateWatch(t *testing.T) {
+	// UpdateWatch on an empty map should behave like InitWatch:
+	// the entry is created with Val == nil and Get returns (zero, false).
+	t.Run("empty map falls through to InitWatch behavior", func(t *testing.T) {
+		m := NewMap[string, testVal]()
+
+		var firstCancelCalled bool
+		m.UpdateWatch("hello", func() { firstCancelCalled = true })
+
+		require.Equal(t, 1, m.Len())
+		require.True(t, m.IsWatched("hello"))
+		got, ok := m.Get("hello")
+		require.False(t, ok, "Val must be nil until Set is called")
+		require.Empty(t, got)
+		require.False(t, firstCancelCalled, "new cancel must not be invoked")
+	})
+
+	// UpdateWatch on a key that already has a stored value must preserve
+	// the value and swap in the new cancel function. The old cancel must
+	// be invoked exactly once.
+	t.Run("existing key preserves stored value and swaps cancel", func(t *testing.T) {
+		m := NewMap[string, testVal]()
+
+		var firstCancelCalls int
+		m.InitWatch("hello", func() { firstCancelCalls++ })
+		require.True(t, m.Set("hello", "world"))
+
+		var secondCancelCalls int
+		m.UpdateWatch("hello", func() { secondCancelCalls++ })
+
+		require.Equal(t, 1, firstCancelCalls, "old cancel must be called exactly once")
+		require.Equal(t, 0, secondCancelCalls, "new cancel must not be called yet")
+
+		got, ok := m.Get("hello")
+		require.True(t, ok, "stored value must survive UpdateWatch")
+		require.Equal(t, testVal("world"), got)
+
+		// CancelWatch must invoke the most recent cancel and clear the entry.
+		m.CancelWatch("hello")
+		require.Equal(t, 1, firstCancelCalls, "old cancel must not be re-invoked")
+		require.Equal(t, 1, secondCancelCalls, "current cancel must be invoked on CancelWatch")
+		require.Equal(t, 0, m.Len())
+	})
+
+	// Repeated UpdateWatch calls without an intervening Set must still
+	// invoke every superseded cancel exactly once.
+	t.Run("repeated UpdateWatch cancels each superseded cancel exactly once", func(t *testing.T) {
+		m := NewMap[string, testVal]()
+
+		var cancelCounts [3]int
+		m.UpdateWatch("k", func() { cancelCounts[0]++ })
+		m.UpdateWatch("k", func() { cancelCounts[1]++ })
+		m.UpdateWatch("k", func() { cancelCounts[2]++ })
+
+		require.Equal(t, 1, cancelCounts[0])
+		require.Equal(t, 1, cancelCounts[1])
+		require.Equal(t, 0, cancelCounts[2], "most recent cancel must still be live")
+
+		m.CancelWatch("k")
+		require.Equal(t, 1, cancelCounts[2])
+	})
+
+	// UpdateWatch must tolerate a nil cancel function, mirroring
+	// InitWatch's contract.
+	t.Run("nil cancel is allowed", func(t *testing.T) {
+		m := NewMap[string, testVal]()
+		require.NotPanics(t, func() { m.UpdateWatch("k", nil) })
+		require.True(t, m.IsWatched("k"))
+		require.NotPanics(t, func() { m.UpdateWatch("k", nil) })
+		require.NotPanics(t, func() { m.CancelWatch("k") })
+	})
+
+	// Set followed by UpdateWatch followed by Set must update the stored
+	// value to the latest value (sanity-check that the entry remains
+	// writable after UpdateWatch).
+	t.Run("Set still works after UpdateWatch", func(t *testing.T) {
+		m := NewMap[string, testVal]()
+		m.InitWatch("k", nil)
+		require.True(t, m.Set("k", "v1"))
+
+		m.UpdateWatch("k", nil)
+		got, ok := m.Get("k")
+		require.True(t, ok)
+		require.Equal(t, testVal("v1"), got)
+
+		require.True(t, m.Set("k", "v2"))
+		got, ok = m.Get("k")
+		require.True(t, ok)
+		require.Equal(t, testVal("v2"), got)
+	})
+}
+
 func TestMap_ForEach(t *testing.T) {
 	m := NewMap[string, testVal]()
 	inputs := map[string]testVal{

--- a/agent/xds/listeners_apigateway.go
+++ b/agent/xds/listeners_apigateway.go
@@ -454,6 +454,16 @@ func getReadyListeners(cfgSnap *proxycfg.ConfigSnapshot) map[string]readyListene
 		// For each route bound to the listener
 		boundListener := cfgSnap.APIGateway.BoundListeners[l.Name]
 		for _, routeRef := range boundListener.Routes {
+			switch routeRef.Kind {
+			case structs.HTTPRoute:
+				if _, ok := cfgSnap.APIGateway.HTTPRoutes.Get(routeRef); !ok {
+					continue
+				}
+			case structs.TCPRoute:
+				if _, ok := cfgSnap.APIGateway.TCPRoutes.Get(routeRef); !ok {
+					continue
+				}
+			}
 			// Get all upstreams for the route
 			routeUpstreams, ok := cfgSnap.APIGateway.Upstreams[routeRef]
 			if !ok {

--- a/agent/xds/listeners_apigateway_test.go
+++ b/agent/xds/listeners_apigateway_test.go
@@ -833,4 +833,171 @@ func TestResolveAPIListenerTLSConfig_InvalidMergedSDS(t *testing.T) {
 	})
 }
 
+// TestGetReadyListeners_SkipsUnloadedHTTPRoute reproduces the Xapo
+// scenario: an HTTPRoute is present in the BoundListener and has
+// Upstreams populated, but its stored config entry has been wiped
+// (HTTPRoutes.Get returns false). Before the fix, getReadyListeners
+// included this routeRef and routesForAPIGateway returned
+// `missing route for routeRef …`, terminating the ADS stream.
+// With the fix, the routeRef must be silently excluded.
+func TestGetReadyListeners_SkipsUnloadedHTTPRoute(t *testing.T) {
+	loadedRoute := &structs.HTTPRouteConfigEntry{
+		Kind: structs.HTTPRoute,
+		Name: "loaded-route",
+		Parents: []structs.ResourceReference{{
+			Kind: structs.APIGateway,
+			Name: "api-gateway",
+		}},
+		Rules: []structs.HTTPRouteRule{{
+			Services: []structs.HTTPService{{Name: "loaded-svc"}},
+		}},
+	}
+	wipedRoute := &structs.HTTPRouteConfigEntry{
+		Kind: structs.HTTPRoute,
+		Name: "wiped-route",
+		Parents: []structs.ResourceReference{{
+			Kind: structs.APIGateway,
+			Name: "api-gateway",
+		}},
+		Rules: []structs.HTTPRouteRule{{
+			Services: []structs.HTTPService{{Name: "wiped-svc"}},
+		}},
+	}
+	loadedRef := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "loaded-route"}
+	wipedRef := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "wiped-route"}
+
+	snap := proxycfg.TestConfigSnapshotAPIGateway(t, "default", nil, func(entry *structs.APIGatewayConfigEntry, bound *structs.BoundAPIGatewayConfigEntry) {
+		entry.Listeners = []structs.APIGatewayListener{{
+			Name:     "http-listener",
+			Protocol: structs.ListenerProtocolHTTP,
+			Port:     8080,
+		}}
+		bound.Listeners = []structs.BoundAPIGatewayListener{{
+			Name:   "http-listener",
+			Routes: []structs.ResourceReference{loadedRef, wipedRef},
+		}}
+	}, []structs.BoundRoute{loadedRoute, wipedRoute}, nil, nil)
+	require.NotNil(t, snap)
+
+	// Sanity: both routes are loaded and have upstreams after snapshot
+	// construction.
+	_, ok := snap.APIGateway.HTTPRoutes.Get(loadedRef)
+	require.True(t, ok)
+	_, ok = snap.APIGateway.HTTPRoutes.Get(wipedRef)
+	require.True(t, ok)
+	require.Contains(t, snap.APIGateway.Upstreams, loadedRef)
+	require.Contains(t, snap.APIGateway.Upstreams, wipedRef)
+
+	// Simulate handleGatewayConfigUpdate's old InitWatch behavior wiping
+	// the stored route entry while leaving Upstreams populated.
+	snap.APIGateway.HTTPRoutes.InitWatch(wipedRef, nil)
+	_, ok = snap.APIGateway.HTTPRoutes.Get(wipedRef)
+	require.False(t, ok, "wipedRoute's value must be cleared to reproduce the bug condition")
+	require.Contains(t, snap.APIGateway.Upstreams, wipedRef, "upstreams stick around after value is wiped")
+
+	ready := getReadyListeners(snap)
+	require.Len(t, ready, 1, "exactly one ready listener expected")
+	rl, ok := ready["http-listener"]
+	require.True(t, ok)
+
+	_, hasLoaded := rl.routeReferences[loadedRef]
+	require.True(t, hasLoaded, "loaded route must appear in readyListener")
+	_, hasWiped := rl.routeReferences[wipedRef]
+	require.False(t, hasWiped, "wiped route must be skipped to avoid ADS-killing error")
+}
+
+// TestGetReadyListeners_SkipsUnloadedTCPRoute mirrors the HTTP test for
+// the TCPRoutes map: a single TCP route is loaded into the snapshot and
+// then its stored value is wiped to simulate the InitWatch race. The
+// guard must exclude it from readyListeners.
+func TestGetReadyListeners_SkipsUnloadedTCPRoute(t *testing.T) {
+	tcpRoute := &structs.TCPRouteConfigEntry{
+		Kind: structs.TCPRoute,
+		Name: "tcp-route",
+		Parents: []structs.ResourceReference{{
+			Kind: structs.APIGateway,
+			Name: "api-gateway",
+		}},
+		Services: []structs.TCPService{{Name: "tcp-backend"}},
+	}
+	routeRef := structs.ResourceReference{Kind: structs.TCPRoute, Name: "tcp-route"}
+
+	snap := proxycfg.TestConfigSnapshotAPIGateway(t, "default", nil, func(entry *structs.APIGatewayConfigEntry, bound *structs.BoundAPIGatewayConfigEntry) {
+		entry.Listeners = []structs.APIGatewayListener{{
+			Name:     "tcp-listener",
+			Protocol: structs.ListenerProtocolTCP,
+			Port:     9000,
+		}}
+		bound.Listeners = []structs.BoundAPIGatewayListener{{
+			Name:   "tcp-listener",
+			Routes: []structs.ResourceReference{routeRef},
+		}}
+	}, []structs.BoundRoute{tcpRoute}, nil, nil)
+	require.NotNil(t, snap)
+
+	// Sanity: route is fully loaded after snapshot construction.
+	readyBefore := getReadyListeners(snap)
+	require.Contains(t, readyBefore, "tcp-listener")
+	require.Contains(t, readyBefore["tcp-listener"].routeReferences, routeRef)
+
+	// Wipe the stored value to reproduce the bug condition.
+	snap.APIGateway.TCPRoutes.InitWatch(routeRef, nil)
+	_, ok := snap.APIGateway.TCPRoutes.Get(routeRef)
+	require.False(t, ok, "stored TCPRoute value must be cleared to reproduce the bug")
+
+	readyAfter := getReadyListeners(snap)
+	if rl, present := readyAfter["tcp-listener"]; present {
+		require.NotContains(t, rl.routeReferences, routeRef,
+			"wiped TCP route must be excluded from readyListeners")
+	}
+}
+
+// TestGetReadyListeners_IncludesAllLoadedRoutes confirms that when every
+// route is fully loaded the new guard does not over-filter.
+func TestGetReadyListeners_IncludesAllLoadedRoutes(t *testing.T) {
+	r1 := &structs.HTTPRouteConfigEntry{
+		Kind: structs.HTTPRoute,
+		Name: "r1",
+		Parents: []structs.ResourceReference{{
+			Kind: structs.APIGateway,
+			Name: "api-gateway",
+		}},
+		Rules: []structs.HTTPRouteRule{{
+			Services: []structs.HTTPService{{Name: "svc1"}},
+		}},
+	}
+	r2 := &structs.HTTPRouteConfigEntry{
+		Kind: structs.HTTPRoute,
+		Name: "r2",
+		Parents: []structs.ResourceReference{{
+			Kind: structs.APIGateway,
+			Name: "api-gateway",
+		}},
+		Rules: []structs.HTTPRouteRule{{
+			Services: []structs.HTTPService{{Name: "svc2"}},
+		}},
+	}
+	ref1 := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "r1"}
+	ref2 := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "r2"}
+
+	snap := proxycfg.TestConfigSnapshotAPIGateway(t, "default", nil, func(entry *structs.APIGatewayConfigEntry, bound *structs.BoundAPIGatewayConfigEntry) {
+		entry.Listeners = []structs.APIGatewayListener{{
+			Name:     "http-listener",
+			Protocol: structs.ListenerProtocolHTTP,
+			Port:     8080,
+		}}
+		bound.Listeners = []structs.BoundAPIGatewayListener{{
+			Name:   "http-listener",
+			Routes: []structs.ResourceReference{ref1, ref2},
+		}}
+	}, []structs.BoundRoute{r1, r2}, nil, nil)
+	require.NotNil(t, snap)
+
+	ready := getReadyListeners(snap)
+	require.Len(t, ready, 1)
+	rl := ready["http-listener"]
+	require.Contains(t, rl.routeReferences, ref1)
+	require.Contains(t, rl.routeReferences, ref2)
+}
+
 // Made with Bob


### PR DESCRIPTION
### Description

Adding a new HTTPRoute (or TCPRoute) to an API gateway with many existing routes caused a transient burst of HTTP 503 cluster_not_found errors on unrelated routes, and a flood of `[WARN] could not find discovery chain for gateway upstream` warnings.

### Root cause: 
`handleGatewayConfigUpdate` calls InitWatch for every route in he BoundAPIGateway on every update. watch.Map.InitWatch cancels the existing watch and wipes the stored value, leaving every HTTPRoutes.Get returning (nil, false). During that window, it returns `missing route for routeRef …`, which fails AllResourcesFromSnapshot and terminates the ADS stream. The xDS pipeline reconnects against a partial snapshot, producing the 503s on routes unrelated to the change.

What was fixed:

- Addedd`Map.UpdateWatch(key, cancel)`. Behaves like `InitWatch` if the key is new; for an existing key, cancels the old context but **preserves the stored `Val`**.
- In `getReadyListeners`, skip routeRefs whose HTTPRoutes/TCPRoutes entry is not loaded yet
- In `AddTrigger`'s goroutine, check `ctx.Done()` before logging the trigger error. The previous order logged `context.Canceled` at ERROR with the misleading message "adding re-reconcilation anyway" even though the request was correctly not being re-enqueued.


### Testing & Reproduction steps

- Tested with the setup provided in the ticket [CSL-14749](https://hashicorp.atlassian.net/browse/CSL-14749)

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern


[CSL-14749]: https://hashicorp.atlassian.net/browse/CSL-14749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ