### PR TITLE
Backport - Implement service ACL checks and validation for transaction operations (#23560)

### DIFF
--- a/.changelog/23560.txt
+++ b/.changelog/23560.txt
@@ -1,0 +1,6 @@
+```release-note:security
+security: Fixed Consul transaction endpoint authorization bypasses where service and check mutations could be authorized using request-provided names while applying changes by ID, including a bypass using the reserved `consul` service name.
+```
+```release-note:bug
+txn: Allow a service-level check write to be authorized in the same atomic transaction that creates its service. Previously, the transaction pre-check rejected the check op with "unknown service ID" because the service was not yet visible in committed FSM state, breaking the supported "register node + service + check in one transaction" workflow (regression in `TestAPI_ClientTxnWrite`). ACL hardening for the case where the service already exists is preserved.
+```

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -194,18 +194,26 @@ func nodePreApply(nodeName, nodeID string) error {
 }
 
 func servicePreApply(service *structs.NodeService, authz resolver.Result, authzCtxFill func(*acl.AuthorizerContext)) error {
+	if err := servicePreApplyValidate(service); err != nil {
+		return err
+	}
+	return serviceACLCheck(service, authz, authzCtxFill)
+}
+
+func servicePreApplyValidate(service *structs.NodeService) error {
 	// Validate the service. This is in addition to the below since
 	// the above just hasn't been moved over yet. We should move it over
 	// in time.
 	if err := service.Validate(); err != nil {
 		return err
 	}
+
 	// Check if service name and service ID are empty.
 	if service.ID == "" && service.Service == "" {
 		return fmt.Errorf("service name (Service.Service) is required; both Service ID (Service.ID) and Service Name cannot be empty")
 	}
 
-	// If no service id, but service name, use default
+	// If no service id, but service name, use default.
 	if service.ID == "" && service.Service != "" {
 		service.ID = service.Service
 	}
@@ -221,21 +229,37 @@ func servicePreApply(service *structs.NodeService, authz resolver.Result, authzC
 		return fmt.Errorf("Invalid service address")
 	}
 
+	return nil
+}
+
+func serviceACLCheck(service *structs.NodeService, authz resolver.Result, authzCtxFill func(*acl.AuthorizerContext)) error {
+	return serviceACLCheckWithConsulExemption(service, authz, authzCtxFill, true)
+}
+
+func serviceACLCheckNoConsulExemption(service *structs.NodeService, authz resolver.Result, authzCtxFill func(*acl.AuthorizerContext)) error {
+	return serviceACLCheckWithConsulExemption(service, authz, authzCtxFill, false)
+}
+
+func serviceACLCheckWithConsulExemption(
+	service *structs.NodeService,
+	authz resolver.Result,
+	authzCtxFill func(*acl.AuthorizerContext),
+	allowConsulExemption bool,
+) error {
 	var authzContext acl.AuthorizerContext
 	authzCtxFill(&authzContext)
 
-	// Apply the ACL policy if any. The 'consul' service is excluded
-	// since it is managed automatically internally (that behavior
-	// is going away after version 0.8). We check this same policy
-	// later if version 0.8 is enabled, so we can eventually just
-	// delete this and do all the ACL checks down there.
-	if service.Service != structs.ConsulServiceName {
+	// The historical servicePreApply path exempted the internal "consul"
+	// service from the early ServiceWriteAllowed check. That exemption must
+	// not be used for public transaction input, because txn mutations are
+	// applied by Service.ID while callers control Service.Service.
+	if !allowConsulExemption || service.Service != structs.ConsulServiceName {
 		if err := authz.ToAllowAuthorizer().ServiceWriteAllowed(service.Service, &authzContext); err != nil {
 			return err
 		}
 	}
 
-	// Proxies must have write permission on their destination
+	// Proxies must have write permission on their destination.
 	if service.Kind == structs.ServiceKindConnectProxy {
 		if err := authz.ToAllowAuthorizer().ServiceWriteAllowed(service.Proxy.DestinationServiceName, &authzContext); err != nil {
 			return err

--- a/agent/consul/txn_endpoint.go
+++ b/agent/consul/txn_endpoint.go
@@ -99,7 +99,15 @@ func (t *Txn) preCheck(authorizer resolver.Result, ops structs.TxnOps) structs.T
 			}
 
 			service := &op.Service.Service
-			if err := servicePreApply(service, authorizer, op.Service.FillAuthzContext); err != nil {
+			if err := servicePreApplyValidate(service); err != nil {
+				errors = append(errors, &structs.TxnError{
+					OpIndex: i,
+					What:    err.Error(),
+				})
+				break
+			}
+
+			if err := t.vetServiceTxnOp(op.Service, authorizer); err != nil {
 				errors = append(errors, &structs.TxnError{
 					OpIndex: i,
 					What:    err.Error(),
@@ -121,7 +129,7 @@ func (t *Txn) preCheck(authorizer resolver.Result, ops structs.TxnOps) structs.T
 			checkPreApply(&op.Check.Check)
 
 			// Check that the token has permissions for the given operation.
-			if err := vetCheckTxnOp(op.Check, authorizer); err != nil {
+			if err := t.vetCheckTxnOp(op.Check, authorizer); err != nil {
 				errors = append(errors, &structs.TxnError{
 					OpIndex: i,
 					What:    err.Error(),
@@ -163,22 +171,129 @@ func vetNodeTxnOp(op *structs.TxnNodeOp, authz resolver.Result) error {
 	return nil
 }
 
-// vetCheckTxnOp applies the given ACL policy to a check transaction operation.
-func vetCheckTxnOp(op *structs.TxnCheckOp, authz resolver.Result) error {
+// vetServiceTxnOp applies ACL policy to a service transaction operation.
+//
+// Service txn mutations are applied by Service.ID, so authorization must not be
+// based solely on the request's Service.Service field. If an existing service is
+// found for the requested node/service ID, authorize against the existing service
+// name and reject attempts to provide a different service name for the same ID.
+func (t *Txn) vetServiceTxnOp(op *structs.TxnServiceOp, authz resolver.Result) error {
+	service := &op.Service
+
+	_, existing, err := t.srv.fsm.State().NodeService(
+		nil,
+		op.Node,
+		service.ID,
+		&service.EnterpriseMeta,
+		service.PeerName,
+	)
+	if err != nil {
+		return fmt.Errorf("service lookup failed: %v", err)
+	}
+
+	if existing != nil {
+		if service.Service != existing.Service {
+			return fmt.Errorf(
+				"service name does not match existing service name for service ID %q on node %q",
+				service.ID,
+				op.Node,
+			)
+		}
+
+		return serviceACLCheckNoConsulExemption(service, authz, func(ctx *acl.AuthorizerContext) {
+			op.FillAuthzContext(ctx)
+			existing.FillAuthzContext(ctx)
+		})
+	}
+
+	// True create path: no existing service ID was found, so authorize against
+	// the requested service name as before.
+	return serviceACLCheckNoConsulExemption(service, authz, func(ctx *acl.AuthorizerContext) {
+		op.FillAuthzContext(ctx)
+		service.FillAuthzContext(ctx)
+	})
+}
+
+// vetCheckTxnOp applies ACL policy to a check transaction operation.
+//
+// Check txn mutations are applied by CheckID. If a check already exists, ACLs
+// must be evaluated against the existing check's real binding from the state
+// store instead of trusting ServiceID or ServiceName supplied in the request.
+func (t *Txn) vetCheckTxnOp(op *structs.TxnCheckOp, authz resolver.Result) error {
+	check := &op.Check
+
+	_, existing, err := t.srv.fsm.State().NodeCheck(
+		check.Node,
+		check.CheckID,
+		&check.EnterpriseMeta,
+		check.PeerName,
+	)
+	if err != nil {
+		return fmt.Errorf("check lookup failed: %v", err)
+	}
+
+	if existing != nil {
+		return t.vetCheckWrite(existing, op, authz)
+	}
+
+	return t.vetCheckWrite(check, op, authz)
+}
+
+func (t *Txn) vetCheckWrite(check *structs.HealthCheck, op *structs.TxnCheckOp, authz resolver.Result) error {
 	var authzContext acl.AuthorizerContext
+
+	if check.ServiceID == "" {
+		// Node-level check.
+		op.FillAuthzContext(&authzContext)
+		check.FillAuthzContext(&authzContext)
+
+		if err := authz.ToAllowAuthorizer().NodeWriteAllowed(check.Node, &authzContext); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Service-level check. Prefer resolving the actual service by ServiceID
+	// from the state store so we don't trust Check.ServiceName from the
+	// request. However, a check may be written in the same atomic transaction
+	// that creates its service (the service won't yet be visible in the
+	// committed FSM state at preCheck time); in that case fall back to
+	// authorizing against the ServiceName declared on the incoming check.
+	_, service, err := t.srv.fsm.State().NodeService(
+		nil,
+		check.Node,
+		check.ServiceID,
+		&check.EnterpriseMeta,
+		check.PeerName,
+	)
+	if err != nil {
+		return fmt.Errorf("service lookup failed: %v", err)
+	}
+
 	op.FillAuthzContext(&authzContext)
 
-	if op.Check.ServiceID == "" {
-		// Node-level check.
-		if err := authz.ToAllowAuthorizer().NodeWriteAllowed(op.Check.Node, &authzContext); err != nil {
-			return err
-		}
+	var serviceName string
+	if service != nil {
+		// Authorize against the real, existing service binding.
+		service.FillAuthzContext(&authzContext)
+		serviceName = service.Service
 	} else {
-		// Service-level check.
-		if err := authz.ToAllowAuthorizer().ServiceWriteAllowed(op.Check.ServiceName, &authzContext); err != nil {
-			return err
+		// Service may be created earlier in the same transaction; fall back
+		// to the ServiceName declared on the check op. Require it to be set
+		// so callers can't bypass ACLs by omitting both the existing service
+		// and the declared name.
+		if check.ServiceName == "" {
+			return fmt.Errorf("unknown service ID %q for check ID %q", check.ServiceID, check.CheckID)
 		}
+		check.FillAuthzContext(&authzContext)
+		serviceName = check.ServiceName
 	}
+
+	if err := authz.ToAllowAuthorizer().ServiceWriteAllowed(serviceName, &authzContext); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/agent/consul/txn_endpoint_test.go
+++ b/agent/consul/txn_endpoint_test.go
@@ -1071,3 +1071,474 @@ func TestTxn_Validation(t *testing.T) {
 		require.Contains(t, out.Errors[0].Error(), tc.expectedError)
 	}
 }
+
+func TestTxn_Apply_ServiceSetRejectsServiceNameMismatchForExistingID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	state := s1.fsm.State()
+	require.NoError(t, state.EnsureNode(1, &structs.Node{
+		Node:    "test-node",
+		Address: "127.0.0.1",
+	}))
+
+	require.NoError(t, state.EnsureService(2, "test-node", &structs.NodeService{
+		ID:      "shared-id",
+		Service: "victim-svc",
+		Address: "127.0.0.1",
+	}))
+
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	token := createTokenFull(t, codec, testTxnRules)
+
+	arg := structs.TxnRequest{
+		Datacenter: "dc1",
+		Ops: structs.TxnOps{
+			{
+				Service: &structs.TxnServiceOp{
+					Verb: api.ServiceSet,
+					Node: "test-node",
+					Service: structs.NodeService{
+						ID:      "shared-id",
+						Service: "test-svc",
+						Address: "127.0.0.1",
+					},
+				},
+			},
+		},
+		WriteRequest: structs.WriteRequest{
+			Token: token.SecretID,
+		},
+	}
+
+	var out structs.TxnResponse
+	require.NoError(t, s1.RPC(context.Background(), "Txn.Apply", &arg, &out))
+	require.Len(t, out.Errors, 1)
+	require.Equal(t, 0, out.Errors[0].OpIndex)
+	require.Contains(t, out.Errors[0].What, `does not match existing service name`)
+}
+
+func TestTxn_Apply_CheckSetAuthorizesResolvedServiceID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	state := s1.fsm.State()
+	require.NoError(t, state.EnsureNode(1, &structs.Node{
+		Node:    "test-node",
+		Address: "127.0.0.1",
+	}))
+
+	require.NoError(t, state.EnsureService(2, "test-node", &structs.NodeService{
+		ID:      "victim-id",
+		Service: "victim-svc",
+		Address: "127.0.0.1",
+	}))
+
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	token := createTokenFull(t, codec, testTxnRules)
+
+	arg := structs.TxnRequest{
+		Datacenter: "dc1",
+		Ops: structs.TxnOps{
+			{
+				Check: &structs.TxnCheckOp{
+					Verb: api.CheckSet,
+					Check: structs.HealthCheck{
+						Node:        "test-node",
+						CheckID:     types.CheckID("victim-check"),
+						Name:        "victim-check",
+						ServiceID:   "victim-id",
+						ServiceName: "test-svc", // spoofed; must not be trusted
+					},
+				},
+			},
+		},
+		WriteRequest: structs.WriteRequest{
+			Token: token.SecretID,
+		},
+	}
+
+	var out structs.TxnResponse
+	require.NoError(t, s1.RPC(context.Background(), "Txn.Apply", &arg, &out))
+	require.Len(t, out.Errors, 1)
+	require.Equal(t, 0, out.Errors[0].OpIndex)
+	acl.RequirePermissionDeniedMessage(
+		t,
+		out.Errors[0].What,
+		token.AccessorID,
+		nil,
+		acl.ResourceService,
+		acl.AccessWrite,
+		"victim-svc",
+	)
+}
+
+// TestTxn_Apply_CheckSetSameTxnAsServiceSet is a regression test for a bug
+// where the transaction pre-check rejected a service-level check write whose
+// service was being created earlier in the same atomic transaction. The
+// pre-check looked the service up in committed FSM state, which does not yet
+// contain ops from the in-flight transaction, and returned an
+// "unknown service ID" error. This broke the supported
+// "register node + service + check in one transaction" workflow (covered by
+// api.TestAPI_ClientTxnWrite).
+func TestTxn_Apply_CheckSetSameTxnAsServiceSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	// testTxnRules grants node:write on "test-node" and service:write on
+	// "test-svc". The transaction creates the node, the service, and a
+	// service-level check that binds to the just-created service - all in
+	// one atomic request.
+	token := createTokenFull(t, codec, testTxnRules)
+
+	arg := structs.TxnRequest{
+		Datacenter: "dc1",
+		Ops: structs.TxnOps{
+			{
+				Node: &structs.TxnNodeOp{
+					Verb: api.NodeSet,
+					Node: structs.Node{
+						Node:    "test-node",
+						Address: "127.0.0.1",
+					},
+				},
+			},
+			{
+				Service: &structs.TxnServiceOp{
+					Verb: api.ServiceSet,
+					Node: "test-node",
+					Service: structs.NodeService{
+						ID:      "test-svc-id",
+						Service: "test-svc",
+						Address: "127.0.0.1",
+						Port:    8080,
+					},
+				},
+			},
+			{
+				Check: &structs.TxnCheckOp{
+					Verb: api.CheckSet,
+					Check: structs.HealthCheck{
+						Node:        "test-node",
+						CheckID:     types.CheckID("test-check"),
+						Name:        "test-check",
+						Status:      api.HealthPassing,
+						ServiceID:   "test-svc-id",
+						ServiceName: "test-svc",
+					},
+				},
+			},
+		},
+		WriteRequest: structs.WriteRequest{
+			Token: token.SecretID,
+		},
+	}
+
+	var out structs.TxnResponse
+	require.NoError(t, s1.RPC(context.Background(), "Txn.Apply", &arg, &out))
+	require.Empty(t, out.Errors, "transaction should succeed; got errors: %+v", out.Errors)
+	require.Len(t, out.Results, 3)
+
+	// Confirm the check is bound to the real service in state.
+	_, gotCheck, err := s1.fsm.State().NodeCheck("test-node", types.CheckID("test-check"), nil, "")
+	require.NoError(t, err)
+	require.NotNil(t, gotCheck)
+	require.Equal(t, "test-svc-id", gotCheck.ServiceID)
+	require.Equal(t, "test-svc", gotCheck.ServiceName)
+}
+
+// TestTxn_Apply_CheckSetUnknownServiceIDEmptyName verifies the safety guard
+// in vetCheckWrite: when a service-level check op references a ServiceID that
+// does not exist in committed state and is not being created in the same
+// transaction, and the caller omits ServiceName, the op is rejected. This
+// prevents the same-txn-create fallback from being used to bypass ACLs by
+// supplying an empty service name (which most authorizers do not match).
+func TestTxn_Apply_CheckSetUnknownServiceIDEmptyName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Pre-create the node so the only failure point is the check op.
+	require.NoError(t, s1.fsm.State().EnsureNode(1, &structs.Node{
+		Node:    "test-node",
+		Address: "127.0.0.1",
+	}))
+
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	token := createTokenFull(t, codec, testTxnRules)
+
+	arg := structs.TxnRequest{
+		Datacenter: "dc1",
+		Ops: structs.TxnOps{
+			{
+				Check: &structs.TxnCheckOp{
+					Verb: api.CheckSet,
+					Check: structs.HealthCheck{
+						Node:    "test-node",
+						CheckID: types.CheckID("ghost-check"),
+						Name:    "ghost-check",
+						// Service-level check (ServiceID set) but the
+						// service does not exist and ServiceName is empty.
+						ServiceID:   "ghost-id",
+						ServiceName: "",
+					},
+				},
+			},
+		},
+		WriteRequest: structs.WriteRequest{
+			Token: token.SecretID,
+		},
+	}
+
+	var out structs.TxnResponse
+	require.NoError(t, s1.RPC(context.Background(), "Txn.Apply", &arg, &out))
+	require.Len(t, out.Errors, 1)
+	require.Equal(t, 0, out.Errors[0].OpIndex)
+	require.Contains(t, out.Errors[0].What, "unknown service ID")
+}
+func TestTxn_Apply_ServiceSet_NoTokenConsulNameDoesNotOverwriteExistingService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	state := s1.fsm.State()
+	require.NoError(t, state.EnsureNode(1, &structs.Node{
+		Node:    "victim-node",
+		Address: "127.0.0.1",
+	}))
+
+	require.NoError(t, state.EnsureService(2, "victim-node", &structs.NodeService{
+		ID:      "victim-id",
+		Service: "victim-service",
+		Address: "127.0.0.1",
+		Port:    9000,
+	}))
+
+	arg := structs.TxnRequest{
+		Datacenter: "dc1",
+		Ops: structs.TxnOps{
+			{
+				Service: &structs.TxnServiceOp{
+					Verb: api.ServiceSet,
+					Node: "victim-node",
+					Service: structs.NodeService{
+						ID:      "victim-id",
+						Service: "consul",
+						Address: "198.51.100.7",
+						Port:    8443,
+					},
+				},
+			},
+		},
+		// Intentionally no token.
+	}
+
+	var txnResp structs.TxnResponse
+	require.NoError(t, s1.RPC(context.Background(), "Txn.Apply", &arg, &txnResp))
+	require.Len(t, txnResp.Errors, 1)
+	require.Contains(t, txnResp.Errors[0].What, "does not match existing service name")
+
+	_, svc, err := state.NodeService(nil, "victim-node", "victim-id", nil, "")
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	require.Equal(t, "victim-service", svc.Service)
+	require.Equal(t, "127.0.0.1", svc.Address)
+	require.Equal(t, 9000, svc.Port)
+}
+
+func TestTxn_Apply_ServiceDelete_NoTokenConsulNameDoesNotDeleteExistingService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	state := s1.fsm.State()
+	require.NoError(t, state.EnsureNode(1, &structs.Node{
+		Node:    "victim-node",
+		Address: "127.0.0.1",
+	}))
+
+	require.NoError(t, state.EnsureService(2, "victim-node", &structs.NodeService{
+		ID:      "victim-id",
+		Service: "victim-service",
+		Address: "127.0.0.1",
+	}))
+
+	arg := structs.TxnRequest{
+		Datacenter: "dc1",
+		Ops: structs.TxnOps{
+			{
+				Service: &structs.TxnServiceOp{
+					Verb: api.ServiceDelete,
+					Node: "victim-node",
+					Service: structs.NodeService{
+						ID:      "victim-id",
+						Service: "consul",
+					},
+				},
+			},
+		},
+		// Intentionally no token.
+	}
+
+	var txnResp structs.TxnResponse
+	require.NoError(t, s1.RPC(context.Background(), "Txn.Apply", &arg, &txnResp))
+	require.Len(t, txnResp.Errors, 1)
+	require.Contains(t, txnResp.Errors[0].What, "does not match existing service name")
+
+	_, svc, err := state.NodeService(nil, "victim-node", "victim-id", nil, "")
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	require.Equal(t, "victim-service", svc.Service)
+}
+
+func TestTxn_Apply_ServiceSet_NoTokenCannotWriteConsulService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	state := s1.fsm.State()
+	require.NoError(t, state.EnsureNode(1, &structs.Node{
+		Node:    "victim-node",
+		Address: "127.0.0.1",
+	}))
+
+	require.NoError(t, state.EnsureService(2, "victim-node", &structs.NodeService{
+		ID:      "consul-id",
+		Service: "consul",
+		Address: "127.0.0.1",
+		Port:    8300,
+	}))
+
+	arg := structs.TxnRequest{
+		Datacenter: "dc1",
+		Ops: structs.TxnOps{
+			{
+				Service: &structs.TxnServiceOp{
+					Verb: api.ServiceSet,
+					Node: "victim-node",
+					Service: structs.NodeService{
+						ID:      "consul-id",
+						Service: "consul",
+						Address: "198.51.100.7",
+						Port:    8443,
+					},
+				},
+			},
+		},
+		// Intentionally no token.
+	}
+
+	var txnResp structs.TxnResponse
+	require.NoError(t, s1.RPC(context.Background(), "Txn.Apply", &arg, &txnResp))
+	require.Len(t, txnResp.Errors, 1)
+
+	_, svc, err := state.NodeService(nil, "victim-node", "consul-id", nil, "")
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	require.Equal(t, "consul", svc.Service)
+	require.Equal(t, "127.0.0.1", svc.Address)
+	require.Equal(t, 8300, svc.Port)
+}


### PR DESCRIPTION
Backport of PR https://github.com/hashicorp/consul/pull/23560

* Implement service ACL checks and validation for transaction operations

* added changelog file

* Fix authorization bypass in Consul transaction endpoint for service mutations

* renamed changelog file

---------


(cherry picked from commit ac4b0196ac7f1f4c143e218e3a5319545c289b99)

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
