### PR TITLE
Fix CVEs

### DIFF
--- a/.changelog/23570.txt
+++ b/.changelog/23570.txt
@@ -1,0 +1,12 @@
+```release-note:security
+docker: Upgrade `curl` to >= 8.20.0 from Alpine edge in the container image to address
+[CVE-2026-6429](https://www.cve.org/CVERecord?id=CVE-2026-6429),
+[CVE-2026-4873](https://www.cve.org/CVERecord?id=CVE-2026-4873),
+[CVE-2026-5773](https://www.cve.org/CVERecord?id=CVE-2026-5773),
+[CVE-2026-6253](https://www.cve.org/CVERecord?id=CVE-2026-6253),
+[CVE-2026-6276](https://www.cve.org/CVERecord?id=CVE-2026-6276),
+[CVE-2026-7168](https://www.cve.org/CVERecord?id=CVE-2026-7168),
+[CVE-2026-5545](https://www.cve.org/CVERecord?id=CVE-2026-5545).
+Alpine 3.23 stable does not yet carry the patched version.
+```
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,27 @@ RUN addgroup consul && \
 
 # Set up certificates, base tools, and Consul.
 # libc6-compat is needed to symlink the shared libraries for ARM builds
+# Upgrade curl to >=8.20.0 from Alpine edge to fix CVE-2026-6429, CVE-2026-4873, CVE-2026-5773,
+# CVE-2026-6253, CVE-2026-6276, CVE-2026-7168, CVE-2026-5545 (fixed in curl 8.20.0).
+# Alpine 3.23 stable does not yet carry the patched version.
 RUN set -eux && \
-    apk add --no-cache --upgrade ca-certificates curl dumb-init gnupg libcap openssl su-exec iputils jq libc6-compat iptables tzdata && \
+    apk add --no-cache --upgrade \
+            ca-certificates \
+            dumb-init \
+            gnupg \
+            gnutls \
+            libcap \
+            openssl \
+            su-exec \
+            iputils \
+            jq \
+            libc6-compat \
+            iptables \
+            tzdata \
+            zlib && \
+    apk add --no-cache --upgrade \
+        --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
+        'curl>=8.20.0' && \
     gpg --keyserver keyserver.ubuntu.com --recv-keys C874011F0AB405110D02105534365D9472D7468F && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
@@ -156,6 +175,9 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
 COPY LICENSE /usr/share/doc/$PRODUCT_NAME/LICENSE.txt
 # Set up certificates and base tools.
 # libc6-compat is needed to symlink the shared libraries for ARM builds
+# Upgrade curl to >=8.20.0 from Alpine edge to fix CVE-2026-6429, CVE-2026-4873, CVE-2026-5773,
+# CVE-2026-6253, CVE-2026-6276, CVE-2026-7168, CVE-2026-5545 (fixed in curl 8.20.0).
+# Alpine 3.23 stable does not yet carry the patched version.
 RUN apk add -v --no-cache --upgrade \
 		dumb-init \
 		libc6-compat \
@@ -164,11 +186,16 @@ RUN apk add -v --no-cache --upgrade \
 		curl \
 		ca-certificates \
 		gnupg \
-		iputils \ 
+		gnutls \
+		iputils \
 		libcap \
 		openssl \
 		su-exec \
-		jq 
+		jq \
+		zlib && \
+    apk add --no-cache --upgrade \
+        --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
+        'curl>=8.20.0'
 
 # Create a consul user and group first so the IDs get set the same way, even as
 # the rest of this may change over time.


### PR DESCRIPTION
Upgrade `curl` to >= 8.20.0 from Alpine edge in the container image to address
[CVE-2026-6429](https://www.cve.org/CVERecord?id=CVE-2026-6429),
[CVE-2026-4873](https://www.cve.org/CVERecord?id=CVE-2026-4873),
[CVE-2026-5773](https://www.cve.org/CVERecord?id=CVE-2026-5773),
[CVE-2026-6253](https://www.cve.org/CVERecord?id=CVE-2026-6253),
[CVE-2026-6276](https://www.cve.org/CVERecord?id=CVE-2026-6276),
[CVE-2026-7168](https://www.cve.org/CVERecord?id=CVE-2026-7168),
[CVE-2026-5545](https://www.cve.org/CVERecord?id=CVE-2026-5545).
Alpine 3.23 stable does not yet carry the patched version.