### PR TITLE
Suppress CVEs - Fix not avialable

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -39,6 +39,8 @@ container {
   triage {
     suppress {
       vulnerabilities = [
+        "CVE-2025-30258", //Alpine Linux's Security Issue Tracker in gnupg@2.4.9-r0
+        "CVE-2026-41989", //Alpine Linux's Security Issue Tracker in libgcrypt@1.11.2-r0
       ]
 
       paths = [


### PR DESCRIPTION
Suppress the CVEs where fix is not available. 
These CVEs are breaking the prepare workflow.
We should periodically review the security-scan.hcl suppressed vulnerabilities to check for the fixes.