### PR TITLE
ent only setup for admin partitions and namespaces

### DIFF
--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/basic.spec.js
@@ -13,18 +13,13 @@ const { isEnterpriseConsul } = require('../../utils/ent-utils');
  * Run on every PR.
  *
  * NOTE: Admin Partitions is an Enterprise-only feature.
- * These tests currently run on CE + ENT for development purposes.
- * To restrict to ENT only: set CONSUL_ENT_ONLY=true in the environment.
+ * These tests are skipped automatically on Community Edition.
  */
 
 test.describe('Admin Partitions - Basic', { tag: '@ent' }, () => {
-  test('admin partitions list page loads', async ({
-    partitionsPage,
-    skipEnt,
-    request,
-    baseURL,
-  }) => {
-    await skipEnt(request, baseURL);
+  test('admin partitions list page loads', async ({ partitionsPage, request, baseURL }) => {
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Admin Partitions is an Enterprise-only feature.');
 
     await partitionsPage.goto();
 

--- a/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/workflows.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/admin-partitions/workflows.spec.js
@@ -27,11 +27,11 @@ test.describe('Admin Partitions - Workflows', { tag: '@ent' }, () => {
   test('navigate to admin partitions via partition selector', async ({
     page,
     partitionsPage,
-    skipEnt,
     request,
     baseURL,
   }) => {
-    await skipEnt(request, baseURL);
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Admin Partitions is an Enterprise-only feature.');
 
     await page.goto(`${baseURL}/ui/dc1/services`, { waitUntil: 'domcontentloaded' });
 
@@ -97,11 +97,11 @@ test.describe('Admin Partitions - Workflows', { tag: '@ent' }, () => {
    */
   test('cancel partition edit discards changes and returns to list', async ({
     partitionsPage,
-    skipEnt,
     request,
     baseURL,
   }) => {
-    await skipEnt(request, baseURL);
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Admin Partitions is an Enterprise-only feature.');
 
     await partitionsPage.gotoEdit('default');
     await expect(partitionsPage.page).toHaveURL(/\/partitions\/default/, { timeout: 15000 });
@@ -123,11 +123,11 @@ test.describe('Admin Partitions - Workflows', { tag: '@ent' }, () => {
    */
   test('search bar filters the partition list', async ({
     partitionsPage,
-    skipEnt,
     request,
     baseURL,
   }) => {
-    await skipEnt(request, baseURL);
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Admin Partitions is an Enterprise-only feature.');
 
     await partitionsPage.goto();
     await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });
@@ -152,11 +152,11 @@ test.describe('Admin Partitions - Workflows', { tag: '@ent' }, () => {
    */
   test('search across scope toggle works on partition list', async ({
     partitionsPage,
-    skipEnt,
     request,
     baseURL,
   }) => {
-    await skipEnt(request, baseURL);
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Admin Partitions is an Enterprise-only feature.');
 
     await partitionsPage.goto();
     await expect(partitionsPage.heading).toBeVisible({ timeout: 15000 });

--- a/ui/packages/consul-ui/e2e-tests/tests/namespaces/basic.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/namespaces/basic.spec.js
@@ -17,8 +17,9 @@ const { isEnterpriseConsul } = require('../../utils/ent-utils');
  */
 
 test.describe('Namespaces - Basic', { tag: '@ent' }, () => {
-  test('namespaces list page loads', async ({ namespacesPage, skipEnt, request, baseURL }) => {
-    await skipEnt(request, baseURL);
+  test('namespaces list page loads', async ({ namespacesPage, request, baseURL }) => {
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Namespaces is an Enterprise-only feature.');
 
     await namespacesPage.goto();
 

--- a/ui/packages/consul-ui/e2e-tests/tests/namespaces/workflows.spec.js
+++ b/ui/packages/consul-ui/e2e-tests/tests/namespaces/workflows.spec.js
@@ -24,11 +24,11 @@ test.describe('Namespaces - Workflows', { tag: '@ent' }, () => {
   test('navigate to namespaces via namespace selector', async ({
     page,
     namespacesPage,
-    skipEnt,
     request,
     baseURL,
   }) => {
-    await skipEnt(request, baseURL);
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Namespaces is an Enterprise-only feature.');
 
     await page.goto(`${baseURL}/ui/dc1/services`, { waitUntil: 'domcontentloaded' });
 
@@ -236,11 +236,11 @@ test.describe('Namespaces - Workflows', { tag: '@ent' }, () => {
    */
   test('cancel namespace edit discards changes and returns to list', async ({
     namespacesPage,
-    skipEnt,
     request,
     baseURL,
   }) => {
-    await skipEnt(request, baseURL);
+    const isEnt = await isEnterpriseConsul(request, baseURL);
+    test.skip(!isEnt, 'Namespaces is an Enterprise-only feature.');
 
     await namespacesPage.gotoEdit('default');
     await expect(namespacesPage.page).toHaveURL(/\/namespaces\/default/, { timeout: 15000 });


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

E2E Tests for Namespaces and Admin Partitions should only run on ENT and not on CE

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
