### PR TITLE
Ubi image version update-9.8

### DIFF
--- a/.changelog/23588.txt
+++ b/.changelog/23588.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-security: Update to UBI base image to 9.8 for better CVE scan results.
+security: Update to UBI base image to 9.8 for fixing [[CVE_2026-2100](https://access.redhat.com/security/cve/cve-2026-2100)]
 ```

--- a/.changelog/23588.txt
+++ b/.changelog/23588.txt
@@ -1,0 +1,3 @@
+```release-note:security
+security: Update to UBI base image to 9.8 for better CVE scan results.
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -244,7 +244,7 @@ CMD ["agent", "-dev", "-client", "0.0.0.0"]
 
 # Red Hat UBI-based image
 # This target is used to build a Consul image for use on OpenShift.
-FROM registry.access.redhat.com/ubi9-minimal:9.7 as ubi
+FROM registry.access.redhat.com/ubi9-minimal:9.8 as ubi
 
 ARG PRODUCT_VERSION
 ARG PRODUCT_REVISION


### PR DESCRIPTION
Ubi image update to 9.8 for fixing [CVE-2026-2100](https://ibm-hashicorp.slack.com/archives/C09KJKW01CP/p1778679518394519)