### PR TITLE
fix: close named pipe descriptor on error path in pipe-bootstrap

### DIFF
--- a/.changelog/23602.txt
+++ b/.changelog/23602.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fix a file descriptor leak in the internal Envoy bootstrap pipe shim when writing the bootstrap payload to the named pipe fails.
+```

--- a/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go
+++ b/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go
@@ -64,6 +64,7 @@ func (c *cmd) Run(args []string) int {
 
 	if _, err := buf.WriteTo(f); err != nil {
 		c.UI.Error(err.Error())
+		f.Close()
 		return 1
 	}
 

--- a/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go
+++ b/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go
@@ -64,7 +64,7 @@ func (c *cmd) Run(args []string) int {
 
 	if _, err := buf.WriteTo(f); err != nil {
 		c.UI.Error(err.Error())
-		f.Close()
+		_ = f.Close()
 		return 1
 	}
 

--- a/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap_linux_test.go
+++ b/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap_linux_test.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package pipebootstrap
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+// countOpenFDs returns the number of file descriptors currently open by this
+// process, read from /proc/self/fd. Linux only, hence this file's _linux
+// suffix.
+func countOpenFDs(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatalf("reading /proc/self/fd: %v", err)
+	}
+	return len(entries)
+}
+
+// TestRun_WriteErrorDoesNotLeakDescriptor verifies that Run closes the named
+// pipe descriptor when writing the bootstrap payload fails. /dev/full can be
+// opened for writing but fails every write with ENOSPC, which exercises the
+// buf.WriteTo error path. Before the fix for issue #23256, the descriptor
+// opened by os.OpenFile was leaked on that path.
+func TestRun_WriteErrorDoesNotLeakDescriptor(t *testing.T) {
+	// Feed non-empty stdin so buf.WriteTo actually attempts a write.
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stdinW.WriteString("bootstrap-payload"); err != nil {
+		t.Fatal(err)
+	}
+	stdinW.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = stdinR
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		stdinR.Close()
+	})
+
+	// Baseline is taken after stdinR replaces os.Stdin, so its descriptor is
+	// already accounted for in the count.
+	before := countOpenFDs(t)
+
+	code := New(cli.NewMockUi()).Run([]string{"/dev/full"})
+	if code != 1 {
+		t.Fatalf("Run: expected exit code 1 on write failure, got %d", code)
+	}
+
+	if after := countOpenFDs(t); after > before {
+		t.Fatalf("file descriptor leaked on write-error path: %d open before Run, %d after", before, after)
+	}
+}

--- a/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap_linux_test.go
+++ b/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap_linux_test.go
@@ -36,13 +36,13 @@ func TestRun_WriteErrorDoesNotLeakDescriptor(t *testing.T) {
 	if _, err := stdinW.WriteString("bootstrap-payload"); err != nil {
 		t.Fatal(err)
 	}
-	stdinW.Close()
+	_ = stdinW.Close()
 
 	origStdin := os.Stdin
 	os.Stdin = stdinR
 	t.Cleanup(func() {
 		os.Stdin = origStdin
-		stdinR.Close()
+		_ = stdinR.Close()
 	})
 
 	// Baseline is taken after stdinR replaces os.Stdin, so its descriptor is


### PR DESCRIPTION
### Description

`Run` in `command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go` opens a file descriptor with `os.OpenFile` and writes the Envoy bootstrap payload into the named pipe via `buf.WriteTo(f)`. When that write fails, the function returned `1` without closing `f`, leaking the descriptor. The success path and the `os.OpenFile` error path are both fine — only the `WriteTo` failure path leaked.

This adds an `f.Close()` on that error path. I deliberately did not switch to `defer f.Close()`: the success path already performs an explicit `f.Close()` with error checking, so a deferred close would result in a double close on the happy path. The targeted fix keeps the existing structure intact.

### Testing & Reproduction steps

Added a Linux regression test (`connect_envoy_pipe-bootstrap_linux_test.go`) that exercises the failure path: it targets `/dev/full` as the pipe path (it opens for writing but every write fails with `ENOSPC`), feeds non-empty stdin, and asserts via `/proc/self/fd` that no descriptor is leaked once `Run` returns.

Verified in a Linux container:

* On the unfixed code the test fails — `file descriptor leaked on write-error path: 10 open before Run, 11 after`.
* With the fix the test passes, and the full package suite + `go vet` pass.

The test is gated to Linux via the `_linux_test.go` filename suffix because it relies on `/dev/full` and `/proc/self/fd`.

### Links

* Fixes #23256

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.