### PR TITLE
fix(ci): increase max-issue budget for stale branch cleanup

### DIFF
--- a/.github/workflows/stale-branches.yaml
+++ b/.github/workflows/stale-branches.yaml
@@ -2,6 +2,7 @@ name: Stale Branches
 on:
   schedule:
     - cron: "0 6 * * 1-5"
+  workflow_dispatch:
 
 permissions:
   issues: write

--- a/.github/workflows/stale-branches.yaml
+++ b/.github/workflows/stale-branches.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Stale Branches
-        uses: crs-k/stale-branches@c6e09a3de1046d68b21eccdca23321d0ec277964 # v7.0.0
+        uses: crs-k/stale-branches@e876b957ab08f0bad43c8cc271a22cdd7604bd09 # v9.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           days-before-stale: 120
@@ -22,3 +22,4 @@ jobs:
           compare-branches: "info"
           ignore-issue-interaction: true
           pr-check: true
+          max-issues: 500

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           days-before-stale: -1
           days-before-close: -1


### PR DESCRIPTION
### Description

- Increased max-issue input to stale-branch workflow from defalt 20 to allow processing of all the branches
- Upgraded actions/stale version in stale-prs workflow to latest
- Upgraded crs-k/stale-branches version in stale-branch workflow to latest

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

Successful run : https://github.com/hashicorp/consul/actions/runs/27195774338/job/80286889805

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
