### PR TITLE
Add Go fuzz tests for OSS-Fuzz integration

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,38 @@
+name: CIFuzz
+on:
+  pull_request:
+    paths:
+      - '**'
+  push:
+    branches: [main, master]
+permissions:
+  contents: read
+jobs:
+  fuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'consul'
+        language: go
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'consul'
+        language: go
+        fuzz-seconds: 300
+        sanitizer: ${{ matrix.sanitizer }}
+        output-sarif: true
+    - name: Upload Sarif
+      if: always() && steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: cifuzz-sarif/results.sarif
+        category: fuzz-${{ matrix.sanitizer }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -6,25 +6,29 @@ on:
       - '.github/workflows/cifuzz.yml'
   push:
     branches: [main, master]
+
 permissions:
   contents: read
+  security-events: write
+
 jobs:
   fuzzing:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address, memory]
+        sanitizer: [address]
     steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@ba0e2e0 # v1.0.0
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@ba0e2e0399a10b7b42afb16e7a6c4ccd3ff52431
       with:
         oss-fuzz-project-name: 'consul'
         language: go
         sanitizer: ${{ matrix.sanitizer }}
     - name: Run Fuzzers (${{ matrix.sanitizer }})
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@ba0e2e0 # v1.0.0
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@ba0e2e0399a10b7b42afb16e7a6c4ccd3ff52431
       with:
         oss-fuzz-project-name: 'consul'
         language: go
@@ -32,8 +36,8 @@ jobs:
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
     - name: Upload Sarif
-      if: steps.build.outcome == 'success'
-      uses: github/codeql-action/upload-sarif@601d5b1 # v3.28.15
+      if: always() && steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@601d5b1bcb3e5ef5eea97a6d0dcdbbb8c2b80116
       with:
         sarif_file: cifuzz-sarif/results.sarif
         category: fuzz-${{ matrix.sanitizer }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,7 +2,8 @@ name: CIFuzz
 on:
   pull_request:
     paths:
-      - '**'
+      - '**.go'
+      - '.github/workflows/cifuzz.yml'
   push:
     branches: [main, master]
 permissions:
@@ -13,17 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address]
+        sanitizer: [address, memory]
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@ba0e2e0 # v1.0.0
       with:
         oss-fuzz-project-name: 'consul'
         language: go
         sanitizer: ${{ matrix.sanitizer }}
     - name: Run Fuzzers (${{ matrix.sanitizer }})
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@ba0e2e0 # v1.0.0
       with:
         oss-fuzz-project-name: 'consul'
         language: go
@@ -31,8 +32,8 @@ jobs:
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
     - name: Upload Sarif
-      if: always() && steps.build.outcome == 'success'
-      uses: github/codeql-action/upload-sarif@v3
+      if: steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@601d5b1 # v3.28.15
       with:
         sarif_file: cifuzz-sarif/results.sarif
         category: fuzz-${{ matrix.sanitizer }}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,54 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package consul_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// FuzzACLTokenUnmarshal tests ACL token JSON parsing with
+// arbitrary attacker-controlled JSON input.
+//
+// ACL tokens control all authorization in Consul. The token
+// JSON parser is a pre-auth boundary — a bug here = privilege
+// escalation across the entire service mesh.
+//
+// 30 GitHub Security Advisories exist for HashiCorp Consul.
+func FuzzACLTokenUnmarshal(f *testing.F) {
+	f.Add([]byte(`{"AccessorID":"test","SecretID":"secret"}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(``))
+	f.Add([]byte(`{`))
+	f.Add(make([]byte, 10000))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1<<16 {
+			return
+		}
+		var token structs.ACLToken
+		_ = token.UnmarshalJSON(data)
+	})
+}
+
+// FuzzACLPolicyUnmarshal tests ACL policy JSON parsing with
+// arbitrary JSON input. ACL policies define the rules that
+// control access in Consul.
+func FuzzACLPolicyUnmarshal(f *testing.F) {
+	f.Add([]byte(`{"ID":"test","Name":"test-policy","Rules":"node { policy = \"read\" }"}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1<<16 {
+			return
+		}
+		var policy structs.ACLPolicy
+		_ = policy.UnmarshalJSON(data)
+	})
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -4,7 +4,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package consul_test
+package consul
 
 import (
 	"testing"


### PR DESCRIPTION
Adds Go native fuzz targets for OSS-Fuzz integration. Consul has 30K stars and 30 GHSA advisories. Fuzz targets: ACL token/policy JSON parsing (pre-auth authorization boundary).