### PR TITLE
fix(pipe-bootstrap): close file descriptor on all error paths

### DIFF
--- a/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go
+++ b/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go
@@ -61,6 +61,12 @@ func (c *cmd) Run(args []string) int {
 		c.UI.Error(err.Error())
 		return 1
 	}
+	// Ensure the file descriptor is closed on all exit paths to avoid leaks.
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			c.UI.Error(cerr.Error())
+		}
+	}()
 
 	if _, err := buf.WriteTo(f); err != nil {
 		c.UI.Error(err.Error())


### PR DESCRIPTION
Found this while looking at #23256. The pipe-bootstrap shim opens a named pipe with os.OpenFile but only closes it on the happy path. If buf.WriteTo fails, the function returns early and the descriptor leaks.

The fix is straightforward: add a deferred f.Close() right after the open succeeds so every exit path releases the descriptor. I kept the explicit f.Close() on the success path too so close errors still surface immediately rather than being swallowed by the defer.

Not 100% sure about the error handling pattern here — happy to adjust if there's a preferred way to log deferred close errors.