### PR TITLE
ci: fix expression injection in embedded-asset-checker.yml

### DIFF
--- a/.github/workflows/embedded-asset-checker.yml
+++ b/.github/workflows/embedded-asset-checker.yml
@@ -25,8 +25,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # by default the checkout action doesn't checkout all branches
       - name: Check for agent/uiserver/dist dir change in diff
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          dist_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" -- agent/uiserver/dist)
+          dist_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${BASE_REF}")" -- agent/uiserver/dist)
           if [[ -z "${dist_files}" ]]; then
             exit 0
           fi


### PR DESCRIPTION
The dist-check step in embedded-asset-checker.yml interpolates
github.event.pull_request.base.ref directly into a shell command:

  git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}"

A pull request whose base branch name contains shell metacharacters
(semicolon, backtick, dollar sign followed by parenthesis, etc.)
would cause arbitrary command execution in the GitHub Actions runner.

The workflow is triggered by the pull_request event on the main and
release/* branches, so only trusted base branch names appear in
practice. However, defence-in-depth and tools such as zizmor and
StepSecurity flag all direct context interpolation regardless.

Fix: move github.event.pull_request.base.ref into a BASE_REF env:
variable and reference it as ${BASE_REF} in the shell step.

No behaviour change is intended.
