### PR TITLE
fix: don't request client cert SDS when only CAFile is set

### DIFF
--- a/.changelog/23679.txt
+++ b/.changelog/23679.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: only emit the client cert SDS block when both CertFile and KeyFile are set.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ terraform.rc
 consul-k8s/
 .vercel
 vendor/
+.claude

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -775,6 +775,24 @@ func TestInjectGatewayServiceAddons_TerminatingGateway_TLSContextUsesSDS(t *test
 	require.Equal(t, envoy_core_v3.ApiVersion_V3, certSDS.SdsConfig.ResourceApiVersion)
 }
 
+func TestInjectGatewayServiceAddons_TerminatingGateway_OneWayTLS_NoCertSDSConfig(t *testing.T) {
+	s := &ResourceGenerator{Logger: hclog.NewNullLogger()}
+	svc := structs.NewServiceName("db", structs.DefaultEnterpriseMetaInDefaultPartition())
+	snap := proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, nil)
+	snap.TerminatingGateway.GatewayServices = map[structs.ServiceName]structs.GatewayService{
+		svc: {Service: svc, CAFile: "ca.pem"},
+	}
+
+	c := &envoy_cluster_v3.Cluster{Name: "db"}
+	err := s.injectGatewayServiceAddons(snap, c, svc, &structs.LoadBalancer{})
+
+	require.NoError(t, err)
+	upstreamTLS := &envoy_tls_v3.UpstreamTlsContext{}
+	err = c.TransportSocket.GetTypedConfig().UnmarshalTo(upstreamTLS)
+	require.NoError(t, err)
+	require.Empty(t, upstreamTLS.CommonTlsContext.TlsCertificateSdsSecretConfigs, "one-way TLS must not request a client cert SDS secret")
+}
+
 func TestInjectGatewayServiceAddons_TerminatingGateway_ServiceNotInMap(t *testing.T) {
 	s := &ResourceGenerator{Logger: hclog.NewNullLogger()}
 	svc := structs.NewServiceName("unknown", structs.DefaultEnterpriseMetaInDefaultPartition())
@@ -887,7 +905,7 @@ func TestInjectGatewayDestinationAddons_TerminatingGateway_TLSContextUsesSDS(t *
 	svc := structs.NewServiceName("cache", structs.DefaultEnterpriseMetaInDefaultPartition())
 	snap := proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, nil)
 	snap.TerminatingGateway.DestinationServices = map[structs.ServiceName]structs.GatewayService{
-		svc: {Service: svc, CAFile: "ca.pem"},
+		svc: {Service: svc, CAFile: "ca.pem", CertFile: "cert.pem", KeyFile: "key.pem"},
 	}
 
 	c := &envoy_cluster_v3.Cluster{Name: "cache"}
@@ -910,6 +928,24 @@ func TestInjectGatewayDestinationAddons_TerminatingGateway_TLSContextUsesSDS(t *
 	require.Equal(t, "cache-ca", sdsCACfg.ValidationContextSdsSecretConfig.Name)
 	_, caUsesADS := sdsCACfg.ValidationContextSdsSecretConfig.SdsConfig.ConfigSourceSpecifier.(*envoy_core_v3.ConfigSource_Ads)
 	require.True(t, caUsesADS)
+}
+
+func TestInjectGatewayDestinationAddons_TerminatingGateway_OneWayTLS_NoCertSDSConfig(t *testing.T) {
+	s := &ResourceGenerator{Logger: hclog.NewNullLogger()}
+	svc := structs.NewServiceName("db", structs.DefaultEnterpriseMetaInDefaultPartition())
+	snap := proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, nil)
+	snap.TerminatingGateway.DestinationServices = map[structs.ServiceName]structs.GatewayService{
+		svc: {Service: svc, CAFile: "ca.pem"},
+	}
+
+	c := &envoy_cluster_v3.Cluster{Name: "db"}
+	err := s.injectGatewayDestinationAddons(snap, c, svc)
+
+	require.NoError(t, err)
+	upstreamTLS := &envoy_tls_v3.UpstreamTlsContext{}
+	err = c.TransportSocket.GetTypedConfig().UnmarshalTo(upstreamTLS)
+	require.NoError(t, err)
+	require.Empty(t, upstreamTLS.CommonTlsContext.TlsCertificateSdsSecretConfigs, "one-way TLS must not request a client cert SDS secret")
 }
 
 func TestInjectGatewayDestinationAddons_TerminatingGateway_DestinationNotInMap(t *testing.T) {

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -2970,21 +2970,7 @@ func makeTransportSocket(name string, config proto.Message) (*envoy_core_v3.Tran
 }
 
 func makeUpstreamTLSContext(mapping structs.GatewayService) *envoy_tls_v3.CommonTlsContext {
-	return &envoy_tls_v3.CommonTlsContext{
-		// This is the CRITICAL change for dynamic rotation.
-		// It tells Envoy: "Ask SDS for a secret named <service-name>".
-		TlsCertificateSdsSecretConfigs: []*envoy_tls_v3.SdsSecretConfig{
-			{
-				Name: mapping.Service.Name + "-cert",
-				SdsConfig: &envoy_core_v3.ConfigSource{
-					ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Ads{
-						Ads: &envoy_core_v3.AggregatedConfigSource{},
-					},
-					ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
-				},
-			},
-		},
-
+	ctx := &envoy_tls_v3.CommonTlsContext{
 		ValidationContextType: &envoy_tls_v3.CommonTlsContext_ValidationContextSdsSecretConfig{
 			ValidationContextSdsSecretConfig: &envoy_tls_v3.SdsSecretConfig{
 				Name: mapping.Service.Name + "-ca",
@@ -2997,6 +2983,26 @@ func makeUpstreamTLSContext(mapping structs.GatewayService) *envoy_tls_v3.Common
 			},
 		},
 	}
+
+	// Only request a client certificate via SDS when mTLS is configured (both
+	// CertFile and KeyFile must be set). When only CAFile is set, Envoy must
+	// not be told to fetch a client-cert secret that will never be served,
+	// which would leave the cluster in a permanent "warming" state.
+	if mapping.CertFile != "" && mapping.KeyFile != "" {
+		ctx.TlsCertificateSdsSecretConfigs = []*envoy_tls_v3.SdsSecretConfig{
+			{
+				Name: mapping.Service.Name + "-cert",
+				SdsConfig: &envoy_core_v3.ConfigSource{
+					ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Ads{
+						Ads: &envoy_core_v3.AggregatedConfigSource{},
+					},
+					ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
+				},
+			},
+		}
+	}
+
+	return ctx
 }
 
 func makeCommonTLSContextFromFiles(caFile, certFile, keyFile string) *envoy_tls_v3.CommonTlsContext {

--- a/agent/xds/secrets_test.go
+++ b/agent/xds/secrets_test.go
@@ -242,7 +242,10 @@ func TestSecretsFromSnapshotTerminatingGateway_SecretNamesUsesServiceName(t *tes
 
 func TestMakeUpstreamTLSContext_SecretNamesMatchServiceName(t *testing.T) {
 	mapping := structs.GatewayService{
-		Service: structs.NewServiceName("payments", structs.DefaultEnterpriseMetaInDefaultPartition()),
+		Service:  structs.NewServiceName("payments", structs.DefaultEnterpriseMetaInDefaultPartition()),
+		CAFile:   "ca.pem",
+		CertFile: "cert.pem",
+		KeyFile:  "key.pem",
 	}
 
 	ctx := makeUpstreamTLSContext(mapping)
@@ -258,7 +261,10 @@ func TestMakeUpstreamTLSContext_SecretNamesMatchServiceName(t *testing.T) {
 
 func TestMakeUpstreamTLSContext_UsesSDS(t *testing.T) {
 	mapping := structs.GatewayService{
-		Service: structs.NewServiceName("web", structs.DefaultEnterpriseMetaInDefaultPartition()),
+		Service:  structs.NewServiceName("web", structs.DefaultEnterpriseMetaInDefaultPartition()),
+		CAFile:   "ca.pem",
+		CertFile: "cert.pem",
+		KeyFile:  "key.pem",
 	}
 
 	ctx := makeUpstreamTLSContext(mapping)
@@ -306,7 +312,10 @@ func TestMakeUpstreamTLSContext_DifferentServiceNames(t *testing.T) {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
 			mapping := structs.GatewayService{
-				Service: structs.NewServiceName(tt.serviceName, structs.DefaultEnterpriseMetaInDefaultPartition()),
+				Service:  structs.NewServiceName(tt.serviceName, structs.DefaultEnterpriseMetaInDefaultPartition()),
+				CAFile:   "ca.pem",
+				CertFile: "cert.pem",
+				KeyFile:  "key.pem",
 			}
 
 			ctx := makeUpstreamTLSContext(mapping)
@@ -318,16 +327,84 @@ func TestMakeUpstreamTLSContext_DifferentServiceNames(t *testing.T) {
 	}
 }
 
-func TestMakeUpstreamTLSContext_AlwaysHasBothCertAndValidationConfig(t *testing.T) {
+func TestMakeUpstreamTLSContext_OneWayTLS_NoCertSDSConfig(t *testing.T) {
 	mapping := structs.GatewayService{
 		Service: structs.NewServiceName("cache", structs.DefaultEnterpriseMetaInDefaultPartition()),
+		CAFile:  "ca.pem",
 	}
 
 	ctx := makeUpstreamTLSContext(mapping)
 
 	require.NotNil(t, ctx)
-	require.Len(t, ctx.TlsCertificateSdsSecretConfigs, 1, "should always have a cert SDS config")
-	require.NotNil(t, ctx.ValidationContextType, "should always have a validation context")
+	require.Empty(t, ctx.TlsCertificateSdsSecretConfigs, "one-way TLS must not request a client cert SDS secret")
+	require.NotNil(t, ctx.ValidationContextType, "CA validation context must still be present")
+}
+
+func TestMakeUpstreamTLSContext_MTLS_HasBothCertAndValidationSDSConfig(t *testing.T) {
+	mapping := structs.GatewayService{
+		Service:  structs.NewServiceName("cache", structs.DefaultEnterpriseMetaInDefaultPartition()),
+		CAFile:   "ca.pem",
+		CertFile: "cert.pem",
+		KeyFile:  "key.pem",
+	}
+
+	ctx := makeUpstreamTLSContext(mapping)
+
+	require.NotNil(t, ctx)
+	require.Len(t, ctx.TlsCertificateSdsSecretConfigs, 1, "mTLS must request a client cert SDS secret")
+	require.NotNil(t, ctx.ValidationContextType, "CA validation context must be present for mTLS")
+}
+
+func TestMakeUpstreamTLSContext_NoFilesConfigured(t *testing.T) {
+	mapping := structs.GatewayService{
+		Service: structs.NewServiceName("db", structs.DefaultEnterpriseMetaInDefaultPartition()),
+	}
+
+	ctx := makeUpstreamTLSContext(mapping)
+
+	require.NotNil(t, ctx)
+	require.Empty(t, ctx.TlsCertificateSdsSecretConfigs)
+	require.NotNil(t, ctx.ValidationContextType)
+}
+
+func TestMakeUpstreamTLSContext_CertFileOnlyNoCertSDSConfig(t *testing.T) {
+	mapping := structs.GatewayService{
+		Service:  structs.NewServiceName("db", structs.DefaultEnterpriseMetaInDefaultPartition()),
+		CAFile:   "ca.pem",
+		CertFile: "cert.pem",
+	}
+
+	ctx := makeUpstreamTLSContext(mapping)
+
+	require.NotNil(t, ctx)
+	require.Empty(t, ctx.TlsCertificateSdsSecretConfigs, "cert SDS must be absent when KeyFile is missing")
+}
+
+func TestMakeUpstreamTLSContext_KeyFileOnlyNoCertSDSConfig(t *testing.T) {
+	mapping := structs.GatewayService{
+		Service: structs.NewServiceName("db", structs.DefaultEnterpriseMetaInDefaultPartition()),
+		CAFile:  "ca.pem",
+		KeyFile: "key.pem",
+	}
+
+	ctx := makeUpstreamTLSContext(mapping)
+
+	require.NotNil(t, ctx)
+	require.Empty(t, ctx.TlsCertificateSdsSecretConfigs, "cert SDS must be absent when CertFile is missing")
+}
+
+func TestMakeUpstreamTLSContext_CertAndKeyWithoutCAFile(t *testing.T) {
+	mapping := structs.GatewayService{
+		Service:  structs.NewServiceName("db", structs.DefaultEnterpriseMetaInDefaultPartition()),
+		CertFile: "cert.pem",
+		KeyFile:  "key.pem",
+	}
+
+	ctx := makeUpstreamTLSContext(mapping)
+
+	require.NotNil(t, ctx)
+	require.Len(t, ctx.TlsCertificateSdsSecretConfigs, 1, "cert SDS must be present when CertFile and KeyFile are both set")
+	require.NotNil(t, ctx.ValidationContextType)
 }
 
 func TestSecretsFromSnapshot_NonTerminatingGatewayKindsReturnNil(t *testing.T) {

--- a/agent/xds/testdata/clusters/terminating-gateway-custom-and-tagged-addresses.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-custom-and-tagged-addresses.latest.golden
@@ -131,15 +131,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-custom-trace-listener.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-custom-trace-listener.latest.golden
@@ -131,15 +131,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-default-service-subset.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-default-service-subset.latest.golden
@@ -131,15 +131,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -168,15 +159,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -205,15 +187,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-hostname-service-subsets.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-hostname-service-subsets.latest.golden
@@ -215,15 +215,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-http2-upstream-subsets.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-http2-upstream-subsets.latest.golden
@@ -34,15 +34,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -96,15 +87,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -158,15 +140,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-http2-upstream.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-http2-upstream.latest.golden
@@ -34,15 +34,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-ignore-extra-resolvers.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-ignore-extra-resolvers.latest.golden
@@ -131,15 +131,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -168,15 +159,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -205,15 +187,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-lb-config-no-hash-policies.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-lb-config-no-hash-policies.latest.golden
@@ -136,15 +136,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -178,15 +169,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -220,15 +202,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-lb-config.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-lb-config.latest.golden
@@ -136,15 +136,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -178,15 +169,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -220,15 +202,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-no-api-cert.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-no-api-cert.latest.golden
@@ -131,15 +131,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-service-max-request-headers.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-service-max-request-headers.latest.golden
@@ -34,15 +34,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-service-subsets.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-service-subsets.latest.golden
@@ -161,15 +161,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -198,15 +189,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -235,15 +217,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-sni.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-sni.latest.golden
@@ -198,16 +198,7 @@
                   "resourceApiVersion": "V3"
                 }
               }
-            },
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ]
+            }
           },
           "sni": "foo.com"
         }

--- a/agent/xds/testdata/clusters/terminating-gateway-tcp-keepalives.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-tcp-keepalives.latest.golden
@@ -152,15 +152,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-with-peer-trust-bundle.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-with-peer-trust-bundle.latest.golden
@@ -131,15 +131,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-with-tls-incoming-cipher-suites.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-with-tls-incoming-cipher-suites.latest.golden
@@ -131,15 +131,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-with-tls-incoming-max-version.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-with-tls-incoming-max-version.latest.golden
@@ -131,15 +131,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway-with-tls-incoming-min-version.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-with-tls-incoming-min-version.latest.golden
@@ -131,15 +131,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/terminating-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway.latest.golden
@@ -131,15 +131,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {

--- a/agent/xds/testdata/clusters/transparent-proxy-terminating-gateway-destinations-only.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-terminating-gateway-destinations-only.latest.golden
@@ -200,16 +200,7 @@
                   "resourceApiVersion": "V3"
                 }
               }
-            },
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "external-hostname-with-SNI-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ]
+            }
           },
           "sni": "api.test.com"
         }

--- a/agent/xds/testdata/clusters/xds-fetch-timeout-ms-term-gw.latest.golden
+++ b/agent/xds/testdata/clusters/xds-fetch-timeout-ms-term-gw.latest.golden
@@ -162,15 +162,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -200,15 +191,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {
@@ -238,15 +220,6 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
           "commonTlsContext": {
-            "tlsCertificateSdsSecretConfigs": [
-              {
-                "name": "web-cert",
-                "sdsConfig": {
-                  "ads": {},
-                  "resourceApiVersion": "V3"
-                }
-              }
-            ],
             "validationContextSdsSecretConfig": {
               "name": "web-ca",
               "sdsConfig": {


### PR DESCRIPTION
### Description

When a Terminating Gateway service is configured with only CAFile (one-way TLS), makeUpstreamTLSContext was unconditionally emitting a TlsCertificateSdsSecretConfigs entry for svc-cert. Since no client cert is configured, the SDS server never pushes that secret, leaving Envoy's upstream cluster stuck in a permanent warming state and dropping all traffic to that service.

Updated the existing tests to handle such scenarios.

### Testing & Reproduction steps

Tested with the setup - 200 OK response. 

```
curl -v http://127.0.0.1:5000

*   Trying 127.0.0.1:5000...
* Connected to 127.0.0.1 (127.0.0.1) port 5000
> GET / HTTP/1.1
> Host: 127.0.0.1:5000
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
...
```

### Links

- [CSL-15511](https://hashicorp.atlassian.net/browse/CSL-15511)

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->
## Test Results

**Envoy dynamic_active_cluster before fix**

```
"common_tls_context": {
                  "tls_certificate_sds_secret_configs": [
                    {
                      "name": "external-dns-service-cert",
                      "sds_config": {
                        "ads": {},
                        "resource_api_version": "V3"
                      }
                    }
                  ],
                  "validation_context_sds_secret_config": {
                    "name": "external-dns-service-ca",
                    "sds_config": {
                      "ads": {},
                      "resource_api_version": "V3"
                    }
                  }
                }
```

**Envoy dynamic_active_cluster after fix**

```
"common_tls_context": {
         "validation_context_sds_secret_config": {
          "name": "external-dns-service-ca",
          "sds_config": {
           "ads": {},
           "resource_api_version": "V3"
          }
         }
        }
       }
```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[CSL-15511]: https://hashicorp.atlassian.net/browse/CSL-15511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ