### PR TITLE
xds: return errors from public listener finalization 

### DIFF
--- a/.changelog/23686.txt
+++ b/.changelog/23686.txt
@@ -1,0 +1,3 @@
+```release-note:security
+xds: Return errors when injecting the L4 intention (RBAC) filter or the mTLS transport socket onto an inbound public listener, so the listener is not served without intention enforcement or mTLS.
+```

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1647,19 +1647,23 @@ func makePermissiveFilterChain(cfgSnap *proxycfg.ConfigSnapshot, opts listenerFi
 	return chain, nil
 }
 
-// finalizePublicListenerFromConfig is used for best-effort injection of Consul filter-chains onto listeners.
-// This include L4 authorization filters and TLS context.
+// finalizePublicListenerFromConfig injects the Consul filter-chains onto the public listener.
+// This includes L4 authorization (intention enforcement) filters and the mTLS context.
+// These are security-critical: if either injection fails we must return the error so the
+// caller drops the listener rather than serving an unauthenticated/unauthorized one.
 func (s *ResourceGenerator) finalizePublicListenerFromConfig(l *envoy_listener_v3.Listener, cfgSnap *proxycfg.ConfigSnapshot, useHTTPFilter bool) error {
 	if !useHTTPFilter {
-		// Best-effort injection of L4 intentions
+		// Inject the L4 intention (RBAC) network filter. Failing to do so would
+		// allow traffic to bypass intention enforcement, so surface the error.
 		if err := s.injectConnectFilters(cfgSnap, l); err != nil {
-			return nil
+			return err
 		}
 	}
 
-	// Always apply TLS certificates
+	// Always apply TLS certificates. Failing to do so would expose a public
+	// listener without mTLS, so surface the error instead of swallowing it.
 	if err := s.injectConnectTLSForPublicListener(cfgSnap, l); err != nil {
-		return nil
+		return err
 	}
 
 	return nil

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -843,7 +843,7 @@ func uintPointer(i uint32) *uint32 {
 }
 
 // TestFinalizePublicListenerFromConfig_PropagatesInjectionErrors is a regression
-// test for SECVULN-41454. Previously finalizePublicListenerFromConfig swallowed
+// test. Previously finalizePublicListenerFromConfig swallowed
 // errors from the L4 intention (RBAC) and mTLS injection steps by returning nil.
 // That allowed an insecure public listener (no mTLS and/or no intention
 // enforcement) to be served while the caller's error check was dead code. The

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/hashicorp/go-hclog"
 	testinf "github.com/mitchellh/go-testing-interface"
@@ -839,4 +840,43 @@ func Test_makeMeshGatewayPeerFilterChain_maxRequestHeadersKb(t *testing.T) {
 // Helper function for uint32 pointers
 func uintPointer(i uint32) *uint32 {
 	return &i
+}
+
+// TestFinalizePublicListenerFromConfig_PropagatesInjectionErrors is a regression
+// test for SECVULN-41454. Previously finalizePublicListenerFromConfig swallowed
+// errors from the L4 intention (RBAC) and mTLS injection steps by returning nil.
+// That allowed an insecure public listener (no mTLS and/or no intention
+// enforcement) to be served while the caller's error check was dead code. The
+// function must instead surface the error so the caller drops the listener.
+func TestFinalizePublicListenerFromConfig_PropagatesInjectionErrors(t *testing.T) {
+	roots, _ := proxycfg.TestCerts(t)
+
+	// A snapshot whose Kind is neither a connect proxy nor a mesh gateway makes
+	// injectConnectTLSForPublicListener (via createDownstreamTransportSocketForConnectTLS)
+	// fail deterministically, so we can assert the error is propagated.
+	newSnap := func() *proxycfg.ConfigSnapshot {
+		return &proxycfg.ConfigSnapshot{
+			Kind:  structs.ServiceKindTerminatingGateway,
+			Roots: roots,
+		}
+	}
+
+	newListener := func() *envoy_listener_v3.Listener {
+		return &envoy_listener_v3.Listener{
+			Name:         "public_listener",
+			FilterChains: []*envoy_listener_v3.FilterChain{{}},
+		}
+	}
+
+	s := &ResourceGenerator{Logger: hclog.NewNullLogger()}
+
+	t.Run("mTLS injection failure is surfaced (HTTP filter path)", func(t *testing.T) {
+		err := s.finalizePublicListenerFromConfig(newListener(), newSnap(), true)
+		require.Error(t, err, "mTLS injection error must not be swallowed")
+	})
+
+	t.Run("injection failure is surfaced (L4 filter path)", func(t *testing.T) {
+		err := s.finalizePublicListenerFromConfig(newListener(), newSnap(), false)
+		require.Error(t, err, "injection error must not be swallowed")
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -279,7 +279,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.mongodb.org/mongo-driver v1.17.4 // indirect
+	go.mongodb.org/mongo-driver v1.17.7 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -768,8 +768,8 @@ github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmB
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
-go.mongodb.org/mongo-driver v1.17.4 h1:jUorfmVzljjr0FLzYQsGP8cgN/qzzxlY9Vh0C9KFXVw=
-go.mongodb.org/mongo-driver v1.17.4/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver v1.17.7 h1:a9w+U3Vt67eYzcfq3k/OAv284/uUUkL0uP75VE5rCOU=
+go.mongodb.org/mongo-driver v1.17.7/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 h1:q4XOmH/0opmeuJtPsbFNivyl7bCt7yRBbeEm2sC/XtQ=


### PR DESCRIPTION
`finalizePublicListenerFromConfig` previously returned `nil` when injecting the
L4 intention (RBAC) filter or the mTLS transport socket failed, so the caller's
error handling never triggered. This returns the error from both paths so an inbound
public listener is dropped rather than served without intention enforcement or mTLS.

Adds `TestFinalizePublicListenerFromConfig_PropagatesInjectionErrors`, which fails
if either error is swallowed again.