### PR TITLE
inference-gateway: ext_proc-based A2LLM inference gateway support

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -340,6 +340,7 @@ func buildAgentService(s *structs.NodeService, dc string) api.AgentService {
 		Weights:           weights,
 		Datacenter:        dc,
 		Locality:          s.Locality.ToAPI(),
+		AI:                s.AI.ToAPI(),
 	}
 
 	if as.Tags == nil {

--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -452,6 +452,11 @@ func (c *FSM) registerStreamSnapshotHandlers() {
 		return c.State().ExportedServicesSnapshot(req, buf)
 	}, true)
 	panicIfErr(err)
+
+	err = c.deps.Publisher.RegisterHandler(state.EventTopicAIGateway, func(req stream.SubscribeRequest, buf stream.SnapshotAppender) (uint64, error) {
+		return c.State().AIGatewaySnapshot(req, buf)
+	}, true)
+	panicIfErr(err)
 }
 
 func panicIfErr(err error) {

--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -268,6 +268,13 @@ func connectNameFromServiceNode(sn *structs.ServiceNode) (string, bool) {
 		// For native, this service supports Connect directly
 		return sn.ServiceName, true
 
+	case sn.ServiceKind == structs.ServiceKindInferenceGateway:
+		// An inference gateway terminates inbound mesh mTLS on its own listener
+		// bearing its own SPIFFE leaf (svc/<gateway-name>), so mesh services dial
+		// it as a connect upstream by its own service name, like a connect-native
+		// service.
+		return sn.ServiceName, true
+
 	default:
 		// Doesn't support Connect at all
 		return "", false

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -4665,6 +4665,39 @@ func TestStateStore_CheckConnectServiceNodes(t *testing.T) {
 	}
 }
 
+func TestStateStore_CheckConnectServiceNodes_InferenceGateway(t *testing.T) {
+	s := testStateStore(t)
+
+	// An inference gateway terminates inbound mesh mTLS on its own listener
+	// bearing its own SPIFFE leaf, so it must be resolvable as a connect
+	// upstream by its own service name (like a connect-native service).
+	ws := memdb.NewWatchSet()
+	idx, nodes, err := s.CheckConnectServiceNodes(ws, "inference-gateway", nil, "")
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(0), idx)
+	assert.Len(t, nodes, 0)
+
+	assert.Nil(t, s.EnsureNode(10, &structs.Node{Node: "foo", Address: "127.0.0.1"}))
+	assert.Nil(t, s.EnsureService(11, "foo", &structs.NodeService{
+		Kind:    structs.ServiceKindInferenceGateway,
+		ID:      "inference-gateway",
+		Service: "inference-gateway",
+		Port:    8443,
+	}))
+	testRegisterCheck(t, s, 12, "foo", "inference-gateway", "check1", api.HealthPassing)
+	assert.True(t, watchFired(ws))
+
+	// The gateway should now resolve as a connect-capable destination by name.
+	ws = memdb.NewWatchSet()
+	idx, nodes, err = s.CheckConnectServiceNodes(ws, "inference-gateway", nil, "")
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(12), idx)
+	assert.Len(t, nodes, 1)
+	assert.Equal(t, structs.ServiceKindInferenceGateway, nodes[0].Service.Kind)
+	assert.Equal(t, "inference-gateway", nodes[0].Service.Service)
+	assert.Equal(t, 8443, nodes[0].Service.Port)
+}
+
 func TestStateStore_CheckConnectServiceNodes_Gateways(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -652,6 +652,7 @@ func validateProposedConfigEntryInGraph(
 	case structs.TCPRoute:
 	case structs.RateLimitIPConfig:
 	case structs.RateLimit:
+	case structs.AIGateway:
 	case structs.JWTProvider:
 		if newEntry == nil && existingEntry != nil {
 			err := validateJWTProviderIsReferenced(tx, kindName, existingEntry)

--- a/agent/consul/state/config_entry_events.go
+++ b/agent/consul/state/config_entry_events.go
@@ -31,6 +31,7 @@ var configEntryKindToTopic = map[string]stream.Topic{
 	structs.SamenessGroup:         EventTopicSamenessGroup,
 	structs.JWTProvider:           EventTopicJWTProvider,
 	structs.ExportedServices:      EventTopicExportedServices,
+	structs.AIGateway:             EventTopicAIGateway,
 }
 
 // EventSubjectConfigEntry is a stream.Subject used to route and receive events
@@ -193,6 +194,12 @@ func (s *Store) JWTProviderSnapshot(req stream.SubscribeRequest, buf stream.Snap
 // exported-services config entries.
 func (s *Store) ExportedServicesSnapshot(req stream.SubscribeRequest, buf stream.SnapshotAppender) (uint64, error) {
 	return s.configEntrySnapshot(structs.ExportedServices, req, buf)
+}
+
+// AIGatewaySnapshot is a stream.SnapshotFunc that returns a snapshot of
+// ai-gateway config entries.
+func (s *Store) AIGatewaySnapshot(req stream.SubscribeRequest, buf stream.SnapshotAppender) (uint64, error) {
+	return s.configEntrySnapshot(structs.AIGateway, req, buf)
 }
 
 func (s *Store) configEntrySnapshot(kind string, req stream.SubscribeRequest, buf stream.SnapshotAppender) (uint64, error) {

--- a/agent/consul/state/events.go
+++ b/agent/consul/state/events.go
@@ -47,7 +47,7 @@ func PBToStreamSubscribeRequest(req *pbsubscribe.SubscribeRequest, entMeta acl.E
 			EventTopicServiceIntentions, EventTopicServiceDefaults, EventTopicAPIGateway,
 			EventTopicTCPRoute, EventTopicHTTPRoute, EventTopicJWTProvider, EventTopicInlineCertificate,
 			EventTopicBoundAPIGateway, EventTopicSamenessGroup, EventTopicExportedServices,
-			EventTopicFileSystemCertificate:
+			EventTopicFileSystemCertificate, EventTopicAIGateway:
 			subject = EventSubjectConfigEntry{
 				Name:           named.Key,
 				EnterpriseMeta: &entMeta,

--- a/agent/consul/state/index_connect_test.go
+++ b/agent/consul/state/index_connect_test.go
@@ -43,6 +43,15 @@ func TestConnectNameFromServiceNode(t *testing.T) {
 			expectedOk: true,
 			expected:   "fOo",
 		},
+		{
+			name: "inference gateway",
+			input: structs.ServiceNode{
+				ServiceKind: structs.ServiceKindInferenceGateway,
+				ServiceName: "inFerence-gateway",
+			},
+			expectedOk: true,
+			expected:   "inFerence-gateway",
+		},
 	}
 
 	for _, tc := range cases {

--- a/agent/consul/state/memdb.go
+++ b/agent/consul/state/memdb.go
@@ -215,6 +215,7 @@ var (
 	EventTopicSamenessGroup         = pbsubscribe.Topic_SamenessGroup
 	EventTopicJWTProvider           = pbsubscribe.Topic_JWTProvider
 	EventTopicExportedServices      = pbsubscribe.Topic_ExportedServices
+	EventTopicAIGateway             = pbsubscribe.Topic_AIGateway
 )
 
 func processDBChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {

--- a/agent/envoyextensions/builtin/ext-proc/ext_proc.go
+++ b/agent/envoyextensions/builtin/ext-proc/ext_proc.go
@@ -134,11 +134,18 @@ func (s *HttpService) validate() error {
 	return resultErr
 }
 
-// Target identifies the processor backend: either a Consul service (reuses the
-// upstream/mesh cluster) or a direct host:port URI (synthesizes a local cluster).
+// Target identifies the processor backend: a Consul service (reuses the
+// upstream/mesh cluster), a direct host:port URI (synthesizes a local TCP
+// cluster), or a Unix domain socket Path (synthesizes a local loopback/UDS
+// cluster). Exactly one must be set. The Path form is the loopback transport
+// used by the inference gateway to reach its co-located policy processor.
 type Target struct {
 	Service api.CompoundServiceName
 	URI     string
+	// Path is an absolute filesystem path to a Unix domain socket the processor
+	// listens on. When set, Envoy reaches the processor over a loopback/UDS
+	// "pipe" address rather than TCP. Mutually exclusive with Service and URI.
+	Path    string
 	Timeout string
 
 	timeout *time.Duration
@@ -148,6 +155,7 @@ type Target struct {
 
 func (t Target) isService() bool { return t.Service.Name != "" }
 func (t Target) isURI() bool     { return t.URI != "" }
+func (t Target) isUDS() bool     { return t.Path != "" }
 
 func (t *Target) normalize() {
 	if t == nil {
@@ -169,13 +177,22 @@ func (t *Target) validate() error {
 	if t == nil {
 		return resultErr
 	}
-	if t.isURI() == t.isService() {
-		resultErr = multierror.Append(resultErr, fmt.Errorf("exactly one of Target.Service or Target.URI must be set"))
+	set := 0
+	for _, isSet := range []bool{t.isService(), t.isURI(), t.isUDS()} {
+		if isSet {
+			set++
+		}
+	}
+	if set != 1 {
+		resultErr = multierror.Append(resultErr, fmt.Errorf("exactly one of Target.Service, Target.URI, or Target.Path must be set"))
 	}
 	if t.isURI() {
 		if t.host, t.port, err = parseAddr(t.URI); err != nil {
 			resultErr = multierror.Append(resultErr, fmt.Errorf("invalid Target.URI %q: %w", t.URI, err))
 		}
+	}
+	if t.isUDS() && !strings.HasPrefix(t.Path, "/") {
+		resultErr = multierror.Append(resultErr, fmt.Errorf("Target.Path %q must be an absolute Unix socket path", t.Path))
 	}
 	if t.Timeout != "" {
 		if d, perr := time.ParseDuration(t.Timeout); perr == nil {
@@ -278,10 +295,12 @@ func (c *extProcConfig) target() *Target {
 
 func (p *extProc) validate() error {
 	var resultErr error
-	if p.ProxyType != api.ServiceKindAPIGateway && p.ProxyType != api.ServiceKindConnectProxy {
+	switch p.ProxyType {
+	case api.ServiceKindAPIGateway, api.ServiceKindConnectProxy, api.ServiceKindInferenceGateway:
+	default:
 		resultErr = multierror.Append(resultErr, fmt.Errorf(
-			"unsupported ProxyType %q, only %q or %q is supported",
-			p.ProxyType, api.ServiceKindAPIGateway, api.ServiceKindConnectProxy))
+			"unsupported ProxyType %q, only %q, %q, or %q is supported",
+			p.ProxyType, api.ServiceKindAPIGateway, api.ServiceKindConnectProxy, api.ServiceKindInferenceGateway))
 	}
 	if p.ListenerType != "inbound" && p.ListenerType != "outbound" {
 		resultErr = multierror.Append(resultErr, fmt.Errorf(
@@ -388,19 +407,43 @@ func (c *extProcConfig) envoyHttpService(cfg *ext_cmn.RuntimeConfig) (*envoy_htt
 	}, nil
 }
 
-// toEnvoyCluster builds a local cluster for URI targets only. Service targets reuse
-// the existing upstream/mesh cluster (returns nil). gRPC URI clusters use HTTP/2.
+// toEnvoyCluster builds a local cluster for URI and UDS (Path) targets. Service
+// targets reuse the existing upstream/mesh cluster (returns nil). gRPC clusters
+// use HTTP/2. UDS targets resolve to a STATIC cluster with a "pipe" address.
 func (c *extProcConfig) toEnvoyCluster(_ *ext_cmn.RuntimeConfig) (*envoy_cluster_v3.Cluster, error) {
 	t := c.target()
 	if t == nil || t.isService() {
 		return nil, nil
 	}
 
-	host, port := t.host, t.port
-	isDNS := net.ParseIP(host) == nil
+	// Resolve the endpoint address and cluster discovery type. UDS targets use a
+	// STATIC cluster pointing at a pipe address; URI targets use STATIC for IPs
+	// and STRICT_DNS for hostnames.
+	var endpointAddr *envoy_core_v3.Address
 	clusterType := &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_STATIC}
-	if isDNS {
-		clusterType = &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_STRICT_DNS}
+	isDNS := false
+	if t.isUDS() {
+		endpointAddr = &envoy_core_v3.Address{
+			Address: &envoy_core_v3.Address_Pipe{
+				Pipe: &envoy_core_v3.Pipe{Path: t.Path},
+			},
+		}
+	} else {
+		host, port := t.host, t.port
+		isDNS = net.ParseIP(host) == nil
+		if isDNS {
+			clusterType = &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_STRICT_DNS}
+		}
+		endpointAddr = &envoy_core_v3.Address{
+			Address: &envoy_core_v3.Address_SocketAddress{
+				SocketAddress: &envoy_core_v3.SocketAddress{
+					Address: host,
+					PortSpecifier: &envoy_core_v3.SocketAddress_PortValue{
+						PortValue: uint32(port),
+					},
+				},
+			},
+		}
 	}
 
 	var httpProtoOpts *envoy_upstreams_http_v3.HttpProtocolOptions
@@ -441,16 +484,7 @@ func (c *extProcConfig) toEnvoyCluster(_ *ext_cmn.RuntimeConfig) (*envoy_cluster
 				LbEndpoints: []*envoy_endpoint_v3.LbEndpoint{{
 					HostIdentifier: &envoy_endpoint_v3.LbEndpoint_Endpoint{
 						Endpoint: &envoy_endpoint_v3.Endpoint{
-							Address: &envoy_core_v3.Address{
-								Address: &envoy_core_v3.Address_SocketAddress{
-									SocketAddress: &envoy_core_v3.SocketAddress{
-										Address: host,
-										PortSpecifier: &envoy_core_v3.SocketAddress_PortValue{
-											PortValue: uint32(port),
-										},
-									},
-								},
-							},
+							Address: endpointAddr,
 						},
 					},
 				}},
@@ -471,7 +505,8 @@ func (p *extProc) CanApply(cfg *ext_cmn.RuntimeConfig) bool {
 }
 
 func (p *extProc) matchesListenerDirection(isInboundListener bool) bool {
-	if p.ProxyType == api.ServiceKindAPIGateway {
+	// Gateways own a single listener, so the filter always applies there.
+	if p.ProxyType == api.ServiceKindAPIGateway || p.ProxyType == api.ServiceKindInferenceGateway {
 		return true
 	}
 	return (!isInboundListener && p.ListenerType == "outbound") || (isInboundListener && p.ListenerType == "inbound")

--- a/agent/envoyextensions/builtin/ext-proc/ext_proc_test.go
+++ b/agent/envoyextensions/builtin/ext-proc/ext_proc_test.go
@@ -102,7 +102,7 @@ func TestConstructor(t *testing.T) {
 					},
 				},
 			},
-			errMsg: `exactly one of Target.Service or Target.URI must be set`,
+			errMsg: `exactly one of Target.Service, Target.URI, or Target.Path must be set`,
 		},
 		"uri and service target": {
 			args: map[string]any{
@@ -116,7 +116,7 @@ func TestConstructor(t *testing.T) {
 					},
 				},
 			},
-			errMsg: `exactly one of Target.Service or Target.URI must be set`,
+			errMsg: `exactly one of Target.Service, Target.URI, or Target.Path must be set`,
 		},
 		"invalid target uri": {
 			args: map[string]any{
@@ -187,6 +187,52 @@ func TestConstructor(t *testing.T) {
 					},
 				},
 			},
+		},
+		"valid grpc uds target on inference-gateway": {
+			args: map[string]any{
+				"ProxyType": "inference-gateway",
+				"Config": map[string]any{
+					"GrpcService": map[string]any{
+						"Target": map[string]any{"Path": "/run/consul/ext_proc.sock"},
+					},
+				},
+			},
+		},
+		"uds and uri target": {
+			args: map[string]any{
+				"ProxyType": "inference-gateway",
+				"Config": map[string]any{
+					"GrpcService": map[string]any{
+						"Target": map[string]any{
+							"Path": "/run/consul/ext_proc.sock",
+							"URI":  "127.0.0.1:9191",
+						},
+					},
+				},
+			},
+			errMsg: `exactly one of Target.Service, Target.URI, or Target.Path must be set`,
+		},
+		"relative uds path": {
+			args: map[string]any{
+				"ProxyType": "inference-gateway",
+				"Config": map[string]any{
+					"GrpcService": map[string]any{
+						"Target": map[string]any{"Path": "run/ext_proc.sock"},
+					},
+				},
+			},
+			errMsg: `must be an absolute Unix socket path`,
+		},
+		"unsupported proxy type": {
+			args: map[string]any{
+				"ProxyType": "mesh-gateway",
+				"Config": map[string]any{
+					"GrpcService": map[string]any{
+						"Target": map[string]any{"URI": "localhost:9191"},
+					},
+				},
+			},
+			errMsg: `unsupported ProxyType "mesh-gateway"`,
 		},
 		"valid camelCase args": {
 			args: map[string]any{
@@ -561,6 +607,30 @@ func TestConfig_toEnvoyCluster(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cluster)
 		require.NotNil(t, cluster.DnsLookupFamily)
+	})
+
+	t.Run("uds path builds static pipe cluster", func(t *testing.T) {
+		const sock = "/run/consul/ext_proc.sock"
+		ext, err := newExtProc(api.EnvoyExtension{
+			Name: api.BuiltinExtProcExtension,
+			Arguments: map[string]any{
+				"ProxyType": "inference-gateway",
+				"Config": map[string]any{
+					"GrpcService": map[string]any{
+						"Target": map[string]any{"Path": sock},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		cluster, err := ext.Config.toEnvoyCluster(&ext_cmn.RuntimeConfig{})
+		require.NoError(t, err)
+		require.NotNil(t, cluster)
+		require.Equal(t, LocalExtProcClusterName, cluster.Name)
+		// STATIC discovery: DNS lookup family stays the default for a pipe address.
+		require.Zero(t, cluster.DnsLookupFamily)
+		ep := cluster.LoadAssignment.Endpoints[0].LbEndpoints[0].GetEndpoint()
+		require.Equal(t, sock, ep.GetAddress().GetPipe().GetPath())
 	})
 }
 

--- a/agent/proxycfg-glue/config_entry.go
+++ b/agent/proxycfg-glue/config_entry.go
@@ -83,6 +83,8 @@ func newConfigEntryRequest(req *structs.ConfigEntryQuery, deps ServerDataSourceD
 		topic = pbsubscribe.Topic_JWTProvider
 	case structs.ExportedServices:
 		topic = pbsubscribe.Topic_ExportedServices
+	case structs.AIGateway:
+		topic = pbsubscribe.Topic_AIGateway
 	default:
 		return nil, fmt.Errorf("cannot map config entry kind: %q to a topic", req.Kind)
 	}

--- a/agent/proxycfg/config_snapshot_glue.go
+++ b/agent/proxycfg/config_snapshot_glue.go
@@ -41,7 +41,7 @@ func (s *ConfigSnapshot) Authorize(authz acl.Authorizer) error {
 		if err := authz.ToAllowAuthorizer().ServiceWriteAllowed(s.Proxy.DestinationServiceName, &authzContext); err != nil {
 			return status.Error(codes.PermissionDenied, err.Error())
 		}
-	case structs.ServiceKindMeshGateway, structs.ServiceKindTerminatingGateway, structs.ServiceKindIngressGateway, structs.ServiceKindAPIGateway:
+	case structs.ServiceKindMeshGateway, structs.ServiceKindTerminatingGateway, structs.ServiceKindIngressGateway, structs.ServiceKindAPIGateway, structs.ServiceKindInferenceGateway:
 		s.ProxyID.FillAuthzContext(&authzContext)
 		if err := authz.ToAllowAuthorizer().ServiceWriteAllowed(s.Service, &authzContext); err != nil {
 			return status.Error(codes.PermissionDenied, err.Error())
@@ -63,6 +63,8 @@ func (s *ConfigSnapshot) LoggerName() string {
 		return logging.MeshGateway
 	case structs.ServiceKindIngressGateway:
 		return logging.IngressGateway
+	case structs.ServiceKindInferenceGateway:
+		return logging.InferenceGateway
 	}
 
 	return ""

--- a/agent/proxycfg/inference_gateway.go
+++ b/agent/proxycfg/inference_gateway.go
@@ -1,0 +1,259 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package proxycfg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/leafcert"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+type handlerInferenceGateway struct {
+	handlerState
+}
+
+// initialize sets up the watches needed for an inference gateway: the CA roots
+// and the gateway's own leaf (for inbound mesh mTLS), the mesh config entry, and
+// the bound ai-gateway config entry (the routing policy). Model upstream watches
+// are added dynamically as the routing policy names candidate clusters.
+func (s *handlerInferenceGateway) initialize(ctx context.Context) (ConfigSnapshot, error) {
+	snap := newConfigSnapshotFromServiceInstance(s.serviceInstance, s.stateConfig)
+
+	// Watch for root changes (inbound mTLS trust).
+	err := s.dataSources.CARoots.Notify(ctx, &structs.DCSpecificRequest{
+		Datacenter:   s.source.Datacenter,
+		QueryOptions: structs.QueryOptions{Token: s.token},
+		Source:       *s.source,
+	}, rootsWatchID, s.ch)
+	if err != nil {
+		s.logger.Error("failed to register watch for root changes", "error", err)
+		return snap, err
+	}
+
+	// Watch the gateway's own leaf cert; it terminates inbound mesh mTLS from
+	// calling agents and is the gateway's SPIFFE identity.
+	err = s.dataSources.LeafCertificate.Notify(ctx, &leafcert.ConnectCALeafRequest{
+		Datacenter:     s.source.Datacenter,
+		Token:          s.token,
+		Service:        s.service,
+		EnterpriseMeta: s.proxyID.EnterpriseMeta,
+	}, leafWatchID, s.ch)
+	if err != nil {
+		s.logger.Error("failed to register watch for leaf cert", "error", err)
+		return snap, err
+	}
+
+	// Watch the mesh config entry.
+	err = s.dataSources.ConfigEntry.Notify(ctx, &structs.ConfigEntryQuery{
+		Kind:           structs.MeshConfig,
+		Name:           structs.MeshConfigMesh,
+		Datacenter:     s.source.Datacenter,
+		QueryOptions:   structs.QueryOptions{Token: s.token},
+		EnterpriseMeta: *structs.DefaultEnterpriseMetaInPartition(s.proxyID.PartitionOrDefault()),
+	}, meshConfigEntryID, s.ch)
+	if err != nil {
+		return snap, err
+	}
+
+	// Watch the bound ai-gateway config entry. By convention the routing policy
+	// shares the gateway's service name.
+	err = s.dataSources.ConfigEntry.Notify(ctx, &structs.ConfigEntryQuery{
+		Kind:           structs.AIGateway,
+		Name:           s.service,
+		Datacenter:     s.source.Datacenter,
+		QueryOptions:   structs.QueryOptions{Token: s.token},
+		EnterpriseMeta: s.proxyID.EnterpriseMeta,
+	}, aiGatewayConfigWatchID, s.ch)
+	if err != nil {
+		s.logger.Error("failed to register watch for ai-gateway config entry", "error", err)
+		return snap, err
+	}
+
+	snap.InferenceGateway.WatchedModels = make(map[structs.ServiceName]context.CancelFunc)
+	snap.InferenceGateway.Models = make(map[structs.ServiceName]*InferenceGatewayModel)
+	return snap, nil
+}
+
+func (s *handlerInferenceGateway) handleUpdate(ctx context.Context, u UpdateEvent, snap *ConfigSnapshot) error {
+	if u.Err != nil {
+		return fmt.Errorf("error filling agent cache: %v", u.Err)
+	}
+
+	switch {
+	case u.CorrelationID == rootsWatchID:
+		roots, ok := u.Result.(*structs.IndexedCARoots)
+		if !ok {
+			return fmt.Errorf("invalid type for response: %T", u.Result)
+		}
+		snap.Roots = roots
+
+	case u.CorrelationID == leafWatchID:
+		leaf, ok := u.Result.(*structs.IssuedCert)
+		if !ok {
+			return fmt.Errorf("invalid type for response: %T", u.Result)
+		}
+		snap.InferenceGateway.Leaf = leaf
+
+	case u.CorrelationID == meshConfigEntryID:
+		resp, ok := u.Result.(*structs.ConfigEntryResponse)
+		if !ok {
+			return fmt.Errorf("invalid type for response: %T", u.Result)
+		}
+		if resp.Entry != nil {
+			meshConf, ok := resp.Entry.(*structs.MeshConfigEntry)
+			if !ok {
+				return fmt.Errorf("invalid type for config entry: %T", resp.Entry)
+			}
+			snap.InferenceGateway.MeshConfig = meshConf
+		} else {
+			snap.InferenceGateway.MeshConfig = nil
+		}
+		snap.InferenceGateway.MeshConfigSet = true
+
+	case u.CorrelationID == aiGatewayConfigWatchID:
+		resp, ok := u.Result.(*structs.ConfigEntryResponse)
+		if !ok {
+			return fmt.Errorf("invalid type for response: %T", u.Result)
+		}
+		if resp.Entry != nil {
+			cfg, ok := resp.Entry.(*structs.AIGatewayConfigEntry)
+			if !ok {
+				return fmt.Errorf("invalid type for config entry: %T", resp.Entry)
+			}
+			snap.InferenceGateway.GatewayConfig = cfg
+		} else {
+			snap.InferenceGateway.GatewayConfig = nil
+		}
+		snap.InferenceGateway.GatewayConfigSet = true
+		return s.reconcileModelWatches(ctx, snap)
+
+	case strings.HasPrefix(u.CorrelationID, inferenceModelServiceIDPrefix):
+		resp, ok := u.Result.(*structs.IndexedCheckServiceNodes)
+		if !ok {
+			return fmt.Errorf("invalid type for response: %T", u.Result)
+		}
+		sn := structs.ServiceNameFromString(strings.TrimPrefix(u.CorrelationID, inferenceModelServiceIDPrefix))
+		s.updateModel(snap, sn, resp.Nodes)
+
+	default:
+		// do nothing
+	}
+
+	return nil
+}
+
+// reconcileModelWatches starts health watches for every candidate model service
+// named by the routing policy and cancels watches for any that are no longer
+// referenced.
+func (s *handlerInferenceGateway) reconcileModelWatches(ctx context.Context, snap *ConfigSnapshot) error {
+	desired := candidateModelServices(snap.InferenceGateway.GatewayConfig, s.proxyID.EnterpriseMeta)
+
+	// Start watches for newly referenced candidates.
+	for sn := range desired {
+		if _, ok := snap.InferenceGateway.WatchedModels[sn]; ok {
+			continue
+		}
+		wctx, cancel := context.WithCancel(ctx)
+		err := s.dataSources.Health.Notify(wctx, &structs.ServiceSpecificRequest{
+			Datacenter:     s.source.Datacenter,
+			QueryOptions:   structs.QueryOptions{Token: s.token},
+			ServiceName:    sn.Name,
+			EnterpriseMeta: sn.EnterpriseMeta,
+			// The gateway routes to these via the terminating gateway, so we want
+			// the model service's own registration (with its ai{} block + meta),
+			// not connect proxies.
+			Connect: false,
+		}, inferenceModelServiceIDPrefix+sn.String(), s.ch)
+		if err != nil {
+			s.logger.Error("failed to register watch for model service",
+				"service", sn.String(), "error", err)
+			cancel()
+			return err
+		}
+		snap.InferenceGateway.WatchedModels[sn] = cancel
+	}
+
+	// Cancel watches for candidates no longer referenced.
+	for sn, cancel := range snap.InferenceGateway.WatchedModels {
+		if _, ok := desired[sn]; !ok {
+			s.logger.Debug("canceling watch for model service", "service", sn.String())
+			cancel()
+			delete(snap.InferenceGateway.WatchedModels, sn)
+			delete(snap.InferenceGateway.Models, sn)
+		}
+	}
+
+	return nil
+}
+
+// updateModel records (or clears) a discovered model upstream. A service is only
+// kept if at least one instance is tagged ai.role == "ai-model"; its catalog
+// Meta supplies the routing labels surfaced in the gateway listener metadata.
+func (s *handlerInferenceGateway) updateModel(snap *ConfigSnapshot, sn structs.ServiceName, nodes structs.CheckServiceNodes) {
+	var (
+		role   string
+		labels map[string]string
+	)
+	for _, node := range nodes {
+		if node.Service == nil || node.Service.AI == nil || node.Service.AI.Role != structs.AIRoleModel {
+			continue
+		}
+		role = node.Service.AI.Role
+		labels = make(map[string]string, len(node.Service.Meta))
+		for k, v := range node.Service.Meta {
+			labels[k] = v
+		}
+		break
+	}
+
+	if role == "" {
+		// Not (or no longer) an ai-model service.
+		delete(snap.InferenceGateway.Models, sn)
+		return
+	}
+
+	snap.InferenceGateway.Models[sn] = &InferenceGatewayModel{
+		Service: sn,
+		Role:    role,
+		Labels:  labels,
+		Nodes:   nodes,
+	}
+}
+
+// candidateModelServices returns the set of model service names referenced by
+// the routing policy (match-rule candidates and fallback chains, the default
+// fallback chain, and any scoring split).
+func candidateModelServices(e *structs.AIGatewayConfigEntry, em acl.EnterpriseMeta) map[structs.ServiceName]struct{} {
+	out := make(map[structs.ServiceName]struct{})
+	if e == nil {
+		return out
+	}
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		out[structs.NewServiceName(name, &em)] = struct{}{}
+	}
+	for _, n := range e.Routing.FallbackChain {
+		add(n)
+	}
+	for _, rule := range e.Routing.MatchRules {
+		for _, n := range rule.Candidates {
+			add(n)
+		}
+		for _, n := range rule.FallbackChain {
+			add(n)
+		}
+	}
+	if e.Routing.Scoring != nil {
+		for _, w := range e.Routing.Scoring.WeightedSplit {
+			add(w.Cluster)
+		}
+	}
+	return out
+}

--- a/agent/proxycfg/inference_gateway_test.go
+++ b/agent/proxycfg/inference_gateway_test.go
@@ -1,0 +1,83 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package proxycfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func TestCandidateModelServices(t *testing.T) {
+	em := *acl.DefaultEnterpriseMeta()
+
+	require.Empty(t, candidateModelServices(nil, em))
+
+	e := &structs.AIGatewayConfigEntry{
+		Routing: structs.AIGatewayRouting{
+			FallbackChain: []string{"vllm-prod"},
+			MatchRules: []structs.AIGatewayMatchRule{
+				{Candidates: []string{"openai-gpt4", "anthropic-sonnet"}, FallbackChain: []string{"vllm-prod"}},
+			},
+			Scoring: &structs.AIGatewayScoring{
+				WeightedSplit: []structs.AIGatewayWeightedTarget{{Cluster: "openai-gpt4", Weight: 80}},
+			},
+		},
+	}
+
+	got := candidateModelServices(e, em)
+	require.Len(t, got, 3) // deduped across all sources
+	for _, name := range []string{"openai-gpt4", "anthropic-sonnet", "vllm-prod"} {
+		_, ok := got[structs.NewServiceName(name, &em)]
+		require.Truef(t, ok, "expected candidate %q", name)
+	}
+}
+
+func TestHandlerInferenceGateway_updateModel(t *testing.T) {
+	h := &handlerInferenceGateway{}
+	snap := &ConfigSnapshot{}
+	snap.InferenceGateway.Models = map[structs.ServiceName]*InferenceGatewayModel{}
+	sn := structs.NewServiceName("openai-gpt4", acl.DefaultEnterpriseMeta())
+
+	modelNodes := structs.CheckServiceNodes{
+		{Service: &structs.NodeService{
+			Service: "openai-gpt4",
+			AI:      &structs.AIConfig{Role: structs.AIRoleModel},
+			Meta:    map[string]string{"provider": "openai", "tier": "premium"},
+		}},
+	}
+
+	// An ai-model service is recorded with its labels.
+	h.updateModel(snap, sn, modelNodes)
+	got, ok := snap.InferenceGateway.Models[sn]
+	require.True(t, ok)
+	require.Equal(t, structs.AIRoleModel, got.Role)
+	require.Equal(t, "openai", got.Labels["provider"])
+	require.Equal(t, "premium", got.Labels["tier"])
+
+	// A service with no ai-model instance is dropped.
+	h.updateModel(snap, sn, structs.CheckServiceNodes{
+		{Service: &structs.NodeService{Service: "openai-gpt4"}},
+	})
+	_, ok = snap.InferenceGateway.Models[sn]
+	require.False(t, ok)
+}
+
+func TestConfigSnapshotInferenceGateway_valid(t *testing.T) {
+	snap := &ConfigSnapshot{Kind: structs.ServiceKindInferenceGateway}
+	require.False(t, snap.Valid())
+
+	snap.Roots = &structs.IndexedCARoots{}
+	snap.InferenceGateway.Leaf = &structs.IssuedCert{}
+	snap.InferenceGateway.MeshConfigSet = true
+	snap.InferenceGateway.GatewayConfigSet = true
+	require.True(t, snap.Valid())
+
+	// Leaf is required for inbound mTLS.
+	snap.InferenceGateway.Leaf = nil
+	require.False(t, snap.Valid())
+}

--- a/agent/proxycfg/proxycfg.deepcopy.go
+++ b/agent/proxycfg/proxycfg.deepcopy.go
@@ -152,6 +152,138 @@ func (o *ConfigSnapshot) DeepCopy() *ConfigSnapshot {
 		retV := o.APIGateway.DeepCopy()
 		cp.APIGateway = *retV
 	}
+	if o.InferenceGateway.Leaf != nil {
+		cp.InferenceGateway.Leaf = new(structs.IssuedCert)
+		*cp.InferenceGateway.Leaf = *o.InferenceGateway.Leaf
+	}
+	if o.InferenceGateway.MeshConfig != nil {
+		cp.InferenceGateway.MeshConfig = o.InferenceGateway.MeshConfig.DeepCopy()
+	}
+	if o.InferenceGateway.GatewayConfig != nil {
+		cp.InferenceGateway.GatewayConfig = new(structs.AIGatewayConfigEntry)
+		*cp.InferenceGateway.GatewayConfig = *o.InferenceGateway.GatewayConfig
+		if o.InferenceGateway.GatewayConfig.ApplyTo != nil {
+			cp.InferenceGateway.GatewayConfig.ApplyTo = make([]string, len(o.InferenceGateway.GatewayConfig.ApplyTo))
+			copy(cp.InferenceGateway.GatewayConfig.ApplyTo, o.InferenceGateway.GatewayConfig.ApplyTo)
+		}
+		if o.InferenceGateway.GatewayConfig.Routing.MatchRules != nil {
+			cp.InferenceGateway.GatewayConfig.Routing.MatchRules = make([]structs.AIGatewayMatchRule, len(o.InferenceGateway.GatewayConfig.Routing.MatchRules))
+			copy(cp.InferenceGateway.GatewayConfig.Routing.MatchRules, o.InferenceGateway.GatewayConfig.Routing.MatchRules)
+			for i6 := range o.InferenceGateway.GatewayConfig.Routing.MatchRules {
+				if o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].When.BodyHas != nil {
+					cp.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].When.BodyHas = make([]string, len(o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].When.BodyHas))
+					copy(cp.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].When.BodyHas, o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].When.BodyHas)
+				}
+				if o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].When.Identity != nil {
+					cp.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].When.Identity = new(structs.AIGatewayIdentityMatch)
+					*cp.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].When.Identity = *o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].When.Identity
+				}
+				if o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].RequireCapabilities != nil {
+					cp.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].RequireCapabilities = make([]string, len(o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].RequireCapabilities))
+					copy(cp.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].RequireCapabilities, o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].RequireCapabilities)
+				}
+				if o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].Candidates != nil {
+					cp.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].Candidates = make([]string, len(o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].Candidates))
+					copy(cp.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].Candidates, o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].Candidates)
+				}
+				if o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].FallbackChain != nil {
+					cp.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].FallbackChain = make([]string, len(o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].FallbackChain))
+					copy(cp.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].FallbackChain, o.InferenceGateway.GatewayConfig.Routing.MatchRules[i6].FallbackChain)
+				}
+			}
+		}
+		if o.InferenceGateway.GatewayConfig.Routing.ComplianceMap != nil {
+			cp.InferenceGateway.GatewayConfig.Routing.ComplianceMap = make(map[string]structs.AIGatewayCompliance, len(o.InferenceGateway.GatewayConfig.Routing.ComplianceMap))
+			for k6, v6 := range o.InferenceGateway.GatewayConfig.Routing.ComplianceMap {
+				var cp_InferenceGateway_GatewayConfig_Routing_ComplianceMap_v6 structs.AIGatewayCompliance
+				if v6.AllowedRegions != nil {
+					cp_InferenceGateway_GatewayConfig_Routing_ComplianceMap_v6.AllowedRegions = make([]string, len(v6.AllowedRegions))
+					copy(cp_InferenceGateway_GatewayConfig_Routing_ComplianceMap_v6.AllowedRegions, v6.AllowedRegions)
+				}
+				if v6.AllowedClusters != nil {
+					cp_InferenceGateway_GatewayConfig_Routing_ComplianceMap_v6.AllowedClusters = make([]string, len(v6.AllowedClusters))
+					copy(cp_InferenceGateway_GatewayConfig_Routing_ComplianceMap_v6.AllowedClusters, v6.AllowedClusters)
+				}
+				cp.InferenceGateway.GatewayConfig.Routing.ComplianceMap[k6] = cp_InferenceGateway_GatewayConfig_Routing_ComplianceMap_v6
+			}
+		}
+		if o.InferenceGateway.GatewayConfig.Routing.FallbackChain != nil {
+			cp.InferenceGateway.GatewayConfig.Routing.FallbackChain = make([]string, len(o.InferenceGateway.GatewayConfig.Routing.FallbackChain))
+			copy(cp.InferenceGateway.GatewayConfig.Routing.FallbackChain, o.InferenceGateway.GatewayConfig.Routing.FallbackChain)
+		}
+		if o.InferenceGateway.GatewayConfig.Routing.Retry != nil {
+			cp.InferenceGateway.GatewayConfig.Routing.Retry = new(structs.AIGatewayRetry)
+			*cp.InferenceGateway.GatewayConfig.Routing.Retry = *o.InferenceGateway.GatewayConfig.Routing.Retry
+			if o.InferenceGateway.GatewayConfig.Routing.Retry.RetryOn != nil {
+				cp.InferenceGateway.GatewayConfig.Routing.Retry.RetryOn = make([]string, len(o.InferenceGateway.GatewayConfig.Routing.Retry.RetryOn))
+				copy(cp.InferenceGateway.GatewayConfig.Routing.Retry.RetryOn, o.InferenceGateway.GatewayConfig.Routing.Retry.RetryOn)
+			}
+		}
+		if o.InferenceGateway.GatewayConfig.Routing.Timeout != nil {
+			cp.InferenceGateway.GatewayConfig.Routing.Timeout = new(structs.AIGatewayTimeout)
+			*cp.InferenceGateway.GatewayConfig.Routing.Timeout = *o.InferenceGateway.GatewayConfig.Routing.Timeout
+		}
+		if o.InferenceGateway.GatewayConfig.Routing.Scoring != nil {
+			cp.InferenceGateway.GatewayConfig.Routing.Scoring = new(structs.AIGatewayScoring)
+			*cp.InferenceGateway.GatewayConfig.Routing.Scoring = *o.InferenceGateway.GatewayConfig.Routing.Scoring
+			if o.InferenceGateway.GatewayConfig.Routing.Scoring.Scorers != nil {
+				cp.InferenceGateway.GatewayConfig.Routing.Scoring.Scorers = make([]string, len(o.InferenceGateway.GatewayConfig.Routing.Scoring.Scorers))
+				copy(cp.InferenceGateway.GatewayConfig.Routing.Scoring.Scorers, o.InferenceGateway.GatewayConfig.Routing.Scoring.Scorers)
+			}
+			if o.InferenceGateway.GatewayConfig.Routing.Scoring.WeightedSplit != nil {
+				cp.InferenceGateway.GatewayConfig.Routing.Scoring.WeightedSplit = make([]structs.AIGatewayWeightedTarget, len(o.InferenceGateway.GatewayConfig.Routing.Scoring.WeightedSplit))
+				copy(cp.InferenceGateway.GatewayConfig.Routing.Scoring.WeightedSplit, o.InferenceGateway.GatewayConfig.Routing.Scoring.WeightedSplit)
+			}
+		}
+		if o.InferenceGateway.GatewayConfig.Routing.Budget != nil {
+			cp.InferenceGateway.GatewayConfig.Routing.Budget = make(map[string]interface{}, len(o.InferenceGateway.GatewayConfig.Routing.Budget))
+			for k6, v6 := range o.InferenceGateway.GatewayConfig.Routing.Budget {
+				cp.InferenceGateway.GatewayConfig.Routing.Budget[k6] = v6
+			}
+		}
+		if o.InferenceGateway.GatewayConfig.Routing.Cache != nil {
+			cp.InferenceGateway.GatewayConfig.Routing.Cache = make(map[string]interface{}, len(o.InferenceGateway.GatewayConfig.Routing.Cache))
+			for k6, v6 := range o.InferenceGateway.GatewayConfig.Routing.Cache {
+				cp.InferenceGateway.GatewayConfig.Routing.Cache[k6] = v6
+			}
+		}
+		if o.InferenceGateway.GatewayConfig.Routing.Mirror != nil {
+			cp.InferenceGateway.GatewayConfig.Routing.Mirror = make(map[string]interface{}, len(o.InferenceGateway.GatewayConfig.Routing.Mirror))
+			for k6, v6 := range o.InferenceGateway.GatewayConfig.Routing.Mirror {
+				cp.InferenceGateway.GatewayConfig.Routing.Mirror[k6] = v6
+			}
+		}
+		if o.InferenceGateway.GatewayConfig.Meta != nil {
+			cp.InferenceGateway.GatewayConfig.Meta = make(map[string]string, len(o.InferenceGateway.GatewayConfig.Meta))
+			for k5, v5 := range o.InferenceGateway.GatewayConfig.Meta {
+				cp.InferenceGateway.GatewayConfig.Meta[k5] = v5
+			}
+		}
+	}
+	if o.InferenceGateway.WatchedModels != nil {
+		cp.InferenceGateway.WatchedModels = make(map[structs.ServiceName]context.CancelFunc, len(o.InferenceGateway.WatchedModels))
+		for k3, v3 := range o.InferenceGateway.WatchedModels {
+			cp.InferenceGateway.WatchedModels[k3] = v3
+		}
+	}
+	if o.InferenceGateway.Models != nil {
+		cp.InferenceGateway.Models = make(map[structs.ServiceName]*InferenceGatewayModel, len(o.InferenceGateway.Models))
+		for k3, v3 := range o.InferenceGateway.Models {
+			var cp_InferenceGateway_Models_v3 *InferenceGatewayModel
+			if v3 != nil {
+				cp_InferenceGateway_Models_v3 = new(InferenceGatewayModel)
+				*cp_InferenceGateway_Models_v3 = *v3
+				if v3.Labels != nil {
+					cp_InferenceGateway_Models_v3.Labels = make(map[string]string, len(v3.Labels))
+					for k6, v6 := range v3.Labels {
+						cp_InferenceGateway_Models_v3.Labels[k6] = v6
+					}
+				}
+				cp_InferenceGateway_Models_v3.Nodes = v3.Nodes.DeepCopy()
+			}
+			cp.InferenceGateway.Models[k3] = cp_InferenceGateway_Models_v3
+		}
+	}
 	if o.computedFields.xdsCommonConfig != nil {
 		cp.computedFields.xdsCommonConfig = new(config.XDSCommonConfig)
 		*cp.computedFields.xdsCommonConfig = *o.computedFields.xdsCommonConfig

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -996,6 +996,9 @@ type ConfigSnapshot struct {
 	// api-gateway specific
 	APIGateway configSnapshotAPIGateway
 
+	// inference-gateway specific
+	InferenceGateway configSnapshotInferenceGateway
+
 	// computedFields exists as a place to store relatively expensive
 	// computed data (such as parsed opaque maps) rather than parsing it
 	// multiple times during xDS generation. All data in this should be
@@ -1051,6 +1054,11 @@ func (s *ConfigSnapshot) Valid() bool {
 		return s.Roots != nil &&
 			s.APIGateway.valid() &&
 			s.APIGateway.MeshConfigSet
+
+	case structs.ServiceKindInferenceGateway:
+		return s.Roots != nil &&
+			s.InferenceGateway.Leaf != nil &&
+			s.InferenceGateway.valid()
 	default:
 		return false
 	}
@@ -1094,6 +1102,8 @@ func (s *ConfigSnapshot) Clone() *ConfigSnapshot {
 		// only api-gateway
 		// snap.APIGateway.LeafCertWatchCancel = nil
 		// snap.APIGateway.
+	case structs.ServiceKindInferenceGateway:
+		snap.InferenceGateway.WatchedModels = nil
 	}
 
 	return snap
@@ -1109,6 +1119,8 @@ func (s *ConfigSnapshot) Leaf() *structs.IssuedCert {
 		return s.APIGateway.Leaf
 	case structs.ServiceKindMeshGateway:
 		return s.MeshGateway.Leaf
+	case structs.ServiceKindInferenceGateway:
+		return s.InferenceGateway.Leaf
 	default:
 		return nil
 	}

--- a/agent/proxycfg/snapshot_inference_gateway.go
+++ b/agent/proxycfg/snapshot_inference_gateway.go
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package proxycfg
+
+import (
+	"context"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// configSnapshotInferenceGateway holds the proxycfg state for an inference
+// gateway: its own inbound-mTLS identity, the bound ai-gateway routing policy,
+// and the set of discovered model upstreams (ai.role == "ai-model").
+type configSnapshotInferenceGateway struct {
+	// Leaf is the gateway's own leaf cert, used to terminate inbound mesh mTLS
+	// from calling agents.
+	Leaf *structs.IssuedCert
+
+	// MeshConfig is the global mesh config entry.
+	MeshConfig    *structs.MeshConfigEntry
+	MeshConfigSet bool
+
+	// GatewayConfig is the bound ai-gateway config entry (the routing policy).
+	GatewayConfig    *structs.AIGatewayConfigEntry
+	GatewayConfigSet bool
+
+	// WatchedModels tracks the per-candidate health watches so they can be
+	// cancelled when a candidate is removed from the routing policy.
+	WatchedModels map[structs.ServiceName]context.CancelFunc
+
+	// Models holds the discovered model upstreams keyed by service name. Only
+	// services whose instances carry ai.role == "ai-model" are kept; the model's
+	// catalog Meta (labels) and healthy endpoints are recorded for routing and
+	// for injection into the gateway listener metadata.
+	Models map[structs.ServiceName]*InferenceGatewayModel
+}
+
+// InferenceGatewayModel is a discovered model upstream.
+type InferenceGatewayModel struct {
+	Service structs.ServiceName
+	Role    string
+	Labels  map[string]string
+	Nodes   structs.CheckServiceNodes
+}
+
+func (c *configSnapshotInferenceGateway) valid() bool {
+	return c.GatewayConfigSet && c.MeshConfigSet
+}
+
+// isEmpty reports whether the snapshot has been initialized.
+func (c *configSnapshotInferenceGateway) isEmpty() bool {
+	if c == nil {
+		return true
+	}
+	return c.Leaf == nil &&
+		!c.MeshConfigSet &&
+		!c.GatewayConfigSet &&
+		len(c.WatchedModels) == 0 &&
+		len(c.Models) == 0
+}

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -41,6 +41,8 @@ const (
 	gatewayServicesWatchID             = "gateway-services"
 	gatewayConfigWatchID               = "gateway-config"
 	apiGatewayConfigWatchID            = "api-gateway-config"
+	aiGatewayConfigWatchID             = "ai-gateway-config"
+	inferenceModelServiceIDPrefix      = "inference-model-service:"
 	boundGatewayConfigWatchID          = "bound-gateway-config"
 	fileSystemCertificateConfigWatchID = "file-system-certificate-config"
 	inlineCertificateConfigWatchID     = "inline-certificate-config"
@@ -228,8 +230,11 @@ func newKindHandler(config stateConfig, s serviceInstance, ch chan UpdateEvent) 
 	case structs.ServiceKindAPIGateway:
 		h.logger = config.logger.Named(logging.APIGateway)
 		handler = &handlerAPIGateway{handlerState: h}
+	case structs.ServiceKindInferenceGateway:
+		h.logger = config.logger.Named(logging.InferenceGateway)
+		handler = &handlerInferenceGateway{handlerState: h}
 	default:
-		return nil, errors.New("not a connect-proxy, terminating-gateway, mesh-gateway, or ingress-gateway")
+		return nil, errors.New("not a connect-proxy, terminating-gateway, mesh-gateway, ingress-gateway, api-gateway, or inference-gateway")
 	}
 
 	return handler, nil

--- a/agent/proxycfg/testing_inference_gateway.go
+++ b/agent/proxycfg/testing_inference_gateway.go
@@ -1,0 +1,86 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package proxycfg
+
+import (
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/mitchellh/go-testing-interface"
+)
+
+// TestConfigSnapshotInferenceGateway returns a fully-populated inference gateway
+// snapshot: its own leaf (inbound mesh mTLS), the bound ai-gateway routing
+// policy (ext_proc UDS + a match rule + fallback), and one discovered ai-model
+// upstream with catalog labels.
+func TestConfigSnapshotInferenceGateway(t testing.T, nsFn func(ns *structs.NodeService), extraUpdates []UpdateEvent) *ConfigSnapshot {
+	roots, leaf := TestCerts(t)
+
+	openai := structs.NewServiceName("openai-gpt4", nil)
+
+	policy := &structs.AIGatewayConfigEntry{
+		Kind: structs.AIGateway,
+		Name: "inference-gateway",
+		Processor: structs.AIGatewayProcessor{
+			UDSPath:     "/run/consul/ext_proc.sock",
+			FailureMode: structs.AIGatewayFailureModeClosed,
+		},
+		Routing: structs.AIGatewayRouting{
+			ConfigValidation: structs.AIGatewayConfigValidationWarn,
+			FallbackChain:    []string{"openai-gpt4"},
+			MatchRules: []structs.AIGatewayMatchRule{
+				{
+					When:       structs.AIGatewayMatch{Path: "/v1/chat/completions"},
+					Candidates: []string{"openai-gpt4"},
+				},
+			},
+		},
+	}
+
+	modelNodes := structs.CheckServiceNodes{
+		{
+			Node: &structs.Node{
+				ID:         "n1",
+				Node:       "test1",
+				Address:    "10.0.0.1",
+				Datacenter: "dc1",
+			},
+			Service: &structs.NodeService{
+				Service: "openai-gpt4",
+				Address: "10.0.0.1",
+				Port:    443,
+				AI:      &structs.AIConfig{Role: structs.AIRoleModel},
+				Meta:    map[string]string{"provider": "openai", "tier": "premium"},
+			},
+		},
+	}
+
+	baseEvents := []UpdateEvent{
+		{
+			CorrelationID: rootsWatchID,
+			Result:        roots,
+		},
+		{
+			CorrelationID: leafWatchID,
+			Result:        leaf,
+		},
+		{
+			CorrelationID: meshConfigEntryID,
+			Result:        &structs.ConfigEntryResponse{Entry: nil},
+		},
+		{
+			CorrelationID: aiGatewayConfigWatchID,
+			Result:        &structs.ConfigEntryResponse{Entry: policy},
+		},
+		{
+			CorrelationID: inferenceModelServiceIDPrefix + openai.String(),
+			Result:        &structs.IndexedCheckServiceNodes{Nodes: modelNodes},
+		},
+	}
+
+	return testConfigSnapshotFixture(t, &structs.NodeService{
+		Kind:    structs.ServiceKindInferenceGateway,
+		Service: "inference-gateway",
+		Address: "1.2.3.4",
+		Port:    8443,
+	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates))
+}

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -47,6 +47,7 @@ const (
 	RateLimitIPConfig string = "control-plane-request-limit"
 	RateLimit         string = "rate-limit"
 	JWTProvider       string = "jwt-provider"
+	AIGateway         string = "ai-gateway"
 
 	ProxyConfigGlobal string = "global"
 	MeshConfigMesh    string = "mesh"
@@ -77,6 +78,7 @@ var AllConfigEntryKinds = []string{
 	RateLimitIPConfig,
 	RateLimit,
 	JWTProvider,
+	AIGateway,
 }
 
 // ConfigEntry is the interface for centralized configuration stored in Raft.
@@ -854,6 +856,8 @@ func MakeConfigEntry(kind, name string) (ConfigEntry, error) {
 		return &TCPRouteConfigEntry{Name: name}, nil
 	case JWTProvider:
 		return &JWTProviderConfigEntry{Name: name}, nil
+	case AIGateway:
+		return &AIGatewayConfigEntry{Name: name}, nil
 	default:
 		return nil, fmt.Errorf("invalid config entry kind: %s", kind)
 	}

--- a/agent/structs/config_entry_ai_gateway.go
+++ b/agent/structs/config_entry_ai_gateway.go
@@ -1,0 +1,332 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package structs
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/consul/acl"
+)
+
+const (
+	// AIGatewayFailureModeClosed rejects the request when the policy processor
+	// is unreachable or errors. It is the default.
+	AIGatewayFailureModeClosed = "closed"
+	// AIGatewayFailureModeOpen lets the request proceed when the processor is
+	// unreachable or errors.
+	AIGatewayFailureModeOpen = "open"
+
+	// AIGatewayConfigValidationWarn loads shadowed match rules and emits a
+	// metric; it is the default.
+	AIGatewayConfigValidationWarn = "warn"
+	// AIGatewayConfigValidationStrict rejects a config that contains shadowed
+	// match rules at load time.
+	AIGatewayConfigValidationStrict = "strict"
+)
+
+// AIGatewayConfigEntry is the routing policy for one or more inference gateways
+// (kind = "inference-gateway"). It binds the gateway's ext_proc filter to a
+// co-located policy processor and describes how A2LLM requests are matched and
+// routed to model upstreams. It is attached to gateways via ApplyTo and is the
+// authoritative source of the gateway's routing behavior (RFC-0002).
+type AIGatewayConfigEntry struct {
+	// Kind of the config entry. This will be set to structs.AIGateway.
+	Kind string
+
+	// Name of the config entry.
+	Name string
+
+	// Processor binds the gateway's ext_proc filter to the co-located policy
+	// processor over a loopback/UDS socket.
+	Processor AIGatewayProcessor
+
+	// ApplyTo lists the inference-gateway service names this policy binds to.
+	// An empty list applies the policy to a gateway whose service name equals
+	// this entry's Name.
+	ApplyTo []string `json:",omitempty"`
+
+	// Routing holds the request-matching and dispatch rules.
+	Routing AIGatewayRouting
+
+	Meta               map[string]string `json:",omitempty"`
+	Hash               uint64            `json:",omitempty" hash:"ignore"`
+	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
+	RaftIndex          `hash:"ignore"`
+}
+
+// AIGatewayProcessor configures the ext_proc binding to the policy processor.
+type AIGatewayProcessor struct {
+	// UDSPath is the absolute Unix domain socket path the ext_proc filter dials
+	// to reach the co-located processor.
+	UDSPath string `json:",omitempty"`
+
+	// FailureMode is "closed" (reject on processor error, the default) or
+	// "open" (allow the request through).
+	FailureMode string `json:",omitempty"`
+}
+
+// AIGatewayRouting holds the Stage 3-6 routing configuration.
+type AIGatewayRouting struct {
+	// MatchRules are evaluated first-match-wins to select candidate model
+	// clusters for a request.
+	MatchRules []AIGatewayMatchRule `json:",omitempty"`
+
+	// ComplianceMap AND-filters a match rule's candidates by compliance class.
+	ComplianceMap map[string]AIGatewayCompliance `json:",omitempty"`
+
+	// FallbackChain is the default priority-ordered cluster list used when a
+	// match rule does not specify its own.
+	FallbackChain []string `json:",omitempty"`
+
+	// Retry and Timeout are the default reliability directives Envoy enforces.
+	Retry   *AIGatewayRetry   `json:",omitempty"`
+	Timeout *AIGatewayTimeout `json:",omitempty"`
+
+	// Scoring is optional and off by default.
+	Scoring *AIGatewayScoring `json:",omitempty"`
+
+	// ConfigValidation is "warn" (default) or "strict"; strict rejects a config
+	// with shadowed match rules at load time.
+	ConfigValidation string `json:",omitempty"`
+
+	// Reserved forward-compatibility blocks. They accept an empty body but
+	// reject any non-empty content at load (deliberate footgun prevention).
+	Budget map[string]interface{} `json:",omitempty"`
+	Cache  map[string]interface{} `json:",omitempty"`
+	Mirror map[string]interface{} `json:",omitempty"`
+}
+
+// AIGatewayMatchRule selects candidate clusters for matching requests.
+type AIGatewayMatchRule struct {
+	When                AIGatewayMatch `json:",omitempty"`
+	RequireCapabilities []string       `json:",omitempty"`
+	Candidates          []string       `json:",omitempty"`
+	FallbackChain       []string       `json:",omitempty"`
+}
+
+// AIGatewayMatch is the predicate for a match rule.
+type AIGatewayMatch struct {
+	Path     string                  `json:",omitempty"`
+	BodyHas  []string                `json:",omitempty"`
+	Identity *AIGatewayIdentityMatch `json:",omitempty"`
+}
+
+// AIGatewayIdentityMatch matches on the calling agent's SPIFFE identity.
+type AIGatewayIdentityMatch struct {
+	Service   string `json:",omitempty"`
+	Partition string `json:",omitempty"`
+	Namespace string `json:",omitempty"`
+}
+
+// AIGatewayCompliance constrains candidate clusters for a compliance class.
+type AIGatewayCompliance struct {
+	AllowedRegions  []string `json:",omitempty"`
+	AllowedClusters []string `json:",omitempty"`
+}
+
+// AIGatewayRetry is the Envoy retry directive.
+type AIGatewayRetry struct {
+	MaxAttempts int      `json:",omitempty"`
+	RetryOn     []string `json:",omitempty"`
+}
+
+// AIGatewayTimeout is the Envoy timeout directive.
+type AIGatewayTimeout struct {
+	Connect string `json:",omitempty"`
+	Request string `json:",omitempty"`
+}
+
+// AIGatewayScoring is the optional Stage 5 scorer configuration.
+type AIGatewayScoring struct {
+	Scorers       []string                  `json:",omitempty"`
+	WeightedSplit []AIGatewayWeightedTarget `json:",omitempty"`
+}
+
+// AIGatewayWeightedTarget is a weighted cluster in a scoring split.
+type AIGatewayWeightedTarget struct {
+	Cluster string
+	Weight  int
+}
+
+func (e *AIGatewayConfigEntry) GetKind() string                        { return AIGateway }
+func (e *AIGatewayConfigEntry) GetName() string                        { return e.Name }
+func (e *AIGatewayConfigEntry) GetMeta() map[string]string             { return e.Meta }
+func (e *AIGatewayConfigEntry) GetRaftIndex() *RaftIndex               { return &e.RaftIndex }
+func (e *AIGatewayConfigEntry) GetEnterpriseMeta() *acl.EnterpriseMeta { return &e.EnterpriseMeta }
+func (e *AIGatewayConfigEntry) GetHash() uint64                        { return e.Hash }
+func (e *AIGatewayConfigEntry) SetHash(h uint64)                       { e.Hash = h }
+
+var _ ConfigEntry = (*AIGatewayConfigEntry)(nil)
+
+func (e *AIGatewayConfigEntry) Normalize() error {
+	if e == nil {
+		return fmt.Errorf("config entry is nil")
+	}
+	e.Kind = AIGateway
+
+	e.Processor.FailureMode = strings.ToLower(e.Processor.FailureMode)
+	if e.Processor.FailureMode == "" {
+		e.Processor.FailureMode = AIGatewayFailureModeClosed
+	}
+
+	e.Routing.ConfigValidation = strings.ToLower(e.Routing.ConfigValidation)
+	if e.Routing.ConfigValidation == "" {
+		e.Routing.ConfigValidation = AIGatewayConfigValidationWarn
+	}
+
+	h, err := HashConfigEntry(e)
+	if err != nil {
+		return err
+	}
+	e.Hash = h
+	return nil
+}
+
+func (e *AIGatewayConfigEntry) Validate() error {
+	if e.Name == "" {
+		return fmt.Errorf("Name is required")
+	}
+	if err := validateConfigEntryMeta(e.Meta); err != nil {
+		return err
+	}
+
+	if e.Processor.UDSPath != "" && !strings.HasPrefix(e.Processor.UDSPath, "/") {
+		return fmt.Errorf("Processor.UDSPath %q must be an absolute Unix socket path", e.Processor.UDSPath)
+	}
+	switch e.Processor.FailureMode {
+	case "", AIGatewayFailureModeOpen, AIGatewayFailureModeClosed:
+	default:
+		return fmt.Errorf("Processor.FailureMode %q must be %q or %q",
+			e.Processor.FailureMode, AIGatewayFailureModeOpen, AIGatewayFailureModeClosed)
+	}
+
+	switch e.Routing.ConfigValidation {
+	case "", AIGatewayConfigValidationWarn, AIGatewayConfigValidationStrict:
+	default:
+		return fmt.Errorf("Routing.ConfigValidation %q must be %q or %q",
+			e.Routing.ConfigValidation, AIGatewayConfigValidationWarn, AIGatewayConfigValidationStrict)
+	}
+
+	// Reserved blocks must be empty.
+	for name, block := range map[string]map[string]interface{}{
+		"Budget": e.Routing.Budget,
+		"Cache":  e.Routing.Cache,
+		"Mirror": e.Routing.Mirror,
+	} {
+		if len(block) > 0 {
+			return fmt.Errorf("Routing.%s is reserved and must be empty", name)
+		}
+	}
+
+	if e.Routing.Timeout != nil {
+		if err := validateOptionalDuration("Routing.Timeout.Connect", e.Routing.Timeout.Connect); err != nil {
+			return err
+		}
+		if err := validateOptionalDuration("Routing.Timeout.Request", e.Routing.Timeout.Request); err != nil {
+			return err
+		}
+	}
+	if e.Routing.Retry != nil && e.Routing.Retry.MaxAttempts < 0 {
+		return fmt.Errorf("Routing.Retry.MaxAttempts must not be negative")
+	}
+
+	for i, rule := range e.Routing.MatchRules {
+		if len(rule.Candidates) == 0 {
+			return fmt.Errorf("Routing.MatchRules[%d] must list at least one Candidate", i)
+		}
+	}
+
+	// First-match-wins means a broad earlier rule silently shadows a more
+	// specific later rule. In strict mode this is a load-time error.
+	if shadows := e.shadowedMatchRules(); len(shadows) > 0 &&
+		e.Routing.ConfigValidation == AIGatewayConfigValidationStrict {
+		return fmt.Errorf("Routing.MatchRules contains shadowed rules (strict mode): %s",
+			strings.Join(shadows, "; "))
+	}
+
+	return nil
+}
+
+// shadowedMatchRules returns human-readable descriptions of (shadowing,
+// shadowed) rule pairs where an earlier rule matches every request a later,
+// more specific rule would.
+func (e *AIGatewayConfigEntry) shadowedMatchRules() []string {
+	var out []string
+	rules := e.Routing.MatchRules
+	for i := range rules {
+		for j := i + 1; j < len(rules); j++ {
+			if matchCovers(rules[i].When, rules[j].When) {
+				out = append(out, fmt.Sprintf("rule %d shadows rule %d", i, j))
+			}
+		}
+	}
+	return out
+}
+
+// matchCovers reports whether predicate a matches every request that predicate
+// b would (so a placed before b makes b unreachable).
+func matchCovers(a, b AIGatewayMatch) bool {
+	// Path: a must be unconstrained or identical to b's path.
+	if a.Path != "" && a.Path != b.Path {
+		return false
+	}
+	// BodyHas: every token a requires must also be required by b.
+	for _, t := range a.BodyHas {
+		if !containsString(b.BodyHas, t) {
+			return false
+		}
+	}
+	// Identity: each constraint a sets must be unconstrained or equal in b.
+	if a.Identity != nil {
+		if b.Identity == nil {
+			return false
+		}
+		if !identityFieldCovers(a.Identity.Service, b.Identity.Service) ||
+			!identityFieldCovers(a.Identity.Partition, b.Identity.Partition) ||
+			!identityFieldCovers(a.Identity.Namespace, b.Identity.Namespace) {
+			return false
+		}
+	}
+	return true
+}
+
+// identityFieldCovers reports whether constraint a covers b for a single
+// identity field. A wildcard "*" or empty a covers anything; otherwise a must
+// equal b.
+func identityFieldCovers(a, b string) bool {
+	return a == "" || a == "*" || a == b
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func validateOptionalDuration(field, value string) error {
+	if value == "" {
+		return nil
+	}
+	if _, err := time.ParseDuration(value); err != nil {
+		return fmt.Errorf("%s %q is not a valid duration: %w", field, value, err)
+	}
+	return nil
+}
+
+func (e *AIGatewayConfigEntry) CanRead(authz acl.Authorizer) error {
+	var authzContext acl.AuthorizerContext
+	e.FillAuthzContext(&authzContext)
+	return authz.ToAllowAuthorizer().ServiceReadAllowed(e.Name, &authzContext)
+}
+
+func (e *AIGatewayConfigEntry) CanWrite(authz acl.Authorizer) error {
+	var authzContext acl.AuthorizerContext
+	e.FillAuthzContext(&authzContext)
+	return authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext)
+}

--- a/agent/structs/config_entry_ai_gateway.go
+++ b/agent/structs/config_entry_ai_gateway.go
@@ -51,6 +51,12 @@ type AIGatewayConfigEntry struct {
 	// Routing holds the request-matching and dispatch rules.
 	Routing AIGatewayRouting
 
+	// Policy holds cross-cutting request/response policy the co-located processor
+	// enforces (PII detection/redaction, audit). Consul does not act on it — it is
+	// stored and returned verbatim so the processor reads the same entry it renders
+	// Envoy from, keeping one source of truth.
+	Policy *AIGatewayPolicy `json:",omitempty"`
+
 	Meta               map[string]string `json:",omitempty"`
 	Hash               uint64            `json:",omitempty" hash:"ignore"`
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
@@ -149,6 +155,61 @@ type AIGatewayScoring struct {
 type AIGatewayWeightedTarget struct {
 	Cluster string
 	Weight  int
+}
+
+// AIGatewayPolicy mirrors the policy processor's Policy block so the PII and audit
+// configuration round-trips through Consul to the processor. Field names match the
+// processor's config structs (which decode this entry's JSON by Go field name), so
+// Consul stores and returns them unchanged.
+type AIGatewayPolicy struct {
+	// PII configures per-detector PII detection and redaction.
+	PII *AIGatewayPII `json:",omitempty"`
+
+	// AuditLevel is the Stage 7 audit verbosity: full | sampling | off.
+	AuditLevel string `json:",omitempty"`
+}
+
+// AIGatewayPII configures per-detector PII detection and redaction for the
+// processor. Consul does not interpret these fields; it carries them to the
+// processor verbatim.
+type AIGatewayPII struct {
+	// Scope selects which bodies the detectors' actions apply to: request |
+	// response | both.
+	Scope string `json:",omitempty"`
+
+	// DefaultAction applies to any detector that does not set its own Action:
+	// placeholder | mask | block | off.
+	DefaultAction string `json:",omitempty"`
+
+	// StreamHoldbackBytes is the trailing content the streaming response redactor
+	// withholds so PII split across chunk boundaries is caught before release.
+	StreamHoldbackBytes int `json:",omitempty"`
+
+	// Mask parameterizes the "mask" action.
+	Mask *AIGatewayPIIMask `json:",omitempty"`
+
+	// Detectors are the PII rules to run.
+	Detectors []AIGatewayPIIDetector `json:",omitempty"`
+}
+
+// AIGatewayPIIMask parameterizes the "mask" redaction action.
+type AIGatewayPIIMask struct {
+	// Char replaces each redacted alphanumeric character (default "*").
+	Char string `json:",omitempty"`
+	// KeepLast leaves the trailing KeepLast characters visible.
+	KeepLast int `json:",omitempty"`
+}
+
+// AIGatewayPIIDetector is one PII rule: a named built-in or a custom Regex, with
+// an Action that overrides the policy's DefaultAction.
+type AIGatewayPIIDetector struct {
+	// Name selects a built-in detector (ssn, credit_card, api_key, email) or names
+	// a custom one.
+	Name string `json:",omitempty"`
+	// Regex is a custom RE2 pattern; empty selects the built-in of Name.
+	Regex string `json:",omitempty"`
+	// Action is placeholder | mask | block | off.
+	Action string `json:",omitempty"`
 }
 
 func (e *AIGatewayConfigEntry) GetKind() string                        { return AIGateway }

--- a/agent/structs/config_entry_ai_gateway_test.go
+++ b/agent/structs/config_entry_ai_gateway_test.go
@@ -1,0 +1,86 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package structs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayConfigEntry_Normalize(t *testing.T) {
+	e := &AIGatewayConfigEntry{Name: "gw"}
+	require.NoError(t, e.Normalize())
+	require.Equal(t, AIGateway, e.Kind)
+	require.Equal(t, AIGatewayFailureModeClosed, e.Processor.FailureMode)
+	require.Equal(t, AIGatewayConfigValidationWarn, e.Routing.ConfigValidation)
+	require.NotZero(t, e.Hash)
+}
+
+func TestAIGatewayConfigEntry_Validate(t *testing.T) {
+	base := func() *AIGatewayConfigEntry {
+		return &AIGatewayConfigEntry{
+			Name:      "gw",
+			Processor: AIGatewayProcessor{UDSPath: "/run/consul/ext_proc.sock", FailureMode: AIGatewayFailureModeClosed},
+			Routing: AIGatewayRouting{
+				ConfigValidation: AIGatewayConfigValidationWarn,
+				MatchRules: []AIGatewayMatchRule{
+					{When: AIGatewayMatch{Path: "/v1/chat/completions", BodyHas: []string{"tools"}}, Candidates: []string{"openai"}},
+				},
+			},
+		}
+	}
+
+	cases := map[string]struct {
+		mutate func(*AIGatewayConfigEntry)
+		errMsg string
+	}{
+		"valid":               {mutate: func(e *AIGatewayConfigEntry) {}},
+		"missing name":        {mutate: func(e *AIGatewayConfigEntry) { e.Name = "" }, errMsg: "Name is required"},
+		"relative uds":        {mutate: func(e *AIGatewayConfigEntry) { e.Processor.UDSPath = "run/x.sock" }, errMsg: "absolute Unix socket path"},
+		"bad failure mode":    {mutate: func(e *AIGatewayConfigEntry) { e.Processor.FailureMode = "bogus" }, errMsg: "Processor.FailureMode"},
+		"bad config valid":    {mutate: func(e *AIGatewayConfigEntry) { e.Routing.ConfigValidation = "loose" }, errMsg: "Routing.ConfigValidation"},
+		"reserved budget set":  {mutate: func(e *AIGatewayConfigEntry) { e.Routing.Budget = map[string]interface{}{"x": 1} }, errMsg: "Routing.Budget is reserved"},
+		"bad timeout":         {mutate: func(e *AIGatewayConfigEntry) { e.Routing.Timeout = &AIGatewayTimeout{Request: "soon"} }, errMsg: "not a valid duration"},
+		"candidate-less rule": {mutate: func(e *AIGatewayConfigEntry) { e.Routing.MatchRules[0].Candidates = nil }, errMsg: "at least one Candidate"},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := base()
+			c.mutate(e)
+			err := e.Validate()
+			if c.errMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, c.errMsg)
+			}
+		})
+	}
+}
+
+func TestAIGatewayConfigEntry_ShadowCheck(t *testing.T) {
+	// A broad rule (no body constraint) placed before a more specific rule
+	// (requires "tools") shadows it.
+	e := &AIGatewayConfigEntry{
+		Name: "gw",
+		Routing: AIGatewayRouting{
+			MatchRules: []AIGatewayMatchRule{
+				{When: AIGatewayMatch{Path: "/v1/chat/completions"}, Candidates: []string{"a"}},
+				{When: AIGatewayMatch{Path: "/v1/chat/completions", BodyHas: []string{"tools"}}, Candidates: []string{"b"}},
+			},
+		},
+	}
+
+	// warn mode: loads despite the shadow.
+	e.Routing.ConfigValidation = AIGatewayConfigValidationWarn
+	require.NoError(t, e.Validate())
+
+	// strict mode: rejected.
+	e.Routing.ConfigValidation = AIGatewayConfigValidationStrict
+	require.ErrorContains(t, e.Validate(), "shadowed")
+
+	// Reordering (specific first) removes the shadow even in strict mode.
+	e.Routing.MatchRules[0], e.Routing.MatchRules[1] = e.Routing.MatchRules[1], e.Routing.MatchRules[0]
+	require.NoError(t, e.Validate())
+}

--- a/agent/structs/config_entry_ai_gateway_test.go
+++ b/agent/structs/config_entry_ai_gateway_test.go
@@ -4,6 +4,7 @@
 package structs
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,76 @@ func TestAIGatewayConfigEntry_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAIGatewayConfigEntry_PolicyRoundTrip verifies the Policy block decodes from
+// a written config entry (as `consul config write` parses it) and round-trips
+// through JSON unchanged — the path the co-located processor reads it back over
+// (`GET /v1/config/ai-gateway/<name>`). Consul stores and returns it verbatim; it
+// does not interpret the PII fields.
+func TestAIGatewayConfigEntry_PolicyRoundTrip(t *testing.T) {
+	raw := map[string]interface{}{
+		"Kind": AIGateway,
+		"Name": "travel-inference-gateway",
+		"Policy": map[string]interface{}{
+			"AuditLevel": "full",
+			"PII": map[string]interface{}{
+				"Scope":               "both",
+				"DefaultAction":       "placeholder",
+				"StreamHoldbackBytes": 128,
+				"Mask":                map[string]interface{}{"Char": "*", "KeepLast": 4},
+				"Detectors": []interface{}{
+					map[string]interface{}{"Name": "ssn", "Action": "block"},
+					map[string]interface{}{"Name": "credit_card", "Action": "mask"},
+					map[string]interface{}{"Name": "badge", "Regex": "B-[0-9]+", "Action": "placeholder"},
+				},
+			},
+		},
+	}
+
+	decoded, err := DecodeConfigEntry(raw)
+	require.NoError(t, err, "unrecognized Policy keys would fail decode")
+	entry, ok := decoded.(*AIGatewayConfigEntry)
+	require.True(t, ok)
+
+	assertPolicy := func(t *testing.T, e *AIGatewayConfigEntry) {
+		t.Helper()
+		require.NotNil(t, e.Policy)
+		require.Equal(t, "full", e.Policy.AuditLevel)
+		require.NotNil(t, e.Policy.PII)
+		require.Equal(t, "both", e.Policy.PII.Scope)
+		require.Equal(t, "placeholder", e.Policy.PII.DefaultAction)
+		require.Equal(t, 128, e.Policy.PII.StreamHoldbackBytes)
+		require.NotNil(t, e.Policy.PII.Mask)
+		require.Equal(t, "*", e.Policy.PII.Mask.Char)
+		require.Equal(t, 4, e.Policy.PII.Mask.KeepLast)
+		require.Len(t, e.Policy.PII.Detectors, 3)
+		require.Equal(t, AIGatewayPIIDetector{Name: "ssn", Action: "block"}, e.Policy.PII.Detectors[0])
+		require.Equal(t, AIGatewayPIIDetector{Name: "credit_card", Action: "mask"}, e.Policy.PII.Detectors[1])
+		require.Equal(t, AIGatewayPIIDetector{Name: "badge", Regex: "B-[0-9]+", Action: "placeholder"}, e.Policy.PII.Detectors[2])
+	}
+
+	// Decoded from the written entry.
+	assertPolicy(t, entry)
+	require.NoError(t, entry.Normalize())
+	require.NoError(t, entry.Validate())
+
+	// Round-trips through the JSON the HTTP API returns to the processor.
+	encoded, err := json.Marshal(entry)
+	require.NoError(t, err)
+	var back AIGatewayConfigEntry
+	require.NoError(t, json.Unmarshal(encoded, &back))
+	assertPolicy(t, &back)
+}
+
+// TestAIGatewayConfigEntry_NoPolicyOmitted verifies an entry without a Policy
+// block marshals it away (omitempty) so existing entries are byte-identical.
+func TestAIGatewayConfigEntry_NoPolicyOmitted(t *testing.T) {
+	e := &AIGatewayConfigEntry{Name: "gw"}
+	require.NoError(t, e.Normalize())
+	encoded, err := json.Marshal(e)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "Policy")
 }
 
 func TestAIGatewayConfigEntry_ShadowCheck(t *testing.T) {

--- a/agent/structs/service_definition.go
+++ b/agent/structs/service_definition.go
@@ -32,6 +32,11 @@ type ServiceDefinition struct {
 	EnableTagOverride bool
 	Locality          *Locality
 
+	// AI, when set, marks this service's role in the Agent Gateway (Inference
+	// plane). A service registered with AI.Role == "ai-model" is discovered by
+	// inference gateways as a routable model upstream.
+	AI *AIConfig
+
 	// Proxy is the configuration set for Kind = connect-proxy. It is mandatory in
 	// that case and an error to be set for any other kind. This config is part of
 	// a proxy service definition. ProxyConfig may be a more natural name here, but
@@ -83,6 +88,7 @@ func (s *ServiceDefinition) NodeService() *NodeService {
 		EnableTagOverride: s.EnableTagOverride,
 		EnterpriseMeta:    s.EnterpriseMeta,
 		Locality:          s.Locality,
+		AI:                s.AI,
 	}
 	ns.Normalize()
 

--- a/agent/structs/structs.deepcopy.go
+++ b/agent/structs/structs.deepcopy.go
@@ -955,6 +955,10 @@ func (o *NodeService) DeepCopy() *NodeService {
 		cp.Locality = new(Locality)
 		*cp.Locality = *o.Locality
 	}
+	if o.AI != nil {
+		cp.AI = new(AIConfig)
+		*cp.AI = *o.AI
+	}
 	{
 		retV := o.Proxy.DeepCopy()
 		cp.Proxy = *retV
@@ -1140,6 +1144,10 @@ func (o *ServiceDefinition) DeepCopy() *ServiceDefinition {
 	if o.Locality != nil {
 		cp.Locality = new(Locality)
 		*cp.Locality = *o.Locality
+	}
+	if o.AI != nil {
+		cp.AI = new(AIConfig)
+		*cp.AI = *o.AI
 	}
 	if o.Proxy != nil {
 		cp.Proxy = o.Proxy.DeepCopy()

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1099,6 +1099,7 @@ type ServiceNode struct {
 	ServiceProxy             ConnectProxyConfig
 	ServiceConnect           ServiceConnect
 	ServiceLocality          *Locality `bexpr:"-"`
+	ServiceAI                *AIConfig `bexpr:"-"`
 
 	// If not empty, PeerName represents the peer that this ServiceNode was imported from.
 	PeerName string `json:",omitempty"`
@@ -1159,6 +1160,7 @@ func (s *ServiceNode) PartialClone() *ServiceNode {
 		ServiceProxy:             s.ServiceProxy,
 		ServiceConnect:           s.ServiceConnect,
 		ServiceLocality:          s.ServiceLocality,
+		ServiceAI:                s.ServiceAI,
 		RaftIndex: RaftIndex{
 			CreateIndex: s.CreateIndex,
 			ModifyIndex: s.ModifyIndex,
@@ -1188,6 +1190,7 @@ func (s *ServiceNode) ToNodeService() *NodeService {
 		PeerName:          s.PeerName,
 		EnterpriseMeta:    s.EnterpriseMeta,
 		Locality:          s.ServiceLocality,
+		AI:                s.ServiceAI,
 		RaftIndex: RaftIndex{
 			CreateIndex: s.CreateIndex,
 			ModifyIndex: s.ModifyIndex,
@@ -1256,7 +1259,8 @@ func (k ServiceKind) IsProxy() bool {
 		ServiceKindMeshGateway,
 		ServiceKindTerminatingGateway,
 		ServiceKindIngressGateway,
-		ServiceKindAPIGateway:
+		ServiceKindAPIGateway,
+		ServiceKindInferenceGateway:
 		return true
 	}
 	return false
@@ -1292,6 +1296,14 @@ const (
 	// This service allows external traffic to enter the mesh based on
 	// centralized configuration.
 	ServiceKindAPIGateway ServiceKind = "api-gateway"
+
+	// ServiceKindInferenceGateway is an Inference Gateway for the Agent Gateway
+	// (Inference plane). It accepts agent (A2LLM) traffic over mesh mTLS,
+	// enforces SPIFFE identity + intentions on inbound like a terminating
+	// gateway, runs an ext_proc filter over a loopback/UDS socket to a
+	// co-located policy processor, and dispatches to LLM providers via a
+	// terminating gateway. Routing is defined in the ai-gateway config entry.
+	ServiceKindInferenceGateway ServiceKind = "inference-gateway"
 
 	// ServiceKindDestination is a Destination  for the Consul Service Mesh feature.
 	// This service allows external traffic to exit the mesh through a terminating gateway
@@ -1394,6 +1406,21 @@ func (a ServiceAddress) ToAPIServiceAddress() api.ServiceAddress {
 
 const SidecarProxySuffix = "-sidecar-proxy"
 
+// AIRoleModel is the AIConfig.Role value marking a service as an LLM model
+// target that inference gateways may route to.
+const AIRoleModel = "ai-model"
+
+// AIConfig describes the AI/inference role a service plays in the Agent Gateway
+// (Inference plane). It is the discriminator the inference gateway uses to
+// discover model upstreams; routing labels (provider, tier, capabilities) ride
+// in the service's catalog Meta, not here.
+type AIConfig struct {
+	// Role identifies the AI role of this service. The only meaningful value
+	// today is "ai-model" (AIRoleModel), marking the service as a routable LLM
+	// model target. The field is extensible for future roles.
+	Role string `json:",omitempty"`
+}
+
 // NodeService is a service provided by a node
 type NodeService struct {
 	// Kind is the kind of service this is. Different kinds of services may
@@ -1413,6 +1440,12 @@ type NodeService struct {
 	Weights           *Weights
 	EnableTagOverride bool
 	Locality          *Locality `json:",omitempty" bexpr:"-"`
+
+	// AI, when set, marks this service's role in the Agent Gateway (Inference
+	// plane). A service registered with AI.Role == "ai-model" is discovered by
+	// inference gateways as a routable model upstream; its catalog Meta carries
+	// the routing labels (provider, tier, capabilities).
+	AI *AIConfig `json:",omitempty" bexpr:"-"`
 
 	// Proxy is the configuration set for Kind = connect-proxy. It is mandatory in
 	// that case and an error to be set for any other kind. This config is part of
@@ -1595,7 +1628,8 @@ func (s *NodeService) IsGateway() bool {
 	return s.Kind == ServiceKindMeshGateway ||
 		s.Kind == ServiceKindTerminatingGateway ||
 		s.Kind == ServiceKindIngressGateway ||
-		s.Kind == ServiceKindAPIGateway
+		s.Kind == ServiceKindAPIGateway ||
+		s.Kind == ServiceKindInferenceGateway
 }
 
 // Validate validates the node service configuration.
@@ -1836,6 +1870,7 @@ func (s *NodeService) IsSame(other *NodeService) bool {
 		!reflect.DeepEqual(s.Weights, other.Weights) ||
 		!reflect.DeepEqual(s.Meta, other.Meta) ||
 		!reflect.DeepEqual(s.Locality, other.Locality) ||
+		!reflect.DeepEqual(s.AI, other.AI) ||
 		s.EnableTagOverride != other.EnableTagOverride ||
 		s.Kind != other.Kind ||
 		!reflect.DeepEqual(s.Proxy, other.Proxy) ||
@@ -1876,6 +1911,7 @@ func (s *ServiceNode) IsSameService(other *ServiceNode) bool {
 		s.ServiceEnableTagOverride != other.ServiceEnableTagOverride ||
 		!reflect.DeepEqual(s.ServiceProxy, other.ServiceProxy) ||
 		!reflect.DeepEqual(s.ServiceConnect, other.ServiceConnect) ||
+		!reflect.DeepEqual(s.ServiceAI, other.ServiceAI) ||
 		!s.IsSame(&other.EnterpriseMeta) {
 		return false
 	}
@@ -1914,6 +1950,7 @@ func (s *NodeService) ToServiceNode(node string) *ServiceNode {
 		ServiceProxy:             s.Proxy,
 		ServiceConnect:           s.Connect,
 		ServiceLocality:          s.Locality,
+		ServiceAI:                s.AI,
 		EnterpriseMeta:           s.EnterpriseMeta,
 		PeerName:                 s.PeerName,
 		RaftIndex: RaftIndex{
@@ -3303,6 +3340,16 @@ func (l *Locality) ToAPI() *api.Locality {
 	return &api.Locality{
 		Region: l.Region,
 		Zone:   l.Zone,
+	}
+}
+
+func (a *AIConfig) ToAPI() *api.AIConfig {
+	if a == nil {
+		return nil
+	}
+
+	return &api.AIConfig{
+		Role: a.Role,
 	}
 }
 

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -76,6 +76,12 @@ func (s *ResourceGenerator) clustersFromSnapshot(cfgSnap *proxycfg.ConfigSnapsho
 			return nil, err
 		}
 		return res, nil
+	case structs.ServiceKindInferenceGateway:
+		res, err := s.clustersFromSnapshotInferenceGateway(cfgSnap)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
 	default:
 		return nil, fmt.Errorf("Invalid service kind: %v", cfgSnap.Kind)
 	}

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -46,6 +46,8 @@ func (s *ResourceGenerator) endpointsFromSnapshot(cfgSnap *proxycfg.ConfigSnapsh
 		return s.endpointsFromSnapshotIngressGateway(cfgSnap)
 	case structs.ServiceKindAPIGateway:
 		return s.endpointsFromSnapshotAPIGateway(cfgSnap)
+	case structs.ServiceKindInferenceGateway:
+		return s.endpointsFromSnapshotInferenceGateway(cfgSnap)
 	default:
 		return nil, fmt.Errorf("Invalid service kind: %v", cfgSnap.Kind)
 	}

--- a/agent/xds/inference_gateway.go
+++ b/agent/xds/inference_gateway.go
@@ -1,0 +1,330 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package xds
+
+import (
+	"sort"
+	"time"
+
+	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_http_ext_proc_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
+	envoy_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoy_upstreams_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	envoy_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+const (
+	// inferenceGatewayListenerName is the name of the inference gateway's single
+	// inbound listener and its RDS route configuration.
+	inferenceGatewayListenerName = "inference-gateway"
+
+	// inferenceExtProcClusterName is the local cluster Envoy uses to reach the
+	// co-located policy processor over the loopback/UDS socket.
+	inferenceExtProcClusterName = "local_ext_proc"
+
+	// inferenceClusterHeader is the header the policy processor sets to select
+	// the resolved model cluster; the gateway routes on it.
+	inferenceClusterHeader = "x-ai-cluster"
+
+	// inferenceListenerMetadataNamespace is the FilterMetadata key carrying the
+	// discovered model catalog for the policy processor.
+	inferenceListenerMetadataNamespace = "consul.ai"
+)
+
+// listenersFromSnapshotInferenceGateway builds the inference gateway's single
+// inbound listener: mesh mTLS + SPIFFE on the downstream (so the calling agent's
+// identity is enforced), an HTTP connection manager with the ext_proc filter
+// (dialing the policy processor over UDS) ahead of the router, and listener
+// metadata carrying the discovered model catalog.
+func (s *ResourceGenerator) listenersFromSnapshotInferenceGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
+	ig := &cfgSnap.InferenceGateway
+
+	addr := cfgSnap.Address
+	if addr == "" {
+		addr = "0.0.0.0"
+	}
+
+	opts := makeListenerOpts{
+		name:       inferenceGatewayListenerName,
+		accessLogs: cfgSnap.Proxy.AccessLogs,
+		addr:       addr,
+		port:       cfgSnap.Port,
+		direction:  envoy_core_v3.TrafficDirection_INBOUND,
+		logger:     s.Logger,
+	}
+	l := makeListener(opts)
+
+	extProcFilter, err := makeInferenceExtProcHTTPFilter(ig.GatewayConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	filterOpts := listenerFilterOpts{
+		protocol:         "http",
+		filterName:       inferenceGatewayListenerName,
+		routeName:        inferenceGatewayListenerName,
+		useRDS:           true,
+		accessLogs:       &cfgSnap.Proxy.AccessLogs,
+		logger:           s.Logger,
+		httpAuthzFilters: []*envoy_http_v3.HttpFilter{extProcFilter},
+	}
+	filter, err := makeListenerFilter(filterOpts)
+	if err != nil {
+		return nil, err
+	}
+	l.FilterChains = []*envoy_listener_v3.FilterChain{{
+		Filters: []*envoy_listener_v3.Filter{filter},
+	}}
+
+	// Surface the discovered model catalog to the processor via listener metadata.
+	if md := makeInferenceListenerMetadata(ig.Models); md != nil {
+		l.Metadata = md
+	}
+
+	// Attach the mesh mTLS downstream context (RequireClientCertificate + SPIFFE).
+	if err := s.finalizePublicListenerFromConfig(l, cfgSnap, true); err != nil {
+		return nil, err
+	}
+
+	return []proto.Message{l}, nil
+}
+
+// makeInferenceExtProcHTTPFilter builds the ext_proc HTTP filter that streams to
+// the co-located policy processor: buffered request body (full transform),
+// streamed response body (token metering pass-through).
+func makeInferenceExtProcHTTPFilter(cfg *structs.AIGatewayConfigEntry) (*envoy_http_v3.HttpFilter, error) {
+	failureModeAllow := cfg != nil && cfg.Processor.FailureMode == structs.AIGatewayFailureModeOpen
+
+	extProc := &envoy_http_ext_proc_v3.ExternalProcessor{
+		GrpcService: &envoy_core_v3.GrpcService{
+			TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+				EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+					ClusterName: inferenceExtProcClusterName,
+				},
+			},
+		},
+		FailureModeAllow: failureModeAllow,
+		ProcessingMode: &envoy_http_ext_proc_v3.ProcessingMode{
+			RequestHeaderMode:   envoy_http_ext_proc_v3.ProcessingMode_SEND,
+			RequestBodyMode:     envoy_http_ext_proc_v3.ProcessingMode_BUFFERED,
+			ResponseHeaderMode:  envoy_http_ext_proc_v3.ProcessingMode_SEND,
+			ResponseBodyMode:    envoy_http_ext_proc_v3.ProcessingMode_STREAMED,
+			RequestTrailerMode:  envoy_http_ext_proc_v3.ProcessingMode_SKIP,
+			ResponseTrailerMode: envoy_http_ext_proc_v3.ProcessingMode_SKIP,
+		},
+	}
+	return makeEnvoyHTTPFilter("envoy.filters.http.ext_proc", extProc)
+}
+
+// makeInferenceListenerMetadata renders the discovered model catalog (names,
+// roles, and catalog labels) into listener FilterMetadata under "consul.ai".
+func makeInferenceListenerMetadata(models map[structs.ServiceName]*proxycfg.InferenceGatewayModel) *envoy_core_v3.Metadata {
+	if len(models) == 0 {
+		return nil
+	}
+
+	names := make([]structs.ServiceName, 0, len(models))
+	for sn := range models {
+		names = append(names, sn)
+	}
+	sort.Slice(names, func(i, j int) bool { return names[i].String() < names[j].String() })
+
+	modelValues := make([]*structpb.Value, 0, len(names))
+	for _, sn := range names {
+		m := models[sn]
+		labelFields := make(map[string]*structpb.Value, len(m.Labels))
+		for k, v := range m.Labels {
+			labelFields[k] = structpb.NewStringValue(v)
+		}
+		modelValues = append(modelValues, structpb.NewStructValue(&structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"name":   structpb.NewStringValue(sn.Name),
+				"role":   structpb.NewStringValue(m.Role),
+				"labels": structpb.NewStructValue(&structpb.Struct{Fields: labelFields}),
+			},
+		}))
+	}
+
+	return &envoy_core_v3.Metadata{
+		FilterMetadata: map[string]*structpb.Struct{
+			inferenceListenerMetadataNamespace: {
+				Fields: map[string]*structpb.Value{
+					"models": structpb.NewListValue(&structpb.ListValue{Values: modelValues}),
+				},
+			},
+		},
+	}
+}
+
+// clustersFromSnapshotInferenceGateway builds the local ext_proc cluster (UDS)
+// and an EDS cluster per discovered model upstream.
+func (s *ResourceGenerator) clustersFromSnapshotInferenceGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
+	ig := &cfgSnap.InferenceGateway
+
+	res := make([]proto.Message, 0, len(ig.Models)+1)
+
+	if ig.GatewayConfig != nil && ig.GatewayConfig.Processor.UDSPath != "" {
+		res = append(res, makeInferenceExtProcCluster(ig.GatewayConfig.Processor.UDSPath))
+	}
+
+	for _, sn := range sortedModelNames(ig.Models) {
+		res = append(res, s.makeGatewayCluster(cfgSnap, clusterOpts{name: sn.Name}))
+	}
+
+	return res, nil
+}
+
+// makeInferenceExtProcCluster builds a STATIC HTTP/2 cluster pointing at the
+// processor's Unix domain socket (loopback transport).
+func makeInferenceExtProcCluster(path string) *envoy_cluster_v3.Cluster {
+	httpProtoOpts := &envoy_upstreams_http_v3.HttpProtocolOptions{
+		UpstreamProtocolOptions: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+			ExplicitHttpConfig: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+				ProtocolConfig: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
+					Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
+				},
+			},
+		},
+	}
+	httpProtoOptsAny, _ := anypb.New(httpProtoOpts)
+
+	return &envoy_cluster_v3.Cluster{
+		Name:                 inferenceExtProcClusterName,
+		ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_STATIC},
+		ConnectTimeout:       durationpb.New(5 * time.Second),
+		LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
+			ClusterName: inferenceExtProcClusterName,
+			Endpoints: []*envoy_endpoint_v3.LocalityLbEndpoints{{
+				LbEndpoints: []*envoy_endpoint_v3.LbEndpoint{{
+					HostIdentifier: &envoy_endpoint_v3.LbEndpoint_Endpoint{
+						Endpoint: &envoy_endpoint_v3.Endpoint{
+							Address: &envoy_core_v3.Address{
+								Address: &envoy_core_v3.Address_Pipe{
+									Pipe: &envoy_core_v3.Pipe{Path: path},
+								},
+							},
+						},
+					},
+				}},
+			}},
+		},
+		TypedExtensionProtocolOptions: map[string]*anypb.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": httpProtoOptsAny,
+		},
+	}
+}
+
+// endpointsFromSnapshotInferenceGateway builds the EDS load assignments for the
+// discovered model upstreams.
+func (s *ResourceGenerator) endpointsFromSnapshotInferenceGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
+	ig := &cfgSnap.InferenceGateway
+
+	res := make([]proto.Message, 0, len(ig.Models))
+	for _, sn := range sortedModelNames(ig.Models) {
+		m := ig.Models[sn]
+		la := makeLoadAssignment(
+			s.Logger,
+			cfgSnap,
+			sn.Name,
+			nil,
+			[]loadAssignmentEndpointGroup{{Endpoints: m.Nodes}},
+			cfgSnap.Locality,
+		)
+		res = append(res, la)
+	}
+	return res, nil
+}
+
+// routesForInferenceGateway builds the RDS route config: the processor sets the
+// x-ai-cluster header to the resolved model and the gateway routes on it, with
+// the routing policy's default fallback as the catch-all.
+func (s *ResourceGenerator) routesForInferenceGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
+	ig := &cfgSnap.InferenceGateway
+
+	vh := &envoy_route_v3.VirtualHost{
+		Name:    inferenceGatewayListenerName,
+		Domains: []string{"*"},
+	}
+
+	for _, sn := range sortedModelNames(ig.Models) {
+		vh.Routes = append(vh.Routes, &envoy_route_v3.Route{
+			Match: &envoy_route_v3.RouteMatch{
+				PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{Prefix: "/"},
+				Headers: []*envoy_route_v3.HeaderMatcher{{
+					Name: inferenceClusterHeader,
+					HeaderMatchSpecifier: &envoy_route_v3.HeaderMatcher_StringMatch{
+						StringMatch: &envoy_matcher_v3.StringMatcher{
+							MatchPattern: &envoy_matcher_v3.StringMatcher_Exact{Exact: sn.Name},
+						},
+					},
+				}},
+			},
+			Action: &envoy_route_v3.Route_Route{
+				Route: &envoy_route_v3.RouteAction{
+					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{Cluster: sn.Name},
+				},
+			},
+		})
+	}
+
+	// Default catch-all: route to the first configured fallback cluster if one
+	// exists, otherwise return 503 so misrouted requests fail closed.
+	if def := defaultInferenceCluster(ig.GatewayConfig, ig.Models); def != "" {
+		vh.Routes = append(vh.Routes, &envoy_route_v3.Route{
+			Match: &envoy_route_v3.RouteMatch{PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{Prefix: "/"}},
+			Action: &envoy_route_v3.Route_Route{
+				Route: &envoy_route_v3.RouteAction{
+					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{Cluster: def},
+				},
+			},
+		})
+	} else {
+		vh.Routes = append(vh.Routes, &envoy_route_v3.Route{
+			Match: &envoy_route_v3.RouteMatch{PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{Prefix: "/"}},
+			Action: &envoy_route_v3.Route_DirectResponse{
+				DirectResponse: &envoy_route_v3.DirectResponseAction{Status: 503},
+			},
+		})
+	}
+
+	return []proto.Message{&envoy_route_v3.RouteConfiguration{
+		Name:         inferenceGatewayListenerName,
+		VirtualHosts: []*envoy_route_v3.VirtualHost{vh},
+	}}, nil
+}
+
+// defaultInferenceCluster returns the default fallback cluster for the routing
+// policy, if one is both configured and a discovered model.
+func defaultInferenceCluster(cfg *structs.AIGatewayConfigEntry, models map[structs.ServiceName]*proxycfg.InferenceGatewayModel) string {
+	if cfg == nil {
+		return ""
+	}
+	for _, name := range cfg.Routing.FallbackChain {
+		sn := structs.NewServiceName(name, &cfg.EnterpriseMeta)
+		if _, ok := models[sn]; ok {
+			return name
+		}
+	}
+	return ""
+}
+
+func sortedModelNames(models map[structs.ServiceName]*proxycfg.InferenceGatewayModel) []structs.ServiceName {
+	names := make([]structs.ServiceName, 0, len(models))
+	for sn := range models {
+		names = append(names, sn)
+	}
+	sort.Slice(names, func(i, j int) bool { return names[i].String() < names[j].String() })
+	return names
+}

--- a/agent/xds/inference_gateway.go
+++ b/agent/xds/inference_gateway.go
@@ -5,6 +5,7 @@ package xds
 
 import (
 	"sort"
+	"strings"
 	"time"
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -13,6 +14,7 @@ import (
 	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_http_ext_proc_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
+	envoy_upstream_codec_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/upstream_codec/v3"
 	envoy_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_upstreams_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoy_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
@@ -34,9 +36,11 @@ const (
 	// co-located policy processor over the loopback/UDS socket.
 	inferenceExtProcClusterName = "local_ext_proc"
 
-	// inferenceClusterHeader is the header the policy processor sets to select
-	// the resolved model cluster; the gateway routes on it.
-	inferenceClusterHeader = "x-ai-cluster"
+	// inferenceModelHeader is the header the downstream (pre-route) ext_proc phase
+	// promotes the request body's model onto; the gateway routes on it (model →
+	// backend cluster) so Envoy owns cluster selection. The upstream (post-route)
+	// ext_proc phase then transforms to the selected backend's native schema.
+	inferenceModelHeader = "x-ai-model"
 
 	// inferenceSpecializationHeader is the caller-supplied header naming a
 	// required capability. Consul renders a native header-match route per
@@ -128,14 +132,47 @@ func (s *ResourceGenerator) listenersFromSnapshotInferenceGateway(cfgSnap *proxy
 	return []proto.Message{l}, nil
 }
 
-// makeInferenceExtProcHTTPFilter builds the ext_proc HTTP filter that streams to
-// the co-located policy processor. The request body and the response body both
-// default to BUFFERED so the processor transforms a full request and normalizes a
-// non-streamed provider response in one pass. AllowModeOverride lets the processor
-// flip the response body to STREAMED per-response for server-sent-event responses,
-// so streamed completions pass through chunk by chunk while the processor meters
-// the stream.
+// makeInferenceExtProcHTTPFilter builds the DOWNSTREAM (pre-route) ext_proc HTTP
+// filter on the HCM chain. It streams the request to the co-located policy
+// processor, which resolves the caller's identity, enforces request PII on the
+// canonical body, and promotes the body model to x-ai-model so Envoy routes on it.
+// The request body is BUFFERED so the processor sees the whole canonical body. The
+// response is not processed here — the upstream (post-route) filter owns response
+// transform, PII, and metering — so response processing is skipped, and no cluster
+// metadata is requested (the downstream phase runs before a backend is selected).
 func makeInferenceExtProcHTTPFilter(cfg *structs.AIGatewayConfigEntry) (*envoy_http_v3.HttpFilter, error) {
+	failureModeAllow := cfg != nil && cfg.Processor.FailureMode == structs.AIGatewayFailureModeOpen
+
+	extProc := &envoy_http_ext_proc_v3.ExternalProcessor{
+		GrpcService: &envoy_core_v3.GrpcService{
+			TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+				EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+					ClusterName: inferenceExtProcClusterName,
+				},
+			},
+		},
+		FailureModeAllow: failureModeAllow,
+		ProcessingMode: &envoy_http_ext_proc_v3.ProcessingMode{
+			RequestHeaderMode:   envoy_http_ext_proc_v3.ProcessingMode_SEND,
+			RequestBodyMode:     envoy_http_ext_proc_v3.ProcessingMode_BUFFERED,
+			ResponseHeaderMode:  envoy_http_ext_proc_v3.ProcessingMode_SKIP,
+			ResponseBodyMode:    envoy_http_ext_proc_v3.ProcessingMode_NONE,
+			RequestTrailerMode:  envoy_http_ext_proc_v3.ProcessingMode_SKIP,
+			ResponseTrailerMode: envoy_http_ext_proc_v3.ProcessingMode_SKIP,
+		},
+	}
+	return makeEnvoyHTTPFilter("envoy.filters.http.ext_proc", extProc)
+}
+
+// makeInferenceUpstreamExtProcHTTPFilter builds the UPSTREAM (post-route) ext_proc
+// HTTP filter attached to each backend model cluster. It streams to the same
+// processor over the same UDS, but runs after Envoy selected the backend, so it
+// receives the chosen cluster's metadata (adapter + model) and name via request
+// attributes. The processor uses that to transform the canonical request into the
+// backend's native schema and to normalize/meter the response. Request and response
+// bodies are BUFFERED for full-body transform; AllowModeOverride lets the processor
+// flip the response to STREAMED per-response for server-sent-event completions.
+func makeInferenceUpstreamExtProcHTTPFilter(cfg *structs.AIGatewayConfigEntry) (*envoy_http_v3.HttpFilter, error) {
 	failureModeAllow := cfg != nil && cfg.Processor.FailureMode == structs.AIGatewayFailureModeOpen
 
 	extProc := &envoy_http_ext_proc_v3.ExternalProcessor{
@@ -156,15 +193,20 @@ func makeInferenceExtProcHTTPFilter(cfg *structs.AIGatewayConfigEntry) (*envoy_h
 			RequestTrailerMode:  envoy_http_ext_proc_v3.ProcessingMode_SKIP,
 			ResponseTrailerMode: envoy_http_ext_proc_v3.ProcessingMode_SKIP,
 		},
-		// Forward the selected route's metadata to the processor. On a native
-		// capability route this carries the model's `consul.ai` routing facts (the
-		// concrete model + wire adapter), so the processor can run the full pipeline
-		// pinned to them without re-deriving the capability. Route header mutations
-		// would not reach the processor — it runs before the router — but request
-		// attributes are evaluated against the already-resolved route.
-		RequestAttributes: []string{"xds.route_metadata"},
+		// The selected backend cluster's consul.ai metadata (adapter + model) names
+		// the transform, and the cluster name attributes the metered usage. Both are
+		// evaluated against the post-route selection, which the downstream phase
+		// cannot see; this is why the transform must run as an upstream filter.
+		RequestAttributes: []string{"xds.cluster_metadata", "xds.cluster_name"},
 	}
 	return makeEnvoyHTTPFilter("envoy.filters.http.ext_proc", extProc)
+}
+
+// makeInferenceUpstreamCodecHTTPFilter builds the terminal upstream_codec filter.
+// An upstream HTTP filter chain must end in the codec (it replaces the router,
+// which does not run in the upstream chain), so it follows the ext_proc filter.
+func makeInferenceUpstreamCodecHTTPFilter() (*envoy_http_v3.HttpFilter, error) {
+	return makeEnvoyHTTPFilter("envoy.filters.http.upstream_codec", &envoy_upstream_codec_v3.UpstreamCodec{})
 }
 
 // makeInferenceListenerMetadata renders the discovered model catalog (names,
@@ -207,13 +249,13 @@ func makeInferenceListenerMetadata(models map[structs.ServiceName]*proxycfg.Infe
 	}
 }
 
-// makeCapabilityRouteMetadata renders the routing facts the policy processor needs
-// for a natively-selected model — the concrete model name to stamp and the wire
-// adapter to transform/normalize with — into route FilterMetadata under
-// "consul.ai". The processor receives this as the ext_proc xds.route_metadata
-// request attribute, so it pins the pipeline to the model Envoy selected without
-// ever having to see or map the capability header itself.
-func makeCapabilityRouteMetadata(m *proxycfg.InferenceGatewayModel) *envoy_core_v3.Metadata {
+// makeInferenceClusterMetadata renders a backend model cluster's routing facts —
+// the wire adapter to transform/normalize with and the concrete model to stamp —
+// into cluster FilterMetadata under "consul.ai". The upstream ext_proc filter
+// receives this as the xds.cluster_metadata request attribute once Envoy selects
+// the cluster, so the processor learns which adapter to transform with without
+// ever routing itself.
+func makeInferenceClusterMetadata(m *proxycfg.InferenceGatewayModel) *envoy_core_v3.Metadata {
 	return &envoy_core_v3.Metadata{
 		FilterMetadata: map[string]*structpb.Struct{
 			inferenceListenerMetadataNamespace: {
@@ -227,7 +269,10 @@ func makeCapabilityRouteMetadata(m *proxycfg.InferenceGatewayModel) *envoy_core_
 }
 
 // clustersFromSnapshotInferenceGateway builds the local ext_proc cluster (UDS)
-// and an EDS cluster per discovered model upstream.
+// and an EDS cluster per discovered model upstream. Each model cluster carries its
+// consul.ai metadata (adapter + model) and an upstream HTTP filter chain
+// (ext_proc → upstream_codec) so the processor transforms to the backend's native
+// schema after Envoy routes to it.
 func (s *ResourceGenerator) clustersFromSnapshotInferenceGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
 	ig := &cfgSnap.InferenceGateway
 
@@ -237,11 +282,50 @@ func (s *ResourceGenerator) clustersFromSnapshotInferenceGateway(cfgSnap *proxyc
 		res = append(res, makeInferenceExtProcCluster(ig.GatewayConfig.Processor.UDSPath))
 	}
 
+	upstreamOpts, err := makeInferenceUpstreamHTTPOptions(ig.GatewayConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, sn := range sortedModelNames(ig.Models) {
-		res = append(res, s.makeGatewayCluster(cfgSnap, clusterOpts{name: sn.Name}))
+		cluster := s.makeGatewayCluster(cfgSnap, clusterOpts{name: sn.Name})
+		cluster.Metadata = makeInferenceClusterMetadata(ig.Models[sn])
+		cluster.TypedExtensionProtocolOptions = map[string]*anypb.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": upstreamOpts,
+		}
+		res = append(res, cluster)
 	}
 
 	return res, nil
+}
+
+// makeInferenceUpstreamHTTPOptions builds the HttpProtocolOptions attached to each
+// backend model cluster: an explicit HTTP/1.1 upstream with the upstream HTTP
+// filter chain ext_proc → upstream_codec. The ext_proc filter runs the provider
+// transform post-route; the terminal upstream_codec encodes the request onto the
+// upstream connection (it replaces the router, which does not run upstream). The
+// options are identical across model clusters, so they are built once and shared.
+func makeInferenceUpstreamHTTPOptions(cfg *structs.AIGatewayConfigEntry) (*anypb.Any, error) {
+	extProc, err := makeInferenceUpstreamExtProcHTTPFilter(cfg)
+	if err != nil {
+		return nil, err
+	}
+	codec, err := makeInferenceUpstreamCodecHTTPFilter()
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &envoy_upstreams_http_v3.HttpProtocolOptions{
+		UpstreamProtocolOptions: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+			ExplicitHttpConfig: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+				ProtocolConfig: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{
+					HttpProtocolOptions: &envoy_core_v3.Http1ProtocolOptions{},
+				},
+			},
+		},
+		HttpFilters: []*envoy_http_v3.HttpFilter{extProc, codec},
+	}
+	return anypb.New(opts)
 }
 
 // makeInferenceExtProcCluster builds a STATIC HTTP/2 cluster pointing at the
@@ -305,9 +389,11 @@ func (s *ResourceGenerator) endpointsFromSnapshotInferenceGateway(cfgSnap *proxy
 	return res, nil
 }
 
-// routesForInferenceGateway builds the RDS route config: the processor sets the
-// x-ai-cluster header to the resolved model and the gateway routes on it, with
-// the routing policy's default fallback as the catch-all.
+// routesForInferenceGateway builds the RDS route config: the downstream ext_proc
+// phase promotes the request body's model to x-ai-model, and the gateway routes
+// that model to the serving backend cluster, with the routing policy's default
+// fallback as the catch-all. The upstream ext_proc filter on the selected cluster
+// then transforms to that backend's native schema.
 func (s *ResourceGenerator) routesForInferenceGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
 	ig := &cfgSnap.InferenceGateway
 
@@ -316,16 +402,18 @@ func (s *ResourceGenerator) routesForInferenceGateway(cfgSnap *proxycfg.ConfigSn
 		Domains: []string{"*"},
 	}
 
+	// Model routes: match the x-ai-model header (the body model the downstream
+	// phase promoted) against each model's `model_family` catalog meta and route to
+	// that model's cluster. A trailing "*" in model_family is a prefix match
+	// (e.g. "gpt-4*"); a model without model_family falls back to its service name.
 	for _, sn := range sortedModelNames(ig.Models) {
 		vh.Routes = append(vh.Routes, &envoy_route_v3.Route{
 			Match: &envoy_route_v3.RouteMatch{
 				PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{Prefix: "/"},
 				Headers: []*envoy_route_v3.HeaderMatcher{{
-					Name: inferenceClusterHeader,
+					Name: inferenceModelHeader,
 					HeaderMatchSpecifier: &envoy_route_v3.HeaderMatcher_StringMatch{
-						StringMatch: &envoy_matcher_v3.StringMatcher{
-							MatchPattern: &envoy_matcher_v3.StringMatcher_Exact{Exact: sn.Name},
-						},
+						StringMatch: inferenceModelMatcher(ig.Models[sn], sn),
 					},
 				}},
 			},
@@ -339,8 +427,9 @@ func (s *ResourceGenerator) routesForInferenceGateway(cfgSnap *proxycfg.ConfigSn
 
 	// Capability routes: match the caller's x-inference-specialization header
 	// against each model's `capabilities` catalog meta and route to that model's
-	// cluster natively — the policy processor plays no part in selection. These
-	// come after the explicit x-ai-cluster routes and before the catch-all.
+	// cluster. Selection is Envoy's; the upstream ext_proc filter on the cluster
+	// reads that cluster's consul.ai metadata to transform. These come after the
+	// x-ai-model routes and before the catch-all.
 	for _, cap := range sortedCapabilities(ig.Models) {
 		sn := capabilityModel(ig.Models, cap)
 		vh.Routes = append(vh.Routes, &envoy_route_v3.Route{
@@ -355,10 +444,6 @@ func (s *ResourceGenerator) routesForInferenceGateway(cfgSnap *proxycfg.ConfigSn
 					},
 				}},
 			},
-			// Carry the selected model's routing facts as route metadata; the
-			// processor reads them via the xds.route_metadata request attribute and
-			// runs the full pipeline pinned to them (see makeInferenceExtProcHTTPFilter).
-			Metadata: makeCapabilityRouteMetadata(ig.Models[sn]),
 			Action: &envoy_route_v3.Route_Route{
 				Route: &envoy_route_v3.RouteAction{
 					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{Cluster: sn.Name},
@@ -406,6 +491,28 @@ func defaultInferenceCluster(cfg *structs.AIGatewayConfigEntry, models map[struc
 		}
 	}
 	return ""
+}
+
+// inferenceModelMatcher builds the x-ai-model header matcher for a model route. It
+// matches the model's `model_family` catalog meta: a trailing "*" is a prefix
+// match (e.g. "gpt-4*" serves gpt-4, gpt-4o, ...), otherwise an exact match. A
+// model without model_family falls back to an exact match on its service name so
+// it stays reachable.
+func inferenceModelMatcher(m *proxycfg.InferenceGatewayModel, sn structs.ServiceName) *envoy_matcher_v3.StringMatcher {
+	family := m.Labels[inferenceModelFamilyLabel]
+	if family == "" {
+		return &envoy_matcher_v3.StringMatcher{
+			MatchPattern: &envoy_matcher_v3.StringMatcher_Exact{Exact: sn.Name},
+		}
+	}
+	if strings.HasSuffix(family, "*") {
+		return &envoy_matcher_v3.StringMatcher{
+			MatchPattern: &envoy_matcher_v3.StringMatcher_Prefix{Prefix: strings.TrimSuffix(family, "*")},
+		}
+	}
+	return &envoy_matcher_v3.StringMatcher{
+		MatchPattern: &envoy_matcher_v3.StringMatcher_Exact{Exact: family},
+	}
 }
 
 // sortedCapabilities returns the distinct `capabilities` meta values advertised

--- a/agent/xds/inference_gateway.go
+++ b/agent/xds/inference_gateway.go
@@ -38,8 +38,29 @@ const (
 	// the resolved model cluster; the gateway routes on it.
 	inferenceClusterHeader = "x-ai-cluster"
 
+	// inferenceSpecializationHeader is the caller-supplied header naming a
+	// required capability. Consul renders a native header-match route per
+	// discovered model capability, so selection happens in Envoy without the
+	// policy processor emitting a cluster.
+	inferenceSpecializationHeader = "x-inference-specialization"
+
+	// inferenceCapabilitiesLabel is the model catalog meta key whose value is the
+	// capability a model advertises (matched against inferenceSpecializationHeader).
+	inferenceCapabilitiesLabel = "capabilities"
+
+	// inferenceModelFamilyLabel is the model catalog meta key naming the concrete
+	// upstream model. The processor stamps it onto a request whose model is "auto".
+	inferenceModelFamilyLabel = "model_family"
+
+	// inferenceModelAPILabel is the model catalog meta key naming the wire/adapter
+	// dialect the terminating gateway exposes for this model (e.g. "openai",
+	// "gemini"). It is deliberately distinct from the vendor: a model may be a
+	// Google model reached through an OpenAI-compatible endpoint.
+	inferenceModelAPILabel = "model_api"
+
 	// inferenceListenerMetadataNamespace is the FilterMetadata key carrying the
-	// discovered model catalog for the policy processor.
+	// discovered model catalog for the policy processor. It is also the route
+	// metadata namespace for a capability route's per-model routing facts.
 	inferenceListenerMetadataNamespace = "consul.ai"
 )
 
@@ -135,6 +156,13 @@ func makeInferenceExtProcHTTPFilter(cfg *structs.AIGatewayConfigEntry) (*envoy_h
 			RequestTrailerMode:  envoy_http_ext_proc_v3.ProcessingMode_SKIP,
 			ResponseTrailerMode: envoy_http_ext_proc_v3.ProcessingMode_SKIP,
 		},
+		// Forward the selected route's metadata to the processor. On a native
+		// capability route this carries the model's `consul.ai` routing facts (the
+		// concrete model + wire adapter), so the processor can run the full pipeline
+		// pinned to them without re-deriving the capability. Route header mutations
+		// would not reach the processor — it runs before the router — but request
+		// attributes are evaluated against the already-resolved route.
+		RequestAttributes: []string{"xds.route_metadata"},
 	}
 	return makeEnvoyHTTPFilter("envoy.filters.http.ext_proc", extProc)
 }
@@ -173,6 +201,25 @@ func makeInferenceListenerMetadata(models map[structs.ServiceName]*proxycfg.Infe
 			inferenceListenerMetadataNamespace: {
 				Fields: map[string]*structpb.Value{
 					"models": structpb.NewListValue(&structpb.ListValue{Values: modelValues}),
+				},
+			},
+		},
+	}
+}
+
+// makeCapabilityRouteMetadata renders the routing facts the policy processor needs
+// for a natively-selected model — the concrete model name to stamp and the wire
+// adapter to transform/normalize with — into route FilterMetadata under
+// "consul.ai". The processor receives this as the ext_proc xds.route_metadata
+// request attribute, so it pins the pipeline to the model Envoy selected without
+// ever having to see or map the capability header itself.
+func makeCapabilityRouteMetadata(m *proxycfg.InferenceGatewayModel) *envoy_core_v3.Metadata {
+	return &envoy_core_v3.Metadata{
+		FilterMetadata: map[string]*structpb.Struct{
+			inferenceListenerMetadataNamespace: {
+				Fields: map[string]*structpb.Value{
+					"model":   structpb.NewStringValue(m.Labels[inferenceModelFamilyLabel]),
+					"adapter": structpb.NewStringValue(m.Labels[inferenceModelAPILabel]),
 				},
 			},
 		},
@@ -290,6 +337,36 @@ func (s *ResourceGenerator) routesForInferenceGateway(cfgSnap *proxycfg.ConfigSn
 		})
 	}
 
+	// Capability routes: match the caller's x-inference-specialization header
+	// against each model's `capabilities` catalog meta and route to that model's
+	// cluster natively — the policy processor plays no part in selection. These
+	// come after the explicit x-ai-cluster routes and before the catch-all.
+	for _, cap := range sortedCapabilities(ig.Models) {
+		sn := capabilityModel(ig.Models, cap)
+		vh.Routes = append(vh.Routes, &envoy_route_v3.Route{
+			Match: &envoy_route_v3.RouteMatch{
+				PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{Prefix: "/"},
+				Headers: []*envoy_route_v3.HeaderMatcher{{
+					Name: inferenceSpecializationHeader,
+					HeaderMatchSpecifier: &envoy_route_v3.HeaderMatcher_StringMatch{
+						StringMatch: &envoy_matcher_v3.StringMatcher{
+							MatchPattern: &envoy_matcher_v3.StringMatcher_Exact{Exact: cap},
+						},
+					},
+				}},
+			},
+			// Carry the selected model's routing facts as route metadata; the
+			// processor reads them via the xds.route_metadata request attribute and
+			// runs the full pipeline pinned to them (see makeInferenceExtProcHTTPFilter).
+			Metadata: makeCapabilityRouteMetadata(ig.Models[sn]),
+			Action: &envoy_route_v3.Route_Route{
+				Route: &envoy_route_v3.RouteAction{
+					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{Cluster: sn.Name},
+				},
+			},
+		})
+	}
+
 	// Default catch-all: route to the first configured fallback cluster if one
 	// exists, otherwise return 503 so misrouted requests fail closed.
 	if def := defaultInferenceCluster(ig.GatewayConfig, ig.Models); def != "" {
@@ -329,6 +406,35 @@ func defaultInferenceCluster(cfg *structs.AIGatewayConfigEntry, models map[struc
 		}
 	}
 	return ""
+}
+
+// sortedCapabilities returns the distinct `capabilities` meta values advertised
+// by the discovered models, in deterministic order.
+func sortedCapabilities(models map[structs.ServiceName]*proxycfg.InferenceGatewayModel) []string {
+	seen := make(map[string]struct{})
+	for _, m := range models {
+		if cap := m.Labels[inferenceCapabilitiesLabel]; cap != "" {
+			seen[cap] = struct{}{}
+		}
+	}
+	caps := make([]string, 0, len(seen))
+	for cap := range seen {
+		caps = append(caps, cap)
+	}
+	sort.Strings(caps)
+	return caps
+}
+
+// capabilityModel returns the model chosen to serve a capability. When more than
+// one model advertises it, the first by sorted service name wins (multi-member
+// pools / failover are out of scope for the demo).
+func capabilityModel(models map[structs.ServiceName]*proxycfg.InferenceGatewayModel, cap string) structs.ServiceName {
+	for _, sn := range sortedModelNames(models) {
+		if models[sn].Labels[inferenceCapabilitiesLabel] == cap {
+			return sn
+		}
+	}
+	return structs.ServiceName{}
 }
 
 func sortedModelNames(models map[structs.ServiceName]*proxycfg.InferenceGatewayModel) []structs.ServiceName {

--- a/agent/xds/inference_gateway.go
+++ b/agent/xds/inference_gateway.go
@@ -108,8 +108,12 @@ func (s *ResourceGenerator) listenersFromSnapshotInferenceGateway(cfgSnap *proxy
 }
 
 // makeInferenceExtProcHTTPFilter builds the ext_proc HTTP filter that streams to
-// the co-located policy processor: buffered request body (full transform),
-// streamed response body (token metering pass-through).
+// the co-located policy processor. The request body and the response body both
+// default to BUFFERED so the processor transforms a full request and normalizes a
+// non-streamed provider response in one pass. AllowModeOverride lets the processor
+// flip the response body to STREAMED per-response for server-sent-event responses,
+// so streamed completions pass through chunk by chunk while the processor meters
+// the stream.
 func makeInferenceExtProcHTTPFilter(cfg *structs.AIGatewayConfigEntry) (*envoy_http_v3.HttpFilter, error) {
 	failureModeAllow := cfg != nil && cfg.Processor.FailureMode == structs.AIGatewayFailureModeOpen
 
@@ -121,12 +125,13 @@ func makeInferenceExtProcHTTPFilter(cfg *structs.AIGatewayConfigEntry) (*envoy_h
 				},
 			},
 		},
-		FailureModeAllow: failureModeAllow,
+		FailureModeAllow:  failureModeAllow,
+		AllowModeOverride: true,
 		ProcessingMode: &envoy_http_ext_proc_v3.ProcessingMode{
 			RequestHeaderMode:   envoy_http_ext_proc_v3.ProcessingMode_SEND,
 			RequestBodyMode:     envoy_http_ext_proc_v3.ProcessingMode_BUFFERED,
 			ResponseHeaderMode:  envoy_http_ext_proc_v3.ProcessingMode_SEND,
-			ResponseBodyMode:    envoy_http_ext_proc_v3.ProcessingMode_STREAMED,
+			ResponseBodyMode:    envoy_http_ext_proc_v3.ProcessingMode_BUFFERED,
 			RequestTrailerMode:  envoy_http_ext_proc_v3.ProcessingMode_SKIP,
 			ResponseTrailerMode: envoy_http_ext_proc_v3.ProcessingMode_SKIP,
 		},

--- a/agent/xds/inference_gateway.go
+++ b/agent/xds/inference_gateway.go
@@ -79,6 +79,12 @@ func (s *ResourceGenerator) listenersFromSnapshotInferenceGateway(cfgSnap *proxy
 		accessLogs:       &cfgSnap.Proxy.AccessLogs,
 		logger:           s.Logger,
 		httpAuthzFilters: []*envoy_http_v3.HttpFilter{extProcFilter},
+		// Forward the downstream client cert details (including the URI SAN /
+		// SPIFFE id) into the x-forwarded-client-cert header so the co-located
+		// policy processor can extract the caller's identity for routing. This
+		// mirrors the connect-proxy public listener (APPEND_FORWARD + Uri:true).
+		forwardClientDetails: true,
+		forwardClientPolicy:  envoy_http_v3.HttpConnectionManager_APPEND_FORWARD,
 	}
 	filter, err := makeListenerFilter(filterOpts)
 	if err != nil {

--- a/agent/xds/inference_gateway_test.go
+++ b/agent/xds/inference_gateway_test.go
@@ -6,8 +6,10 @@ package xds
 import (
 	"testing"
 
+	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_http_ext_proc_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
+	envoy_upstreams_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/acl"
@@ -22,7 +24,7 @@ func testInferenceModels(t *testing.T) map[structs.ServiceName]*proxycfg.Inferen
 		structs.NewServiceName("openai-gpt4", em): {
 			Service: structs.NewServiceName("openai-gpt4", em),
 			Role:    structs.AIRoleModel,
-			Labels:  map[string]string{"provider": "openai", "tier": "premium"},
+			Labels:  map[string]string{"provider": "openai", "tier": "premium", "model_family": "gpt-4", "model_api": "openai"},
 			Nodes: structs.CheckServiceNodes{
 				{Service: &structs.NodeService{Service: "openai-gpt4", Address: "10.0.0.1", Port: 443}},
 			},
@@ -51,11 +53,15 @@ func TestMakeInferenceExtProcHTTPFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "envoy.filters.http.ext_proc", f.Name)
 
-	// The selected route's metadata is forwarded to the processor so it can pin the
-	// pipeline on a native capability route.
+	// The downstream (pre-route) filter buffers the request but does not process the
+	// response (the upstream filter owns it) and requests no cluster metadata (no
+	// backend is selected yet).
 	var ep envoy_http_ext_proc_v3.ExternalProcessor
 	require.NoError(t, f.GetTypedConfig().UnmarshalTo(&ep))
-	require.Equal(t, []string{"xds.route_metadata"}, ep.RequestAttributes)
+	require.Empty(t, ep.RequestAttributes)
+	require.Equal(t, envoy_http_ext_proc_v3.ProcessingMode_BUFFERED, ep.ProcessingMode.RequestBodyMode)
+	require.Equal(t, envoy_http_ext_proc_v3.ProcessingMode_SKIP, ep.ProcessingMode.ResponseHeaderMode)
+	require.Equal(t, envoy_http_ext_proc_v3.ProcessingMode_NONE, ep.ProcessingMode.ResponseBodyMode)
 
 	// Open failure mode flips FailureModeAllow (verified via the typed config).
 	f, err = makeInferenceExtProcHTTPFilter(&structs.AIGatewayConfigEntry{
@@ -63,6 +69,22 @@ func TestMakeInferenceExtProcHTTPFilter(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, f.GetTypedConfig())
+}
+
+func TestMakeInferenceUpstreamExtProcHTTPFilter(t *testing.T) {
+	f, err := makeInferenceUpstreamExtProcHTTPFilter(&structs.AIGatewayConfigEntry{})
+	require.NoError(t, err)
+	require.Equal(t, "envoy.filters.http.ext_proc", f.Name)
+
+	// The upstream (post-route) filter receives the selected cluster's metadata and
+	// name, buffers both bodies for transform, and allows the per-response STREAMED
+	// override for SSE completions.
+	var ep envoy_http_ext_proc_v3.ExternalProcessor
+	require.NoError(t, f.GetTypedConfig().UnmarshalTo(&ep))
+	require.Equal(t, []string{"xds.cluster_metadata", "xds.cluster_name"}, ep.RequestAttributes)
+	require.True(t, ep.AllowModeOverride)
+	require.Equal(t, envoy_http_ext_proc_v3.ProcessingMode_BUFFERED, ep.ProcessingMode.RequestBodyMode)
+	require.Equal(t, envoy_http_ext_proc_v3.ProcessingMode_BUFFERED, ep.ProcessingMode.ResponseBodyMode)
 }
 
 func TestMakeInferenceExtProcCluster(t *testing.T) {
@@ -89,17 +111,59 @@ func TestRoutesForInferenceGateway(t *testing.T) {
 	rc := res[0].(*envoy_route_v3.RouteConfiguration)
 	require.Equal(t, inferenceGatewayListenerName, rc.Name)
 	routes := rc.VirtualHosts[0].Routes
-	// one header-match route for the model + one default fallback route
+	// one model-match route + one default fallback route
 	require.Len(t, routes, 2)
 
-	// First route matches on the x-ai-cluster header.
+	// First route matches the x-ai-model header against the model_family and routes
+	// to the model's cluster.
 	hdr := routes[0].Match.Headers[0]
-	require.Equal(t, inferenceClusterHeader, hdr.Name)
-	require.Equal(t, "openai-gpt4", hdr.GetStringMatch().GetExact())
+	require.Equal(t, inferenceModelHeader, hdr.Name)
+	require.Equal(t, "gpt-4", hdr.GetStringMatch().GetExact())
 	require.Equal(t, "openai-gpt4", routes[0].GetRoute().GetCluster())
 
 	// Default route falls back to the configured cluster.
 	require.Equal(t, "openai-gpt4", routes[1].GetRoute().GetCluster())
+}
+
+func TestClustersForInferenceGateway(t *testing.T) {
+	g := NewResourceGenerator(testutil.Logger(t), nil, false)
+
+	cfgSnap := &proxycfg.ConfigSnapshot{Kind: structs.ServiceKindInferenceGateway}
+	cfgSnap.InferenceGateway.Models = testInferenceModels(t)
+	cfgSnap.InferenceGateway.GatewayConfig = &structs.AIGatewayConfigEntry{
+		Processor: structs.AIGatewayProcessor{UDSPath: "/run/consul/ext_proc.sock"},
+	}
+
+	res, err := g.clustersFromSnapshotInferenceGateway(cfgSnap)
+	require.NoError(t, err)
+	// the local ext_proc cluster + one model cluster
+	require.Len(t, res, 2)
+
+	var model *envoy_cluster_v3.Cluster
+	for _, r := range res {
+		c := r.(*envoy_cluster_v3.Cluster)
+		if c.Name == "openai-gpt4" {
+			model = c
+		}
+	}
+	require.NotNil(t, model, "model cluster rendered")
+
+	// The backend's adapter + model live in cluster metadata; the upstream ext_proc
+	// filter reads it via xds.cluster_metadata to pick the transform.
+	consulAI := model.Metadata.FilterMetadata[inferenceListenerMetadataNamespace]
+	require.NotNil(t, consulAI)
+	require.Equal(t, "openai", consulAI.Fields["adapter"].GetStringValue())
+	require.Equal(t, "gpt-4", consulAI.Fields["model"].GetStringValue())
+
+	// The cluster carries an upstream HTTP filter chain ending in upstream_codec,
+	// with ext_proc ahead of it.
+	optsAny := model.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+	require.NotNil(t, optsAny)
+	var opts envoy_upstreams_http_v3.HttpProtocolOptions
+	require.NoError(t, optsAny.UnmarshalTo(&opts))
+	require.Len(t, opts.HttpFilters, 2)
+	require.Equal(t, "envoy.filters.http.ext_proc", opts.HttpFilters[0].Name)
+	require.Equal(t, "envoy.filters.http.upstream_codec", opts.HttpFilters[1].Name)
 }
 
 func TestRoutesForInferenceGateway_capabilities(t *testing.T) {
@@ -124,24 +188,24 @@ func TestRoutesForInferenceGateway_capabilities(t *testing.T) {
 	require.Len(t, res, 1)
 
 	routes := res[0].(*envoy_route_v3.RouteConfiguration).VirtualHosts[0].Routes
-	// x-ai-cluster route + capability route + fail-closed catch-all.
+	// x-ai-model route + capability route + fail-closed catch-all.
 	require.Len(t, routes, 3)
 
+	// The model route matches x-ai-model against the model_family.
+	modelHdr := routes[0].Match.Headers[0]
+	require.Equal(t, inferenceModelHeader, modelHdr.Name)
+	require.Equal(t, "gemini-1.5-pro", modelHdr.GetStringMatch().GetExact())
+
 	// The capability route matches x-inference-specialization and routes natively
-	// to the model's cluster (no ext_proc selection).
+	// to the model's cluster (no ext_proc selection). Under two-phase it carries no
+	// route metadata — the adapter lives in the destination cluster's metadata,
+	// which the upstream ext_proc filter reads post-route.
 	capRoute := routes[1]
 	hdr := capRoute.Match.Headers[0]
 	require.Equal(t, inferenceSpecializationHeader, hdr.Name)
 	require.Equal(t, "travel-planner", hdr.GetStringMatch().GetExact())
 	require.Equal(t, "gemini-travel", capRoute.GetRoute().GetCluster())
-
-	// Route metadata carries the model's routing facts for the processor to read via
-	// the xds.route_metadata request attribute: the concrete model to stamp and the
-	// wire adapter to transform/normalize with.
-	consulAI := capRoute.Metadata.FilterMetadata[inferenceListenerMetadataNamespace]
-	require.NotNil(t, consulAI)
-	require.Equal(t, "gemini-1.5-pro", consulAI.Fields["model"].GetStringValue())
-	require.Equal(t, "openai", consulAI.Fields["adapter"].GetStringValue())
+	require.Nil(t, capRoute.Metadata, "capability routes carry no metadata under two-phase")
 
 	// No fallback configured → catch-all fails closed with a 503.
 	require.NotNil(t, routes[2].GetDirectResponse())

--- a/agent/xds/inference_gateway_test.go
+++ b/agent/xds/inference_gateway_test.go
@@ -1,0 +1,96 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package xds
+
+import (
+	"testing"
+
+	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+func testInferenceModels(t *testing.T) map[structs.ServiceName]*proxycfg.InferenceGatewayModel {
+	em := acl.DefaultEnterpriseMeta()
+	return map[structs.ServiceName]*proxycfg.InferenceGatewayModel{
+		structs.NewServiceName("openai-gpt4", em): {
+			Service: structs.NewServiceName("openai-gpt4", em),
+			Role:    structs.AIRoleModel,
+			Labels:  map[string]string{"provider": "openai", "tier": "premium"},
+			Nodes: structs.CheckServiceNodes{
+				{Service: &structs.NodeService{Service: "openai-gpt4", Address: "10.0.0.1", Port: 443}},
+			},
+		},
+	}
+}
+
+func TestMakeInferenceListenerMetadata(t *testing.T) {
+	require.Nil(t, makeInferenceListenerMetadata(nil))
+
+	md := makeInferenceListenerMetadata(testInferenceModels(t))
+	require.NotNil(t, md)
+	consulAI := md.FilterMetadata[inferenceListenerMetadataNamespace]
+	require.NotNil(t, consulAI)
+	models := consulAI.Fields["models"].GetListValue()
+	require.Len(t, models.Values, 1)
+	model := models.Values[0].GetStructValue()
+	require.Equal(t, "openai-gpt4", model.Fields["name"].GetStringValue())
+	require.Equal(t, structs.AIRoleModel, model.Fields["role"].GetStringValue())
+	require.Equal(t, "openai", model.Fields["labels"].GetStructValue().Fields["provider"].GetStringValue())
+}
+
+func TestMakeInferenceExtProcHTTPFilter(t *testing.T) {
+	// Defaults to fail-closed.
+	f, err := makeInferenceExtProcHTTPFilter(&structs.AIGatewayConfigEntry{})
+	require.NoError(t, err)
+	require.Equal(t, "envoy.filters.http.ext_proc", f.Name)
+
+	// Open failure mode flips FailureModeAllow (verified via the typed config).
+	f, err = makeInferenceExtProcHTTPFilter(&structs.AIGatewayConfigEntry{
+		Processor: structs.AIGatewayProcessor{FailureMode: structs.AIGatewayFailureModeOpen},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, f.GetTypedConfig())
+}
+
+func TestMakeInferenceExtProcCluster(t *testing.T) {
+	c := makeInferenceExtProcCluster("/run/consul/ext_proc.sock")
+	require.Equal(t, inferenceExtProcClusterName, c.Name)
+	ep := c.LoadAssignment.Endpoints[0].LbEndpoints[0].GetEndpoint()
+	require.Equal(t, "/run/consul/ext_proc.sock", ep.GetAddress().GetPipe().GetPath())
+	require.Contains(t, c.TypedExtensionProtocolOptions, "envoy.extensions.upstreams.http.v3.HttpProtocolOptions")
+}
+
+func TestRoutesForInferenceGateway(t *testing.T) {
+	g := NewResourceGenerator(testutil.Logger(t), nil, false)
+
+	cfgSnap := &proxycfg.ConfigSnapshot{Kind: structs.ServiceKindInferenceGateway}
+	cfgSnap.InferenceGateway.Models = testInferenceModels(t)
+	cfgSnap.InferenceGateway.GatewayConfig = &structs.AIGatewayConfigEntry{
+		Routing: structs.AIGatewayRouting{FallbackChain: []string{"openai-gpt4"}},
+	}
+
+	res, err := g.routesForInferenceGateway(cfgSnap)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	rc := res[0].(*envoy_route_v3.RouteConfiguration)
+	require.Equal(t, inferenceGatewayListenerName, rc.Name)
+	routes := rc.VirtualHosts[0].Routes
+	// one header-match route for the model + one default fallback route
+	require.Len(t, routes, 2)
+
+	// First route matches on the x-ai-cluster header.
+	hdr := routes[0].Match.Headers[0]
+	require.Equal(t, inferenceClusterHeader, hdr.Name)
+	require.Equal(t, "openai-gpt4", hdr.GetStringMatch().GetExact())
+	require.Equal(t, "openai-gpt4", routes[0].GetRoute().GetCluster())
+
+	// Default route falls back to the configured cluster.
+	require.Equal(t, "openai-gpt4", routes[1].GetRoute().GetCluster())
+}

--- a/agent/xds/inference_gateway_test.go
+++ b/agent/xds/inference_gateway_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_http_ext_proc_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/acl"
@@ -49,6 +50,12 @@ func TestMakeInferenceExtProcHTTPFilter(t *testing.T) {
 	f, err := makeInferenceExtProcHTTPFilter(&structs.AIGatewayConfigEntry{})
 	require.NoError(t, err)
 	require.Equal(t, "envoy.filters.http.ext_proc", f.Name)
+
+	// The selected route's metadata is forwarded to the processor so it can pin the
+	// pipeline on a native capability route.
+	var ep envoy_http_ext_proc_v3.ExternalProcessor
+	require.NoError(t, f.GetTypedConfig().UnmarshalTo(&ep))
+	require.Equal(t, []string{"xds.route_metadata"}, ep.RequestAttributes)
 
 	// Open failure mode flips FailureModeAllow (verified via the typed config).
 	f, err = makeInferenceExtProcHTTPFilter(&structs.AIGatewayConfigEntry{
@@ -93,4 +100,50 @@ func TestRoutesForInferenceGateway(t *testing.T) {
 
 	// Default route falls back to the configured cluster.
 	require.Equal(t, "openai-gpt4", routes[1].GetRoute().GetCluster())
+}
+
+func TestRoutesForInferenceGateway_capabilities(t *testing.T) {
+	g := NewResourceGenerator(testutil.Logger(t), nil, false)
+	em := acl.DefaultEnterpriseMeta()
+
+	cfgSnap := &proxycfg.ConfigSnapshot{Kind: structs.ServiceKindInferenceGateway}
+	cfgSnap.InferenceGateway.Models = map[structs.ServiceName]*proxycfg.InferenceGatewayModel{
+		structs.NewServiceName("gemini-travel", em): {
+			Service: structs.NewServiceName("gemini-travel", em),
+			Role:    structs.AIRoleModel,
+			Labels:  map[string]string{"capabilities": "travel-planner", "model_family": "gemini-1.5-pro", "model_api": "openai"},
+			Nodes: structs.CheckServiceNodes{
+				{Service: &structs.NodeService{Service: "gemini-travel", Address: "10.0.0.2", Port: 443}},
+			},
+		},
+	}
+	cfgSnap.InferenceGateway.GatewayConfig = &structs.AIGatewayConfigEntry{}
+
+	res, err := g.routesForInferenceGateway(cfgSnap)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	routes := res[0].(*envoy_route_v3.RouteConfiguration).VirtualHosts[0].Routes
+	// x-ai-cluster route + capability route + fail-closed catch-all.
+	require.Len(t, routes, 3)
+
+	// The capability route matches x-inference-specialization and routes natively
+	// to the model's cluster (no ext_proc selection).
+	capRoute := routes[1]
+	hdr := capRoute.Match.Headers[0]
+	require.Equal(t, inferenceSpecializationHeader, hdr.Name)
+	require.Equal(t, "travel-planner", hdr.GetStringMatch().GetExact())
+	require.Equal(t, "gemini-travel", capRoute.GetRoute().GetCluster())
+
+	// Route metadata carries the model's routing facts for the processor to read via
+	// the xds.route_metadata request attribute: the concrete model to stamp and the
+	// wire adapter to transform/normalize with.
+	consulAI := capRoute.Metadata.FilterMetadata[inferenceListenerMetadataNamespace]
+	require.NotNil(t, consulAI)
+	require.Equal(t, "gemini-1.5-pro", consulAI.Fields["model"].GetStringValue())
+	require.Equal(t, "openai", consulAI.Fields["adapter"].GetStringValue())
+
+	// No fallback configured → catch-all fails closed with a 503.
+	require.NotNil(t, routes[2].GetDirectResponse())
+	require.Equal(t, uint32(503), routes[2].GetDirectResponse().GetStatus())
 }

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1287,6 +1287,7 @@ func createDownstreamTransportSocketForConnectTLS(cfgSnap *proxycfg.ConfigSnapsh
 	switch cfgSnap.Kind {
 	case structs.ServiceKindConnectProxy:
 	case structs.ServiceKindMeshGateway:
+	case structs.ServiceKindInferenceGateway:
 	default:
 		return nil, fmt.Errorf("cannot inject peering trust bundles for kind %q", cfgSnap.Kind)
 	}

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -69,6 +69,8 @@ func (s *ResourceGenerator) listenersFromSnapshot(cfgSnap *proxycfg.ConfigSnapsh
 		structs.ServiceKindIngressGateway,
 		structs.ServiceKindAPIGateway:
 		return s.listenersFromSnapshotGateway(cfgSnap)
+	case structs.ServiceKindInferenceGateway:
+		return s.listenersFromSnapshotInferenceGateway(cfgSnap)
 	default:
 		return nil, fmt.Errorf("Invalid service kind: %v", cfgSnap.Kind)
 	}

--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -155,6 +155,12 @@ func TestAllResourcesFromSnapshot(t *testing.T) {
 			},
 		},
 		{
+			name: "inference-gateway",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshotInferenceGateway(t, nil, nil)
+			},
+		},
+		{
 			name:   "telemetry-collector",
 			create: proxycfg.TestConfigSnapshotTelemetryCollector,
 		},

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -50,6 +50,8 @@ func (s *ResourceGenerator) routesFromSnapshot(cfgSnap *proxycfg.ConfigSnapshot)
 		return s.routesForTerminatingGateway(cfgSnap)
 	case structs.ServiceKindMeshGateway:
 		return s.routesForMeshGateway(cfgSnap)
+	case structs.ServiceKindInferenceGateway:
+		return s.routesForInferenceGateway(cfgSnap)
 	default:
 		return nil, fmt.Errorf("Invalid service kind: %v", cfgSnap.Kind)
 	}

--- a/agent/xds/secrets.go
+++ b/agent/xds/secrets.go
@@ -30,7 +30,8 @@ func (s *ResourceGenerator) secretsFromSnapshot(cfgSnap *proxycfg.ConfigSnapshot
 		return s.secretsFromSnapshotTerminatingGateway(cfgSnap), nil
 	case structs.ServiceKindConnectProxy,
 		structs.ServiceKindMeshGateway,
-		structs.ServiceKindIngressGateway:
+		structs.ServiceKindIngressGateway,
+		structs.ServiceKindInferenceGateway:
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("Invalid service kind: %v", cfgSnap.Kind)

--- a/agent/xds/testcommon/testcommon.go
+++ b/agent/xds/testcommon/testcommon.go
@@ -28,6 +28,9 @@ func SetupTLSRootsAndLeaf(t *testing.T, snap *proxycfg.ConfigSnapshot) {
 		case structs.ServiceKindAPIGateway:
 			snap.APIGateway.Leaf.CertPEM = loadTestResource(t, "test-leaf-cert")
 			snap.APIGateway.Leaf.PrivateKeyPEM = loadTestResource(t, "test-leaf-key")
+		case structs.ServiceKindInferenceGateway:
+			snap.InferenceGateway.Leaf.CertPEM = loadTestResource(t, "test-leaf-cert")
+			snap.InferenceGateway.Leaf.PrivateKeyPEM = loadTestResource(t, "test-leaf-key")
 		}
 	}
 	if snap.Roots != nil {

--- a/agent/xds/testdata/clusters/inference-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/inference-gateway.latest.golden
@@ -1,0 +1,52 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "local_ext_proc",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "pipe": {
+                      "path": "/run/consul/ext_proc.sock"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "name": "local_ext_proc",
+      "type": "STATIC",
+      "typedExtensionProtocolOptions": {
+        "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+          "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+          "explicitHttpConfig": {
+            "http2ProtocolOptions": {}
+          }
+        }
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "connectTimeout": "5s",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {},
+          "resourceApiVersion": "V3"
+        }
+      },
+      "name": "openai-gpt4",
+      "outlierDetection": {},
+      "type": "EDS"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/clusters/inference-gateway.latest.golden
+++ b/agent/xds/testdata/clusters/inference-gateway.latest.golden
@@ -42,9 +42,57 @@
           "resourceApiVersion": "V3"
         }
       },
+      "metadata": {
+        "filterMetadata": {
+          "consul.ai": {
+            "adapter": "",
+            "model": ""
+          }
+        }
+      },
       "name": "openai-gpt4",
       "outlierDetection": {},
-      "type": "EDS"
+      "type": "EDS",
+      "typedExtensionProtocolOptions": {
+        "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+          "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+          "explicitHttpConfig": {
+            "httpProtocolOptions": {}
+          },
+          "httpFilters": [
+            {
+              "name": "envoy.filters.http.ext_proc",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor",
+                "allowModeOverride": true,
+                "grpcService": {
+                  "envoyGrpc": {
+                    "clusterName": "local_ext_proc"
+                  }
+                },
+                "processingMode": {
+                  "requestBodyMode": "BUFFERED",
+                  "requestHeaderMode": "SEND",
+                  "requestTrailerMode": "SKIP",
+                  "responseBodyMode": "BUFFERED",
+                  "responseHeaderMode": "SEND",
+                  "responseTrailerMode": "SKIP"
+                },
+                "requestAttributes": [
+                  "xds.cluster_metadata",
+                  "xds.cluster_name"
+                ]
+              }
+            },
+            {
+              "name": "envoy.filters.http.upstream_codec",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec"
+              }
+            }
+          ]
+        }
+      }
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",

--- a/agent/xds/testdata/endpoints/inference-gateway.latest.golden
+++ b/agent/xds/testdata/endpoints/inference-gateway.latest.golden
@@ -1,0 +1,29 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "openai-gpt4",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.0.0.1",
+                    "portValue": 443
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/listeners/inference-gateway.latest.golden
+++ b/agent/xds/testdata/listeners/inference-gateway.latest.golden
@@ -1,0 +1,114 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8443
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.ext_proc",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor",
+                      "grpcService": {
+                        "envoyGrpc": {
+                          "clusterName": "local_ext_proc"
+                        }
+                      },
+                      "processingMode": {
+                        "requestBodyMode": "BUFFERED",
+                        "requestHeaderMode": "SEND",
+                        "requestTrailerMode": "SKIP",
+                        "responseBodyMode": "STREAMED",
+                        "responseHeaderMode": "SEND",
+                        "responseTrailerMode": "SKIP"
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "rds": {
+                  "configSource": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  },
+                  "routeConfigName": "inference-gateway"
+                },
+                "statPrefix": "inference-gateway",
+                "tracing": {
+                  "randomSampling": {}
+                },
+                "upgradeConfigs": [
+                  {
+                    "upgradeType": "websocket"
+                  }
+                ]
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "tlsParams": {},
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "metadata": {
+        "filterMetadata": {
+          "consul.ai": {
+            "models": [
+              {
+                "labels": {
+                  "provider": "openai",
+                  "tier": "premium"
+                },
+                "name": "openai-gpt4",
+                "role": "ai-model"
+              }
+            ]
+          }
+        }
+      },
+      "name": "inference-gateway:1.2.3.4:8443",
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/listeners/inference-gateway.latest.golden
+++ b/agent/xds/testdata/listeners/inference-gateway.latest.golden
@@ -16,6 +16,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "APPEND_FORWARD",
                 "httpFilters": [
                   {
                     "name": "envoy.filters.http.ext_proc",
@@ -49,6 +50,13 @@
                     "resourceApiVersion": "V3"
                   },
                   "routeConfigName": "inference-gateway"
+                },
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
                 },
                 "statPrefix": "inference-gateway",
                 "tracing": {

--- a/agent/xds/testdata/listeners/inference-gateway.latest.golden
+++ b/agent/xds/testdata/listeners/inference-gateway.latest.golden
@@ -22,7 +22,6 @@
                     "name": "envoy.filters.http.ext_proc",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor",
-                      "allowModeOverride": true,
                       "grpcService": {
                         "envoyGrpc": {
                           "clusterName": "local_ext_proc"
@@ -32,13 +31,9 @@
                         "requestBodyMode": "BUFFERED",
                         "requestHeaderMode": "SEND",
                         "requestTrailerMode": "SKIP",
-                        "responseBodyMode": "BUFFERED",
-                        "responseHeaderMode": "SEND",
+                        "responseHeaderMode": "SKIP",
                         "responseTrailerMode": "SKIP"
-                      },
-                      "requestAttributes": [
-                        "xds.route_metadata"
-                      ]
+                      }
                     }
                   },
                   {

--- a/agent/xds/testdata/listeners/inference-gateway.latest.golden
+++ b/agent/xds/testdata/listeners/inference-gateway.latest.golden
@@ -35,7 +35,10 @@
                         "responseBodyMode": "BUFFERED",
                         "responseHeaderMode": "SEND",
                         "responseTrailerMode": "SKIP"
-                      }
+                      },
+                      "requestAttributes": [
+                        "xds.route_metadata"
+                      ]
                     }
                   },
                   {

--- a/agent/xds/testdata/listeners/inference-gateway.latest.golden
+++ b/agent/xds/testdata/listeners/inference-gateway.latest.golden
@@ -22,6 +22,7 @@
                     "name": "envoy.filters.http.ext_proc",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor",
+                      "allowModeOverride": true,
                       "grpcService": {
                         "envoyGrpc": {
                           "clusterName": "local_ext_proc"
@@ -31,7 +32,7 @@
                         "requestBodyMode": "BUFFERED",
                         "requestHeaderMode": "SEND",
                         "requestTrailerMode": "SKIP",
-                        "responseBodyMode": "STREAMED",
+                        "responseBodyMode": "BUFFERED",
                         "responseHeaderMode": "SEND",
                         "responseTrailerMode": "SKIP"
                       }

--- a/agent/xds/testdata/routes/inference-gateway.latest.golden
+++ b/agent/xds/testdata/routes/inference-gateway.latest.golden
@@ -1,0 +1,45 @@
+{
+  "nonce": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+      "name": "inference-gateway",
+      "virtualHosts": [
+        {
+          "domains": [
+            "*"
+          ],
+          "name": "inference-gateway",
+          "routes": [
+            {
+              "match": {
+                "headers": [
+                  {
+                    "name": "x-ai-cluster",
+                    "stringMatch": {
+                      "exact": "openai-gpt4"
+                    }
+                  }
+                ],
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "openai-gpt4"
+              }
+            },
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "openai-gpt4"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+  "versionInfo": "00000001"
+}

--- a/agent/xds/testdata/routes/inference-gateway.latest.golden
+++ b/agent/xds/testdata/routes/inference-gateway.latest.golden
@@ -15,7 +15,7 @@
               "match": {
                 "headers": [
                   {
-                    "name": "x-ai-cluster",
+                    "name": "x-ai-model",
                     "stringMatch": {
                       "exact": "openai-gpt4"
                     }

--- a/agent/xds/testdata/secrets/inference-gateway.latest.golden
+++ b/agent/xds/testdata/secrets/inference-gateway.latest.golden
@@ -1,0 +1,5 @@
+{
+  "nonce": "00000001",
+  "typeUrl": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+  "versionInfo": "00000001"
+}

--- a/api/agent.go
+++ b/api/agent.go
@@ -46,6 +46,14 @@ const (
 	// This service will ingress connections based of configuration defined in
 	// the api-gateway config entry.
 	ServiceKindAPIGateway ServiceKind = "api-gateway"
+
+	// ServiceKindInferenceGateway is an Inference Gateway for the Agent Gateway
+	// (Inference plane). It accepts agent (A2LLM) traffic over mesh mTLS,
+	// enforces SPIFFE identity + intentions on inbound like a terminating
+	// gateway, runs an ext_proc filter over a loopback/UDS socket to a
+	// co-located policy processor, and dispatches to LLM providers via a
+	// terminating gateway. Routing is defined in the ai-gateway config entry.
+	ServiceKindInferenceGateway ServiceKind = "inference-gateway"
 )
 
 // UpstreamDestType is the type of upstream discovery mechanism.
@@ -167,6 +175,17 @@ type AgentService struct {
 	// Datacenter is only ever returned and is ignored if presented.
 	Datacenter string    `json:",omitempty" bexpr:"-" hash:"ignore"`
 	Locality   *Locality `json:",omitempty" bexpr:"-" hash:"ignore"`
+	// AI, when set, marks this service's role in the Agent Gateway (Inference
+	// plane). A service registered with AI.Role == "ai-model" is discovered by
+	// inference gateways as a routable model upstream.
+	AI *AIConfig `json:",omitempty" bexpr:"-" hash:"ignore"`
+}
+
+// AIConfig marks a service's role in the Agent Gateway (Inference plane). A
+// service registered with Role == "ai-model" is a routable LLM model target;
+// routing labels (provider, tier, capabilities) ride in the service's Meta.
+type AIConfig struct {
+	Role string `json:",omitempty"`
 }
 
 func (a AgentService) DefaultPort() int {
@@ -368,6 +387,7 @@ type AgentServiceRegistration struct {
 	Namespace         string                          `json:",omitempty" bexpr:"-" hash:"ignore"`
 	Partition         string                          `json:",omitempty" bexpr:"-" hash:"ignore"`
 	Locality          *Locality                       `json:",omitempty" bexpr:"-" hash:"ignore"`
+	AI                *AIConfig                       `json:",omitempty" bexpr:"-" hash:"ignore"`
 }
 
 func (a *AgentServiceRegistration) IsConnectEnabled() bool {

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -38,6 +38,7 @@ const (
 	InlineCertificate     string = "inline-certificate"
 	HTTPRoute             string = "http-route"
 	JWTProvider           string = "jwt-provider"
+	AIGateway             string = "ai-gateway"
 )
 
 const (
@@ -476,6 +477,8 @@ func makeConfigEntry(kind, name string) (ConfigEntry, error) {
 		return &GlobalRateLimitConfigEntry{Kind: kind, Name: name}, nil
 	case JWTProvider:
 		return &JWTProviderConfigEntry{Kind: kind, Name: name}, nil
+	case AIGateway:
+		return &AIGatewayConfigEntry{Kind: kind, Name: name}, nil
 	default:
 		return nil, fmt.Errorf("invalid config entry kind: %s", kind)
 	}

--- a/api/config_entry_ai_gateway.go
+++ b/api/config_entry_ai_gateway.go
@@ -1,0 +1,122 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+// AIGatewayConfigEntry is the routing policy for one or more inference gateways
+// (kind = "inference-gateway"). It binds the gateway's ext_proc filter to a
+// co-located policy processor and describes how A2LLM requests are matched and
+// routed to model upstreams.
+type AIGatewayConfigEntry struct {
+	// Kind must be "ai-gateway".
+	Kind string
+
+	// Name of the config entry.
+	Name string
+
+	// Processor binds the gateway's ext_proc filter to the co-located policy
+	// processor over a loopback/UDS socket.
+	Processor AIGatewayProcessor
+
+	// ApplyTo lists the inference-gateway service names this policy binds to.
+	ApplyTo []string `json:",omitempty"`
+
+	// Routing holds the request-matching and dispatch rules.
+	Routing AIGatewayRouting
+
+	// Partition is the partition the config entry is associated with.
+	// Partitioning is a Consul Enterprise feature.
+	Partition string `json:",omitempty"`
+
+	// Namespace is the namespace the config entry is associated with.
+	// Namespacing is a Consul Enterprise feature.
+	Namespace string `json:",omitempty"`
+
+	Meta map[string]string `json:",omitempty"`
+
+	// CreateIndex is the Raft index this entry was created at.
+	CreateIndex uint64
+
+	// ModifyIndex is used for Check-And-Set operations.
+	ModifyIndex uint64
+}
+
+// AIGatewayProcessor configures the ext_proc binding to the policy processor.
+type AIGatewayProcessor struct {
+	UDSPath     string `json:",omitempty"`
+	FailureMode string `json:",omitempty"`
+}
+
+// AIGatewayRouting holds the request-routing configuration.
+type AIGatewayRouting struct {
+	MatchRules       []AIGatewayMatchRule           `json:",omitempty"`
+	ComplianceMap    map[string]AIGatewayCompliance `json:",omitempty"`
+	FallbackChain    []string                       `json:",omitempty"`
+	Retry            *AIGatewayRetry                `json:",omitempty"`
+	Timeout          *AIGatewayTimeout              `json:",omitempty"`
+	Scoring          *AIGatewayScoring              `json:",omitempty"`
+	ConfigValidation string                         `json:",omitempty"`
+	Budget           map[string]interface{}         `json:",omitempty"`
+	Cache            map[string]interface{}         `json:",omitempty"`
+	Mirror           map[string]interface{}         `json:",omitempty"`
+}
+
+// AIGatewayMatchRule selects candidate clusters for matching requests.
+type AIGatewayMatchRule struct {
+	When                AIGatewayMatch `json:",omitempty"`
+	RequireCapabilities []string       `json:",omitempty"`
+	Candidates          []string       `json:",omitempty"`
+	FallbackChain       []string       `json:",omitempty"`
+}
+
+// AIGatewayMatch is the predicate for a match rule.
+type AIGatewayMatch struct {
+	Path     string                  `json:",omitempty"`
+	BodyHas  []string                `json:",omitempty"`
+	Identity *AIGatewayIdentityMatch `json:",omitempty"`
+}
+
+// AIGatewayIdentityMatch matches on the calling agent's SPIFFE identity.
+type AIGatewayIdentityMatch struct {
+	Service   string `json:",omitempty"`
+	Partition string `json:",omitempty"`
+	Namespace string `json:",omitempty"`
+}
+
+// AIGatewayCompliance constrains candidate clusters for a compliance class.
+type AIGatewayCompliance struct {
+	AllowedRegions  []string `json:",omitempty"`
+	AllowedClusters []string `json:",omitempty"`
+}
+
+// AIGatewayRetry is the Envoy retry directive.
+type AIGatewayRetry struct {
+	MaxAttempts int      `json:",omitempty"`
+	RetryOn     []string `json:",omitempty"`
+}
+
+// AIGatewayTimeout is the Envoy timeout directive.
+type AIGatewayTimeout struct {
+	Connect string `json:",omitempty"`
+	Request string `json:",omitempty"`
+}
+
+// AIGatewayScoring is the optional scorer configuration.
+type AIGatewayScoring struct {
+	Scorers       []string                  `json:",omitempty"`
+	WeightedSplit []AIGatewayWeightedTarget `json:",omitempty"`
+}
+
+// AIGatewayWeightedTarget is a weighted cluster in a scoring split.
+type AIGatewayWeightedTarget struct {
+	Cluster string
+	Weight  int
+}
+
+func (e *AIGatewayConfigEntry) GetKind() string            { return e.Kind }
+func (e *AIGatewayConfigEntry) GetName() string            { return e.Name }
+func (e *AIGatewayConfigEntry) GetPartition() string       { return e.Partition }
+func (e *AIGatewayConfigEntry) GetNamespace() string       { return e.Namespace }
+func (e *AIGatewayConfigEntry) GetMeta() map[string]string { return e.Meta }
+func (e *AIGatewayConfigEntry) GetCreateIndex() uint64     { return e.CreateIndex }
+func (e *AIGatewayConfigEntry) GetModifyIndex() uint64     { return e.ModifyIndex }

--- a/api/config_entry_ai_gateway.go
+++ b/api/config_entry_ai_gateway.go
@@ -24,6 +24,10 @@ type AIGatewayConfigEntry struct {
 	// Routing holds the request-matching and dispatch rules.
 	Routing AIGatewayRouting
 
+	// Policy holds cross-cutting request/response policy (PII, audit) the
+	// co-located processor enforces. Consul carries it verbatim to the processor.
+	Policy *AIGatewayPolicy `json:",omitempty"`
+
 	// Partition is the partition the config entry is associated with.
 	// Partitioning is a Consul Enterprise feature.
 	Partition string `json:",omitempty"`
@@ -111,6 +115,37 @@ type AIGatewayScoring struct {
 type AIGatewayWeightedTarget struct {
 	Cluster string
 	Weight  int
+}
+
+// AIGatewayPolicy mirrors the policy processor's Policy block so the PII and audit
+// configuration round-trips through Consul to the processor.
+type AIGatewayPolicy struct {
+	PII        *AIGatewayPII `json:",omitempty"`
+	AuditLevel string        `json:",omitempty"`
+}
+
+// AIGatewayPII configures per-detector PII detection and redaction for the
+// processor. Consul carries these fields verbatim.
+type AIGatewayPII struct {
+	Scope               string                 `json:",omitempty"`
+	DefaultAction       string                 `json:",omitempty"`
+	StreamHoldbackBytes int                    `json:",omitempty"`
+	Mask                *AIGatewayPIIMask      `json:",omitempty"`
+	Detectors           []AIGatewayPIIDetector `json:",omitempty"`
+}
+
+// AIGatewayPIIMask parameterizes the "mask" redaction action.
+type AIGatewayPIIMask struct {
+	Char     string `json:",omitempty"`
+	KeepLast int    `json:",omitempty"`
+}
+
+// AIGatewayPIIDetector is one PII rule: a named built-in or a custom Regex, with
+// an Action that overrides the policy's DefaultAction.
+type AIGatewayPIIDetector struct {
+	Name   string `json:",omitempty"`
+	Regex  string `json:",omitempty"`
+	Action string `json:",omitempty"`
 }
 
 func (e *AIGatewayConfigEntry) GetKind() string            { return e.Kind }

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -89,6 +89,10 @@ type cmd struct {
 	gatewaySvcName string
 	gatewayKind    api.ServiceKind
 
+	// inference-gateway co-launch
+	extProcBin         string
+	extProcConfigEntry string
+
 	dialFunc func(network string, address string) (net.Conn, error)
 
 	//checks if the consul agent is configured to use both IPv4 and IPv6 addresses.
@@ -199,6 +203,17 @@ func (c *cmd) init() {
 
 	c.flags.StringVar(&c.gatewaySvcName, "service", "",
 		"Service name to use for the registration")
+
+	c.flags.StringVar(&c.extProcBin, "ext-proc-bin", "consul-inference-gateway",
+		"For an inference gateway: the co-located policy processor binary. Instead of "+
+			"exec'ing Envoy directly, Consul exec's this binary with the rendered "+
+			"bootstrap; the processor launches Envoy and runs the ext_proc server, "+
+			"supervising both as one process tree.")
+
+	c.flags.StringVar(&c.extProcConfigEntry, "ext-proc-config-entry", "",
+		"For an inference gateway: the ai-gateway config entry name the co-located "+
+			"processor loads (for its PII policy and to derive the ext_proc socket). "+
+			"Defaults to -service.")
 
 	c.flags.BoolVar(&c.exposeServers, "expose-servers", false,
 		"Expose the servers for WAN federation via this mesh gateway")
@@ -497,8 +512,17 @@ func (c *cmd) run(args []string) int {
 		}
 	}
 
-	c.logger.Debug("Executing envoy binary")
-	err = execEnvoy(binary, nil, args, bootstrapJson)
+	if c.gatewayKind == api.ServiceKindInferenceGateway {
+		// The inference gateway runs Envoy and the co-located policy processor as one
+		// process tree: instead of exec'ing Envoy directly, exec the processor with
+		// the rendered bootstrap so it launches Envoy and serves ext_proc, supervising
+		// both. This keeps one failure unit and one command for the operator.
+		c.logger.Debug("Executing inference gateway processor")
+		err = execInferenceGateway(c.extProcBin, binary, c.inferenceProcArgs(), bootstrapJson)
+	} else {
+		c.logger.Debug("Executing envoy binary")
+		err = execEnvoy(binary, nil, args, bootstrapJson)
+	}
 	if err == errUnsupportedOS {
 		c.UI.Error("Directly running Envoy is only supported on linux and macOS " +
 			"since envoy itself doesn't build on other platforms currently.")
@@ -511,6 +535,25 @@ func (c *cmd) run(args []string) int {
 	}
 
 	return 0
+}
+
+// inferenceProcArgs builds the extra arguments passed to the co-located policy
+// processor: which ai-gateway config entry to load (for its PII policy and to
+// derive the ext_proc socket) and how to reach the Consul agent to fetch it. The
+// entry name defaults to the gateway service name.
+func (c *cmd) inferenceProcArgs() []string {
+	entry := c.extProcConfigEntry
+	if entry == "" {
+		entry = c.gatewaySvcName
+	}
+	args := []string{"--config-entry", entry}
+	if addr := c.http.Addr(); addr != "" {
+		args = append(args, "--consul-http-addr", addr)
+	}
+	if token := c.http.Token(); token != "" {
+		args = append(args, "--consul-token", token)
+	}
+	return args
 }
 
 func (c *cmd) proxyRegistration(svcForSidecar *api.AgentService) (*api.AgentServiceRegistration, error) {

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -92,6 +92,7 @@ type cmd struct {
 	// inference-gateway co-launch
 	extProcBin         string
 	extProcConfigEntry string
+	extProcLogLevel    string
 
 	dialFunc func(network string, address string) (net.Conn, error)
 
@@ -214,6 +215,10 @@ func (c *cmd) init() {
 		"For an inference gateway: the ai-gateway config entry name the co-located "+
 			"processor loads (for its PII policy and to derive the ext_proc socket). "+
 			"Defaults to -service.")
+
+	c.flags.StringVar(&c.extProcLogLevel, "ext-proc-log-level", "",
+		"For an inference gateway: --log-level for the co-located processor "+
+			"(debug|info|warn|error). Empty uses the processor's own default.")
 
 	c.flags.BoolVar(&c.exposeServers, "expose-servers", false,
 		"Expose the servers for WAN federation via this mesh gateway")
@@ -552,6 +557,9 @@ func (c *cmd) inferenceProcArgs() []string {
 	}
 	if token := c.http.Token(); token != "" {
 		args = append(args, "--consul-token", token)
+	}
+	if c.extProcLogLevel != "" {
+		args = append(args, "--log-level", c.extProcLogLevel)
 	}
 	return args
 }

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -106,10 +106,12 @@ const (
 var defaultEnvoyVersion = xdscommon.EnvoyVersions[0]
 
 var supportedGateways = map[string]api.ServiceKind{
-	"api":         api.ServiceKindAPIGateway,
-	"mesh":        api.ServiceKindMeshGateway,
-	"terminating": api.ServiceKindTerminatingGateway,
-	"ingress":     api.ServiceKindIngressGateway,
+	"api":               api.ServiceKindAPIGateway,
+	"mesh":              api.ServiceKindMeshGateway,
+	"terminating":       api.ServiceKindTerminatingGateway,
+	"ingress":           api.ServiceKindIngressGateway,
+	"inference":         api.ServiceKindInferenceGateway,
+	"inference-gateway": api.ServiceKindInferenceGateway,
 }
 
 func (c *cmd) init() {
@@ -126,7 +128,7 @@ func (c *cmd) init() {
 		"Configure Envoy as a Mesh Gateway.")
 
 	c.flags.StringVar(&c.gateway, "gateway", "",
-		"The type of gateway to register. One of: terminating, ingress, or mesh")
+		"The type of gateway to register. One of: api, terminating, ingress, mesh, or inference")
 
 	c.flags.StringVar(&c.sidecarFor, "sidecar-for", os.Getenv("CONNECT_SIDECAR_FOR"),
 		"The ID of a service instance on the local agent that this proxy should "+
@@ -346,7 +348,7 @@ func (c *cmd) run(args []string) int {
 	if c.gateway != "" {
 		kind, ok := supportedGateways[c.gateway]
 		if !ok {
-			c.UI.Error("Gateway must be one of: api, terminating, mesh, or ingress")
+			c.UI.Error("Gateway must be one of: api, terminating, mesh, ingress, or inference")
 			return 1
 		}
 		c.gatewayKind = kind

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -141,6 +141,42 @@ type generateConfigTestCase struct {
 // encapsulate all the argument and default handling code which is where most of
 // the logic is. We also allow generating golden files but only for cases that
 // pass the test of having their template args generated as expected.
+func TestInferenceProcArgs(t *testing.T) {
+	newCmd := func() *cmd {
+		ui := cli.NewMockUi()
+		c := New(ui)
+		c.init()
+		return c
+	}
+
+	t.Run("config entry defaults to the service name", func(t *testing.T) {
+		c := newCmd()
+		c.gatewaySvcName = "travel-inference-gateway"
+		require.Equal(t, []string{"--config-entry", "travel-inference-gateway"}, c.inferenceProcArgs())
+	})
+
+	t.Run("explicit config entry wins", func(t *testing.T) {
+		c := newCmd()
+		c.gatewaySvcName = "travel-inference-gateway"
+		c.extProcConfigEntry = "shared-ai-policy"
+		require.Equal(t, []string{"--config-entry", "shared-ai-policy"}, c.inferenceProcArgs())
+	})
+
+	t.Run("consul address and token are forwarded", func(t *testing.T) {
+		c := newCmd()
+		require.NoError(t, c.flags.Parse([]string{
+			"-service", "gw",
+			"-http-addr", "127.0.0.1:8501",
+			"-token", "secret",
+		}))
+		require.Equal(t, []string{
+			"--config-entry", "gw",
+			"--consul-http-addr", "127.0.0.1:8501",
+			"--consul-token", "secret",
+		}, c.inferenceProcArgs())
+	})
+}
+
 func TestGenerateConfig(t *testing.T) {
 
 	b, err := os.ReadFile("../../../test/ca/root.cer")

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -162,17 +162,19 @@ func TestInferenceProcArgs(t *testing.T) {
 		require.Equal(t, []string{"--config-entry", "shared-ai-policy"}, c.inferenceProcArgs())
 	})
 
-	t.Run("consul address and token are forwarded", func(t *testing.T) {
+	t.Run("consul address, token, and log level are forwarded", func(t *testing.T) {
 		c := newCmd()
 		require.NoError(t, c.flags.Parse([]string{
 			"-service", "gw",
 			"-http-addr", "127.0.0.1:8501",
 			"-token", "secret",
+			"-ext-proc-log-level", "debug",
 		}))
 		require.Equal(t, []string{
 			"--config-entry", "gw",
 			"--consul-http-addr", "127.0.0.1:8501",
 			"--consul-token", "secret",
+			"--log-level", "debug",
 		}, c.inferenceProcArgs())
 	})
 }

--- a/command/connect/envoy/exec_unix.go
+++ b/command/connect/envoy/exec_unix.go
@@ -66,6 +66,34 @@ func makeBootstrapPipe(bootstrapJSON []byte) (string, error) {
 	return pipeFile, nil
 }
 
+// execInferenceGateway hands the rendered Envoy bootstrap to the co-located policy
+// processor instead of exec'ing Envoy directly. The processor launches Envoy from
+// that bootstrap (over the same pipe) and runs the ext_proc server, supervising
+// both — so the inference gateway is one process tree and one failure unit. It
+// exec's the processor, replacing this command, mirroring execEnvoy.
+func execInferenceGateway(extProcBin, envoyBinary string, procArgs []string, bootstrapJSON []byte) error {
+	binary, err := exec.LookPath(extProcBin)
+	if err != nil {
+		return fmt.Errorf("couldn't find inference gateway processor %q: %w", extProcBin, err)
+	}
+
+	pipeFile, err := makeBootstrapPipe(bootstrapJSON)
+	if err != nil {
+		os.RemoveAll(pipeFile)
+		return err
+	}
+	// Like execEnvoy, we don't defer cleanup: we are about to Exec, so the child
+	// pipe-writer cleans up the FIFO once Envoy opens it.
+
+	args := []string{binary, "--envoy-config", pipeFile, "--envoy-bin", envoyBinary}
+	args = append(args, procArgs...)
+
+	if err := unix.Exec(binary, args, os.Environ()); err != nil {
+		return errors.New("Failed to exec inference gateway processor: " + err.Error())
+	}
+	return nil
+}
+
 func execEnvoy(binary string, prefixArgs, suffixArgs []string, bootstrapJSON []byte) error {
 	pipeFile, err := makeBootstrapPipe(bootstrapJSON)
 	if err != nil {

--- a/command/connect/envoy/exec_unsupported.go
+++ b/command/connect/envoy/exec_unsupported.go
@@ -8,3 +8,7 @@ package envoy
 func execEnvoy(binary string, prefixArgs, suffixArgs []string, bootstrapJson []byte) error {
 	return errUnsupportedOS
 }
+
+func execInferenceGateway(extProcBin, envoyBinary string, procArgs []string, bootstrapJSON []byte) error {
+	return errUnsupportedOS
+}

--- a/command/connect/envoy/exec_windows.go
+++ b/command/connect/envoy/exec_windows.go
@@ -74,6 +74,32 @@ func startProc(binary string, args []string) (p *os.Process, err error) {
 	return nil, err
 }
 
+// execInferenceGateway launches the co-located policy processor with the rendered
+// Envoy bootstrap instead of Envoy directly; the processor launches Envoy and runs
+// the ext_proc server, supervising both. See the unix implementation for detail.
+func execInferenceGateway(extProcBin, envoyBinary string, procArgs []string, bootstrapJSON []byte) error {
+	binary, err := exec.LookPath(extProcBin)
+	if err != nil {
+		return fmt.Errorf("couldn't find inference gateway processor %q: %w", extProcBin, err)
+	}
+
+	pipeFile, err := makeBootstrapPipe(bootstrapJSON)
+	if err != nil {
+		os.RemoveAll(pipeFile)
+		return err
+	}
+
+	args := []string{binary, "--envoy-config", pipeFile, "--envoy-bin", envoyBinary}
+	args = append(args, procArgs...)
+
+	if proc, err := startProc(binary, args); err == nil {
+		proc.Wait()
+	} else {
+		return errors.New("Failed to exec inference gateway processor: " + err.Error())
+	}
+	return nil
+}
+
 func execEnvoy(binary string, prefixArgs, suffixArgs []string, bootstrapJSON []byte) error {
 	tempFile, err := makeBootstrapPipe(bootstrapJSON)
 	if err != nil {

--- a/logging/names.go
+++ b/logging/names.go
@@ -42,6 +42,7 @@ const (
 	Manager               string = "manager"
 	Memberlist            string = "memberlist"
 	APIGateway            string = "api_gateway"
+	InferenceGateway      string = "inference_gateway"
 	MeshGateway           string = "mesh_gateway"
 	Namespace             string = "namespace"
 	NetworkAreas          string = "network_areas"

--- a/proto/private/pbconfigentry/config_entry.gen.go
+++ b/proto/private/pbconfigentry/config_entry.gen.go
@@ -4,6 +4,250 @@ package pbconfigentry
 
 import "github.com/hashicorp/consul/agent/structs"
 
+func AIGatewayToStructs(s *AIGateway, t *structs.AIGatewayConfigEntry) {
+	if s == nil {
+		return
+	}
+	if s.Processor != nil {
+		AIGatewayProcessorToStructs(s.Processor, &t.Processor)
+	}
+	t.ApplyTo = s.ApplyTo
+	if s.Routing != nil {
+		AIGatewayRoutingToStructs(s.Routing, &t.Routing)
+	}
+	t.Meta = s.Meta
+	t.Hash = s.Hash
+}
+func AIGatewayFromStructs(t *structs.AIGatewayConfigEntry, s *AIGateway) {
+	if s == nil {
+		return
+	}
+	{
+		var x AIGatewayProcessor
+		AIGatewayProcessorFromStructs(&t.Processor, &x)
+		s.Processor = &x
+	}
+	s.ApplyTo = t.ApplyTo
+	{
+		var x AIGatewayRouting
+		AIGatewayRoutingFromStructs(&t.Routing, &x)
+		s.Routing = &x
+	}
+	s.Meta = t.Meta
+	s.Hash = t.Hash
+}
+func AIGatewayIdentityMatchToStructs(s *AIGatewayIdentityMatch, t *structs.AIGatewayIdentityMatch) {
+	if s == nil {
+		return
+	}
+	t.Service = s.Service
+	t.Partition = s.Partition
+	t.Namespace = s.Namespace
+}
+func AIGatewayIdentityMatchFromStructs(t *structs.AIGatewayIdentityMatch, s *AIGatewayIdentityMatch) {
+	if s == nil {
+		return
+	}
+	s.Service = t.Service
+	s.Partition = t.Partition
+	s.Namespace = t.Namespace
+}
+func AIGatewayMatchToStructs(s *AIGatewayMatch, t *structs.AIGatewayMatch) {
+	if s == nil {
+		return
+	}
+	t.Path = s.Path
+	t.BodyHas = s.BodyHas
+	if s.Identity != nil {
+		var x structs.AIGatewayIdentityMatch
+		AIGatewayIdentityMatchToStructs(s.Identity, &x)
+		t.Identity = &x
+	}
+}
+func AIGatewayMatchFromStructs(t *structs.AIGatewayMatch, s *AIGatewayMatch) {
+	if s == nil {
+		return
+	}
+	s.Path = t.Path
+	s.BodyHas = t.BodyHas
+	if t.Identity != nil {
+		var x AIGatewayIdentityMatch
+		AIGatewayIdentityMatchFromStructs(t.Identity, &x)
+		s.Identity = &x
+	}
+}
+func AIGatewayMatchRuleToStructs(s *AIGatewayMatchRule, t *structs.AIGatewayMatchRule) {
+	if s == nil {
+		return
+	}
+	if s.When != nil {
+		AIGatewayMatchToStructs(s.When, &t.When)
+	}
+	t.RequireCapabilities = s.RequireCapabilities
+	t.Candidates = s.Candidates
+	t.FallbackChain = s.FallbackChain
+}
+func AIGatewayMatchRuleFromStructs(t *structs.AIGatewayMatchRule, s *AIGatewayMatchRule) {
+	if s == nil {
+		return
+	}
+	{
+		var x AIGatewayMatch
+		AIGatewayMatchFromStructs(&t.When, &x)
+		s.When = &x
+	}
+	s.RequireCapabilities = t.RequireCapabilities
+	s.Candidates = t.Candidates
+	s.FallbackChain = t.FallbackChain
+}
+func AIGatewayProcessorToStructs(s *AIGatewayProcessor, t *structs.AIGatewayProcessor) {
+	if s == nil {
+		return
+	}
+	t.UDSPath = s.UDSPath
+	t.FailureMode = s.FailureMode
+}
+func AIGatewayProcessorFromStructs(t *structs.AIGatewayProcessor, s *AIGatewayProcessor) {
+	if s == nil {
+		return
+	}
+	s.UDSPath = t.UDSPath
+	s.FailureMode = t.FailureMode
+}
+func AIGatewayRetryToStructs(s *AIGatewayRetry, t *structs.AIGatewayRetry) {
+	if s == nil {
+		return
+	}
+	t.MaxAttempts = int(s.MaxAttempts)
+	t.RetryOn = s.RetryOn
+}
+func AIGatewayRetryFromStructs(t *structs.AIGatewayRetry, s *AIGatewayRetry) {
+	if s == nil {
+		return
+	}
+	s.MaxAttempts = int32(t.MaxAttempts)
+	s.RetryOn = t.RetryOn
+}
+func AIGatewayRoutingToStructs(s *AIGatewayRouting, t *structs.AIGatewayRouting) {
+	if s == nil {
+		return
+	}
+	{
+		t.MatchRules = make([]structs.AIGatewayMatchRule, len(s.MatchRules))
+		for i := range s.MatchRules {
+			if s.MatchRules[i] != nil {
+				AIGatewayMatchRuleToStructs(s.MatchRules[i], &t.MatchRules[i])
+			}
+		}
+	}
+	t.FallbackChain = s.FallbackChain
+	if s.Retry != nil {
+		var x structs.AIGatewayRetry
+		AIGatewayRetryToStructs(s.Retry, &x)
+		t.Retry = &x
+	}
+	if s.Timeout != nil {
+		var x structs.AIGatewayTimeout
+		AIGatewayTimeoutToStructs(s.Timeout, &x)
+		t.Timeout = &x
+	}
+	if s.Scoring != nil {
+		var x structs.AIGatewayScoring
+		AIGatewayScoringToStructs(s.Scoring, &x)
+		t.Scoring = &x
+	}
+	t.ConfigValidation = s.ConfigValidation
+}
+func AIGatewayRoutingFromStructs(t *structs.AIGatewayRouting, s *AIGatewayRouting) {
+	if s == nil {
+		return
+	}
+	{
+		s.MatchRules = make([]*AIGatewayMatchRule, len(t.MatchRules))
+		for i := range t.MatchRules {
+			{
+				var x AIGatewayMatchRule
+				AIGatewayMatchRuleFromStructs(&t.MatchRules[i], &x)
+				s.MatchRules[i] = &x
+			}
+		}
+	}
+	s.FallbackChain = t.FallbackChain
+	if t.Retry != nil {
+		var x AIGatewayRetry
+		AIGatewayRetryFromStructs(t.Retry, &x)
+		s.Retry = &x
+	}
+	if t.Timeout != nil {
+		var x AIGatewayTimeout
+		AIGatewayTimeoutFromStructs(t.Timeout, &x)
+		s.Timeout = &x
+	}
+	if t.Scoring != nil {
+		var x AIGatewayScoring
+		AIGatewayScoringFromStructs(t.Scoring, &x)
+		s.Scoring = &x
+	}
+	s.ConfigValidation = t.ConfigValidation
+}
+func AIGatewayScoringToStructs(s *AIGatewayScoring, t *structs.AIGatewayScoring) {
+	if s == nil {
+		return
+	}
+	t.Scorers = s.Scorers
+	{
+		t.WeightedSplit = make([]structs.AIGatewayWeightedTarget, len(s.WeightedSplit))
+		for i := range s.WeightedSplit {
+			if s.WeightedSplit[i] != nil {
+				AIGatewayWeightedTargetToStructs(s.WeightedSplit[i], &t.WeightedSplit[i])
+			}
+		}
+	}
+}
+func AIGatewayScoringFromStructs(t *structs.AIGatewayScoring, s *AIGatewayScoring) {
+	if s == nil {
+		return
+	}
+	s.Scorers = t.Scorers
+	{
+		s.WeightedSplit = make([]*AIGatewayWeightedTarget, len(t.WeightedSplit))
+		for i := range t.WeightedSplit {
+			{
+				var x AIGatewayWeightedTarget
+				AIGatewayWeightedTargetFromStructs(&t.WeightedSplit[i], &x)
+				s.WeightedSplit[i] = &x
+			}
+		}
+	}
+}
+func AIGatewayTimeoutToStructs(s *AIGatewayTimeout, t *structs.AIGatewayTimeout) {
+	if s == nil {
+		return
+	}
+	t.Connect = s.Connect
+	t.Request = s.Request
+}
+func AIGatewayTimeoutFromStructs(t *structs.AIGatewayTimeout, s *AIGatewayTimeout) {
+	if s == nil {
+		return
+	}
+	s.Connect = t.Connect
+	s.Request = t.Request
+}
+func AIGatewayWeightedTargetToStructs(s *AIGatewayWeightedTarget, t *structs.AIGatewayWeightedTarget) {
+	if s == nil {
+		return
+	}
+	t.Cluster = s.Cluster
+	t.Weight = int(s.Weight)
+}
+func AIGatewayWeightedTargetFromStructs(t *structs.AIGatewayWeightedTarget, s *AIGatewayWeightedTarget) {
+	if s == nil {
+		return
+	}
+	s.Cluster = t.Cluster
+	s.Weight = int32(t.Weight)
+}
 func APIGatewayToStructs(s *APIGateway, t *structs.APIGatewayConfigEntry) {
 	if s == nil {
 		return

--- a/proto/private/pbconfigentry/config_entry.go
+++ b/proto/private/pbconfigentry/config_entry.go
@@ -133,6 +133,14 @@ func ConfigEntryToStructs(s *ConfigEntry) structs.ConfigEntry {
 		pbcommon.RaftIndexToStructs(s.RaftIndex, &target.RaftIndex)
 		pbcommon.EnterpriseMetaToStructs(s.EnterpriseMeta, &target.EnterpriseMeta)
 		return &target
+	case Kind_KindAIGateway:
+		var target structs.AIGatewayConfigEntry
+		target.Name = s.Name
+
+		AIGatewayToStructs(s.GetAIGateway(), &target)
+		pbcommon.RaftIndexToStructs(s.RaftIndex, &target.RaftIndex)
+		pbcommon.EnterpriseMetaToStructs(s.EnterpriseMeta, &target.EnterpriseMeta)
+		return &target
 	default:
 		panic(fmt.Sprintf("unable to convert ConfigEntry of kind %s to structs", s.Kind))
 	}
@@ -259,6 +267,14 @@ func ConfigEntryFromStructs(s structs.ConfigEntry) *ConfigEntry {
 		configEntry.Kind = Kind_KindExportedServices
 		configEntry.Entry = &ConfigEntry_ExportedServices{
 			ExportedServices: &es,
+		}
+	case *structs.AIGatewayConfigEntry:
+		var aigw AIGateway
+		AIGatewayFromStructs(v, &aigw)
+
+		configEntry.Kind = Kind_KindAIGateway
+		configEntry.Entry = &ConfigEntry_AIGateway{
+			AIGateway: &aigw,
 		}
 	default:
 		panic(fmt.Sprintf("unable to convert %T to proto", s))

--- a/proto/private/pbconfigentry/config_entry.pb.binary.go
+++ b/proto/private/pbconfigentry/config_entry.pb.binary.go
@@ -1096,3 +1096,103 @@ func (msg *ExportedServicesConsumer) MarshalBinary() ([]byte, error) {
 func (msg *ExportedServicesConsumer) UnmarshalBinary(b []byte) error {
 	return proto.Unmarshal(b, msg)
 }
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIGateway) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIGateway) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIGatewayProcessor) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIGatewayProcessor) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIGatewayRouting) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIGatewayRouting) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIGatewayMatchRule) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIGatewayMatchRule) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIGatewayMatch) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIGatewayMatch) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIGatewayIdentityMatch) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIGatewayIdentityMatch) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIGatewayRetry) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIGatewayRetry) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIGatewayTimeout) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIGatewayTimeout) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIGatewayScoring) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIGatewayScoring) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIGatewayWeightedTarget) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIGatewayWeightedTarget) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}

--- a/proto/private/pbconfigentry/config_entry.pb.go
+++ b/proto/private/pbconfigentry/config_entry.pb.go
@@ -46,6 +46,7 @@ const (
 	Kind_KindJWTProvider           Kind = 12
 	Kind_KindExportedServices      Kind = 13
 	Kind_KindFileSystemCertificate Kind = 14
+	Kind_KindAIGateway             Kind = 15
 )
 
 // Enum value maps for Kind.
@@ -66,6 +67,7 @@ var (
 		12: "KindJWTProvider",
 		13: "KindExportedServices",
 		14: "KindFileSystemCertificate",
+		15: "KindAIGateway",
 	}
 	Kind_value = map[string]int32{
 		"KindUnknown":               0,
@@ -83,6 +85,7 @@ var (
 		"KindJWTProvider":           12,
 		"KindExportedServices":      13,
 		"KindFileSystemCertificate": 14,
+		"KindAIGateway":             15,
 	}
 )
 
@@ -1103,6 +1106,7 @@ type ConfigEntry struct {
 	//	*ConfigEntry_JWTProvider
 	//	*ConfigEntry_ExportedServices
 	//	*ConfigEntry_FileSystemCertificate
+	//	*ConfigEntry_AIGateway
 	Entry         isConfigEntry_Entry `protobuf_oneof:"Entry"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1299,6 +1303,15 @@ func (x *ConfigEntry) GetFileSystemCertificate() *FileSystemCertificate {
 	return nil
 }
 
+func (x *ConfigEntry) GetAIGateway() *AIGateway {
+	if x != nil {
+		if x, ok := x.Entry.(*ConfigEntry_AIGateway); ok {
+			return x.AIGateway
+		}
+	}
+	return nil
+}
+
 type isConfigEntry_Entry interface {
 	isConfigEntry_Entry()
 }
@@ -1359,6 +1372,10 @@ type ConfigEntry_FileSystemCertificate struct {
 	FileSystemCertificate *FileSystemCertificate `protobuf:"bytes,18,opt,name=FileSystemCertificate,proto3,oneof"`
 }
 
+type ConfigEntry_AIGateway struct {
+	AIGateway *AIGateway `protobuf:"bytes,19,opt,name=AIGateway,proto3,oneof"`
+}
+
 func (*ConfigEntry_MeshConfig) isConfigEntry_Entry() {}
 
 func (*ConfigEntry_ServiceResolver) isConfigEntry_Entry() {}
@@ -1386,6 +1403,8 @@ func (*ConfigEntry_JWTProvider) isConfigEntry_Entry() {}
 func (*ConfigEntry_ExportedServices) isConfigEntry_Entry() {}
 
 func (*ConfigEntry_FileSystemCertificate) isConfigEntry_Entry() {}
+
+func (*ConfigEntry_AIGateway) isConfigEntry_Entry() {}
 
 // mog annotation:
 //
@@ -8649,6 +8668,668 @@ func (x *ExportedServicesConsumer) GetSamenessGroup() string {
 	return ""
 }
 
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayConfigEntry
+// output=config_entry.gen.go
+// name=Structs
+// ignore-fields=Name,Kind,RaftIndex,EnterpriseMeta
+type AIGateway struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Processor     *AIGatewayProcessor    `protobuf:"bytes,1,opt,name=Processor,proto3" json:"Processor,omitempty"`
+	ApplyTo       []string               `protobuf:"bytes,2,rep,name=ApplyTo,proto3" json:"ApplyTo,omitempty"`
+	Routing       *AIGatewayRouting      `protobuf:"bytes,3,opt,name=Routing,proto3" json:"Routing,omitempty"`
+	Meta          map[string]string      `protobuf:"bytes,4,rep,name=Meta,proto3" json:"Meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Hash          uint64                 `protobuf:"varint,5,opt,name=Hash,proto3" json:"Hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AIGateway) Reset() {
+	*x = AIGateway{}
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[109]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIGateway) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIGateway) ProtoMessage() {}
+
+func (x *AIGateway) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[109]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIGateway.ProtoReflect.Descriptor instead.
+func (*AIGateway) Descriptor() ([]byte, []int) {
+	return file_private_pbconfigentry_config_entry_proto_rawDescGZIP(), []int{109}
+}
+
+func (x *AIGateway) GetProcessor() *AIGatewayProcessor {
+	if x != nil {
+		return x.Processor
+	}
+	return nil
+}
+
+func (x *AIGateway) GetApplyTo() []string {
+	if x != nil {
+		return x.ApplyTo
+	}
+	return nil
+}
+
+func (x *AIGateway) GetRouting() *AIGatewayRouting {
+	if x != nil {
+		return x.Routing
+	}
+	return nil
+}
+
+func (x *AIGateway) GetMeta() map[string]string {
+	if x != nil {
+		return x.Meta
+	}
+	return nil
+}
+
+func (x *AIGateway) GetHash() uint64 {
+	if x != nil {
+		return x.Hash
+	}
+	return 0
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayProcessor
+// output=config_entry.gen.go
+// name=Structs
+type AIGatewayProcessor struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UDSPath       string                 `protobuf:"bytes,1,opt,name=UDSPath,proto3" json:"UDSPath,omitempty"`
+	FailureMode   string                 `protobuf:"bytes,2,opt,name=FailureMode,proto3" json:"FailureMode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AIGatewayProcessor) Reset() {
+	*x = AIGatewayProcessor{}
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[110]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIGatewayProcessor) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIGatewayProcessor) ProtoMessage() {}
+
+func (x *AIGatewayProcessor) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[110]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIGatewayProcessor.ProtoReflect.Descriptor instead.
+func (*AIGatewayProcessor) Descriptor() ([]byte, []int) {
+	return file_private_pbconfigentry_config_entry_proto_rawDescGZIP(), []int{110}
+}
+
+func (x *AIGatewayProcessor) GetUDSPath() string {
+	if x != nil {
+		return x.UDSPath
+	}
+	return ""
+}
+
+func (x *AIGatewayProcessor) GetFailureMode() string {
+	if x != nil {
+		return x.FailureMode
+	}
+	return ""
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayRouting
+// output=config_entry.gen.go
+// name=Structs
+// ignore-fields=ComplianceMap,Budget,Cache,Mirror
+type AIGatewayRouting struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	MatchRules       []*AIGatewayMatchRule  `protobuf:"bytes,1,rep,name=MatchRules,proto3" json:"MatchRules,omitempty"`
+	FallbackChain    []string               `protobuf:"bytes,2,rep,name=FallbackChain,proto3" json:"FallbackChain,omitempty"`
+	Retry            *AIGatewayRetry        `protobuf:"bytes,3,opt,name=Retry,proto3" json:"Retry,omitempty"`
+	Timeout          *AIGatewayTimeout      `protobuf:"bytes,4,opt,name=Timeout,proto3" json:"Timeout,omitempty"`
+	Scoring          *AIGatewayScoring      `protobuf:"bytes,5,opt,name=Scoring,proto3" json:"Scoring,omitempty"`
+	ConfigValidation string                 `protobuf:"bytes,6,opt,name=ConfigValidation,proto3" json:"ConfigValidation,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *AIGatewayRouting) Reset() {
+	*x = AIGatewayRouting{}
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[111]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIGatewayRouting) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIGatewayRouting) ProtoMessage() {}
+
+func (x *AIGatewayRouting) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[111]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIGatewayRouting.ProtoReflect.Descriptor instead.
+func (*AIGatewayRouting) Descriptor() ([]byte, []int) {
+	return file_private_pbconfigentry_config_entry_proto_rawDescGZIP(), []int{111}
+}
+
+func (x *AIGatewayRouting) GetMatchRules() []*AIGatewayMatchRule {
+	if x != nil {
+		return x.MatchRules
+	}
+	return nil
+}
+
+func (x *AIGatewayRouting) GetFallbackChain() []string {
+	if x != nil {
+		return x.FallbackChain
+	}
+	return nil
+}
+
+func (x *AIGatewayRouting) GetRetry() *AIGatewayRetry {
+	if x != nil {
+		return x.Retry
+	}
+	return nil
+}
+
+func (x *AIGatewayRouting) GetTimeout() *AIGatewayTimeout {
+	if x != nil {
+		return x.Timeout
+	}
+	return nil
+}
+
+func (x *AIGatewayRouting) GetScoring() *AIGatewayScoring {
+	if x != nil {
+		return x.Scoring
+	}
+	return nil
+}
+
+func (x *AIGatewayRouting) GetConfigValidation() string {
+	if x != nil {
+		return x.ConfigValidation
+	}
+	return ""
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayMatchRule
+// output=config_entry.gen.go
+// name=Structs
+type AIGatewayMatchRule struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	When                *AIGatewayMatch        `protobuf:"bytes,1,opt,name=When,proto3" json:"When,omitempty"`
+	RequireCapabilities []string               `protobuf:"bytes,2,rep,name=RequireCapabilities,proto3" json:"RequireCapabilities,omitempty"`
+	Candidates          []string               `protobuf:"bytes,3,rep,name=Candidates,proto3" json:"Candidates,omitempty"`
+	FallbackChain       []string               `protobuf:"bytes,4,rep,name=FallbackChain,proto3" json:"FallbackChain,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *AIGatewayMatchRule) Reset() {
+	*x = AIGatewayMatchRule{}
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[112]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIGatewayMatchRule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIGatewayMatchRule) ProtoMessage() {}
+
+func (x *AIGatewayMatchRule) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[112]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIGatewayMatchRule.ProtoReflect.Descriptor instead.
+func (*AIGatewayMatchRule) Descriptor() ([]byte, []int) {
+	return file_private_pbconfigentry_config_entry_proto_rawDescGZIP(), []int{112}
+}
+
+func (x *AIGatewayMatchRule) GetWhen() *AIGatewayMatch {
+	if x != nil {
+		return x.When
+	}
+	return nil
+}
+
+func (x *AIGatewayMatchRule) GetRequireCapabilities() []string {
+	if x != nil {
+		return x.RequireCapabilities
+	}
+	return nil
+}
+
+func (x *AIGatewayMatchRule) GetCandidates() []string {
+	if x != nil {
+		return x.Candidates
+	}
+	return nil
+}
+
+func (x *AIGatewayMatchRule) GetFallbackChain() []string {
+	if x != nil {
+		return x.FallbackChain
+	}
+	return nil
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayMatch
+// output=config_entry.gen.go
+// name=Structs
+type AIGatewayMatch struct {
+	state         protoimpl.MessageState  `protogen:"open.v1"`
+	Path          string                  `protobuf:"bytes,1,opt,name=Path,proto3" json:"Path,omitempty"`
+	BodyHas       []string                `protobuf:"bytes,2,rep,name=BodyHas,proto3" json:"BodyHas,omitempty"`
+	Identity      *AIGatewayIdentityMatch `protobuf:"bytes,3,opt,name=Identity,proto3" json:"Identity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AIGatewayMatch) Reset() {
+	*x = AIGatewayMatch{}
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[113]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIGatewayMatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIGatewayMatch) ProtoMessage() {}
+
+func (x *AIGatewayMatch) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[113]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIGatewayMatch.ProtoReflect.Descriptor instead.
+func (*AIGatewayMatch) Descriptor() ([]byte, []int) {
+	return file_private_pbconfigentry_config_entry_proto_rawDescGZIP(), []int{113}
+}
+
+func (x *AIGatewayMatch) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *AIGatewayMatch) GetBodyHas() []string {
+	if x != nil {
+		return x.BodyHas
+	}
+	return nil
+}
+
+func (x *AIGatewayMatch) GetIdentity() *AIGatewayIdentityMatch {
+	if x != nil {
+		return x.Identity
+	}
+	return nil
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayIdentityMatch
+// output=config_entry.gen.go
+// name=Structs
+type AIGatewayIdentityMatch struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Service       string                 `protobuf:"bytes,1,opt,name=Service,proto3" json:"Service,omitempty"`
+	Partition     string                 `protobuf:"bytes,2,opt,name=Partition,proto3" json:"Partition,omitempty"`
+	Namespace     string                 `protobuf:"bytes,3,opt,name=Namespace,proto3" json:"Namespace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AIGatewayIdentityMatch) Reset() {
+	*x = AIGatewayIdentityMatch{}
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[114]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIGatewayIdentityMatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIGatewayIdentityMatch) ProtoMessage() {}
+
+func (x *AIGatewayIdentityMatch) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[114]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIGatewayIdentityMatch.ProtoReflect.Descriptor instead.
+func (*AIGatewayIdentityMatch) Descriptor() ([]byte, []int) {
+	return file_private_pbconfigentry_config_entry_proto_rawDescGZIP(), []int{114}
+}
+
+func (x *AIGatewayIdentityMatch) GetService() string {
+	if x != nil {
+		return x.Service
+	}
+	return ""
+}
+
+func (x *AIGatewayIdentityMatch) GetPartition() string {
+	if x != nil {
+		return x.Partition
+	}
+	return ""
+}
+
+func (x *AIGatewayIdentityMatch) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayRetry
+// output=config_entry.gen.go
+// name=Structs
+type AIGatewayRetry struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// mog: func-to=int func-from=int32
+	MaxAttempts   int32    `protobuf:"varint,1,opt,name=MaxAttempts,proto3" json:"MaxAttempts,omitempty"`
+	RetryOn       []string `protobuf:"bytes,2,rep,name=RetryOn,proto3" json:"RetryOn,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AIGatewayRetry) Reset() {
+	*x = AIGatewayRetry{}
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[115]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIGatewayRetry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIGatewayRetry) ProtoMessage() {}
+
+func (x *AIGatewayRetry) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[115]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIGatewayRetry.ProtoReflect.Descriptor instead.
+func (*AIGatewayRetry) Descriptor() ([]byte, []int) {
+	return file_private_pbconfigentry_config_entry_proto_rawDescGZIP(), []int{115}
+}
+
+func (x *AIGatewayRetry) GetMaxAttempts() int32 {
+	if x != nil {
+		return x.MaxAttempts
+	}
+	return 0
+}
+
+func (x *AIGatewayRetry) GetRetryOn() []string {
+	if x != nil {
+		return x.RetryOn
+	}
+	return nil
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayTimeout
+// output=config_entry.gen.go
+// name=Structs
+type AIGatewayTimeout struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Connect       string                 `protobuf:"bytes,1,opt,name=Connect,proto3" json:"Connect,omitempty"`
+	Request       string                 `protobuf:"bytes,2,opt,name=Request,proto3" json:"Request,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AIGatewayTimeout) Reset() {
+	*x = AIGatewayTimeout{}
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[116]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIGatewayTimeout) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIGatewayTimeout) ProtoMessage() {}
+
+func (x *AIGatewayTimeout) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[116]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIGatewayTimeout.ProtoReflect.Descriptor instead.
+func (*AIGatewayTimeout) Descriptor() ([]byte, []int) {
+	return file_private_pbconfigentry_config_entry_proto_rawDescGZIP(), []int{116}
+}
+
+func (x *AIGatewayTimeout) GetConnect() string {
+	if x != nil {
+		return x.Connect
+	}
+	return ""
+}
+
+func (x *AIGatewayTimeout) GetRequest() string {
+	if x != nil {
+		return x.Request
+	}
+	return ""
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayScoring
+// output=config_entry.gen.go
+// name=Structs
+type AIGatewayScoring struct {
+	state         protoimpl.MessageState     `protogen:"open.v1"`
+	Scorers       []string                   `protobuf:"bytes,1,rep,name=Scorers,proto3" json:"Scorers,omitempty"`
+	WeightedSplit []*AIGatewayWeightedTarget `protobuf:"bytes,2,rep,name=WeightedSplit,proto3" json:"WeightedSplit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AIGatewayScoring) Reset() {
+	*x = AIGatewayScoring{}
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[117]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIGatewayScoring) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIGatewayScoring) ProtoMessage() {}
+
+func (x *AIGatewayScoring) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[117]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIGatewayScoring.ProtoReflect.Descriptor instead.
+func (*AIGatewayScoring) Descriptor() ([]byte, []int) {
+	return file_private_pbconfigentry_config_entry_proto_rawDescGZIP(), []int{117}
+}
+
+func (x *AIGatewayScoring) GetScorers() []string {
+	if x != nil {
+		return x.Scorers
+	}
+	return nil
+}
+
+func (x *AIGatewayScoring) GetWeightedSplit() []*AIGatewayWeightedTarget {
+	if x != nil {
+		return x.WeightedSplit
+	}
+	return nil
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayWeightedTarget
+// output=config_entry.gen.go
+// name=Structs
+type AIGatewayWeightedTarget struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Cluster string                 `protobuf:"bytes,1,opt,name=Cluster,proto3" json:"Cluster,omitempty"`
+	// mog: func-to=int func-from=int32
+	Weight        int32 `protobuf:"varint,2,opt,name=Weight,proto3" json:"Weight,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AIGatewayWeightedTarget) Reset() {
+	*x = AIGatewayWeightedTarget{}
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[118]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIGatewayWeightedTarget) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIGatewayWeightedTarget) ProtoMessage() {}
+
+func (x *AIGatewayWeightedTarget) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbconfigentry_config_entry_proto_msgTypes[118]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIGatewayWeightedTarget.ProtoReflect.Descriptor instead.
+func (*AIGatewayWeightedTarget) Descriptor() ([]byte, []int) {
+	return file_private_pbconfigentry_config_entry_proto_rawDescGZIP(), []int{118}
+}
+
+func (x *AIGatewayWeightedTarget) GetCluster() string {
+	if x != nil {
+		return x.Cluster
+	}
+	return ""
+}
+
+func (x *AIGatewayWeightedTarget) GetWeight() int32 {
+	if x != nil {
+		return x.Weight
+	}
+	return 0
+}
+
 var File_private_pbconfigentry_config_entry_proto protoreflect.FileDescriptor
 
 const file_private_pbconfigentry_config_entry_proto_rawDesc = "" +
@@ -8677,7 +9358,7 @@ const file_private_pbconfigentry_config_entry_proto_rawDesc = "" +
 	"\n" +
 	"SourcePeer\x18\x03 \x01(\tR\n" +
 	"SourcePeer\x12(\n" +
-	"\x0fSourcePartition\x18\x04 \x01(\tR\x0fSourcePartition\"\xcf\f\n" +
+	"\x0fSourcePartition\x18\x04 \x01(\tR\x0fSourcePartition\"\xa1\r\n" +
 	"\vConfigEntry\x12?\n" +
 	"\x04Kind\x18\x01 \x01(\x0e2+.hashicorp.consul.internal.configentry.KindR\x04Kind\x12\x12\n" +
 	"\x04Name\x18\x02 \x01(\tR\x04Name\x12X\n" +
@@ -8701,7 +9382,8 @@ const file_private_pbconfigentry_config_entry_proto_rawDesc = "" +
 	"\rSamenessGroup\x18\x0f \x01(\v24.hashicorp.consul.internal.configentry.SamenessGroupH\x00R\rSamenessGroup\x12V\n" +
 	"\vJWTProvider\x18\x10 \x01(\v22.hashicorp.consul.internal.configentry.JWTProviderH\x00R\vJWTProvider\x12e\n" +
 	"\x10ExportedServices\x18\x11 \x01(\v27.hashicorp.consul.internal.configentry.ExportedServicesH\x00R\x10ExportedServices\x12t\n" +
-	"\x15FileSystemCertificate\x18\x12 \x01(\v2<.hashicorp.consul.internal.configentry.FileSystemCertificateH\x00R\x15FileSystemCertificateB\a\n" +
+	"\x15FileSystemCertificate\x18\x12 \x01(\v2<.hashicorp.consul.internal.configentry.FileSystemCertificateH\x00R\x15FileSystemCertificate\x12P\n" +
+	"\tAIGateway\x18\x13 \x01(\v20.hashicorp.consul.internal.configentry.AIGatewayH\x00R\tAIGatewayB\a\n" +
 	"\x05Entry\"\xf8\x04\n" +
 	"\n" +
 	"MeshConfig\x12m\n" +
@@ -9310,7 +9992,55 @@ const file_private_pbconfigentry_config_entry_proto_rawDesc = "" +
 	"\x18ExportedServicesConsumer\x12\x1c\n" +
 	"\tPartition\x18\x01 \x01(\tR\tPartition\x12\x12\n" +
 	"\x04Peer\x18\x02 \x01(\tR\x04Peer\x12$\n" +
-	"\rSamenessGroup\x18\x03 \x01(\tR\rSamenessGroup*\xe2\x02\n" +
+	"\rSamenessGroup\x18\x03 \x01(\tR\rSamenessGroup\"\xee\x02\n" +
+	"\tAIGateway\x12W\n" +
+	"\tProcessor\x18\x01 \x01(\v29.hashicorp.consul.internal.configentry.AIGatewayProcessorR\tProcessor\x12\x18\n" +
+	"\aApplyTo\x18\x02 \x03(\tR\aApplyTo\x12Q\n" +
+	"\aRouting\x18\x03 \x01(\v27.hashicorp.consul.internal.configentry.AIGatewayRoutingR\aRouting\x12N\n" +
+	"\x04Meta\x18\x04 \x03(\v2:.hashicorp.consul.internal.configentry.AIGateway.MetaEntryR\x04Meta\x12\x12\n" +
+	"\x04Hash\x18\x05 \x01(\x04R\x04Hash\x1a7\n" +
+	"\tMetaEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"P\n" +
+	"\x12AIGatewayProcessor\x12\x18\n" +
+	"\aUDSPath\x18\x01 \x01(\tR\aUDSPath\x12 \n" +
+	"\vFailureMode\x18\x02 \x01(\tR\vFailureMode\"\xb2\x03\n" +
+	"\x10AIGatewayRouting\x12Y\n" +
+	"\n" +
+	"MatchRules\x18\x01 \x03(\v29.hashicorp.consul.internal.configentry.AIGatewayMatchRuleR\n" +
+	"MatchRules\x12$\n" +
+	"\rFallbackChain\x18\x02 \x03(\tR\rFallbackChain\x12K\n" +
+	"\x05Retry\x18\x03 \x01(\v25.hashicorp.consul.internal.configentry.AIGatewayRetryR\x05Retry\x12Q\n" +
+	"\aTimeout\x18\x04 \x01(\v27.hashicorp.consul.internal.configentry.AIGatewayTimeoutR\aTimeout\x12Q\n" +
+	"\aScoring\x18\x05 \x01(\v27.hashicorp.consul.internal.configentry.AIGatewayScoringR\aScoring\x12*\n" +
+	"\x10ConfigValidation\x18\x06 \x01(\tR\x10ConfigValidation\"\xd7\x01\n" +
+	"\x12AIGatewayMatchRule\x12I\n" +
+	"\x04When\x18\x01 \x01(\v25.hashicorp.consul.internal.configentry.AIGatewayMatchR\x04When\x120\n" +
+	"\x13RequireCapabilities\x18\x02 \x03(\tR\x13RequireCapabilities\x12\x1e\n" +
+	"\n" +
+	"Candidates\x18\x03 \x03(\tR\n" +
+	"Candidates\x12$\n" +
+	"\rFallbackChain\x18\x04 \x03(\tR\rFallbackChain\"\x99\x01\n" +
+	"\x0eAIGatewayMatch\x12\x12\n" +
+	"\x04Path\x18\x01 \x01(\tR\x04Path\x12\x18\n" +
+	"\aBodyHas\x18\x02 \x03(\tR\aBodyHas\x12Y\n" +
+	"\bIdentity\x18\x03 \x01(\v2=.hashicorp.consul.internal.configentry.AIGatewayIdentityMatchR\bIdentity\"n\n" +
+	"\x16AIGatewayIdentityMatch\x12\x18\n" +
+	"\aService\x18\x01 \x01(\tR\aService\x12\x1c\n" +
+	"\tPartition\x18\x02 \x01(\tR\tPartition\x12\x1c\n" +
+	"\tNamespace\x18\x03 \x01(\tR\tNamespace\"L\n" +
+	"\x0eAIGatewayRetry\x12 \n" +
+	"\vMaxAttempts\x18\x01 \x01(\x05R\vMaxAttempts\x12\x18\n" +
+	"\aRetryOn\x18\x02 \x03(\tR\aRetryOn\"F\n" +
+	"\x10AIGatewayTimeout\x12\x18\n" +
+	"\aConnect\x18\x01 \x01(\tR\aConnect\x12\x18\n" +
+	"\aRequest\x18\x02 \x01(\tR\aRequest\"\x92\x01\n" +
+	"\x10AIGatewayScoring\x12\x18\n" +
+	"\aScorers\x18\x01 \x03(\tR\aScorers\x12d\n" +
+	"\rWeightedSplit\x18\x02 \x03(\v2>.hashicorp.consul.internal.configentry.AIGatewayWeightedTargetR\rWeightedSplit\"K\n" +
+	"\x17AIGatewayWeightedTarget\x12\x18\n" +
+	"\aCluster\x18\x01 \x01(\tR\aCluster\x12\x16\n" +
+	"\x06Weight\x18\x02 \x01(\x05R\x06Weight*\xf5\x02\n" +
 	"\x04Kind\x12\x0f\n" +
 	"\vKindUnknown\x10\x00\x12\x12\n" +
 	"\x0eKindMeshConfig\x10\x01\x12\x17\n" +
@@ -9327,7 +10057,8 @@ const file_private_pbconfigentry_config_entry_proto_rawDesc = "" +
 	"\x11KindSamenessGroup\x10\v\x12\x13\n" +
 	"\x0fKindJWTProvider\x10\f\x12\x18\n" +
 	"\x14KindExportedServices\x10\r\x12\x1d\n" +
-	"\x19KindFileSystemCertificate\x10\x0e*\xfe\x01\n" +
+	"\x19KindFileSystemCertificate\x10\x0e\x12\x11\n" +
+	"\rKindAIGateway\x10\x0f*\xfe\x01\n" +
 	"\x1cPathWithEscapedSlashesAction\x12'\n" +
 	"#PathWithEscapedSlashesActionDefault\x10\x00\x12$\n" +
 	" PathWithEscapedSlashesActionKeep\x10\x01\x12&\n" +
@@ -9403,7 +10134,7 @@ func file_private_pbconfigentry_config_entry_proto_rawDescGZIP() []byte {
 }
 
 var file_private_pbconfigentry_config_entry_proto_enumTypes = make([]protoimpl.EnumInfo, 13)
-var file_private_pbconfigentry_config_entry_proto_msgTypes = make([]protoimpl.MessageInfo, 132)
+var file_private_pbconfigentry_config_entry_proto_msgTypes = make([]protoimpl.MessageInfo, 143)
 var file_private_pbconfigentry_config_entry_proto_goTypes = []any{
 	(Kind)(0),                                   // 0: hashicorp.consul.internal.configentry.Kind
 	(PathWithEscapedSlashesAction)(0),           // 1: hashicorp.consul.internal.configentry.PathWithEscapedSlashesAction
@@ -9527,44 +10258,55 @@ var file_private_pbconfigentry_config_entry_proto_goTypes = []any{
 	(*ExportedServices)(nil),                    // 119: hashicorp.consul.internal.configentry.ExportedServices
 	(*ExportedServicesService)(nil),             // 120: hashicorp.consul.internal.configentry.ExportedServicesService
 	(*ExportedServicesConsumer)(nil),            // 121: hashicorp.consul.internal.configentry.ExportedServicesConsumer
-	nil,                                         // 122: hashicorp.consul.internal.configentry.MeshConfig.MetaEntry
-	nil,                                         // 123: hashicorp.consul.internal.configentry.ServiceResolver.SubsetsEntry
-	nil,                                         // 124: hashicorp.consul.internal.configentry.ServiceResolver.FailoverEntry
-	nil,                                         // 125: hashicorp.consul.internal.configentry.ServiceResolver.MetaEntry
-	nil,                                         // 126: hashicorp.consul.internal.configentry.IngressGateway.MetaEntry
-	nil,                                         // 127: hashicorp.consul.internal.configentry.IngressService.MetaEntry
-	nil,                                         // 128: hashicorp.consul.internal.configentry.HTTPHeaderModifiers.AddEntry
-	nil,                                         // 129: hashicorp.consul.internal.configentry.HTTPHeaderModifiers.SetEntry
-	nil,                                         // 130: hashicorp.consul.internal.configentry.ServiceIntentions.MetaEntry
-	nil,                                         // 131: hashicorp.consul.internal.configentry.SourceIntention.LegacyMetaEntry
-	nil,                                         // 132: hashicorp.consul.internal.configentry.ServiceDefaults.MetaEntry
-	nil,                                         // 133: hashicorp.consul.internal.configentry.APIGateway.MetaEntry
-	nil,                                         // 134: hashicorp.consul.internal.configentry.BoundAPIGateway.MetaEntry
-	nil,                                         // 135: hashicorp.consul.internal.configentry.BoundAPIGateway.ServicesEntry
-	nil,                                         // 136: hashicorp.consul.internal.configentry.FileSystemCertificate.MetaEntry
-	nil,                                         // 137: hashicorp.consul.internal.configentry.InlineCertificate.MetaEntry
-	nil,                                         // 138: hashicorp.consul.internal.configentry.HTTPRoute.MetaEntry
-	nil,                                         // 139: hashicorp.consul.internal.configentry.HTTPHeaderFilter.AddEntry
-	nil,                                         // 140: hashicorp.consul.internal.configentry.HTTPHeaderFilter.SetEntry
-	nil,                                         // 141: hashicorp.consul.internal.configentry.TCPRoute.MetaEntry
-	nil,                                         // 142: hashicorp.consul.internal.configentry.SamenessGroup.MetaEntry
-	nil,                                         // 143: hashicorp.consul.internal.configentry.JWTProvider.MetaEntry
-	nil,                                         // 144: hashicorp.consul.internal.configentry.ExportedServices.MetaEntry
-	(*pbcommon.EnterpriseMeta)(nil),             // 145: hashicorp.consul.internal.common.EnterpriseMeta
-	(*pbcommon.RaftIndex)(nil),                  // 146: hashicorp.consul.internal.common.RaftIndex
-	(*durationpb.Duration)(nil),                 // 147: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),               // 148: google.protobuf.Timestamp
-	(*pbcommon.EnvoyExtension)(nil),             // 149: hashicorp.consul.internal.common.EnvoyExtension
+	(*AIGateway)(nil),                           // 122: hashicorp.consul.internal.configentry.AIGateway
+	(*AIGatewayProcessor)(nil),                  // 123: hashicorp.consul.internal.configentry.AIGatewayProcessor
+	(*AIGatewayRouting)(nil),                    // 124: hashicorp.consul.internal.configentry.AIGatewayRouting
+	(*AIGatewayMatchRule)(nil),                  // 125: hashicorp.consul.internal.configentry.AIGatewayMatchRule
+	(*AIGatewayMatch)(nil),                      // 126: hashicorp.consul.internal.configentry.AIGatewayMatch
+	(*AIGatewayIdentityMatch)(nil),              // 127: hashicorp.consul.internal.configentry.AIGatewayIdentityMatch
+	(*AIGatewayRetry)(nil),                      // 128: hashicorp.consul.internal.configentry.AIGatewayRetry
+	(*AIGatewayTimeout)(nil),                    // 129: hashicorp.consul.internal.configentry.AIGatewayTimeout
+	(*AIGatewayScoring)(nil),                    // 130: hashicorp.consul.internal.configentry.AIGatewayScoring
+	(*AIGatewayWeightedTarget)(nil),             // 131: hashicorp.consul.internal.configentry.AIGatewayWeightedTarget
+	nil,                                         // 132: hashicorp.consul.internal.configentry.MeshConfig.MetaEntry
+	nil,                                         // 133: hashicorp.consul.internal.configentry.ServiceResolver.SubsetsEntry
+	nil,                                         // 134: hashicorp.consul.internal.configentry.ServiceResolver.FailoverEntry
+	nil,                                         // 135: hashicorp.consul.internal.configentry.ServiceResolver.MetaEntry
+	nil,                                         // 136: hashicorp.consul.internal.configentry.IngressGateway.MetaEntry
+	nil,                                         // 137: hashicorp.consul.internal.configentry.IngressService.MetaEntry
+	nil,                                         // 138: hashicorp.consul.internal.configentry.HTTPHeaderModifiers.AddEntry
+	nil,                                         // 139: hashicorp.consul.internal.configentry.HTTPHeaderModifiers.SetEntry
+	nil,                                         // 140: hashicorp.consul.internal.configentry.ServiceIntentions.MetaEntry
+	nil,                                         // 141: hashicorp.consul.internal.configentry.SourceIntention.LegacyMetaEntry
+	nil,                                         // 142: hashicorp.consul.internal.configentry.ServiceDefaults.MetaEntry
+	nil,                                         // 143: hashicorp.consul.internal.configentry.APIGateway.MetaEntry
+	nil,                                         // 144: hashicorp.consul.internal.configentry.BoundAPIGateway.MetaEntry
+	nil,                                         // 145: hashicorp.consul.internal.configentry.BoundAPIGateway.ServicesEntry
+	nil,                                         // 146: hashicorp.consul.internal.configentry.FileSystemCertificate.MetaEntry
+	nil,                                         // 147: hashicorp.consul.internal.configentry.InlineCertificate.MetaEntry
+	nil,                                         // 148: hashicorp.consul.internal.configentry.HTTPRoute.MetaEntry
+	nil,                                         // 149: hashicorp.consul.internal.configentry.HTTPHeaderFilter.AddEntry
+	nil,                                         // 150: hashicorp.consul.internal.configentry.HTTPHeaderFilter.SetEntry
+	nil,                                         // 151: hashicorp.consul.internal.configentry.TCPRoute.MetaEntry
+	nil,                                         // 152: hashicorp.consul.internal.configentry.SamenessGroup.MetaEntry
+	nil,                                         // 153: hashicorp.consul.internal.configentry.JWTProvider.MetaEntry
+	nil,                                         // 154: hashicorp.consul.internal.configentry.ExportedServices.MetaEntry
+	nil,                                         // 155: hashicorp.consul.internal.configentry.AIGateway.MetaEntry
+	(*pbcommon.EnterpriseMeta)(nil),             // 156: hashicorp.consul.internal.common.EnterpriseMeta
+	(*pbcommon.RaftIndex)(nil),                  // 157: hashicorp.consul.internal.common.RaftIndex
+	(*durationpb.Duration)(nil),                 // 158: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),               // 159: google.protobuf.Timestamp
+	(*pbcommon.EnvoyExtension)(nil),             // 160: hashicorp.consul.internal.common.EnvoyExtension
 }
 var file_private_pbconfigentry_config_entry_proto_depIdxs = []int32{
 	15,  // 0: hashicorp.consul.internal.configentry.GetResolvedExportedServicesResponse.services:type_name -> hashicorp.consul.internal.configentry.ResolvedExportedService
-	145, // 1: hashicorp.consul.internal.configentry.ResolvedExportedService.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	156, // 1: hashicorp.consul.internal.configentry.ResolvedExportedService.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
 	16,  // 2: hashicorp.consul.internal.configentry.ResolvedExportedService.Consumers:type_name -> hashicorp.consul.internal.configentry.Consumers
 	19,  // 3: hashicorp.consul.internal.configentry.GetImportedServicesResponse.Services:type_name -> hashicorp.consul.internal.configentry.ImportedService
-	145, // 4: hashicorp.consul.internal.configentry.ImportedService.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	156, // 4: hashicorp.consul.internal.configentry.ImportedService.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
 	0,   // 5: hashicorp.consul.internal.configentry.ConfigEntry.Kind:type_name -> hashicorp.consul.internal.configentry.Kind
-	145, // 6: hashicorp.consul.internal.configentry.ConfigEntry.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
-	146, // 7: hashicorp.consul.internal.configentry.ConfigEntry.RaftIndex:type_name -> hashicorp.consul.internal.common.RaftIndex
+	156, // 6: hashicorp.consul.internal.configentry.ConfigEntry.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	157, // 7: hashicorp.consul.internal.configentry.ConfigEntry.RaftIndex:type_name -> hashicorp.consul.internal.common.RaftIndex
 	21,  // 8: hashicorp.consul.internal.configentry.ConfigEntry.MeshConfig:type_name -> hashicorp.consul.internal.configentry.MeshConfig
 	29,  // 9: hashicorp.consul.internal.configentry.ConfigEntry.ServiceResolver:type_name -> hashicorp.consul.internal.configentry.ServiceResolver
 	41,  // 10: hashicorp.consul.internal.configentry.ConfigEntry.IngressGateway:type_name -> hashicorp.consul.internal.configentry.IngressGateway
@@ -9579,190 +10321,201 @@ var file_private_pbconfigentry_config_entry_proto_depIdxs = []int32{
 	103, // 19: hashicorp.consul.internal.configentry.ConfigEntry.JWTProvider:type_name -> hashicorp.consul.internal.configentry.JWTProvider
 	119, // 20: hashicorp.consul.internal.configentry.ConfigEntry.ExportedServices:type_name -> hashicorp.consul.internal.configentry.ExportedServices
 	83,  // 21: hashicorp.consul.internal.configentry.ConfigEntry.FileSystemCertificate:type_name -> hashicorp.consul.internal.configentry.FileSystemCertificate
-	22,  // 22: hashicorp.consul.internal.configentry.MeshConfig.TransparentProxy:type_name -> hashicorp.consul.internal.configentry.TransparentProxyMeshConfig
-	23,  // 23: hashicorp.consul.internal.configentry.MeshConfig.TLS:type_name -> hashicorp.consul.internal.configentry.MeshTLSConfig
-	25,  // 24: hashicorp.consul.internal.configentry.MeshConfig.HTTP:type_name -> hashicorp.consul.internal.configentry.MeshHTTPConfig
-	122, // 25: hashicorp.consul.internal.configentry.MeshConfig.Meta:type_name -> hashicorp.consul.internal.configentry.MeshConfig.MetaEntry
-	27,  // 26: hashicorp.consul.internal.configentry.MeshConfig.Peering:type_name -> hashicorp.consul.internal.configentry.PeeringMeshConfig
-	24,  // 27: hashicorp.consul.internal.configentry.MeshTLSConfig.Incoming:type_name -> hashicorp.consul.internal.configentry.MeshDirectionalTLSConfig
-	24,  // 28: hashicorp.consul.internal.configentry.MeshTLSConfig.Outgoing:type_name -> hashicorp.consul.internal.configentry.MeshDirectionalTLSConfig
-	26,  // 29: hashicorp.consul.internal.configentry.MeshHTTPConfig.Incoming:type_name -> hashicorp.consul.internal.configentry.MeshDirectionalHTTPConfig
-	28,  // 30: hashicorp.consul.internal.configentry.MeshDirectionalHTTPConfig.RequestNormalization:type_name -> hashicorp.consul.internal.configentry.RequestNormalizationMeshConfig
-	1,   // 31: hashicorp.consul.internal.configentry.RequestNormalizationMeshConfig.PathWithEscapedSlashesAction:type_name -> hashicorp.consul.internal.configentry.PathWithEscapedSlashesAction
-	2,   // 32: hashicorp.consul.internal.configentry.RequestNormalizationMeshConfig.HeadersWithUnderscoresAction:type_name -> hashicorp.consul.internal.configentry.HeadersWithUnderscoresAction
-	123, // 33: hashicorp.consul.internal.configentry.ServiceResolver.Subsets:type_name -> hashicorp.consul.internal.configentry.ServiceResolver.SubsetsEntry
-	31,  // 34: hashicorp.consul.internal.configentry.ServiceResolver.Redirect:type_name -> hashicorp.consul.internal.configentry.ServiceResolverRedirect
-	124, // 35: hashicorp.consul.internal.configentry.ServiceResolver.Failover:type_name -> hashicorp.consul.internal.configentry.ServiceResolver.FailoverEntry
-	147, // 36: hashicorp.consul.internal.configentry.ServiceResolver.ConnectTimeout:type_name -> google.protobuf.Duration
-	36,  // 37: hashicorp.consul.internal.configentry.ServiceResolver.LoadBalancer:type_name -> hashicorp.consul.internal.configentry.LoadBalancer
-	125, // 38: hashicorp.consul.internal.configentry.ServiceResolver.Meta:type_name -> hashicorp.consul.internal.configentry.ServiceResolver.MetaEntry
-	147, // 39: hashicorp.consul.internal.configentry.ServiceResolver.RequestTimeout:type_name -> google.protobuf.Duration
-	34,  // 40: hashicorp.consul.internal.configentry.ServiceResolver.PrioritizeByLocality:type_name -> hashicorp.consul.internal.configentry.ServiceResolverPrioritizeByLocality
-	35,  // 41: hashicorp.consul.internal.configentry.ServiceResolverFailover.Targets:type_name -> hashicorp.consul.internal.configentry.ServiceResolverFailoverTarget
-	33,  // 42: hashicorp.consul.internal.configentry.ServiceResolverFailover.Policy:type_name -> hashicorp.consul.internal.configentry.ServiceResolverFailoverPolicy
-	37,  // 43: hashicorp.consul.internal.configentry.LoadBalancer.RingHashConfig:type_name -> hashicorp.consul.internal.configentry.RingHashConfig
-	38,  // 44: hashicorp.consul.internal.configentry.LoadBalancer.LeastRequestConfig:type_name -> hashicorp.consul.internal.configentry.LeastRequestConfig
-	39,  // 45: hashicorp.consul.internal.configentry.LoadBalancer.HashPolicies:type_name -> hashicorp.consul.internal.configentry.HashPolicy
-	40,  // 46: hashicorp.consul.internal.configentry.HashPolicy.CookieConfig:type_name -> hashicorp.consul.internal.configentry.CookieConfig
-	147, // 47: hashicorp.consul.internal.configentry.CookieConfig.TTL:type_name -> google.protobuf.Duration
-	43,  // 48: hashicorp.consul.internal.configentry.IngressGateway.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSConfig
-	45,  // 49: hashicorp.consul.internal.configentry.IngressGateway.Listeners:type_name -> hashicorp.consul.internal.configentry.IngressListener
-	126, // 50: hashicorp.consul.internal.configentry.IngressGateway.Meta:type_name -> hashicorp.consul.internal.configentry.IngressGateway.MetaEntry
-	42,  // 51: hashicorp.consul.internal.configentry.IngressGateway.Defaults:type_name -> hashicorp.consul.internal.configentry.IngressServiceConfig
-	65,  // 52: hashicorp.consul.internal.configentry.IngressServiceConfig.PassiveHealthCheck:type_name -> hashicorp.consul.internal.configentry.PassiveHealthCheck
-	44,  // 53: hashicorp.consul.internal.configentry.GatewayTLSConfig.SDS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSSDSConfig
-	46,  // 54: hashicorp.consul.internal.configentry.IngressListener.Services:type_name -> hashicorp.consul.internal.configentry.IngressService
-	43,  // 55: hashicorp.consul.internal.configentry.IngressListener.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSConfig
-	47,  // 56: hashicorp.consul.internal.configentry.IngressService.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayServiceTLSConfig
-	48,  // 57: hashicorp.consul.internal.configentry.IngressService.RequestHeaders:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderModifiers
-	48,  // 58: hashicorp.consul.internal.configentry.IngressService.ResponseHeaders:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderModifiers
-	127, // 59: hashicorp.consul.internal.configentry.IngressService.Meta:type_name -> hashicorp.consul.internal.configentry.IngressService.MetaEntry
-	145, // 60: hashicorp.consul.internal.configentry.IngressService.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
-	65,  // 61: hashicorp.consul.internal.configentry.IngressService.PassiveHealthCheck:type_name -> hashicorp.consul.internal.configentry.PassiveHealthCheck
-	44,  // 62: hashicorp.consul.internal.configentry.GatewayServiceTLSConfig.SDS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSSDSConfig
-	128, // 63: hashicorp.consul.internal.configentry.HTTPHeaderModifiers.Add:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderModifiers.AddEntry
-	129, // 64: hashicorp.consul.internal.configentry.HTTPHeaderModifiers.Set:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderModifiers.SetEntry
-	53,  // 65: hashicorp.consul.internal.configentry.ServiceIntentions.Sources:type_name -> hashicorp.consul.internal.configentry.SourceIntention
-	130, // 66: hashicorp.consul.internal.configentry.ServiceIntentions.Meta:type_name -> hashicorp.consul.internal.configentry.ServiceIntentions.MetaEntry
-	50,  // 67: hashicorp.consul.internal.configentry.ServiceIntentions.JWT:type_name -> hashicorp.consul.internal.configentry.IntentionJWTRequirement
-	51,  // 68: hashicorp.consul.internal.configentry.IntentionJWTRequirement.Providers:type_name -> hashicorp.consul.internal.configentry.IntentionJWTProvider
-	52,  // 69: hashicorp.consul.internal.configentry.IntentionJWTProvider.VerifyClaims:type_name -> hashicorp.consul.internal.configentry.IntentionJWTClaimVerification
-	3,   // 70: hashicorp.consul.internal.configentry.SourceIntention.Action:type_name -> hashicorp.consul.internal.configentry.IntentionAction
-	54,  // 71: hashicorp.consul.internal.configentry.SourceIntention.Permissions:type_name -> hashicorp.consul.internal.configentry.IntentionPermission
-	4,   // 72: hashicorp.consul.internal.configentry.SourceIntention.Type:type_name -> hashicorp.consul.internal.configentry.IntentionSourceType
-	131, // 73: hashicorp.consul.internal.configentry.SourceIntention.LegacyMeta:type_name -> hashicorp.consul.internal.configentry.SourceIntention.LegacyMetaEntry
-	148, // 74: hashicorp.consul.internal.configentry.SourceIntention.LegacyCreateTime:type_name -> google.protobuf.Timestamp
-	148, // 75: hashicorp.consul.internal.configentry.SourceIntention.LegacyUpdateTime:type_name -> google.protobuf.Timestamp
-	145, // 76: hashicorp.consul.internal.configentry.SourceIntention.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
-	3,   // 77: hashicorp.consul.internal.configentry.IntentionPermission.Action:type_name -> hashicorp.consul.internal.configentry.IntentionAction
-	55,  // 78: hashicorp.consul.internal.configentry.IntentionPermission.HTTP:type_name -> hashicorp.consul.internal.configentry.IntentionHTTPPermission
-	50,  // 79: hashicorp.consul.internal.configentry.IntentionPermission.JWT:type_name -> hashicorp.consul.internal.configentry.IntentionJWTRequirement
-	56,  // 80: hashicorp.consul.internal.configentry.IntentionHTTPPermission.Header:type_name -> hashicorp.consul.internal.configentry.IntentionHTTPHeaderPermission
-	5,   // 81: hashicorp.consul.internal.configentry.ServiceDefaults.Mode:type_name -> hashicorp.consul.internal.configentry.ProxyMode
-	58,  // 82: hashicorp.consul.internal.configentry.ServiceDefaults.TransparentProxy:type_name -> hashicorp.consul.internal.configentry.TransparentProxyConfig
-	59,  // 83: hashicorp.consul.internal.configentry.ServiceDefaults.MeshGateway:type_name -> hashicorp.consul.internal.configentry.MeshGatewayConfig
-	60,  // 84: hashicorp.consul.internal.configentry.ServiceDefaults.Expose:type_name -> hashicorp.consul.internal.configentry.ExposeConfig
-	62,  // 85: hashicorp.consul.internal.configentry.ServiceDefaults.UpstreamConfig:type_name -> hashicorp.consul.internal.configentry.UpstreamConfiguration
-	66,  // 86: hashicorp.consul.internal.configentry.ServiceDefaults.Destination:type_name -> hashicorp.consul.internal.configentry.DestinationConfig
-	67,  // 87: hashicorp.consul.internal.configentry.ServiceDefaults.RateLimits:type_name -> hashicorp.consul.internal.configentry.RateLimits
-	132, // 88: hashicorp.consul.internal.configentry.ServiceDefaults.Meta:type_name -> hashicorp.consul.internal.configentry.ServiceDefaults.MetaEntry
-	149, // 89: hashicorp.consul.internal.configentry.ServiceDefaults.EnvoyExtensions:type_name -> hashicorp.consul.internal.common.EnvoyExtension
-	6,   // 90: hashicorp.consul.internal.configentry.ServiceDefaults.MutualTLSMode:type_name -> hashicorp.consul.internal.configentry.MutualTLSMode
-	7,   // 91: hashicorp.consul.internal.configentry.MeshGatewayConfig.Mode:type_name -> hashicorp.consul.internal.configentry.MeshGatewayMode
-	61,  // 92: hashicorp.consul.internal.configentry.ExposeConfig.Paths:type_name -> hashicorp.consul.internal.configentry.ExposePath
-	63,  // 93: hashicorp.consul.internal.configentry.UpstreamConfiguration.Overrides:type_name -> hashicorp.consul.internal.configentry.UpstreamConfig
-	63,  // 94: hashicorp.consul.internal.configentry.UpstreamConfiguration.Defaults:type_name -> hashicorp.consul.internal.configentry.UpstreamConfig
-	145, // 95: hashicorp.consul.internal.configentry.UpstreamConfig.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
-	64,  // 96: hashicorp.consul.internal.configentry.UpstreamConfig.Limits:type_name -> hashicorp.consul.internal.configentry.UpstreamLimits
-	65,  // 97: hashicorp.consul.internal.configentry.UpstreamConfig.PassiveHealthCheck:type_name -> hashicorp.consul.internal.configentry.PassiveHealthCheck
-	59,  // 98: hashicorp.consul.internal.configentry.UpstreamConfig.MeshGateway:type_name -> hashicorp.consul.internal.configentry.MeshGatewayConfig
-	147, // 99: hashicorp.consul.internal.configentry.PassiveHealthCheck.Interval:type_name -> google.protobuf.Duration
-	147, // 100: hashicorp.consul.internal.configentry.PassiveHealthCheck.BaseEjectionTime:type_name -> google.protobuf.Duration
-	68,  // 101: hashicorp.consul.internal.configentry.RateLimits.InstanceLevel:type_name -> hashicorp.consul.internal.configentry.InstanceLevelRateLimits
-	69,  // 102: hashicorp.consul.internal.configentry.InstanceLevelRateLimits.Routes:type_name -> hashicorp.consul.internal.configentry.InstanceLevelRouteRateLimits
-	133, // 103: hashicorp.consul.internal.configentry.APIGateway.Meta:type_name -> hashicorp.consul.internal.configentry.APIGateway.MetaEntry
-	73,  // 104: hashicorp.consul.internal.configentry.APIGateway.Listeners:type_name -> hashicorp.consul.internal.configentry.APIGatewayListener
-	71,  // 105: hashicorp.consul.internal.configentry.APIGateway.Status:type_name -> hashicorp.consul.internal.configentry.Status
-	43,  // 106: hashicorp.consul.internal.configentry.APIGateway.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSConfig
-	64,  // 107: hashicorp.consul.internal.configentry.APIGateway.Defaults:type_name -> hashicorp.consul.internal.configentry.UpstreamLimits
-	72,  // 108: hashicorp.consul.internal.configentry.Status.Conditions:type_name -> hashicorp.consul.internal.configentry.Condition
-	79,  // 109: hashicorp.consul.internal.configentry.Condition.Resource:type_name -> hashicorp.consul.internal.configentry.ResourceReference
-	148, // 110: hashicorp.consul.internal.configentry.Condition.LastTransitionTime:type_name -> google.protobuf.Timestamp
-	8,   // 111: hashicorp.consul.internal.configentry.APIGatewayListener.Protocol:type_name -> hashicorp.consul.internal.configentry.APIGatewayListenerProtocol
-	74,  // 112: hashicorp.consul.internal.configentry.APIGatewayListener.TLS:type_name -> hashicorp.consul.internal.configentry.APIGatewayTLSConfiguration
-	75,  // 113: hashicorp.consul.internal.configentry.APIGatewayListener.Override:type_name -> hashicorp.consul.internal.configentry.APIGatewayPolicy
-	75,  // 114: hashicorp.consul.internal.configentry.APIGatewayListener.Default:type_name -> hashicorp.consul.internal.configentry.APIGatewayPolicy
-	79,  // 115: hashicorp.consul.internal.configentry.APIGatewayTLSConfiguration.Certificates:type_name -> hashicorp.consul.internal.configentry.ResourceReference
-	44,  // 116: hashicorp.consul.internal.configentry.APIGatewayTLSConfiguration.SDS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSSDSConfig
-	76,  // 117: hashicorp.consul.internal.configentry.APIGatewayPolicy.JWT:type_name -> hashicorp.consul.internal.configentry.APIGatewayJWTRequirement
-	77,  // 118: hashicorp.consul.internal.configentry.APIGatewayJWTRequirement.Providers:type_name -> hashicorp.consul.internal.configentry.APIGatewayJWTProvider
-	78,  // 119: hashicorp.consul.internal.configentry.APIGatewayJWTProvider.VerifyClaims:type_name -> hashicorp.consul.internal.configentry.APIGatewayJWTClaimVerification
-	145, // 120: hashicorp.consul.internal.configentry.ResourceReference.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
-	134, // 121: hashicorp.consul.internal.configentry.BoundAPIGateway.Meta:type_name -> hashicorp.consul.internal.configentry.BoundAPIGateway.MetaEntry
-	82,  // 122: hashicorp.consul.internal.configentry.BoundAPIGateway.Listeners:type_name -> hashicorp.consul.internal.configentry.BoundAPIGatewayListener
-	135, // 123: hashicorp.consul.internal.configentry.BoundAPIGateway.Services:type_name -> hashicorp.consul.internal.configentry.BoundAPIGateway.ServicesEntry
-	79,  // 124: hashicorp.consul.internal.configentry.ListOfResourceReference.Ref:type_name -> hashicorp.consul.internal.configentry.ResourceReference
-	79,  // 125: hashicorp.consul.internal.configentry.BoundAPIGatewayListener.Certificates:type_name -> hashicorp.consul.internal.configentry.ResourceReference
-	79,  // 126: hashicorp.consul.internal.configentry.BoundAPIGatewayListener.Routes:type_name -> hashicorp.consul.internal.configentry.ResourceReference
-	136, // 127: hashicorp.consul.internal.configentry.FileSystemCertificate.Meta:type_name -> hashicorp.consul.internal.configentry.FileSystemCertificate.MetaEntry
-	137, // 128: hashicorp.consul.internal.configentry.InlineCertificate.Meta:type_name -> hashicorp.consul.internal.configentry.InlineCertificate.MetaEntry
-	138, // 129: hashicorp.consul.internal.configentry.HTTPRoute.Meta:type_name -> hashicorp.consul.internal.configentry.HTTPRoute.MetaEntry
-	79,  // 130: hashicorp.consul.internal.configentry.HTTPRoute.Parents:type_name -> hashicorp.consul.internal.configentry.ResourceReference
-	86,  // 131: hashicorp.consul.internal.configentry.HTTPRoute.Rules:type_name -> hashicorp.consul.internal.configentry.HTTPRouteRule
-	71,  // 132: hashicorp.consul.internal.configentry.HTTPRoute.Status:type_name -> hashicorp.consul.internal.configentry.Status
-	91,  // 133: hashicorp.consul.internal.configentry.HTTPRouteRule.Filters:type_name -> hashicorp.consul.internal.configentry.HTTPFilters
-	87,  // 134: hashicorp.consul.internal.configentry.HTTPRouteRule.Matches:type_name -> hashicorp.consul.internal.configentry.HTTPMatch
-	98,  // 135: hashicorp.consul.internal.configentry.HTTPRouteRule.Services:type_name -> hashicorp.consul.internal.configentry.HTTPService
-	92,  // 136: hashicorp.consul.internal.configentry.HTTPRouteRule.ResponseFilters:type_name -> hashicorp.consul.internal.configentry.HTTPResponseFilters
-	88,  // 137: hashicorp.consul.internal.configentry.HTTPMatch.Headers:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderMatch
-	9,   // 138: hashicorp.consul.internal.configentry.HTTPMatch.Method:type_name -> hashicorp.consul.internal.configentry.HTTPMatchMethod
-	89,  // 139: hashicorp.consul.internal.configentry.HTTPMatch.Path:type_name -> hashicorp.consul.internal.configentry.HTTPPathMatch
-	90,  // 140: hashicorp.consul.internal.configentry.HTTPMatch.Query:type_name -> hashicorp.consul.internal.configentry.HTTPQueryMatch
-	10,  // 141: hashicorp.consul.internal.configentry.HTTPHeaderMatch.Match:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderMatchType
-	11,  // 142: hashicorp.consul.internal.configentry.HTTPPathMatch.Match:type_name -> hashicorp.consul.internal.configentry.HTTPPathMatchType
-	12,  // 143: hashicorp.consul.internal.configentry.HTTPQueryMatch.Match:type_name -> hashicorp.consul.internal.configentry.HTTPQueryMatchType
-	97,  // 144: hashicorp.consul.internal.configentry.HTTPFilters.Headers:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderFilter
-	93,  // 145: hashicorp.consul.internal.configentry.HTTPFilters.URLRewrite:type_name -> hashicorp.consul.internal.configentry.URLRewrite
-	94,  // 146: hashicorp.consul.internal.configentry.HTTPFilters.RetryFilter:type_name -> hashicorp.consul.internal.configentry.RetryFilter
-	95,  // 147: hashicorp.consul.internal.configentry.HTTPFilters.TimeoutFilter:type_name -> hashicorp.consul.internal.configentry.TimeoutFilter
-	96,  // 148: hashicorp.consul.internal.configentry.HTTPFilters.JWT:type_name -> hashicorp.consul.internal.configentry.JWTFilter
-	97,  // 149: hashicorp.consul.internal.configentry.HTTPResponseFilters.Headers:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderFilter
-	147, // 150: hashicorp.consul.internal.configentry.TimeoutFilter.RequestTimeout:type_name -> google.protobuf.Duration
-	147, // 151: hashicorp.consul.internal.configentry.TimeoutFilter.IdleTimeout:type_name -> google.protobuf.Duration
-	77,  // 152: hashicorp.consul.internal.configentry.JWTFilter.Providers:type_name -> hashicorp.consul.internal.configentry.APIGatewayJWTProvider
-	139, // 153: hashicorp.consul.internal.configentry.HTTPHeaderFilter.Add:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderFilter.AddEntry
-	140, // 154: hashicorp.consul.internal.configentry.HTTPHeaderFilter.Set:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderFilter.SetEntry
-	91,  // 155: hashicorp.consul.internal.configentry.HTTPService.Filters:type_name -> hashicorp.consul.internal.configentry.HTTPFilters
-	145, // 156: hashicorp.consul.internal.configentry.HTTPService.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
-	92,  // 157: hashicorp.consul.internal.configentry.HTTPService.ResponseFilters:type_name -> hashicorp.consul.internal.configentry.HTTPResponseFilters
-	47,  // 158: hashicorp.consul.internal.configentry.HTTPService.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayServiceTLSConfig
-	64,  // 159: hashicorp.consul.internal.configentry.HTTPService.Limits:type_name -> hashicorp.consul.internal.configentry.UpstreamLimits
-	141, // 160: hashicorp.consul.internal.configentry.TCPRoute.Meta:type_name -> hashicorp.consul.internal.configentry.TCPRoute.MetaEntry
-	79,  // 161: hashicorp.consul.internal.configentry.TCPRoute.Parents:type_name -> hashicorp.consul.internal.configentry.ResourceReference
-	100, // 162: hashicorp.consul.internal.configentry.TCPRoute.Services:type_name -> hashicorp.consul.internal.configentry.TCPService
-	71,  // 163: hashicorp.consul.internal.configentry.TCPRoute.Status:type_name -> hashicorp.consul.internal.configentry.Status
-	145, // 164: hashicorp.consul.internal.configentry.TCPService.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
-	47,  // 165: hashicorp.consul.internal.configentry.TCPService.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayServiceTLSConfig
-	64,  // 166: hashicorp.consul.internal.configentry.TCPService.Limits:type_name -> hashicorp.consul.internal.configentry.UpstreamLimits
-	102, // 167: hashicorp.consul.internal.configentry.SamenessGroup.Members:type_name -> hashicorp.consul.internal.configentry.SamenessGroupMember
-	142, // 168: hashicorp.consul.internal.configentry.SamenessGroup.Meta:type_name -> hashicorp.consul.internal.configentry.SamenessGroup.MetaEntry
-	145, // 169: hashicorp.consul.internal.configentry.SamenessGroup.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
-	104, // 170: hashicorp.consul.internal.configentry.JWTProvider.JSONWebKeySet:type_name -> hashicorp.consul.internal.configentry.JSONWebKeySet
-	113, // 171: hashicorp.consul.internal.configentry.JWTProvider.Locations:type_name -> hashicorp.consul.internal.configentry.JWTLocation
-	117, // 172: hashicorp.consul.internal.configentry.JWTProvider.Forwarding:type_name -> hashicorp.consul.internal.configentry.JWTForwardingConfig
-	118, // 173: hashicorp.consul.internal.configentry.JWTProvider.CacheConfig:type_name -> hashicorp.consul.internal.configentry.JWTCacheConfig
-	143, // 174: hashicorp.consul.internal.configentry.JWTProvider.Meta:type_name -> hashicorp.consul.internal.configentry.JWTProvider.MetaEntry
-	105, // 175: hashicorp.consul.internal.configentry.JSONWebKeySet.Local:type_name -> hashicorp.consul.internal.configentry.LocalJWKS
-	106, // 176: hashicorp.consul.internal.configentry.JSONWebKeySet.Remote:type_name -> hashicorp.consul.internal.configentry.RemoteJWKS
-	147, // 177: hashicorp.consul.internal.configentry.RemoteJWKS.CacheDuration:type_name -> google.protobuf.Duration
-	111, // 178: hashicorp.consul.internal.configentry.RemoteJWKS.RetryPolicy:type_name -> hashicorp.consul.internal.configentry.JWKSRetryPolicy
-	107, // 179: hashicorp.consul.internal.configentry.RemoteJWKS.JWKSCluster:type_name -> hashicorp.consul.internal.configentry.JWKSCluster
-	108, // 180: hashicorp.consul.internal.configentry.JWKSCluster.TLSCertificates:type_name -> hashicorp.consul.internal.configentry.JWKSTLSCertificate
-	147, // 181: hashicorp.consul.internal.configentry.JWKSCluster.ConnectTimeout:type_name -> google.protobuf.Duration
-	109, // 182: hashicorp.consul.internal.configentry.JWKSTLSCertificate.CaCertificateProviderInstance:type_name -> hashicorp.consul.internal.configentry.JWKSTLSCertProviderInstance
-	110, // 183: hashicorp.consul.internal.configentry.JWKSTLSCertificate.TrustedCA:type_name -> hashicorp.consul.internal.configentry.JWKSTLSCertTrustedCA
-	112, // 184: hashicorp.consul.internal.configentry.JWKSRetryPolicy.RetryPolicyBackOff:type_name -> hashicorp.consul.internal.configentry.RetryPolicyBackOff
-	147, // 185: hashicorp.consul.internal.configentry.RetryPolicyBackOff.BaseInterval:type_name -> google.protobuf.Duration
-	147, // 186: hashicorp.consul.internal.configentry.RetryPolicyBackOff.MaxInterval:type_name -> google.protobuf.Duration
-	114, // 187: hashicorp.consul.internal.configentry.JWTLocation.Header:type_name -> hashicorp.consul.internal.configentry.JWTLocationHeader
-	115, // 188: hashicorp.consul.internal.configentry.JWTLocation.QueryParam:type_name -> hashicorp.consul.internal.configentry.JWTLocationQueryParam
-	116, // 189: hashicorp.consul.internal.configentry.JWTLocation.Cookie:type_name -> hashicorp.consul.internal.configentry.JWTLocationCookie
-	145, // 190: hashicorp.consul.internal.configentry.ExportedServices.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
-	144, // 191: hashicorp.consul.internal.configentry.ExportedServices.Meta:type_name -> hashicorp.consul.internal.configentry.ExportedServices.MetaEntry
-	120, // 192: hashicorp.consul.internal.configentry.ExportedServices.Services:type_name -> hashicorp.consul.internal.configentry.ExportedServicesService
-	121, // 193: hashicorp.consul.internal.configentry.ExportedServicesService.Consumers:type_name -> hashicorp.consul.internal.configentry.ExportedServicesConsumer
-	30,  // 194: hashicorp.consul.internal.configentry.ServiceResolver.SubsetsEntry.value:type_name -> hashicorp.consul.internal.configentry.ServiceResolverSubset
-	32,  // 195: hashicorp.consul.internal.configentry.ServiceResolver.FailoverEntry.value:type_name -> hashicorp.consul.internal.configentry.ServiceResolverFailover
-	81,  // 196: hashicorp.consul.internal.configentry.BoundAPIGateway.ServicesEntry.value:type_name -> hashicorp.consul.internal.configentry.ListOfResourceReference
-	13,  // 197: hashicorp.consul.internal.configentry.ConfigEntryService.GetResolvedExportedServices:input_type -> hashicorp.consul.internal.configentry.GetResolvedExportedServicesRequest
-	17,  // 198: hashicorp.consul.internal.configentry.ConfigEntryService.GetImportedServices:input_type -> hashicorp.consul.internal.configentry.GetImportedServicesRequest
-	14,  // 199: hashicorp.consul.internal.configentry.ConfigEntryService.GetResolvedExportedServices:output_type -> hashicorp.consul.internal.configentry.GetResolvedExportedServicesResponse
-	18,  // 200: hashicorp.consul.internal.configentry.ConfigEntryService.GetImportedServices:output_type -> hashicorp.consul.internal.configentry.GetImportedServicesResponse
-	199, // [199:201] is the sub-list for method output_type
-	197, // [197:199] is the sub-list for method input_type
-	197, // [197:197] is the sub-list for extension type_name
-	197, // [197:197] is the sub-list for extension extendee
-	0,   // [0:197] is the sub-list for field type_name
+	122, // 22: hashicorp.consul.internal.configentry.ConfigEntry.AIGateway:type_name -> hashicorp.consul.internal.configentry.AIGateway
+	22,  // 23: hashicorp.consul.internal.configentry.MeshConfig.TransparentProxy:type_name -> hashicorp.consul.internal.configentry.TransparentProxyMeshConfig
+	23,  // 24: hashicorp.consul.internal.configentry.MeshConfig.TLS:type_name -> hashicorp.consul.internal.configentry.MeshTLSConfig
+	25,  // 25: hashicorp.consul.internal.configentry.MeshConfig.HTTP:type_name -> hashicorp.consul.internal.configentry.MeshHTTPConfig
+	132, // 26: hashicorp.consul.internal.configentry.MeshConfig.Meta:type_name -> hashicorp.consul.internal.configentry.MeshConfig.MetaEntry
+	27,  // 27: hashicorp.consul.internal.configentry.MeshConfig.Peering:type_name -> hashicorp.consul.internal.configentry.PeeringMeshConfig
+	24,  // 28: hashicorp.consul.internal.configentry.MeshTLSConfig.Incoming:type_name -> hashicorp.consul.internal.configentry.MeshDirectionalTLSConfig
+	24,  // 29: hashicorp.consul.internal.configentry.MeshTLSConfig.Outgoing:type_name -> hashicorp.consul.internal.configentry.MeshDirectionalTLSConfig
+	26,  // 30: hashicorp.consul.internal.configentry.MeshHTTPConfig.Incoming:type_name -> hashicorp.consul.internal.configentry.MeshDirectionalHTTPConfig
+	28,  // 31: hashicorp.consul.internal.configentry.MeshDirectionalHTTPConfig.RequestNormalization:type_name -> hashicorp.consul.internal.configentry.RequestNormalizationMeshConfig
+	1,   // 32: hashicorp.consul.internal.configentry.RequestNormalizationMeshConfig.PathWithEscapedSlashesAction:type_name -> hashicorp.consul.internal.configentry.PathWithEscapedSlashesAction
+	2,   // 33: hashicorp.consul.internal.configentry.RequestNormalizationMeshConfig.HeadersWithUnderscoresAction:type_name -> hashicorp.consul.internal.configentry.HeadersWithUnderscoresAction
+	133, // 34: hashicorp.consul.internal.configentry.ServiceResolver.Subsets:type_name -> hashicorp.consul.internal.configentry.ServiceResolver.SubsetsEntry
+	31,  // 35: hashicorp.consul.internal.configentry.ServiceResolver.Redirect:type_name -> hashicorp.consul.internal.configentry.ServiceResolverRedirect
+	134, // 36: hashicorp.consul.internal.configentry.ServiceResolver.Failover:type_name -> hashicorp.consul.internal.configentry.ServiceResolver.FailoverEntry
+	158, // 37: hashicorp.consul.internal.configentry.ServiceResolver.ConnectTimeout:type_name -> google.protobuf.Duration
+	36,  // 38: hashicorp.consul.internal.configentry.ServiceResolver.LoadBalancer:type_name -> hashicorp.consul.internal.configentry.LoadBalancer
+	135, // 39: hashicorp.consul.internal.configentry.ServiceResolver.Meta:type_name -> hashicorp.consul.internal.configentry.ServiceResolver.MetaEntry
+	158, // 40: hashicorp.consul.internal.configentry.ServiceResolver.RequestTimeout:type_name -> google.protobuf.Duration
+	34,  // 41: hashicorp.consul.internal.configentry.ServiceResolver.PrioritizeByLocality:type_name -> hashicorp.consul.internal.configentry.ServiceResolverPrioritizeByLocality
+	35,  // 42: hashicorp.consul.internal.configentry.ServiceResolverFailover.Targets:type_name -> hashicorp.consul.internal.configentry.ServiceResolverFailoverTarget
+	33,  // 43: hashicorp.consul.internal.configentry.ServiceResolverFailover.Policy:type_name -> hashicorp.consul.internal.configentry.ServiceResolverFailoverPolicy
+	37,  // 44: hashicorp.consul.internal.configentry.LoadBalancer.RingHashConfig:type_name -> hashicorp.consul.internal.configentry.RingHashConfig
+	38,  // 45: hashicorp.consul.internal.configentry.LoadBalancer.LeastRequestConfig:type_name -> hashicorp.consul.internal.configentry.LeastRequestConfig
+	39,  // 46: hashicorp.consul.internal.configentry.LoadBalancer.HashPolicies:type_name -> hashicorp.consul.internal.configentry.HashPolicy
+	40,  // 47: hashicorp.consul.internal.configentry.HashPolicy.CookieConfig:type_name -> hashicorp.consul.internal.configentry.CookieConfig
+	158, // 48: hashicorp.consul.internal.configentry.CookieConfig.TTL:type_name -> google.protobuf.Duration
+	43,  // 49: hashicorp.consul.internal.configentry.IngressGateway.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSConfig
+	45,  // 50: hashicorp.consul.internal.configentry.IngressGateway.Listeners:type_name -> hashicorp.consul.internal.configentry.IngressListener
+	136, // 51: hashicorp.consul.internal.configentry.IngressGateway.Meta:type_name -> hashicorp.consul.internal.configentry.IngressGateway.MetaEntry
+	42,  // 52: hashicorp.consul.internal.configentry.IngressGateway.Defaults:type_name -> hashicorp.consul.internal.configentry.IngressServiceConfig
+	65,  // 53: hashicorp.consul.internal.configentry.IngressServiceConfig.PassiveHealthCheck:type_name -> hashicorp.consul.internal.configentry.PassiveHealthCheck
+	44,  // 54: hashicorp.consul.internal.configentry.GatewayTLSConfig.SDS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSSDSConfig
+	46,  // 55: hashicorp.consul.internal.configentry.IngressListener.Services:type_name -> hashicorp.consul.internal.configentry.IngressService
+	43,  // 56: hashicorp.consul.internal.configentry.IngressListener.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSConfig
+	47,  // 57: hashicorp.consul.internal.configentry.IngressService.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayServiceTLSConfig
+	48,  // 58: hashicorp.consul.internal.configentry.IngressService.RequestHeaders:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderModifiers
+	48,  // 59: hashicorp.consul.internal.configentry.IngressService.ResponseHeaders:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderModifiers
+	137, // 60: hashicorp.consul.internal.configentry.IngressService.Meta:type_name -> hashicorp.consul.internal.configentry.IngressService.MetaEntry
+	156, // 61: hashicorp.consul.internal.configentry.IngressService.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	65,  // 62: hashicorp.consul.internal.configentry.IngressService.PassiveHealthCheck:type_name -> hashicorp.consul.internal.configentry.PassiveHealthCheck
+	44,  // 63: hashicorp.consul.internal.configentry.GatewayServiceTLSConfig.SDS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSSDSConfig
+	138, // 64: hashicorp.consul.internal.configentry.HTTPHeaderModifiers.Add:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderModifiers.AddEntry
+	139, // 65: hashicorp.consul.internal.configentry.HTTPHeaderModifiers.Set:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderModifiers.SetEntry
+	53,  // 66: hashicorp.consul.internal.configentry.ServiceIntentions.Sources:type_name -> hashicorp.consul.internal.configentry.SourceIntention
+	140, // 67: hashicorp.consul.internal.configentry.ServiceIntentions.Meta:type_name -> hashicorp.consul.internal.configentry.ServiceIntentions.MetaEntry
+	50,  // 68: hashicorp.consul.internal.configentry.ServiceIntentions.JWT:type_name -> hashicorp.consul.internal.configentry.IntentionJWTRequirement
+	51,  // 69: hashicorp.consul.internal.configentry.IntentionJWTRequirement.Providers:type_name -> hashicorp.consul.internal.configentry.IntentionJWTProvider
+	52,  // 70: hashicorp.consul.internal.configentry.IntentionJWTProvider.VerifyClaims:type_name -> hashicorp.consul.internal.configentry.IntentionJWTClaimVerification
+	3,   // 71: hashicorp.consul.internal.configentry.SourceIntention.Action:type_name -> hashicorp.consul.internal.configentry.IntentionAction
+	54,  // 72: hashicorp.consul.internal.configentry.SourceIntention.Permissions:type_name -> hashicorp.consul.internal.configentry.IntentionPermission
+	4,   // 73: hashicorp.consul.internal.configentry.SourceIntention.Type:type_name -> hashicorp.consul.internal.configentry.IntentionSourceType
+	141, // 74: hashicorp.consul.internal.configentry.SourceIntention.LegacyMeta:type_name -> hashicorp.consul.internal.configentry.SourceIntention.LegacyMetaEntry
+	159, // 75: hashicorp.consul.internal.configentry.SourceIntention.LegacyCreateTime:type_name -> google.protobuf.Timestamp
+	159, // 76: hashicorp.consul.internal.configentry.SourceIntention.LegacyUpdateTime:type_name -> google.protobuf.Timestamp
+	156, // 77: hashicorp.consul.internal.configentry.SourceIntention.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	3,   // 78: hashicorp.consul.internal.configentry.IntentionPermission.Action:type_name -> hashicorp.consul.internal.configentry.IntentionAction
+	55,  // 79: hashicorp.consul.internal.configentry.IntentionPermission.HTTP:type_name -> hashicorp.consul.internal.configentry.IntentionHTTPPermission
+	50,  // 80: hashicorp.consul.internal.configentry.IntentionPermission.JWT:type_name -> hashicorp.consul.internal.configentry.IntentionJWTRequirement
+	56,  // 81: hashicorp.consul.internal.configentry.IntentionHTTPPermission.Header:type_name -> hashicorp.consul.internal.configentry.IntentionHTTPHeaderPermission
+	5,   // 82: hashicorp.consul.internal.configentry.ServiceDefaults.Mode:type_name -> hashicorp.consul.internal.configentry.ProxyMode
+	58,  // 83: hashicorp.consul.internal.configentry.ServiceDefaults.TransparentProxy:type_name -> hashicorp.consul.internal.configentry.TransparentProxyConfig
+	59,  // 84: hashicorp.consul.internal.configentry.ServiceDefaults.MeshGateway:type_name -> hashicorp.consul.internal.configentry.MeshGatewayConfig
+	60,  // 85: hashicorp.consul.internal.configentry.ServiceDefaults.Expose:type_name -> hashicorp.consul.internal.configentry.ExposeConfig
+	62,  // 86: hashicorp.consul.internal.configentry.ServiceDefaults.UpstreamConfig:type_name -> hashicorp.consul.internal.configentry.UpstreamConfiguration
+	66,  // 87: hashicorp.consul.internal.configentry.ServiceDefaults.Destination:type_name -> hashicorp.consul.internal.configentry.DestinationConfig
+	67,  // 88: hashicorp.consul.internal.configentry.ServiceDefaults.RateLimits:type_name -> hashicorp.consul.internal.configentry.RateLimits
+	142, // 89: hashicorp.consul.internal.configentry.ServiceDefaults.Meta:type_name -> hashicorp.consul.internal.configentry.ServiceDefaults.MetaEntry
+	160, // 90: hashicorp.consul.internal.configentry.ServiceDefaults.EnvoyExtensions:type_name -> hashicorp.consul.internal.common.EnvoyExtension
+	6,   // 91: hashicorp.consul.internal.configentry.ServiceDefaults.MutualTLSMode:type_name -> hashicorp.consul.internal.configentry.MutualTLSMode
+	7,   // 92: hashicorp.consul.internal.configentry.MeshGatewayConfig.Mode:type_name -> hashicorp.consul.internal.configentry.MeshGatewayMode
+	61,  // 93: hashicorp.consul.internal.configentry.ExposeConfig.Paths:type_name -> hashicorp.consul.internal.configentry.ExposePath
+	63,  // 94: hashicorp.consul.internal.configentry.UpstreamConfiguration.Overrides:type_name -> hashicorp.consul.internal.configentry.UpstreamConfig
+	63,  // 95: hashicorp.consul.internal.configentry.UpstreamConfiguration.Defaults:type_name -> hashicorp.consul.internal.configentry.UpstreamConfig
+	156, // 96: hashicorp.consul.internal.configentry.UpstreamConfig.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	64,  // 97: hashicorp.consul.internal.configentry.UpstreamConfig.Limits:type_name -> hashicorp.consul.internal.configentry.UpstreamLimits
+	65,  // 98: hashicorp.consul.internal.configentry.UpstreamConfig.PassiveHealthCheck:type_name -> hashicorp.consul.internal.configentry.PassiveHealthCheck
+	59,  // 99: hashicorp.consul.internal.configentry.UpstreamConfig.MeshGateway:type_name -> hashicorp.consul.internal.configentry.MeshGatewayConfig
+	158, // 100: hashicorp.consul.internal.configentry.PassiveHealthCheck.Interval:type_name -> google.protobuf.Duration
+	158, // 101: hashicorp.consul.internal.configentry.PassiveHealthCheck.BaseEjectionTime:type_name -> google.protobuf.Duration
+	68,  // 102: hashicorp.consul.internal.configentry.RateLimits.InstanceLevel:type_name -> hashicorp.consul.internal.configentry.InstanceLevelRateLimits
+	69,  // 103: hashicorp.consul.internal.configentry.InstanceLevelRateLimits.Routes:type_name -> hashicorp.consul.internal.configentry.InstanceLevelRouteRateLimits
+	143, // 104: hashicorp.consul.internal.configentry.APIGateway.Meta:type_name -> hashicorp.consul.internal.configentry.APIGateway.MetaEntry
+	73,  // 105: hashicorp.consul.internal.configentry.APIGateway.Listeners:type_name -> hashicorp.consul.internal.configentry.APIGatewayListener
+	71,  // 106: hashicorp.consul.internal.configentry.APIGateway.Status:type_name -> hashicorp.consul.internal.configentry.Status
+	43,  // 107: hashicorp.consul.internal.configentry.APIGateway.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSConfig
+	64,  // 108: hashicorp.consul.internal.configentry.APIGateway.Defaults:type_name -> hashicorp.consul.internal.configentry.UpstreamLimits
+	72,  // 109: hashicorp.consul.internal.configentry.Status.Conditions:type_name -> hashicorp.consul.internal.configentry.Condition
+	79,  // 110: hashicorp.consul.internal.configentry.Condition.Resource:type_name -> hashicorp.consul.internal.configentry.ResourceReference
+	159, // 111: hashicorp.consul.internal.configentry.Condition.LastTransitionTime:type_name -> google.protobuf.Timestamp
+	8,   // 112: hashicorp.consul.internal.configentry.APIGatewayListener.Protocol:type_name -> hashicorp.consul.internal.configentry.APIGatewayListenerProtocol
+	74,  // 113: hashicorp.consul.internal.configentry.APIGatewayListener.TLS:type_name -> hashicorp.consul.internal.configentry.APIGatewayTLSConfiguration
+	75,  // 114: hashicorp.consul.internal.configentry.APIGatewayListener.Override:type_name -> hashicorp.consul.internal.configentry.APIGatewayPolicy
+	75,  // 115: hashicorp.consul.internal.configentry.APIGatewayListener.Default:type_name -> hashicorp.consul.internal.configentry.APIGatewayPolicy
+	79,  // 116: hashicorp.consul.internal.configentry.APIGatewayTLSConfiguration.Certificates:type_name -> hashicorp.consul.internal.configentry.ResourceReference
+	44,  // 117: hashicorp.consul.internal.configentry.APIGatewayTLSConfiguration.SDS:type_name -> hashicorp.consul.internal.configentry.GatewayTLSSDSConfig
+	76,  // 118: hashicorp.consul.internal.configentry.APIGatewayPolicy.JWT:type_name -> hashicorp.consul.internal.configentry.APIGatewayJWTRequirement
+	77,  // 119: hashicorp.consul.internal.configentry.APIGatewayJWTRequirement.Providers:type_name -> hashicorp.consul.internal.configentry.APIGatewayJWTProvider
+	78,  // 120: hashicorp.consul.internal.configentry.APIGatewayJWTProvider.VerifyClaims:type_name -> hashicorp.consul.internal.configentry.APIGatewayJWTClaimVerification
+	156, // 121: hashicorp.consul.internal.configentry.ResourceReference.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	144, // 122: hashicorp.consul.internal.configentry.BoundAPIGateway.Meta:type_name -> hashicorp.consul.internal.configentry.BoundAPIGateway.MetaEntry
+	82,  // 123: hashicorp.consul.internal.configentry.BoundAPIGateway.Listeners:type_name -> hashicorp.consul.internal.configentry.BoundAPIGatewayListener
+	145, // 124: hashicorp.consul.internal.configentry.BoundAPIGateway.Services:type_name -> hashicorp.consul.internal.configentry.BoundAPIGateway.ServicesEntry
+	79,  // 125: hashicorp.consul.internal.configentry.ListOfResourceReference.Ref:type_name -> hashicorp.consul.internal.configentry.ResourceReference
+	79,  // 126: hashicorp.consul.internal.configentry.BoundAPIGatewayListener.Certificates:type_name -> hashicorp.consul.internal.configentry.ResourceReference
+	79,  // 127: hashicorp.consul.internal.configentry.BoundAPIGatewayListener.Routes:type_name -> hashicorp.consul.internal.configentry.ResourceReference
+	146, // 128: hashicorp.consul.internal.configentry.FileSystemCertificate.Meta:type_name -> hashicorp.consul.internal.configentry.FileSystemCertificate.MetaEntry
+	147, // 129: hashicorp.consul.internal.configentry.InlineCertificate.Meta:type_name -> hashicorp.consul.internal.configentry.InlineCertificate.MetaEntry
+	148, // 130: hashicorp.consul.internal.configentry.HTTPRoute.Meta:type_name -> hashicorp.consul.internal.configentry.HTTPRoute.MetaEntry
+	79,  // 131: hashicorp.consul.internal.configentry.HTTPRoute.Parents:type_name -> hashicorp.consul.internal.configentry.ResourceReference
+	86,  // 132: hashicorp.consul.internal.configentry.HTTPRoute.Rules:type_name -> hashicorp.consul.internal.configentry.HTTPRouteRule
+	71,  // 133: hashicorp.consul.internal.configentry.HTTPRoute.Status:type_name -> hashicorp.consul.internal.configentry.Status
+	91,  // 134: hashicorp.consul.internal.configentry.HTTPRouteRule.Filters:type_name -> hashicorp.consul.internal.configentry.HTTPFilters
+	87,  // 135: hashicorp.consul.internal.configentry.HTTPRouteRule.Matches:type_name -> hashicorp.consul.internal.configentry.HTTPMatch
+	98,  // 136: hashicorp.consul.internal.configentry.HTTPRouteRule.Services:type_name -> hashicorp.consul.internal.configentry.HTTPService
+	92,  // 137: hashicorp.consul.internal.configentry.HTTPRouteRule.ResponseFilters:type_name -> hashicorp.consul.internal.configentry.HTTPResponseFilters
+	88,  // 138: hashicorp.consul.internal.configentry.HTTPMatch.Headers:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderMatch
+	9,   // 139: hashicorp.consul.internal.configentry.HTTPMatch.Method:type_name -> hashicorp.consul.internal.configentry.HTTPMatchMethod
+	89,  // 140: hashicorp.consul.internal.configentry.HTTPMatch.Path:type_name -> hashicorp.consul.internal.configentry.HTTPPathMatch
+	90,  // 141: hashicorp.consul.internal.configentry.HTTPMatch.Query:type_name -> hashicorp.consul.internal.configentry.HTTPQueryMatch
+	10,  // 142: hashicorp.consul.internal.configentry.HTTPHeaderMatch.Match:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderMatchType
+	11,  // 143: hashicorp.consul.internal.configentry.HTTPPathMatch.Match:type_name -> hashicorp.consul.internal.configentry.HTTPPathMatchType
+	12,  // 144: hashicorp.consul.internal.configentry.HTTPQueryMatch.Match:type_name -> hashicorp.consul.internal.configentry.HTTPQueryMatchType
+	97,  // 145: hashicorp.consul.internal.configentry.HTTPFilters.Headers:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderFilter
+	93,  // 146: hashicorp.consul.internal.configentry.HTTPFilters.URLRewrite:type_name -> hashicorp.consul.internal.configentry.URLRewrite
+	94,  // 147: hashicorp.consul.internal.configentry.HTTPFilters.RetryFilter:type_name -> hashicorp.consul.internal.configentry.RetryFilter
+	95,  // 148: hashicorp.consul.internal.configentry.HTTPFilters.TimeoutFilter:type_name -> hashicorp.consul.internal.configentry.TimeoutFilter
+	96,  // 149: hashicorp.consul.internal.configentry.HTTPFilters.JWT:type_name -> hashicorp.consul.internal.configentry.JWTFilter
+	97,  // 150: hashicorp.consul.internal.configentry.HTTPResponseFilters.Headers:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderFilter
+	158, // 151: hashicorp.consul.internal.configentry.TimeoutFilter.RequestTimeout:type_name -> google.protobuf.Duration
+	158, // 152: hashicorp.consul.internal.configentry.TimeoutFilter.IdleTimeout:type_name -> google.protobuf.Duration
+	77,  // 153: hashicorp.consul.internal.configentry.JWTFilter.Providers:type_name -> hashicorp.consul.internal.configentry.APIGatewayJWTProvider
+	149, // 154: hashicorp.consul.internal.configentry.HTTPHeaderFilter.Add:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderFilter.AddEntry
+	150, // 155: hashicorp.consul.internal.configentry.HTTPHeaderFilter.Set:type_name -> hashicorp.consul.internal.configentry.HTTPHeaderFilter.SetEntry
+	91,  // 156: hashicorp.consul.internal.configentry.HTTPService.Filters:type_name -> hashicorp.consul.internal.configentry.HTTPFilters
+	156, // 157: hashicorp.consul.internal.configentry.HTTPService.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	92,  // 158: hashicorp.consul.internal.configentry.HTTPService.ResponseFilters:type_name -> hashicorp.consul.internal.configentry.HTTPResponseFilters
+	47,  // 159: hashicorp.consul.internal.configentry.HTTPService.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayServiceTLSConfig
+	64,  // 160: hashicorp.consul.internal.configentry.HTTPService.Limits:type_name -> hashicorp.consul.internal.configentry.UpstreamLimits
+	151, // 161: hashicorp.consul.internal.configentry.TCPRoute.Meta:type_name -> hashicorp.consul.internal.configentry.TCPRoute.MetaEntry
+	79,  // 162: hashicorp.consul.internal.configentry.TCPRoute.Parents:type_name -> hashicorp.consul.internal.configentry.ResourceReference
+	100, // 163: hashicorp.consul.internal.configentry.TCPRoute.Services:type_name -> hashicorp.consul.internal.configentry.TCPService
+	71,  // 164: hashicorp.consul.internal.configentry.TCPRoute.Status:type_name -> hashicorp.consul.internal.configentry.Status
+	156, // 165: hashicorp.consul.internal.configentry.TCPService.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	47,  // 166: hashicorp.consul.internal.configentry.TCPService.TLS:type_name -> hashicorp.consul.internal.configentry.GatewayServiceTLSConfig
+	64,  // 167: hashicorp.consul.internal.configentry.TCPService.Limits:type_name -> hashicorp.consul.internal.configentry.UpstreamLimits
+	102, // 168: hashicorp.consul.internal.configentry.SamenessGroup.Members:type_name -> hashicorp.consul.internal.configentry.SamenessGroupMember
+	152, // 169: hashicorp.consul.internal.configentry.SamenessGroup.Meta:type_name -> hashicorp.consul.internal.configentry.SamenessGroup.MetaEntry
+	156, // 170: hashicorp.consul.internal.configentry.SamenessGroup.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	104, // 171: hashicorp.consul.internal.configentry.JWTProvider.JSONWebKeySet:type_name -> hashicorp.consul.internal.configentry.JSONWebKeySet
+	113, // 172: hashicorp.consul.internal.configentry.JWTProvider.Locations:type_name -> hashicorp.consul.internal.configentry.JWTLocation
+	117, // 173: hashicorp.consul.internal.configentry.JWTProvider.Forwarding:type_name -> hashicorp.consul.internal.configentry.JWTForwardingConfig
+	118, // 174: hashicorp.consul.internal.configentry.JWTProvider.CacheConfig:type_name -> hashicorp.consul.internal.configentry.JWTCacheConfig
+	153, // 175: hashicorp.consul.internal.configentry.JWTProvider.Meta:type_name -> hashicorp.consul.internal.configentry.JWTProvider.MetaEntry
+	105, // 176: hashicorp.consul.internal.configentry.JSONWebKeySet.Local:type_name -> hashicorp.consul.internal.configentry.LocalJWKS
+	106, // 177: hashicorp.consul.internal.configentry.JSONWebKeySet.Remote:type_name -> hashicorp.consul.internal.configentry.RemoteJWKS
+	158, // 178: hashicorp.consul.internal.configentry.RemoteJWKS.CacheDuration:type_name -> google.protobuf.Duration
+	111, // 179: hashicorp.consul.internal.configentry.RemoteJWKS.RetryPolicy:type_name -> hashicorp.consul.internal.configentry.JWKSRetryPolicy
+	107, // 180: hashicorp.consul.internal.configentry.RemoteJWKS.JWKSCluster:type_name -> hashicorp.consul.internal.configentry.JWKSCluster
+	108, // 181: hashicorp.consul.internal.configentry.JWKSCluster.TLSCertificates:type_name -> hashicorp.consul.internal.configentry.JWKSTLSCertificate
+	158, // 182: hashicorp.consul.internal.configentry.JWKSCluster.ConnectTimeout:type_name -> google.protobuf.Duration
+	109, // 183: hashicorp.consul.internal.configentry.JWKSTLSCertificate.CaCertificateProviderInstance:type_name -> hashicorp.consul.internal.configentry.JWKSTLSCertProviderInstance
+	110, // 184: hashicorp.consul.internal.configentry.JWKSTLSCertificate.TrustedCA:type_name -> hashicorp.consul.internal.configentry.JWKSTLSCertTrustedCA
+	112, // 185: hashicorp.consul.internal.configentry.JWKSRetryPolicy.RetryPolicyBackOff:type_name -> hashicorp.consul.internal.configentry.RetryPolicyBackOff
+	158, // 186: hashicorp.consul.internal.configentry.RetryPolicyBackOff.BaseInterval:type_name -> google.protobuf.Duration
+	158, // 187: hashicorp.consul.internal.configentry.RetryPolicyBackOff.MaxInterval:type_name -> google.protobuf.Duration
+	114, // 188: hashicorp.consul.internal.configentry.JWTLocation.Header:type_name -> hashicorp.consul.internal.configentry.JWTLocationHeader
+	115, // 189: hashicorp.consul.internal.configentry.JWTLocation.QueryParam:type_name -> hashicorp.consul.internal.configentry.JWTLocationQueryParam
+	116, // 190: hashicorp.consul.internal.configentry.JWTLocation.Cookie:type_name -> hashicorp.consul.internal.configentry.JWTLocationCookie
+	156, // 191: hashicorp.consul.internal.configentry.ExportedServices.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	154, // 192: hashicorp.consul.internal.configentry.ExportedServices.Meta:type_name -> hashicorp.consul.internal.configentry.ExportedServices.MetaEntry
+	120, // 193: hashicorp.consul.internal.configentry.ExportedServices.Services:type_name -> hashicorp.consul.internal.configentry.ExportedServicesService
+	121, // 194: hashicorp.consul.internal.configentry.ExportedServicesService.Consumers:type_name -> hashicorp.consul.internal.configentry.ExportedServicesConsumer
+	123, // 195: hashicorp.consul.internal.configentry.AIGateway.Processor:type_name -> hashicorp.consul.internal.configentry.AIGatewayProcessor
+	124, // 196: hashicorp.consul.internal.configentry.AIGateway.Routing:type_name -> hashicorp.consul.internal.configentry.AIGatewayRouting
+	155, // 197: hashicorp.consul.internal.configentry.AIGateway.Meta:type_name -> hashicorp.consul.internal.configentry.AIGateway.MetaEntry
+	125, // 198: hashicorp.consul.internal.configentry.AIGatewayRouting.MatchRules:type_name -> hashicorp.consul.internal.configentry.AIGatewayMatchRule
+	128, // 199: hashicorp.consul.internal.configentry.AIGatewayRouting.Retry:type_name -> hashicorp.consul.internal.configentry.AIGatewayRetry
+	129, // 200: hashicorp.consul.internal.configentry.AIGatewayRouting.Timeout:type_name -> hashicorp.consul.internal.configentry.AIGatewayTimeout
+	130, // 201: hashicorp.consul.internal.configentry.AIGatewayRouting.Scoring:type_name -> hashicorp.consul.internal.configentry.AIGatewayScoring
+	126, // 202: hashicorp.consul.internal.configentry.AIGatewayMatchRule.When:type_name -> hashicorp.consul.internal.configentry.AIGatewayMatch
+	127, // 203: hashicorp.consul.internal.configentry.AIGatewayMatch.Identity:type_name -> hashicorp.consul.internal.configentry.AIGatewayIdentityMatch
+	131, // 204: hashicorp.consul.internal.configentry.AIGatewayScoring.WeightedSplit:type_name -> hashicorp.consul.internal.configentry.AIGatewayWeightedTarget
+	30,  // 205: hashicorp.consul.internal.configentry.ServiceResolver.SubsetsEntry.value:type_name -> hashicorp.consul.internal.configentry.ServiceResolverSubset
+	32,  // 206: hashicorp.consul.internal.configentry.ServiceResolver.FailoverEntry.value:type_name -> hashicorp.consul.internal.configentry.ServiceResolverFailover
+	81,  // 207: hashicorp.consul.internal.configentry.BoundAPIGateway.ServicesEntry.value:type_name -> hashicorp.consul.internal.configentry.ListOfResourceReference
+	13,  // 208: hashicorp.consul.internal.configentry.ConfigEntryService.GetResolvedExportedServices:input_type -> hashicorp.consul.internal.configentry.GetResolvedExportedServicesRequest
+	17,  // 209: hashicorp.consul.internal.configentry.ConfigEntryService.GetImportedServices:input_type -> hashicorp.consul.internal.configentry.GetImportedServicesRequest
+	14,  // 210: hashicorp.consul.internal.configentry.ConfigEntryService.GetResolvedExportedServices:output_type -> hashicorp.consul.internal.configentry.GetResolvedExportedServicesResponse
+	18,  // 211: hashicorp.consul.internal.configentry.ConfigEntryService.GetImportedServices:output_type -> hashicorp.consul.internal.configentry.GetImportedServicesResponse
+	210, // [210:212] is the sub-list for method output_type
+	208, // [208:210] is the sub-list for method input_type
+	208, // [208:208] is the sub-list for extension type_name
+	208, // [208:208] is the sub-list for extension extendee
+	0,   // [0:208] is the sub-list for field type_name
 }
 
 func init() { file_private_pbconfigentry_config_entry_proto_init() }
@@ -9785,6 +10538,7 @@ func file_private_pbconfigentry_config_entry_proto_init() {
 		(*ConfigEntry_JWTProvider)(nil),
 		(*ConfigEntry_ExportedServices)(nil),
 		(*ConfigEntry_FileSystemCertificate)(nil),
+		(*ConfigEntry_AIGateway)(nil),
 	}
 	file_private_pbconfigentry_config_entry_proto_msgTypes[44].OneofWrappers = []any{}
 	file_private_pbconfigentry_config_entry_proto_msgTypes[60].OneofWrappers = []any{}
@@ -9794,7 +10548,7 @@ func file_private_pbconfigentry_config_entry_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_private_pbconfigentry_config_entry_proto_rawDesc), len(file_private_pbconfigentry_config_entry_proto_rawDesc)),
 			NumEnums:      13,
-			NumMessages:   132,
+			NumMessages:   143,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/private/pbconfigentry/config_entry.proto
+++ b/proto/private/pbconfigentry/config_entry.proto
@@ -76,6 +76,7 @@ enum Kind {
   KindJWTProvider = 12;
   KindExportedServices = 13;
   KindFileSystemCertificate = 14;
+  KindAIGateway = 15;
 }
 
 message ConfigEntry {
@@ -100,6 +101,7 @@ message ConfigEntry {
     JWTProvider JWTProvider = 16;
     ExportedServices ExportedServices = 17;
     FileSystemCertificate FileSystemCertificate = 18;
+    AIGateway AIGateway = 19;
   }
 }
 
@@ -1438,4 +1440,119 @@ message ExportedServicesConsumer {
   string Partition = 1;
   string Peer = 2;
   string SamenessGroup = 3;
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayConfigEntry
+// output=config_entry.gen.go
+// name=Structs
+// ignore-fields=Name,Kind,RaftIndex,EnterpriseMeta
+message AIGateway {
+  AIGatewayProcessor Processor = 1;
+  repeated string ApplyTo = 2;
+  AIGatewayRouting Routing = 3;
+  map<string, string> Meta = 4;
+  uint64 Hash = 5;
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayProcessor
+// output=config_entry.gen.go
+// name=Structs
+message AIGatewayProcessor {
+  string UDSPath = 1;
+  string FailureMode = 2;
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayRouting
+// output=config_entry.gen.go
+// name=Structs
+// ignore-fields=ComplianceMap,Budget,Cache,Mirror
+message AIGatewayRouting {
+  repeated AIGatewayMatchRule MatchRules = 1;
+  repeated string FallbackChain = 2;
+  AIGatewayRetry Retry = 3;
+  AIGatewayTimeout Timeout = 4;
+  AIGatewayScoring Scoring = 5;
+  string ConfigValidation = 6;
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayMatchRule
+// output=config_entry.gen.go
+// name=Structs
+message AIGatewayMatchRule {
+  AIGatewayMatch When = 1;
+  repeated string RequireCapabilities = 2;
+  repeated string Candidates = 3;
+  repeated string FallbackChain = 4;
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayMatch
+// output=config_entry.gen.go
+// name=Structs
+message AIGatewayMatch {
+  string Path = 1;
+  repeated string BodyHas = 2;
+  AIGatewayIdentityMatch Identity = 3;
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayIdentityMatch
+// output=config_entry.gen.go
+// name=Structs
+message AIGatewayIdentityMatch {
+  string Service = 1;
+  string Partition = 2;
+  string Namespace = 3;
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayRetry
+// output=config_entry.gen.go
+// name=Structs
+message AIGatewayRetry {
+  // mog: func-to=int func-from=int32
+  int32 MaxAttempts = 1;
+  repeated string RetryOn = 2;
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayTimeout
+// output=config_entry.gen.go
+// name=Structs
+message AIGatewayTimeout {
+  string Connect = 1;
+  string Request = 2;
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayScoring
+// output=config_entry.gen.go
+// name=Structs
+message AIGatewayScoring {
+  repeated string Scorers = 1;
+  repeated AIGatewayWeightedTarget WeightedSplit = 2;
+}
+
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIGatewayWeightedTarget
+// output=config_entry.gen.go
+// name=Structs
+message AIGatewayWeightedTarget {
+  string Cluster = 1;
+  // mog: func-to=int func-from=int32
+  int32 Weight = 2;
 }

--- a/proto/private/pbservice/node.gen.go
+++ b/proto/private/pbservice/node.gen.go
@@ -51,6 +51,11 @@ func NodeServiceToStructs(s *NodeService, t *structs.NodeService) {
 	t.Weights = WeightsPtrToStructs(s.Weights)
 	t.EnableTagOverride = s.EnableTagOverride
 	t.Locality = LocalityToStructs(s.Locality)
+	if s.AI != nil {
+		var x structs.AIConfig
+		AIConfigToStructs(s.AI, &x)
+		t.AI = &x
+	}
 	if s.Proxy != nil {
 		ConnectProxyConfigToStructs(s.Proxy, &t.Proxy)
 	}
@@ -79,6 +84,11 @@ func NodeServiceFromStructs(t *structs.NodeService, s *NodeService) {
 	s.Weights = NewWeightsPtrFromStructs(t.Weights)
 	s.EnableTagOverride = t.EnableTagOverride
 	s.Locality = LocalityFromStructs(t.Locality)
+	if t.AI != nil {
+		var x AIConfig
+		AIConfigFromStructs(t.AI, &x)
+		s.AI = &x
+	}
 	{
 		var x ConnectProxyConfig
 		ConnectProxyConfigFromStructs(&t.Proxy, &x)

--- a/proto/private/pbservice/node.pb.go
+++ b/proto/private/pbservice/node.pb.go
@@ -335,7 +335,9 @@ type NodeService struct {
 	// mog: func-to=LocalityToStructs func-from=LocalityFromStructs
 	Locality *pbcommon.Locality `protobuf:"bytes,19,opt,name=Locality,proto3" json:"Locality,omitempty"`
 	// mog: func-to=PortsToStructs func-from=NewPortsFromStructs
-	Ports         []*ServicePort `protobuf:"bytes,20,rep,name=Ports,proto3" json:"Ports,omitempty"`
+	Ports []*ServicePort `protobuf:"bytes,20,rep,name=Ports,proto3" json:"Ports,omitempty"`
+	// AI marks the service's role in the Agent Gateway (Inference plane).
+	AI            *AIConfig `protobuf:"bytes,21,opt,name=AI,proto3" json:"AI,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -503,6 +505,13 @@ func (x *NodeService) GetPorts() []*ServicePort {
 	return nil
 }
 
+func (x *NodeService) GetAI() *AIConfig {
+	if x != nil {
+		return x.AI
+	}
+	return nil
+}
+
 var File_private_pbservice_node_proto protoreflect.FileDescriptor
 
 const file_private_pbservice_node_proto_rawDesc = "" +
@@ -534,7 +543,7 @@ const file_private_pbservice_node_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a7\n" +
 	"\tMetaEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb7\t\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xf4\t\n" +
 	"\vNodeService\x12\x12\n" +
 	"\x04Kind\x18\x01 \x01(\tR\x04Kind\x12\x0e\n" +
 	"\x02ID\x18\x02 \x01(\tR\x02ID\x12\x18\n" +
@@ -556,7 +565,8 @@ const file_private_pbservice_node_proto_rawDesc = "" +
 	"\bPeerName\x18\x12 \x01(\tR\bPeerName\x12I\n" +
 	"\tRaftIndex\x18\x0e \x01(\v2+.hashicorp.consul.internal.common.RaftIndexR\tRaftIndex\x12F\n" +
 	"\bLocality\x18\x13 \x01(\v2*.hashicorp.consul.internal.common.LocalityR\bLocality\x12D\n" +
-	"\x05Ports\x18\x14 \x03(\v2..hashicorp.consul.internal.service.ServicePortR\x05Ports\x1au\n" +
+	"\x05Ports\x18\x14 \x03(\v2..hashicorp.consul.internal.service.ServicePortR\x05Ports\x12;\n" +
+	"\x02AI\x18\x15 \x01(\v2+.hashicorp.consul.internal.service.AIConfigR\x02AI\x1au\n" +
 	"\x14TaggedAddressesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12G\n" +
 	"\x05value\x18\x02 \x01(\v21.hashicorp.consul.internal.service.ServiceAddressR\x05value:\x028\x01\x1a7\n" +
@@ -595,7 +605,8 @@ var file_private_pbservice_node_proto_goTypes = []any{
 	(*ServiceConnect)(nil),           // 13: hashicorp.consul.internal.service.ServiceConnect
 	(*pbcommon.EnterpriseMeta)(nil),  // 14: hashicorp.consul.internal.common.EnterpriseMeta
 	(*ServicePort)(nil),              // 15: hashicorp.consul.internal.service.ServicePort
-	(*ServiceAddress)(nil),           // 16: hashicorp.consul.internal.service.ServiceAddress
+	(*AIConfig)(nil),                 // 16: hashicorp.consul.internal.service.AIConfig
+	(*ServiceAddress)(nil),           // 17: hashicorp.consul.internal.service.ServiceAddress
 }
 var file_private_pbservice_node_proto_depIdxs = []int32{
 	1,  // 0: hashicorp.consul.internal.service.IndexedCheckServiceNodes.Nodes:type_name -> hashicorp.consul.internal.service.CheckServiceNode
@@ -615,12 +626,13 @@ var file_private_pbservice_node_proto_depIdxs = []int32{
 	9,  // 14: hashicorp.consul.internal.service.NodeService.RaftIndex:type_name -> hashicorp.consul.internal.common.RaftIndex
 	10, // 15: hashicorp.consul.internal.service.NodeService.Locality:type_name -> hashicorp.consul.internal.common.Locality
 	15, // 16: hashicorp.consul.internal.service.NodeService.Ports:type_name -> hashicorp.consul.internal.service.ServicePort
-	16, // 17: hashicorp.consul.internal.service.NodeService.TaggedAddressesEntry.value:type_name -> hashicorp.consul.internal.service.ServiceAddress
-	18, // [18:18] is the sub-list for method output_type
-	18, // [18:18] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	16, // 17: hashicorp.consul.internal.service.NodeService.AI:type_name -> hashicorp.consul.internal.service.AIConfig
+	17, // 18: hashicorp.consul.internal.service.NodeService.TaggedAddressesEntry.value:type_name -> hashicorp.consul.internal.service.ServiceAddress
+	19, // [19:19] is the sub-list for method output_type
+	19, // [19:19] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_private_pbservice_node_proto_init() }

--- a/proto/private/pbservice/node.proto
+++ b/proto/private/pbservice/node.proto
@@ -127,4 +127,7 @@ message NodeService {
 
   // mog: func-to=PortsToStructs func-from=NewPortsFromStructs
   repeated ServicePort Ports = 20;
+
+  // AI marks the service's role in the Agent Gateway (Inference plane).
+  AIConfig AI = 21;
 }

--- a/proto/private/pbservice/service.gen.go
+++ b/proto/private/pbservice/service.gen.go
@@ -4,6 +4,18 @@ package pbservice
 
 import "github.com/hashicorp/consul/agent/structs"
 
+func AIConfigToStructs(s *AIConfig, t *structs.AIConfig) {
+	if s == nil {
+		return
+	}
+	t.Role = s.Role
+}
+func AIConfigFromStructs(t *structs.AIConfig, s *AIConfig) {
+	if s == nil {
+		return
+	}
+	s.Role = t.Role
+}
 func AccessLogsConfigToStructs(s *AccessLogsConfig, t *structs.AccessLogsConfig) {
 	if s == nil {
 		return
@@ -196,6 +208,11 @@ func ServiceDefinitionToStructs(s *ServiceDefinition, t *structs.ServiceDefiniti
 	t.Token = s.Token
 	t.EnableTagOverride = s.EnableTagOverride
 	t.Locality = LocalityToStructs(s.Locality)
+	if s.AI != nil {
+		var x structs.AIConfig
+		AIConfigToStructs(s.AI, &x)
+		t.AI = &x
+	}
 	t.Proxy = ConnectProxyConfigPtrToStructs(s.Proxy)
 	t.EnterpriseMeta = EnterpriseMetaToStructs(s.EnterpriseMeta)
 	t.Connect = ServiceConnectPtrToStructs(s.Connect)
@@ -224,6 +241,11 @@ func ServiceDefinitionFromStructs(t *structs.ServiceDefinition, s *ServiceDefini
 	s.Token = t.Token
 	s.EnableTagOverride = t.EnableTagOverride
 	s.Locality = LocalityFromStructs(t.Locality)
+	if t.AI != nil {
+		var x AIConfig
+		AIConfigFromStructs(t.AI, &x)
+		s.AI = &x
+	}
 	s.Proxy = NewConnectProxyConfigPtrFromStructs(t.Proxy)
 	s.EnterpriseMeta = NewEnterpriseMetaFromStructs(t.EnterpriseMeta)
 	s.Connect = NewServiceConnectPtrFromStructs(t.Connect)

--- a/proto/private/pbservice/service.pb.binary.go
+++ b/proto/private/pbservice/service.pb.binary.go
@@ -108,6 +108,16 @@ func (msg *ServiceDefinition) UnmarshalBinary(b []byte) error {
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler
+func (msg *AIConfig) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(msg)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (msg *AIConfig) UnmarshalBinary(b []byte) error {
+	return proto.Unmarshal(b, msg)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
 func (msg *ServicePort) MarshalBinary() ([]byte, error) {
 	return proto.Marshal(msg)
 }

--- a/proto/private/pbservice/service.pb.go
+++ b/proto/private/pbservice/service.pb.go
@@ -953,7 +953,9 @@ type ServiceDefinition struct {
 	Locality *pbcommon.Locality `protobuf:"bytes,19,opt,name=Locality,proto3" json:"Locality,omitempty"`
 	// Ports is a list of ports that the service exposes.
 	// mog: func-to=PortsToStructs func-from=NewPortsFromStructs
-	Ports         []*ServicePort `protobuf:"bytes,20,rep,name=Ports,proto3" json:"Ports,omitempty"`
+	Ports []*ServicePort `protobuf:"bytes,20,rep,name=Ports,proto3" json:"Ports,omitempty"`
+	// AI marks the service's role in the Agent Gateway (Inference plane).
+	AI            *AIConfig `protobuf:"bytes,21,opt,name=AI,proto3" json:"AI,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1121,6 +1123,64 @@ func (x *ServiceDefinition) GetPorts() []*ServicePort {
 	return nil
 }
 
+func (x *ServiceDefinition) GetAI() *AIConfig {
+	if x != nil {
+		return x.AI
+	}
+	return nil
+}
+
+// AIConfig marks a service's role in the Agent Gateway (Inference plane).
+//
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIConfig
+// output=service.gen.go
+// name=Structs
+type AIConfig struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Role          string                 `protobuf:"bytes,1,opt,name=Role,proto3" json:"Role,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AIConfig) Reset() {
+	*x = AIConfig{}
+	mi := &file_private_pbservice_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AIConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AIConfig) ProtoMessage() {}
+
+func (x *AIConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_private_pbservice_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AIConfig.ProtoReflect.Descriptor instead.
+func (*AIConfig) Descriptor() ([]byte, []int) {
+	return file_private_pbservice_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *AIConfig) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
 // ServicePort contains the port information for a service.
 // mog annotation:
 //
@@ -1142,7 +1202,7 @@ type ServicePort struct {
 
 func (x *ServicePort) Reset() {
 	*x = ServicePort{}
-	mi := &file_private_pbservice_service_proto_msgTypes[10]
+	mi := &file_private_pbservice_service_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1154,7 +1214,7 @@ func (x *ServicePort) String() string {
 func (*ServicePort) ProtoMessage() {}
 
 func (x *ServicePort) ProtoReflect() protoreflect.Message {
-	mi := &file_private_pbservice_service_proto_msgTypes[10]
+	mi := &file_private_pbservice_service_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1167,7 +1227,7 @@ func (x *ServicePort) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServicePort.ProtoReflect.Descriptor instead.
 func (*ServicePort) Descriptor() ([]byte, []int) {
-	return file_private_pbservice_service_proto_rawDescGZIP(), []int{10}
+	return file_private_pbservice_service_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ServicePort) GetPort() int32 {
@@ -1203,7 +1263,7 @@ type ServiceAddress struct {
 
 func (x *ServiceAddress) Reset() {
 	*x = ServiceAddress{}
-	mi := &file_private_pbservice_service_proto_msgTypes[11]
+	mi := &file_private_pbservice_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1215,7 +1275,7 @@ func (x *ServiceAddress) String() string {
 func (*ServiceAddress) ProtoMessage() {}
 
 func (x *ServiceAddress) ProtoReflect() protoreflect.Message {
-	mi := &file_private_pbservice_service_proto_msgTypes[11]
+	mi := &file_private_pbservice_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1228,7 +1288,7 @@ func (x *ServiceAddress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceAddress.ProtoReflect.Descriptor instead.
 func (*ServiceAddress) Descriptor() ([]byte, []int) {
-	return file_private_pbservice_service_proto_rawDescGZIP(), []int{11}
+	return file_private_pbservice_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ServiceAddress) GetAddress() string {
@@ -1258,7 +1318,7 @@ type Weights struct {
 
 func (x *Weights) Reset() {
 	*x = Weights{}
-	mi := &file_private_pbservice_service_proto_msgTypes[12]
+	mi := &file_private_pbservice_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1270,7 +1330,7 @@ func (x *Weights) String() string {
 func (*Weights) ProtoMessage() {}
 
 func (x *Weights) ProtoReflect() protoreflect.Message {
-	mi := &file_private_pbservice_service_proto_msgTypes[12]
+	mi := &file_private_pbservice_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1283,7 +1343,7 @@ func (x *Weights) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Weights.ProtoReflect.Descriptor instead.
 func (*Weights) Descriptor() ([]byte, []int) {
-	return file_private_pbservice_service_proto_rawDescGZIP(), []int{12}
+	return file_private_pbservice_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *Weights) GetPassing() int32 {
@@ -1374,7 +1434,7 @@ const file_private_pbservice_service_proto_rawDesc = "" +
 	"JSONFormat\x12\x1e\n" +
 	"\n" +
 	"TextFormat\x18\x06 \x01(\tR\n" +
-	"TextFormat\"\xbc\t\n" +
+	"TextFormat\"\xf9\t\n" +
 	"\x11ServiceDefinition\x12\x12\n" +
 	"\x04Kind\x18\x01 \x01(\tR\x04Kind\x12\x0e\n" +
 	"\x02ID\x18\x02 \x01(\tR\x02ID\x12\x12\n" +
@@ -1397,13 +1457,16 @@ const file_private_pbservice_service_proto_rawDesc = "" +
 	"\x0eEnterpriseMeta\x18\x11 \x01(\v20.hashicorp.consul.internal.common.EnterpriseMetaR\x0eEnterpriseMeta\x12K\n" +
 	"\aConnect\x18\x0f \x01(\v21.hashicorp.consul.internal.service.ServiceConnectR\aConnect\x12F\n" +
 	"\bLocality\x18\x13 \x01(\v2*.hashicorp.consul.internal.common.LocalityR\bLocality\x12D\n" +
-	"\x05Ports\x18\x14 \x03(\v2..hashicorp.consul.internal.service.ServicePortR\x05Ports\x1au\n" +
+	"\x05Ports\x18\x14 \x03(\v2..hashicorp.consul.internal.service.ServicePortR\x05Ports\x12;\n" +
+	"\x02AI\x18\x15 \x01(\v2+.hashicorp.consul.internal.service.AIConfigR\x02AI\x1au\n" +
 	"\x14TaggedAddressesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12G\n" +
 	"\x05value\x18\x02 \x01(\v21.hashicorp.consul.internal.service.ServiceAddressR\x05value:\x028\x01\x1a7\n" +
 	"\tMetaEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"O\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x1e\n" +
+	"\bAIConfig\x12\x12\n" +
+	"\x04Role\x18\x01 \x01(\tR\x04Role\"O\n" +
 	"\vServicePort\x12\x12\n" +
 	"\x04Port\x18\x01 \x01(\x05R\x04Port\x12\x12\n" +
 	"\x04Name\x18\x02 \x01(\tR\x04Name\x12\x18\n" +
@@ -1428,7 +1491,7 @@ func file_private_pbservice_service_proto_rawDescGZIP() []byte {
 	return file_private_pbservice_service_proto_rawDescData
 }
 
-var file_private_pbservice_service_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_private_pbservice_service_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_private_pbservice_service_proto_goTypes = []any{
 	(*ConnectProxyConfig)(nil),      // 0: hashicorp.consul.internal.service.ConnectProxyConfig
 	(*Upstream)(nil),                // 1: hashicorp.consul.internal.service.Upstream
@@ -1440,47 +1503,49 @@ var file_private_pbservice_service_proto_goTypes = []any{
 	(*TransparentProxyConfig)(nil),  // 7: hashicorp.consul.internal.service.TransparentProxyConfig
 	(*AccessLogsConfig)(nil),        // 8: hashicorp.consul.internal.service.AccessLogsConfig
 	(*ServiceDefinition)(nil),       // 9: hashicorp.consul.internal.service.ServiceDefinition
-	(*ServicePort)(nil),             // 10: hashicorp.consul.internal.service.ServicePort
-	(*ServiceAddress)(nil),          // 11: hashicorp.consul.internal.service.ServiceAddress
-	(*Weights)(nil),                 // 12: hashicorp.consul.internal.service.Weights
-	nil,                             // 13: hashicorp.consul.internal.service.ServiceDefinition.TaggedAddressesEntry
-	nil,                             // 14: hashicorp.consul.internal.service.ServiceDefinition.MetaEntry
-	(*structpb.Struct)(nil),         // 15: google.protobuf.Struct
-	(*pbcommon.EnvoyExtension)(nil), // 16: hashicorp.consul.internal.common.EnvoyExtension
-	(*CheckType)(nil),               // 17: hashicorp.consul.internal.service.CheckType
-	(*pbcommon.EnterpriseMeta)(nil), // 18: hashicorp.consul.internal.common.EnterpriseMeta
-	(*pbcommon.Locality)(nil),       // 19: hashicorp.consul.internal.common.Locality
+	(*AIConfig)(nil),                // 10: hashicorp.consul.internal.service.AIConfig
+	(*ServicePort)(nil),             // 11: hashicorp.consul.internal.service.ServicePort
+	(*ServiceAddress)(nil),          // 12: hashicorp.consul.internal.service.ServiceAddress
+	(*Weights)(nil),                 // 13: hashicorp.consul.internal.service.Weights
+	nil,                             // 14: hashicorp.consul.internal.service.ServiceDefinition.TaggedAddressesEntry
+	nil,                             // 15: hashicorp.consul.internal.service.ServiceDefinition.MetaEntry
+	(*structpb.Struct)(nil),         // 16: google.protobuf.Struct
+	(*pbcommon.EnvoyExtension)(nil), // 17: hashicorp.consul.internal.common.EnvoyExtension
+	(*CheckType)(nil),               // 18: hashicorp.consul.internal.service.CheckType
+	(*pbcommon.EnterpriseMeta)(nil), // 19: hashicorp.consul.internal.common.EnterpriseMeta
+	(*pbcommon.Locality)(nil),       // 20: hashicorp.consul.internal.common.Locality
 }
 var file_private_pbservice_service_proto_depIdxs = []int32{
-	10, // 0: hashicorp.consul.internal.service.ConnectProxyConfig.LocalServicePorts:type_name -> hashicorp.consul.internal.service.ServicePort
-	15, // 1: hashicorp.consul.internal.service.ConnectProxyConfig.Config:type_name -> google.protobuf.Struct
+	11, // 0: hashicorp.consul.internal.service.ConnectProxyConfig.LocalServicePorts:type_name -> hashicorp.consul.internal.service.ServicePort
+	16, // 1: hashicorp.consul.internal.service.ConnectProxyConfig.Config:type_name -> google.protobuf.Struct
 	1,  // 2: hashicorp.consul.internal.service.ConnectProxyConfig.Upstreams:type_name -> hashicorp.consul.internal.service.Upstream
 	6,  // 3: hashicorp.consul.internal.service.ConnectProxyConfig.MeshGateway:type_name -> hashicorp.consul.internal.service.MeshGatewayConfig
 	4,  // 4: hashicorp.consul.internal.service.ConnectProxyConfig.Expose:type_name -> hashicorp.consul.internal.service.ExposeConfig
 	7,  // 5: hashicorp.consul.internal.service.ConnectProxyConfig.TransparentProxy:type_name -> hashicorp.consul.internal.service.TransparentProxyConfig
-	16, // 6: hashicorp.consul.internal.service.ConnectProxyConfig.EnvoyExtensions:type_name -> hashicorp.consul.internal.common.EnvoyExtension
+	17, // 6: hashicorp.consul.internal.service.ConnectProxyConfig.EnvoyExtensions:type_name -> hashicorp.consul.internal.common.EnvoyExtension
 	8,  // 7: hashicorp.consul.internal.service.ConnectProxyConfig.AccessLogs:type_name -> hashicorp.consul.internal.service.AccessLogsConfig
-	15, // 8: hashicorp.consul.internal.service.Upstream.Config:type_name -> google.protobuf.Struct
+	16, // 8: hashicorp.consul.internal.service.Upstream.Config:type_name -> google.protobuf.Struct
 	6,  // 9: hashicorp.consul.internal.service.Upstream.MeshGateway:type_name -> hashicorp.consul.internal.service.MeshGatewayConfig
 	9,  // 10: hashicorp.consul.internal.service.ServiceConnect.SidecarService:type_name -> hashicorp.consul.internal.service.ServiceDefinition
 	3,  // 11: hashicorp.consul.internal.service.ServiceConnect.PeerMeta:type_name -> hashicorp.consul.internal.service.PeeringServiceMeta
 	5,  // 12: hashicorp.consul.internal.service.ExposeConfig.Paths:type_name -> hashicorp.consul.internal.service.ExposePath
-	13, // 13: hashicorp.consul.internal.service.ServiceDefinition.TaggedAddresses:type_name -> hashicorp.consul.internal.service.ServiceDefinition.TaggedAddressesEntry
-	14, // 14: hashicorp.consul.internal.service.ServiceDefinition.Meta:type_name -> hashicorp.consul.internal.service.ServiceDefinition.MetaEntry
-	17, // 15: hashicorp.consul.internal.service.ServiceDefinition.Check:type_name -> hashicorp.consul.internal.service.CheckType
-	17, // 16: hashicorp.consul.internal.service.ServiceDefinition.Checks:type_name -> hashicorp.consul.internal.service.CheckType
-	12, // 17: hashicorp.consul.internal.service.ServiceDefinition.Weights:type_name -> hashicorp.consul.internal.service.Weights
+	14, // 13: hashicorp.consul.internal.service.ServiceDefinition.TaggedAddresses:type_name -> hashicorp.consul.internal.service.ServiceDefinition.TaggedAddressesEntry
+	15, // 14: hashicorp.consul.internal.service.ServiceDefinition.Meta:type_name -> hashicorp.consul.internal.service.ServiceDefinition.MetaEntry
+	18, // 15: hashicorp.consul.internal.service.ServiceDefinition.Check:type_name -> hashicorp.consul.internal.service.CheckType
+	18, // 16: hashicorp.consul.internal.service.ServiceDefinition.Checks:type_name -> hashicorp.consul.internal.service.CheckType
+	13, // 17: hashicorp.consul.internal.service.ServiceDefinition.Weights:type_name -> hashicorp.consul.internal.service.Weights
 	0,  // 18: hashicorp.consul.internal.service.ServiceDefinition.Proxy:type_name -> hashicorp.consul.internal.service.ConnectProxyConfig
-	18, // 19: hashicorp.consul.internal.service.ServiceDefinition.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
+	19, // 19: hashicorp.consul.internal.service.ServiceDefinition.EnterpriseMeta:type_name -> hashicorp.consul.internal.common.EnterpriseMeta
 	2,  // 20: hashicorp.consul.internal.service.ServiceDefinition.Connect:type_name -> hashicorp.consul.internal.service.ServiceConnect
-	19, // 21: hashicorp.consul.internal.service.ServiceDefinition.Locality:type_name -> hashicorp.consul.internal.common.Locality
-	10, // 22: hashicorp.consul.internal.service.ServiceDefinition.Ports:type_name -> hashicorp.consul.internal.service.ServicePort
-	11, // 23: hashicorp.consul.internal.service.ServiceDefinition.TaggedAddressesEntry.value:type_name -> hashicorp.consul.internal.service.ServiceAddress
-	24, // [24:24] is the sub-list for method output_type
-	24, // [24:24] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	20, // 21: hashicorp.consul.internal.service.ServiceDefinition.Locality:type_name -> hashicorp.consul.internal.common.Locality
+	11, // 22: hashicorp.consul.internal.service.ServiceDefinition.Ports:type_name -> hashicorp.consul.internal.service.ServicePort
+	10, // 23: hashicorp.consul.internal.service.ServiceDefinition.AI:type_name -> hashicorp.consul.internal.service.AIConfig
+	12, // 24: hashicorp.consul.internal.service.ServiceDefinition.TaggedAddressesEntry.value:type_name -> hashicorp.consul.internal.service.ServiceAddress
+	25, // [25:25] is the sub-list for method output_type
+	25, // [25:25] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_private_pbservice_service_proto_init() }
@@ -1495,7 +1560,7 @@ func file_private_pbservice_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_private_pbservice_service_proto_rawDesc), len(file_private_pbservice_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/private/pbservice/service.proto
+++ b/proto/private/pbservice/service.proto
@@ -325,6 +325,20 @@ message ServiceDefinition {
   // Ports is a list of ports that the service exposes.
   // mog: func-to=PortsToStructs func-from=NewPortsFromStructs
   repeated ServicePort Ports = 20;
+
+  // AI marks the service's role in the Agent Gateway (Inference plane).
+  AIConfig AI = 21;
+}
+
+// AIConfig marks a service's role in the Agent Gateway (Inference plane).
+//
+// mog annotation:
+//
+// target=github.com/hashicorp/consul/agent/structs.AIConfig
+// output=service.gen.go
+// name=Structs
+message AIConfig {
+  string Role = 1;
 }
 
 // ServicePort contains the port information for a service.

--- a/proto/private/pbsubscribe/subscribe.pb.go
+++ b/proto/private/pbsubscribe/subscribe.pb.go
@@ -85,6 +85,8 @@ const (
 	Topic_FileSystemCertificate Topic = 18
 	// GlobalRateLimit topic contains events for changes to global rate limits.
 	Topic_GlobalRateLimit Topic = 19
+	// AIGateway topic contains events for changes to ai-gateway config entries.
+	Topic_AIGateway Topic = 20
 )
 
 // Enum value maps for Topic.
@@ -110,6 +112,7 @@ var (
 		17: "ExportedServices",
 		18: "FileSystemCertificate",
 		19: "GlobalRateLimit",
+		20: "AIGateway",
 	}
 	Topic_value = map[string]int32{
 		"Unknown":               0,
@@ -132,6 +135,7 @@ var (
 		"ExportedServices":      17,
 		"FileSystemCertificate": 18,
 		"GlobalRateLimit":       19,
+		"AIGateway":             20,
 	}
 )
 
@@ -956,7 +960,7 @@ const file_private_pbsubscribe_subscribe_proto_rawDesc = "" +
 	"\x02Op\x18\x01 \x01(\x0e2\x14.subscribe.CatalogOpR\x02Op\x12\x12\n" +
 	"\x04Name\x18\x02 \x01(\tR\x04Name\x12X\n" +
 	"\x0eEnterpriseMeta\x18\x03 \x01(\v20.hashicorp.consul.internal.common.EnterpriseMetaR\x0eEnterpriseMeta\x12\x1a\n" +
-	"\bPeerName\x18\x04 \x01(\tR\bPeerName*\x8b\x03\n" +
+	"\bPeerName\x18\x04 \x01(\tR\bPeerName*\x9a\x03\n" +
 	"\x05Topic\x12\v\n" +
 	"\aUnknown\x10\x00\x12\x11\n" +
 	"\rServiceHealth\x10\x01\x12\x18\n" +
@@ -980,7 +984,8 @@ const file_private_pbsubscribe_subscribe_proto_rawDesc = "" +
 	"\vJWTProvider\x10\x10\x12\x14\n" +
 	"\x10ExportedServices\x10\x11\x12\x19\n" +
 	"\x15FileSystemCertificate\x10\x12\x12\x13\n" +
-	"\x0fGlobalRateLimit\x10\x13*)\n" +
+	"\x0fGlobalRateLimit\x10\x13\x12\r\n" +
+	"\tAIGateway\x10\x14*)\n" +
 	"\tCatalogOp\x12\f\n" +
 	"\bRegister\x10\x00\x12\x0e\n" +
 	"\n" +

--- a/proto/private/pbsubscribe/subscribe.proto
+++ b/proto/private/pbsubscribe/subscribe.proto
@@ -115,6 +115,9 @@ enum Topic {
 
   // GlobalRateLimit topic contains events for changes to global rate limits.
   GlobalRateLimit = 19;
+
+  // AIGateway topic contains events for changes to ai-gateway config entries.
+  AIGateway = 20;
 }
 
 message NamedSubject {


### PR DESCRIPTION
Adds first-class **inference-gateway** support to Consul: a new gateway kind that fronts Agent-to-LLM (A2LLM) traffic, terminates mesh mTLS, and runs an Envoy `ext_proc` filter pointing at a co-located policy processor which classifies, routes, and translates LLM requests to model upstreams. Targets the `ext-proc-api-gateway` integration branch.

## What's included

1. **Foundation** — `ServiceKindInferenceGateway`, the service `ai { role = "ai-model" }` block (`AIConfig`) that marks a service as a routable model upstream, the ext_proc-over-UDS plumbing, and `consul connect envoy -gateway inference` CLI support.
2. **`ai-gateway` config entry** (`AIGatewayConfigEntry`) — the routing policy bound to a gateway: `Processor` (UDS path, failure mode), `Routing.MatchRules` (first-match candidate selection), `FallbackChain`, `Retry`, `Timeout`, `ComplianceMap`, `ApplyTo`, with shadowed-rule validation.
3. **proxycfg handler + snapshot** — `configSnapshotInferenceGateway`: the gateway's own leaf, mesh config, the bound config entry, and discovered model upstreams (services whose instances carry `ai.role == "ai-model"`).
4. **xDS** — inbound mesh-mTLS listener + HCM with the `ext_proc` filter → `local_ext_proc` UDS cluster; an EDS cluster per discovered model; RDS routes matching `x-ai-cluster: <service>`; the discovered-model catalog surfaced to the processor via `consul.ai` listener metadata.
5. **Golden xDS tests + e2e integration fixes.**
6. **Forward client-cert details to ext_proc via XFCC** — render the HCM with `ForwardClientCertDetails: APPEND_FORWARD` + `SetCurrentClientCertDetails{Uri: true}` so the caller's SVID reaches the processor as `x-forwarded-client-cert` (without it the processor's identity stage fails closed). Golden regenerated.
7. **Resolve an inference-gateway as a connect upstream** — index the inference-gateway kind in `connectNameFromServiceNode` so a downstream sidecar's upstream to the gateway resolves its endpoints (it terminates mTLS under its own `svc/<name>` SAN, like a connect-native service).

## Validation

- `GOTOOLCHAIN=auto go build ./...` clean; `api/` untouched.
- Golden xDS (`TestAllResourcesFromSnapshot`) and connect-index/health state tests pass (`TestConnectNameFromServiceNode`, `TestStateStore_CheckConnectServiceNodes_InferenceGateway`).
- Driven end-to-end against the AI inference gateway: a downstream mesh service calls the gateway by service name → mesh mTLS → ext_proc resolves the real SPIFFE identity from XFCC → request routed/translated to the model upstream (verified live against both a mock and a real provider).