### PR TITLE
ensure only alive members are treated as joined in FloodJoins

### DIFF
--- a/.changelog/23709.txt
+++ b/.changelog/23709.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+serf: Fix WAN flood-join to ignore non-alive destination members (leaving/left/failed), allowing rejoined servers to heal back to alive in WAN membership.
+```

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/google/tcpproxy"
-	"github.com/hashicorp/go-metrics"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/raft"
@@ -1276,6 +1276,146 @@ func TestServer_Leave(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		r.Check(wantPeers(s1, 1))
 		r.Check(wantPeers(s2, 1))
+	})
+}
+
+func TestServer_WANFlood_RejoinAfterGracefulLeave(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.Bootstrap = true
+		c.NodeName = "server1"
+		c.Datacenter = "dc1"
+		c.SerfFloodInterval = 100 * time.Millisecond
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		c.Bootstrap = false
+		c.NodeName = "server2"
+		c.Datacenter = "dc1"
+		c.SerfFloodInterval = 100 * time.Millisecond
+	})
+	defer os.RemoveAll(dir2)
+
+	joinLAN(t, s2, s1)
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	wanNodeName := "server2.dc1"
+	wanStatus := func(s *Server, name string) (string, bool) {
+		for _, m := range s.WANMembers() {
+			if m.Name == name {
+				return m.Status.String(), true
+			}
+		}
+		return "", false
+	}
+
+	retry.Run(t, func(r *retry.R) {
+		status, ok := wanStatus(s1, wanNodeName)
+		require.True(r, ok, "expected WAN member to exist")
+		require.Equal(r, "alive", status)
+	})
+
+	require.NoError(t, s2.Leave())
+	s2.Shutdown()
+
+	retry.Run(t, func(r *retry.R) {
+		status, ok := wanStatus(s1, wanNodeName)
+		require.True(r, ok, "expected stale WAN member to remain visible")
+		require.NotEqual(r, "alive", status)
+	})
+
+	dir3, s2Rejoined := testServerWithConfig(t, func(c *Config) {
+		c.Bootstrap = false
+		c.NodeName = "server2"
+		c.Datacenter = "dc1"
+		c.SerfFloodInterval = 100 * time.Millisecond
+	})
+	defer os.RemoveAll(dir3)
+	defer s2Rejoined.Shutdown()
+
+	joinLAN(t, s2Rejoined, s1)
+
+	retry.Run(t, func(r *retry.R) {
+		status, ok := wanStatus(s1, wanNodeName)
+		require.True(r, ok, "expected WAN member to exist after rejoin")
+		require.Equal(r, "alive", status, "WAN member should heal back to alive after rejoin")
+	})
+}
+
+func TestServer_WANFlood_RejoinAfterFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.Bootstrap = true
+		c.NodeName = "server1"
+		c.Datacenter = "dc1"
+		c.SerfFloodInterval = 100 * time.Millisecond
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		c.Bootstrap = false
+		c.NodeName = "server2"
+		c.Datacenter = "dc1"
+		c.SerfFloodInterval = 100 * time.Millisecond
+	})
+	defer os.RemoveAll(dir2)
+
+	joinLAN(t, s2, s1)
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	wanNodeName := "server2.dc1"
+	wanStatus := func(s *Server, name string) (string, bool) {
+		for _, m := range s.WANMembers() {
+			if m.Name == name {
+				return m.Status.String(), true
+			}
+		}
+		return "", false
+	}
+
+	retry.Run(t, func(r *retry.R) {
+		status, ok := wanStatus(s1, wanNodeName)
+		require.True(r, ok, "expected WAN member to exist")
+		require.Equal(r, "alive", status)
+	})
+
+	// Abrupt shutdown to trigger failed/non-alive transitions.
+	s2.Shutdown()
+
+	retry.Run(t, func(r *retry.R) {
+		status, ok := wanStatus(s1, wanNodeName)
+		require.True(r, ok, "expected stale WAN member to remain visible")
+		require.NotEqual(r, "alive", status)
+	})
+
+	dir3, s2Rejoined := testServerWithConfig(t, func(c *Config) {
+		c.Bootstrap = false
+		c.NodeName = "server2"
+		c.Datacenter = "dc1"
+		c.SerfFloodInterval = 100 * time.Millisecond
+	})
+	defer os.RemoveAll(dir3)
+	defer s2Rejoined.Shutdown()
+
+	joinLAN(t, s2Rejoined, s1)
+
+	retry.Run(t, func(r *retry.R) {
+		status, ok := wanStatus(s1, wanNodeName)
+		require.True(r, ok, "expected WAN member to exist after rejoin")
+		require.Equal(r, "alive", status, "WAN member should heal back to alive after rejoin")
 	})
 }
 

--- a/agent/router/serf_flooder.go
+++ b/agent/router/serf_flooder.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/serf"
+
+	"github.com/hashicorp/consul/agent/metadata"
 )
 
 // FloodAddrFn gets the address and port to use for a given server when
@@ -31,6 +32,12 @@ func FloodJoins(logger hclog.Logger, addrFn FloodAddrFn,
 	// with cheap lookups.
 	index := make(map[string]*metadata.Server)
 	for _, m := range dstSerf.Members() {
+		// Only treat alive members as already joined. Non-alive members
+		// (leaving/left/failed) must not suppress re-join attempts.
+		if m.Status != serf.StatusAlive {
+			continue
+		}
+
 		ok, server := metadata.IsConsulServer(m)
 		if !ok {
 			continue


### PR DESCRIPTION
### Description

ensure only alive members are treated as joined in FloodJoins

### Testing & Reproduction steps

Scope

OSS fix in consul/agent/router/serf_flooder.go
OSS regression tests in consul/agent/consul/server_test.go


Automated Validation

In consul:
Command:
go test ./agent/consul -run TestServer_WANFlood_RejoinAfterGracefulLeave|TestServer_WANFlood_RejoinAfterFailure -count=1 -v

Expected:
Both tests pass.

In consul:
Command:
go test ./agent/router -count=1

Expected:
Package passes.

In consul-enterprise:
Command:
go test ./agent/consul -run TestServer_WANFlood_RejoinAfterGracefulLeave|TestServer_WANFlood_RejoinAfterFailure -count=1 -v

Expected:
Both tests pass.

Manual Reproduction And Verification (consul only)

Build consul binary:
Command:
cd /Users/sanikachavan/Documents/GitHub/consul
go build -o bin/consul .

Start two servers in one datacenter with unique LAN, WAN, HTTP, RPC, DNS, and grpc_tls ports.
Requirements:

server1 and server2 must use different port values for all listeners
both must have retry_join to each others LAN port
same node names used across restart, for example server2
Confirm initial WAN state from server1:
Command:
./bin/consul members -wan -http-addr 127.0.0.1:<server1_http_port>

Expected:
server1.dc1 alive
server2.dc1 alive

Force explicit graceful leave of server2:
Command:
./bin/consul leave -http-addr 127.0.0.1:<server2_http_port>

Confirm WAN non-alive state appears on server1:
Command:
./bin/consul members -wan -http-addr 127.0.0.1:<server1_http_port>

Expected:
server2.dc1 is leaving or left or failed
In observed run: left

Restart server2 with same node name and same configured ports.

Poll LAN and WAN status from server1 until both are alive:
Commands:
./bin/consul members -http-addr 127.0.0.1:<server1_http_port>
./bin/consul members -wan -http-addr 127.0.0.1:<server1_http_port>

Expected:
server2 becomes alive in LAN and alive in WAN
In observed run: WAN healed quickly after restart

Observed Manual Result

```
[1] 20306
[2] 20307
PORTS http1=33538 http2=33638 lan1=33536 lan2=33636 wan1=33537 wan2=33637
INITIAL_WAN
Node         Address          Status  Type    Build     Protocol  DC   Partition  Segment
server1.dc1  127.0.0.1:33537  alive   server  2.0.0dev  2         dc1  default    <all>
server2.dc1  127.0.0.1:33637  alive   server  2.0.0dev  2         dc1  default    <all>
SERVER2_EXPLICIT_LEAVE
[2]  + done       ./bin/consul agent -config-file "$WORKDIR/server2.hcl" >  2>&1
WAN_NONALIVE_AT=1 status=left
WAN_AFTER_LEAVE
Node         Address          Status  Type    Build     Protocol  DC   Partition  Segment
server1.dc1  127.0.0.1:33537  alive   server  2.0.0dev  2         dc1  default    <all>
server2.dc1  127.0.0.1:33637  left    server  2.0.0dev  2         dc1  default    <all>
RESTART_SERVER2
[2] 20520
POLL t=1 lan=left wan=left
HEALED_AT=2
FINAL_WAN
Node         Address          Status  Type    Build     Protocol  DC   Partition  Segment
server1.dc1  127.0.0.1:33537  alive   server  2.0.0dev  2         dc1  default    <all>
server2.dc1  127.0.0.1:33637  alive   server  2.0.0dev  2         dc1  default    <all>
SEEN_NONALIVE=1 HEALED=1
CONSUL_MANUAL_STRICT_VERDICT=PASS
```

WAN reached non-alive after leave
WAN healed back to alive after restart
Verdict: pass

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
