### PR TITLE
upgrade alpine base image to 3.24

### DIFF
--- a/.changelog/23711.txt
+++ b/.changelog/23711.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Upgrade alpine base image version to 3.24 to address [CVE-2026-41989], [ALPINE-CVE-2026-2100].
+```

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -39,8 +39,10 @@ container {
   triage {
     suppress {
       vulnerabilities = [
-        "CVE-2025-30258", //Alpine Linux's Security Issue Tracker in gnupg@2.4.9-r0: 
-        // gpg is only used in official docker build target but is uninstalled 
+        "CVE-2025-30258", //Alpine Linux's Security Issue Tracker in gnupg@2.4.9-r0:
+        // 2.4.x is the stable version of gnupg and the latest is 2.4.9 which is not affected by the vulnerability 
+        // according to NVD - CVE-2025-30258, but our scanner is still flagging it. Hence suppressing it for now.
+        // Impact: gpg is only used in official docker build target but is uninstalled 
         // just after verifying the signature of the Consul binary. This CVE is not exploitable in this context.
       ]
 

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -39,8 +39,9 @@ container {
   triage {
     suppress {
       vulnerabilities = [
-        "CVE-2025-30258", //Alpine Linux's Security Issue Tracker in gnupg@2.4.9-r0
-        "CVE-2026-41989", //Alpine Linux's Security Issue Tracker in libgcrypt@1.11.2-r0
+        "CVE-2025-30258", //Alpine Linux's Security Issue Tracker in gnupg@2.4.9-r0: 
+        // gpg is only used in official docker build target but is uninstalled 
+        // just after verifying the signature of the Consul binary. This CVE is not exploitable in this context.
       ]
 
       paths = [

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # Official docker image that includes binaries from releases.hashicorp.com. This
 # downloads the release from releases.hashicorp.com and therefore requires that
 # the release is published before building the Docker image.
-FROM docker.mirror.hashicorp.services/alpine:3.23 AS official
+FROM docker.mirror.hashicorp.services/alpine:3.24 AS official
 
 # This is the release of Consul to pull in.
 ARG VERSION
@@ -66,9 +66,6 @@ RUN set -eux && \
             iptables \
             tzdata \
             zlib && \
-    apk add --no-cache --upgrade \
-        --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
-        'curl>=8.20.0' && \
     gpg --keyserver keyserver.ubuntu.com --recv-keys C874011F0AB405110D02105534365D9472D7468F && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
@@ -136,7 +133,7 @@ CMD ["agent", "-dev", "-client", "0.0.0.0"]
 
 # Production docker image that uses CI built binaries.
 # Remember, this image cannot be built locally.
-FROM docker.mirror.hashicorp.services/alpine:3.23 AS default
+FROM docker.mirror.hashicorp.services/alpine:3.24 AS default
 
 ARG PRODUCT_VERSION
 ARG BIN_NAME
@@ -189,10 +186,7 @@ RUN apk add -v --no-cache --upgrade \
 		openssl \
 		su-exec \
 		jq \
-		zlib && \
-    apk add --no-cache --upgrade \
-        --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
-        'curl>=8.20.0'
+		zlib
 
 # Create a consul user and group first so the IDs get set the same way, even as
 # the rest of this may change over time.

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ RUN set -eux && \
             libc6-compat \
             iptables \
             tzdata \
-            zlib && \
+            zlib \
+            curl && \
     gpg --keyserver keyserver.ubuntu.com --recv-keys C874011F0AB405110D02105534365D9472D7468F && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
@@ -180,7 +181,8 @@ RUN apk add -v --no-cache --upgrade \
 		openssl \
 		su-exec \
 		jq \
-		zlib
+		zlib \
+        curl
 
 # Create a consul user and group first so the IDs get set the same way, even as
 # the rest of this may change over time.

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,6 @@ RUN addgroup consul && \
 
 # Set up certificates, base tools, and Consul.
 # libc6-compat is needed to symlink the shared libraries for ARM builds
-# Upgrade curl to >=8.20.0 from Alpine edge to fix CVE-2026-6429, CVE-2026-4873, CVE-2026-5773,
-# CVE-2026-6253, CVE-2026-6276, CVE-2026-7168, CVE-2026-5545 (fixed in curl 8.20.0).
-# Alpine 3.23 stable does not yet carry the patched version.
 RUN set -eux && \
     apk add --no-cache --upgrade \
             ca-certificates \
@@ -170,9 +167,6 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
 COPY LICENSE /usr/share/doc/$PRODUCT_NAME/LICENSE.txt
 # Set up certificates and base tools.
 # libc6-compat is needed to symlink the shared libraries for ARM builds
-# Upgrade curl to >=8.20.0 from Alpine edge to fix CVE-2026-6429, CVE-2026-4873, CVE-2026-5773,
-# CVE-2026-6253, CVE-2026-6276, CVE-2026-7168, CVE-2026-5545 (fixed in curl 8.20.0).
-# Alpine 3.23 stable does not yet carry the patched version.
 RUN apk add -v --no-cache --upgrade \
 		dumb-init \
 		libc6-compat \


### PR DESCRIPTION
### Description

Upgraded alpine base image to v3.24 to resolve known vulnerabilities CVE-2026-41989 and ALPINE-CVE-2026-2100.
<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
