### PR TITLE
ui: add acceptance coverage for Service.Namespace dashboard URLs

### DIFF
--- a/.changelog/23727.txt
+++ b/.changelog/23727.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Add acceptance coverage for `Service.Namespace` in dashboard URL templates
+```

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show.feature
@@ -261,6 +261,26 @@ Feature: dc / services / show: Show Service
     ---
     # The external dashboard link should use the Service.Name not the ID
     And I see href on the dashboardAnchor like "https://something.com?service-0&dc1"
+  Scenario: Given a dashboard template includes service namespace
+    Given 1 datacenter model with the value "dc1"
+    And 1 node models
+    And 1 service model from yaml
+    ---
+    - Service:
+        Kind: ~
+        Namespace: team-a
+    ---
+    And ui_config from yaml
+    ---
+    dashboard_url_templates:
+      service: https://something.com?{{Service.Name}}&{{Service.Namespace}}&{{Datacenter}}
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0
+    ---
+    And I see href on the dashboardAnchor like "https://something.com?service-0&team-a&dc1"
   Scenario: With no access to service
     Given 1 datacenter model with the value "dc1"
     And permissions from yaml


### PR DESCRIPTION
## Summary

- Adds an acceptance scenario for `{{Service.Namespace}}` substitution in `dashboard_url_templates` on the service page
- Closes the testing gap left after #11640 wired the placeholder into the UI templates

## Context

#11324 reported that `Service.Namespace` was documented but not available in dashboard URL templates. The UI wiring landed in #11640, but no acceptance test asserted namespace substitution. This PR adds that coverage.

## Test plan

- [ ] `cd ui/packages/consul-ui && ember test --filter="dashboard template includes service namespace"`
- [ ] Existing dashboard template scenario still passes

Fixes #11324