### PR TITLE
feat(dns): Add configurable DNS SRV priority on a per-service-instance basis.

### DIFF
--- a/.changelog/23728.txt
+++ b/.changelog/23728.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+dns: Add configurable per-service priority to DNS SRV responses.
+```

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -338,6 +338,7 @@ func buildAgentService(s *structs.NodeService, dc string) api.AgentService {
 		CreateIndex:       s.CreateIndex,
 		ModifyIndex:       s.ModifyIndex,
 		Weights:           weights,
+		Priority:          s.Priority,
 		Datacenter:        dc,
 		Locality:          s.Locality.ToAPI(),
 	}
@@ -1223,6 +1224,9 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		if err := structs.ValidateWeights(ns.Weights); err != nil {
 			return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid Weights: %v", err)}
 		}
+	}
+	if err := structs.ValidateServicePriority(ns.Priority); err != nil {
+		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid Priority: %v", err)}
 	}
 	if err := structs.ValidateServiceMetadata(ns.Kind, ns.Meta, false); err != nil {
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid Service Meta: %v", err)}

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -339,6 +339,7 @@ func buildAgentService(s *structs.NodeService, dc string) api.AgentService {
 		CreateIndex:       s.CreateIndex,
 		ModifyIndex:       s.ModifyIndex,
 		Weights:           weights,
+		Priority:          s.Priority,
 		Datacenter:        dc,
 		Locality:          s.Locality.ToAPI(),
 	}
@@ -1253,6 +1254,9 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		if err := structs.ValidateWeights(ns.Weights); err != nil {
 			return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid Weights: %v", err)}
 		}
+	}
+	if err := structs.ValidateServicePriority(ns.Priority); err != nil {
+		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid Priority: %v", err)}
 	}
 	if err := structs.ValidateServiceMetadata(ns.Kind, ns.Meta, false); err != nil {
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid Service Meta: %v", err)}

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -21,13 +21,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-metrics"
 	"github.com/mitchellh/hashstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/serf/serf"
 
@@ -8624,6 +8624,51 @@ func TestAgent_RegisterService_MultiPort(t *testing.T) {
 			if !svc.Ports.IsSame(tc.args.Ports) {
 				t.Fatalf("Ports do not match. Expected: %v, got: %v", tc.args.Ports, svc.Ports)
 			}
+		})
+	}
+}
+
+func TestAgent_RegisterService_Priority(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	testCases := []struct {
+		name               string
+		priority           int
+		expectedStatusCode int
+	}{
+		{name: "valid-priority", priority: 10, expectedStatusCode: http.StatusOK},
+		{name: "invalid-priority", priority: 65536, expectedStatusCode: http.StatusBadRequest},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := &structs.ServiceDefinition{
+				ID:       tc.name,
+				Name:     tc.name,
+				Port:     8080,
+				Priority: &tc.priority,
+			}
+			req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+			resp := httptest.NewRecorder()
+			a.srv.h.ServeHTTP(resp, req)
+
+			require.Equal(t, tc.expectedStatusCode, resp.Code)
+			svc := a.State.Service(structs.NewServiceID(tc.name, nil))
+			if tc.expectedStatusCode == http.StatusBadRequest {
+				require.Nil(t, svc)
+				require.Contains(t, resp.Body.String(), "Invalid Priority")
+				return
+			}
+
+			require.NotNil(t, svc)
+			require.NotNil(t, svc.Priority)
+			require.Equal(t, tc.priority, *svc.Priority)
 		})
 	}
 }

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -21,13 +21,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-metrics"
 	"github.com/mitchellh/hashstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/serf/serf"
 
@@ -8722,6 +8722,51 @@ func TestAgent_RegisterService_MultiPort(t *testing.T) {
 			if !svc.Ports.IsSame(tc.args.Ports) {
 				t.Fatalf("Ports do not match. Expected: %v, got: %v", tc.args.Ports, svc.Ports)
 			}
+		})
+	}
+}
+
+func TestAgent_RegisterService_Priority(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	testCases := []struct {
+		name               string
+		priority           int
+		expectedStatusCode int
+	}{
+		{name: "valid-priority", priority: 10, expectedStatusCode: http.StatusOK},
+		{name: "invalid-priority", priority: 65536, expectedStatusCode: http.StatusBadRequest},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := &structs.ServiceDefinition{
+				ID:       tc.name,
+				Name:     tc.name,
+				Port:     8080,
+				Priority: &tc.priority,
+			}
+			req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+			resp := httptest.NewRecorder()
+			a.srv.h.ServeHTTP(resp, req)
+
+			require.Equal(t, tc.expectedStatusCode, resp.Code)
+			svc := a.State.Service(structs.NewServiceID(tc.name, nil))
+			if tc.expectedStatusCode == http.StatusBadRequest {
+				require.Nil(t, svc)
+				require.Contains(t, resp.Body.String(), "Invalid Priority")
+				return
+			}
+
+			require.NotNil(t, svc)
+			require.NotNil(t, svc.Priority)
+			require.Equal(t, tc.priority, *svc.Priority)
 		})
 	}
 }

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -20,11 +20,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-metrics/prometheus"
 	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics/prometheus"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-sockaddr/template"
 	"github.com/hashicorp/memberlist"
@@ -1791,6 +1791,9 @@ func (b *builder) serviceVal(v *ServiceDefinition) *structs.ServiceDefinition {
 	if err := structs.ValidateWeights(serviceWeights); err != nil {
 		b.err = multierror.Append(b.err, fmt.Errorf("Invalid weight definition for service %s: %s", stringVal(v.Name), err))
 	}
+	if err := structs.ValidateServicePriority(v.Priority); err != nil {
+		b.err = multierror.Append(b.err, fmt.Errorf("Invalid priority definition for service %s: %s", stringVal(v.Name), err))
+	}
 
 	if (v.Port != nil || v.Address != nil) && (v.SocketPath != nil) {
 		b.err = multierror.Append(b.err,
@@ -1812,6 +1815,7 @@ func (b *builder) serviceVal(v *ServiceDefinition) *structs.ServiceDefinition {
 		Token:             stringVal(v.Token),
 		EnableTagOverride: boolVal(v.EnableTagOverride),
 		Weights:           serviceWeights,
+		Priority:          v.Priority,
 		Checks:            checks,
 		Proxy:             b.serviceProxyVal(v.Proxy),
 		Connect:           b.serviceConnectVal(v.Connect),

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1830,6 +1830,9 @@ func (b *builder) serviceVal(v *ServiceDefinition) *structs.ServiceDefinition {
 	if err := structs.ValidateWeights(serviceWeights); err != nil {
 		b.err = multierror.Append(b.err, fmt.Errorf("Invalid weight definition for service %s: %s", stringVal(v.Name), err))
 	}
+	if err := structs.ValidateServicePriority(v.Priority); err != nil {
+		b.err = multierror.Append(b.err, fmt.Errorf("Invalid priority definition for service %s: %s", stringVal(v.Name), err))
+	}
 
 	if (v.Port != nil || v.Address != nil) && (v.SocketPath != nil) {
 		b.err = multierror.Append(b.err,
@@ -1851,6 +1854,7 @@ func (b *builder) serviceVal(v *ServiceDefinition) *structs.ServiceDefinition {
 		Token:             stringVal(v.Token),
 		EnableTagOverride: boolVal(v.EnableTagOverride),
 		Weights:           serviceWeights,
+		Priority:          v.Priority,
 		Checks:            checks,
 		Proxy:             b.serviceProxyVal(v.Proxy),
 		Connect:           b.serviceConnectVal(v.Connect),

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -383,13 +383,15 @@ func TestBuilder_ServiceVal_MultiError(t *testing.T) {
 		Checks: []CheckDefinition{
 			{Interval: strPtr("bad-interval")},
 		},
-		Weights: &ServiceWeights{Passing: intPtr(-1)},
+		Weights:  &ServiceWeights{Passing: intPtr(-1)},
+		Priority: intPtr(-1),
 	})
 	require.Error(t, b.err)
-	require.Contains(t, b.err.Error(), "4 errors")
+	require.Contains(t, b.err.Error(), "5 errors")
 	require.Contains(t, b.err.Error(), "bad-interval")
 	require.Contains(t, b.err.Error(), "Key cannot be blank")
 	require.Contains(t, b.err.Error(), "Invalid weight")
+	require.Contains(t, b.err.Error(), "Invalid priority")
 	require.Contains(t, b.err.Error(), "cannot have both socket path")
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -415,6 +415,7 @@ type ServiceDefinition struct {
 	Checks            []CheckDefinition         `mapstructure:"checks"`
 	Token             *string                   `mapstructure:"token"`
 	Weights           *ServiceWeights           `mapstructure:"weights"`
+	Priority          *int                      `mapstructure:"priority"`
 	EnableTagOverride *bool                     `mapstructure:"enable_tag_override"`
 	Proxy             *ServiceProxy             `mapstructure:"proxy"`
 	Connect           *ServiceConnect           `mapstructure:"connect"`

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -424,6 +424,7 @@ type ServiceDefinition struct {
 	Checks            []CheckDefinition         `mapstructure:"checks"`
 	Token             *string                   `mapstructure:"token"`
 	Weights           *ServiceWeights           `mapstructure:"weights"`
+	Priority          *int                      `mapstructure:"priority"`
 	EnableTagOverride *bool                     `mapstructure:"enable_tag_override"`
 	Proxy             *ServiceProxy             `mapstructure:"proxy"`
 	Connect           *ServiceConnect           `mapstructure:"connect"`

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -21,9 +21,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/go-metrics/prometheus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
+
+	"github.com/hashicorp/go-metrics/prometheus"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/cache"
@@ -2615,11 +2616,11 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 		json: []string{
 			`{ "service": { "name": "a", "port": 80 } }`,
-			`{ "service": { "name": "b", "port": 90, "meta": {"my": "value"}, "weights": {"passing": 13} } }`,
+			`{ "service": { "name": "b", "port": 90, "meta": {"my": "value"}, "weights": {"passing": 13}, "priority": 0 } }`,
 		},
 		hcl: []string{
 			`service = { name = "a" port = 80 }`,
-			`service = { name = "b" port = 90 meta={my="value"}, weights={passing=13}}`,
+			`service = { name = "b" port = 90 meta={my="value"}, weights={passing=13}, priority=0}`,
 		},
 		expected: func(rt *RuntimeConfig) {
 			rt.Services = []*structs.ServiceDefinition{
@@ -2639,10 +2640,24 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 						Passing: 13,
 						Warning: 1,
 					},
+					Priority: intPtr(0),
 				},
 			}
 			rt.DataDir = dataDir
 		},
+	})
+	run(t, testCase{
+		desc: "service priority out of range",
+		args: []string{
+			`-data-dir=` + dataDir,
+		},
+		json: []string{
+			`{ "service": { "name": "a", "port": 80, "priority": 65536 } }`,
+		},
+		hcl: []string{
+			`service = { name = "a" port = 80 priority = 65536 }`,
+		},
+		expectedErr: `Invalid priority definition for service a: DNS SRV Priority must be between 0 and 65535`,
 	})
 	run(t, testCase{
 		desc: "service with wrong meta: too long key",
@@ -6733,12 +6748,13 @@ func TestLoad_FullConfig(t *testing.T) {
 		ServerPort:              3757,
 		Services: []*structs.ServiceDefinition{
 			{
-				ID:      "wI1dzxS4",
-				Name:    "7IszXMQ1",
-				Tags:    []string{"0Zwg8l6v", "zebELdN5"},
-				Address: "9RhqPSPB",
-				Token:   "myjKJkWH",
-				Port:    72219,
+				ID:       "wI1dzxS4",
+				Name:     "7IszXMQ1",
+				Tags:     []string{"0Zwg8l6v", "zebELdN5"},
+				Address:  "9RhqPSPB",
+				Token:    "myjKJkWH",
+				Port:     72219,
+				Priority: intPtr(32767),
 				Weights: &structs.Weights{
 					Passing: 1,
 					Warning: 1,

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -21,9 +21,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/go-metrics/prometheus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
+
+	"github.com/hashicorp/go-metrics/prometheus"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/cache"
@@ -2623,11 +2624,11 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 		json: []string{
 			`{ "service": { "name": "a", "port": 80 } }`,
-			`{ "service": { "name": "b", "port": 90, "meta": {"my": "value"}, "weights": {"passing": 13} } }`,
+			`{ "service": { "name": "b", "port": 90, "meta": {"my": "value"}, "weights": {"passing": 13}, "priority": 0 } }`,
 		},
 		hcl: []string{
 			`service = { name = "a" port = 80 }`,
-			`service = { name = "b" port = 90 meta={my="value"}, weights={passing=13}}`,
+			`service = { name = "b" port = 90 meta={my="value"}, weights={passing=13}, priority=0}`,
 		},
 		expected: func(rt *RuntimeConfig) {
 			rt.Services = []*structs.ServiceDefinition{
@@ -2647,10 +2648,24 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 						Passing: 13,
 						Warning: 1,
 					},
+					Priority: intPtr(0),
 				},
 			}
 			rt.DataDir = dataDir
 		},
+	})
+	run(t, testCase{
+		desc: "service priority out of range",
+		args: []string{
+			`-data-dir=` + dataDir,
+		},
+		json: []string{
+			`{ "service": { "name": "a", "port": 80, "priority": 65536 } }`,
+		},
+		hcl: []string{
+			`service = { name = "a" port = 80 priority = 65536 }`,
+		},
+		expectedErr: `Invalid priority definition for service a: DNS SRV Priority must be between 0 and 65535`,
 	})
 	run(t, testCase{
 		desc: "service with wrong meta: too long key",
@@ -6743,12 +6758,13 @@ func TestLoad_FullConfig(t *testing.T) {
 		ServerPort:              3757,
 		Services: []*structs.ServiceDefinition{
 			{
-				ID:      "wI1dzxS4",
-				Name:    "7IszXMQ1",
-				Tags:    []string{"0Zwg8l6v", "zebELdN5"},
-				Address: "9RhqPSPB",
-				Token:   "myjKJkWH",
-				Port:    72219,
+				ID:       "wI1dzxS4",
+				Name:     "7IszXMQ1",
+				Tags:     []string{"0Zwg8l6v", "zebELdN5"},
+				Address:  "9RhqPSPB",
+				Token:    "myjKJkWH",
+				Port:     72219,
+				Priority: intPtr(32767),
 				Weights: &structs.Weights{
 					Passing: 1,
 					Warning: 1,

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -391,6 +391,7 @@
             "Name": "foo",
             "Port": 0,
             "Ports": [],
+            "Priority": null,
             "Proxy": null,
             "SocketPath": "",
             "TaggedAddresses": {},

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -393,6 +393,7 @@
             "Name": "foo",
             "Port": 0,
             "Ports": [],
+            "Priority": null,
             "Proxy": null,
             "SocketPath": "",
             "TaggedAddresses": {},

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -529,6 +529,7 @@ services = [
         address = "9RhqPSPB"
         token = "myjKJkWH"
         port = 72219
+        priority = 32767
         enable_tag_override = true
         check = {
             id = "qmfeO5if"

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -530,6 +530,7 @@ services = [
         address = "9RhqPSPB"
         token = "myjKJkWH"
         port = 72219
+        priority = 32767
         enable_tag_override = true
         check = {
             id = "qmfeO5if"

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -621,6 +621,7 @@
       "address": "9RhqPSPB",
       "token": "myjKJkWH",
       "port": 72219,
+      "priority": 32767,
       "enable_tag_override": true,
       "check": {
         "id": "qmfeO5if",

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -622,6 +622,7 @@
       "address": "9RhqPSPB",
       "token": "myjKJkWH",
       "port": 72219,
+      "priority": 32767,
       "enable_tag_override": true,
       "check": {
         "id": "qmfeO5if",

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -17,10 +17,10 @@ import (
 	"time"
 
 	"github.com/armon/go-radix"
-	"github.com/hashicorp/go-metrics"
 	"github.com/miekg/dns"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics"
 
 	"github.com/hashicorp/consul/acl"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
@@ -1813,6 +1813,13 @@ func findWeight(node structs.CheckServiceNode) int {
 	}
 }
 
+func findPriority(node structs.CheckServiceNode) uint16 {
+	if node.Service.Priority == nil {
+		return 1
+	}
+	return uint16(*node.Service.Priority)
+}
+
 func (d *DNSServer) encodeIPAsFqdn(questionName string, serviceNode structs.CheckServiceNode, ip net.IP) string {
 	ipv4 := ip.To4()
 	respDomain := d.getResponseDomain(questionName)
@@ -1926,7 +1933,7 @@ func (d *DNSServer) makeRecordFromServiceNode(lookup serviceLookup, serviceNode 
 					Class:  dns.ClassINET,
 					Ttl:    uint32(ttl / time.Second),
 				},
-				Priority: 1,
+				Priority: findPriority(serviceNode),
 				Weight:   uint16(findWeight(serviceNode)),
 				Port:     uint16(d.agent.TranslateServicePort(lookup.Datacenter, port, serviceNode.Service.TaggedAddresses)),
 				Target:   nodeFQDN,
@@ -1961,7 +1968,7 @@ func (d *DNSServer) makeRecordFromIP(lookup serviceLookup, addr net.IP, serviceN
 					Class:  dns.ClassINET,
 					Ttl:    uint32(ttl / time.Second),
 				},
-				Priority: 1,
+				Priority: findPriority(serviceNode),
 				Weight:   uint16(findWeight(serviceNode)),
 				Port:     uint16(d.agent.TranslateServicePort(lookup.Datacenter, port, serviceNode.Service.TaggedAddresses)),
 				Target:   ipFQDN,
@@ -2010,7 +2017,7 @@ MORE_REC:
 					Class:  dns.ClassINET,
 					Ttl:    uint32(ttl / time.Second),
 				},
-				Priority: 1,
+				Priority: findPriority(serviceNode),
 				Weight:   uint16(findWeight(serviceNode)),
 				Port:     uint16(d.agent.TranslateServicePort(lookup.Datacenter, port, serviceNode.Service.TaggedAddresses)),
 				Target:   dns.Fqdn(fqdn),

--- a/agent/dns_service_lookup_test.go
+++ b/agent/dns_service_lookup_test.go
@@ -378,18 +378,20 @@ func TestDNS_ServiceAddressWithTagLookup(t *testing.T) {
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	priority := 10
 
 	{
 		// This emulates a Nomad service registration.
 		// Using an internal RPC for Catalog.Register will not trigger the same condition.
 		err := a.Client().Agent().ServiceRegister(&api.AgentServiceRegistration{
-			Kind:    api.ServiceKindTypical,
-			ID:      "db-1",
-			Name:    "db",
-			Tags:    []string{"primary"},
-			Address: "127.0.0.1",
-			Port:    12345,
-			Checks:  make([]*api.AgentServiceCheck, 0),
+			Kind:     api.ServiceKindTypical,
+			ID:       "db-1",
+			Name:     "db",
+			Tags:     []string{"primary"},
+			Address:  "127.0.0.1",
+			Port:     12345,
+			Priority: &priority,
+			Checks:   make([]*api.AgentServiceCheck, 0),
 		})
 		require.NoError(t, err)
 	}
@@ -424,6 +426,7 @@ func TestDNS_ServiceAddressWithTagLookup(t *testing.T) {
 		srvRec, ok := in.Answer[0].(*dns.SRV)
 		require.True(t, ok, "Expected an SRV record in the Answer section")
 		require.Equal(t, uint16(12345), srvRec.Port)
+		require.Equal(t, uint16(10), srvRec.Priority)
 		require.Equal(t, "7f000001.addr.dc1.consul.", srvRec.Target)
 
 		aRec, ok := in.Extra[0].(*dns.A)
@@ -1185,6 +1188,7 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 		       `)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	priority := 0
 
 	// Register a node with a service whose address isn't an IP.
 	{
@@ -1193,10 +1197,11 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 			Node:       "foo",
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
-				Service: "db",
-				Tags:    []string{"primary"},
-				Address: "www.google.com",
-				Port:    12345,
+				Service:  "db",
+				Tags:     []string{"primary"},
+				Address:  "www.google.com",
+				Port:     12345,
+				Priority: &priority,
 			},
 		}
 
@@ -1256,6 +1261,7 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 		if srvRec.Port != 12345 {
 			t.Fatalf("Bad: %#v", srvRec)
 		}
+		require.Equal(t, uint16(0), srvRec.Priority)
 		if srvRec.Target != "www.google.com." {
 			t.Fatalf("Bad: %#v", srvRec)
 		}

--- a/agent/grpc-external/services/peerstream/subscription_manager.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager.go
@@ -11,12 +11,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/hashicorp/consul/ipaddr"
-	"github.com/hashicorp/consul/lib/retry"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/cache"
@@ -27,6 +25,8 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/submatview"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/ipaddr"
+	"github.com/hashicorp/consul/lib/retry"
 	"github.com/hashicorp/consul/proto/private/pbcommon"
 	"github.com/hashicorp/consul/proto/private/pbpeering"
 	"github.com/hashicorp/consul/proto/private/pbpeerstream"
@@ -662,6 +662,7 @@ func createDiscoChainHealth(
 				Port:            gwService.Port,
 				SocketPath:      gwService.SocketPath,
 				Weights:         gwService.Weights,
+				Priority:        gwService.Priority,
 				Connect: &pbservice.ServiceConnect{
 					PeerMeta: peerMeta,
 				},

--- a/agent/structs/service_definition.go
+++ b/agent/structs/service_definition.go
@@ -28,6 +28,7 @@ type ServiceDefinition struct {
 	Check             CheckType
 	Checks            CheckTypes
 	Weights           *Weights
+	Priority          *int `json:",omitempty"`
 	Token             string
 	EnableTagOverride bool
 	Locality          *Locality
@@ -80,6 +81,7 @@ func (s *ServiceDefinition) NodeService() *NodeService {
 		Ports:             s.Ports,
 		SocketPath:        s.SocketPath,
 		Weights:           s.Weights,
+		Priority:          s.Priority,
 		EnableTagOverride: s.EnableTagOverride,
 		EnterpriseMeta:    s.EnterpriseMeta,
 		Locality:          s.Locality,

--- a/agent/structs/structs.deepcopy.go
+++ b/agent/structs/structs.deepcopy.go
@@ -1003,6 +1003,10 @@ func (o *NodeService) DeepCopy() *NodeService {
 		cp.Weights = new(Weights)
 		*cp.Weights = *o.Weights
 	}
+	if o.Priority != nil {
+		cp.Priority = new(int)
+		*cp.Priority = *o.Priority
+	}
 	if o.Locality != nil {
 		cp.Locality = new(Locality)
 		*cp.Locality = *o.Locality
@@ -1188,6 +1192,10 @@ func (o *ServiceDefinition) DeepCopy() *ServiceDefinition {
 	if o.Weights != nil {
 		cp.Weights = new(Weights)
 		*cp.Weights = *o.Weights
+	}
+	if o.Priority != nil {
+		cp.Priority = new(int)
+		*cp.Priority = *o.Priority
 	}
 	if o.Locality != nil {
 		cp.Locality = new(Locality)

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1034,6 +1034,17 @@ func ValidateWeights(weights *Weights) error {
 	return nil
 }
 
+// ValidateServicePriority checks that a DNS SRV priority is valid.
+func ValidateServicePriority(priority *int) error {
+	if priority == nil {
+		return nil
+	}
+	if *priority < 0 || *priority > 65535 {
+		return fmt.Errorf("DNS SRV Priority must be between 0 and 65535")
+	}
+	return nil
+}
+
 // validateMetaPair checks that the given key/value pair is in a valid format
 func validateMetaPair(key, value string, allowConsulPrefix bool, allowedConsulKeys map[string]struct{}) error {
 	if key == "" {
@@ -1091,6 +1102,7 @@ type ServiceNode struct {
 	ServiceAddress           string
 	ServiceTaggedAddresses   map[string]ServiceAddress `json:",omitempty"`
 	ServiceWeights           Weights
+	ServicePriority          *int `json:",omitempty"`
 	ServiceMeta              map[string]string
 	ServicePort              int
 	ServicePorts             ServicePorts `bexpr:"-"`
@@ -1139,6 +1151,12 @@ func (s *ServiceNode) PartialClone() *ServiceNode {
 		}
 	}
 
+	var servicePriority *int
+	if s.ServicePriority != nil {
+		servicePriority = new(int)
+		*servicePriority = *s.ServicePriority
+	}
+
 	return &ServiceNode{
 		// Skip ID, see above.
 		Node: s.Node,
@@ -1155,6 +1173,7 @@ func (s *ServiceNode) PartialClone() *ServiceNode {
 		ServicePorts:             s.ServicePorts,
 		ServiceMeta:              nsmeta,
 		ServiceWeights:           s.ServiceWeights,
+		ServicePriority:          servicePriority,
 		ServiceEnableTagOverride: s.ServiceEnableTagOverride,
 		ServiceProxy:             s.ServiceProxy,
 		ServiceConnect:           s.ServiceConnect,
@@ -1182,6 +1201,7 @@ func (s *ServiceNode) ToNodeService() *NodeService {
 		SocketPath:        s.ServiceSocketPath,
 		Meta:              s.ServiceMeta,
 		Weights:           &s.ServiceWeights,
+		Priority:          s.ServicePriority,
 		EnableTagOverride: s.ServiceEnableTagOverride,
 		Proxy:             s.ServiceProxy,
 		Connect:           s.ServiceConnect,
@@ -1411,6 +1431,7 @@ type NodeService struct {
 	Ports             ServicePorts `json:",omitempty" bexpr:"-"`
 	SocketPath        string       `json:",omitempty"` // TODO This might be integrated into Address somehow, but not sure about the ergonomics. Only one of (address,port) or socketpath can be defined.
 	Weights           *Weights
+	Priority          *int `json:",omitempty"`
 	EnableTagOverride bool
 	Locality          *Locality `json:",omitempty" bexpr:"-"`
 
@@ -1645,6 +1666,10 @@ func (s *NodeService) Validate() error {
 func (s *NodeService) ValidateForAgent() error {
 	var result error
 
+	if err := ValidateServicePriority(s.Priority); err != nil {
+		result = multierror.Append(result, err)
+	}
+
 	// TODO(partitions): remember to double check that this doesn't cross partition boundaries
 
 	// ConnectProxy validation
@@ -1834,6 +1859,7 @@ func (s *NodeService) IsSame(other *NodeService) bool {
 		s.SocketPath != other.SocketPath ||
 		!reflect.DeepEqual(s.TaggedAddresses, other.TaggedAddresses) ||
 		!reflect.DeepEqual(s.Weights, other.Weights) ||
+		!reflect.DeepEqual(s.Priority, other.Priority) ||
 		!reflect.DeepEqual(s.Meta, other.Meta) ||
 		!reflect.DeepEqual(s.Locality, other.Locality) ||
 		s.EnableTagOverride != other.EnableTagOverride ||
@@ -1873,6 +1899,7 @@ func (s *ServiceNode) IsSameService(other *ServiceNode) bool {
 		!s.ServicePorts.IsSame(other.ServicePorts) ||
 		!reflect.DeepEqual(s.ServiceMeta, other.ServiceMeta) ||
 		!reflect.DeepEqual(s.ServiceWeights, other.ServiceWeights) ||
+		!reflect.DeepEqual(s.ServicePriority, other.ServicePriority) ||
 		s.ServiceEnableTagOverride != other.ServiceEnableTagOverride ||
 		!reflect.DeepEqual(s.ServiceProxy, other.ServiceProxy) ||
 		!reflect.DeepEqual(s.ServiceConnect, other.ServiceConnect) ||
@@ -1910,6 +1937,7 @@ func (s *NodeService) ToServiceNode(node string) *ServiceNode {
 		ServiceSocketPath:        s.SocketPath,
 		ServiceMeta:              s.Meta,
 		ServiceWeights:           theWeights,
+		ServicePriority:          s.Priority,
 		ServiceEnableTagOverride: s.EnableTagOverride,
 		ServiceProxy:             s.Proxy,
 		ServiceConnect:           s.Connect,

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1036,6 +1036,17 @@ func ValidateWeights(weights *Weights) error {
 	return nil
 }
 
+// ValidateServicePriority checks that a DNS SRV priority is valid.
+func ValidateServicePriority(priority *int) error {
+	if priority == nil {
+		return nil
+	}
+	if *priority < 0 || *priority > 65535 {
+		return fmt.Errorf("DNS SRV Priority must be between 0 and 65535")
+	}
+	return nil
+}
+
 // validateMetaPair checks that the given key/value pair is in a valid format
 func validateMetaPair(key, value string, allowConsulPrefix bool, allowedConsulKeys map[string]struct{}) error {
 	if key == "" {
@@ -1093,6 +1104,7 @@ type ServiceNode struct {
 	ServiceAddress           string
 	ServiceTaggedAddresses   map[string]ServiceAddress `json:",omitempty"`
 	ServiceWeights           Weights
+	ServicePriority          *int `json:",omitempty"`
 	ServiceMeta              map[string]string
 	ServicePort              int
 	ServicePorts             ServicePorts `bexpr:"-"`
@@ -1141,6 +1153,12 @@ func (s *ServiceNode) PartialClone() *ServiceNode {
 		}
 	}
 
+	var servicePriority *int
+	if s.ServicePriority != nil {
+		servicePriority = new(int)
+		*servicePriority = *s.ServicePriority
+	}
+
 	return &ServiceNode{
 		// Skip ID, see above.
 		Node: s.Node,
@@ -1157,6 +1175,7 @@ func (s *ServiceNode) PartialClone() *ServiceNode {
 		ServicePorts:             s.ServicePorts,
 		ServiceMeta:              nsmeta,
 		ServiceWeights:           s.ServiceWeights,
+		ServicePriority:          servicePriority,
 		ServiceEnableTagOverride: s.ServiceEnableTagOverride,
 		ServiceProxy:             s.ServiceProxy,
 		ServiceConnect:           s.ServiceConnect,
@@ -1184,6 +1203,7 @@ func (s *ServiceNode) ToNodeService() *NodeService {
 		SocketPath:        s.ServiceSocketPath,
 		Meta:              s.ServiceMeta,
 		Weights:           &s.ServiceWeights,
+		Priority:          s.ServicePriority,
 		EnableTagOverride: s.ServiceEnableTagOverride,
 		Proxy:             s.ServiceProxy,
 		Connect:           s.ServiceConnect,
@@ -1413,6 +1433,7 @@ type NodeService struct {
 	Ports             ServicePorts `json:",omitempty" bexpr:"-"`
 	SocketPath        string       `json:",omitempty"` // TODO This might be integrated into Address somehow, but not sure about the ergonomics. Only one of (address,port) or socketpath can be defined.
 	Weights           *Weights
+	Priority          *int `json:",omitempty"`
 	EnableTagOverride bool
 	Locality          *Locality `json:",omitempty" bexpr:"-"`
 
@@ -1647,6 +1668,10 @@ func (s *NodeService) Validate() error {
 func (s *NodeService) ValidateForAgent() error {
 	var result error
 
+	if err := ValidateServicePriority(s.Priority); err != nil {
+		result = multierror.Append(result, err)
+	}
+
 	// TODO(partitions): remember to double check that this doesn't cross partition boundaries
 
 	// ConnectProxy validation
@@ -1836,6 +1861,7 @@ func (s *NodeService) IsSame(other *NodeService) bool {
 		s.SocketPath != other.SocketPath ||
 		!reflect.DeepEqual(s.TaggedAddresses, other.TaggedAddresses) ||
 		!reflect.DeepEqual(s.Weights, other.Weights) ||
+		!reflect.DeepEqual(s.Priority, other.Priority) ||
 		!reflect.DeepEqual(s.Meta, other.Meta) ||
 		!reflect.DeepEqual(s.Locality, other.Locality) ||
 		s.EnableTagOverride != other.EnableTagOverride ||
@@ -1875,6 +1901,7 @@ func (s *ServiceNode) IsSameService(other *ServiceNode) bool {
 		!s.ServicePorts.IsSame(other.ServicePorts) ||
 		!reflect.DeepEqual(s.ServiceMeta, other.ServiceMeta) ||
 		!reflect.DeepEqual(s.ServiceWeights, other.ServiceWeights) ||
+		!reflect.DeepEqual(s.ServicePriority, other.ServicePriority) ||
 		s.ServiceEnableTagOverride != other.ServiceEnableTagOverride ||
 		!reflect.DeepEqual(s.ServiceProxy, other.ServiceProxy) ||
 		!reflect.DeepEqual(s.ServiceConnect, other.ServiceConnect) ||
@@ -1912,6 +1939,7 @@ func (s *NodeService) ToServiceNode(node string) *ServiceNode {
 		ServiceSocketPath:        s.SocketPath,
 		ServiceMeta:              s.Meta,
 		ServiceWeights:           theWeights,
+		ServicePriority:          s.Priority,
 		ServiceEnableTagOverride: s.EnableTagOverride,
 		ServiceProxy:             s.Proxy,
 		ServiceConnect:           s.Connect,

--- a/agent/structs/structs_filtering_test.go
+++ b/agent/structs/structs_filtering_test.go
@@ -478,6 +478,11 @@ var expectedFieldConfigNodeService bexpr.FieldConfigurations = bexpr.FieldConfig
 		StructFieldName: "Weights",
 		SubFields:       expectedFieldConfigWeights,
 	},
+	"Priority": &bexpr.FieldConfiguration{
+		StructFieldName:     "Priority",
+		CoerceFn:            bexpr.CoerceInt,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual},
+	},
 	"EnableTagOverride": &bexpr.FieldConfiguration{
 		StructFieldName:     "EnableTagOverride",
 		CoerceFn:            bexpr.CoerceBool,
@@ -581,6 +586,11 @@ var expectedFieldConfigServiceNode bexpr.FieldConfigurations = bexpr.FieldConfig
 	"ServiceWeights": &bexpr.FieldConfiguration{
 		StructFieldName: "ServiceWeights",
 		SubFields:       expectedFieldConfigWeights,
+	},
+	"ServicePriority": &bexpr.FieldConfiguration{
+		StructFieldName:     "ServicePriority",
+		CoerceFn:            bexpr.CoerceInt,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual},
 	},
 	"ServiceEnableTagOverride": &bexpr.FieldConfiguration{
 		StructFieldName:     "ServiceEnableTagOverride",

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -191,6 +191,7 @@ func TestStructs_RegisterRequest_ChangesNode(t *testing.T) {
 
 // testServiceNode gives a fully filled out ServiceNode instance.
 func testServiceNode(t *testing.T) *ServiceNode {
+	priority := 10
 	return &ServiceNode{
 		ID:         types.NodeID("40e4a748-2192-161a-0510-9bf59fe950b5"),
 		Node:       "node1",
@@ -217,7 +218,8 @@ func testServiceNode(t *testing.T) *ServiceNode {
 				Port:    80,
 			},
 		},
-		ServicePort: 8080,
+		ServicePort:     8080,
+		ServicePriority: &priority,
 		ServicePorts: ServicePorts{
 			{
 				Name:    "http",
@@ -477,6 +479,13 @@ func TestStructs_ServiceNode_IsSameService(t *testing.T) {
 			},
 		},
 		{
+			name: "ServicePriority",
+			setup: func(sn *ServiceNode) {
+				priority := 20
+				sn.ServicePriority = &priority
+			},
+		},
+		{
 			name: "ServiceProxy",
 			setup: func(sn *ServiceNode) {
 				sn.ServiceProxy = ConnectProxyConfig{}
@@ -595,6 +604,12 @@ func TestStructs_ServiceNode_PartialClone(t *testing.T) {
 		t.Fatalf("clone wasn't independent of the original for Meta")
 	}
 	sn.ServiceWeights.Passing = oldPassingWeight
+	oldPriority := *clone.ServicePriority
+	*sn.ServicePriority = 1000
+	if reflect.DeepEqual(sn, clone) {
+		t.Fatalf("clone wasn't independent of the original for Priority")
+	}
+	*sn.ServicePriority = oldPriority
 	sn.ServiceMeta["new_meta"] = "new_value"
 	if reflect.DeepEqual(sn, clone) {
 		t.Fatalf("clone wasn't independent of the original for Meta")
@@ -1550,6 +1565,7 @@ func TestStructs_NodeService_ConnectNativeEmptyPortError(t *testing.T) {
 }
 
 func TestStructs_NodeService_IsSame(t *testing.T) {
+	nsPriority, otherPriority := 10, 10
 	ns := &NodeService{
 		ID:      "node1",
 		Service: "theservice",
@@ -1587,7 +1603,8 @@ func TestStructs_NodeService_IsSame(t *testing.T) {
 				"foo": "bar",
 			},
 		},
-		Weights: &Weights{Passing: 1, Warning: 1},
+		Weights:  &Weights{Passing: 1, Warning: 1},
+		Priority: &nsPriority,
 	}
 	if !ns.IsSame(ns) {
 		t.Fatalf("should be equal to itself")
@@ -1631,7 +1648,8 @@ func TestStructs_NodeService_IsSame(t *testing.T) {
 				"foo": "bar",
 			},
 		},
-		Weights: &Weights{Passing: 1, Warning: 1},
+		Weights:  &Weights{Passing: 1, Warning: 1},
+		Priority: &otherPriority,
 		RaftIndex: RaftIndex{
 			CreateIndex: 1,
 			ModifyIndex: 2,
@@ -1664,6 +1682,7 @@ func TestStructs_NodeService_IsSame(t *testing.T) {
 	check(func() { other.Tags = []string{"foo"} }, func() { other.Tags = []string{"foo", "bar"} })
 	check(func() { other.Address = "XXX" }, func() { other.Address = "127.0.0.1" })
 	check(func() { other.Port = 9999 }, func() { other.Port = 1234 })
+	check(func() { *other.Priority = 20 }, func() { *other.Priority = 10 })
 	check(func() { other.Meta["meta2"] = "wrongValue" }, func() { other.Meta["meta2"] = "value2" })
 	check(func() { other.EnableTagOverride = false }, func() { other.EnableTagOverride = true })
 	check(func() { other.Kind = ServiceKindConnectProxy }, func() { other.Kind = "" })
@@ -3435,4 +3454,27 @@ func TestServicePorts_GetPortWithName(t *testing.T) {
 	p, ok = ports.GetPortWithName("other")
 	require.False(t, ok)
 	require.Equal(t, 0, p)
+}
+
+func TestStructs_NodeService_ValidatePriority(t *testing.T) {
+	zero, maximum, negative, overMaximum := 0, 65535, -1, 65536
+	for name, tc := range map[string]struct {
+		priority *int
+		wantErr  bool
+	}{
+		"unset":        {priority: nil},
+		"zero":         {priority: &zero},
+		"maximum":      {priority: &maximum},
+		"negative":     {priority: &negative, wantErr: true},
+		"over maximum": {priority: &overMaximum, wantErr: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := (&NodeService{Priority: tc.priority}).ValidateForAgent()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }

--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -229,6 +229,7 @@ func (s *HTTPHandlers) convertOps(resp http.ResponseWriter, req *http.Request) (
 							Passing: svc.Weights.Passing,
 							Warning: svc.Weights.Warning,
 						},
+						Priority:          svc.Priority,
 						EnableTagOverride: svc.EnableTagOverride,
 						EnterpriseMeta: acl.NewEnterpriseMetaWithPartition(
 							svc.Partition,

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -13,9 +13,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/raft"
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
@@ -714,7 +715,8 @@ func TestTxnEndpoint_NodeService(t *testing.T) {
 		  	"Node": "%s",
 		  	"Service": {
 				"Service": "test",
-				"Port": 4444
+				"Port": 4444,
+				"Priority": 0
 		  	}
 		}
 	},
@@ -773,13 +775,15 @@ func TestTxnEndpoint_NodeService(t *testing.T) {
 	require.Equal(t, 3, len(txnResp.Results))
 
 	index := txnResp.Results[0].Service.ModifyIndex
+	priority := 0
 	expected := structs.TxnResponse{
 		Results: structs.TxnResults{
 			&structs.TxnResult{
 				Service: &structs.NodeService{
-					Service: "test",
-					ID:      "test",
-					Port:    4444,
+					Service:  "test",
+					ID:       "test",
+					Port:     4444,
+					Priority: &priority,
 					Weights: &structs.Weights{
 						Passing: 1,
 						Warning: 1,

--- a/api/agent.go
+++ b/api/agent.go
@@ -152,6 +152,7 @@ type AgentService struct {
 	SocketPath        string                    `json:",omitempty"`
 	TaggedAddresses   map[string]ServiceAddress `json:",omitempty"`
 	Weights           AgentWeights
+	Priority          *int `json:",omitempty"`
 	EnableTagOverride bool
 	CreateIndex       uint64                          `json:",omitempty" bexpr:"-"`
 	ModifyIndex       uint64                          `json:",omitempty" bexpr:"-"`
@@ -361,6 +362,7 @@ type AgentServiceRegistration struct {
 	EnableTagOverride bool                      `json:",omitempty"`
 	Meta              map[string]string         `json:",omitempty"`
 	Weights           *AgentWeights             `json:",omitempty"`
+	Priority          *int                      `json:",omitempty"`
 	Check             *AgentServiceCheck
 	Checks            AgentServiceChecks
 	Proxy             *AgentServiceConnectProxyConfig `json:",omitempty"`

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -929,10 +929,12 @@ func TestAPI_AgentService(t *testing.T) {
 
 	agent := c.Agent()
 
+	priority := 0
 	reg := &AgentServiceRegistration{
-		Name: "foo",
-		Tags: []string{"bar", "baz"},
-		Port: 8000,
+		Name:     "foo",
+		Tags:     []string{"bar", "baz"},
+		Port:     8000,
+		Priority: &priority,
 		Checks: AgentServiceChecks{
 			&AgentServiceCheck{
 				TTL: "15s",
@@ -951,8 +953,9 @@ func TestAPI_AgentService(t *testing.T) {
 		ID:          "foo",
 		Service:     "foo",
 		Tags:        []string{"bar", "baz"},
-		ContentHash: "c4bb6737c185ed93",
+		ContentHash: "9cd014f837990abf",
 		Port:        8000,
+		Priority:    &priority,
 		Weights: AgentWeights{
 			Passing: 1,
 			Warning: 1,

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -47,6 +47,7 @@ type CatalogService struct {
 	ServiceMeta              map[string]string
 	ServicePort              int
 	ServiceWeights           Weights
+	ServicePriority          *int `json:",omitempty"`
 	ServiceEnableTagOverride bool
 	ServiceProxy             *AgentServiceConnectProxyConfig
 	ServiceLocality          *Locality `json:",omitempty"`

--- a/proto/private/pbservice/convert.go
+++ b/proto/private/pbservice/convert.go
@@ -130,6 +130,22 @@ func NewWeightsPtrFromStructs(t *structs.Weights) *Weights {
 	return &s
 }
 
+func Int32PtrToIntPtr(v *int32) *int {
+	if v == nil {
+		return nil
+	}
+	result := int(*v)
+	return &result
+}
+
+func IntPtrToInt32Ptr(v *int) *int32 {
+	if v == nil {
+		return nil
+	}
+	result := int32(*v)
+	return &result
+}
+
 // TODO: handle this with mog
 func MapStringServiceAddressToStructs(s map[string]*ServiceAddress) map[string]structs.ServiceAddress {
 	t := make(map[string]structs.ServiceAddress, len(s))

--- a/proto/private/pbservice/node.gen.go
+++ b/proto/private/pbservice/node.gen.go
@@ -49,6 +49,7 @@ func NodeServiceToStructs(s *NodeService, t *structs.NodeService) {
 	t.Ports = PortsToStructs(s.Ports)
 	t.SocketPath = s.SocketPath
 	t.Weights = WeightsPtrToStructs(s.Weights)
+	t.Priority = Int32PtrToIntPtr(s.Priority)
 	t.EnableTagOverride = s.EnableTagOverride
 	t.Locality = LocalityToStructs(s.Locality)
 	if s.Proxy != nil {
@@ -77,6 +78,7 @@ func NodeServiceFromStructs(t *structs.NodeService, s *NodeService) {
 	s.Ports = NewPortsFromStructs(t.Ports)
 	s.SocketPath = t.SocketPath
 	s.Weights = NewWeightsPtrFromStructs(t.Weights)
+	s.Priority = IntPtrToInt32Ptr(t.Priority)
 	s.EnableTagOverride = t.EnableTagOverride
 	s.Locality = LocalityFromStructs(t.Locality)
 	{

--- a/proto/private/pbservice/node.pb.go
+++ b/proto/private/pbservice/node.pb.go
@@ -292,8 +292,10 @@ type NodeService struct {
 	Port       int32  `protobuf:"varint,7,opt,name=Port,proto3" json:"Port,omitempty"`
 	SocketPath string `protobuf:"bytes,17,opt,name=SocketPath,proto3" json:"SocketPath,omitempty"`
 	// mog: func-to=WeightsPtrToStructs func-from=NewWeightsPtrFromStructs
-	Weights           *Weights `protobuf:"bytes,8,opt,name=Weights,proto3" json:"Weights,omitempty"`
-	EnableTagOverride bool     `protobuf:"varint,9,opt,name=EnableTagOverride,proto3" json:"EnableTagOverride,omitempty"`
+	Weights *Weights `protobuf:"bytes,8,opt,name=Weights,proto3" json:"Weights,omitempty"`
+	// mog: func-to=Int32PtrToIntPtr func-from=IntPtrToInt32Ptr
+	Priority          *int32 `protobuf:"varint,21,opt,name=Priority,proto3,oneof" json:"Priority,omitempty"`
+	EnableTagOverride bool   `protobuf:"varint,9,opt,name=EnableTagOverride,proto3" json:"EnableTagOverride,omitempty"`
 	// Proxy is the configuration set for Kind = connect-proxy. It is mandatory in
 	// that case and an error to be set for any other kind. This config is part of
 	// a proxy service definition and is distinct from but shares some fields with
@@ -440,6 +442,13 @@ func (x *NodeService) GetWeights() *Weights {
 	return nil
 }
 
+func (x *NodeService) GetPriority() int32 {
+	if x != nil && x.Priority != nil {
+		return *x.Priority
+	}
+	return 0
+}
+
 func (x *NodeService) GetEnableTagOverride() bool {
 	if x != nil {
 		return x.EnableTagOverride
@@ -534,7 +543,7 @@ const file_private_pbservice_node_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a7\n" +
 	"\tMetaEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb7\t\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe5\t\n" +
 	"\vNodeService\x12\x12\n" +
 	"\x04Kind\x18\x01 \x01(\tR\x04Kind\x12\x0e\n" +
 	"\x02ID\x18\x02 \x01(\tR\x02ID\x12\x18\n" +
@@ -547,7 +556,8 @@ const file_private_pbservice_node_proto_rawDesc = "" +
 	"\n" +
 	"SocketPath\x18\x11 \x01(\tR\n" +
 	"SocketPath\x12D\n" +
-	"\aWeights\x18\b \x01(\v2*.hashicorp.consul.internal.service.WeightsR\aWeights\x12,\n" +
+	"\aWeights\x18\b \x01(\v2*.hashicorp.consul.internal.service.WeightsR\aWeights\x12\x1f\n" +
+	"\bPriority\x18\x15 \x01(\x05H\x00R\bPriority\x88\x01\x01\x12,\n" +
 	"\x11EnableTagOverride\x18\t \x01(\bR\x11EnableTagOverride\x12K\n" +
 	"\x05Proxy\x18\v \x01(\v25.hashicorp.consul.internal.service.ConnectProxyConfigR\x05Proxy\x12K\n" +
 	"\aConnect\x18\f \x01(\v21.hashicorp.consul.internal.service.ServiceConnectR\aConnect\x12>\n" +
@@ -562,7 +572,8 @@ const file_private_pbservice_node_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v21.hashicorp.consul.internal.service.ServiceAddressR\x05value:\x028\x01\x1a7\n" +
 	"\tMetaEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x8f\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\v\n" +
+	"\t_PriorityB\x8f\x02\n" +
 	"%com.hashicorp.consul.internal.serviceB\tNodeProtoP\x01Z3github.com/hashicorp/consul/proto/private/pbservice\xa2\x02\x04HCIS\xaa\x02!Hashicorp.Consul.Internal.Service\xca\x02!Hashicorp\\Consul\\Internal\\Service\xe2\x02-Hashicorp\\Consul\\Internal\\Service\\GPBMetadata\xea\x02$Hashicorp::Consul::Internal::Serviceb\x06proto3"
 
 var (
@@ -630,6 +641,7 @@ func file_private_pbservice_node_proto_init() {
 	}
 	file_private_pbservice_healthcheck_proto_init()
 	file_private_pbservice_service_proto_init()
+	file_private_pbservice_node_proto_msgTypes[3].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/proto/private/pbservice/node.proto
+++ b/proto/private/pbservice/node.proto
@@ -76,6 +76,8 @@ message NodeService {
 
   // mog: func-to=WeightsPtrToStructs func-from=NewWeightsPtrFromStructs
   Weights Weights = 8;
+  // mog: func-to=Int32PtrToIntPtr func-from=IntPtrToInt32Ptr
+  optional int32 Priority = 21;
   bool EnableTagOverride = 9;
 
   // Proxy is the configuration set for Kind = connect-proxy. It is mandatory in

--- a/proto/private/pbservice/service.gen.go
+++ b/proto/private/pbservice/service.gen.go
@@ -193,6 +193,7 @@ func ServiceDefinitionToStructs(s *ServiceDefinition, t *structs.ServiceDefiniti
 	}
 	t.Checks = CheckTypesToStructs(s.Checks)
 	t.Weights = WeightsPtrToStructs(s.Weights)
+	t.Priority = Int32PtrToIntPtr(s.Priority)
 	t.Token = s.Token
 	t.EnableTagOverride = s.EnableTagOverride
 	t.Locality = LocalityToStructs(s.Locality)
@@ -221,6 +222,7 @@ func ServiceDefinitionFromStructs(t *structs.ServiceDefinition, s *ServiceDefini
 	}
 	s.Checks = NewCheckTypesFromStructs(t.Checks)
 	s.Weights = NewWeightsPtrFromStructs(t.Weights)
+	s.Priority = IntPtrToInt32Ptr(t.Priority)
 	s.Token = t.Token
 	s.EnableTagOverride = t.EnableTagOverride
 	s.Locality = LocalityFromStructs(t.Locality)

--- a/proto/private/pbservice/service.pb.go
+++ b/proto/private/pbservice/service.pb.go
@@ -929,9 +929,11 @@ type ServiceDefinition struct {
 	// mog: func-to=CheckTypesToStructs func-from=NewCheckTypesFromStructs
 	Checks []*CheckType `protobuf:"bytes,9,rep,name=Checks,proto3" json:"Checks,omitempty"`
 	// mog: func-to=WeightsPtrToStructs func-from=NewWeightsPtrFromStructs
-	Weights           *Weights `protobuf:"bytes,10,opt,name=Weights,proto3" json:"Weights,omitempty"`
-	Token             string   `protobuf:"bytes,11,opt,name=Token,proto3" json:"Token,omitempty"`
-	EnableTagOverride bool     `protobuf:"varint,12,opt,name=EnableTagOverride,proto3" json:"EnableTagOverride,omitempty"`
+	Weights *Weights `protobuf:"bytes,10,opt,name=Weights,proto3" json:"Weights,omitempty"`
+	// mog: func-to=Int32PtrToIntPtr func-from=IntPtrToInt32Ptr
+	Priority          *int32 `protobuf:"varint,21,opt,name=Priority,proto3,oneof" json:"Priority,omitempty"`
+	Token             string `protobuf:"bytes,11,opt,name=Token,proto3" json:"Token,omitempty"`
+	EnableTagOverride bool   `protobuf:"varint,12,opt,name=EnableTagOverride,proto3" json:"EnableTagOverride,omitempty"`
 	// Proxy is the configuration set for Kind = connect-proxy. It is mandatory in
 	// that case and an error to be set for any other kind. This config is part of
 	// a proxy service definition and is distinct from but shares some fields with
@@ -1070,6 +1072,13 @@ func (x *ServiceDefinition) GetWeights() *Weights {
 		return x.Weights
 	}
 	return nil
+}
+
+func (x *ServiceDefinition) GetPriority() int32 {
+	if x != nil && x.Priority != nil {
+		return *x.Priority
+	}
+	return 0
 }
 
 func (x *ServiceDefinition) GetToken() string {
@@ -1374,7 +1383,7 @@ const file_private_pbservice_service_proto_rawDesc = "" +
 	"JSONFormat\x12\x1e\n" +
 	"\n" +
 	"TextFormat\x18\x06 \x01(\tR\n" +
-	"TextFormat\"\xbc\t\n" +
+	"TextFormat\"\xea\t\n" +
 	"\x11ServiceDefinition\x12\x12\n" +
 	"\x04Kind\x18\x01 \x01(\tR\x04Kind\x12\x0e\n" +
 	"\x02ID\x18\x02 \x01(\tR\x02ID\x12\x12\n" +
@@ -1390,7 +1399,8 @@ const file_private_pbservice_service_proto_rawDesc = "" +
 	"\x05Check\x18\b \x01(\v2,.hashicorp.consul.internal.service.CheckTypeR\x05Check\x12D\n" +
 	"\x06Checks\x18\t \x03(\v2,.hashicorp.consul.internal.service.CheckTypeR\x06Checks\x12D\n" +
 	"\aWeights\x18\n" +
-	" \x01(\v2*.hashicorp.consul.internal.service.WeightsR\aWeights\x12\x14\n" +
+	" \x01(\v2*.hashicorp.consul.internal.service.WeightsR\aWeights\x12\x1f\n" +
+	"\bPriority\x18\x15 \x01(\x05H\x00R\bPriority\x88\x01\x01\x12\x14\n" +
 	"\x05Token\x18\v \x01(\tR\x05Token\x12,\n" +
 	"\x11EnableTagOverride\x18\f \x01(\bR\x11EnableTagOverride\x12K\n" +
 	"\x05Proxy\x18\x0e \x01(\v25.hashicorp.consul.internal.service.ConnectProxyConfigR\x05Proxy\x12X\n" +
@@ -1403,7 +1413,8 @@ const file_private_pbservice_service_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v21.hashicorp.consul.internal.service.ServiceAddressR\x05value:\x028\x01\x1a7\n" +
 	"\tMetaEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"O\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\v\n" +
+	"\t_Priority\"O\n" +
 	"\vServicePort\x12\x12\n" +
 	"\x04Port\x18\x01 \x01(\x05R\x04Port\x12\x12\n" +
 	"\x04Name\x18\x02 \x01(\tR\x04Name\x12\x18\n" +
@@ -1489,6 +1500,7 @@ func file_private_pbservice_service_proto_init() {
 		return
 	}
 	file_private_pbservice_healthcheck_proto_init()
+	file_private_pbservice_service_proto_msgTypes[9].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/proto/private/pbservice/service.proto
+++ b/proto/private/pbservice/service.proto
@@ -296,6 +296,8 @@ message ServiceDefinition {
   repeated CheckType Checks = 9;
   // mog: func-to=WeightsPtrToStructs func-from=NewWeightsPtrFromStructs
   Weights Weights = 10;
+  // mog: func-to=Int32PtrToIntPtr func-from=IntPtrToInt32Ptr
+  optional int32 Priority = 21;
   string Token = 11;
   bool EnableTagOverride = 12;
 


### PR DESCRIPTION
This PR introduces an optional priority field (0-65535) for service definitions to natively support RFC 2782 failover routing.

DNS SRV responses use the configured value for node, IP, FQDN, and prepared-query results; A/AAAA responses remain unchanged.

This change only affects SRV record construction. It does not change health filtering, weight calculation or prepared-query result selection.

When priority is unset the default priority is left at `1` preserving existing behavior. Explicit priority `0` remains distinguishable from an unset value.

While this feature is quite small it required a lot of mechanical fiddling; the implementation follows the [service-definition config checklist](https://github.com/hashicorp/consul/blob/main/docs/config/checklist-adding-config-fields.md#adding-a-new-field-to-service-definition) and was modeled after #22769 and #16581 which both added a service config field. 

The new priority field has been plumbed through the service registration lifecycle, from the API and protobuf layers down to the catalog and peering state.

There is no data migration. Reverting this PR is sufficient to roll back the feature; older code will continue using the existing fixed SRV priority.

### Testing & Reproduction steps

1. Checkout to the branch
2. Start a consul dev server `go run . agent -dev` from the root directory.
3. Register a service with `priority` set `consul services register ./myservice.hcl`
```hcl
service {
    name = "my-service"
    id = "my-service-id"
    port = 8080
    priority = 100
}
```
4. Query the service through `curl localhost:8500/v1/catalog/service/my-service`
```json
<snip>
        "ServiceKind": "",
        "ServiceID": "my-service-id",
        "ServiceName": "my-service",
        "ServiceTags": [],
        "ServiceAddress": "",
        "ServiceWeights": {
            "Passing": 1,
            "Warning": 1
        },
        "ServicePriority": 100,
        "ServiceMeta": {},
        "ServicePort": 8080,
<snip>
```

5. Query SRV records via DNS `dig @127.0.0.1 -p 8600 my-service.service.consul. SRV`

```shell
;; QUESTION SECTION:
;my-service.service.consul.	IN	SRV

;; ANSWER SECTION:
my-service.service.consul. 0	IN	SRV	100 1 8080 baddad-devthang.node.dc1.consul.
```

### Links

Resolves #23728

- RFC 2782 — A DNS RR for specifying the location of services (https://datatracker.ietf.org/doc/html/rfc2782)

### PR Checklist

- [x] updated test coverage
- [ ] external facing docs updated - will update in a separate PR
- [x] appropriate backport labels added - N/A; no backport is currently planned for this new feature
- [x] not a security concern

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
    - No additional rollback procedure or data migration is required.
- [x] If applicable, I've documented the impact of any changes to security controls.
    - Not applicable. This change does not modify access control, authentication, authorization, audit logging, or other security controls.