### PR TITLE
ui: expose Service.Meta in dashboard URL templates

### DIFF
--- a/.changelog/23730.txt
+++ b/.changelog/23730.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Include `Service.Meta` into available variables for `dashboard_url_templates`
+```

--- a/ui/packages/consul-ui/app/helpers/render-template.mdx
+++ b/ui/packages/consul-ui/app/helpers/render-template.mdx
@@ -11,6 +11,9 @@ regex based, template engine. For example:
       Datacenter="dc1"
       Service=(hash
         Name="Hello-Service"
+        Meta=(hash
+          dashboard="G7Z29GzMGz"
+        )
       )
     )
   }}
@@ -18,6 +21,8 @@ regex based, template engine. For example:
 </figure>
 
 ```
+
+Currently supported variables include `Datacenter`, `Service.Name`, `Service.Namespace`, `Service.Partition`, and `Service.Meta.<key>`.
 
 Additionally the variables passed into the template are automatically URL
 encoded as our primary usecase for this is for creating dynamic links/URLs. If

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -181,6 +181,7 @@ as |items item dc|}}
                       Name=item.Service.Service
                       Namespace=(or item.Service.Namespace '')
                       Partition=(or item.Service.Partition '')
+                      Meta=(or item.Service.Meta (hash))
                     )
                   )
                 }}

--- a/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
@@ -167,6 +167,7 @@ as |nspace dc items topology|}}
               Name=(get items "firstObject.Name")
               Namespace=(or (get items "firstObject.Namespace") '')
               Partition=(or (get items "firstObject.Partition") '')
+              Meta=(or (get items "firstObject.Meta") (hash))
             )
           )
         }}

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show.feature
@@ -261,6 +261,27 @@ Feature: dc / services / show: Show Service
     ---
     # The external dashboard link should use the Service.Name not the ID
     And I see href on the dashboardAnchor like "https://something.com?service-0&dc1"
+  Scenario: Given a dashboard template includes service meta
+    Given 1 datacenter model with the value "dc1"
+    And 1 node models
+    And 1 service model from yaml
+    ---
+    - Service:
+        Kind: ~
+        Meta:
+          dashboard: G7Z29GzMGz
+    ---
+    And ui_config from yaml
+    ---
+    dashboard_url_templates:
+      service: https://grafana.service.consul/d/{{Service.Meta.dashboard}}
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0
+    ---
+    And I see href on the dashboardAnchor like "https://grafana.service.consul/d/G7Z29GzMGz"
   Scenario: With no access to service
     Given 1 datacenter model with the value "dc1"
     And permissions from yaml

--- a/ui/packages/consul-ui/tests/integration/helpers/render-template-test.js
+++ b/ui/packages/consul-ui/tests/integration/helpers/render-template-test.js
@@ -89,7 +89,18 @@ module('Integration | Helper | render-template', function (hooks) {
       result: 'http://localhost/?=',
     },
     {
-      href: 'http://localhost/?={{deep.Name}}',
+      href: 'http://localhost/?={{Service.Meta.dashboard}}',
+      vars: {
+        Service: {
+          Name: 'my-service',
+          Meta: {
+            dashboard: 'G7Z29GzMGz',
+          },
+        },
+      },
+      result: 'http://localhost/?=G7Z29GzMGz',
+    },
+    {
       vars: {
         deep: {
           Name: '#Na/me',


### PR DESCRIPTION
## Summary

- Pass `Service.Meta` into `dashboard_url_templates` interpolation on the service page and topology view
- Add integration and acceptance coverage for `{{Service.Meta.dashboard}}`
- Document supported template variables in `render-template.mdx`

## Context

#12401 requests support for placeholders like `{{Service.Meta.dashboard}}` in dashboard URL templates. The `render-template` helper already resolves dot paths; the templates only needed to supply `Meta` from the catalog service instance.

## Test plan

- [ ] `cd ui/packages/consul-ui && ember test --filter="render-template"`
- [ ] Acceptance scenario: dashboard template includes service meta

Fixes #12401