### PR TITLE
fix debug token leak.

### DIFF
--- a/.changelog/23731.txt
+++ b/.changelog/23731.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Log the deprecated token query parameter warning only once per agent lifetime instead of on every request, and avoid logging the raw token in debug-level content-type logs.
+```

--- a/.changelog/23731.txt
+++ b/.changelog/23731.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-agent: Log the deprecated token query parameter warning only once per agent lifetime instead of on every request, and avoid logging the raw token in debug-level content-type logs.
+agent: Stop logging the raw ACL token in debug-level content-type logs by logging the request path instead of the full request URL.
 ```

--- a/.changelog/23731.txt
+++ b/.changelog/23731.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-agent: Stop logging the raw ACL token in debug-level content-type logs by logging the request path instead of the full request URL.
+agent: Stop logging the raw ACL token in debug-level content-type logs.
 ```

--- a/agent/http.go
+++ b/agent/http.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -97,6 +98,11 @@ type HTTPHandlers struct {
 	configReloaders []ConfigReloader
 	h               http.Handler
 	metricsProxyCfg atomic.Value
+
+	// tokenQueryParamWarningOnce ensures the deprecation warning for using the
+	// token query parameter is only logged once per agent lifetime, to avoid
+	// flooding the logs when clients repeatedly authenticate via query param.
+	tokenQueryParamWarningOnce sync.Once
 
 	// proxyTransport is used by UIMetricsProxy to keep
 	// a managed pool of connections.
@@ -357,14 +363,14 @@ func ensureContentTypeHeader(next http.Handler, logger hclog.Logger) http.Handle
 		contentType := api.GetContentType(req)
 
 		if req != nil {
-			logger.Debug("warning: request content-type is not supported", "request-path", req.URL)
+			logger.Debug("warning: request content-type is not supported", "request-path", req.URL.Path)
 			req.Header.Set(contentTypeHeader, contentType)
 		}
 
 		if resp != nil {
 			respContentType := resp.Header().Get(contentTypeHeader)
 			if respContentType == "" || respContentType != contentType {
-				logger.Debug("warning: response content-type header not explicitly set.", "request-path", req.URL)
+				logger.Debug("warning: response content-type header not explicitly set.", "request-path", req.URL.Path)
 				resp.Header().Set(contentTypeHeader, contentType)
 			}
 		}
@@ -428,9 +434,14 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 				}
 				logURL = strings.ReplaceAll(logURL, token, "<hidden>")
 			}
-			httpLogger.Warn("This request used the token query parameter "+
-				"which is deprecated and will be removed in a future Consul version",
-				"logUrl", logURL)
+			// Only log the deprecation warning once per agent lifetime to avoid
+			// flooding the logs for clients that authenticate via the token
+			// query parameter on every request.
+			s.tokenQueryParamWarningOnce.Do(func() {
+				httpLogger.Warn("This request used the token query parameter "+
+					"which is deprecated and will be removed in a future Consul version",
+					"logUrl", logURL)
+			})
 		}
 		logURL = aclEndpointRE.ReplaceAllString(logURL, "$1<hidden>$4")
 

--- a/agent/http.go
+++ b/agent/http.go
@@ -16,7 +16,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -98,11 +97,6 @@ type HTTPHandlers struct {
 	configReloaders []ConfigReloader
 	h               http.Handler
 	metricsProxyCfg atomic.Value
-
-	// tokenQueryParamWarningOnce ensures the deprecation warning for using the
-	// token query parameter is only logged once per agent lifetime, to avoid
-	// flooding the logs when clients repeatedly authenticate via query param.
-	tokenQueryParamWarningOnce sync.Once
 
 	// proxyTransport is used by UIMetricsProxy to keep
 	// a managed pool of connections.
@@ -434,14 +428,9 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 				}
 				logURL = strings.ReplaceAll(logURL, token, "<hidden>")
 			}
-			// Only log the deprecation warning once per agent lifetime to avoid
-			// flooding the logs for clients that authenticate via the token
-			// query parameter on every request.
-			s.tokenQueryParamWarningOnce.Do(func() {
-				httpLogger.Warn("This request used the token query parameter "+
-					"which is deprecated and will be removed in a future Consul version",
-					"logUrl", logURL)
-			})
+			httpLogger.Warn("This request used the token query parameter "+
+				"which is deprecated and will be removed in a future Consul version",
+				"logUrl", logURL)
 		}
 		logURL = aclEndpointRE.ReplaceAllString(logURL, "$1<hidden>$4")
 


### PR DESCRIPTION

## Problem
At debug level, it also logged the full request URL, exposing the ACL token in plaintext.

## Root Cause
- ensureContentTypeHeader logged req.URL, which includes the query string and token.

## Fix / Solution
- Use req.URL.Path instead of req.URL in debug logs to prevent token exposure. 

## Testing
- the raw token never appears in the logs, only <hidden>, while running at debug level.

Also verified the behavior before and after the fix, and go build ./agent/ passes.

Backported PRs:
- https://github.com/hashicorp/consul/pull/23742
- https://github.com/hashicorp/consul-enterprise/pull/13127
- https://github.com/hashicorp/consul-enterprise/pull/13128
- https://github.com/hashicorp/consul-enterprise/pull/13129
- https://github.com/hashicorp/consul-enterprise/pull/13130
