### PR TITLE
docs: remove dead demo.consul.io link from README (fixes #23257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Consul provides several key features:
   for storing configuration parameters and application metadata.
 
 Consul runs on Linux, macOS, FreeBSD, Solaris, and Windows and includes an
-optional [browser based UI](https://demo.consul.io). A commercial version
+optional browser based UI. A commercial version
 called [Consul Enterprise](https://developer.hashicorp.com/consul/docs/enterprise) is also
 available.
 


### PR DESCRIPTION
Hi, and thank you for Consul.

The README links to a demo site that no longer resolves. `README.md` (line 42):

> optional [browser based UI](https://demo.consul.io).

`demo.consul.io` returns NXDOMAIN (no DNS record) — verified with `dig +short demo.consul.io` (empty), while `consul.io` resolves fine, so the subdomain is decommissioned. This is tracked in the open issue #23257 ("The demo.consul.io site is down").

This PR removes the dead link, keeping "browser based UI" as plain text (the UI itself still ships with Consul). Fixes #23257. If you'd prefer to point it at a live page (e.g. the UI docs) instead of removing the link, happy to adjust.

For transparency: I used AI assistance to spot and draft this; I verified the dead DNS and the open issue myself.
