### PR TITLE
Increase stale PR windows to 90/60 days

### DIFF
--- a/.changelog/23734.txt
+++ b/.changelog/23734.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ci: Increased the stale PR automation windows to 90 days before marking a pull request stale and 60 days before closing it.
+```

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -16,12 +16,12 @@ jobs:
         with:
           days-before-stale: -1
           days-before-close: -1
-          days-before-pr-stale: 60
-          days-before-pr-close: 30
+          days-before-pr-stale: 90
+          days-before-pr-close: 60
           stale-pr-message: This pull request has been automatically flagged
-            for inactivity because it has not been acted upon in the last 60
+            for inactivity because it has not been acted upon in the last 90
             days. It will be closed if no new activity occurs in the next
-            30 days. Please feel free to re-open to resurrect the change if
+            60 days. Please feel free to re-open to resurrect the change if
             you feel this has happened by mistake. Thank you for your
             contributions.
           close-pr-message: Closing due to inactivity. If you feel this was a

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           days-before-stale: -1
           days-before-close: -1


### PR DESCRIPTION
### Description

The stale PR automation was closing pull requests too aggressively (60 days to stale, 30 days to close). 

###Fix
- Updated days-before-pr-stale from 60 to 90 and days-before-pr-close from 30 to 60 in the existing stale PR workflows.
- Updated the stale-PR message text to reflect the new 90/60 day windows.