### PR TITLE
Backport: fix debug token leak to 2.0.x

### DIFF
--- a/.changelog/23731.txt
+++ b/.changelog/23731.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Stop logging the raw ACL token in debug-level content-type logs.
+```

--- a/agent/http.go
+++ b/agent/http.go
@@ -357,14 +357,14 @@ func ensureContentTypeHeader(next http.Handler, logger hclog.Logger) http.Handle
 		contentType := api.GetContentType(req)
 
 		if req != nil {
-			logger.Debug("warning: request content-type is not supported", "request-path", req.URL)
+			logger.Debug("warning: request content-type is not supported", "request-path", req.URL.Path)
 			req.Header.Set(contentTypeHeader, contentType)
 		}
 
 		if resp != nil {
 			respContentType := resp.Header().Get(contentTypeHeader)
 			if respContentType == "" || respContentType != contentType {
-				logger.Debug("warning: response content-type header not explicitly set.", "request-path", req.URL)
+				logger.Debug("warning: response content-type header not explicitly set.", "request-path", req.URL.Path)
 				resp.Header().Set(contentTypeHeader, contentType)
 			}
 		}


### PR DESCRIPTION

## Problem
At debug level, it also logged the full request URL, exposing the ACL token in plaintext.

## Root Cause
- ensureContentTypeHeader logged req.URL, which includes the query string and token.

## Fix / Solution
- Use req.URL.Path instead of req.URL in debug logs to prevent token exposure. 

## Testing
- the raw token never appears in the logs, only <hidden>, while running at debug level.

Also verified the behavior before and after the fix, and go build ./agent/ passes.
