### PR TITLE
ui: fix Vercel build — explicit config, drop public flag, relax pnpm engine constraint

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -54,6 +54,9 @@ List of available project commands.  `pnpm run <command-name>`
 | doc:toc             | Re-builds the ToC for this README. |
 | compliance:licenses | Checks that all dependencies have CE-compatible licenses. |
 
+For Vercel preview deployments, the workspace-level configuration lives in
+`./vercel.json`.
+
 ## Contributing
 
 ### Building ToC

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
   "packageManager": "pnpm@10.16.1+sha512.0e155aa2629db8672b49e8475da6226aa4bdea85fdcdfdc15350874946d4f3c91faaf64cbdc4a5d1ab8002f473d5c3fcedcd197989cf0390f9badd3c04678706",
   "engines": {
     "node": "24",
-    "pnpm": ">= 10.*"
+    "pnpm": ">= 9"
   },
   "pnpm": {
     "overrides": {

--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,6 +1,9 @@
 {
-  "public": true,
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "github": { "silent": true },
+  "installCommand": "pnpm install --no-frozen-lockfile",
+  "buildCommand": "make dist-vercel",
+  "outputDirectory": "dist",
   "redirects": [{ "source": "/", "destination": "/ui/" }],
   "rewrites": [{ "source": "/ui/(.*)", "destination": "/ui/index.html" }]
 }


### PR DESCRIPTION
### Description

Isolates the Vercel build fixes from #23707 into a standalone PR targeting `main`.

Three files changed, all under `ui/`:

#### `ui/vercel.json`
- Add `$schema` for editor/validator support
- Remove unsupported `"public": true` flag (caused Vercel deploy errors)
- Add explicit `installCommand`: `pnpm install --no-frozen-lockfile`
  — `--no-frozen-lockfile` avoids install failures when Vercel's Node environment
  produces a different lockfile hash than the one committed
- Add explicit `buildCommand`: `make dist-vercel`
- Add explicit `outputDirectory`: `dist`

#### `ui/package.json`
- Relax `engines.pnpm` from `">= 10.*"` to `">= 9"` so Vercel's bundled
  pnpm 9 satisfies the constraint without requiring a global install step

#### `ui/README.md`
- Add one-line note pointing to `./vercel.json` for Vercel preview deployment config

### Testing & Reproduction steps

Vercel preview deployment on a branch should now complete without:
- `ERR_INVALID_ARG_TYPE` / unsupported config key errors (`public`)
- `ERR_PNPM_FROZEN_LOCKFILE` failures
- pnpm engine version mismatch errors

### Links

- Parent PR: #23707

### PR Checklist

* [x] not a security concern
* [ ] updated test coverage (n/a — config-only change)
* [ ] external facing docs updated (n/a)
* [x] appropriate backport labels added