### PR TITLE
ci: upgrade pnpm/action-setup from v4.1.0 to v6.0.9 in frontend workflow

### DIFF
--- a/.changelog/23747.txt
+++ b/.changelog/23747.txt
@@ -1,0 +1,3 @@
+```release-note:other
+ci: upgrade `pnpm/action-setup` from v4.1.0 to v6.0.9 in the frontend workflow to resolve a syntax error on older system Node versions
+```

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           run_install: false
           package_json_file: ui/package.json
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           run_install: false
           package_json_file: ui/package.json
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           run_install: false
           package_json_file: ui/package.json
@@ -157,7 +157,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           run_install: false
           package_json_file: ui/package.json
@@ -206,7 +206,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           run_install: false
           package_json_file: ui/package.json
@@ -349,7 +349,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           run_install: false
           package_json_file: ui/package.json


### PR DESCRIPTION
### Description

Upgrades `pnpm/action-setup` from `v4.1.0` to `v6.0.9` across all 6 jobs in `.github/workflows/frontend.yml`.

#### Why

The `consul-enterprise` `release/1.22.x` workflow was already on `v6.0.8` for 4 of its 6 jobs, while CE `main` was still on `v4.1.0`. This inconsistency caused the ENT backport PR [#13136](https://github.com/hashicorp/consul-enterprise/pull/13136) to fail:

- `v6.0.8` uses a new bootstrap mechanism that runs `@pnpm/exe/setup.js` via the **system `node`** binary before `actions/setup-node` has had a chance to install Node 24
- The system node on the ENT runners was too old to parse optional chaining (`err?.code`) used in `@pnpm/exe/setup.js`, causing `SyntaxError: Unexpected token '.'`
- `v6.0.9` (released 2026-06-15) fixes this with improved system Node version detection and a standalone fallback

#### Changes

- All 6 `pnpm/action-setup` references updated: `a7487c7e` (`v4.1.0`) → `0ebf47130e` (`v6.0.9`)
- Jobs affected: `workspace-tests`, `node-tests`, `ember-build-test`, `ember-build-test-ent`, `e2e-tests`, `e2e-tests-ent`

#### Follow-up

Once this merges, backport to `release/2.0.x` and the ENT `release/1.22.x` to bring all branches into sync and unblock [consul-enterprise#13136](https://github.com/hashicorp/consul-enterprise/pull/13136).

### PR Checklist

* [x] not a security concern
* [x] updated test coverage (n/a — CI config only)
* [x] external facing docs updated (n/a)
* [x] appropriate backport labels added