### PR TITLE
fix(peering): clearer error when peering is disabled

### DIFF
--- a/agent/cache-types/peerings_test.go
+++ b/agent/cache-types/peerings_test.go
@@ -86,7 +86,7 @@ func TestPeerings_PeeringDisabled(t *testing.T) {
 
 	// Expect the proper call, but return the peering disabled error
 	client.On("PeeringList", mock.Anything, mock.Anything, mock.Anything).
-		Return(resp, grpcstatus.Error(codes.FailedPrecondition, "peering must be enabled to use this endpoint"))
+		Return(resp, grpcstatus.Error(codes.FailedPrecondition, "peering is disabled"))
 
 	// Fetch and assert against the result.
 	result, err := typ.Fetch(context.Background(), cache.FetchOptions{}, &PeeringListRequest{

--- a/agent/cache-types/trust_bundles_test.go
+++ b/agent/cache-types/trust_bundles_test.go
@@ -92,7 +92,7 @@ func TestTrustBundles_PeeringDisabled(t *testing.T) {
 	// Expect the proper call.
 	// This also returns the canned response above.
 	client.On("TrustBundleListByService", mock.Anything, mock.Anything, mock.Anything).
-		Return(resp, grpcstatus.Error(codes.FailedPrecondition, "peering must be enabled to use this endpoint"))
+		Return(resp, grpcstatus.Error(codes.FailedPrecondition, "peering is disabled"))
 
 	// Fetch and assert against the result.
 	result, err := typ.Fetch(

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -196,7 +196,7 @@ type Store interface {
 	TrustBundleListByService(ws memdb.WatchSet, service, dc string, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.PeeringTrustBundle, error)
 }
 
-var peeringNotEnabledErr = grpcstatus.Error(codes.FailedPrecondition, "peering must be enabled to use this endpoint")
+var peeringNotEnabledErr = grpcstatus.Error(codes.FailedPrecondition, "peering is disabled")
 
 // GenerateToken implements the PeeringService RPC method to generate a
 // peering token which is the initial step in establishing a peering relationship

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -1611,7 +1611,7 @@ func TestPeeringService_PeeringDisabled(t *testing.T) {
 		actErr, ok := grpcstatus.FromError(err)
 		require.True(t, ok)
 		require.Equal(t, codes.FailedPrecondition, actErr.Code())
-		require.Equal(t, "peering must be enabled to use this endpoint", actErr.Message())
+		require.Equal(t, "peering is disabled", actErr.Message())
 	}
 
 	// Test all the endpoints.

--- a/command/peering/list/list_test.go
+++ b/command/peering/list/list_test.go
@@ -134,3 +134,28 @@ func TestListCommand(t *testing.T) {
 		require.Equal(t, "foo", outputList[1].Name)
 	})
 }
+
+func TestListCommand_PeeringDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, `peering { enabled = false }`)
+	t.Cleanup(func() { _ = a.Shutdown() })
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	ui := cli.NewMockUi()
+	cmd := New(ui)
+
+	code := cmd.Run([]string{
+		"-http-addr=" + a.HTTPAddr(),
+	})
+	require.Equal(t, 1, code)
+
+	output := ui.ErrorWriter.String()
+	require.Contains(t, output, "Error listing peerings")
+	require.Contains(t, output, "peering is disabled")
+}


### PR DESCRIPTION
### Description

When a cluster is configured with `peering.enabled = false`, operators running `consul peering list` used to get a vague failure and had to dig into logs to understand why.

This change makes the peering RPC layer return a clear `peering is disabled` error for all peering endpoints when peering is turned off. The CLI already surfaces the RPC error as:

```
Error listing peerings: Unexpected response code: 500 (peering is disabled)
```

So the reason is now explicit and matches the wording requested in the issue.

### Testing & Reproduction steps

1. Start a server with peering disabled:

```hcl
peering {
  enabled = false
}
```

2. Run:

```
consul peering list
```

3. Expect an error that includes `peering is disabled` rather than a bare `Error listing peerings`.

Unit / integration coverage:

- `TestPeeringService_PeeringDisabled` (updated expected message)
- `TestListCommand_PeeringDisabled` (new CLI regression test)
- cache-type tests updated for the new error string

### Links

Fixes #14896

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.