### PR TITLE
fix: raise minUUIDLookupLen from 2 to 8 to prevent short node names from being incorrectly treated as UUID prefixes

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -39,7 +39,7 @@ const (
 	// minUUIDLookupLen is used as a minimum length of a node name required before
 	// we test to see if the name is actually a UUID and perform an ID-based node
 	// lookup.
-	minUUIDLookupLen = 2
+	minUUIDLookupLen = 8
 )
 
 var (


### PR DESCRIPTION
## Description

Fixes #23724

When a short node name (e.g., `ba1`, 3 characters) is queried and does not exist as a node name, Consul falls back to a UUID prefix lookup because `minUUIDLookupLen = 2` treats any 2+ character hex string as a potential UUID prefix. If a node happens to have a UUID starting with those characters, Consul returns an incorrect random node.

## Root Cause

The `minUUIDLookupLen` constant in `agent/consul/state/catalog.go` was set to `2`, which is too short. Any node name of 2+ characters that happens to be valid hex (like "ba1") triggers a UUID prefix lookup in the memdb table. This can match unrelated nodes' UUIDs, causing DNS to return incorrect results.

## Fix

Raised `minUUIDLookupLen` from `2` to `8`, which was the value suggested by the original maintainer in the commit that introduced this behavior (fe49c0a0abe8d0779abfca0bc13ad557173f664d). With a minimum of 8 hex characters, the probability of a false UUID prefix match drops to approximately 1 in 4 billion, eliminating the issue for common short hostnames while still allowing UUID-based lookups for sufficiently long prefixes.

## Testing

- Existing tests continue to pass
- The change only affects the minimum length threshold for UUID prefix lookups, which is a purely defensive check — no behavior change for node names longer than 8 characters or for valid UUID lookups (which are 32+ hex characters)