### PR TITLE
ui: fix 3 high-severity frontend security vulnerabilities

### DIFF
--- a/.changelog/23786.txt
+++ b/.changelog/23786.txt
@@ -1,0 +1,9 @@
+```release-note:security
+Update `socket.io-parser` to address [CVE-2026-69185](https://github.com/advisories/GHSA-2m8v-j782-fhvr) (Zero-attachment Memory Exhaustion).
+```
+```release-note:security
+Update `fast-uri` to address [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) (Host Confusion via backslash authority introducer).
+```
+```release-note:security
+Update `brace-expansion` to address [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (DoS via unbounded intermediate arrays).
+```

--- a/ui/package.json
+++ b/ui/package.json
@@ -45,11 +45,11 @@
       "underscore": ">=1.13.8",
       "immutable": ">=5.1.8",
       "serialize-javascript@<=7.0.4": ">=7.0.5",
-      "socket.io-parser@<4.2.6": ">=4.2.6",
+      "socket.io-parser@<4.2.7": ">=4.2.7",
       "handlebars@<4.7.9": ">=4.7.9",
       "yaml@>=2.0.0 <2.8.3": ">=2.8.3",
       "picomatch@<2.3.2": "^2.3.2",
-      "brace-expansion": "^5.0.8",
+      "brace-expansion": "^5.0.9",
       "ajv@<6.14.0": "^6.14.0",
       "ajv@>=7.0.0-alpha.0 <8.18.0": "^8.18.0",
       "lodash@>=4.0.0 <=4.17.22": "^4.18.0",
@@ -67,7 +67,7 @@
       "follow-redirects@<=1.15.11": ">=1.16.0",
       "uuid@<14.0.0": ">=14.0.0",
       "postcss@<8.5.18": ">=8.5.18",
-      "fast-uri@<3.1.4": ">=3.1.4",
+      "fast-uri@<4.1.2": ">=4.1.2",
       "@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3": "^7.29.4",
       "ws@<8.21.0": ">=8.21.0",
       "@babel/core@<7.29.6": "^7.29.6",
@@ -79,7 +79,7 @@
     },
     "patchedDependencies": {
       "js-yaml@4.3.0": "patches/js-yaml@4.3.0.patch",
-      "brace-expansion@5.0.8": "patches/brace-expansion@5.0.8.patch"
+      "brace-expansion@5.0.9": "patches/brace-expansion@5.0.9.patch"
     }
   }
 }

--- a/ui/patches/brace-expansion@5.0.9.patch
+++ b/ui/patches/brace-expansion@5.0.9.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
+index be9df86be09c7655787a65c55ae6da01858894c3..b2468881976f2d7cf0000b3076e6f6d92fe9fbd8 100644
+--- a/dist/commonjs/index.js
++++ b/dist/commonjs/index.js
+@@ -30,6 +30,8 @@ exports.EXPANSION_MAX = 100_000;
+ // realistic expansion (100k results hitting `EXPANSION_MAX` measure ~1M
+ // characters) so legitimate input is unaffected.
+ exports.EXPANSION_MAX_LENGTH = 4_000_000;
++// minimatch <9 calls the required module directly; v5 only exports named `expand`.
++module.exports = Object.assign(expand, exports);
+ function numeric(str) {
+     return !isNaN(str) ? parseInt(str, 10) : str.charCodeAt(0);
+ }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -30,11 +30,11 @@ overrides:
   underscore: '>=1.13.8'
   immutable: '>=5.1.8'
   serialize-javascript@<=7.0.4: '>=7.0.5'
-  socket.io-parser@<4.2.6: '>=4.2.6'
+  socket.io-parser@<4.2.7: '>=4.2.7'
   handlebars@<4.7.9: '>=4.7.9'
   yaml@>=2.0.0 <2.8.3: '>=2.8.3'
   picomatch@<2.3.2: ^2.3.2
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
   ajv@<6.14.0: ^6.14.0
   ajv@>=7.0.0-alpha.0 <8.18.0: ^8.18.0
   lodash@>=4.0.0 <=4.17.22: ^4.18.0
@@ -52,7 +52,7 @@ overrides:
   follow-redirects@<=1.15.11: '>=1.16.0'
   uuid@<14.0.0: '>=14.0.0'
   postcss@<8.5.18: '>=8.5.18'
-  fast-uri@<3.1.4: '>=3.1.4'
+  fast-uri@<4.1.2: '>=4.1.2'
   '@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3': ^7.29.4
   ws@<8.21.0: '>=8.21.0'
   '@babel/core@<7.29.6': ^7.29.6
@@ -63,9 +63,9 @@ overrides:
   '@ember/test-waiters': 3.1.0
 
 patchedDependencies:
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     hash: e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105
-    path: patches/brace-expansion@5.0.8.patch
+    path: patches/brace-expansion@5.0.9.patch
   js-yaml@4.3.0:
     hash: 6b54952aa3f509cb42ade844ea9fd31217552fb5cc9f293bb92fbdb6c9675ab2
     path: patches/js-yaml@4.3.0.patch
@@ -2603,8 +2603,8 @@ packages:
   body@5.1.0:
     resolution: {integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -4419,8 +4419,8 @@ packages:
     resolution: {integrity: sha512-7h9/x25c6AQwdU3mA8MZDUMR3UCy50f237egBrBkuwjnUZSmfu4ptCf91PZSKzON2Uh5VvIHozYKWcPPgcjxIw==}
     engines: {node: 10.* || >= 12.*}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -6803,8 +6803,8 @@ packages:
   socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   socket.io@4.7.5:
@@ -10179,7 +10179,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10530,7 +10530,7 @@ snapshots:
       raw-body: 1.1.7
       safe-json-parse: 1.0.1
 
-  brace-expansion@5.0.8(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105):
+  brace-expansion@5.0.9(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105):
     dependencies:
       balanced-match: 4.0.4
 
@@ -13386,7 +13386,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fastq@1.17.1:
     dependencies:
@@ -14908,23 +14908,23 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105)
+      brace-expansion: 5.0.9(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105)
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105)
+      brace-expansion: 5.0.9(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105)
 
   minimatch@7.4.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105)
+      brace-expansion: 5.0.9(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105)
 
   minimatch@8.0.7:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105)
+      brace-expansion: 5.0.9(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105)
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105)
+      brace-expansion: 5.0.9(patch_hash=e58de2ab8e032ed8cc45661640a3b51cde9861d6c175610338b677917e57d105)
 
   minimist@1.2.8: {}
 
@@ -16070,7 +16070,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
@@ -16085,7 +16085,7 @@ snapshots:
       debug: 4.3.7
       engine.io: 6.6.9
       socket.io-adapter: 2.5.5
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
## Summary

Fixes 3 high-severity npm vulnerabilities identified by `pnpm audit` in the frontend workspace.

## Vulnerabilities Fixed

| Package | Advisory | Severity | Installed | Fixed |
|---|---|---|---|---|
| `socket.io-parser` | [CVE-2026-69185](https://github.com/advisories/GHSA-2m8v-j782-fhvr) — Zero-attachment Memory Exhaustion | **High** | 4.2.6 | >=4.2.7 |
| `fast-uri` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — Host Confusion via backslash | **High** | 4.1.1 | >=4.1.2 |
| `brace-expansion` | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays | **High** | 5.0.8 | >=5.0.9 |

## Changes

- `ui/package.json`: Updated three `pnpm.overrides` entries and the `patchedDependencies` key for `brace-expansion`
- `ui/patches/brace-expansion@5.0.9.patch`: Compatibility shim updated to target v5.0.9
- `ui/pnpm-lock.yaml`: Regenerated lockfile with resolved secure versions

## Verification

```
$ pnpm audit
No known vulnerabilities found
```