### PR TITLE
tls cert create: reject an invalid -additional-ipaddress

### DIFF
--- a/.changelog/23788.txt
+++ b/.changelog/23788.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: `consul tls cert create` now rejects an invalid `-additional-ipaddress` value instead of silently writing a corrupted certificate.
+```

--- a/command/tls/cert/create/tls_cert_create.go
+++ b/command/tls/cert/create/tls_cert_create.go
@@ -109,7 +109,12 @@ func (c *cmd) Run(args []string) int {
 
 	for _, i := range c.ipaddresses {
 		if len(i) > 0 {
-			IPAddresses = append(IPAddresses, net.ParseIP(strings.TrimSpace(i)))
+			ip := net.ParseIP(strings.TrimSpace(i))
+			if ip == nil {
+				c.UI.Error(fmt.Sprintf("Invalid -additional-ipaddress: %q is not a valid IP address", i))
+				return 1
+			}
+			IPAddresses = append(IPAddresses, ip)
 		}
 	}
 

--- a/command/tls/cert/create/tls_cert_create_test.go
+++ b/command/tls/cert/create/tls_cert_create_test.go
@@ -57,6 +57,9 @@ func TestTlsCertCreateCommand_InvalidArgs(t *testing.T) {
 			"-node requires -server"},
 		"cli+node": {[]string{"-cli", "-node", "foo"},
 			"-node requires -server"},
+
+		"invalid additional-ipaddress": {[]string{"-client", "-additional-ipaddress", "not-an-ip"},
+			`Invalid -additional-ipaddress: "not-an-ip" is not a valid IP address`},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
`net.ParseIP` returns `nil` on unparseable input, but `-additional-ipaddress`'s value was appended to `IPAddresses` unchecked. The nil `net.IP` flows into the generated certificate's SAN IPAddress field. `x509.CreateCertificate` doesn't validate IP length on encode, so it silently produces a corrupted certificate — `consul tls cert create` reports success and writes cert/key files, but the cert is rejected by `x509.ParseCertificate` and any real TLS peer.

Repro (before the fix):
```go
badIP := net.ParseIP("not-an-ip") // nil
// ... gets appended into IPAddresses unchecked, then:
der, _ := x509.CreateCertificate(rand.Reader, template, template, &pub, priv) // succeeds!
_, err := x509.ParseCertificate(der) // "x509: cannot parse IP address of length 0"
```

Fixed by validating each `-additional-ipaddress` value at parse time and failing with a clear error instead of writing a broken cert.

Added a test case to the existing `TestTlsCertCreateCommand_InvalidArgs` table. Confirmed it fails on unpatched code (the invalid IP is silently accepted and the command instead fails later with an unrelated, misleading "Error reading CA" message) and passes after the fix.
