### PR TITLE
cache: fix background refresh dying with the request that started it

### DIFF
--- a/.changelog/23806.txt
+++ b/.changelog/23806.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fix a regression where a background-refreshed cache entry (for example `/v1/health/service/:service?cached`) could get permanently stuck serving stale data with a frozen `X-Consul-Index`. The background refresh for a cache key was bound to the context of whichever request happened to start it, so that client disconnecting stopped the refresh while leaving the entry valid, causing all later requests to be served from the frozen entry.
+```

--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -158,9 +158,15 @@ type Cache struct {
 	rateLimitCancel  context.CancelFunc
 }
 
+// fetchHandle tracks a single in-flight fetch goroutine for a cache key. Its
+// ctx is scoped to the fetch itself rather than to the caller that started it,
+// because a fetch is shared by all current and future callers of the key and,
+// for refreshing types, keeps the entry up to date on their behalf. The ctx is
+// canceled when the handle is replaced by a newer fetch or retired.
 type fetchHandle struct {
 	id     uint64
-	stopCh chan struct{}
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // typeEntry is a single type that is registered with a Cache.
@@ -523,7 +529,7 @@ RETRY_GET:
 
 	// At this point, we know we either don't have a value at all or the
 	// value we have is too old. We need to wait for new data.
-	waiterCh := c.fetch(ctx, key, r, true, 0, false)
+	waiterCh := c.fetch(key, r, true, 0, false)
 
 	// No longer our first time through
 	first = false
@@ -558,7 +564,13 @@ func makeEntryKey(t, dc, peerName, token, key string) string {
 // If allowNew is true then the fetch should create the cache entry
 // if it doesn't exist. If this is false, then fetch will do nothing
 // if the entry doesn't exist. This latter case is to support refreshing.
-func (c *Cache) fetch(ctx context.Context, key string, r getOptions, allowNew bool, attempt uint, ignoreExisting bool) <-chan struct{} {
+//
+// This deliberately takes no caller context. The fetch it starts is shared by
+// all present and future callers of the key and, for refreshing types, becomes
+// a long-lived loop that keeps the entry fresh, so a single caller going away
+// must not stop the entry from being refreshed. Fetches are instead bounded by
+// the fetchHandle, entry eviction, and Close.
+func (c *Cache) fetch(key string, r getOptions, allowNew bool, attempt uint, ignoreExisting bool) <-chan struct{} {
 	// We acquire a write lock because we may have to set Fetching to true.
 	c.entriesLock.Lock()
 	defer c.entriesLock.Unlock()
@@ -665,8 +677,10 @@ func (c *Cache) fetch(ctx context.Context, key string, r getOptions, allowNew bo
 			entry.Error = fmt.Errorf("rateLimitContext canceled: %s", err.Error())
 			return
 		}
-		// Start building the new entry by blocking on the fetch.
-		result, err := r.Fetch(ctx, fOpts)
+		// Start building the new entry by blocking on the fetch. This uses the
+		// handle's context so the fetch is not canceled just because the caller
+		// that happened to trigger it went away.
+		result, err := r.Fetch(handle.ctx, fOpts)
 		if connectedTimer != nil {
 			connectedTimer.Stop()
 		}
@@ -674,7 +688,7 @@ func (c *Cache) fetch(ctx context.Context, key string, r getOptions, allowNew bo
 		// If we were stopped while waiting on a blocking query now would be a
 		// good time to detect that.
 		select {
-		case <-handle.stopCh:
+		case <-handle.ctx.Done():
 			return
 		default:
 		}
@@ -839,9 +853,7 @@ func (c *Cache) fetch(ctx context.Context, key string, r getOptions, allowNew bo
 
 			select {
 			case <-time.After(wait):
-			case <-ctx.Done():
-				return
-			case <-handle.stopCh:
+			case <-handle.ctx.Done():
 				return
 			}
 
@@ -850,7 +862,7 @@ func (c *Cache) fetch(ctx context.Context, key string, r getOptions, allowNew bo
 			// happened, we don't want to create a new entry.
 			r.Info.MustRevalidate = false
 			r.Info.MinIndex = 0
-			c.fetch(ctx, key, r, false, attempt, true)
+			c.fetch(key, r, false, attempt, true)
 		}
 	}(handle)
 
@@ -862,14 +874,21 @@ func (c *Cache) getOrReplaceFetchHandle(key string) fetchHandle {
 	defer c.fetchLock.Unlock()
 
 	if prevHandle, ok := c.fetchHandles[key]; ok {
-		close(prevHandle.stopCh)
+		prevHandle.cancel()
 	}
 
 	c.lastFetchID++
 
+	// This context is intentionally not derived from any caller's context, nor
+	// from the Cache's rate limit context. It is canceled only when this handle
+	// is replaced or retired, which preserves the documented Close behavior
+	// that in-flight fetches run to completion.
+	ctx, cancel := context.WithCancel(context.Background())
+
 	handle := fetchHandle{
 		id:     c.lastFetchID,
-		stopCh: make(chan struct{}),
+		ctx:    ctx,
+		cancel: cancel,
 	}
 
 	c.fetchHandles[key] = handle
@@ -888,6 +907,7 @@ func (c *Cache) deleteFetchHandle(key string, fetchID uint64) {
 	}
 
 	if handle.id == fetchID {
+		handle.cancel()
 		delete(c.fetchHandles, key)
 	}
 }

--- a/agent/cache/cache_test.go
+++ b/agent/cache/cache_test.go
@@ -2000,10 +2000,8 @@ func TestFetch_ExistingValid_NoIgnore(t *testing.T) {
 	}
 
 	opts := newGetOptions(c.types["t"], TestRequest(t, RequestInfo{Key: "key"}))
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	// Should return a closed channel immediately
-	ch := c.fetch(ctx, key, opts, true, 0, false)
+	ch := c.fetch(key, opts, true, 0, false)
 
 	select {
 	case <-ch:
@@ -2028,9 +2026,7 @@ func TestFetch_AllowNewFalse(t *testing.T) {
 
 	key := "test/missing"
 	opts := newGetOptions(c.types["t"], TestRequest(t, RequestInfo{Key: "missing"}))
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ch := c.fetch(ctx, key, opts, false, 0, false)
+	ch := c.fetch(key, opts, false, 0, false)
 
 	select {
 	case <-ch:
@@ -2065,10 +2061,8 @@ func TestFetch_Coalescing(t *testing.T) {
 	}
 
 	opts := newGetOptions(c.types["t"], TestRequest(t, RequestInfo{Key: "coalesce"}))
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	// Call fetch
-	ch := c.fetch(ctx, key, opts, true, 0, false)
+	ch := c.fetch(key, opts, true, 0, false)
 
 	// Ensure we got the exact same channel back.
 	// Note: We cast the local bidirectional channel to read-only for comparison.
@@ -2096,10 +2090,8 @@ func TestFetch_StopCh(t *testing.T) {
 
 	opts := newGetOptions(c.types["t"], TestRequest(t, RequestInfo{Key: "k"}))
 	key := makeEntryKey("t", "", "", "", "k")
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	// Start fetch
-	waiter := c.fetch(ctx, key, opts, true, 0, false)
+	waiter := c.fetch(key, opts, true, 0, false)
 
 	// Ensure fetch has started (Wait for Fetching to be true)
 	assert.Eventually(t, func() bool {
@@ -2140,9 +2132,7 @@ func TestFetch_ResultStateOnly(t *testing.T) {
 		Return(FetchResult{Value: nil, State: "some_state"}, nil)
 
 	opts := newGetOptions(c.types["t"], TestRequest(t, RequestInfo{Key: "state_only"}))
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	waiter := c.fetch(ctx, key, opts, true, 0, false)
+	waiter := c.fetch(key, opts, true, 0, false)
 	<-waiter
 
 	c.entriesLock.RLock()
@@ -2171,9 +2161,7 @@ func TestFetch_ZeroIndexSafety(t *testing.T) {
 		Return(FetchResult{Value: "val", Index: 0}, nil)
 
 	opts := newGetOptions(c.types["t"], TestRequest(t, RequestInfo{Key: "zero_idx"}))
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	waiter := c.fetch(ctx, key, opts, true, 0, false)
+	waiter := c.fetch(key, opts, true, 0, false)
 	<-waiter
 
 	c.entriesLock.RLock()
@@ -2199,21 +2187,18 @@ func TestFetch_ReplacesHandle(t *testing.T) {
 	handle := c.getOrReplaceFetchHandle(key)
 
 	// Start a new fetch for the same key. This calls getOrReplaceFetchHandle again.
-	// We expect the previous handle's stopCh to be closed.
+	// We expect the previous handle's context to be canceled.
 
 	typ.On("Fetch", mock.Anything, mock.Anything, mock.Anything).
 		Return(FetchResult{Value: "val"}, nil)
 
 	opts := newGetOptions(c.types["t"], TestRequest(t, RequestInfo{Key: "k"}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	waiter := c.fetch(ctx, key, opts, true, 0, true) // ignoreExisting forces new fetch logic
+	waiter := c.fetch(key, opts, true, 0, true) // ignoreExisting forces new fetch logic
 	<-waiter
 
 	select {
-	case <-handle.stopCh:
+	case <-handle.ctx.Done():
 		// Success: the previous handle was signaled to stop
 	default:
 		t.Fatal("Expected previous fetch handle to be stopped")
@@ -2245,10 +2230,8 @@ func TestFetch_EvictionRace(t *testing.T) {
 
 	opts := newGetOptions(c.types["t"], TestRequest(t, RequestInfo{Key: "evict"}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	// Start fetch in background
-	go c.fetch(ctx, key, opts, true, 0, false)
+	go c.fetch(key, opts, true, 0, false)
 
 	<-fetchStarted
 
@@ -2306,10 +2289,7 @@ func TestFetch_Refresh_Backoff_Logic(t *testing.T) {
 	opts := newGetOptions(c.types["t"], TestRequest(t, RequestInfo{Key: "refresh"}))
 
 	// Start initial fetch
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	c.fetch(ctx, key, opts, true, 0, false)
+	c.fetch(key, opts, true, 0, false)
 
 	// Wait for first fetch
 	<-fetched
@@ -2320,5 +2300,108 @@ func TestFetch_Refresh_Backoff_Logic(t *testing.T) {
 		// Success, recursion worked
 	case <-time.After(2 * time.Second):
 		t.Fatal("Background refresh did not trigger second fetch")
+	}
+}
+
+// TestFetch_BackgroundRefreshSurvivesCallerCancel is a regression test for a
+// bug where a cache entry could get permanently stuck serving stale data.
+//
+// The first Get for a key is what starts the background refresh loop. If that
+// loop is bound to the calling request's context, then when that one client
+// disconnects the refresh dies -- but the entry is left behind still marked
+// Valid. Every later Get then hits that frozen entry and returns the stale
+// value with a frozen X-Consul-Index, forever (until the LastGetTTL, which is
+// refreshed by those very same Gets, so in practice never).
+func TestFetch_BackgroundRefreshSurvivesCallerCancel(t *testing.T) {
+	t.Parallel()
+
+	typ := &MockType{}
+	typ.On("RegisterOptions").Return(RegisterOptions{
+		Refresh:          true,
+		SupportsBlocking: true,
+		RefreshTimer:     5 * time.Millisecond,
+		QueryTimeout:     10 * time.Minute,
+	})
+
+	var index uint64 = 10
+	var fetches int64
+	typ.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(
+		func(ctx context.Context, opts FetchOptions, r Request) FetchResult {
+			atomic.AddInt64(&fetches, 1)
+			i := atomic.AddUint64(&index, 1)
+			return FetchResult{Value: int(i), Index: i}
+		},
+		func(ctx context.Context, opts FetchOptions, r Request) error { return nil },
+	)
+
+	c := New(Options{})
+	defer c.Close()
+	c.RegisterType("t", typ)
+
+	req := TestRequest(t, RequestInfo{Key: "hello"})
+
+	// A short-lived caller populates the entry and starts the refresh loop.
+	ctx, cancel := context.WithCancel(context.Background())
+	_, _, err := c.Get(ctx, "t", req)
+	require.NoError(t, err)
+
+	// That caller disconnects.
+	cancel()
+
+	// The background refresh must keep running for later callers.
+	before := atomic.LoadInt64(&fetches)
+	retry.Run(t, func(r *retry.R) {
+		require.Greater(r, atomic.LoadInt64(&fetches), before,
+			"background refresh stopped after the caller that started it was canceled")
+	})
+
+	// And a fresh caller must observe an advancing index, not a frozen one.
+	_, meta1, err := c.Get(context.Background(), "t", req)
+	require.NoError(t, err)
+	retry.Run(t, func(r *retry.R) {
+		_, meta2, err := c.Get(context.Background(), "t", req)
+		require.NoError(r, err)
+		require.Greater(r, meta2.Index, meta1.Index, "cache entry index is stuck")
+	})
+}
+
+// TestFetch_CloseDuringInflightFetchUnblocksGet verifies that closing the Cache
+// while a fetch is in flight still unblocks callers waiting on that fetch,
+// matching the documented Close behavior that in-flight fetches are allowed to
+// run to completion.
+func TestFetch_CloseDuringInflightFetchUnblocksGet(t *testing.T) {
+	t.Parallel()
+
+	c := New(Options{})
+	typ := &MockType{}
+	typ.On("RegisterOptions").Return(RegisterOptions{})
+	c.RegisterType("t", typ)
+
+	release := make(chan struct{})
+	typ.On("Fetch", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { <-release }).
+		Return(FetchResult{Value: "v", Index: 5}, nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// We only care that Get returns at all, not what it returns.
+		_, _, _ = c.Get(context.Background(), "t", TestRequest(t, RequestInfo{Key: "k"}))
+	}()
+
+	// Let the fetch start, then close the cache and let the fetch finish.
+	retry.Run(t, func(r *retry.R) {
+		c.entriesLock.RLock()
+		defer c.entriesLock.RUnlock()
+		e, ok := c.entries[makeEntryKey("t", "", "", "", "k")]
+		require.True(r, ok && e.Fetching)
+	})
+	require.NoError(t, c.Close())
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Get did not return after Close during an in-flight fetch")
 	}
 }


### PR DESCRIPTION
### Description

Upgrading from 1.21.5 to 2.0.2 introduced a bug where a background-refreshed cache entry can get permanently stuck serving stale data with a frozen X-Consul-Index. In our case a service moved to a new node in Nomad, but the local agent kept returning the old node's address indefinitely from:

/v1/health/service/<name>?passing&near=_agent&cached

The first Get for a cache key is what starts that key's shared background refresh loop. Since #23157 that loop inherited the context.Context of whichever caller happened to trigger it. When that one client disconnected, the refresh goroutine returned early, but left the entry in c.entries still marked Valid. Every subsequent Get then matched the frozen entry in getEntryLocked and was served as a cache hit without ever re-fetching.

The entry can't self-heal either: those same Get calls invoke entriesExpiryHeap.Update on every lookup, so LastGetTTL is continually renewed and the entry is never evicted. Under steady traffic it stays frozen indefinitely.

The fix scopes the background fetch to the fetch itself rather than to the caller, by giving fetchHandle its own context, and removes the caller context from fetch() so it can't be reintroduced. This restores the pre-#23157 behavior (every cache-type Fetch issued its RPC with context.Background()) while keeping the cancel-on-replace semantics the handle's stopCh previously provided.

Two deliberate design decisions worth calling out for review:
- The handle context is not derived from the cache's rate limit context. Close() cancels that, which would make in-flight fetches return before close(entry.Waiter) and hang every blocked Get. I hit this while developing the fix and added a test for it. Shutdown is already handled by the existing c.stopped check, and eviction by the allowNew=false path.
- context.Background() rather than context.WithoutCancel(ctx). WithoutCancel preserves values but is wrong here: the refresh loop is shared, so it would permanently stamp whichever client arrived first onto RPCs serving everyone, misattributing SourceAddr, which feeds rate-limit server exemptions and audit logging. There's also no tracing on this path (all go.opentelemetry.io deps are // indirect, no otel usage in agent/), and Client.RPC ignores ctx entirely on client agents. Threading it through the recursive refresh also grows the context chain unboundedly (I measured 84 → 349 nested wrappers in 400ms).

Background fetches remain bounded without a caller deadline: blocking cache types set MaxQueryTime from RegisterOptions.QueryTimeout (server-clamped in RPCQueryTimeout), and non-blocking types are registered Refresh: false and never enter the refresh loop. I audited all 23 cache types to confirm this.

### Testing & Reproduction steps

Reproduction (real cluster): with a service registered via Nomad, drive sustained concurrent load at the agent's ?cached endpoint using the parameters above, sever all client connections at once (simulating an app restart), reconnect, then relocate the job to a different node. The agent's cached response stays pinned to the old node's address with a frozen X-Consul-Index, while an uncached query against the servers returns the new address. I have a python script that can reliably reproduce as well on an active cluster which I can share.

Verified fixed on a live cluster - the cached endpoint now follows the service to the new node.

Unit tests added in agent/cache/cache_test.go:
- TestFetch_BackgroundRefreshSurvivesCallerCancel - the primary regression test. Confirmed non-vacuous: it fails on unfixed main with "background refresh stopped after the caller that started it was canceled" and passes with the fix.
- TestFetch_CloseDuringInflightFetchUnblocksGet - guards the Close()-during-in-flight-fetch hang described above. Passes on unfixed main (that behavior was already correct) and catches the regression an incorrect fix would introduce.

Existing tests updated mechanically for the fetch() signature change; TestFetch_ReplacesHandle now asserts on handle.ctx.Done() instead of handle.stopCh, verifying the same semantics.

I also verified via throwaway tests (not committed) that there are no goroutine or memory leaks: after Close() the fetch goroutine is gone (confirmed by stack dump), evicted entries stop refreshing, and Notify watch deregistration still terminates fetching, the actual goal of #23157.

go build, gofmt, and go vet are clean. Full -race suite passes for agent/cache, agent/cache-types, agent/rpcclient/, agent/proxycfg/, and agent/submatview; cache tests run at -count=5 with no flakes.

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

- Regression introduced in #23157 (agent/cache/cache.go); #23255 removed one of the three caller-context checks but not the two that stop the refresh loop.

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [X] updated test coverage
* [ ] external facing docs updated
      (N/A)
* [ ] appropriate backport labels added 
    (backport/2.0.x and backport/1.22.x)
* [X] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

Can just revert the PR

- [X] If applicable, I've documented the impact of any changes to security controls.

No security controls are changed. Worth noting explicitly for reviewers: background refresh RPCs continue to carry no caller-derived SourceAddr (as before #23157), so rate limiting and audit logging attribute them as agent-internal background work rather than to an arbitrary client. Preserving caller context here would have degraded that attribution (see the WithoutCancel rationale above).