### PR TITLE
fix: avoid watch cancellation panic

### DIFF
--- a/.changelog/23809.txt
+++ b/.changelog/23809.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+watch: prevent a panic when a watch is stopped while starting a request
+```

--- a/api/watch/plan.go
+++ b/api/watch/plan.go
@@ -236,12 +236,12 @@ func (p *Plan) shouldStop() bool {
 func (p *Plan) setCancelFunc(cancel context.CancelFunc) {
 	p.stopLock.Lock()
 	defer p.stopLock.Unlock()
+	p.cancelFunc = cancel
 	if p.shouldStop() {
 		// The watch is stopped and execute the new cancel func to stop watchFactory
 		cancel()
 		return
 	}
-	p.cancelFunc = cancel
 }
 
 func (p *Plan) IsStopped() bool {

--- a/api/watch/plan_test.go
+++ b/api/watch/plan_test.go
@@ -151,3 +151,11 @@ func TestRunWithClientAndLogger_NilLogger(t *testing.T) {
 		t.Fatalf("watcher didn't exit")
 	}
 }
+
+func TestMakeQueryOptionsWithContextAfterStop(t *testing.T) {
+	plan := mustParse(t, `{"type":"noop"}`)
+	plan.Stop()
+
+	makeQueryOptionsWithContext(plan, false)
+	defer plan.cancelFunc()
+}


### PR DESCRIPTION
### Description

Store a newly created watch request cancel function before checking whether the plan has stopped. If `Stop` wins the race, `setCancelFunc` still cancels the context, while deferred watch cleanup now receives a non-nil function.

Fixes #19020.

### Testing & Reproduction steps

Before this change, `TestMakeQueryOptionsWithContextAfterStop` deterministically panics when cleanup invokes the nil cancel function. After the change:

- `go test ./watch -run '^TestMakeQueryOptionsWithContextAfterStop$' -count=1`
- `go test -race ./watch -run '^TestMakeQueryOptionsWithContextAfterStop$' -count=1`
- `go test -short ./watch -count=1`
- `go test -race -short ./watch -count=1`
- `go vet ./watch`

All pass. Full non-short watch suite requires a `consul` binary on `$PATH` and was not available locally.

### Links

- #19020

### PR Checklist

* [x] updated test coverage
* [x] external facing docs not applicable
* [ ] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] Revert plan is reverting this pull request.
- [x] No security controls are changed.