### PR TITLE
fix: fill Port for multi-port services in more places

### DIFF
--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -486,6 +486,10 @@ RETRY_ONCE:
 			if s.Tags == nil {
 				s.Tags = make([]string, 0)
 			}
+			if s.Port == 0 && len(s.Ports) > 0 {
+				// Populate `port` with default port for backward compatibility
+				s.Port = s.DefaultPort()
+			}
 		}
 	}
 	metrics.IncrCounterWithLabels([]string{"client", "api", "success", "catalog_node_services"}, 1,
@@ -538,6 +542,10 @@ RETRY_ONCE:
 	for _, s := range out.NodeServices.Services {
 		if s.Tags == nil {
 			s.Tags = make([]string, 0)
+		}
+		if s.Port == 0 && len(s.Ports) > 0 {
+			// Populate `port` with default port for backward compatibility
+			s.Port = s.DefaultPort()
 		}
 	}
 	metrics.IncrCounterWithLabels([]string{"client", "api", "success", "catalog_node_service_list"}, 1,

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -1663,6 +1663,66 @@ func TestCatalogNodeServiceList(t *testing.T) {
 	require.Equal(t, args.Service.Proxy, proxySvc.Proxy)
 }
 
+func TestCatalogNodeServices_DefaultPort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	// Register node with a multi-port service (Port: 0, Ports with Default: true)
+	args := &structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       "foo",
+		Address:    "127.0.0.1",
+		Service: &structs.NodeService{
+			ID:      "api-1",
+			Service: "api",
+			Ports: structs.ServicePorts{
+				{
+					Name:    "http",
+					Port:    8080,
+					Default: true,
+				},
+			},
+		},
+	}
+
+	var out struct{}
+	require.NoError(t, a.RPC(context.Background(), "Catalog.Register", args, &out))
+
+	// CatalogNodeServices
+	{
+		req, _ := http.NewRequest("GET", "/v1/catalog/node/foo?dc=dc1", nil)
+		resp := httptest.NewRecorder()
+		obj, err := a.srv.CatalogNodeServices(resp, req)
+		require.NoError(t, err)
+		assertIndex(t, resp)
+
+		nodeServices := obj.(*structs.NodeServices)
+		require.NotNil(t, nodeServices)
+		require.Contains(t, nodeServices.Services, "api-1")
+		require.Equal(t, 8080, nodeServices.Services["api-1"].Port)
+	}
+
+	// CatalogNodeServiceList
+	{
+		req, _ := http.NewRequest("GET", "/v1/catalog/node-services/foo?dc=dc1", nil)
+		resp := httptest.NewRecorder()
+		obj, err := a.srv.CatalogNodeServiceList(resp, req)
+		require.NoError(t, err)
+		assertIndex(t, resp)
+
+		nodeServiceList := obj.(*structs.NodeServiceList)
+		require.NotNil(t, nodeServiceList)
+		require.Len(t, nodeServiceList.Services, 1)
+		require.Equal(t, 8080, nodeServiceList.Services[0].Port)
+	}
+}
+
 func TestCatalogNodeServiceList_MergeCentralConfig(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -952,6 +952,14 @@ func (c *Catalog) NodeServices(args *structs.NodeSpecificRequest, reply *structs
 			if err != nil {
 				return err
 			}
+			if services != nil {
+				for _, svc := range services.Services {
+					if svc.Port == 0 && len(svc.Ports) > 0 {
+						// Populate `port` with default port for backward compatibility
+						svc.Port = svc.DefaultPort()
+					}
+				}
+			}
 			reply.Index, reply.NodeServices = index, services
 
 			// Note: we filter the results with ACLs *before* applying the user-supplied
@@ -1017,6 +1025,14 @@ func (c *Catalog) NodeServiceList(args *structs.NodeSpecificRequest, reply *stru
 			index, services, err := state.NodeServiceList(ws, args.Node, &args.EnterpriseMeta, args.PeerName)
 			if err != nil {
 				return err
+			}
+			if services != nil {
+				for _, svc := range services.Services {
+					if svc.Port == 0 && len(svc.Ports) > 0 {
+						// Populate `port` with default port for backward compatibility
+						svc.Port = svc.DefaultPort()
+					}
+				}
 			}
 
 			mergedServices := services

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -2868,6 +2868,67 @@ func TestCatalog_Register_FailedCase1(t *testing.T) {
 	}
 }
 
+func TestCatalog_NodeServices_DefaultPort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Register node with a multi-port service (Port: 0, Ports with Default: true)
+	if err := s1.fsm.State().EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if err := s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{
+		ID:      "api-1",
+		Service: "api",
+		Port:    0,
+		Ports: structs.ServicePorts{
+			{
+				Name:    "http",
+				Port:    8080,
+				Default: true,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// NodeServices
+	{
+		args := structs.NodeSpecificRequest{
+			Datacenter: "dc1",
+			Node:       "foo",
+		}
+		var out structs.IndexedNodeServices
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.NodeServices", &args, &out))
+		require.NotNil(t, out.NodeServices)
+		require.Contains(t, out.NodeServices.Services, "api-1")
+		require.Equal(t, 8080, out.NodeServices.Services["api-1"].Port)
+	}
+
+	// NodeServiceList
+	{
+		args := structs.NodeSpecificRequest{
+			Datacenter: "dc1",
+			Node:       "foo",
+		}
+		var out structs.IndexedNodeServiceList
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.NodeServiceList", &args, &out))
+		require.NotNil(t, out.NodeServices)
+		require.Len(t, out.NodeServices.Services, 1)
+		require.Equal(t, 8080, out.NodeServices.Services[0].Port)
+	}
+}
+
 func testACLFilterServer(t *testing.T) (dir, token string, srv *Server, codec rpc.ClientCodec) {
 	dir, srv = testServerWithConfig(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -586,6 +586,15 @@ func (p *PreparedQuery) execute(query *structs.PreparedQuery,
 		nodes = tagFilter(query.Service.Tags, nodes)
 	}
 
+	for i := range nodes {
+		// Populate `port` with default port for backward compatibility
+		if nodes[i].Service != nil && nodes[i].Service.Port == 0 && len(nodes[i].Service.Ports) > 0 {
+			clone := *nodes[i].Service
+			clone.Port = clone.DefaultPort()
+			nodes[i].Service = &clone
+		}
+	}
+
 	// Capture the nodes and pass the DNS information through to the reply.
 	reply.Service = query.Service.Service
 	reply.EnterpriseMeta = query.Service.EnterpriseMeta

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -2671,6 +2671,69 @@ func TestPreparedQuery_Execute_ConnectExact(t *testing.T) {
 		codec, "PreparedQuery.Apply", &query, &query.Query.ID))
 }
 
+func TestPreparedQuery_Execute_DefaultPort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Register node with a multi-port service (Port: 0, Ports with Default: true)
+	regReq := structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       "api-node",
+		Address:    "127.0.0.100",
+		Service: &structs.NodeService{
+			ID:      "api-1",
+			Service: "api-svc",
+			Port:    0,
+			Ports: structs.ServicePorts{
+				{
+					Name:    "http",
+					Port:    8080,
+					Default: true,
+				},
+			},
+		},
+	}
+	var regReply struct{}
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &regReq, &regReply))
+
+	// Create a prepared query for this service
+	query := structs.PreparedQueryRequest{
+		Datacenter: "dc1",
+		Op:         structs.PreparedQueryCreate,
+		Query: &structs.PreparedQuery{
+			Name: "test-default-port",
+			Service: structs.ServiceQuery{
+				Service: "api-svc",
+			},
+			DNS: structs.QueryDNSOptions{
+				TTL: "10s",
+			},
+		},
+	}
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "PreparedQuery.Apply", &query, &query.Query.ID))
+
+	// Execute the prepared query
+	execReq := structs.PreparedQueryExecuteRequest{
+		Datacenter:    "dc1",
+		QueryIDOrName: query.Query.ID,
+	}
+	var execReply structs.PreparedQueryExecuteResponse
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "PreparedQuery.Execute", &execReq, &execReply))
+
+	require.Len(t, execReply.Nodes, 1)
+	require.Equal(t, 8080, execReply.Nodes[0].Service.Port)
+}
+
 func TestPreparedQuery_tagFilter(t *testing.T) {
 	t.Parallel()
 	testNodes := func() structs.CheckServiceNodes {


### PR DESCRIPTION
### Description

A few spots filled in `Port` when `Ports` was defined but it wasn't done in enough spots. Crucially if you're running `v1.21.x` in another datacenter, it will get `Port: 0` over RPC. I'm not sure if there are more spots that are needed but this at least covers the ones I was able to uncover.

I would like this backported to v1.22 but I'm not sure how to add the labels.

Fixes #23815

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

I included steps in #23815 but I also added unit tests in this PR.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
