### PR TITLE
ci: gate PR merges on per-package coverage regression

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -593,6 +593,111 @@ jobs:
             exit 1
           fi
 
+  coverage-regression-gate:
+    name: coverage-regression-gate
+    needs: [coverage-report]
+    # Only runs on PRs — a push to main has no baseline to regress against
+    # (it IS the new baseline). Only gate when the report succeeded.
+    if: "!cancelled() && github.event_name == 'pull_request' && needs.coverage-report.result == 'success'"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download pkg-summary artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pkg-summary
+          path: .
+
+      - name: Enforce per-package coverage regression gate
+        env:
+          TOTAL: ${{ needs.coverage-report.outputs.total }}
+        run: |
+          set -euo pipefail
+
+          # If no coverage profiles were produced (e.g. only non-Go files
+          # changed), there is nothing to compare — pass.
+          if [ "${TOTAL:-N/A}" = "N/A" ]; then
+            echo "::notice::No coverage data produced; regression gate skipped."
+            {
+              echo "### ✅ Coverage regression gate passed"
+              echo ""
+              echo "No coverage data was produced (no coverable Go files), so there is nothing to compare."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # If no baseline file exists yet (first run after this feature merges),
+          # skip gracefully — the next push to main will create it.
+          if [ ! -f ".github/coverage-baseline.txt" ]; then
+            echo "::notice::No coverage baseline found (.github/coverage-baseline.txt). Skipping regression check."
+            {
+              echo "### ✅ Coverage regression gate passed"
+              echo ""
+              echo "No coverage baseline file found. The baseline will be created on the next merge to \`main\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          BASELINE=".github/coverage-baseline.txt"
+          PR_SUMMARY="pkg-summary.txt"
+
+          FAILED=0
+          TABLE_ROWS=""
+
+          # For every package in the PR summary, check if its average dropped
+          # below the stored baseline value. Packages not in the baseline (new
+          # packages) are skipped — they have no prior coverage to regress from.
+          while IFS= read -r line; do
+            pkg=$(echo "$line" | awk '{print $1}')
+            pr_pct=$(echo "$line" | awk '{print $2}' | tr -d '%')
+
+            # Look up this package in the baseline.
+            base_line=$(grep "^${pkg} " "$BASELINE" || true)
+            if [ -z "$base_line" ]; then
+              # New package — no baseline to compare against, pass.
+              TABLE_ROWS="${TABLE_ROWS}| \`${pkg}\` | N/A (new) | ${pr_pct}% | — | ✅ new package |\n"
+              continue
+            fi
+
+            base_pct=$(echo "$base_line" | awk '{print $2}' | tr -d '%')
+
+            # Compare: fail if PR average is strictly less than baseline.
+            if awk "BEGIN { exit !(${pr_pct} < ${base_pct}) }"; then
+              delta=$(awk "BEGIN { printf \"%.1f\", ${pr_pct} - ${base_pct} }")
+              TABLE_ROWS="${TABLE_ROWS}| \`${pkg}\` | ${base_pct}% | ${pr_pct}% | ${delta}% | ❌ REGRESSED |\n"
+              echo "::error::Package '${pkg}' coverage dropped from ${base_pct}% to ${pr_pct}% (${delta}%)"
+              FAILED=1
+            else
+              delta=$(awk "BEGIN { printf \"%.1f\", ${pr_pct} - ${base_pct} }")
+              prefix=""
+              [ "$(awk "BEGIN{print (${delta}>0)}")" = "1" ] && prefix="+"
+              TABLE_ROWS="${TABLE_ROWS}| \`${pkg}\` | ${base_pct}% | ${pr_pct}% | ${prefix}${delta}% | ✅ OK |\n"
+            fi
+          done < "$PR_SUMMARY"
+
+          # Write the full table to the step summary regardless of pass/fail.
+          {
+            if [ "$FAILED" -eq 1 ]; then
+              echo "### ❌ Coverage regression gate failed"
+              echo ""
+              echo "One or more packages have lower average coverage than the \`main\` baseline."
+              echo "Add or restore tests to bring these packages back to or above their baseline coverage."
+            else
+              echo "### ✅ Coverage regression gate passed"
+              echo ""
+              echo "All packages maintain or improve their coverage compared to the \`main\` baseline."
+            fi
+            echo ""
+            echo "| Package | Baseline | PR | Delta | Status |"
+            echo "|---------|----------|----|-------|--------|"
+            printf "%b" "$TABLE_ROWS"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$FAILED" -eq 1 ]; then
+            exit 1
+          fi
+
   noop:
     runs-on: ubuntu-latest
     steps:
@@ -639,6 +744,7 @@ jobs:
     # - go-test-s390x
     - coverage-report
     - coverage-gate
+    - coverage-regression-gate
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
     if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -133,6 +133,47 @@ jobs:
 
           go tool cover -html=merged-coverage.out -o coverage.html
 
+      - name: Upload pkg-summary artifact
+        # Upload pkg-summary.txt so the regression gate job can download it.
+        # Must run before the "Update coverage badge" step, which switches the
+        # working tree to the badges branch and wipes all untracked files.
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pkg-summary
+          path: pkg-summary.txt
+          if-no-files-found: ignore
+
+      - name: Commit coverage baseline to main
+        # On every merge to main, commit the updated pkg-summary.txt as the
+        # authoritative per-package baseline for the regression gate.
+        # PRs compare their per-package averages against this file to detect
+        # regressions before they can be merged.
+        # Must run before the "Update coverage badge" step, which switches the
+        # working tree to the badges branch (destroying pkg-summary.txt).
+        if: github.ref == 'refs/heads/main' && steps.coverage.outputs.total != 'N/A'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
+          # Pull latest main to avoid conflicts with concurrent commits.
+          git fetch origin main --depth=1
+          git pull --ff-only origin main
+
+          mkdir -p .github
+          cp pkg-summary.txt .github/coverage-baseline.txt
+          git add .github/coverage-baseline.txt
+          if git diff --staged --quiet; then
+            echo "Coverage baseline unchanged, skipping commit"
+          else
+            git commit -m "ci: update coverage baseline [skip ci]"
+            git push origin HEAD:main
+          fi
+
       - name: Compute patch coverage
         id: patch
         if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'


### PR DESCRIPTION
## Summary

Adds a **per-package coverage regression gate** to consul. It prevents PRs from being merged if they cause the average test coverage of any Go package to drop below its current value on `main`.

This is a companion to the existing `coverage-gate` (≥90% patch coverage) introduced in #23692. The two gates work together:
- **Patch gate** (#23692) — new/changed code must be ≥90% covered.
- **Regression gate** (this PR) — no package's overall average may drop below its current baseline.

> **Dependency:** This PR stacks on top of #23692 (`ci/enforce-patch-coverage`), which provides the `upload-coverage` input to `reusable-unit.yml` that makes coverage profiles available for merging. Merge #23692 first, then this PR.

---

## How it works

### On every merge to `main` (`reusable-coverage-report.yml`)
- The existing workflow already computes `pkg-summary.txt` (per-package average coverage grouped by top-level directory).
- A new **"Upload pkg-summary artifact"** step makes the PR's per-package data available to the regression gate job via a named artifact.
- A new **"Commit coverage baseline to main"** step commits that file as `.github/coverage-baseline.txt` — the authoritative baseline that all PRs compare against. This keeps the baseline always current without a separate nightly job.

> **Note:** Both new steps are placed **before** the existing "Update coverage badge" step intentionally. The badge step does `git checkout -B badges origin/badges` + `git rm -rf .`, which switches the working tree to the badges branch and destroys all untracked files including `pkg-summary.txt`. The new steps must run while the file still exists.

### On every PR (`go-tests.yml`)
- A new **`coverage-regression-gate`** job runs after `coverage-report`.
- Checks out the repo (to read `.github/coverage-baseline.txt`) and downloads the `pkg-summary` artifact (to read the PR's per-package averages).
- Compares every package against `.github/coverage-baseline.txt`.
- If any package's average **dropped** below its baseline, the job **fails** with a clear error and a full per-package table in the step summary (baseline %, PR %, delta, status).
- Packages not in the baseline (brand-new packages) are **skipped** — they have no prior coverage to regress from.

### Passes automatically when
- No coverage data produced (docs-only / non-Go PRs).
- No baseline file yet (first run after this PR merges — the next push to `main` creates `.github/coverage-baseline.txt`).

---

## Files changed

### `.github/workflows/reusable-coverage-report.yml`
- New step: **Upload pkg-summary artifact** — uploads `pkg-summary.txt` as a named artifact so the regression gate job can download it directly
- New step: **Commit coverage baseline to main** (main-only, idempotent) — commits `pkg-summary.txt` as `.github/coverage-baseline.txt` on every push to `main`

### `.github/workflows/go-tests.yml`
- New job: **`coverage-regression-gate`** — mirrors `coverage-gate` structure; uses `if: !cancelled() && github.event_name == 'pull_request' && needs.coverage-report.result == 'success'` consistent with existing consul gate pattern
- `coverage-regression-gate` added to `go-tests-success` `needs` list so branch protection enforces it

---

## One-time admin step after merge
Add **`coverage-regression-gate`** as a required status check in branch protection for `main` (same process as was done for `coverage-gate`).