### PR TITLE
add ignore type unknown flag to feature gate writes

### DIFF
--- a/agent/consul/fsm/commands_ce_test.go
+++ b/agent/consul/fsm/commands_ce_test.go
@@ -1128,7 +1128,7 @@ func TestFSM_FeatureGateUpdate(t *testing.T) {
 			},
 		},
 	}
-	buf, err := structs.Encode(structs.FeatureGateRequestType, req)
+	buf, err := structs.Encode(structs.FeatureGateRequestType|structs.IgnoreUnknownTypeFlag, req)
 	require.NoError(t, err)
 	require.Equal(t, true, fsm.Apply(makeLog(buf)))
 
@@ -1154,7 +1154,7 @@ func TestFSM_FeatureGateUpdate_EmitsMetrics(t *testing.T) {
 			},
 		},
 	}
-	buf, err := structs.Encode(structs.FeatureGateRequestType, req)
+	buf, err := structs.Encode(structs.FeatureGateRequestType|structs.IgnoreUnknownTypeFlag, req)
 	require.NoError(t, err)
 	require.Equal(t, true, fsm.Apply(makeLog(buf)))
 

--- a/agent/consul/leader_feature_gate.go
+++ b/agent/consul/leader_feature_gate.go
@@ -92,7 +92,15 @@ func (s *Server) reconcileFeatureGates() error {
 		request.ExpectedStatusIndex = currentStatus.ModifyIndex
 	}
 
-	response, err := s.leaderRaftApply("FeatureGate.Apply", structs.FeatureGateRequestType, request)
+	// Feature-gate state is safe for pre-framework servers to omit: those
+	// binaries cannot consume it, and current binaries commit the complete
+	// policy and resolved status together. Always mark the command ignorable so
+	// a downgraded follower can replay entries written before it joined.
+	response, err := s.leaderRaftApply(
+		"FeatureGate.Apply",
+		structs.FeatureGateRequestType|structs.IgnoreUnknownTypeFlag,
+		request,
+	)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/operator_feature_gate_endpoint.go
+++ b/agent/consul/operator_feature_gate_endpoint.go
@@ -107,7 +107,13 @@ func (op *Operator) FeatureGateSet(args *structs.FeatureGateSetRequest, reply *s
 		ExpectedPolicyIndex: policy.ModifyIndex,
 		ExpectedStatusIndex: status.ModifyIndex,
 	}
-	response, err := op.srv.raftApplyMsgpack(structs.FeatureGateRequestType, request)
+	// See reconcileFeatureGates: this state can be ignored by binaries that
+	// predate the framework, including when they replay an older log entry
+	// during a downgrade.
+	response, err := op.srv.raftApplyMsgpack(
+		structs.FeatureGateRequestType|structs.IgnoreUnknownTypeFlag,
+		request,
+	)
 	if err != nil {
 		return fmt.Errorf("raft apply failed: %w", err)
 	}


### PR DESCRIPTION
### Description

Add ignore type unknown flag to avoid server crash on downgrade.
<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps
I ran an actual three-server mixed-version cluster:
Patched Consul 2.1.0
Released Consul 2.0.3, which has no feature-gate framework
Three Raft voters with explicit leadership transfers

Scenario	Result
2.1.0 leader with two 2.0.3 servers	No error. Feature gates were not initialized because the cluster did not meet version 2.1.0.
All servers upgraded to 2.1.0	Framework initialized automatically. Gate became desired/effective true.
One follower downgraded to 2.0.3	It replayed the flagged entries, logged ignoring unknown message type ... 45 twice, and remained a healthy voter.
2.1.0 leader after downgrade	Gate became fail-closed: desired true, effective false, reason below-minimum-version.
Leadership transferred to 2.0.3	Transfer succeeded. The old leader accepted a KV write and did not remove feature state from newer followers.
Feature API while old server was leader	Returned rpc: can't find method Operator.FeatureGateGet, as expected because the old binary lacks that RPC.
Leadership transferred back to 2.1.0	Original policy remained intact: policy index 35, status index 48.
Old node re-upgraded to 2.1.0	Retained logs replayed successfully, gate became effective again, and the re-upgraded node successfully became leader.


However, the forced-snapshot test failed:
Forced a feature-containing snapshot at index 70.
Restarted that server using 2.0.3.

Startup failed with:
failed to restore snapshot: Unrecognized msg type 45
Failed to start Raft: failed to load any existing snapshots

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
