### PR TITLE
ui: migrate intentions UI to HDS

### DIFF
--- a/ui/packages/consul-ui/app/components/composite-row/index.scss
+++ b/ui/packages/consul-ui/app/components/composite-row/index.scss
@@ -67,9 +67,6 @@
 .consul-service-instance-list .mesh dt + dd {
   margin-left: 0;
 }
-.consul-intention-permission-list > ul {
-  border-top: 1px solid var(--token-color-surface-interactive-active);
-}
 .consul-service-instance-list .port dt,
 .consul-service-instance-list .port dt::before {
   display: none;

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
@@ -220,7 +220,7 @@
         @color='tertiary'
         @icon='plus'
         data-test-create-permission
-        {{on "click" (action this.openModal)}}
+        {{on "click" (action this.openModal undefined)}}
       />
     </div>
     <div class="permissions-content">
@@ -228,7 +228,7 @@
       <Consul::Intention::Notice::Permissions />
       <Consul::Intention::Permission::List
         @items={{@item.Permissions}}
-        @onclick={{queue (action (mut this.permission)) (action this.openModal)}}
+        @onclick={{queue (action this.setPermission) (action this.openModal)}}
         @ondelete={{action 'delete' 'Permissions' @item}}
       />
 {{else}}
@@ -269,43 +269,41 @@
   </fieldset>
 {{/if}}
 
-  <ModalDialog
+{{#if this.isPermissionModalOpen}}
+  <Hds::Modal
     class="consul-intention-permission-modal"
-    @onclose={{action (mut this.permission) undefined}}
-    @aria={{hash
-      label="Edit Permission"
-    }}
+    @onClose={{action this.closeModal}}
+    @size="large"
+    as |M|
   >
-    <:default as |modal|>
-          <Ref @target={{this}} @name="modal" @value={{modal}} />
-    </:default>
-    <:header>
-      <h3>Edit Permission</h3>
-    </:header>
-    <:body>
+    <M.Header>
+      Add permission
+    </M.Header>
+    <M.Body>
       <Consul::Intention::Permission::Form
         @item={{this.permission}}
         @onsubmit={{action 'add' 'Permissions' @item}}
       as |permissionForm|>
         <Ref @target={{this}} @name="permissionForm" @value={{permissionForm}} />
       </Consul::Intention::Permission::Form>
-    </:body>
-    <:actions as |close|>
+    </M.Body>
+    <M.Footer as |F|>
       <Hds::ButtonSet>
         <Hds::Button
           @text='Save'
           data-test-intention-permission-submit
           @color='primary'
           disabled={{if (not this.permissionForm.isDirty) 'disabled'}}
-          onclick={{queue (action this.permissionForm.submit) (action close)}}
+          {{on 'click' (queue (action this.permissionForm.submit) F.close)}}
         />
         <Hds::Button
           @text='Cancel'
           @color='secondary'
-          onclick={{queue (action this.permissionForm.reset) (action close)}}
+          {{on 'click' (queue (action this.permissionForm.reset) F.close)}}
         />
       </Hds::ButtonSet>
-    </:actions>
-  </ModalDialog>
+    </M.Footer>
+  </Hds::Modal>
+{{/if}}
 
 </div>

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
@@ -223,7 +223,6 @@
         {{on "click" (action this.openModal undefined)}}
       />
     </div>
-    <div class="permissions-content">
 {{#if (gt @item.Permissions.length 0) }}
       <Consul::Intention::Notice::Permissions />
       <Consul::Intention::Permission::List
@@ -232,6 +231,7 @@
         @ondelete={{action 'delete' 'Permissions' @item}}
       />
 {{else}}
+    <div class="permissions-content">
       <EmptyState>
         <:header>
           <h3>
@@ -264,8 +264,8 @@
           </li>
         </:actions>
       </EmptyState>
-{{/if}}
     </div>
+{{/if}}
   </fieldset>
 {{/if}}
 

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
@@ -10,11 +10,11 @@
 >
   <fieldset disabled={{@disabled}}>
     <div role="group">
-      <fieldset>
-        <h2>Source</h2>
-        <label data-test-source-element class="type-select{{if @item.error.SourceName ' has-error'}}">
-          <span>Source Service</span>
+      <div class="consul-intention-fieldset-card">
+        <fieldset>
+          <legend>Source</legend>
           <SuperSelectWithCreate
+            data-test-source-element
             @disabled={{not @create}}
             @options={{@services}}
             @searchField="Name"
@@ -23,9 +23,11 @@
             @buildSuggestion="Use a Consul Service called '__TERM__'"
             @showCreateWhen={{action "isUnique" @services}}
             @onChange={{action @onchange "SourceName"}}
-            @label="Source Service"
+            @label="Source service"
             @listboxAriaLabel="Available source services"
             @isOptional={{false}}
+            @helperText={{if @create "Search for an existing service, or enter any service name."}}
+            @errorText={{@item.error.SourceName.validation}}
           as |service|>
             {{#if (eq service.Name '*') }}
               * (All Services)
@@ -33,15 +35,9 @@
               {{service.Name}}
             {{/if}}
           </SuperSelectWithCreate>
-
-        {{#if @create}}
-          <em>Search for an existing service, or enter any Service name.</em>
-        {{/if}}
-        </label>
-  {{#if (can 'choose nspaces')}}
-        <label data-test-source-nspace class="type-select{{if @item.error.SourceNS ' has-error'}}">
-          <span>Source Namespace</span>
+    {{#if (can 'choose nspaces')}}
           <SuperSelectWithCreate
+            data-test-source-nspace
             @disabled={{not @create}}
             @options={{@nspaces}}
             @searchField="Name"
@@ -50,9 +46,11 @@
             @buildSuggestion="Use a Consul Namespace called '__TERM__'"
             @showCreateWhen={{action "isUnique" @nspaces}}
             @onChange={{action @onchange "SourceNS"}}
-            @label="Source Namespace"
+            @label="Source namespace"
             @listboxAriaLabel="Available source namespaces"
             @isOptional={{false}}
+            @helperText={{if @create "Search for an existing namespace, or enter any namespace name."}}
+            @errorText={{@item.error.SourceNS.validation}}
           as |nspace|>
             {{#if (eq nspace.Name '*') }}
               * (All Namespaces)
@@ -60,15 +58,10 @@
               {{nspace.Name}}
             {{/if}}
           </SuperSelectWithCreate>
-        {{#if @create}}
-          <em>Search for an existing namespace, or enter any Namespace name.</em>
-        {{/if}}
-        </label>
-  {{/if}}
-  {{#if (can 'choose partitions' dc=@dc)}}
-        <label data-test-source-partition class="type-select{{if @item.error.SourcePartition ' has-error'}}">
-          <span>Source Partition</span>
+    {{/if}}
+    {{#if (can 'choose partitions' dc=@dc)}}
           <SuperSelectWithCreate
+            data-test-source-partition
             @disabled={{not @create}}
             @options={{@partitions}}
             @searchField="Name"
@@ -77,24 +70,22 @@
             @buildSuggestion="Use a Consul Partition called '__TERM__'"
             @showCreateWhen={{action "isUnique" @partitions}}
             @onChange={{action @onchange "SourcePartition"}}
-            @label="Source Partition"
+            @label="Source partition"
             @listboxAriaLabel="Available source partitions"
             @isOptional={{false}}
+            @helperText={{if @create "Search for an existing partition, or enter any partition name."}}
+            @errorText={{@item.error.SourcePartition.validation}}
           as |partition|>
             {{partition.Name}}
           </SuperSelectWithCreate>
-        {{#if @create}}
-          <em>Search for an existing partition, or enter any Partition name.</em>
-        {{/if}}
-        </label>
-  {{/if}}
-      </fieldset>
-      <fieldset>
-        <h2>Destination</h2>
-        <label data-test-destination-element class="type-select{{if @item.error.DestinationName ' has-error'}}">
-          <span>Destination Service</span>
-
+    {{/if}}
+        </fieldset>
+      </div>
+      <div class="consul-intention-fieldset-card">
+        <fieldset>
+          <legend>Destination</legend>
           <SuperSelectWithCreate
+            data-test-destination-element
             @disabled={{not @create}}
             @options={{@services}}
             @searchField="Name"
@@ -103,9 +94,11 @@
             @buildSuggestion="Use a Consul Service called '__TERM__'"
             @showCreateWhen={{action "isUnique" @services}}
             @onChange={{action @onchange "DestinationName"}}
-            @label="Destination Service"
+            @label="Destination service"
             @listboxAriaLabel="Available destination services"
             @isOptional={{false}}
+            @helperText={{if @create "Search for an existing service, or enter any service name."}}
+            @errorText={{@item.error.DestinationName.validation}}
           as |service|>
             {{#if (eq service.Name '*') }}
               * (All Services)
@@ -113,14 +106,9 @@
               {{service.Name}}
             {{/if}}
           </SuperSelectWithCreate>
-        {{#if @create}}
-          <em>Search for an existing service, or enter any Service name.</em>
-        {{/if}}
-        </label>
-  {{#if (can 'choose nspaces')}}
-        <label data-test-destination-nspace class="type-select{{if @item.error.DestinationNS ' has-error'}}">
-          <span>Destination Namespace</span>
+    {{#if (can 'choose nspaces')}}
           <SuperSelectWithCreate
+            data-test-destination-nspace
             @disabled={{not @create}}
             @options={{@nspaces}}
             @searchField="Name"
@@ -129,9 +117,11 @@
             @buildSuggestion="Use a future Consul Namespace called '__TERM__'"
             @showCreateWhen={{action "isUnique" @nspaces}}
             @onChange={{action @onchange "DestinationNS"}}
-            @label="Destination Namespace"
+            @label="Destination namespace"
             @listboxAriaLabel="Available destination namespaces"
             @isOptional={{false}}
+            @helperText={{if @create "Search for an existing namespace, or enter any namespace name."}}
+            @errorText={{@item.error.DestinationNS.validation}}
           as |nspace|>
             {{#if (eq nspace.Name '*') }}
               * (All Namespaces)
@@ -139,15 +129,10 @@
               {{nspace.Name}}
             {{/if}}
           </SuperSelectWithCreate>
-        {{#if @create}}
-          <em>For the destination, you may choose any namespace for which you have access.</em>
-        {{/if}}
-        </label>
-  {{/if}}
-  {{#if (can 'choose partitions' dc=@dc)}}
-        <label data-test-destination-partition class="type-select{{if @item.error.DestinationPartition ' has-error'}}">
-          <span>Destination Partition</span>
+    {{/if}}
+    {{#if (can 'choose partitions' dc=@dc)}}
           <SuperSelectWithCreate
+            data-test-destination-partition
             @disabled={{not @create}}
             @options={{@partitions}}
             @searchField="Name"
@@ -156,24 +141,33 @@
             @buildSuggestion="Use a future Consul Partition called '__TERM__'"
             @showCreateWhen={{action "isUnique" @partitions}}
             @onChange={{action @onchange "DestinationPartition"}}
-            @label="Destination Partition"
+            @label="Destination partition"
             @listboxAriaLabel="Available destination partitions"
             @isOptional={{false}}
+            @helperText={{if @create "Search for an existing partition, or enter any partition name."}}
+            @errorText={{@item.error.DestinationPartition.validation}}
           as |partition|>
             {{partition.Name}}
           </SuperSelectWithCreate>
-        {{#if @create}}
-          <em>For the destination, you may choose any partition for which you have access.</em>
-        {{/if}}
-        </label>
-  {{/if}}
-      </fieldset>
+    {{/if}}
+        </fieldset>
+      </div>
     </div>
   <fieldset>
-    <label class="type-text{{if @item.error.Description ' has-error'}}">
-      <span>Description (Optional)</span>
-      <input type="text" name="Description" value={{@item.Description}} placeholder="Description (Optional)" onchange={{action @onchange}} />
-    </label>
+    <Hds::Form::TextInput::Field
+      name="Description"
+      @value={{@item.Description}}
+      @isOptional={{true}}
+      @isInvalid={{if @item.error.Description true false}}
+      placeholder="Enter description here"
+      {{on "change" (action @onchange)}}
+      as |F|
+    >
+      <F.Label>Description</F.Label>
+      {{#if @item.error.Description}}
+        <F.Error>{{@item.error.Description.validation}}</F.Error>
+      {{/if}}
+    </Hds::Form::TextInput::Field>
   </fieldset>
     <div>
       <span class="label">Should this source connect to the destination?</span>
@@ -183,16 +177,19 @@
             (hash
               intent="allow"
               header="Allow"
+              icon="check-circle"
               body="The source service will be allowed to connect to the destination."
             )
             (hash
               intent="deny"
               header="Deny"
+              icon="skip"
               body="The source service will not be allowed to connect to the destination."
             )
             (hash
               intent=""
-              header="Application Aware"
+              header="Application aware"
+              icon="layers"
               body="The source service may or may not connect to the destination service via unique permissions based on Layer 7 criteria: path, header, or method."
             )
           )
@@ -203,70 +200,72 @@
             @checked={{if (eq (or @item.Action '') _action.intent) 'checked'}}
             @onchange={{action @onchange}}
             @name="Action"
-          as |radio|>
-            <header>
-              {{_action.header}}
-            </header>
-            <p>
-              {{_action.body}}
-            </p>
+            @icon={{_action.icon}}
+          >
+            <header>{{_action.header}}</header>
+            <p>{{_action.body}}</p>
           </RadioCard>
         {{/each}}
       </div>
     </div>
   </fieldset>
 {{#if (eq (or @item.Action '') '')}}
+  <Hds::Separator />
   <fieldset class="permissions">
-    <Hds::Button
-      @text='Add permission'
-      @size='small'
-      @color='tertiary'
-      @icon='plus'
-      data-test-create-permission
-      {{on "click" (action this.openModal)}}
-    />
-    <h2>Permissions</h2>
+    <div class="permissions-header">
+      <h2>Permissions</h2>
+      <Hds::Button
+        @text='Add permission'
+        @size='small'
+        @color='tertiary'
+        @icon='plus'
+        data-test-create-permission
+        {{on "click" (action this.openModal)}}
+      />
+    </div>
+    <div class="permissions-content">
 {{#if (gt @item.Permissions.length 0) }}
-    <Consul::Intention::Notice::Permissions />
-    <Consul::Intention::Permission::List
-      @items={{@item.Permissions}}
-      @onclick={{queue (action (mut this.permission)) (action this.openModal)}}
-      @ondelete={{action 'delete' 'Permissions' @item}}
-    />
+      <Consul::Intention::Notice::Permissions />
+      <Consul::Intention::Permission::List
+        @items={{@item.Permissions}}
+        @onclick={{queue (action (mut this.permission)) (action this.openModal)}}
+        @ondelete={{action 'delete' 'Permissions' @item}}
+      />
 {{else}}
-    <EmptyState>
-      <:header>
-        <h3>
-          No permissions yet
-        </h3>
-      </:header>
-      <:body>
-        <p>
-          Permissions intercept an Intention's traffic using Layer 7 criteria, such as path prefixes and http headers.
-        </p>
-      </:body>
-      <:actions>
-        <li>
-          <Hds::Link::Standalone
-            @text='Documentation'
-            @href="{{env 'CONSUL_DOCS_URL'}}/commands/intention"
-            @icon='docs-link'
-            @iconPosition='trailing'
-            @size='small'
-          />
-        </li>
-        <li>
-          <Hds::Link::Standalone
-            @text='Read the guide'
-            @href="{{env 'CONSUL_DOCS_LEARN_URL'}}/consul/getting-started/connect"
-            @icon='learn-link'
-            @iconPosition='trailing'
-            @size='small'
-          />
-        </li>
-      </:actions>
-    </EmptyState>
+      <EmptyState>
+        <:header>
+          <h3>
+            No permissions yet
+          </h3>
+        </:header>
+        <:body>
+          <p>
+            Permissions intercept an Intention's traffic using Layer 7 criteria, such as path prefixes and http headers.
+          </p>
+        </:body>
+        <:actions>
+          <li>
+            <Hds::Link::Standalone
+              @text='Documentation'
+              @href="{{env 'CONSUL_DOCS_URL'}}/commands/intention"
+              @icon='docs-link'
+              @iconPosition='trailing'
+              @size='small'
+            />
+          </li>
+          <li>
+            <Hds::Link::Standalone
+              @text='Read the guide'
+              @href="{{env 'CONSUL_DOCS_LEARN_URL'}}/consul/getting-started/connect"
+              @icon='learn-link'
+              @iconPosition='trailing'
+              @size='small'
+            />
+          </li>
+        </:actions>
+      </EmptyState>
 {{/if}}
+    </div>
   </fieldset>
 {{/if}}
 

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.js
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.js
@@ -4,13 +4,26 @@
  */
 
 import Component from '@ember/component';
+import { set } from '@ember/object';
 
 export default Component.extend({
   tagName: '',
-  shouldShowPermissionForm: false,
+  isPermissionModalOpen: false,
 
-  openModal() {
-    this.modal?.open();
+  openModal(permission) {
+    if (permission !== undefined) {
+      set(this, 'permission', permission);
+    }
+    set(this, 'isPermissionModalOpen', true);
+  },
+
+  closeModal() {
+    set(this, 'isPermissionModalOpen', false);
+    set(this, 'permission', undefined);
+  },
+
+  setPermission(permission) {
+    set(this, 'permission', permission);
   },
 
   actions: {

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/layout.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/layout.scss
@@ -4,21 +4,84 @@
  */
 
 .consul-intention-fieldsets {
+  // Outer disabled fieldset is the main flex column — 24px between each section
+  // (Figma Frame 1000002920: flex-col gap-[24px])
+  > fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+  [role='group'] {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  .consul-intention-fieldset-card {
+    background: var(--token-color-surface-primary);
+    border: 1px solid var(--token-color-border-primary);
+    border-radius: 6px;
+    padding: 24px 16px;
+
+    // Each SuperSelectWithCreate must fill the full card width
+    .super-select-with-create {
+      width: 100%;
+    }
+
+    // Remove default fieldset chrome so only the card styles apply
+    fieldset {
+      border: none;
+      padding: 0;
+      margin: 0;
+      min-width: 0;
+      width: 100%;
+      // 24px gap between the three select fields (Figma: Frame 1000002948/49 gap-[24px])
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    // Style the legend as a section heading matching Figma's 24px "Source"/"Destination" labels
+    // float + width clears it into normal flow so the fieldset gap takes over below it
+    legend {
+      @extend %display-300-semibold;
+      float: left;
+      width: 100%;
+      // 8px below legend before first field (Figma: card header gap-[8px])
+      margin-bottom: 8px;
+    }
+  }
   [role='radiogroup'] {
     overflow: visible !important;
     display: grid;
-    grid-gap: 12px;
-    grid-template-columns: repeat(auto-fit, minmax(270px, auto));
+    grid-gap: 16px;
+    // 3 equal columns to match Figma's single-row radio card layout
+    grid-template-columns: repeat(3, 1fr);
   }
   .radio-card {
-    @extend %radio-card-with-icon;
+    @extend %radio-card;
   }
-  .radio-card header > * {
-    display: inline;
+  // Permissions content container — bordered card matching Figma node 3463:98595
+  // border: 1px solid var(--token-color-border-primary), radius: 6px, padding: 16px
+  .permissions-content {
+    width: 100%;
+    border: 1px solid var(--token-color-border-primary);
+    border-radius: 6px;
+    padding: 16px;
+    background: var(--token-color-surface-primary);
   }
-  .permissions > button {
-    @extend %anchor, %body-100-regular;
-    float: right;
+
+  // Permissions section header: "Permissions" heading on the left,
+  // "Add permission" button on the right (Figma: justify-between flex row)
+  .permissions-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+
+    h2 {
+      @extend %display-300-semibold;
+      margin: 0;
+    }
   }
 }
 .consul-intention-permission-modal [role='dialog'] {

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/layout.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/layout.scss
@@ -60,8 +60,8 @@
   .radio-card {
     @extend %radio-card;
   }
-  // Permissions content container — bordered card matching Figma node 3463:98595
-  // border: 1px solid var(--token-color-border-primary), radius: 6px, padding: 16px
+  // Permissions empty-state container — bordered card (Figma node 3463:98595)
+  // Only shown when there are no permissions yet
   .permissions-content {
     width: 100%;
     border: 1px solid var(--token-color-border-primary);
@@ -69,7 +69,6 @@
     padding: 16px;
     background: var(--token-color-surface-primary);
   }
-
   // Permissions section header: "Permissions" heading on the left,
   // "Add permission" button on the right (Figma: justify-between flex row)
   .permissions-header {

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/skin.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/skin.scss
@@ -4,13 +4,12 @@
  */
 
 .consul-intention-fieldsets {
-  .value-allow > :last-child::before {
-    @extend %with-allow-500;
+  // Icon colours per intent — applied to the HDS icon element inside the card
+  .value-allow .radio-card-content .hds-icon {
+    color: var(--token-color-foreground-success-on-surface);
   }
-  .value-deny > :last-child::before {
-    @extend %with-deny-500;
+  .value-deny .radio-card-content .hds-icon {
+    color: var(--token-color-foreground-critical-on-surface);
   }
-  .value- > :last-child::before {
-    @extend %with-l7-500;
-  }
+  // value- (Application aware / L7) uses the default foreground colour — no override needed
 }

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
@@ -222,7 +222,7 @@ as |item readonly|}}
           @text='Delete'
           @color='critical'
           data-test-confirm-delete
-          {{on 'click' (queue this.closeDeleteModal this.pendingDelete)}}
+          {{on 'click' this.confirmDelete}}
         />
         <Hds::Button
           @text='Cancel'

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
@@ -158,7 +158,7 @@ as |item readonly|}}
           @create={{api.isCreate}}
           @onchange={{api.change}}
         />
-        <div>
+        <div class="consul-intention-form__actions">
           <Hds::ButtonSet>
             <Hds::Button
               @text='Save'
@@ -172,29 +172,18 @@ as |item readonly|}}
               disabled={{api.disabled}}
               {{on 'click' (fn this.oncancel item)}}
             />
+          </Hds::ButtonSet>
 {{#if (not api.isCreate)}}
   {{#if (not-eq item.ID 'anonymous') }}
-          <ConfirmationDialog @message="Are you sure you want to delete this Intention?">
-            <:action as |confirm|>
-              <Hds::Button
-                @text='Delete'
-                @color='critical'
-                disabled={{api.disabled}}
-                {{on 'click' confirm}}
-                data-test-delete
-              />
-            </:action>
-            <:dialog as |execute cancel message|>
-              <DeleteConfirmation
-                @message={{message}}
-                @execute={{queue execute api.delete}}
-                @cancel={{cancel}}
-              />
-            </:dialog>
-          </ConfirmationDialog>
+          <Hds::Button
+            @text='Delete'
+            @color='critical'
+            disabled={{api.disabled}}
+            {{on 'click' (fn this.openDeleteModal api.delete)}}
+            data-test-delete
+          />
   {{/if}}
 {{/if}}
-          </Hds::ButtonSet>
         </div>
       </form>
   {{else}}
@@ -215,6 +204,36 @@ as |item readonly|}}
       data-test-readonly
     />
   {{/if}}
+
+{{#if this.isDeleteModalOpen}}
+  <Hds::Modal
+    id="confirm-modal"
+    @color="critical"
+    @onClose={{this.closeDeleteModal}}
+    as |M|
+  >
+    <M.Header @icon="alert-diamond">Confirm delete</M.Header>
+    <M.Body>
+      <p>Are you sure you want to delete this intention?</p>
+    </M.Body>
+    <M.Footer as |F|>
+      <Hds::ButtonSet>
+        <Hds::Button
+          @text='Delete'
+          @color='critical'
+          data-test-confirm-delete
+          {{on 'click' (queue this.closeDeleteModal this.pendingDelete)}}
+        />
+        <Hds::Button
+          @text='Cancel'
+          @color='secondary'
+          {{on 'click' F.close}}
+        />
+      </Hds::ButtonSet>
+    </M.Footer>
+  </Hds::Modal>
+{{/if}}
+
 {{/let}}
 
   </:form>

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.js
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.js
@@ -24,7 +24,7 @@ export default class ConsulIntentionForm extends Component {
   @tracked isManagedByCRDs;
 
   @tracked isDeleteModalOpen = false;
-  pendingDelete = null;
+  @tracked pendingDelete = null;
 
   modal = null; // reference to the warning modal
 
@@ -45,6 +45,15 @@ export default class ConsulIntentionForm extends Component {
   closeDeleteModal() {
     this.isDeleteModalOpen = false;
     this.pendingDelete = null;
+  }
+
+  @action
+  confirmDelete() {
+    const deleteFn = this.pendingDelete;
+    this.closeDeleteModal();
+    if (deleteFn) {
+      deleteFn();
+    }
   }
 
   @action

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.js
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.js
@@ -23,6 +23,9 @@ export default class ConsulIntentionForm extends Component {
 
   @tracked isManagedByCRDs;
 
+  @tracked isDeleteModalOpen = false;
+  pendingDelete = null;
+
   modal = null; // reference to the warning modal
 
   @service('repository/intention') repo;
@@ -30,6 +33,18 @@ export default class ConsulIntentionForm extends Component {
   constructor(owner, args) {
     super(...arguments);
     this.updateCRDManagement();
+  }
+
+  @action
+  openDeleteModal(deleteFn) {
+    this.pendingDelete = deleteFn;
+    this.isDeleteModalOpen = true;
+  }
+
+  @action
+  closeDeleteModal() {
+    this.isDeleteModalOpen = false;
+    this.pendingDelete = null;
   }
 
   @action

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.scss
@@ -3,6 +3,19 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+// Give the <form> a 24px top margin so there is breathing room between the
+// CRD warning alert (or the cross-partition alert) and the fieldsets below.
+// When no alert is present the margin simply adds consistent spacing below
+// the page title. Also use flex-column with gap so every direct child
+// (fieldsets component + button row) has consistent 24px separation regardless
+// of which sections are visible.
+.consul-intention > form {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 .consul-intention-action-warn-modal {
   .modal-dialog-window {
     max-width: 450px;

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.scss
@@ -16,6 +16,12 @@
   gap: 24px;
 }
 
+.consul-intention-form__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .consul-intention-action-warn-modal {
   .modal-dialog-window {
     max-width: 450px;

--- a/ui/packages/consul-ui/app/components/consul/intention/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/index.scss
@@ -9,6 +9,7 @@
 @import './list';
 @import './form';
 @import './form/fieldsets';
+@import './view';
 @import './permission/list';
 @import './permission/form';
 @import './permission/header/list';

--- a/ui/packages/consul-ui/app/components/consul/intention/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/list/index.hbs
@@ -9,7 +9,7 @@
   {{did-update this.updateCRDManagement @items}}
 >
 {{yield (hash
-  Table=(component 'consul/intention/list/table' delete=@delete items=this.items)
+  Table=(component 'consul/intention/list/table' delete=@delete items=this.items card=@card)
   CheckNotice=(if this.checkedItem
     (component 'consul/intention/list/check' item=this.checkedItem)
     ''
@@ -18,5 +18,6 @@
     (component 'consul/intention/notice/custom-resource')
     ''
   )
+  isManagedByCRDs=this.isManagedByCRDs
 )}}
 </div>

--- a/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
@@ -10,6 +10,9 @@
     @initialSortBy="action"
     @ariaLabel="Intentions"
   >
+    <:toolbar>
+      {{yield to="toolbar"}}
+    </:toolbar>
     <:row as |item B|>
       <B.Td>
         <span class="consul-intention-list-table__name" data-test-intention={{item.ID}}>
@@ -87,8 +90,8 @@
   </Consul::DataTable>
 
   {{#if this.itemToDelete}}
-    <Hds::Modal id="confirm-modal" @color="warning" @onClose={{this.cancelDelete}} as |M|>
-      <M.Header @icon="alert-triangle">
+    <Hds::Modal id="confirm-modal" @color="critical" @onClose={{this.cancelDelete}} as |M|>
+      <M.Header @icon="alert-diamond">
         Confirm Delete
       </M.Header>
       <M.Body>

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/form/index.hbs
@@ -22,26 +22,26 @@ as |group|>
 
   <fieldset>
     <div data-property="action">
-      <span class="label">
-        Should this permission allow the source connect to the destination?
-      </span>
-      <div role="radiogroup" class={{if this.changeset.error.Action ' has-error'}}>
+      <Hds::Form::Radio::Group
+        @name="Action"
+        @layout="horizontal"
+        as |G|
+      >
+        <G.Legend>Should this permission allow the source connect to the destination?</G.Legend>
         {{#each this.intents as |intent|}}
-          <label>
-            <span>{{capitalize intent}}</span>
-            <input
-              type="radio"
-              name="Action"
-              value={{intent}}
-              checked={{if (eq this.changeset.Action intent) 'checked'}}
-              onchange={{action (changeset-set this.changeset 'Action') value="target.value"}}
-            />
-          </label>
+          <G.RadioField
+            @value={{intent}}
+            checked={{eq this.changeset.Action intent}}
+            {{on "change" (action (changeset-set this.changeset 'Action') value="target.value")}}
+          as |F|>
+            <F.Label>{{capitalize intent}}</F.Label>
+          </G.RadioField>
         {{/each}}
-      </div>
+      </Hds::Form::Radio::Group>
     </div>
   </fieldset>
 
+  <Hds::Separator />
   <fieldset>
       <h2>Path</h2>
     <div>
@@ -91,71 +91,60 @@ as |group|>
     </div>
   </fieldset>
 
+  <Hds::Separator />
   <fieldset>
     <h2>Methods</h2>
-    <div class="type-toggle">
-      <span>All methods are applied by default unless specified</span>
-      <group.Element
-        @name="allMethods"
-      as |el|>
-        <el.Checkbox
-          checked={{if this.allMethods 'checked'}}
-          onchange={{action 'change' 'allMethods' this.changeset}}
-        />
-        <el.Label>
-          All Methods
-        </el.Label>
-      </group.Element>
-    </div>
+    <p class="methods-description">All methods are applied by default unless specified</p>
+    <Hds::Form::Toggle::Field
+      data-property="allmethods"
+      @value="allMethods"
+      checked={{this.allMethods}}
+      {{on "change" (action 'change' 'allMethods' this.changeset)}}
+    as |F|>
+      <F.Label>All methods</F.Label>
+    </Hds::Form::Toggle::Field>
 
-{{#if this.shouldShowMethods}}
     <div class="checkbox-group" role="group">
       {{#each this.methods as |method|}}
-        <label class="type-checkbox">
-          <input
-            type="checkbox"
-            name="method"
-            value={{method}}
-            checked={{if (includes method this.changeset.HTTP.Methods) 'checked'}}
-            onchange={{action 'change' 'method' this.changeset}}
-          />
-          <span>{{method}}</span>
-        </label>
+        <Hds::Form::Checkbox::Field
+          @value={{method}}
+          checked={{or this.allMethods (includes method this.changeset.HTTP.Methods)}}
+          disabled={{this.allMethods}}
+          {{on "change" (action 'change' 'method' this.changeset)}}
+        as |F|>
+          <F.Label>{{method}}</F.Label>
+        </Hds::Form::Checkbox::Field>
       {{/each}}
     </div>
-{{/if}}
   </fieldset>
 
+  <Hds::Separator />
   <fieldset>
     <h2>Headers</h2>
 
-    <Consul::Intention::Permission::Header::List
-      @items={{changeset-get this.changeset 'HTTP.Header'}}
-      @ondelete={{action 'delete' 'HTTP.Header' this.changeset}}
-    as |headerList|>
+    <div class="headers-content">
+      <Consul::Intention::Permission::Header::List
+        @items={{changeset-get this.changeset 'HTTP.Header'}}
+        @ondelete={{action 'delete' 'HTTP.Header' this.changeset}}
+      />
 
-    </Consul::Intention::Permission::Header::List>
+      <Consul::Intention::Permission::Header::Form
+        @onsubmit={{action 'add' 'HTTP.Header' this.changeset}}
+      as |headerForm|>
+        <Ref @target={{this}} @name="headerForm" @value={{headerForm}} />
+      </Consul::Intention::Permission::Header::Form>
 
-    <Consul::Intention::Permission::Header::Form
-      @onsubmit={{action 'add' 'HTTP.Header' this.changeset}}
-    as |headerForm|>
-      <Ref @target={{this}} @name="headerForm" @value={{headerForm}} />
-    </Consul::Intention::Permission::Header::Form>
-
-    <Hds::ButtonSet>
       <Hds::Button
         data-test-add-header
-        @text='Add{{if (gt (get (changeset-get this.changeset 'HTTP.Header') 'length') 0) ' another' ''}} header'
-        @color='primary'
-        disabled={{if (not this.headerForm.isDirty) 'disabled'}}
-        onclick={{action this.headerForm.submit}}
-      />
-      <Hds::Button
-        @text='Cancel'
+        @text='Add another header'
+        @icon='plus'
+        @iconPosition='leading'
         @color='secondary'
-        onclick={{action this.headerForm.reset}}
+        @size='small'
+        disabled={{if (not this.headerForm.isDirty) 'disabled'}}
+        {{on 'click' (action this.headerForm.submit)}}
       />
-    </Hds::ButtonSet>
+    </div>
   </fieldset>
   </FormGroup>
 </div>

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/form/layout.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/form/layout.scss
@@ -3,28 +3,105 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+// Shared header-row grid — columns: [type] [name] [info] [40px trash icon]
+// align-items: start keeps labels flush at the top across all cells.
+// Error messages expand a cell downward without shifting siblings.
+%header-row-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 40px;
+  gap: 12px;
+  align-items: start;
+}
+
 .consul-intention-permission-form {
+  // Section headings sit directly below the Hds::Separator — only bottom margin needed
   h2 {
-    padding-top: 1.4em;
-    margin-top: 0.2em;
-    margin-bottom: 0.6em;
+    margin-top: 16px;
+    margin-bottom: 12px;
   }
   .consul-intention-permission-header-form {
-    margin-top: 10px;
-  }
-  fieldset:nth-child(2) > div,
-  .consul-intention-permission-header-form fieldset > div {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    grid-gap: 12px;
-  }
-  fieldset:nth-child(2) > div label:last-child {
-    grid-column: span 2;
+    margin-top: 0;
   }
   .ember-basic-dropdown-trigger {
     padding: 5px;
   }
+  // Method checkboxes — always-visible wrap grid
   .checkbox-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    margin-top: 8px;
+  }
+  // Flex column container for the full headers section content
+  .headers-content {
+    display: flex;
     flex-direction: column;
+    gap: 0;
+
+    // Space before "Add another header" button — sits 12px below the last row border
+    // align-self: flex-start prevents the button from stretching to full flex width
+    > .hds-button {
+      margin-top: 12px;
+      align-self: flex-start;
+    }
+  }
+}
+
+// Shared header row — used by both saved list rows and the entry form
+.consul-intention-permission-header-form,
+.consul-intention-permission-header-list {
+  .header-row {
+    @extend %header-row-grid;
+  }
+
+  // Each column cell: label on top, input on bottom
+  .header-col {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  // Shared column label typography (matches HDS body-100 semibold)
+  .header-col-label {
+    font-size: var(--token-typography-body-100-font-size);
+    font-weight: var(--token-typography-font-weight-semibold);
+    line-height: var(--token-typography-body-100-line-height);
+    color: var(--token-color-foreground-strong);
+    white-space: nowrap;
+  }
+
+  // Spacer col when value field is hidden — keeps trash in col 4
+  .header-col--spacer {
+    visibility: hidden;
+  }
+
+  // Action col (column 4 for the trash button): flex-column matching the other
+  // header-col cells so the button sits beside the inputs, not beside the labels.
+  // An invisible label spacer of the same line-height pushes the button down.
+  .header-col--action {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    &::before {
+      content: '';
+      display: block;
+      height: var(--token-typography-body-100-line-height, 20px);
+      flex-shrink: 0;
+    }
+  }
+
+  // "Case sensitive" checkbox sits below the row, indented to align with inputs
+  .header-case-display {
+    margin-top: 8px;
+  }
+}
+
+// Entry form row: styled as a "saved row" — same border-bottom + 12px padding
+.consul-intention-permission-header-form {
+  fieldset {
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--token-color-border-primary);
   }
 }

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/form/skin.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/form/skin.scss
@@ -5,8 +5,13 @@
 
 .consul-intention-permission-form {
   h2 {
-    border-top: 1px solid var(--token-color-foreground-action);
     @extend %display-400-semibold;
+  }
+  .methods-description {
+    font-size: var(--token-typography-body-100-font-size);
+    line-height: var(--token-typography-body-100-line-height);
+    color: var(--token-color-foreground-faint);
+    margin: 0 0 8px;
   }
   button.type-submit {
     @extend %frame-blue-300;

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/header/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/header/form/index.hbs
@@ -21,73 +21,86 @@
     )}}
 
     <fieldset>
-      <div>
-        <group.Element
-          @name="HeaderType"
-          @type="select"
-        as |el|>
-          <el.Label>Header type</el.Label>
-          <Hds::Form::SuperSelect::Single::Field
-            @options={{this.headerTypes}}
-            @selected={{this.headerType}}
-            @onChange={{action 'change' 'HeaderType' this.changeset}}
-            @label="Header type"
-            @listboxAriaLabel="Header type options"
-            id="header-type-select"
-          as |F|>
-            <F.Options>{{get this.headerLabels F.options}}</F.Options>
-          </Hds::Form::SuperSelect::Single::Field>
-        </group.Element>
+      <div class="header-row">
+        {{! Header type }}
+        <div class="header-col">
+          <span class="header-col-label">Header type</span>
+          <group.Element
+            @name="HeaderType"
+            @type="select"
+          as |el|>
+            <Hds::Form::SuperSelect::Single::Field
+              @options={{this.headerTypes}}
+              @selected={{this.headerType}}
+              @onChange={{action 'change' 'HeaderType' this.changeset}}
+              @label="Header type"
+              @listboxAriaLabel="Header type options"
+              id="header-type-select"
+            as |F|>
+              <F.Options>{{get this.headerLabels F.options}}</F.Options>
+            </Hds::Form::SuperSelect::Single::Field>
+          </group.Element>
+        </div>
 
-
-        <group.Element
-          @name="Name"
-          @error={{changeset-get this.changeset 'error.Name'}}
-        as |el|>
-          <el.Label>Header name</el.Label>
-          <el.Text
-            @value={{changeset-get this.changeset 'Name'}}
-            oninput={{action 'change' 'Name' this.changeset}}
-          />
-          <State @state={{el.state}} @matches="error">
-            <el.Error>
-              {{changeset-get this.changeset 'error.Name.validation'}}
-            </el.Error>
-          </State>
-        </group.Element>
+        {{! Header name }}
+        <div class="header-col">
+          <span class="header-col-label">Header name</span>
+          <group.Element
+            @name="Name"
+            @error={{changeset-get this.changeset 'error.Name'}}
+          as |el|>
+            <el.Text
+              placeholder="Enter header name"
+              @value={{changeset-get this.changeset 'Name'}}
+              oninput={{action 'change' 'Name' this.changeset}}
+            />
+            <State @state={{el.state}} @matches="error">
+              <el.Error>
+                {{changeset-get this.changeset 'error.Name.validation'}}
+              </el.Error>
+            </State>
+          </group.Element>
+        </div>
 
   {{#if this.shouldShowValueField}}
-        <group.Element
-          @name="Value"
-          @error={{changeset-get this.changeset 'error.Value'}}
-        as |el|>
-          <el.Label>Header {{lowercase (get this.headerLabels this.headerType)}}</el.Label>
-          <el.Text
-            @value={{changeset-get this.changeset 'Value'}}
-            oninput={{action 'change' 'Value' this.changeset}}
-          />
-          <State @state={{el.state}} @matches="error">
-            <el.Error>
-              {{changeset-get this.changeset 'error.Value.validation'}}
-            </el.Error>
-          </State>
-        </group.Element>
+        {{! Header information (value) }}
+        <div class="header-col">
+          <span class="header-col-label">Header information</span>
+          <group.Element
+            @name="Value"
+            @error={{changeset-get this.changeset 'error.Value'}}
+          as |el|>
+            <el.Text
+              placeholder="Enter header information"
+              @value={{changeset-get this.changeset 'Value'}}
+              oninput={{action 'change' 'Value' this.changeset}}
+            />
+            <State @state={{el.state}} @matches="error">
+              <el.Error>
+                {{changeset-get this.changeset 'error.Value.validation'}}
+              </el.Error>
+            </State>
+          </group.Element>
+        </div>
+  {{else}}
+        {{! Spacer so the delete icon stays in column 4 when value field is hidden }}
+        <div class="header-col header-col--spacer"></div>
   {{/if}}
+
+        {{! Delete placeholder — keeps grid column 4 aligned to inputs }}
+        <div class="header-col header-col--action"></div>
+
+      </div>{{! /.header-row }}
 
   {{#if this.shouldShowIgnoreCaseField}}
-        <group.Element
-          @name="IgnoreCase"
-          @error={{changeset-get this.changeset 'error.IgnoreCase'}}
-        as |el|>
-          <el.Label>Ignore Case</el.Label>
-          <el.Checkbox
-            checked={{if (changeset-get this.changeset 'IgnoreCase') 'checked'}}
-            onchange={{action 'change' 'IgnoreCase' this.changeset}}
-          />
-        </group.Element>
+      <Hds::Form::Checkbox::Field
+        @name="IgnoreCase"
+        checked={{if (changeset-get this.changeset 'IgnoreCase') true false}}
+        {{on "change" (action 'change' 'IgnoreCase' this.changeset)}}
+      as |F|>
+        <F.Label>Case sensitive</F.Label>
+      </Hds::Form::Checkbox::Field>
   {{/if}}
-
-      </div>
     </fieldset>
   </FormGroup>
 </div>

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/header/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/header/list/index.hbs
@@ -6,7 +6,7 @@
 {{#if (gt @items.length 0)}}
 <ul class="consul-intention-permission-header-list">
   {{#each @items as |item|}}
-  <li>
+  <li data-test-list-row>
     <div class="header-row">
       <div class="header-col">
         <span class="header-col-label">Header type</span>

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/header/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/header/list/index.hbs
@@ -4,44 +4,57 @@
 }}
 
 {{#if (gt @items.length 0)}}
-<ListCollection
-  class="consul-intention-permission-header-list"
-  @items={{@items}}
-  @scroll="native"
-  @cellHeight={{42}}>
-  <:details as |item|>
-    <dl>
-      <dt {{hds-tooltip "Header" options=(detached-tooltip-options)}}>
-        Header
-      </dt>
-      <dd>
-        {{item.Name}} {{route-match item}}
-      </dd>
-    </dl>
-  </:details>
-  <:actions as |item index Actions|>
-    <Actions as |Action|>
-      <Action data-test-delete-action @onclick={{action @ondelete item}} class="dangerous">
-        <:label>
-          Delete
-        </:label>
-        <:confirmation as |Confirmation|>
-          <Confirmation class="warning">
-            <:header>
-              Confirm delete
-            </:header>
-            <:body>
-              <p>
-                Are you sure you want to delete this header?
-              </p>
-            </:body>
-            <:confirm as |Confirm|>
-              <Confirm>Delete</Confirm>
-            </:confirm>
-          </Confirmation>
-        </:confirmation>
-      </Action>
-    </Actions>
-  </:actions>
-</ListCollection>
+<ul class="consul-intention-permission-header-list">
+  {{#each @items as |item|}}
+  <li>
+    <div class="header-row">
+      <div class="header-col">
+        <span class="header-col-label">Header type</span>
+        <div class="header-type-display">
+          <span>{{route-match item}}</span>
+        </div>
+      </div>
+      <div class="header-col">
+        <span class="header-col-label">Header name</span>
+        <div class="header-name-display">
+          <span>{{item.Name}}</span>
+        </div>
+      </div>
+      <div class="header-col">
+        <span class="header-col-label">Header information</span>
+        <div class="header-value-display">
+          {{#if item.Present}}
+            <span>—</span>
+          {{else}}
+            <span>{{or item.Exact item.Prefix item.Suffix item.Contains item.Regex ''}}</span>
+          {{/if}}
+        </div>
+      </div>
+      <div class="header-col header-col--action">
+        <Hds::Button
+          @icon='trash'
+          @isIconOnly={{true}}
+          @color='secondary'
+          @size='small'
+          @text='Delete header'
+          data-test-delete-action
+          {{on 'click' (fn @ondelete item)}}
+        />
+      </div>
+    </div>
+    {{#if (not-eq item.IgnoreCase undefined)}}
+      {{#if item.IgnoreCase}}
+      <div class="header-case-display">
+        <Hds::Form::Checkbox::Field
+          checked={{true}}
+          disabled={{true}}
+        as |F|>
+          <F.Label>Case sensitive</F.Label>
+        </Hds::Form::Checkbox::Field>
+      </div>
+      {{/if}}
+    {{/if}}
+  </li>
+  {{/each}}
+</ul>
 {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/header/list/layout.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/header/list/layout.scss
@@ -4,6 +4,13 @@
  */
 
 .consul-intention-permission-header-list {
-  max-height: 200px;
-  overflow: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  > li {
+    padding-bottom: 12px;
+    margin-bottom: 0;
+    border-bottom: 1px solid var(--token-color-border-primary);
+  }
 }

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/header/list/skin.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/header/list/skin.scss
@@ -4,8 +4,12 @@
  */
 
 .consul-intention-permission-header-list {
-  dt::before {
-    @extend %with-glyph-icon;
-    content: 'H';
+  // Saved row values — same body text style as input values
+  .header-type-display span,
+  .header-name-display span,
+  .header-value-display span {
+    font-size: var(--token-typography-body-100-font-size);
+    line-height: var(--token-typography-body-100-line-height);
+    color: var(--token-color-foreground-primary);
   }
 }

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/list/index.hbs
@@ -4,77 +4,133 @@
 }}
 
 {{#if (gt @items.length 0)}}
-<ListCollection
-  class="consul-intention-permission-list{{if (not @onclick) ' readonly'}}"
-  @scroll="native"
-  @items={{@items}}
-  @showActions={{if @onclick true false}}
-  @partial={{5}}>
-  <:details as |item|>
-    <div onclick={{action (optional @onclick) item}}>
-      <Consul::Intention::Action @action={{item.Action}} @label={{capitalize (or item.Action 'App aware')}} />
-{{#if (gt item.HTTP.Methods.length 0)}}
-        <dl class="permission-methods">
-          <dt {{hds-tooltip "Methods" options=(detached-tooltip-options)}}>
-            Methods
-          </dt>
-          <dd>
-{{#each item.HTTP.Methods as |item|}}
-            {{item}}
-{{/each}}
-          </dd>
-        </dl>
-{{/if}}
-{{#if item.HTTP.Path}}
-        <dl class="permission-path">
-          <dt {{hds-tooltip item.HTTP.PathType options=(detached-tooltip-options)}}>
-            {{item.HTTP.PathType}}
-          </dt>
-          <dd>
-            {{item.HTTP.Path}}
-          </dd>
-        </dl>
-{{/if}}
-{{#each item.HTTP.Header as |item|}}
-        <dl class="permission-header">
-          <dt {{hds-tooltip "Header" options=(detached-tooltip-options)}}>
-            Header
-          </dt>
-          <dd>
-            {{item.Name}} {{route-match item}}
-          </dd>
-        </dl>
-{{/each}}
+<div class="consul-intention-permission-list{{if (not @onclick) ' readonly'}}">
+  {{#each @items as |item index|}}
+  <Hds::Card::Container
+    @level="base"
+    @hasBorder={{true}}
+    class="consul-intention-permission-card"
+    data-test-list-row
+  >
+    <div class="consul-intention-permission-card__top-row">
+      <div class="consul-intention-permission-card__action-badge">
+        <Consul::Intention::Action
+          @action={{item.Action}}
+          @label={{capitalize (or item.Action 'App aware')}}
+        />
+      </div>
+
+      {{#if item.HTTP.Path}}
+      <div class="consul-intention-permission-card__column">
+        <span class="consul-intention-permission-card__column-label">Path</span>
+        <span class="consul-intention-permission-card__column-value">
+          {{item.HTTP.PathType}}{{item.HTTP.Path}}
+        </span>
+      </div>
+      {{/if}}
+
+      {{#if (gt item.HTTP.Methods.length 0)}}
+      <div class="consul-intention-permission-card__column">
+        <span class="consul-intention-permission-card__column-label">Methods</span>
+        <span class="consul-intention-permission-card__column-value">
+          {{#each item.HTTP.Methods as |method index|}}{{method}}{{#unless (eq index (sub item.HTTP.Methods.length 1))}}, {{/unless}}{{/each}}
+        </span>
+      </div>
+      {{/if}}
+
+      {{#if @onclick}}
+      <div class="consul-intention-permission-card__actions">
+        <Hds::Button
+          @text='Edit'
+          @color='secondary'
+          @size='small'
+          @icon='edit'
+          @iconPosition='leading'
+          data-test-edit-action
+          {{on 'click' (action (optional @onclick) item)}}
+        />
+        <Hds::Button
+          @text='Delete'
+          @color='critical'
+          @size='small'
+          @icon='trash'
+          @iconPosition='leading'
+          data-test-delete-action
+          {{on 'click' (fn this.confirmDelete item)}}
+        />
+      </div>
+      {{/if}}
     </div>
-  </:details>
-  <:actions as |item index Actions|>
-    <Actions as |Action|>
-      <Action data-test-edit-action @onclick={{action (optional @onclick) item}} @close={{true}}>
-        <:label>
-          Edit
-        </:label>
-      </Action>
-      <Action data-test-delete-action @onclick={{action (optional @ondelete) item}} class="dangerous">
-        <:label>
-          Delete
-        </:label>
-        <:confirmation as |Confirmation|>
-          <Confirmation class="warning">
-            <:header>
-              Confirm delete
-            </:header>
-            <:body>
-              <p>
-                Are you sure you want to delete this permission?
-              </p>
-            </:body>
-            <:confirm as |Confirm|>
-              <Confirm>Delete</Confirm>
-            </:confirm>
-          </Confirmation>
-        </:confirmation>
-      </Action>
-    </Actions>
-  </:actions>
-</ListCollection>
+
+    {{#if (gt item.HTTP.Header.length 0)}}
+    <div class="consul-intention-permission-card__headers">
+      <span class="consul-intention-permission-card__headers-label">Headers</span>
+      <Hds::Table class="consul-intention-permission-card__headers-table">
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Header type</H.Th>
+            <H.Th>Header name</H.Th>
+            <H.Th>Header information</H.Th>
+            <H.Th>Case sensitive</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
+          {{#each item.HTTP.Header as |header|}}
+          <B.Tr>
+            <B.Td>{{route-match header}}</B.Td>
+            <B.Td>{{header.Name}}</B.Td>
+            <B.Td>
+              {{#if header.Present}}
+                —
+              {{else}}
+                {{or header.Exact header.Prefix header.Suffix header.Contains header.Regex ''}}
+              {{/if}}
+            </B.Td>
+            <B.Td>
+              {{#if (not-eq header.IgnoreCase undefined)}}
+                {{if header.IgnoreCase 'No' 'Yes'}}
+              {{else}}
+                —
+              {{/if}}
+            </B.Td>
+          </B.Tr>
+          {{/each}}
+        </:body>
+      </Hds::Table>
+    </div>
+    {{/if}}
+  </Hds::Card::Container>
+  {{/each}}
+</div>
+{{/if}}
+
+{{#if this.itemToDelete}}
+  <Hds::Modal
+    id="confirm-delete-permission-modal"
+    @color="critical"
+    @onClose={{this.cancelDelete}}
+    as |M|
+  >
+    <M.Header @icon="alert-diamond">
+      Confirm delete
+    </M.Header>
+    <M.Body>
+      <p>Are you sure you want to delete this permission?</p>
+    </M.Body>
+    <M.Footer as |F|>
+      <Hds::ButtonSet>
+        <Hds::Button
+          @text="Delete"
+          @color="critical"
+          data-test-confirm-action
+          {{on 'click' this.invokeDelete}}
+        />
+        <Hds::Button
+          @text="Cancel"
+          @color="secondary"
+          {{on 'click' F.close}}
+        />
+      </Hds::ButtonSet>
+    </M.Footer>
+  </Hds::Modal>
 {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/list/index.js
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/list/index.js
@@ -3,8 +3,39 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import Component from '@ember/component';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
-export default Component.extend({
-  tagName: '',
-});
+/**
+ * Consul::Intention::Permission::List
+ *
+ * Renders the list of L7 permission cards for an intention's create/edit page.
+ * The Delete button opens a confirmation modal rather than deleting immediately;
+ * `itemToDelete` holds the pending permission while the modal is open.
+ */
+export default class ConsulIntentionPermissionList extends Component {
+  @tracked itemToDelete = null;
+
+  @action
+  confirmDelete(item) {
+    this.itemToDelete = item;
+  }
+
+  @action
+  cancelDelete() {
+    this.itemToDelete = null;
+  }
+
+  @action
+  invokeDelete() {
+    const item = this.itemToDelete;
+    this.itemToDelete = null;
+    if (item) {
+      // optional() is not needed here — args.ondelete is passed by the parent
+      if (typeof this.args.ondelete === 'function') {
+        this.args.ondelete(item);
+      }
+    }
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/list/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/list/index.scss
@@ -5,12 +5,3 @@
 
 @import './skin';
 @import './layout';
-.consul-intention-permission-list > ul > li {
-  @extend %list-row-200;
-}
-.consul-intention-permission-list:not(.readonly) > ul > li {
-  @extend %with-composite-row-intent;
-}
-.consul-intention-permission-list .consul-intention-action-badge {
-  display: inline-flex;
-}

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/list/layout.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/list/layout.scss
@@ -4,11 +4,75 @@
  */
 
 .consul-intention-permission-list {
-  .detail > div {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.consul-intention-permission-card {
+  padding: 16px;
+
+  &__top-row {
     display: flex;
-    width: 100%;
+    align-items: center;
+    gap: 24px;
   }
-  .consul-intention-action-badge {
-    margin-right: 8px;
+
+  &__action-badge {
+    flex-shrink: 0;
+  }
+
+  &__column {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    flex: 1;
+
+    &-label {
+      font-size: var(--token-typography-body-100-font-size);
+      line-height: var(--token-typography-body-100-line-height);
+      font-weight: var(--token-typography-font-weight-semibold);
+      color: var(--token-color-foreground-strong);
+    }
+
+    &-value {
+      font-size: var(--token-typography-body-100-font-size);
+      line-height: var(--token-typography-body-100-line-height);
+      color: var(--token-color-foreground-primary);
+    }
+  }
+
+  &__actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-shrink: 0;
+    margin-left: auto;
+  }
+
+  &__headers {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 8px;
+
+    &-label {
+      font-size: var(--token-typography-body-100-font-size);
+      line-height: var(--token-typography-body-100-line-height);
+      font-weight: var(--token-typography-font-weight-semibold);
+      color: var(--token-color-foreground-strong);
+    }
+
+    &-table {
+      width: 100%;
+
+      /* The legacy `%table th span::after` rule injects a stray info-circle icon
+         after every <span> inside an HDS <th>. Suppress it here. */
+      .hds-table__th span::after {
+        content: none;
+        display: none;
+        margin: 0;
+      }
+    }
   }
 }

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/list/pageobject.js
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/list/pageobject.js
@@ -3,11 +3,15 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { collection } from 'ember-cli-page-object';
+import { collection, clickable } from 'ember-cli-page-object';
 
 export default (scope = '.consul-intention-permission-list') => {
   return {
     scope: scope,
-    intentionPermissions: collection('[data-test-list-row]', {}),
+    intentionPermissions: collection('[data-test-list-row]', {
+      edit: clickable('[data-test-edit-action]'),
+      delete: clickable('[data-test-delete-action]'),
+    }),
+    confirmDelete: clickable('[data-test-confirm-action]'),
   };
 };

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/list/skin.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/list/skin.scss
@@ -3,17 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-.consul-intention-permission-list {
-  dt::before {
-    @extend %with-glyph-icon;
-  }
-  dl.permission-methods dt::before {
-    content: 'M';
-  }
-  dl.permission-path dt::before {
-    content: 'P';
-  }
-  dl.permission-header dt::before {
-    content: 'H';
-  }
+.consul-intention-permission-list .consul-intention-action-badge {
+  display: inline-flex;
 }

--- a/ui/packages/consul-ui/app/components/consul/intention/toolbar/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/toolbar/index.scss
@@ -3,9 +3,12 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/* The toolbar is rendered inside the .consul-data-table__card (above the
+   table). Give it the same faint-surface background and bottom-row separator
+   that the nodes/services toolbars use so it matches their appearance. */
 .consul-intention-toolbar {
-  padding-bottom: 16px;
-  margin-bottom: 16px;
+  padding: 8px;
+  background-color: var(--token-color-surface-faint);
 
   .consul-intention-toolbar__access {
     flex: 0 0 auto;
@@ -33,6 +36,14 @@
   .consul-intention-toolbar__access-button[data-test-access-filter='app-aware'] .hds-icon {
     color: var(--token-color-foreground-faint);
   }
+}
+
+/* Separator between the controls row (Filters / Search / quick-filter buttons)
+   and the applied-filters area ("No filters applied" / active filter tags).
+   Matches the nodes/services toolbar pattern. */
+.consul-intention-toolbar .hds-filter-bar__actions {
+  border-bottom: 1px solid var(--token-color-border-faint);
+  padding-bottom: 8px;
 }
 
 /* The intentions index uses the HDS Filter Bar for its toolbar, so drop the

--- a/ui/packages/consul-ui/app/components/consul/intention/view/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/view/index.hbs
@@ -8,46 +8,59 @@
   ...attributes
 >
 
-  <div class="definition-table">
-      <dl>
-        <dt>Destination</dt>
-        <dd>
-          <Consul::Bucket::List
-            @item={{hash
-              Namespace=@item.DestinationNS
-              Partition=@item.DestinationPartition
-              Service=@item.DestinationName
-            }}
-            @nspace="-"
-            @partition="-"
-            @service={{true}}
-          />
-        </dd>
-        <dt>Source</dt>
-        <dd>
-          <Consul::Bucket::List
-            @item={{hash
-              Namespace=@item.SourceNS
-              Partition=@item.SourcePartition
-              Service=@item.SourceName
-              PeerName=@item.SourcePeer
-            }}
-            @nspace="-"
-            @partition="-"
-            @service={{true}}
-          />
-        </dd>
-{{#if @item.Action}}
-        <dt>Action</dt>
-        <dd>
-          {{@item.Action}}
-        </dd>
-{{/if}}
-        <dt>Description</dt>
-        <dd>
-          {{or @item.Description 'N/A'}}
-        </dd>
+  <div class="consul-intention-view__cards">
+    <Hds::Card::Container
+      @level="base"
+      @hasBorder={{true}}
+      class="consul-intention-view__card"
+      data-test-source-card
+    >
+      <h2 class="consul-intention-view__card-title">Source</h2>
+      <dl class="consul-intention-view__dl">
+        <dt>Source service</dt>
+        <dd data-test-source-name>{{or @item.SourceName '*'}}</dd>
+        <dt>Source namespace</dt>
+        <dd data-test-source-nspace>{{or @item.SourceNS 'default'}}</dd>
+        <dt>Source partition</dt>
+        <dd data-test-source-partition>{{or @item.SourcePartition 'default'}}</dd>
       </dl>
+    </Hds::Card::Container>
+
+    <Hds::Card::Container
+      @level="base"
+      @hasBorder={{true}}
+      class="consul-intention-view__card"
+      data-test-destination-card
+    >
+      <h2 class="consul-intention-view__card-title">Destination</h2>
+      <dl class="consul-intention-view__dl">
+        <dt>Destination service</dt>
+        <dd data-test-destination-name>{{or @item.DestinationName '*'}}</dd>
+        <dt>Destination namespace</dt>
+        <dd data-test-destination-nspace>{{or @item.DestinationNS 'default'}}</dd>
+        <dt>Destination partition</dt>
+        <dd data-test-destination-partition>{{or @item.DestinationPartition 'default'}}</dd>
+      </dl>
+    </Hds::Card::Container>
+  </div>
+
+{{#if @item.Action}}
+  <div class="consul-intention-view__field" data-test-action>
+    <span class="consul-intention-view__field-label">Action</span>
+    <div class="consul-intention-view__field-value">
+      <Consul::Intention::Action
+        @action={{@item.Action}}
+        @label={{capitalize @item.Action}}
+      />
+    </div>
+  </div>
+{{/if}}
+
+  <div class="consul-intention-view__field" data-test-description>
+    <span class="consul-intention-view__field-label">Description</span>
+    <p class="consul-intention-view__field-value">
+      {{or @item.Description 'No description added.'}}
+    </p>
   </div>
 
 {{#if (gt @item.Permissions.length 0) }}

--- a/ui/packages/consul-ui/app/components/consul/intention/view/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/view/index.scss
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+.consul-intention-view {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+// Side-by-side Source / Destination cards
+.consul-intention-view__cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.consul-intention-view__card {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.consul-intention-view__card-title {
+  font-size: var(--token-typography-display-200-font-size);
+  font-weight: var(--token-typography-font-weight-semibold);
+  line-height: var(--token-typography-display-200-line-height);
+  color: var(--token-color-foreground-strong);
+  margin: 0;
+}
+
+// Key/value definition list inside each card
+.consul-intention-view__dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 32px;
+  row-gap: 16px;
+  margin: 0;
+}
+
+.consul-intention-view__dl dt {
+  font-size: var(--token-typography-body-300-font-size);
+  font-weight: var(--token-typography-font-weight-semibold);
+  line-height: var(--token-typography-body-300-line-height);
+  color: var(--token-color-foreground-primary);
+  white-space: nowrap;
+}
+
+.consul-intention-view__dl dd {
+  font-size: var(--token-typography-body-300-font-size);
+  font-weight: var(--token-typography-font-weight-regular);
+  line-height: var(--token-typography-body-300-line-height);
+  color: var(--token-color-foreground-primary);
+  margin: 0;
+  word-break: break-word;
+}
+
+// Action / Description field rows
+.consul-intention-view__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.consul-intention-view__field-label {
+  font-size: var(--token-typography-body-300-font-size);
+  font-weight: var(--token-typography-font-weight-semibold);
+  line-height: var(--token-typography-body-300-line-height);
+  color: var(--token-color-foreground-primary);
+}
+
+.consul-intention-view__field-value {
+  font-size: var(--token-typography-body-300-font-size);
+  font-weight: var(--token-typography-font-weight-regular);
+  line-height: var(--token-typography-body-300-line-height);
+  color: var(--token-color-foreground-primary);
+  margin: 0;
+}

--- a/ui/packages/consul-ui/app/components/radio-card/index.hbs
+++ b/ui/packages/consul-ui/app/components/radio-card/index.hbs
@@ -7,15 +7,19 @@
   ...attributes
   class="radio-card{{if @checked ' checked'}}"
 >
-  <div>
-    {{! workaround FF/Ember problem where you cannnot set a value to be value="" (empty)}}
+  {{! Top content section: icon (if provided) + header + body text }}
+  <div class="radio-card-content">
+    {{#if @icon}}
+      <Hds::Icon @name={{@icon}} @size="24" />
+    {{/if}}
+    {{yield}}
+  </div>
+  {{! Bottom control strip: the radio input centred in a full-width footer }}
+  <div class="radio-card-control">
     {{#if (gt @value.length 0) }}
       <input type="radio" name={{@name}} value={{@value}} checked={{@checked}} onchange={{action @onchange}} />
     {{else}}
       <input type="radio" name={{@name}} value="" checked={{@checked}} onchange={{action @onchange}} />
     {{/if}}
-  </div>
-  <div>
-    {{yield}}
   </div>
 </label>

--- a/ui/packages/consul-ui/app/components/radio-card/layout.scss
+++ b/ui/packages/consul-ui/app/components/radio-card/layout.scss
@@ -3,19 +3,32 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+// Figma: flex-col card, content on top, radio strip pinned to bottom
 %radio-card {
   float: none !important;
   margin-right: 0 !important;
-}
-%radio-card {
   display: flex !important;
+  flex-direction: column;
+  justify-content: space-between;
 }
-%radio-card > :first-child {
-  padding: 10px;
-  display: grid;
+
+// Content area: icon + header + body, 24px padding, 8px gap between items
+%radio-card > .radio-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 24px;
+  flex: 1;
+}
+
+// Control strip: centred radio input, border-top, 8px vertical padding
+%radio-card > .radio-card-control {
+  display: flex;
   align-items: center;
-  justify-items: center;
-}
-%radio-card > :last-child {
-  padding: 18px;
+  justify-content: center;
+  padding: 8px 0;
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-radius: 0 0 6px 6px;
+  overflow: hidden;
 }

--- a/ui/packages/consul-ui/app/components/radio-card/skin.scss
+++ b/ui/packages/consul-ui/app/components/radio-card/skin.scss
@@ -3,35 +3,49 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+// Card shell — unselected state
 %radio-card {
-  border: var(--decor-border-100);
-  border-radius: var(--decor-radius-100);
-  border-color: var(--token-color-surface-interactive-active);
-  box-shadow: var(--token-surface-mid-box-shadow);
-  color: var(--token-color-foreground-faint);
+  border: 1px solid var(--token-color-border-primary);
+  border-radius: 6px;
   cursor: pointer;
+  // Figma Elevation/Mid
+  box-shadow:
+    0px 8px 16px -10px var(--token-color-palette-alpha-200),
+    0px 2px 3px 0px var(--token-color-palette-alpha-100);
+  background: var(--token-color-surface-primary);
 }
+
+// Card shell — selected state: blue border
 %radio-card.checked {
-  border-color: var(--token-color-foreground-action);
+  border-color: var(--token-color-palette-blue-300);
 }
-%radio-card > :first-child {
-  background-color: var(--token-color-surface-strong);
-}
-%radio-card.checked > :first-child {
-  background-color: var(--token-color-surface-action);
-}
+
+// Header text: strong/black, 18px bold, -0.5px tracking (Figma Display/300/Bold)
 %radio-card header {
-  margin-bottom: 0.5em;
+  margin: 0;
+  color: var(--token-color-foreground-strong);
+  font-size: var(--token-typography-display-300-font-size, 18px);
+  font-weight: var(--token-typography-font-weight-bold, 700);
+  line-height: var(--token-typography-display-300-line-height, 24px);
+  letter-spacing: -0.5px;
 }
-%radio-card header {
-  color: var(--token-color-hashicorp-brand);
+
+// Body text: primary colour (Figma Body/100/Regular)
+%radio-card p {
+  margin: 0;
+  color: var(--token-color-foreground-primary);
+  font-size: var(--token-typography-body-100-font-size, 13px);
+  line-height: var(--token-typography-body-100-line-height, 18px);
 }
-%radio-card-with-icon > :last-child {
-  padding-left: 47px;
-  position: relative;
+
+// Control strip unselected: surface-faint bg, border-primary top
+%radio-card > .radio-card-control {
+  background: var(--token-color-surface-faint);
+  border-top-color: var(--token-color-border-primary);
 }
-%radio-card-with-icon > :last-child::before {
-  position: absolute;
-  left: 14px;
-  font-size: 1rem;
+
+// Control strip selected: action bg, action border top
+%radio-card.checked > .radio-card-control {
+  background: var(--token-color-surface-action);
+  border-top-color: var(--token-color-border-action);
 }

--- a/ui/packages/consul-ui/app/components/super-select-with-create/index.hbs
+++ b/ui/packages/consul-ui/app/components/super-select-with-create/index.hbs
@@ -22,6 +22,10 @@
     @searchPlaceholder={{@searchPlaceholder}}
     id={{@id}}
   as |F|>
+    {{#if @label}}
+      <F.Label>{{@label}}</F.Label>
+    {{/if}}
+
     <F.Options>
       {{#if F.options.__isSuggestion__}}
         <div class="create-option">

--- a/ui/packages/consul-ui/app/styles/routes/dc/intentions/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/intentions/index.scss
@@ -6,3 +6,19 @@
 html[data-route^='dc.intentions.edit'] .definition-table {
   margin-bottom: 1em;
 }
+
+// The intention create/edit form uses card panels and HDS fields that carry
+// their own visual separation — remove the global app-view title and fieldset
+// border-bottom rules that would otherwise draw unwanted divider lines.
+// Covers both dc.intentions.create and dc.intentions.edit routes.
+html[data-route='dc.intentions.create'],
+html[data-route^='dc.intentions.edit'] {
+  .app-view .title {
+    border-bottom: none;
+  }
+  .app-view form:not(.filter-bar) fieldset {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+}

--- a/ui/packages/consul-ui/app/templates/dc/intentions/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/intentions/edit.hbs
@@ -35,7 +35,7 @@ as |item readOnly|}}
     {{#if item.ID}}
             <route.Title @title="Edit Intention" />
     {{else}}
-            <route.Title @title="New Intention" />
+            <route.Title @title="Create Intention" />
     {{/if}}
   {{else}}
             <route.Title @title="View Intention" />

--- a/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
@@ -54,7 +54,6 @@ as |route|>
           <h1>
             <route.Title @title="Intentions" />
           </h1>
-          <label for="toolbar-toggle"></label>
       </:header>
       <:actions>
   {{#if (can 'create intentions')}}
@@ -65,18 +64,6 @@ as |route|>
     />
   {{/if}}
       </:actions>
-      <:toolbar>
-
-  {{#if (gt items.length 0) }}
-        <Consul::Intention::Toolbar
-          @search={{this.search}}
-          @onsearch={{action (mut this.search) value="target.value"}}
-          @filter={{filters}}
-          @sort={{sort}}
-        />
-  {{/if}}
-
-      </:toolbar>
       <:content>
         {{#let (refresh-route) as |refreshRoute|}}
         <DataWriter
@@ -91,63 +78,81 @@ as |route|>
           @ondelete={{refreshRoute}}
           @onchange={{refreshRoute}}>
           <:content as |writer|>
-            <DataCollection
-              @type="intention"
-              @sort={{sort.value}}
-              @filters={{filters}}
-              @search={{this.search}}
+            {{! CRD alert renders above the card when intentions are CRD-managed }}
+            <Consul::Intention::List
               @items={{items}}
-            as |collection|>
-              <collection.Collection>
-                <Consul::Intention::List
-                  @items={{collection.items}}
-                  @delete={{writer.delete}}
-                as |list|>
-                    <list.CustomResourceNotice />
-                    <list.Table />
-                </Consul::Intention::List>
-              </collection.Collection>
-              <collection.Empty>
-                <EmptyState
-                  @login={{route.model.app.login.open}}
-                >
-                  <:header>
-                    <h2>
-                      {{t 'routes.dc.intentions.index.empty.header'
+              @delete={{writer.delete}}
+            as |list|>
+              {{#if list.isManagedByCRDs}}
+                <Consul::Intention::Notice::CustomResource />
+              {{/if}}
+              <DataCollection
+                @type="intention"
+                @sort={{sort.value}}
+                @filters={{filters}}
+                @search={{this.search}}
+                @items={{items}}
+              as |collection|>
+                <collection.Collection>
+                  <Consul::Intention::List::Table
+                    @items={{collection.items}}
+                    @delete={{writer.delete}}
+                  >
+                    {{! Toolbar lives inside the card, above the table }}
+                    <:toolbar>
+                      {{#if (gt items.length 0)}}
+                        <Consul::Intention::Toolbar
+                          @search={{this.search}}
+                          @onsearch={{action (mut this.search) value="target.value"}}
+                          @filter={{filters}}
+                          @sort={{sort}}
+                        />
+                      {{/if}}
+                    </:toolbar>
+                  </Consul::Intention::List::Table>
+                </collection.Collection>
+                <collection.Empty>
+                  <EmptyState
+                    @login={{route.model.app.login.open}}
+                  >
+                    <:header>
+                      <h2>
+                        {{t 'routes.dc.intentions.index.empty.header'
+                          items=items.length
+                        }}
+                      </h2>
+                    </:header>
+                    <:body>
+                      {{t 'routes.dc.intentions.index.empty.body'
                         items=items.length
+                        canUseACLs=(can "use acls")
+                        htmlSafe=true
                       }}
-                    </h2>
-                  </:header>
-                  <:body>
-                    {{t 'routes.dc.intentions.index.empty.body'
-                      items=items.length
-                      canUseACLs=(can "use acls")
-                      htmlSafe=true
-                    }}
-                  </:body>
-                  <:actions>
-                    <li>
-                      <Hds::Link::Standalone
-                        @text='Documentation on intentions'
-                        @href="{{env 'CONSUL_DOCS_URL'}}/commands/intention"
-                        @icon='docs-link'
-                        @iconPosition='trailing'
-                        @size='small'
-                      />
-                    </li>
-                    <li>
-                      <Hds::Link::Standalone
-                        @text='Take the tutorial'
-                        @href="{{env 'CONSUL_DOCS_LEARN_URL'}}/consul/getting-started/connect"
-                        @icon='learn-link'
-                        @iconPosition='trailing'
-                        @size='small'
-                      />
-                    </li>
-                  </:actions>
-                </EmptyState>
-              </collection.Empty>
-            </DataCollection>
+                    </:body>
+                    <:actions>
+                      <li>
+                        <Hds::Link::Standalone
+                          @text='Documentation on intentions'
+                          @href="{{env 'CONSUL_DOCS_URL'}}/commands/intention"
+                          @icon='docs-link'
+                          @iconPosition='trailing'
+                          @size='small'
+                        />
+                      </li>
+                      <li>
+                        <Hds::Link::Standalone
+                          @text='Take the tutorial'
+                          @href="{{env 'CONSUL_DOCS_LEARN_URL'}}/consul/getting-started/connect"
+                          @icon='learn-link'
+                          @iconPosition='trailing'
+                          @size='small'
+                        />
+                      </li>
+                    </:actions>
+                  </EmptyState>
+                </collection.Empty>
+              </DataCollection>
+            </Consul::Intention::List>
           </:content>
         </DataWriter>
         {{/let}}

--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/create-test.js
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/create-test.js
@@ -47,7 +47,7 @@ module('Acceptance | dc / intentions / create: Intention Create', function (hook
       await visit('intention', { dc: 'datacenter' }, { nspace });
 
       assert.equal(currentURL(), withNspace(nspace, '/datacenter/intentions/create'));
-      assert.equal(document.title, 'New Intention - Consul');
+      assert.equal(document.title, 'Create Intention - Consul');
 
       // Set source
       await click('[data-test-source-element] .ember-power-select-trigger');
@@ -117,7 +117,7 @@ module('Acceptance | dc / intentions / create: Intention Create', function (hook
       await visit('intention', { dc: 'datacenter' }, { nspace });
 
       assert.equal(currentURL(), withNspace(nspace, '/datacenter/intentions/create'));
-      assert.equal(document.title, 'New Intention - Consul');
+      assert.equal(document.title, 'Create Intention - Consul');
 
       // Set source
       await click('[data-test-source-element] .ember-power-select-trigger');

--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/permissions/create.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/permissions/create.feature
@@ -7,7 +7,7 @@ Feature: dc / intentions / permissions / create: Intention Permission Create
       dc: datacenter
     ---
     Then the url should be /datacenter/intentions/create
-    And the title should be "New Intention - Consul"
+    And the title should be "Create Intention - Consul"
     # Specifically set L7
     And I click ".value-"
 

--- a/ui/packages/consul-ui/tests/pages/dc/intentions/edit.js
+++ b/ui/packages/consul-ui/tests/pages/dc/intentions/edit.js
@@ -45,5 +45,12 @@ export default function (
     ...submitable(),
     ...cancelable(),
     ...deletable(),
+    // The delete confirmation button renders inside an Hds::Modal which is
+    // portalled outside <main>, so we must override confirmDelete to target
+    // the modal's confirm button directly.
+    confirmDelete: clickable('#confirm-modal [data-test-confirm-delete]', {
+      resetScope: true,
+      testContainer: 'body',
+    }),
   };
 }


### PR DESCRIPTION
## Summary

This PR migrates the Consul UI **Intentions** components to the HashiCorp Design System (HDS).

## Commits

- `2a73a6333f` ui: migrate intentions index to HDS card layout
- `3d0bd92496` ui: HDS migration for Create Intention form
- `9cf3824eca` ui: migrate Add Permission modal to HDS components
- `476cef3ae9` Migrate intention permission list components to HDS
- `f4a74e34fe` feat(ui): migrate intentions components to HDS

## Changes

### Intentions Index
- Migrated intentions list (`dc/intentions/index.hbs`) to HDS layout and table components
- Updated `intention/list` and `intention/list/table` templates to use HDS components
- Added route-level styles (`styles/routes/dc/intentions/index.scss`)

### Create / Edit Intention Form
- Refactored `intention/form/index.hbs` and `.js` to use HDS form controls and layout primitives
- Updated `form/fieldsets/index.hbs` and `layout.scss` to use HDS grid/fieldset patterns
- Added `form/index.scss` for HDS-specific overrides

### Permission Form & List (Add Permission modal)
- Migrated `intention/permission/form` to HDS modal and form components
- Migrated `intention/permission/list` to HDS table/badge components, updating JS, layout, and skin styles
- Updated `permission/header/form` and `permission/header/list` templates to HDS

### Intention View
- Migrated `intention/view/index.hbs` to HDS layout
- Added `intention/view/index.scss`

### Shared Components
- Updated `radio-card` component (`.hbs`, `layout.scss`, `skin.scss`) for HDS compatibility
- Updated `super-select-with-create` and `composite-row` for HDS alignment

### Tests
- Updated acceptance test `dc/intentions/create-test.js` and Cucumber feature `permissions/create.feature` for new selectors

## Testing

- [x] Acceptance tests updated
- [x] Manually verified intention create/edit/view flows
