### PR TITLE
ci: update metrics-checker action

### DIFF
--- a/.github/scripts/metrics_checker.sh
+++ b/.github/scripts/metrics_checker.sh
@@ -5,26 +5,45 @@
 set -uo pipefail
 
 ### This script checks if any metric behavior has been modified.
-### The checks rely on the git diff against origin/main
+### The checks rely on the git diff against the PR base branch (or origin/main)
 ### It is still up to the reviewer to make sure that any tests added are needed and meaningful.
 
+base_branch="origin/${PR_BASE:-main}"
+
 # search for any "new" or modified metric emissions
-metrics_modified=$(git --no-pager diff origin/main...HEAD | grep -i "SetGauge\|EmitKey\|IncrCounter\|AddSample\|MeasureSince\|UpdateFilter" | grep "^[+-]")
+metrics_modified=$(git --no-pager diff "$base_branch"...HEAD | grep -i "SetGauge\|EmitKey\|IncrCounter\|AddSample\|MeasureSince\|UpdateFilter" | grep "^[+-]" || true)
 # search for PR body or title metric references
-metrics_in_pr_body=$(echo "${PR_BODY-""}" | grep -i "metric")
-metrics_in_pr_title=$(echo "${PR_TITLE-""}" | grep -i "metric")
+metrics_in_pr_body=$(echo "${PR_BODY-""}" | grep -i "metric" || true)
+metrics_in_pr_title=$(echo "${PR_TITLE-""}" | grep -i "metric" || true)
 
 # if there have been code changes to any metric or mention of metrics in the pull request body
 if [ "$metrics_modified" ] || [ "$metrics_in_pr_body" ] || [ "$metrics_in_pr_title" ]; then
+  
+  REASON=""
+  if [ -n "$metrics_modified" ]; then
+    REASON+="PR diff seems to modify metrics behavior / "
+  fi
+  if [ -n "$metrics_in_pr_title" ]; then
+    REASON+="PR title mentions metrics / "
+  fi
+  if [ -n "$metrics_in_pr_body" ]; then
+    REASON+="PR body mentions metrics / "
+  fi
+  REASON="${REASON% / }"
+
   # need to check if there are modifications to metrics_test
   test_files_regex="*_test.go"
-  modified_metrics_test_files=$(git --no-pager diff HEAD "$(git merge-base HEAD "origin/main")" -- "$test_files_regex" | grep -i "metric" | grep "^[+-]")
+  modified_metrics_test_files=$(git --no-pager diff HEAD "$(git merge-base HEAD "$base_branch")" -- "$test_files_regex" | grep -i "metric" | grep "^[+-]" || true)
   if [ "$modified_metrics_test_files" ]; then
     # 1 happy path: metrics_test has been modified bc we modified metrics behavior
+    echo "{ $REASON }"
+    echo ""
     echo "PR seems to modify metrics behavior. It seems it may have added tests to the metrics as well."
     exit 0
   else
-    echo "PR seems to modify metrics behavior. It seems no tests or test behavior has been modified."
+    echo "{ $REASON }"
+    echo ""
+    echo "It seems no tests or test behavior has been modified."
     echo "Please update the PR with any relevant updated testing or add a pr/no-metrics-test label to skip this check."
     exit 1
   fi

--- a/.github/workflows/pr-metrics-test-checker.yml
+++ b/.github/workflows/pr-metrics-test-checker.yml
@@ -4,7 +4,7 @@
 name: "Check for metrics tests"
 on:
   pull_request:
-    types: [ opened, synchronize, labeled ]
+    types: [ opened, synchronize, reopened ]
     # Runs on PRs to main
     branches:
       - main
@@ -25,4 +25,5 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
         shell: bash


### PR DESCRIPTION
Fixes #12515

This PR addresses the requested updates to the metrics-checker GitHub action:
- **S1**: Indicates exactly which condition triggered the metrics check in the script's output.
- **S3**: The action now only triggers on push/commits to PRs (changed events to \opened\, \synchronize\, \eopened\).
- **S4**: The script now uses the PR's base branch instead of hardcoding \origin/main\.

Note: S2 was already addressed in a previous PR (#13413).

Signed-off-by: vjymisal0 <vijay.looprai@gmail.com>