### PR TITLE
ui: migrate admin partitions pages to HDS

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/data-table/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/data-table/index.scss
@@ -148,6 +148,14 @@
     box-shadow: none;
   }
 
+  /* The legacy `%table tbody tr { cursor: pointer }` rule (app/components/table)
+     applies a pointer cursor to every <tr> in the page. Reset it on HDS table
+     rows so the pointer only appears over the actual clickable link cell (handled
+     by the @for loop below). */
+  .hds-table__tbody .hds-table__tr {
+    cursor: default;
+  }
+
   /* Only the link column (@linkColumn, 1-based; defaults to the first column)
      holds the clickable link, so limit the pointer cursor and link styling to
      that cell rather than the entire row. The clickable column is published as

--- a/ui/packages/consul-ui/app/components/consul/partition/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/partition/form/index.hbs
@@ -57,82 +57,89 @@ as |readOnly item Name Description|}}
   {{disabled readOnly}}
 >
 
-<StateChart
-  @src={{state-chart 'validate'}}
-as |State Guard ChartAction dispatch state|>
-
   <fieldset>
-{{#if (is "new partition" item=item)}}
-    <TextInput
-      @name="Name"
-      @placeholder="Name"
-      @item={{item}}
-      @validations={{Name}}
-      @chart={{hash
-        state=state
-        dispatch=dispatch
-      }}
-    />
-{{/if}}
-    <TextInput
-      @expanded={{true}}
-      @name="Description"
-      @label="Description (Optional)"
-      @item={{item}}
-      @validations={{Description}}
-      @chart={{hash
-        state=state
-        dispatch=dispatch
-      }}
-    />
+    {{#if (is "new partition" item=item)}}
+      <Hds::Form::TextInput::Field
+        name='Name'
+        @value={{item.Name}}
+        @isRequired={{true}}
+        as |F|
+      >
+        <F.Label>Name</F.Label>
+        <F.HelperText>{{Name.help}}</F.HelperText>
+      </Hds::Form::TextInput::Field>
+    {{/if}}
+    <Hds::Form::TextInput::Field
+      name='Description'
+      @value={{item.Description}}
+      as |F|
+    >
+      <F.Label>Description <span class='consul-partition-form__optional'>(Optional)</span></F.Label>
+    </Hds::Form::TextInput::Field>
   </fieldset>
 
-  <div>
+  <div class='consul-partition-form__actions'>
     <Hds::ButtonSet>
-
-
-{{#if (and (is "new partition" item=item) (can "create partitions")) }}
-  <Hds::Button
-    @text='Save'
-    type='submit'
-    disabled={{or (is "pristine partition" item=item) (state-matches state "error")}}
-  />
-{{else if (not readOnly)}}
-  <Hds::Button
-    @text='Save'
-    type='submit'
-  />
-{{/if}}
+      {{#if (and (is "new partition" item=item) (can "create partitions"))}}
+        <Hds::Button
+          @text='Save'
+          type='submit'
+          disabled={{is "pristine partition" item=item}}
+        />
+      {{else if (not readOnly)}}
+        <Hds::Button
+          @text='Save'
+          type='submit'
+        />
+      {{/if}}
       <Hds::Button
         @text='Cancel'
         type='reset'
         @color='secondary'
         {{on 'click' (if @oncancel (fn (optional @oncancel item)) (fn (optional @onsubmit item)))}}
       />
-
-{{#if (and (not (is "new partition" item=item)) (can "delete partition" item=item))}}
-      <ConfirmationDialog @message="Are you sure you want to delete this Partition?">
-        <:action as |confirm|>
-          <Hds::Button
-            @text='Delete'
-            data-test-delete
-            @color='critical'
-            {{on 'click' confirm}}
-          />
-        </:action>
-        <:dialog as |execute cancel message|>
-          <DeleteConfirmation
-            @message={{message}}
-            @execute={{queue execute (fn writer.delete item)}}
-            @cancel={{cancel}}
-          />
-        </:dialog>
-      </ConfirmationDialog>
-{{/if}}
     </Hds::ButtonSet>
+    {{#if (and (not (is "new partition" item=item)) (can "delete partition" item=item))}}
+      <Hds::Button
+        @text='Delete'
+        @color='critical'
+        data-test-delete
+        {{on 'click' this.confirmDelete}}
+      />
+    {{/if}}
   </div>
 
-</StateChart>
+  {{#if this.isConfirmingDelete}}
+    <Hds::Modal
+      id='confirm-partition-delete-modal'
+      @color='critical'
+      @onClose={{this.cancelDelete}}
+      as |M|
+    >
+      <M.Header @icon='alert-diamond'>
+        Confirm delete
+      </M.Header>
+      <M.Body>
+        <p>Are you sure you want to delete this partition?</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::ButtonSet>
+          <Hds::Button
+            @text='Delete'
+            @color='critical'
+            data-test-id='confirm-action'
+            {{on 'click' (queue (fn writer.delete item) this.cancelDelete)}}
+          />
+          <Hds::Button
+            @text='Cancel'
+            @color='secondary'
+            {{on 'click' F.close}}
+          />
+        </Hds::ButtonSet>
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
+
 </form>
 
 {{/let}}

--- a/ui/packages/consul-ui/app/components/consul/partition/form/index.js
+++ b/ui/packages/consul-ui/app/components/consul/partition/form/index.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class ConsulPartitionForm extends Component {
+  // Holds the pending item while the delete-confirmation modal is open.
+  @tracked isConfirmingDelete = false;
+
+  @action
+  confirmDelete() {
+    this.isConfirmingDelete = true;
+  }
+
+  @action
+  cancelDelete() {
+    this.isConfirmingDelete = false;
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/partition/form/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/partition/form/index.scss
@@ -1,0 +1,40 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/* Suppress the %app-view-title border-bottom under the page heading, and the
+   %app-view-content fieldset separator inside the form. Both opposing rules
+   have specificity (0,2,3+) — too high to beat with selectors alone. */
+.app-view:has(.consul-partition-form) > header .title {
+  border-bottom: none;
+}
+
+.consul-partition-form {
+  margin-top: 0 !important;
+}
+
+.consul-partition-form fieldset {
+  border: none !important;
+  padding-bottom: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+/* Space between stacked form fields — matches the HDS form field gap standard. */
+.consul-partition-form fieldset [class^='hds-form-field'] {
+  margin-bottom: 16px;
+}
+
+/* Split the form actions row: Save+Cancel on the left, Delete on the right. */
+.consul-partition-form__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+/* Muted "(Optional)" text in the Description label. */
+.consul-partition-form__optional {
+  font-weight: var(--token-typography-font-weight-regular);
+  color: var(--token-color-foreground-faint);
+}

--- a/ui/packages/consul-ui/app/components/consul/partition/list/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/partition/list/table/index.hbs
@@ -1,0 +1,100 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<div class="consul-partition-list-table" ...attributes>
+  <Consul::DataTable
+    @items={{@items}}
+    @columns={{this.columns}}
+    @initialSortBy="name"
+    @ariaLabel="Admin partitions"
+    @card={{true}}
+  >
+    <:toolbar>
+      {{yield to="toolbar"}}
+    </:toolbar>
+    <:row as |item B|>
+      <B.Td>
+        {{#if item.DeletedAt}}
+          <span class="consul-partition-list-table__name" data-test-partition={{item.Name}}>
+            Deleting {{item.Name}}...
+          </span>
+        {{else}}
+          <a
+            class="consul-partition-list-table__name"
+            data-test-partition={{item.Name}}
+            href={{href-to 'dc.partitions.edit' item.Name}}
+          >
+            {{item.Name}}
+          </a>
+        {{/if}}
+      </B.Td>
+      <B.Td data-test-description>
+        {{item.Description}}
+      </B.Td>
+      <B.Td @align="right">
+        {{#if (not item.DeletedAt)}}
+          <Hds::Dropdown
+            @listPosition="bottom-right"
+            class="consul-partition-list-table__actions"
+            as |dd|
+          >
+            <dd.ToggleIcon
+              @icon="more-horizontal"
+              @text="Open actions menu"
+              @hasChevron={{false}}
+              @size="small"
+              data-test-actions-menu
+            />
+            <dd.Interactive
+              @icon={{if (can "write partition" item=item) "edit" "eye"}}
+              @route='dc.partitions.edit'
+              @model={{item.Name}}
+              data-test-edit-action
+            >
+              {{#if (can "write partition" item=item)}}
+                Edit
+              {{else}}
+                View
+              {{/if}}
+            </dd.Interactive>
+            {{#if (can "delete partition" item=item)}}
+              <dd.Separator />
+              <dd.Interactive
+                @color="critical"
+                @icon="trash"
+                data-test-delete-action
+                {{on 'click' (fn this.confirmDelete item)}}
+              >
+                Delete
+              </dd.Interactive>
+            {{/if}}
+          </Hds::Dropdown>
+        {{/if}}
+      </B.Td>
+    </:row>
+  </Consul::DataTable>
+
+  {{#if this.itemToDelete}}
+    <Hds::Modal id="confirm-partition-delete-modal" @color="critical" @onClose={{this.cancelDelete}} as |M|>
+      <M.Header @icon="alert-diamond">
+        Confirm delete
+      </M.Header>
+      <M.Body>
+        <p>Are you sure you want to delete this partition?</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::ButtonSet>
+          <Hds::Button
+            @text="Delete"
+            @color="critical"
+            data-test-id="confirm-action"
+            {{on 'click' this.invokeDelete}}
+          />
+          <Hds::Button @text="Cancel" @color="secondary" {{on 'click' F.close}} />
+        </Hds::ButtonSet>
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
+</div>

--- a/ui/packages/consul-ui/app/components/consul/partition/list/table/index.js
+++ b/ui/packages/consul-ui/app/components/consul/partition/list/table/index.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+// Column definitions for the admin partitions table.
+// The Name column is sortable; Description and Actions are not.
+const COLUMNS = [
+  {
+    label: 'Name',
+    sortKey: 'name',
+    sortValue: (item) => (item.Name || '').toLowerCase(),
+  },
+  {
+    label: 'Description',
+  },
+  {
+    label: 'Actions',
+    align: 'right',
+  },
+];
+
+/**
+ * Consul::Partition::List::Table
+ *
+ * Admin-partitions-index specific configuration for the generic
+ * Consul::DataTable. Supplies the concrete column definitions and renders each
+ * row's cells via the :row block. Owns no sorting / pagination state — that
+ * all lives in the generic table. Receives already-filtered/searched @items
+ * from the data layer and delegates row deletion to @ondelete.
+ */
+export default class ConsulPartitionListTable extends Component {
+  columns = COLUMNS;
+
+  // The HDS Dropdown's Delete item opens a confirmation modal rather than
+  // deleting immediately; itemToDelete holds the pending partition while the
+  // modal is open.
+  @tracked itemToDelete = null;
+
+  @action
+  confirmDelete(item) {
+    this.itemToDelete = item;
+  }
+
+  @action
+  cancelDelete() {
+    this.itemToDelete = null;
+  }
+
+  @action
+  invokeDelete() {
+    const item = this.itemToDelete;
+    this.itemToDelete = null;
+    if (item) {
+      this.args.ondelete(item);
+    }
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/partition/list/table/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/partition/list/table/index.scss
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+.consul-partition-list-table {
+  /* Give the table room to breathe below the toolbar above it. */
+  margin-top: 16px;
+
+  /* Keep column headers on a single line so the header row doesn't grow. */
+  .hds-table__th {
+    white-space: nowrap;
+  }
+}
+
+.consul-partition-list-table__name {
+  font-weight: var(--token-typography-font-weight-semibold);
+
+  a {
+    font-weight: var(--token-typography-font-weight-semibold);
+  }
+}
+
+.consul-partition-list-table__actions {
+  display: inline-flex;
+}

--- a/ui/packages/consul-ui/app/components/consul/partition/list/test-support.js
+++ b/ui/packages/consul-ui/app/components/consul/partition/list/test-support.js
@@ -4,18 +4,18 @@
  */
 
 export const selectors = () => ({
-  ['.consul-partition-list']: {
+  ['.consul-partition-list-table']: {
     row: {
-      $: '[data-test-list-row]',
-      partition: 'a',
+      $: '[data-test-tabular-row]',
+      partition: 'a[data-test-partition]',
       name: '[data-test-partition]',
       description: '[data-test-description]',
     },
   },
 });
 export const pageObject = (collection, clickable, attribute, text, actions) => () => {
-  return collection('.consul-partition-list [data-test-list-row]', {
-    partition: clickable('a'),
+  return collection('.consul-partition-list-table [data-test-tabular-row]', {
+    partition: clickable('a[data-test-partition]'),
     name: attribute('data-test-partition', '[data-test-partition]'),
     description: text('[data-test-description]'),
     ...actions(['edit', 'delete']),

--- a/ui/packages/consul-ui/app/components/consul/partition/toolbar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/partition/toolbar/index.hbs
@@ -1,0 +1,53 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+{{!
+  Admin-partitions toolbar. All Filter Bar wiring (applied filter tags, search
+  input, "Search across" dropdown, stay-expanded behaviour) lives in the
+  generic Consul::ListToolbar. This component only adds the sort dropdown.
+}}
+<Consul::ListToolbar
+  class="consul-partition-toolbar"
+  ...attributes
+  @filter={{@filter}}
+  @search={{@search}}
+  @onsearch={{@onsearch}}
+  @filterGroups={{this.filterGroups}}
+  @searchPlaceholder="Search"
+>
+  <:quickFilters>
+    {{#if @sort}}
+      <Hds::Dropdown
+        class="consul-partition-toolbar__sort"
+        @listPosition="bottom-left"
+        @preserveContentInDom={{true}}
+        data-test-sort-control
+        as |dd|
+      >
+        <dd.ToggleButton
+          @text={{if
+            (eq @sort.value "Name:asc")
+            (t "common.sort.alpha.asc")
+            (t "common.sort.alpha.desc")
+          }}
+          @color="secondary"
+          data-test-sort-toggle
+        />
+        <dd.Interactive
+          data-test-sort-option
+          {{on "click" (fn @sort.change (hash target=(hash selected="Name:asc")))}}
+        >
+          {{t "common.sort.alpha.asc"}}
+        </dd.Interactive>
+        <dd.Interactive
+          data-test-sort-option
+          {{on "click" (fn @sort.change (hash target=(hash selected="Name:desc")))}}
+        >
+          {{t "common.sort.alpha.desc"}}
+        </dd.Interactive>
+      </Hds::Dropdown>
+    {{/if}}
+  </:quickFilters>
+</Consul::ListToolbar>

--- a/ui/packages/consul-ui/app/components/consul/partition/toolbar/index.js
+++ b/ui/packages/consul-ui/app/components/consul/partition/toolbar/index.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+
+/**
+ * Consul::Partition::Toolbar
+ *
+ * Admin-partitions-index specific configuration for the generic
+ * Consul::ListToolbar. Admin partitions have no categorical filter groups
+ * (only free-text search + a sort dropdown), so filterGroups is empty.
+ * The sort dropdown ("A to Z" / "Z to A") is provided via the :quickFilters
+ * slot, matching the pattern used on the intentions index page.
+ */
+export default class ConsulPartitionToolbar extends Component {
+  // Admin partitions have no categorical filter options; only free-text
+  // search (built into ListToolbar) and the sort quick-filter below.
+  filterGroups = [];
+}

--- a/ui/packages/consul-ui/app/components/consul/partition/toolbar/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/partition/toolbar/index.scss
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/* The toolbar renders inside .consul-data-table__card, above the table.
+   Give it the same faint-surface background and bottom row separator that
+   the intentions / nodes / services toolbars use. */
+.consul-partition-toolbar {
+  padding: 8px;
+  background-color: var(--token-color-surface-faint);
+
+  /* Sort dropdown sits at the right end of the quick-filters row. */
+  .consul-partition-toolbar__sort {
+    flex: 0 0 auto;
+    margin-left: auto;
+
+    .hds-dropdown-toggle-button {
+      min-height: 2.25rem;
+    }
+  }
+}
+
+/* Separator between the controls row and the applied-filters area.
+   Matches the intentions toolbar pattern. */
+.consul-partition-toolbar .hds-filter-bar__actions {
+  border-bottom: 1px solid var(--token-color-border-faint);
+  padding-bottom: 8px;
+}
+
+/* Drop the default header underline above the toolbar to avoid a
+   doubled-up separator (consistent with the services / nodes / intentions
+   index pages). */
+html[data-route='dc.partitions.index'] .app-view > header .title {
+  border-bottom: none;
+}

--- a/ui/packages/consul-ui/app/components/nav-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/nav-selector/index.hbs
@@ -11,6 +11,7 @@
       @isInline={{true}}
       @preserveContentInDom={{true}}
       @matchToggleWidth={{true}}
+      @height='300px'
       class='hds-side-nav__dropdown'
       ...attributes
       as |DD|

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -20,6 +20,7 @@
 @import 'consul-ui/components/consul/service-instance/table';
 @import 'consul-ui/components/consul/service-instance/toolbar';
 @import 'consul-ui/components/consul/intention/toolbar';
+@import 'consul-ui/components/consul/partition/toolbar';
 @import 'consul-ui/components/confirmation-dialog';
 @import 'consul-ui/components/consul-copy-button';
 @import 'consul-ui/components/definition-table';
@@ -127,6 +128,7 @@
 @import 'consul-ui/components/topology-metrics/stats';
 @import 'consul-ui/components/topology-metrics/status';
 @import 'consul-ui/components/consul/intention/list/table';
+@import 'consul-ui/components/consul/partition/list/table';
 @import 'consul-ui/components/consul/peer';
 @import 'consul-ui/components/consul/peer/list';
 @import 'consul-ui/components/consul/peer/toolbar';

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -21,6 +21,7 @@
 @import 'consul-ui/components/consul/service-instance/toolbar';
 @import 'consul-ui/components/consul/intention/toolbar';
 @import 'consul-ui/components/consul/partition/toolbar';
+@import 'consul-ui/components/consul/partition/form';
 @import 'consul-ui/components/confirmation-dialog';
 @import 'consul-ui/components/consul-copy-button';
 @import 'consul-ui/components/definition-table';

--- a/ui/packages/consul-ui/app/templates/dc/partitions/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/partitions/edit.hbs
@@ -39,12 +39,12 @@ as |dc partition nspace item|}}
           @title={{if
             (is "new partition" item=item)
               "New Partition"
-              (concat "Edit " item.Name)
+              item.Name
           }}
         />
       </h1>
     </:header>
-    <:content>
+  <:content>
 
       <Consul::Partition::Form
         @item={{item}}

--- a/ui/packages/consul-ui/app/templates/dc/partitions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/partitions/index.hbs
@@ -60,18 +60,6 @@ as |route|>
   />
 {{/if}}
       </:actions>
-      <:toolbar>
-      {{#if (gt items.length 0)}}
-        <Consul::Partition::SearchBar
-          @search={{this.search}}
-          @onsearch={{action (mut this.search) value="target.value"}}
-
-          @sort={{sort}}
-
-          @filter={{filters}}
-        />
-      {{/if}}
-      </:toolbar>
       <:content>
         {{#let (refresh-route) as |refreshRoute|}}
         <DataWriter
@@ -102,10 +90,19 @@ as |route|>
           @items={{items}}
         as |collection|>
           <collection.Collection>
-            <Consul::Partition::List
+            <Consul::Partition::List::Table
               @items={{collection.items}}
               @ondelete={{writer.delete}}
-            />
+            >
+              <:toolbar>
+                <Consul::Partition::Toolbar
+                  @search={{this.search}}
+                  @onsearch={{action (mut this.search) value="target.value"}}
+                  @sort={{sort}}
+                  @filter={{filters}}
+                />
+              </:toolbar>
+            </Consul::Partition::List::Table>
           </collection.Collection>
           <collection.Empty>
             <EmptyState
@@ -125,13 +122,14 @@ as |route|>
                 </p>
               </:body>
               <:actions>
-                <li class="docs-link">
-                  <Action
+                <li>
+                  <Hds::Link::Standalone
+                    @text='Documentation on Admin Partitions'
                     @href="{{env 'CONSUL_DOCS_URL'}}/enterprise/admin-partitions"
-                    @external={{true}}
-                  >
-                    Documentation on Admin Partitions
-                  </Action>
+                    @icon='docs-link'
+                    @iconPosition='trailing'
+                    @size='small'
+                  />
                 </li>
               </:actions>
             </EmptyState>


### PR DESCRIPTION
## Summary

Migrates the Admin Partitions list and edit/create pages to HashiCorp Design System (HDS) components, continuing the HDS migration started in the intentions branch.

## Changes

### `ui: migrate admin partitions list page to HDS`
- Add `Consul::Partition::List::Table` component wrapping `Consul::DataTable` with Name (sortable), Description, and Actions columns. Delete confirmation uses `Hds::Modal` matching the intentions table pattern.
- Add `Consul::Partition::Toolbar` component wrapping `Consul::ListToolbar` with a sort dropdown (A→Z / Z→A) in the `quickFilters` slot.
- Update `dc/partitions/index.hbs`: replace `SearchBar` + `ListCollection`-based list with the new table and toolbar; update empty-state docs link to `Hds::Link::Standalone`.
- Update `partition/list/test-support.js` selectors to reference HDS table rows (`data-test-tabular-row`) and the new component class name.
- Import new SCSS files in `app/styles/components.scss`.
- Fix `cursor: pointer` leaking onto all HDS table rows from the legacy `%table` rule; reset to `cursor: default` on `.hds-table__tr` so the pointer only appears over the clickable link cell.

### `ui: fix nav-selector dropdown overflow for large partition/nspace/dc lists`
- Add `@height='300px'` to the `Hds::Dropdown` in `NavSelector` so the content panel gets a max-height, making items below the viewport fold reachable via scroll.

### `ui: migrate admin partition edit/create page to HDS`
- Replace legacy `TextInput` with `Hds::Form::TextInput::Field` for Name and Description fields; remove `StateChart`/validate wiring.
- Fix button layout: Save + Cancel (`Hds::ButtonSet`) on left, Delete (critical) on right via space-between flex.
- Replace legacy `ConfirmationDialog` + `DeleteConfirmation` with `Hds::Modal` (matches Figma and list/table pattern); add form component JS to hold `isConfirmingDelete` tracked state.
- Add `partition/form/index.scss` with layout overrides to suppress legacy global rules and align with HDS spacing.
- Change page title from `Edit <name>` to raw partition name.

## Files Changed
- `app/components/consul/data-table/index.scss`
- `app/components/consul/partition/form/index.hbs`
- `app/components/consul/partition/form/index.js`
- `app/components/consul/partition/form/index.scss` *(new)*
- `app/components/consul/partition/list/table/index.hbs` *(new)*
- `app/components/consul/partition/list/table/index.js` *(new)*
- `app/components/consul/partition/list/table/index.scss` *(new)*
- `app/components/consul/partition/list/test-support.js`
- `app/components/consul/partition/toolbar/index.hbs` *(new)*
- `app/components/consul/partition/toolbar/index.js` *(new)*
- `app/components/consul/partition/toolbar/index.scss` *(new)*
- `app/components/nav-selector/index.hbs`
- `app/styles/components.scss`
- `app/templates/dc/partitions/edit.hbs`
- `app/templates/dc/partitions/index.hbs`