### PR TITLE
ui: migrate namespaces list and form pages to HDS

### DIFF
--- a/ui/packages/consul-ui/app/components/composite-row/index.scss
+++ b/ui/packages/consul-ui/app/components/composite-row/index.scss
@@ -38,7 +38,6 @@
 }
 // TODO: This hides the iconless dt's in the below lists as they don't have
 // tooltips the todo would be to wrap these texts in spans
-.consul-nspace-list > ul > li:not(:first-child) dt,
 .consul-token-list > ul > li:not(:first-child) dt,
 .consul-policy-list > ul li:not(:first-child) dl:not(.datacenter) dt,
 .consul-role-list > ul > li:not(:first-child) dt {

--- a/ui/packages/consul-ui/app/components/consul/data-table/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/data-table/index.scss
@@ -11,17 +11,6 @@
      bottom of the viewport. */
   margin-bottom: 2em;
 
-  /* Card wrapper: groups the :toolbar block and the scrollable table together.
-     Only present when a caller provides a :toolbar named block. Gives the card
-     its border, rounded corners, and overflow clipping so row backgrounds and
-     the last row's border are clipped to the rounded corners. Pagination sits
-     outside this wrapper so it always renders below the card border. */
-  .consul-data-table__card {
-    border: 1px solid var(--token-color-border-faint);
-    border-radius: 6px;
-    overflow: hidden;
-  }
-
   /* The viewport positions the edge fade overlays over the scroll area. */
   .consul-data-table__viewport {
     position: relative;

--- a/ui/packages/consul-ui/app/components/consul/nspace/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/nspace/form/index.hbs
@@ -40,61 +40,50 @@
       }}
         <form {{on "submit" (fn writer.persist item)}} {{disabled readOnly}}>
 
-          <StateChart
-            @src={{state-chart "validate"}}
-            as |State Guard ChartAction dispatch state|
-          >
-
             <fieldset>
               {{#if (is "new nspace" item=item)}}
-                <TextInput
-                  @name="Name"
-                  @placeholder="Name"
-                  @item={{item}}
-                  @validations={{Name}}
-                  @chart={{hash state=state dispatch=dispatch}}
-                />
+                <Hds::Form::TextInput::Field
+                  name="Name"
+                  @value={{item.Name}}
+                  @isRequired={{true}}
+                  disabled={{readOnly}}
+                  as |F|
+                >
+                  <F.Label>Name</F.Label>
+                  <F.HelperText>{{Name.help}}</F.HelperText>
+                </Hds::Form::TextInput::Field>
               {{/if}}
-              <TextInput
-                @expanded={{true}}
-                @name="Description"
-                @label="Description (Optional)"
-                @item={{item}}
-                @validations={{Description}}
-                @chart={{hash state=state dispatch=dispatch}}
-              />
+              <Hds::Form::TextInput::Field
+                name="Description"
+                @value={{item.Description}}
+                @isOptional={{true}}
+                placeholder="Enter description here"
+                disabled={{readOnly}}
+                {{on 'input' (fn this.updateDescription item)}}
+                as |F|
+              >
+                <F.Label>Description</F.Label>
+              </Hds::Form::TextInput::Field>
             </fieldset>
             {{#if (can "use acls")}}
+              <Hds::Separator />
               <fieldset id="roles">
-                <h2>Roles</h2>
-                <p>
-                  {{#if (can "write nspace" item=item)}}
-                    By adding roles to this namespaces, you will apply them to
-                    all tokens created within this namespace.
-                  {{else}}
-                    The following roles are applied to all tokens created within
-                    this namespace.
-                  {{/if}}
-                </p>
                 <RoleSelector
                   @dc={{@dc}}
                   @nspace="default"
                   @partition={{@partition}}
                   @disabled={{readOnly}}
                   @items={{item.ACLs.RoleDefaults}}
+                  @showHeader={{true}}
+                  @descriptionText={{if
+                    (can "write nspace" item=item)
+                    "By adding roles to this namespaces, you will apply them to all tokens created within this namespace."
+                    "The following roles are applied to all tokens created within this namespace."
+                  }}
                 />
               </fieldset>
+              <Hds::Separator />
               <fieldset id="policies">
-                <h2>Policies</h2>
-                <p>
-                  {{#if (not readOnly)}}
-                    By adding policies to this namespace, you will apply them to
-                    all tokens created within this namespace.
-                  {{else}}
-                    The following policies are applied to all tokens created
-                    within this namespace.
-                  {{/if}}
-                </p>
                 <PolicySelector
                   @dc={{@dc}}
                   @nspace="default"
@@ -102,18 +91,21 @@
                   @disabled={{readOnly}}
                   @allowIdentity={{false}}
                   @items={{item.ACLs.PolicyDefaults}}
+                  @showHeader={{true}}
+                  @descriptionText={{if
+                    (not readOnly)
+                    "By adding policies to this namespace, you will apply them to all tokens created within this namespace."
+                    "The following policies are applied to all tokens created within this namespace."
+                  }}
                 />
               </fieldset>
             {{/if}}
-            <div>
+            <div class='consul-nspace-form__actions'>
               <Hds::ButtonSet>
               {{#if (and (is "new nspace" item=item) (can "create nspaces"))}}
                 <Hds::Button
                   type="submit"
-                  disabled={{or
-                      (is "pristine nspace" item=item)
-                      (state-matches state "error")
-                  }}
+                  disabled={{is "pristine nspace" item=item}}
                   @text='Save'
                 />
               {{else if (can "write nspace" item=item)}}
@@ -129,6 +121,7 @@
                   @text='Cancel'
                   {{on 'click' (fn this.onCancel item)}}
                 />
+              </Hds::ButtonSet>
 
               {{#if
                 (and
@@ -136,29 +129,43 @@
                   (can "delete nspace" item=item)
                 )
               }}
-                <ConfirmationDialog
-                  @message="Are you sure you want to delete this Namespace?"
-                >
-                  <:action as |confirm|>
-                    <Hds::Button
-                      data-test-delete
-                      @color='critical'
-                      @text='Delete'
-                      {{on "click" confirm }}
-                    />
-                  </:action>
-                  <:dialog as |execute cancel message|>
-                    <DeleteConfirmation
-                      @message={{message}}
-                      @execute={{queue execute (fn writer.delete item)}}
-                      @cancel={{cancel}}
-                    />
-                  </:dialog>
-                </ConfirmationDialog>
+                <Hds::Button
+                  data-test-delete
+                  @color='critical'
+                  @text='Delete'
+                  {{on 'click' this.confirmDelete}}
+                />
               {{/if}}
-              </Hds::ButtonSet>
             </div>
-          </StateChart>
+
+            {{#if this.isConfirmingDelete}}
+              <Hds::Modal
+                id='confirm-nspace-delete-modal'
+                @color='critical'
+                @onClose={{this.cancelDelete}}
+                as |M|
+              >
+                <M.Header @icon='alert-diamond'>Confirm delete</M.Header>
+                <M.Body>
+                  <p>Are you sure you want to delete this Namespace?</p>
+                </M.Body>
+                <M.Footer as |F|>
+                  <Hds::ButtonSet>
+                    <Hds::Button
+                      @text='Delete'
+                      @color='critical'
+                      data-test-id='confirm-action'
+                      {{on 'click' (queue (fn writer.delete item) this.cancelDelete)}}
+                    />
+                    <Hds::Button
+                      @text='Cancel'
+                      @color='secondary'
+                      {{on 'click' F.close}}
+                    />
+                  </Hds::ButtonSet>
+                </M.Footer>
+              </Hds::Modal>
+            {{/if}}
         </form>
       {{/let}}
     </:content>

--- a/ui/packages/consul-ui/app/components/consul/nspace/form/index.js
+++ b/ui/packages/consul-ui/app/components/consul/nspace/form/index.js
@@ -4,9 +4,20 @@
  */
 
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { action, set } from '@ember/object';
 
 export default class NspaceForm extends Component {
+  @tracked isConfirmingDelete = false;
+
+  @action confirmDelete() {
+    this.isConfirmingDelete = true;
+  }
+
+  @action cancelDelete() {
+    this.isConfirmingDelete = false;
+  }
+
   @action onSubmit(item) {
     const onSubmit = this.args.onsubmit;
     if (onSubmit) return onSubmit(item);
@@ -22,6 +33,10 @@ export default class NspaceForm extends Component {
         return onsubmit(item);
       }
     }
+  }
+
+  @action updateDescription(item, event) {
+    set(item, 'Description', event.target.value);
   }
 
   @action onCancel(item) {

--- a/ui/packages/consul-ui/app/components/consul/nspace/form/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/nspace/form/index.scss
@@ -1,0 +1,109 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+// Shared header styles (.consul-nspace-form-section-*) are in
+// consul-ui/components/selector-section-header, imported via components.scss.
+
+.consul-nspace-form {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+
+  fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+}
+
+/* Split the form actions row: Save+Cancel on the left, Delete on the right. */
+.consul-nspace-form__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+
+// Override legacy global table styles that bleed into Hds::Table in the roles fieldset
+#roles {
+  // Global rule sets table th to display-100 (13px); correct back to 14px
+  .hds-table__th {
+    font-size: var(--token-typography-body-200-font-size, 14px) !important;
+  }
+
+  // Global rule adds an ⓘ ::after pseudo-element to every table th span; remove it
+  .hds-table__th span::after {
+    display: none;
+  }
+
+  // Global rule sets td:first-child to semibold; roles name cell should be regular weight
+  .hds-table__tbody .hds-table__td:first-child {
+    font-weight: var(--token-typography-font-weight-regular, 400) !important;
+  }
+
+  // Role name link: action color, no underline (matches Figma plain-text link style)
+  .hds-table__tbody .hds-table__td:first-child a {
+    color: var(--token-color-foreground-action, #1060ff) !important;
+    font-weight: var(--token-typography-font-weight-regular, 400) !important;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  // Column widths: Role description takes all remaining space; Actions shrinks to content
+  .hds-table__th:nth-child(2),
+  .hds-table__td:nth-child(2) {
+    width: 100%;
+  }
+
+  .hds-table__th:last-child,
+  .hds-table__td:last-child {
+    width: 1%;
+    white-space: nowrap;
+  }
+
+  // Actions cell: the td has text-align:right from HDS; make dropdown inline-block
+  // so the text-align on the td positions it to the right
+  .hds-table__tbody .hds-table__td:last-child > .hds-dropdown {
+    display: inline-block;
+  }
+}
+
+// Accordion item content row: datacenter info left, Remove button right
+.policy-accordion-content-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.policy-accordion-datacenter-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 0;
+
+  dt {
+    font-size: var(--token-typography-body-100-font-size, 13px);
+    font-weight: var(--token-typography-font-weight-medium, 500);
+    color: var(--token-color-foreground-faint, #656a76);
+    line-height: var(--token-typography-body-100-line-height, 18px);
+  }
+
+  dd {
+    font-size: var(--token-typography-body-100-font-size, 13px);
+    font-weight: var(--token-typography-font-weight-regular, 400);
+    color: var(--token-color-foreground-primary, #3b3d45);
+    line-height: var(--token-typography-body-100-line-height, 18px);
+    margin: 0;
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/nspace/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/nspace/list/index.hbs
@@ -3,79 +3,136 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<ListCollection
-  class="consul-nspace-list"
-  ...attributes
-  @items={{@items}}
-  @linkable="linkable nspace"
->
-  <:header as |item|>
-    {{#if item.DeletedAt}}
-      <p>
-        Deleting
-        {{item.Name}}...
-      </p>
-    {{else}}
-      <a
-        data-test-nspace={{item.Name}}
-        href={{href-to "dc.nspaces.edit" item.Name}}
-      >{{item.Name}}</a>
-    {{/if}}
-  </:header>
-  <:details as |item|>
-    {{#if item.Description}}
-      <dl>
-        <dt>Description</dt>
-        <dd data-test-description>
-          {{item.Description}}
-        </dd>
-      </dl>
-    {{/if}}
-    {{#if (env "CONSUL_ACLS_ENABLED")}}
-      <Consul::Token::Ruleset::List @item={{item}} />
-    {{/if}}
-  </:details>
-  <:actions as |item index Actions|>
-    {{#if (not item.DeletedAt)}}
-      <Actions as |Action|>
-        <Action
-          data-test-edit-action
-          @href={{href-to "dc.nspaces.edit" item.Name}}
-        >
-          <:label>
-            {{#if (can "write nspace" item=item)}}
-              Edit
-            {{else}}
-              View
-            {{/if}}
-          </:label>
-        </Action>
-        {{#if (can "delete nspace" item=item)}}
-          <Action
-            data-test-delete-action
-            @onclick={{action @ondelete item}}
-            class="dangerous"
-          >
-            <:label>
-              Delete
-            </:label>
-            <:confirmHeader>
-              Confirm delete
-            </:confirmHeader>
-            <:confirmBody>
-              <p>
-                Are you sure you want to delete this namespace?
-              </p>
-            </:confirmBody>
-            <:confirmFooter as |Params|>
-              <Params.button
-                @text="Delete"
-                {{on "click" Params.confirmAction}}
-              />
-            </:confirmFooter>
-          </Action>
+<div class="consul-nspace-list" ...attributes>
+  <Consul::DataTable
+    @items={{@items}}
+    @columns={{this.columns}}
+    @ariaLabel="Namespaces"
+    @card={{true}}
+  >
+    <:row as |item B|>
+
+      {{! ---- Name (management policy badge renders beneath the link) ---- }}
+      <B.Td>
+        <span class="consul-nspace-list__name">
+          {{#if item.DeletedAt}}
+            <p>
+              Deleting
+              {{item.Name}}...
+            </p>
+          {{else}}
+            <a
+              data-test-nspace={{item.Name}}
+              href={{href-to "dc.nspaces.edit" item.Name}}
+            >{{item.Name}}</a>
+          {{/if}}
+          {{! Management policy badge sits under the name link, same as the
+              tokens list. Only rendered when ACLs are enabled. }}
+          {{#if (env "CONSUL_ACLS_ENABLED")}}
+            {{#let (policy/group (or item.ACLs.PolicyDefaults (array))) as |groups|}}
+              {{#each groups.management as |policy|}}
+                <Consul::Acl::RulesetBadge
+                  @item={{policy}}
+                  @type={{policy/typeof policy}}
+                  data-test-policy
+                />
+              {{/each}}
+            {{/let}}
+          {{/if}}
+        </span>
+      </B.Td>
+
+      {{! ---- Policies (plain policies from PolicyDefaults) ---- }}
+      <B.Td>
+        {{#if (env "CONSUL_ACLS_ENABLED")}}
+          {{#let (policy/group (or item.ACLs.PolicyDefaults (array))) as |groups|}}
+            <span class="consul-nspace-list__badges">
+              {{#each groups.policies as |policy|}}
+                <Consul::Acl::RulesetBadge
+                  @item={{policy}}
+                  @type={{policy/typeof policy}}
+                  data-test-policy
+                />
+              {{/each}}
+            </span>
+          {{/let}}
         {{/if}}
-      </Actions>
-    {{/if}}
-  </:actions>
-</ListCollection>
+      </B.Td>
+
+      {{! ---- Roles ---- }}
+      <B.Td>
+        {{#if (env "CONSUL_ACLS_ENABLED")}}
+          <span class="consul-nspace-list__badges">
+            {{#each (or item.ACLs.RoleDefaults (array)) as |role|}}
+              <Consul::Acl::RulesetBadge
+                @item={{role}}
+                @type={{policy/typeof role}}
+                data-test-policy
+              />
+            {{/each}}
+          </span>
+        {{/if}}
+      </B.Td>
+
+      {{! ---- Description ---- }}
+      <B.Td>
+        <em class="consul-nspace-list__description" data-test-description>
+          {{item.Description}}
+        </em>
+      </B.Td>
+
+      {{! ---- Actions ---- }}
+      <B.Td @align="right">
+        {{#if (not item.DeletedAt)}}
+          <Hds::Dropdown @listPosition="bottom-right" class="consul-nspace-list__actions" as |dd|>
+            <dd.ToggleIcon
+              @icon="more-horizontal"
+              @text="Open actions menu"
+              @hasChevron={{false}}
+              @size="small"
+              data-test-actions-menu
+            />
+            <dd.Interactive
+              @icon={{if (can "write nspace" item=item) "edit" "eye"}}
+              @route="dc.nspaces.edit"
+              @model={{item.Name}}
+              data-test-edit
+            >
+              {{#if (can "write nspace" item=item)}}Edit{{else}}View{{/if}}
+            </dd.Interactive>
+            {{#if (can "delete nspace" item=item)}}
+              <dd.Separator />
+              <dd.Interactive
+                @color="critical"
+                @icon="trash"
+                data-test-delete
+                {{on "click" (fn this.confirmDelete item)}}
+              >Delete</dd.Interactive>
+            {{/if}}
+          </Hds::Dropdown>
+        {{/if}}
+      </B.Td>
+
+    </:row>
+  </Consul::DataTable>
+
+  {{#if this.itemToDelete}}
+    <Hds::Modal id="confirm-modal" @color="critical" @onClose={{this.cancelDelete}} as |M|>
+      <M.Header @icon="trash">Confirm delete</M.Header>
+      <M.Body>
+        <p>Are you sure you want to delete this namespace?</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::ButtonSet>
+          <Hds::Button
+            @text="Delete"
+            @color="critical"
+            data-test-id="confirm-action"
+            {{on "click" this.invokeDelete}}
+          />
+          <Hds::Button @text="Cancel" @color="secondary" {{on "click" F.close}} />
+        </Hds::ButtonSet>
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
+</div>

--- a/ui/packages/consul-ui/app/components/consul/nspace/list/index.js
+++ b/ui/packages/consul-ui/app/components/consul/nspace/list/index.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+// Column definitions for the namespaces table. Sorting and searching continue
+// to be driven by the toolbar, so columns are non-sortable here; cell
+// rendering lives in the template's :row block. The trailing "Actions" column
+// is right-aligned.
+const COLUMNS = [
+  { label: 'Name' },
+  { label: 'Policies' },
+  { label: 'Roles' },
+  { label: 'Description' },
+  { label: 'Actions', align: 'right' },
+];
+
+/**
+ * Consul::Nspace::List
+ *
+ * Namespaces-specific configuration for the generic Consul::DataTable. It
+ * supplies the columns and renders each row's cells via the :row block. It
+ * owns no sorting / pagination / data fetching; it receives already
+ * fetched/filtered/searched `@items` and delegates delete to the handler
+ * passed in. The delete action opens a confirmation modal before invoking
+ * its handler.
+ */
+export default class ConsulNspaceList extends Component {
+  columns = COLUMNS;
+
+  // Holds the pending namespace while its delete confirmation modal is open.
+  @tracked itemToDelete = null;
+
+  @action
+  confirmDelete(item) {
+    this.itemToDelete = item;
+  }
+
+  @action
+  cancelDelete() {
+    this.itemToDelete = null;
+  }
+
+  @action
+  invokeDelete() {
+    const item = this.itemToDelete;
+    this.itemToDelete = null;
+    if (item) {
+      this.args.ondelete(item);
+    }
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/nspace/list/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/nspace/list/index.scss
@@ -1,0 +1,119 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+.consul-nspace-list {
+  /* Keep multi-word column headers on a single line. */
+  .hds-table__th {
+    white-space: nowrap;
+  }
+
+  /* Name column: enforce a minimum width so short-but-hyphenated names like
+     "team-08" are never squeezed into a multi-line stack by overflow-wrap. */
+  .hds-table__th:nth-child(1),
+  .hds-table__td:nth-child(1) {
+    min-width: 120px;
+  }
+
+  /* Let the Description column (4th) absorb all the surplus width so the
+     trailing Actions column collapses to just the menu button. Without an
+     explicit stretch column the spare width would be spread across every
+     column — including Actions, leaving a large empty gap before the menu
+     button. Give it a min-width so it stays readable when the table
+     overflows into horizontal scroll. */
+  .hds-table__th:nth-child(4),
+  .hds-table__td:nth-child(4) {
+    width: 100%;
+    min-width: 200px;
+  }
+
+  /* Badge columns (Policies=2, Roles=3): cap width so they
+     don't push the Description column off-screen on narrow viewports.
+     The badges themselves wrap via flex-wrap on the inner container. */
+  .hds-table__th:nth-child(2),
+  .hds-table__td:nth-child(2),
+  .hds-table__th:nth-child(3),
+  .hds-table__td:nth-child(3) {
+    max-width: 280px;
+  }
+
+  /* Wrap long values (including unbreakable ones with no spaces, e.g. a
+     namespace name with no whitespace) onto multiple lines instead of
+     forcing the column endlessly wider. The trailing Actions column is
+     excluded so its menu button stays on one line. */
+  .hds-table__td:not(:last-child) {
+    overflow-wrap: anywhere;
+  }
+
+  /* The legacy `%table` rules (app/components/table/index.scss, reached because
+     `.app-shell__main` @extends `%main-content`, whose `table` descendants
+     extend `%table`) force every body cell's child to
+     `white-space: nowrap; overflow: hidden; text-overflow: ellipsis`.
+     Because the HDS table reuses native <table>/<td> markup, those rules
+     apply here and truncate the cell content with an ellipsis. Override them
+     on the content columns so the text wraps to the next line and is shown in
+     full (no clip, no ellipsis). The extra class selectors raise specificity
+     above the legacy rule. The trailing Actions column is left untouched so
+     its menu button stays on one line. */
+  .hds-table__tbody .hds-table__td:not(:last-child) > * {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+  }
+
+  /* HDS badges must not have white-space:normal forced onto them — they need
+     their own nowrap to keep the icon + label on one line. Re-apply it after
+     the legacy-override rule above. */
+  .hds-table__tbody .hds-table__td .hds-badge {
+    white-space: nowrap;
+  }
+
+  /* Actions is the last column: shrink it to just fit the menu button so the
+     remaining width goes to the content columns. */
+  .hds-table__th:last-child,
+  .hds-table__td:last-child {
+    width: 1%;
+    white-space: nowrap;
+  }
+}
+
+/* Name cell: flex column so the management badge sits below the name link,
+   matching the tokens list layout. */
+.consul-nspace-list__name {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  font-weight: var(--token-typography-font-weight-semibold);
+
+  /* allow the flex container (and its link) to shrink below the name's
+     intrinsic width so a long, unbreakable name wraps instead of stretching
+     the column. */
+  min-width: 0;
+
+  a {
+    font-weight: var(--token-typography-font-weight-semibold);
+    overflow-wrap: anywhere;
+    min-width: 0;
+  }
+}
+
+.consul-nspace-list__description {
+  display: block;
+  color: var(--token-color-foreground-faint);
+  font-style: normal;
+}
+
+.consul-nspace-list__actions {
+  display: inline-flex;
+}
+
+/* Badge group wrapper: wrap badges onto multiple lines so that e.g.
+   "drive-policy  abcd-policy" sits on one row and "bandwidth-policy"
+   wraps to the next — matching the Figma cell layout. */
+.consul-nspace-list__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}

--- a/ui/packages/consul-ui/app/components/consul/nspace/list/pageobject.js
+++ b/ui/packages/consul-ui/app/components/consul/nspace/list/pageobject.js
@@ -4,7 +4,7 @@
  */
 
 export default (collection, clickable, attribute, text, actions) => () => {
-  return collection('.consul-nspace-list [data-test-list-row]', {
+  return collection('.consul-nspace-list [data-test-tabular-row]', {
     nspace: clickable('a'),
     name: attribute('data-test-nspace', '[data-test-nspace]'),
     description: text('[data-test-description]'),

--- a/ui/packages/consul-ui/app/components/consul/nspace/list/pageobject.js
+++ b/ui/packages/consul-ui/app/components/consul/nspace/list/pageobject.js
@@ -4,10 +4,17 @@
  */
 
 export default (collection, clickable, attribute, text, actions) => () => {
+  const confirm = clickable("#confirm-modal [data-test-id='confirm-action']", {
+    resetScope: true,
+    testContainer: 'body', // modal is rendered in the body
+  });
   return collection('.consul-nspace-list [data-test-tabular-row]', {
     nspace: clickable('a'),
     name: attribute('data-test-nspace', '[data-test-nspace]'),
     description: text('[data-test-description]'),
-    ...actions(['edit', 'delete']),
+    actions: clickable('[data-test-actions-menu]'),
+    edit: clickable('[data-test-edit]'),
+    delete: clickable('[data-test-delete]'),
+    confirmDelete: confirm,
   });
 };

--- a/ui/packages/consul-ui/app/components/consul/nspace/toolbar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/nspace/toolbar/index.hbs
@@ -1,0 +1,45 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+{{!
+  Namespaces-index toolbar. All the Filter Bar wiring (search, "Search across"
+  dropdown, stay-expanded behaviour) lives in the generic Consul::ListToolbar.
+  Namespaces have no categorical filter groups, so this component only supplies
+  the Name sort dropdown (A to Z / Z to A).
+}}
+<Consul::ListToolbar
+  class="consul-nspace-toolbar"
+  ...attributes
+  @filter={{@filter}}
+  @search={{@search}}
+  @onsearch={{@onsearch}}
+  @searchPlaceholder="Search"
+>
+  <:quickFilters>
+    {{#if @sort}}
+      <Hds::Dropdown
+        class="consul-nspace-toolbar__sort"
+        @listPosition="bottom-right"
+        @preserveContentInDom={{true}}
+        data-test-sort-control
+        as |dd|
+      >
+        <dd.ToggleButton
+          @text={{if (eq @sort.value "Name:asc") (t "common.sort.alpha.asc") (t "common.sort.alpha.desc")}}
+          @color="secondary"
+          data-test-sort-toggle
+        />
+        <dd.Interactive
+          data-test-sort-option
+          {{on "click" (fn @sort.change (hash target=(hash selected="Name:asc")))}}
+        >{{t "common.sort.alpha.asc"}}</dd.Interactive>
+        <dd.Interactive
+          data-test-sort-option
+          {{on "click" (fn @sort.change (hash target=(hash selected="Name:desc")))}}
+        >{{t "common.sort.alpha.desc"}}</dd.Interactive>
+      </Hds::Dropdown>
+    {{/if}}
+  </:quickFilters>
+</Consul::ListToolbar>

--- a/ui/packages/consul-ui/app/components/consul/nspace/toolbar/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/nspace/toolbar/index.scss
@@ -1,0 +1,29 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/* The toolbar is rendered directly above the table card. It shares the same
+   card chrome (background, border, radius) on three sides; the bottom border
+   is removed so the toolbar and the table card merge into a single visual unit
+   with no gap or doubled border between them. */
+.consul-nspace-toolbar {
+  padding: 8px;
+  background-color: var(--token-color-surface-faint);
+  border: 1px solid var(--token-color-border-faint);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+}
+
+/* Separator between the controls row (Search / Search Across / sort) and the
+   applied-filters area ("No filters applied" / active filter tags) below. */
+.consul-nspace-toolbar .hds-filter-bar__actions {
+  border-bottom: 1px solid var(--token-color-border-faint);
+  padding-bottom: 8px;
+}
+
+/* Drop the default header underline above the toolbar to avoid a doubled
+   separator at the top of the card. */
+html[data-route='dc.nspaces.index'] .app-view > header .title {
+  border-bottom: none;
+}

--- a/ui/packages/consul-ui/app/components/consul/partition/toolbar/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/partition/toolbar/index.scss
@@ -9,6 +9,9 @@
 .consul-partition-toolbar {
   padding: 8px;
   background-color: var(--token-color-surface-faint);
+  border: 1px solid var(--token-color-border-faint);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
 
   /* Sort dropdown sits at the right end of the quick-filters row. */
   .consul-partition-toolbar__sort {

--- a/ui/packages/consul-ui/app/components/consul/token/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/fieldsets/index.hbs
@@ -25,8 +25,8 @@
   </label>
 </fieldset>
 <fieldset id="roles">
-  <h2>Roles</h2>
   <RoleSelector
+    @showHeader={{true}}
     @disabled={{not (can "write token" item=@item)}}
     @dc={{@dc}}
     @partition={{@partition}}
@@ -35,8 +35,8 @@
   />
 </fieldset>
 <fieldset id="policies">
-  <h2>Policies</h2>
   <PolicySelector
+    @showHeader={{true}}
     @disabled={{not (can "write token" item=@item)}}
     @dc={{@dc}}
     @partition={{@partition}}

--- a/ui/packages/consul-ui/app/components/policy-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/policy-selector/index.hbs
@@ -3,6 +3,69 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
+{{#if @showHeader}}
+  <div class="consul-nspace-form-section-header">
+    <div class="consul-nspace-form-section-header__text">
+      <p class="consul-nspace-form-section-title">Policies</p>
+      <p class="consul-nspace-form-section-description">{{@descriptionText}}</p>
+    </div>
+    {{#if (not @disabled)}}
+      <Hds::Button
+        @text='Create new policy'
+        @size='medium'
+        @color='tertiary'
+        @icon='plus'
+        class='type-dialog'
+        data-test-policy-create
+        {{on 'click' (action this.openModal)}}
+      />
+    {{/if}}
+  </div>
+{{/if}}
+
+{{#if (not (has-block 'trigger'))}}
+  <ModalDialog
+    data-test-policy-form
+    id='new-policy'
+    @onopen={{action 'open'}}
+    @aria={{hash label='New Policy'}}
+  >
+    <:default as |modal|>
+      <Ref @target={{this}} @name="modal" @value={{modal}} />
+    </:default>
+    <:header>
+      <h2>New Policy</h2>
+    </:header>
+    <:body>
+      <PolicyForm
+        @form={{this.form}}
+        @nspace={{@nspace}}
+        @partition={{@partition}}
+        @dc={{@dc}}
+        @allowServiceIdentity={{@allowServiceIdentity}}
+      />
+    </:body>
+    <:actions as |close|>
+      <Hds::ButtonSet>
+        <Hds::Button
+          type='submit'
+          @isLoading={{this.item.isSaving}}
+          onclick={{perform this.save this.item @items (queue (action close) (action 'reset'))}}
+          disabled={{if (or this.item.isSaving this.item.isPristine this.item.isInvalid) 'disabled'}}
+          @text='Create and apply'
+        />
+        <Hds::Button
+          type='reset'
+          @color='secondary'
+          disabled={{if this.item.isSaving 'disabled'}}
+          {{on 'click' (action (queue (action close) (action 'reset')))}}
+          @text='Cancel'
+        />
+      </Hds::ButtonSet>
+    </:actions>
+  </ModalDialog>
+{{/if}}
+
 <ChildSelector
   @disabled={{@disabled}}
   @repo={{this.repo}}
@@ -19,206 +82,142 @@
   <:label>
     <span data-test-apply-policy>Apply an existing policy</span>
   </:label>
-  <:create >
+  <:create>
     {{#if (has-block 'trigger')}}
       {{yield to='trigger'}}
-    {{else}}
-      <Hds::Button
-        @text='Create new policy'
-        @size='small'
-        @color='tertiary'
-        @icon='plus'
-        class='type-dialog'
-        data-test-policy-create
-        {{on 'click' (action this.openModal)}}
-      />
-      {{!TODO: potentially call trigger something else}}
-      {{!the modal has to go here so that if you provide a slot to trigger it doesn't get rendered}}
-      <ModalDialog
-        data-test-policy-form
-        id='new-policy'
-        @onopen={{action 'open'}}
-        @aria={{hash label='New Policy'}}
-      >
-        <:default as |modal|>
-          <Ref @target={{this}} @name="modal" @value={{modal}} />
-        </:default>
-        <:header>
-          <h2>New Policy</h2>
-        </:header>
-        <:body>
-          <PolicyForm
-            @form={{this.form}}
-            @nspace={{@nspace}}
-            @partition={{@partition}}
-            @dc={{@dc}}
-            @allowServiceIdentity={{@allowServiceIdentity}}
-          />
-        </:body>
-        <:actions as |close|>
-          <Hds::ButtonSet>
-            <Hds::Button
-              type='submit'
-              @isLoading={{this.item.isSaving}}
-              onclick={{perform this.save this.item @items (queue (action close) (action 'reset'))}}
-              disabled={{if (or this.item.isSaving this.item.isPristine this.item.isInvalid) 'disabled'}}
-              @text='Create and apply'
-            />
-            <Hds::Button
-              type='reset'
-              @color='secondary'
-              disabled={{if this.item.isSaving 'disabled'}}
-              {{on 'click' (action (queue (action close) (action 'reset')))}}
-              @text='Cancel'
-            />
-          </Hds::ButtonSet>
-        </:actions>
-      </ModalDialog>
     {{/if}}
   </:create>
   <:option as |option|>
     {{option.Name}}
   </:option>
   <:set as |remove|>
-    <TabularDetails
-      data-test-policies
-      @onchange={{action 'open'}}
-      @items={{sort-by 'CreateTime:desc' 'Name:asc' @items}}
-    >
-      <:header>
-        <th>Name</th>
-      </:header>
-      <:row as |item index|>
-        <td class={{policy/typeof item}}>
-          {{#if item.ID}}
-            <a href={{href-to 'dc.acls.policies.edit' item.ID}}>{{item.Name}}</a>
-          {{else}}
-            <a name={{item.Name}}>{{item.Name}}</a>
-          {{/if}}
-        </td>
-      </:row>
-      <:details as |item index|>
-        {{#if (eq item.template '')}}
-          <DataSource
-            @src={{uri
-              '/${partition}/${nspace}/${dc}/policy/${id}'
-              (hash partition=@partition nspace=@nspace dc=@dc id=item.ID)
-            }}
-            @onchange={{action (mut this.loadedItem) value='data'}}
-            @loading='lazy'
-          />
-        {{/if}}
-        {{#if (eq item.template 'node-identity')}}
-          <dl>
-            <dt>Datacenter:</dt>
-            <dd>
-              {{item.Datacenter}}
-            </dd>
-          </dl>
-        {{else}}
-          <dl>
-            <dt>Datacenters:</dt>
-            <dd>
-              {{join ', ' (policy/datacenters (or this.loadedItem item))}}
-            </dd>
-          </dl>
-        {{/if}}
-        <label class='type-text'>
-          {{#if (eq item.template 'service-identity')}}
-            <Hds::CodeBlock
-              @language='hcl'
-              @value={{service-identity-template
-                item.Name
-                partition=@partition
-                nspace=@nspace
-                canUsePartitions=(can 'use partitions')
-                canUseNspaces=(can 'use nspaces')
-              }}
-              as |CB|
-            >
-              <CB.Title @tag='span'>
-                Rules
-                <a
-                  href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
-                  rel='help noopener noreferrer'
-                  target='_blank'
-                  style="color: inherit;"
-                >(HCL Format)</a>
-              </CB.Title></Hds::CodeBlock>
-          {{else if (eq item.template 'node-identity')}}
-            <Hds::CodeBlock
-              @language='hcl'
-              @value={{node-identity-template
-                item.Name
-                partition=@partition
-                canUsePartitions=(can 'use partitions')
-                canUseNspaces=(can 'use nspaces')
-              }}
-              as |CB|
-            >
-              <CB.Title @tag='span'>
-                Rules
-                <a
-                  href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
-                  rel='help noopener noreferrer'
-                  target='_blank'
-                  style="color: inherit;"
-                >(HCL Format)</a>
-              </CB.Title></Hds::CodeBlock>
-          {{else}}
-            <Hds::CodeBlock @language='hcl' @value={{or this.loadedItem.Rules this.item.Rules ''}} as |CB|>
-              <CB.Title @tag='span'>
-                Rules
-                <a
-                  href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
-                  rel='help noopener noreferrer'
-                  target='_blank'
-                  style="color: inherit;"
-                >(HCL Format)</a>
-              </CB.Title>
-            </Hds::CodeBlock>
-          {{/if}}
-        </label>
-        {{#if (not @disabled)}}
-          <div>
-            <ConfirmationDialog
-              @message='Are you sure you want to remove this policy from this token?'
-            >
-              <:action as |confirm|>
+    <Hds::Accordion data-test-policies as |A|>
+      {{#each (sort-by 'CreateTime:desc' 'Name:asc' @items) as |item index|}}
+        <A.Item>
+          <:toggle>
+            {{#if item.ID}}
+              <a href={{href-to 'dc.acls.policies.edit' item.ID}}>{{item.Name}}</a>
+            {{else}}
+              {{item.Name}}
+            {{/if}}
+          </:toggle>
+          <:content>
+            {{#if (eq item.template '')}}
+              <DataSource
+                @src={{uri
+                  '/${partition}/${nspace}/${dc}/policy/${id}'
+                  (hash partition=@partition nspace=@nspace dc=@dc id=item.ID)
+                }}
+                @onchange={{action (mut this.loadedItem) value='data'}}
+                @loading='lazy'
+              />
+            {{/if}}
+            <div class="policy-accordion-content-row">
+              {{#if (eq item.template 'node-identity')}}
+                <dl class="policy-accordion-datacenter-info">
+                  <dt>Datacenter:</dt>
+                  <dd>{{item.Datacenter}}</dd>
+                </dl>
+              {{else}}
+                <dl class="policy-accordion-datacenter-info">
+                  <dt>Datacenters:</dt>
+                  <dd>{{join ', ' (policy/datacenters (or this.loadedItem item))}}</dd>
+                </dl>
+              {{/if}}
+              {{#if (not @disabled)}}
                 <Hds::Button
                   @text='Remove'
                   @color='critical'
                   @size='small'
-                  {{action confirm}}
                   data-test-delete
+                  {{on 'click' (action this.confirmRemove item remove)}}
                 />
-              </:action>
-              <:dialog as |execute cancel message|>
-                <p>
-                  {{message}}
-                </p>
-                <Hds::ButtonSet>
-                  <Hds::Button
-                    @text='Confirm remove'
-                    @color='critical'
-                    @size='small'
-                    {{action (queue execute (action remove item @items))}}
-                    data-test-delete
-                  />
-                  <Hds::Button
-                    @text='Cancel'
-                    @color='secondary'
-                    @size='small'
-                    {{action cancel}}
-                    data-test-delete
-                  />
-                </Hds::ButtonSet>
-              </:dialog>
-            </ConfirmationDialog>
-          </div>
-        {{/if}}
-      </:details>
-    </TabularDetails>
+              {{/if}}
+            </div>
+            {{#if (eq item.template 'service-identity')}}
+              <Hds::CodeBlock
+                @language='hcl'
+                @value={{service-identity-template
+                  item.Name
+                  partition=@partition
+                  nspace=@nspace
+                  canUsePartitions=(can 'use partitions')
+                  canUseNspaces=(can 'use nspaces')
+                }}
+                as |CB|
+              >
+                <CB.Title @tag='span'>
+                  Rules
+                  <a
+                    href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
+                    rel='help noopener noreferrer'
+                    target='_blank'
+                    style="color: inherit;"
+                  >(HCL Format)</a>
+                </CB.Title>
+              </Hds::CodeBlock>
+            {{else if (eq item.template 'node-identity')}}
+              <Hds::CodeBlock
+                @language='hcl'
+                @value={{node-identity-template
+                  item.Name
+                  partition=@partition
+                  canUsePartitions=(can 'use partitions')
+                  canUseNspaces=(can 'use nspaces')
+                }}
+                as |CB|
+              >
+                <CB.Title @tag='span'>
+                  Rules
+                  <a
+                    href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
+                    rel='help noopener noreferrer'
+                    target='_blank'
+                    style="color: inherit;"
+                  >(HCL Format)</a>
+                </CB.Title>
+              </Hds::CodeBlock>
+            {{else}}
+              <Hds::CodeBlock @language='hcl' @value={{or this.loadedItem.Rules this.item.Rules ''}} as |CB|>
+                <CB.Title @tag='span'>
+                  Rules
+                  <a
+                    href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
+                    rel='help noopener noreferrer'
+                    target='_blank'
+                    style="color: inherit;"
+                  >(HCL Format)</a>
+                </CB.Title>
+              </Hds::CodeBlock>
+            {{/if}}
+          </:content>
+        </A.Item>
+      {{/each}}
+    </Hds::Accordion>
 
+    {{#if this.policyToRemove}}
+      <Hds::Modal
+        id='confirm-remove-policy-modal'
+        @color='critical'
+        @onClose={{action this.cancelRemove}}
+        as |M|
+      >
+        <M.Header @icon='alert-diamond'>Confirm remove</M.Header>
+        <M.Body>
+          <p>Are you sure you want to remove this policy?</p>
+        </M.Body>
+        <M.Footer as |F|>
+          <Hds::ButtonSet>
+            <Hds::Button
+              @text='Remove'
+              @color='critical'
+              data-test-id='confirm-action'
+              {{on 'click' (action this.invokeRemove)}}
+            />
+            <Hds::Button @text='Cancel' @color='secondary' {{on 'click' F.close}} />
+          </Hds::ButtonSet>
+        </M.Footer>
+      </Hds::Modal>
+    {{/if}}
   </:set>
 </ChildSelector>

--- a/ui/packages/consul-ui/app/components/policy-selector/index.js
+++ b/ui/packages/consul-ui/app/components/policy-selector/index.js
@@ -17,6 +17,17 @@ export default ChildSelectorComponent.extend({
   type: 'policy',
   allowIdentity: true,
   classNames: ['policy-selector'],
+  confirmRemove: function (item, removeFn) {
+    set(this, 'policyToRemove', { item, removeFn });
+  },
+  cancelRemove: function () {
+    set(this, 'policyToRemove', null);
+  },
+  invokeRemove: function () {
+    const { item, removeFn } = this.policyToRemove;
+    removeFn(item, this.items);
+    set(this, 'policyToRemove', null);
+  },
   init: function () {
     this._super(...arguments);
     const source = this.source;

--- a/ui/packages/consul-ui/app/components/policy-selector/pageobject.js
+++ b/ui/packages/consul-ui/app/components/policy-selector/pageobject.js
@@ -3,21 +3,23 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-export default (clickable, deletable, collection, alias, policyForm) =>
+import { clickable } from 'ember-cli-page-object';
+
+export default (clickableArg, deletable, collection, alias, policyForm) =>
   (scope = '#policies', createSelector = '[data-test-policy-create]') => {
+    const confirmDelete = clickable("[data-test-id='confirm-action']", {
+      resetScope: true,
+      testContainer: 'body',
+    });
     return {
       scope: scope,
-      create: clickable(createSelector),
+      create: clickableArg(createSelector),
       form: policyForm('#new-policy'),
       policies: alias('selectedOptions'),
-      selectedOptions: collection(
-        '[data-test-policies] [data-test-tabular-row]',
-        deletable(
-          {
-            expand: clickable('label'),
-          },
-          '+ tr'
-        )
-      ),
+      selectedOptions: collection('[data-test-policies] .hds-accordion-item', {
+        expand: clickableArg('button.hds-accordion-item__button'),
+        delete: clickableArg('[data-test-delete]'),
+        confirmDelete: confirmDelete,
+      }),
     };
   };

--- a/ui/packages/consul-ui/app/components/role-form/index.hbs
+++ b/ui/packages/consul-ui/app/components/role-form/index.hbs
@@ -27,11 +27,11 @@
 </fieldset>
 {{!TODO: temporary policies id, look at the inception token modals and get rid of id="policies" and use something else}}
 <fieldset id="policies" class="policies">
-  <h2>Policies</h2>
   {{#if (has-block 'policy')}}
     {{yield this.item to='policy'}}
   {{else}}
     <PolicySelector
+      @showHeader={{true}}
       @disabled={{not (can "write role" item=this.item)}}
       @dc={{@dc}}
       @partition={{@partition}}

--- a/ui/packages/consul-ui/app/components/role-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/role-selector/index.hbs
@@ -106,6 +106,26 @@
   </:actions>
 </ModalDialog>
 
+{{#if @showHeader}}
+  <div class="consul-nspace-form-section-header">
+    <div class="consul-nspace-form-section-header__text">
+      <p class="consul-nspace-form-section-title">Roles</p>
+      <p class="consul-nspace-form-section-description">{{@descriptionText}}</p>
+    </div>
+    {{#if (not @disabled)}}
+      <Hds::Button
+        @text='Create new role'
+        @size='medium'
+        @color='tertiary'
+        @icon='plus'
+        class='type-dialog'
+        data-test-role-create
+        {{on "click" (optional this.modal.open)}}
+      />
+    {{/if}}
+  </div>
+{{/if}}
+
 <ChildSelector
   @disabled={{@disabled}}
   @repo={{this.repo}}
@@ -119,73 +139,75 @@
   <:label>
     Apply an existing role
   </:label>
-  <:create>
-    <Hds::Button
-      @text='Create new role'
-      @size='small'
-      @color='tertiary'
-      @icon='plus'
-      class='type-dialog'
-      data-test-role-create
-      {{on "click" (optional this.modal.open)}}
-    />
-  </:create>
   <:option as |option|>
     {{option.Name}}
   </:option>
   <:set as |remove|>
-    <TabularCollection
-        data-test-roles
-        @rows={{5}}
-        @items={{sort-by 'CreateTime:desc' 'Name:asc' @items}}
-    >
-      <:header>
-        <th>Name</th>
-        <th>Description</th>
-      </:header>
-      <:row as |item index|>
-        <td>
-          <a href={{href-to 'dc.acls.roles.edit' item.ID}}>{{item.Name}}</a>
-        </td>
-        <td>
-          {{item.Description}}
-        </td>
-      </:row>
-      <:actions as |item index change checked|>
-        <PopoverMenu @expanded={{if (eq checked index) true false}} @onchange={{action change index}} @keyboardAccess={{true}}>
-          <:trigger>
-            More
-          </:trigger>
-          <:menu as |components confirm keypressClick|>
-              <components.MenuItem @href={{href-to 'dc.acls.roles.edit' item.ID}}>
-                <:label>
-                  {{#if (can "edit role" item=item)}}
-                    Edit
-                  {{else}}
-                    View
-                  {{/if}}
-                </:label>
-              </components.MenuItem>
+    <Hds::Table data-test-roles>
+      <:head as |H|>
+        <H.Tr>
+          <H.Th>Role name</H.Th>
+          <H.Th>Role description</H.Th>
+          <H.Th @align="right">Actions</H.Th>
+        </H.Tr>
+      </:head>
+      <:body as |B|>
+        {{#each (sort-by 'CreateTime:desc' 'Name:asc' @items) as |item index|}}
+          <B.Tr data-test-tabular-row>
+            <B.Td>
+              <a href={{href-to 'dc.acls.roles.edit' item.ID}}>{{item.Name}}</a>
+            </B.Td>
+            <B.Td>{{item.Description}}</B.Td>
+            <B.Td @align="right">
+              <Hds::Dropdown @listPosition="bottom-right" as |dd|>
+                <dd.ToggleIcon
+                  @icon="more-horizontal"
+                  @text="Open actions menu"
+                  @hasChevron={{false}}
+                  @size="small"
+                  data-test-role-actions
+                />
+                <dd.Interactive
+                  @icon={{if (can "edit role" item=item) "edit" "eye"}}
+                  @href={{href-to 'dc.acls.roles.edit' item.ID}}
+                  data-test-edit
+                >
+                  {{if (can "edit role" item=item) "Edit" "View"}}
+                </dd.Interactive>
+                {{#if (not @disabled)}}
+                  <dd.Separator />
+                  <dd.Interactive
+                    @color="critical"
+                    @icon="trash"
+                    data-test-delete
+                    {{on "click" (action this.confirmRemove item remove)}}
+                  >Remove</dd.Interactive>
+                {{/if}}
+              </Hds::Dropdown>
+            </B.Td>
+          </B.Tr>
+        {{/each}}
+      </:body>
+    </Hds::Table>
 
-            {{#if (not @disabled)}}
-              <components.MenuItem class="dangerous" @onclick={{fn remove item @items}} data-test-delete>
-                <:label>
-                  Remove
-                </:label>
-                <:confirmHeader>
-                  Confirm Remove
-                </:confirmHeader>
-                <:confirmBody>
-                  Are you sure you want to remove this role?
-                </:confirmBody>
-                <:confirmFooter as |Params|>
-                  <Params.button @text='Remove' {{on 'click' Params.confirmAction}} />
-                </:confirmFooter>
-              </components.MenuItem>
-            {{/if}}
-          </:menu>
-        </PopoverMenu>
-      </:actions>
-    </TabularCollection>
+    {{#if this.roleToRemove}}
+      <Hds::Modal id="confirm-remove-role-modal" @color="critical" @onClose={{action this.cancelRemove}} as |M|>
+        <M.Header @icon="alert-diamond">Confirm remove</M.Header>
+        <M.Body>
+          <p>Are you sure you want to remove this role?</p>
+        </M.Body>
+        <M.Footer as |F|>
+          <Hds::ButtonSet>
+            <Hds::Button
+              @text="Remove"
+              @color="critical"
+              data-test-id="confirm-action"
+              {{on "click" (action this.invokeRemove)}}
+            />
+            <Hds::Button @text="Cancel" @color="secondary" {{on "click" F.close}} />
+          </Hds::ButtonSet>
+        </M.Footer>
+      </Hds::Modal>
+    {{/if}}
   </:set>
 </ChildSelector>

--- a/ui/packages/consul-ui/app/components/role-selector/index.js
+++ b/ui/packages/consul-ui/app/components/role-selector/index.js
@@ -25,6 +25,17 @@ export default ChildSelectorComponent.extend({
     set(this, 'policyForm', this.formContainer.form('policy'));
     this.source = new EventSource();
   },
+  confirmRemove: function (item, removeFn) {
+    set(this, 'roleToRemove', { item, removeFn });
+  },
+  cancelRemove: function () {
+    set(this, 'roleToRemove', null);
+  },
+  invokeRemove: function () {
+    const { item, removeFn } = this.roleToRemove;
+    removeFn(item, this.items);
+    set(this, 'roleToRemove', null);
+  },
   actions: {
     reset: function (e) {
       this._super(...arguments);

--- a/ui/packages/consul-ui/app/components/role-selector/pageobject.js
+++ b/ui/packages/consul-ui/app/components/role-selector/pageobject.js
@@ -3,19 +3,21 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-export default (clickable, deletable, collection, alias, roleForm) =>
+import { clickable } from 'ember-cli-page-object';
+
+export default (clickableArg, deletable, collection, alias, roleForm) =>
   (scope = '#roles') => {
     return {
       scope: scope,
-      create: clickable('[data-test-role-create]'),
+      create: clickableArg('[data-test-role-create]'),
       form: roleForm(),
       roles: alias('selectedOptions'),
       selectedOptions: collection('[data-test-roles] [data-test-tabular-row]', {
-        actions: clickable('label > button'),
-        delete: clickable('[data-test-delete] [role="menuitem"]'),
-        confirmDelete: clickable("#confirm-modal [data-test-id='confirm-action']", {
+        actions: clickableArg('[data-test-role-actions]'),
+        delete: clickableArg('[data-test-delete]'),
+        confirmDelete: clickable("[data-test-id='confirm-action']", {
           resetScope: true,
-          testContainer: 'body', // modal is rendered in the body
+          testContainer: 'body',
         }),
       }),
     };

--- a/ui/packages/consul-ui/app/components/selector-section-header.scss
+++ b/ui/packages/consul-ui/app/components/selector-section-header.scss
@@ -1,0 +1,37 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+// Shared header block rendered by RoleSelector and PolicySelector when
+// @showHeader={{true}}. Used in the namespace form, token form, and role form.
+.consul-nspace-form-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.consul-nspace-form-section-header__text {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.consul-nspace-form-section-title {
+  font-size: 24px !important;
+  font-weight: 510 !important;
+  line-height: 32px !important;
+  color: var(--token-color-foreground-strong, #0c0c0e) !important;
+  margin: 0 !important;
+}
+
+.consul-nspace-form-section-description {
+  font-size: 16px !important;
+  font-weight: 400 !important;
+  line-height: 24px !important;
+  color: var(--token-color-foreground-primary, #3b3d45) !important;
+  margin: 0 !important;
+}

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -118,6 +118,8 @@
 @import 'consul-ui/components/consul/policy/toolbar';
 @import 'consul-ui/components/consul/role/list';
 @import 'consul-ui/components/consul/role/toolbar';
+@import 'consul-ui/components/consul/nspace/list';
+@import 'consul-ui/components/consul/nspace/toolbar';
 @import 'consul-ui/components/consul/acl/ruleset-badge';
 
 @import 'consul-ui/components/role-selector';

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -120,6 +120,8 @@
 @import 'consul-ui/components/consul/role/toolbar';
 @import 'consul-ui/components/consul/nspace/list';
 @import 'consul-ui/components/consul/nspace/toolbar';
+@import 'consul-ui/components/consul/nspace/form';
+@import 'consul-ui/components/selector-section-header';
 @import 'consul-ui/components/consul/acl/ruleset-badge';
 
 @import 'consul-ui/components/role-selector';

--- a/ui/packages/consul-ui/app/styles/layout.scss
+++ b/ui/packages/consul-ui/app/styles/layout.scss
@@ -97,7 +97,6 @@ html[data-route$='edit'] .app-view > header + div > *:first-child {
 }
 /* turn off top borders for things flush up to a filter bar */
 html[data-route='dc.services.index'] .consul-service-list ul,
-.consul-nspace-list ul,
 .consul-service-instance-list ul,
 .consul-role-list ul,
 .consul-policy-list ul,

--- a/ui/packages/consul-ui/app/styles/routes.scss
+++ b/ui/packages/consul-ui/app/styles/routes.scss
@@ -7,6 +7,7 @@
 @import 'routes/dc/nodes/index';
 @import 'routes/dc/acls/index';
 @import 'routes/dc/kv/index';
+@import 'routes/dc/nspaces/index';
 @import 'routes/dc/intentions/index';
 @import 'routes/dc/overview/serverstatus';
 @import 'routes/dc/overview/license';

--- a/ui/packages/consul-ui/app/styles/routes/dc/nspaces/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/nspaces/index.scss
@@ -1,0 +1,27 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/* The namespace create/edit form uses HDS::Separator for section dividers, so
+   the legacy `app-view` rules that draw a border-bottom under the page title
+   and under every fieldset would produce duplicate/unwanted lines.
+   The margin-bottom that the global rule added for spacing between the last
+   fieldset and the action buttons is restored explicitly below. */
+html[data-route='dc.nspaces.edit'],
+html[data-route='dc.nspaces.create'] {
+  .app-view .title {
+    border-bottom: none;
+  }
+
+  .app-view form:not(.filter-bar) fieldset {
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 0;
+  }
+
+  /* Restore spacing above the action buttons (Save / Cancel / Delete) */
+  .app-view form:not(.filter-bar) fieldset:last-of-type {
+    margin-bottom: 2em;
+  }
+}

--- a/ui/packages/consul-ui/app/templates/dc/nspaces/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nspaces/index.hbs
@@ -60,20 +60,16 @@ as |route|>
     />
   {{/if}}
       </:actions>
-      <:toolbar>
-      {{#if (gt items.length 0)}}
-        <Consul::Nspace::SearchBar
-          @search={{this.search}}
-          @onsearch={{action (mut this.search) value="target.value"}}
-
-          @sort={{sort}}
-
-          @filter={{filters}}
-        />
-      {{/if}}
-      </:toolbar>
       <:content>
         {{#let (refresh-route) as |refreshRoute|}}
+        {{#if (gt items.length 0)}}
+          <Consul::Nspace::Toolbar
+            @search={{this.search}}
+            @onsearch={{action (mut this.search) value="target.value"}}
+            @sort={{sort}}
+            @filter={{filters}}
+          />
+        {{/if}}
         <DataWriter
           @sink={{uri '/${partition}/${dc}/${nspace}/nspace/'
             (hash

--- a/ui/packages/consul-ui/tests/acceptance/dc/nspaces/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nspaces/index.feature
@@ -31,7 +31,7 @@ Feature: dc / nspaces / index: Nspaces List
     Then I see 3 nspace models
     Then I fill in with yaml
     ---
-    s: default
+    search: default
     ---
     And I see 1 nspace model
     And I see 1 nspace model with the description "The default namespace"

--- a/ui/packages/consul-ui/tests/pages.js
+++ b/ui/packages/consul-ui/tests/pages.js
@@ -231,7 +231,7 @@ export default {
       intentionPermissionList
     )
   ),
-  nspaces: create(nspaces(visitable, creatable, consulNspaceList, popoverSelect)),
+  nspaces: create(nspaces(visitable, creatable, consulNspaceList, clickable, collection)),
   nspace: create(
     nspace(visitable, submitable, deletable, cancelable, policySelector, roleSelector)
   ),

--- a/ui/packages/consul-ui/tests/pages/dc/nspaces/edit.js
+++ b/ui/packages/consul-ui/tests/pages/dc/nspaces/edit.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+import { clickable } from 'ember-cli-page-object';
+
 export default function (
   visitable,
   submitable,
@@ -16,6 +18,10 @@ export default function (
     ...submitable({}, 'main form > div'),
     ...cancelable({}, 'main form > div'),
     ...deletable({}, 'main form > div'),
+    confirmDelete: clickable("[data-test-id='confirm-action']", {
+      resetScope: true,
+      testContainer: 'body',
+    }),
     policies: policySelector(),
     roles: roleSelector(),
   };

--- a/ui/packages/consul-ui/tests/pages/dc/nspaces/index.js
+++ b/ui/packages/consul-ui/tests/pages/dc/nspaces/index.js
@@ -3,10 +3,17 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-export default function (visitable, creatable, nspaces, popoverSelect) {
+export default function (visitable, creatable, nspaces, clickable, collection) {
   return creatable({
     visit: visitable('/:dc/namespaces'),
     nspaces: nspaces(),
-    sort: popoverSelect('[data-test-sort-control]'),
+    sort: {
+      selected: clickable('[data-test-sort-control] button', { at: 0 }),
+      options: collection('[data-test-sort-option]', {
+        resetScope: true,
+        testContainer: 'html',
+        button: clickable(),
+      }),
+    },
   });
 }


### PR DESCRIPTION
## Summary

Migrates the Namespaces list and edit/create pages to HashiCorp Design System (HDS) components, continuing the HDS migration started in the admin-partitions branch.

---

## Changes

### `ui: migrate namespaces list page to HDS table`
- Replace `ListCollection` card layout with `Consul::DataTable`.
- Add `Consul::Nspace::List` component (JS, HBS, SCSS) with Name (sortable), Policies, Roles, and Actions columns.
- Add `Consul::Nspace::Toolbar` component (HBS, SCSS) with card chrome and sort dropdown.
- Update `dc/nspaces/index` route template: toolbar in `<:content>`, `DataWriter`/`DataCollection` wiring.
- Remove Identities column (namespaces cannot have identities).
- Badge cells (Policies, Roles) use `flex-wrap` container.
- Delete confirmation modal uses `@color=critical`.
- Name column `min-width` to prevent hyphenated names from wrapping.
- Update pageobject row selector to `data-test-tabular-row`.
- Register new SCSS in `components.scss`.
- Remove dead `.consul-nspace-list` selectors from `layout.scss` and `composite-row/index.scss`.
- Remove `.consul-data-table__card` border/radius (now owned by each toolbar).
- Align `consul-partition-toolbar` card chrome with `consul-nspace-toolbar`.

### `fix(nspace): update test page objects and feature for HDS migration`
- `pageobject.js`: replace `more-popover-menu` label selector with HDS Dropdown selectors (`data-test-actions-menu`, `data-test-edit`, `data-test-delete`, `confirm-modal confirm-action`).
- `tests/pages/dc/nspaces/index.js`: replace `popoverSelect` with inline HDS sort object (`data-test-sort-control button` + `data-test-sort-option`).
- `tests/pages.js`: pass `clickable`/`collection` to nspaces factory instead of `popoverSelect`.
- `tests/acceptance/dc/nspaces/index.feature`: change search fill-in key from `s` (freetext-filter) to `search` (HDS FilterBar).

### `feat: migrate namespace form, policy/role selectors to HDS components`
- `Consul::Nspace::Form`: replace legacy `TextInput` with `Hds::Form::TextInput::Field` for Name and Description; replace `ConfirmationDialog` + `DeleteConfirmation` with `Hds::Modal`; fix button layout (`Hds::ButtonSet` for Save/Cancel on left, Delete critical on right); add `nspace/form/index.scss` for layout overrides.
- `PolicySelector`: migrate modal to `Hds::Modal`; update pageobject selectors.
- `RoleSelector`: migrate modal to `Hds::Modal`; update pageobject selectors.
- `Consul::Token::Fieldsets`: update `RoleSelector` wiring for HDS.
- `role-form/index.hbs`: minor HDS alignment fix.
- Add `selector-section-header.scss` for shared section header styles.
- Register new SCSS files in `components.scss` and `routes.scss`.
- Add `tests/pages/dc/nspaces/edit.js` page object additions.

## Files Changed
- `app/components/composite-row/index.scss`
- `app/components/consul/data-table/index.scss`
- `app/components/consul/nspace/form/index.hbs`
- `app/components/consul/nspace/form/index.js`
- `app/components/consul/nspace/form/index.scss` *(new)*
- `app/components/consul/nspace/list/index.hbs`
- `app/components/consul/nspace/list/index.js`
- `app/components/consul/nspace/list/index.scss`
- `app/components/consul/nspace/list/pageobject.js`
- `app/components/consul/nspace/toolbar/index.hbs` *(new)*
- `app/components/consul/nspace/toolbar/index.scss` *(new)*
- `app/components/consul/partition/toolbar/index.scss`
- `app/components/consul/token/fieldsets/index.hbs`
- `app/components/policy-selector/index.hbs`
- `app/components/policy-selector/index.js`
- `app/components/policy-selector/pageobject.js`
- `app/components/role-form/index.hbs`
- `app/components/role-selector/index.hbs`
- `app/components/role-selector/index.js`
- `app/components/role-selector/pageobject.js`
- `app/components/selector-section-header.scss` *(new)*
- `app/styles/components.scss`
- `app/styles/layout.scss`
- `app/styles/routes.scss`
- `app/styles/routes/dc/nspaces/index.scss` *(new)*
- `app/templates/dc/nspaces/index.hbs`
- `tests/acceptance/dc/nspaces/index.feature`
- `tests/pages.js`
- `tests/pages/dc/nspaces/edit.js`
- `tests/pages/dc/nspaces/index.js`
