### PR TITLE
feat: migrate tokens UI to HDS components

### DIFF
--- a/ui/packages/consul-ui/app/components/child-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/child-selector/index.hbs
@@ -11,43 +11,37 @@
 {{yield}}
 {{#if (not @disabled)}}
   {{yield to="create"}}
-  <label class="type-text">
-    <span>{{yield to="label"}}</span>
-    {{!-- {{#if isOpen}} --}}
-      <DataSource
-        @src={{uri '/${partition}/${nspace}/${dc}/${type}'
-          (hash
-            partition=@partition
-            nspace=@nspace
-            dc=@dc
-            type=(pluralize this.type)
-          )
-        }}
-        @onchange={{action "setAllOptions" value="data"}}
-      />
-    {{!-- {{/if}} --}}
-    <DataCollection
-      @type={{this.type}}
-      @sort='Name:asc'
-      @filters={{hash
-        searchproperties=(array 'Name')
-      }}
-      @items={{this.options}}
-    as |collection|>
-      <Hds::Form::SuperSelect::Single::Field
-        @searchEnabled={{true}}
-        @onFilter={{action collection.search}}
-        @options={{sort-by 'Name:asc' this.options}}
-        @placeholder={{@placeholder}}
-        @onChange={{action "change" "items[]" @items}}
-        @label="Select {{this.type}}"
-        @isOptional={{true}}
-        @searchField="Name"
-      as |F|>
-        <F.Options>{{F.options.Name}}</F.Options>
-      </Hds::Form::SuperSelect::Single::Field>
-    </DataCollection>
-  </label>
+  <DataSource
+    @src={{uri '/${partition}/${nspace}/${dc}/${type}'
+      (hash
+        partition=@partition
+        nspace=@nspace
+        dc=@dc
+        type=(pluralize this.type)
+      )
+    }}
+    @onchange={{action "setAllOptions" value="data"}}
+  />
+  <DataCollection
+    @type={{this.type}}
+    @sort='Name:asc'
+    @filters={{hash
+      searchproperties=(array 'Name')
+    }}
+    @items={{this.options}}
+  as |collection|>
+    <Hds::Form::SuperSelect::Single::Field
+      @searchEnabled={{true}}
+      @onFilter={{action collection.search}}
+      @options={{sort-by 'Name:asc' this.options}}
+      @placeholder={{@placeholder}}
+      @onChange={{action "change" "items[]" @items}}
+      @searchField="Name"
+    as |F|>
+      <F.Label>{{yield to="label"}}</F.Label>
+      <F.Options>{{F.options.Name}}</F.Options>
+    </Hds::Form::SuperSelect::Single::Field>
+  </DataCollection>
 {{/if}}
 {{#if (gt @items.length 0)}}
   {{yield (action "remove") to="set"}}

--- a/ui/packages/consul-ui/app/components/consul/token/fieldsets-legacy/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/fieldsets-legacy/index.hbs
@@ -22,7 +22,7 @@
     {{on 'input' @onChange}}
     as |F|
   >
-    <F.Label>Name</F.Label>
+    <F.Label>Description</F.Label>
   </Hds::Form::TextInput::Field>
   <label class='type-text'>
     <Hds::CodeEditor

--- a/ui/packages/consul-ui/app/components/consul/token/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/fieldsets/index.hbs
@@ -6,24 +6,77 @@
 <fieldset
   disabled={{if (not (can "write token" item=@item)) "disabled"}}
 >
-{{#if @create }}
-  <div class="type-toggle">
-    <label>
-      <input type="checkbox" name="Local" checked={{if @local 'checked' }} onchange={{@onChange}} />
-      <span>Restrict this token to a local datacenter?</span>
-    </label>
-    <em>Local tokens get set in the Raft store of the local DC and do not ever get transmitted to the primary DC or replicated to any other DC.</em>
-  </div>
-{{/if}}
-  <label class="type-text">
-    <span>Name</span>
-    <input type="text" name="Name" value={{@item.Name}} oninput={{@onChange}} />
-  </label>
-  <label class="type-text validate-optional">
-    <span>Description (Optional)</span>
-    <textarea name="Description" oninput={{@onChange}}>{{@item.Description}}</textarea>
-  </label>
+  {{! Read-only fields (AccessorID, Token, Scope) — edit mode only }}
+  {{#unless @create}}
+    <Hds::Form::MaskedInput::Field
+      readonly
+      @isContentMasked={{false}}
+      @hasCopyButton={{true}}
+      @value={{@item.AccessorID}}
+      as |F|
+    >
+      <F.Label>AccessorID</F.Label>
+    </Hds::Form::MaskedInput::Field>
+
+    <Hds::Form::MaskedInput::Field
+      readonly
+      @isContentMasked={{true}}
+      @hasCopyButton={{true}}
+      @value={{@item.SecretID}}
+      as |F|
+    >
+      <F.Label>Token</F.Label>
+    </Hds::Form::MaskedInput::Field>
+
+    {{#unless (token/is-legacy @item)}}
+      <Hds::Form::TextInput::Field
+        readonly
+        @value={{if @item.Local 'local' 'global'}}
+        as |F|
+      >
+        <F.Label>Scope</F.Label>
+      </Hds::Form::TextInput::Field>
+    {{/unless}}
+  {{/unless}}
+
+  {{! Local-scope toggle — create mode only }}
+  {{#if @create}}
+    <Hds::Form::Toggle::Field
+      name="Local"
+      checked={{if @local true false}}
+      {{on "change" @onChange}}
+      as |F|
+    >
+      <F.Label>Restrict this token to a local datacenter?</F.Label>
+      <F.HelperText>
+        Local tokens get set in the Raft store of the local DC and do not ever
+        get transmitted to the primary DC or replicated to any other DC.
+      </F.HelperText>
+    </Hds::Form::Toggle::Field>
+  {{/if}}
+
+  <Hds::Form::TextInput::Field
+    @value={{@item.Name}}
+    name="Name"
+    {{on "input" @onChange}}
+    as |F|
+  >
+    <F.Label>Name</F.Label>
+  </Hds::Form::TextInput::Field>
+
+  <Hds::Form::Textarea::Field
+    @value={{@item.Description}}
+    name="Description"
+    @isOptional={{true}}
+    {{on "input" @onChange}}
+    as |F|
+  >
+    <F.Label>Description</F.Label>
+  </Hds::Form::Textarea::Field>
 </fieldset>
+
+<Hds::Separator />
+
 <fieldset id="roles">
   <RoleSelector
     @showHeader={{true}}
@@ -34,6 +87,9 @@
     @items={{@item.Roles}}
   />
 </fieldset>
+
+<Hds::Separator />
+
 <fieldset id="policies">
   <PolicySelector
     @showHeader={{true}}

--- a/ui/packages/consul-ui/app/components/consul/token/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/form/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<form>
+<form class="consul-token-form">
   {{!-- fieldsets already converted to components --}}
   {{#if (not (token/is-legacy @item))}}
     <Consul::Token::Fieldsets
@@ -24,7 +24,7 @@
     />
   {{/if}}
 
-  <div>
+  <div class="consul-token-form__actions">
     <Hds::ButtonSet>
       {{#if (and @create (can "create tokens")) }}
         <Hds::Button
@@ -50,22 +50,43 @@
         type='reset'
         {{on 'click' @onCancel}}
       />
-
-      {{# if (and (not @create) (can "delete token" item=@item token=@token) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this Token?">
-          <:action as |confirm|>
-            <Hds::Button
-              @text='Delete'
-              @color='critical'
-              {{on 'click' confirm}}
-              data-test-delete
-            />
-          </:action>
-          <:dialog as |execute cancel message|>
-            <DeleteConfirmation @message={{message}} @execute={{queue execute (fn @onDelete @item)}} @cancel={{cancel}} />
-          </:dialog>
-        </ConfirmationDialog>
-      {{/if}}
     </Hds::ButtonSet>
+
+    {{#if (and (not @create) (can "delete token" item=@item token=@token))}}
+      <Hds::Button
+        @text='Delete'
+        @color='critical'
+        {{on 'click' this.openDeleteModal}}
+        data-test-delete
+      />
+    {{/if}}
   </div>
+
+  {{#if this.showDeleteModal}}
+    <Hds::Modal
+      @color='critical'
+      @onClose={{this.closeDeleteModal}}
+      as |M|
+    >
+      <M.Header @icon='trash'>Confirm delete</M.Header>
+      <M.Body>
+        <p>Are you sure you want to delete this token?</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::ButtonSet>
+          <Hds::Button
+            @text='Delete'
+            @color='critical'
+            data-test-confirm-delete
+            {{on 'click' this.confirmDelete}}
+          />
+          <Hds::Button
+            @text='Cancel'
+            @color='secondary'
+            {{on 'click' F.close}}
+          />
+        </Hds::ButtonSet>
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
 </form>

--- a/ui/packages/consul-ui/app/components/consul/token/form/index.js
+++ b/ui/packages/consul-ui/app/components/consul/token/form/index.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+/**
+ * Consul::Token::Form
+ *
+ * Owns the Delete confirmation modal state.  All other actions (Save, Cancel,
+ * Delete invoke) are delegated to the parent via @onCreate / @onUpdate /
+ * @onCancel / @onDelete args.
+ */
+export default class ConsulTokenForm extends Component {
+  // true while the delete-confirmation modal is open
+  @tracked showDeleteModal = false;
+
+  @action
+  openDeleteModal() {
+    this.showDeleteModal = true;
+  }
+
+  @action
+  closeDeleteModal() {
+    this.showDeleteModal = false;
+  }
+
+  @action
+  confirmDelete() {
+    this.showDeleteModal = false;
+    this.args.onDelete(this.args.item);
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/token/form/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/token/form/index.scss
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+// Token create/edit form layout.
+// Mirrors the nspaces form pattern: flex column with 32px gap between each
+// top-level child (fieldsets, separators, button row).  The separators
+// themselves carry 24px margin on each side via hds-separator--spacing-24,
+// so the 32px form gap + 24px separator margin matches the Figma rhythm.
+.consul-token-form {
+  display: flex;
+  flex-direction: column;
+  // All section-level spacing is driven by this single gap value.
+  // The separators' built-in margins are reset to zero below so they
+  // don't add extra space on top of the gap.
+  gap: 32px;
+
+  // Reset HDS separator margins so the form gap is the sole source of spacing.
+  > .hds-separator {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  // All top-level fieldsets: flex column so HDS form fields stack with a 24px gap.
+  // Covers the main token fields, #roles, and #policies sections.
+  > fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+  &__actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
@@ -26,7 +26,63 @@
           >
             {{#if item.Name}}{{truncate item.Name 100}}{{else}}{{substr item.AccessorID -8}}{{/if}}
           </a>
-          <Consul::Token::Ruleset::List @item={{item}} />
+          {{! Management badge stays under the name (global-management star badge) }}
+          {{#let (policy/group (or item.Policies item.ACLs.PolicyDefaults (array))) as |grouped|}}
+            {{#each grouped.management as |policy|}}
+              <Consul::Acl::RulesetBadge
+                @item={{policy}}
+                @type={{policy/typeof policy}}
+                data-test-policy
+              />
+            {{/each}}
+          {{/let}}
+        </span>
+      </B.Td>
+
+      {{! ---- Identities ---- }}
+      <B.Td>
+        <span class="consul-token-list__badges" data-test-identities>
+          {{#let (policy/group (or item.Policies item.ACLs.PolicyDefaults (array))) as |grouped|}}
+            {{#each grouped.identities as |policy|}}
+              <Consul::Acl::RulesetBadge
+                @item={{policy}}
+                @type={{policy/typeof policy}}
+                data-test-policy
+              />
+            {{/each}}
+          {{/let}}
+        </span>
+      </B.Td>
+
+      {{! ---- Rules-policies ---- }}
+      <B.Td>
+        <span class="consul-token-list__badges" data-test-rules-policies>
+          {{#if (token/is-legacy item)}}
+            <em class="consul-token-list__legacy-rules">Legacy rules</em>
+          {{else}}
+            {{#let (policy/group (or item.Policies item.ACLs.PolicyDefaults (array))) as |grouped|}}
+              {{#each grouped.policies as |policy|}}
+                <Consul::Acl::RulesetBadge
+                  @item={{policy}}
+                  @type={{policy/typeof policy}}
+                  data-test-policy
+                />
+              {{/each}}
+            {{/let}}
+          {{/if}}
+        </span>
+      </B.Td>
+
+      {{! ---- Rules-roles ---- }}
+      <B.Td>
+        <span class="consul-token-list__badges" data-test-rules-roles>
+          {{#each (or item.Roles item.ACLs.RoleDefaults (array)) as |role|}}
+            <Consul::Acl::RulesetBadge
+              @item={{role}}
+              @type={{policy/typeof role}}
+              data-test-policy
+            />
+          {{/each}}
         </span>
       </B.Td>
 
@@ -85,8 +141,8 @@
   </Consul::DataTable>
 
   {{#if this.itemToConfirm}}
-    <Hds::Modal id="confirm-modal" @color="warning" @onClose={{this.cancelConfirm}} as |M|>
-      <M.Header @icon="alert-triangle">
+    <Hds::Modal id="confirm-modal" @color={{if (eq this.confirmType 'delete') 'critical' 'warning'}} @onClose={{this.cancelConfirm}} as |M|>
+      <M.Header @icon={{if (eq this.confirmType 'delete') 'trash' 'alert-triangle'}}>
         {{#if (eq this.confirmType 'use')}}Confirm use{{else if (eq this.confirmType 'logout')}}Confirm logout{{else}}Confirm delete{{/if}}
       </M.Header>
       <M.Body>

--- a/ui/packages/consul-ui/app/components/consul/token/list/index.js
+++ b/ui/packages/consul-ui/app/components/consul/token/list/index.js
@@ -9,16 +9,20 @@ import { action } from '@ember/object';
 
 // Column definitions for the tokens table. Sorting and searching continue to be
 // driven by the toolbar SearchBar, so columns are non-sortable here; cell
-// rendering lives in the template's :row block. The trailing "Actions" column
-// is right-aligned.
+// rendering lives in the template's :row block.
+//
+// Column order matches the HDS migration Figma design:
+//   Name | Identities | Rules-policies | Rules-roles | Scope | Description | Secret | Actions
 const COLUMNS = [
   { label: 'Name' },
+  { label: 'Identities' },
+  { label: 'Rules-policies' },
+  { label: 'Rules-roles' },
   { label: 'Scope' },
   { label: 'Description' },
   { label: 'Secret' },
   { label: 'Actions', align: 'right' },
 ];
-// Secret column shows the SecretID copy link; trailing Actions column is right-aligned.
 
 /**
  * Consul::Token::List

--- a/ui/packages/consul-ui/app/components/consul/token/list/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/token/list/index.scss
@@ -23,6 +23,8 @@
 .consul-token-list__name {
   display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
   font-weight: var(--token-typography-font-weight-semibold);
 
   a {
@@ -39,10 +41,27 @@
   margin-right: 4px;
 }
 
+/* Badge cells (Identities, Rules-policies, Rules-roles): wrap badges onto
+   multiple lines when there are more than fit on one row, matching the Figma
+   design where e.g. token-0 shows 3 policy badges across two lines. */
+.consul-token-list__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: flex-start;
+}
+
 .consul-token-list__description {
   display: block;
   color: var(--token-color-foreground-faint);
   font-style: normal;
+}
+
+/* Legacy tokens show an italic note in the Rules-policies cell instead of
+   individual policy badges. */
+.consul-token-list__legacy-rules {
+  color: var(--token-color-foreground-faint);
+  font-style: italic;
 }
 
 /* The copy button extends %button, which adds ~2.2em of horizontal padding and

--- a/ui/packages/consul-ui/app/components/policy-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/policy-selector/index.hbs
@@ -4,15 +4,12 @@
 }}
 
 {{#if @showHeader}}
-  <div class="consul-nspace-form-section-header">
-    <div class="consul-nspace-form-section-header__text">
-      <p class="consul-nspace-form-section-title">Policies</p>
-      <p class="consul-nspace-form-section-description">{{@descriptionText}}</p>
-    </div>
+  <div class="consul-token-section-header">
+    <Hds::Text::Display @size="300" @tag="h2">Policies</Hds::Text::Display>
     {{#if (not @disabled)}}
       <Hds::Button
         @text='Create new policy'
-        @size='medium'
+        @size='large'
         @color='tertiary'
         @icon='plus'
         class='type-dialog'

--- a/ui/packages/consul-ui/app/components/role-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/role-selector/index.hbs
@@ -107,15 +107,12 @@
 </ModalDialog>
 
 {{#if @showHeader}}
-  <div class="consul-nspace-form-section-header">
-    <div class="consul-nspace-form-section-header__text">
-      <p class="consul-nspace-form-section-title">Roles</p>
-      <p class="consul-nspace-form-section-description">{{@descriptionText}}</p>
-    </div>
+  <div class="consul-token-section-header">
+    <Hds::Text::Display @size="300" @tag="h2">Roles</Hds::Text::Display>
     {{#if (not @disabled)}}
       <Hds::Button
         @text='Create new role'
-        @size='medium'
+        @size='large'
         @color='tertiary'
         @icon='plus'
         class='type-dialog'

--- a/ui/packages/consul-ui/app/components/role-selector/index.scss
+++ b/ui/packages/consul-ui/app/components/role-selector/index.scss
@@ -12,3 +12,9 @@
     display: block;
   }
 }
+
+.child-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/ui/packages/consul-ui/app/components/selector-section-header.scss
+++ b/ui/packages/consul-ui/app/components/selector-section-header.scss
@@ -35,3 +35,12 @@
   color: var(--token-color-foreground-primary, #3b3d45) !important;
   margin: 0 !important;
 }
+
+// HDS-migrated section header used by the token create/edit form.
+// Replaces .consul-nspace-form-section-header in that context.
+.consul-token-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}

--- a/ui/packages/consul-ui/app/controllers/dc/acls/tokens/edit.js
+++ b/ui/packages/consul-ui/app/controllers/dc/acls/tokens/edit.js
@@ -6,12 +6,16 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class EditController extends Controller {
   @service('dom') dom;
   @service('form') builder;
 
   isScoped = false;
+
+  // Tracks the pending item while the "Use" confirmation modal is open.
+  @tracked itemToUse = null;
 
   constructor() {
     super(...arguments);
@@ -45,6 +49,30 @@ export default class EditController extends Controller {
           throw err;
       }
     }
+  }
+
+  @action
+  openUseModal(item) {
+    this.itemToUse = item;
+  }
+
+  @action
+  closeUseModal() {
+    this.itemToUse = null;
+  }
+
+  @action
+  confirmUse() {
+    const item = this.itemToUse;
+    this.itemToUse = null;
+    if (item) {
+      this.target.send('use', item);
+    }
+  }
+
+  @action
+  onClone(item) {
+    this.target.send('clone', item);
   }
 
   @action

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -111,6 +111,7 @@
 @import 'consul-ui/components/consul/auth-method';
 @import 'consul-ui/components/consul/auth-method/list';
 @import 'consul-ui/components/consul/auth-method/toolbar';
+@import 'consul-ui/components/consul/token/form';
 @import 'consul-ui/components/consul/token/ruleset/list';
 @import 'consul-ui/components/consul/token/list';
 @import 'consul-ui/components/consul/token/toolbar';

--- a/ui/packages/consul-ui/app/styles/routes/dc/acls/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/acls/index.scss
@@ -3,6 +3,18 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/* The token create/edit form uses HDS::Separator for section dividers, so the
+   global app-view rules that add border-bottom, padding-bottom, and
+   margin-bottom on every fieldset are redundant and must be suppressed. */
+html[data-route='dc.acls.tokens.create'],
+html[data-route='dc.acls.tokens.edit'] {
+  .app-view form:not(.filter-bar) fieldset {
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 0;
+  }
+}
+
 html[data-route^='dc.acls.index'] main td strong {
   @extend %pill-500, %frame-gray-900;
   margin-right: 3px;

--- a/ui/packages/consul-ui/app/templates/dc/acls/tokens/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/tokens/edit.hbs
@@ -52,50 +52,59 @@ as |dc partition nspace item create|}}
       <:actions>
   {{#if (not create)}}
     <Hds::ButtonSet>
-    {{#if (not-eq item.AccessorID this.token.AccessorID)}}
-        <ConfirmationDialog @message="Are you sure you want to use this ACL token?">
-          <:action as |confirm|>
-            <Hds::Button
-              @text='Use'
-              @color='secondary'
-              data-test-use
-              {{ action confirm }}
-            />
-          </:action>
-          <:dialog as |execute cancel message|>
-            <p>
-                {{message}}
-            </p>
-            <Hds::ButtonSet>
-              <Hds::Button
-                @text='Confirm Use'
-                @color='critical'
-                data-test-confirm-use
-                {{action (queue execute (fn this.use item))}}
-              />
-              <Hds::Button
-                @text='Cancel'
-                @color='secondary'
-                {{action cancel}}
-              />
-            </Hds::ButtonSet>
-          </:dialog>
-        </ConfirmationDialog>
-    {{/if}}
-    {{#if (can "duplicate token" item=item)}}
-      <Hds::Button
-        @text='Duplicate'
-        @color='secondary'
-        data-test-clone
-        {{ action "clone" item }}
-      />
-    {{/if}}
+      {{#if (not-eq item.AccessorID this.token.AccessorID)}}
+        <Hds::Button
+          @text='Use'
+          @color='secondary'
+          @icon='sign-in'
+          @iconPosition='leading'
+          data-test-use
+          {{on 'click' (fn this.openUseModal item)}}
+        />
+      {{/if}}
+      {{#if (can "duplicate token" item=item)}}
+        <Hds::Button
+          @text='Duplicate'
+          @color='secondary'
+          @icon='duplicate'
+          @iconPosition='leading'
+          data-test-clone
+          {{on 'click' (fn this.onClone item)}}
+        />
+      {{/if}}
     </Hds::ButtonSet>
   {{/if}}
       </:actions>
       <:content>
+  {{#if this.itemToUse}}
+    <Hds::Modal
+      @color='neutral'
+      @onClose={{this.closeUseModal}}
+      as |M|
+    >
+      <M.Header @icon='info'>Confirm use</M.Header>
+      <M.Body>
+        <p>Are you sure you want to use this ACL token?</p>
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::ButtonSet>
+          <Hds::Button
+            @text='Use'
+            @color='primary'
+            data-test-confirm-use
+            {{on 'click' this.confirmUse}}
+          />
+          <Hds::Button
+            @text='Cancel'
+            @color='secondary'
+            {{on 'click' F.close}}
+          />
+        </Hds::ButtonSet>
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
           {{#if (token/is-legacy item)}}
-            <Hds::Alert @type='inline' class='mb-6' as |A|>
+            <Hds::Alert @type='inline' as |A|>
               <A.Title>Update</A.Title>
               <A.Description>We have upgraded our ACL system by allowing you to create reusable policies which you can then apply to tokens. Don't worry, even though this token was written in the old style, it is still valid. However, we do recommend upgrading your old tokens to the new style.</A.Description>
               <A.Link::Standalone @text='Learn more'
@@ -104,33 +113,6 @@ as |dc partition nspace item create|}}
                                   @iconPosition='trailing' />
             </Hds::Alert>
           {{/if}}
-  {{#if (not create) }}
-        <div class="definition-table">
-            <dl>
-              <dt>AccessorID</dt>
-              <dd>
-                <CopyableCode
-                  @value={{item.AccessorID}}
-                  @name="AccessorID"
-                />
-              </dd>
-              <dt>Token</dt>
-              <dd>
-                <CopyableCode
-                  @obfuscated={{true}}
-                  @value={{item.SecretID}}
-                  @name="Token"
-                />
-              </dd>
-  {{#if (and (not (token/is-legacy item)) (not create))}}
-              <dt>Scope</dt>
-              <dd>
-                {{if item.Local 'local' 'global' }}
-              </dd>
-  {{/if}}
-            </dl>
-        </div>
-  {{/if}}
           <Consul::Token::Form
             @form={{this.form}}
             @item={{item}}

--- a/ui/packages/consul-ui/tests/pages/dc/acls/tokens/edit.js
+++ b/ui/packages/consul-ui/tests/pages/dc/acls/tokens/edit.js
@@ -16,7 +16,11 @@ export default function (
     visit: visitable(['/:dc/acls/tokens/:token', '/:dc/acls/tokens/create']),
     ...submitable({}, 'main form > div'),
     ...cancelable({}, 'main form > div'),
+    // The token form uses a two-step HDS modal delete flow:
+    //   delete        → [data-test-delete]         opens the confirmation modal
+    //   confirmDelete → [data-test-confirm-delete]  confirms inside the modal
     ...deletable({}, 'main form > div'),
+    confirmDelete: clickable('[data-test-confirm-delete]', { testContainer: '#ember-testing' }),
     use: clickable('[data-test-use]'),
     confirmUse: clickable('[data-test-confirm-use]'),
     clone: clickable('[data-test-clone]'),


### PR DESCRIPTION
## Summary

Migrates the ACL Tokens UI to Hashicorp Design System (HDS) components, continuing the HDS migration work from the namespace branch.

## Changes

### Components
- **`consul/token/list`** — Replace legacy card/list layout with HDS-based table and toolbar; add sort, filter, and action controls
- **`consul/token/form`** — New JS and SCSS for the token edit/create form using HDS form fields and modal delete confirmation
- **`consul/token/fieldsets`** — Migrate fieldsets to HDS form components
- **`consul/token/fieldsets-legacy`** — Update legacy fieldsets for HDS compatibility
- **`child-selector`** — Update template for HDS selector pattern
- **`policy-selector`** — Migrate to HDS selector components
- **`role-selector`** — Migrate to HDS selector components (template + styles)
- **`selector-section-header`** — Update styles for HDS-aligned section headers

### Routes & Controllers
- **`dc/acls/tokens/edit`** — Update controller and template to wire HDS modal delete confirmation and HDS form fields

### Styles
- **`app/styles/components.scss`** — Register new component SCSS
- **`app/styles/routes/dc/acls/index.scss`** — Remove legacy ACL-specific overrides superseded by HDS tokens

### Tests
- **`tests/pages/dc/acls/tokens/edit.js`** — Update page objects to use HDS selector targets

## Related
- Builds on: `suresh/namespace-hds-migration`
