### PR TITLE
feat: migrate roles ACL components to HDS

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/role/fieldsets/README.mdx
+++ b/ui/packages/consul-ui/app/components/consul/role/fieldsets/README.mdx
@@ -1,0 +1,38 @@
+# Consul::Role::Fieldsets
+
+HDS-native fieldset component for the Role create/edit form. Mirrors `Consul::Token::Fieldsets`.
+
+Renders:
+- **Role ID** `Hds::Form::MaskedInput::Field` with copy button (edit mode only)
+- **Name** `Hds::Form::TextInput::Field` with helper text and inline error
+- **Description** `Hds::Form::Textarea::Field` (optional)
+- `Hds::Separator`
+- **Policies** `PolicySelector` inside a `<fieldset id="policies">`
+
+## Usage
+
+```hbs
+<Consul::Role::Fieldsets
+  @item={{item}}
+  @create={{create}}
+  @onChange={{action 'change'}}
+  @dc={{dc}}
+  @nspace={{nspace}}
+  @partition={{partition}}
+/>
+```
+
+## Arguments
+
+| Arg | Type | Required | Description |
+|---|---:|:---:|---|
+| `@item` | object | yes | Role model / changeset. |
+| `@create` | boolean | no | True when rendering the create flow (hides Role ID field). |
+| `@onChange` | function | no | Handler forwarded to Name/Description inputs. |
+| `@dc` | string | no | Datacenter id passed to `PolicySelector`. |
+| `@nspace` | string | no | Namespace passed to `PolicySelector`. |
+| `@partition` | string | no | Partition passed to `PolicySelector`. |
+
+## See
+
+- Template: ./index.hbs

--- a/ui/packages/consul-ui/app/components/consul/role/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/role/fieldsets/index.hbs
@@ -1,0 +1,59 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<fieldset
+  disabled={{if (not (can "write role" item=@item)) "disabled"}}
+>
+  {{#unless @create}}
+    <Hds::Form::MaskedInput::Field
+      readonly
+      @isContentMasked={{false}}
+      @hasCopyButton={{true}}
+      @value={{@item.ID}}
+      as |F|
+    >
+      <F.Label>Role ID</F.Label>
+    </Hds::Form::MaskedInput::Field>
+  {{/unless}}
+
+  <Hds::Form::TextInput::Field
+    @value={{@item.Name}}
+    name="role[Name]"
+    @isInvalid={{if @item.error.Name true false}}
+    {{on "input" @onChange}}
+    as |F|
+  >
+    <F.Label>Name</F.Label>
+    <F.HelperText>
+      Maximum 256 characters. May only include letters (uppercase and/or lowercase) and/or numbers. Must be unique.
+    </F.HelperText>
+    {{#if @item.error.Name}}
+      <F.Error>{{@item.error.Name.validation}}</F.Error>
+    {{/if}}
+  </Hds::Form::TextInput::Field>
+
+  <Hds::Form::Textarea::Field
+    @value={{@item.Description}}
+    name="role[Description]"
+    @isOptional={{true}}
+    {{on "input" @onChange}}
+    as |F|
+  >
+    <F.Label>Description</F.Label>
+  </Hds::Form::Textarea::Field>
+</fieldset>
+
+<Hds::Separator />
+
+<fieldset id="policies">
+  <PolicySelector
+    @showHeader={{true}}
+    @disabled={{not (can "write role" item=@item)}}
+    @dc={{@dc}}
+    @partition={{@partition}}
+    @nspace={{@nspace}}
+    @items={{@item.Policies}}
+  />
+</fieldset>

--- a/ui/packages/consul-ui/app/components/consul/role/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/role/form/index.hbs
@@ -3,14 +3,16 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<form>
-  <RoleForm
-    @form={{@form}}
+<form class="consul-role-form">
+  <Consul::Role::Fieldsets
     @item={{@item}}
+    @create={{@create}}
+    @onChange={{@onChange}}
     @dc={{@dc}}
     @nspace={{@nspace}}
     @partition={{@partition}}
   />
+
   {{#if (not @create)}}
     <DataSource
       @src={{uri '/${partition}/${nspace}/${dc}/tokens/for-role/${id}'
@@ -23,16 +25,23 @@
       }}
       as |loader|>
       {{#if (gt loader.data.length 0)}}
-        <h2>Where is this role used?</h2>
-        <p>
-          We're only able to show information for the primary datacenter and the current datacenter. This list may not
-          show every case where this role is applied.
-        </p>
-        <TokenList @caption="Tokens" @items={{loader.data}} />
+        <div class="consul-role-form__used-by">
+          <Hds::Separator />
+          <div class="consul-role-form__usage">
+            <Hds::Text::Display @size="300" @tag="h2">Where is this role used?</Hds::Text::Display>
+            <Hds::Text::Body @size="200" @tag="p">
+              We're only able to show information for the primary datacenter and the current datacenter. This list may not
+              show every case where this role is applied.
+            </Hds::Text::Body>
+            <Hds::Form::Label @controlId="tokens-table">Tokens</Hds::Form::Label>
+            <TokenList @caption="Tokens" @items={{loader.data}} />
+          </div>
+        </div>
       {{/if}}
     </DataSource>
   {{/if}}
-  <div>
+
+  <div class="consul-role-form__actions">
     <Hds::ButtonSet>
       {{#if (and @create (can "create roles")) }}
         <Hds::Button
@@ -57,60 +66,55 @@
         type='reset'
         {{on 'click' @onCancel}}
       />
-
-      {{# if (and (not @create) (can "delete role" item=@item) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this Role?">
-          <:action as |confirm|>
-            <Hds::Button
-              @text='Delete'
-              @color='critical'
-              {{on 'click' confirm}}
-              data-test-delete
-            />
-          </:action>
-          <:dialog as |execute cancel message|>
-            {{#if (gt @items.length 0)}}
-              <ModalDialog
-                @onclose={{cancel}}
-                @aria={{hash
-                label="Role in Use"
-              }}
-              >
-                <:header>
-                  <h2>Role in Use</h2>
-                </:header>
-                <:body>
-                  <p>
-                    This Role is currently in use. If you choose to delete this Role, it will be removed from the
-                    following <strong>{{@items.length}} Tokens</strong>:
-                  </p>
-                  <TokenList @items={{@items}} @target="_blank" />
-                  <p>
-                    This action cannot be undone. {{message}}
-                  </p>
-                </:body>
-                <:actions as |close|>
-                  <Hds::ButtonSet>
-                    <Hds::Button
-                      @text='Yes, Delete'
-                      @color='critical'
-                      data-test-delete
-                      {{on 'click' (queue execute (fn @onDelete @item))}}
-                    />
-                    <Hds::Button
-                      @text='Cancel'
-                      @color='secondary'
-                      {{on 'click' close}}
-                    />
-                  </Hds::ButtonSet>
-                </:actions>
-              </ModalDialog>
-            {{else}}
-              <DeleteConfirmation @message={{message}} @execute={{queue execute (fn @onDelete @item)}} @cancel={{cancel}} />
-            {{/if}}
-          </:dialog>
-        </ConfirmationDialog>
-      {{/if}}
     </Hds::ButtonSet>
+
+    {{#if (and (not @create) (can "delete role" item=@item))}}
+      <ConfirmationDialog @message="Are you sure you want to delete this Role?">
+        <:action as |confirm|>
+          <Hds::Button
+            @text='Delete'
+            @color='critical'
+            {{on 'click' confirm}}
+            data-test-delete
+          />
+        </:action>
+        <:dialog as |execute cancel message|>
+          {{#if (gt @items.length 0)}}
+            <Hds::Modal
+              @color='critical'
+              @onClose={{cancel}}
+              as |M|
+            >
+              <M.Header @icon='alert-diamond'>Role in Use</M.Header>
+              <M.Body>
+                <p>
+                  This Role is currently in use. If you choose to delete this Role, it will be removed from the
+                  following <strong>{{@items.length}} Tokens</strong>:
+                </p>
+                <TokenList @items={{@items}} @target="_blank" />
+                <p>This action cannot be undone. {{message}}</p>
+              </M.Body>
+              <M.Footer as |F|>
+                <Hds::ButtonSet>
+                  <Hds::Button
+                    @text='Yes, Delete'
+                    @color='critical'
+                    data-test-delete
+                    {{on 'click' (queue execute (fn @onDelete @item))}}
+                  />
+                  <Hds::Button
+                    @text='Cancel'
+                    @color='secondary'
+                    {{on 'click' F.close}}
+                  />
+                </Hds::ButtonSet>
+              </M.Footer>
+            </Hds::Modal>
+          {{else}}
+            <DeleteConfirmation @message={{message}} @execute={{queue execute (fn @onDelete @item)}} @cancel={{cancel}} />
+          {{/if}}
+        </:dialog>
+      </ConfirmationDialog>
+    {{/if}}
   </div>
 </form>

--- a/ui/packages/consul-ui/app/components/consul/role/form/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/role/form/index.scss
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+// Role create/edit form layout.
+// Mirrors the token form pattern: flex column with 32px gap between each
+// top-level child (fieldsets, separators, button row). The separators
+// themselves carry their built-in margins reset to zero so the gap is
+// the sole source of vertical rhythm.
+.consul-role-form {
+  display: flex;
+  flex-direction: column;
+  // 32px between every top-level section (fieldsets, separator, usage block, actions).
+  gap: 32px;
+
+  // Reset HDS separator margins so the form gap is the sole source of spacing.
+  > .hds-separator {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  // Fields fieldset and policies fieldset: stack HDS form fields with 24px gap.
+  > fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  // Wrapper that groups the separator + usage block as one flex child so the
+  // form gap only fires once above this section.
+  &__used-by {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+
+    // Reset HDS separator margins so gap is the sole source of spacing.
+    > .hds-separator {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  // "Where is this role used?" section: heading + body text + label + table stacked at 8px.
+  &__usage {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  // Actions row: Save/Cancel on the left, Delete on the right.
+  &__actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/role/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/role/list/index.hbs
@@ -10,15 +10,48 @@
     @ariaLabel="Roles"
   >
     <:row as |item B|>
-      {{! ---- Role name ---- }}
+      {{! ---- Name ---- }}
       <B.Td>
-        <span class="consul-role-list__name">
-          <a
-            data-test-role={{item.Name}}
-            data-test-name
-            href={{href-to 'dc.acls.roles.edit' item.ID}}
-          >{{item.Name}}</a>
-          <Consul::Token::Ruleset::List @item={{item}} />
+        <a
+          class="consul-role-list__name"
+          data-test-role={{item.Name}}
+          data-test-name
+          href={{href-to 'dc.acls.roles.edit' item.ID}}
+        >{{item.Name}}</a>
+      </B.Td>
+
+      {{! ---- Identities (ServiceIdentities + NodeIdentities) ---- }}
+      <B.Td>
+        <span class="consul-role-list__badges" data-test-identities>
+          {{#each item.ServiceIdentities as |identity|}}
+            <Hds::Badge
+              @text={{identity.ServiceName}}
+              @color="neutral"
+              @type="filled"
+              @size="small"
+            />
+          {{/each}}
+          {{#each item.NodeIdentities as |identity|}}
+            <Hds::Badge
+              @text={{identity.NodeName}}
+              @color="neutral"
+              @type="filled"
+              @size="small"
+            />
+          {{/each}}
+        </span>
+      </B.Td>
+
+      {{! ---- Rules (Policies) ---- }}
+      <B.Td>
+        <span class="consul-role-list__badges" data-test-rules>
+          {{#each item.Policies as |policy|}}
+            <Consul::Acl::RulesetBadge
+              @item={{policy}}
+              @type={{policy/typeof policy}}
+              data-test-policy
+            />
+          {{/each}}
         </span>
       </B.Td>
 
@@ -57,8 +90,8 @@
   </Consul::DataTable>
 
   {{#if this.itemToDelete}}
-    <Hds::Modal id="confirm-modal" @color="warning" @onClose={{this.cancelDelete}} as |M|>
-      <M.Header @icon="alert-triangle">Confirm delete</M.Header>
+    <Hds::Modal id="confirm-modal" @color="critical" @onClose={{this.cancelDelete}} as |M|>
+      <M.Header @icon="trash">Confirm delete</M.Header>
       <M.Body>
         <p>Are you sure you want to delete this role?</p>
       </M.Body>

--- a/ui/packages/consul-ui/app/components/consul/role/list/index.js
+++ b/ui/packages/consul-ui/app/components/consul/role/list/index.js
@@ -12,7 +12,9 @@ import { action } from '@ember/object';
 // rendering lives in the template's :row block. The trailing "Actions" column
 // is right-aligned.
 const COLUMNS = [
-  { label: 'Role name' },
+  { label: 'Name' },
+  { label: 'Identities' },
+  { label: 'Rules' },
   { label: 'Description' },
   { label: 'Actions', align: 'right' },
 ];

--- a/ui/packages/consul-ui/app/components/consul/role/list/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/role/list/index.scss
@@ -4,27 +4,22 @@
  */
 
 .consul-role-list {
-  margin-top: 16px;
-
   /* Keep multi-word column headers on a single line. */
   .hds-table__th {
     white-space: nowrap;
   }
 
-  /* Let the Description column (2nd) absorb all the surplus width so the
-     trailing Actions column collapses to just the menu button. This table has
-     no naturally wide column, so without an explicit stretch column the spare
-     width would be spread across every column — including Actions, leaving a
-     large empty gap before the menu button. */
-  .hds-table__th:nth-child(2),
-  .hds-table__td:nth-child(2) {
+  /* Let the Description column (4th in the 5-column layout: Name, Identities,
+     Rules, Description, Actions) absorb all the surplus width so the trailing
+     Actions column collapses to just the menu button. */
+  .hds-table__th:nth-child(4),
+  .hds-table__td:nth-child(4) {
     width: 100%;
   }
 
-  /* Wrap long values (including unbreakable ones with no spaces, e.g. a role
-     name or description with no whitespace) onto multiple lines instead of
-     forcing the column endlessly wider. The trailing Actions column is excluded
-     so its menu button stays on one line. */
+  /* Wrap long values (including unbreakable ones with no spaces) onto multiple
+     lines instead of forcing the column endlessly wider. The trailing Actions
+     column is excluded so its menu button stays on one line. */
   .hds-table__td:not(:last-child) {
     overflow-wrap: anywhere;
   }
@@ -54,23 +49,20 @@
   }
 }
 
+/* Name cell: semibold link, wraps on long unbreakable values. */
 .consul-role-list__name {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 6px;
   font-weight: var(--token-typography-font-weight-semibold);
-
-  /* allow the flex container (and its link) to shrink below the name's
-     intrinsic width so a long, unbreakable name wraps instead of stretching
-     the column. */
+  overflow-wrap: anywhere;
   min-width: 0;
+}
 
-  a {
-    font-weight: var(--token-typography-font-weight-semibold);
-    overflow-wrap: anywhere;
-    min-width: 0;
-  }
+/* Badge rows used in the Identities and Rules columns: badges wrap onto
+   multiple lines when there are many of them. */
+.consul-role-list__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: flex-start;
 }
 
 .consul-role-list__description {

--- a/ui/packages/consul-ui/app/components/consul/role/toolbar/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/role/toolbar/index.scss
@@ -3,7 +3,17 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/* The toolbar is now a standalone element rendered directly above the table
+   card. It shares the same card chrome (border, radius) on three sides;
+   the bottom border is removed so the toolbar and the table card merge
+   into a single visual unit with no gap or doubled border between them. */
 .consul-role-toolbar {
+  padding: 8px;
+  background-color: var(--token-color-surface-faint);
+  border: 1px solid var(--token-color-border-faint);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+
   /* the sorter sits at the right end of the toolbar row */
   .consul-role-toolbar__sort {
     flex: 0 0 auto;
@@ -13,6 +23,12 @@
       min-height: 2.25rem;
     }
   }
+}
+
+/* Separator between the controls row and the applied-filters area below. */
+.consul-role-toolbar .hds-filter-bar__actions {
+  border-bottom: 1px solid var(--token-color-border-faint);
+  padding-bottom: 8px;
 }
 
 /* The roles index uses the HDS Filter Bar for its toolbar, so drop the

--- a/ui/packages/consul-ui/app/components/consul/token/list/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/token/list/index.scss
@@ -4,8 +4,6 @@
  */
 
 .consul-token-list {
-  margin-top: 16px;
-
   /* Keep multi-word column headers on a single line. */
   .hds-table__th {
     white-space: nowrap;

--- a/ui/packages/consul-ui/app/components/consul/token/toolbar/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/token/toolbar/index.scss
@@ -3,7 +3,17 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/* The toolbar is now a standalone element rendered directly above the table
+   card. It shares the same card chrome (border, radius) on three sides;
+   the bottom border is removed so the toolbar and the table card merge
+   into a single visual unit with no gap or doubled border between them. */
 .consul-token-toolbar {
+  padding: 8px;
+  background-color: var(--token-color-surface-faint);
+  border: 1px solid var(--token-color-border-faint);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+
   /* the sorter sits at the right end of the toolbar row */
   .consul-token-toolbar-row__sort {
     flex: 0 0 auto;
@@ -13,6 +23,12 @@
       min-height: 2.25rem;
     }
   }
+}
+
+/* Separator between the controls row and the applied-filters area below. */
+.consul-token-toolbar .hds-filter-bar__actions {
+  border-bottom: 1px solid var(--token-color-border-faint);
+  padding-bottom: 8px;
 }
 
 /* The tokens index uses the HDS Filter Bar for its toolbar, so drop the

--- a/ui/packages/consul-ui/app/components/token-list/index.hbs
+++ b/ui/packages/consul-ui/app/components/token-list/index.hbs
@@ -5,32 +5,31 @@
 
 {{yield}}
 {{#if (gt @items.length 0)}}
-  <TabularCollection
-      data-test-tokens
-      class="token-list"
-      @rows={{5}}
-      @items={{sort-by 'AccessorID:asc' @items}}
+  <Hds::Table
+    data-test-tokens
+    aria-label={{@caption}}
   >
-    <:caption>
-      {{#if @caption}}
-        {{@caption}}
-      {{/if}}
-    </:caption>
-    <:header>
-        <th>AccessorID</th>
-        <th>Scope</th>
-        <th>Description</th>
-    </:header>
-    <:row as |item index|>
-        <td data-test-token={{item.AccessorID}}>
-          <a href={{href-to 'dc.acls.tokens.edit' item.AccessorID}} target={{or @target ''}}>{{truncate item.AccessorID 8 false}}</a>
-        </td>
-        <td>
-          {{if item.Local 'local' 'global'}}
-        </td>
-        <td>
-          <p>{{item.Description}}</p>
-        </td>
-    </:row>
-  </TabularCollection>
+    <:head as |H|>
+      <H.Tr>
+        <H.Th>AccessorID</H.Th>
+        <H.Th>Scope</H.Th>
+        <H.Th>Description</H.Th>
+      </H.Tr>
+    </:head>
+    <:body as |B|>
+      {{#each (sort-by 'AccessorID:asc' @items) as |item|}}
+        <B.Tr>
+          <B.Td data-test-token={{item.AccessorID}}>
+            <a href={{href-to 'dc.acls.tokens.edit' item.AccessorID}} target={{or @target ''}}>{{truncate item.AccessorID 8 false}}</a>
+          </B.Td>
+          <B.Td>
+            {{if item.Local 'local' 'global'}}
+          </B.Td>
+          <B.Td>
+            {{item.Description}}
+          </B.Td>
+        </B.Tr>
+      {{/each}}
+    </:body>
+  </Hds::Table>
 {{/if}}

--- a/ui/packages/consul-ui/app/components/token-list/pageobject.js
+++ b/ui/packages/consul-ui/app/components/token-list/pageobject.js
@@ -4,7 +4,7 @@
  */
 
 export default (clickable, attribute, collection, deletable) => () => {
-  return collection('[data-test-tokens] [data-test-tabular-row]', {
+  return collection('[data-test-tokens] tbody tr', {
     id: attribute('data-test-token', '[data-test-token]'),
     token: clickable('a'),
     ...deletable(),

--- a/ui/packages/consul-ui/app/controllers/dc/acls/roles/edit.js
+++ b/ui/packages/consul-ui/app/controllers/dc/acls/roles/edit.js
@@ -11,6 +11,9 @@ export default class EditController extends Controller {
   @service('form')
   builder;
 
+  @service('dom')
+  dom;
+
   items = [];
 
   constructor() {
@@ -30,6 +33,21 @@ export default class EditController extends Controller {
         return prev;
       }, model)
     );
+  }
+
+  @action
+  change(e, value, item) {
+    const event = this.dom.normalizeEvent(e, value);
+    const form = this.form;
+    try {
+      form.handleEvent(event);
+    } catch (err) {
+      const target = event.target;
+      switch (target.name) {
+        default:
+          throw err;
+      }
+    }
   }
 
   // Forwarders replacing route-action helper usage

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -112,6 +112,7 @@
 @import 'consul-ui/components/consul/auth-method/list';
 @import 'consul-ui/components/consul/auth-method/toolbar';
 @import 'consul-ui/components/consul/token/form';
+@import 'consul-ui/components/consul/role/form';
 @import 'consul-ui/components/consul/token/ruleset/list';
 @import 'consul-ui/components/consul/token/list';
 @import 'consul-ui/components/consul/token/toolbar';

--- a/ui/packages/consul-ui/app/styles/routes/dc/acls/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/acls/index.scss
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* The token create/edit form uses HDS::Separator for section dividers, so the
-   global app-view rules that add border-bottom, padding-bottom, and
+/* The token and role create/edit forms use HDS::Separator for section dividers,
+   so the global app-view rules that add border-bottom, padding-bottom, and
    margin-bottom on every fieldset are redundant and must be suppressed. */
 html[data-route='dc.acls.tokens.create'],
-html[data-route='dc.acls.tokens.edit'] {
+html[data-route='dc.acls.tokens.edit'],
+html[data-route='dc.acls.roles.create'],
+html[data-route='dc.acls.roles.edit'] {
   .app-view form:not(.filter-bar) fieldset {
     border-bottom: none;
     padding-bottom: 0;

--- a/ui/packages/consul-ui/app/templates/dc/acls/roles/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/roles/edit.hbs
@@ -50,19 +50,6 @@ as |dc partition nspace item create|}}
           </h1>
       </:header>
       <:content>
-  {{#if (not create) }}
-        <div class="definition-table">
-            <dl>
-              <dt>Role ID</dt>
-              <dd>
-                <CopyableCode
-                  @value={{item.ID}}
-                  @name="Role ID"
-                />
-              </dd>
-            </dl>
-        </div>
-  {{/if}}
         <Consul::Role::Form
           @form={{this.form}}
           @item={{item}}
@@ -72,6 +59,7 @@ as |dc partition nspace item create|}}
           @create={{create}}
           @id={{route.params.id}}
           @items={{this.items}}
+          @onChange={{action 'change'}}
           @onCreate={{fn this.onCreate item}}
           @onUpdate={{fn this.onUpdate item}}
           @onCancel={{fn this.onCancel item}}

--- a/ui/packages/consul-ui/app/templates/dc/acls/roles/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/roles/index.hbs
@@ -67,17 +67,18 @@ as |route|>
       />
   {{/if}}
       </:actions>
-      <:toolbar>
-      {{#if (gt items.length 0) }}
-        <Consul::Role::Toolbar
-          @search={{this.search}}
-          @onsearch={{action (mut this.search) value="target.value"}}
-          @sort={{sort}}
-          @filter={{filters}}
-        />
-      {{/if}}
-      </:toolbar>
       <:content>
+        {{! Toolbar is rendered outside DataCollection so it persists
+            when filters/search reduce the visible rows to zero. It only
+            appears when there are actual roles in the catalog. }}
+        {{#if (gt items.length 0) }}
+          <Consul::Role::Toolbar
+            @search={{this.search}}
+            @onsearch={{action (mut this.search) value="target.value"}}
+            @sort={{sort}}
+            @filter={{filters}}
+          />
+        {{/if}}
         <DataCollection
           @type="role"
           @sort={{sort.value}}

--- a/ui/packages/consul-ui/app/templates/dc/acls/tokens/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/tokens/index.hbs
@@ -71,29 +71,30 @@ as |route|>
     />
   {{/if}}
       </:actions>
-      <:toolbar>
-    {{#if (gt items.length 0)}}
-        <Consul::Token::Toolbar
-          @search={{this.search}}
-          @onsearch={{action (mut this.search) value="target.value"}}
-          @filter={{filters}}
-        >
-          <:quickFilters>
-          {{! TODO: migrate this sort control to the new toolbar/table later }}
-          <Hds::Dropdown class="consul-token-toolbar-row__sort" @listPosition="bottom-right" @preserveContentInDom={{true}} data-test-sort-control as |dd|>
-            <dd.ToggleButton
-              @text={{if (eq sort.value "CreateTime:asc") (t "common.sort.age.asc") (t "common.sort.age.desc")}}
-              @color="secondary"
-              data-test-sort-toggle
-            />
-            <dd.Interactive data-test-sort-option {{on "click" (fn sort.change (hash target=(hash selected="CreateTime:desc")))}}>{{t "common.sort.age.desc"}}</dd.Interactive>
-            <dd.Interactive data-test-sort-option {{on "click" (fn sort.change (hash target=(hash selected="CreateTime:asc")))}}>{{t "common.sort.age.asc"}}</dd.Interactive>
-          </Hds::Dropdown>
-          </:quickFilters>
-        </Consul::Token::Toolbar>
-    {{/if}}
-      </:toolbar>
       <:content>
+        {{! Toolbar is rendered outside DataCollection so it persists
+            when filters/search reduce the visible rows to zero. It only
+            appears when there are actual tokens in the catalog. }}
+        {{#if (gt items.length 0)}}
+          <Consul::Token::Toolbar
+            @search={{this.search}}
+            @onsearch={{action (mut this.search) value="target.value"}}
+            @filter={{filters}}
+          >
+            <:quickFilters>
+            {{! TODO: migrate this sort control to the new toolbar/table later }}
+            <Hds::Dropdown class="consul-token-toolbar-row__sort" @listPosition="bottom-right" @preserveContentInDom={{true}} data-test-sort-control as |dd|>
+              <dd.ToggleButton
+                @text={{if (eq sort.value "CreateTime:asc") (t "common.sort.age.asc") (t "common.sort.age.desc")}}
+                @color="secondary"
+                data-test-sort-toggle
+              />
+              <dd.Interactive data-test-sort-option {{on "click" (fn sort.change (hash target=(hash selected="CreateTime:desc")))}}>{{t "common.sort.age.desc"}}</dd.Interactive>
+              <dd.Interactive data-test-sort-option {{on "click" (fn sort.change (hash target=(hash selected="CreateTime:asc")))}}>{{t "common.sort.age.asc"}}</dd.Interactive>
+            </Hds::Dropdown>
+            </:quickFilters>
+          </Consul::Token::Toolbar>
+        {{/if}}
     {{#if (token/is-legacy items)}}
       <Hds::Alert @type='inline' class='mb-3 mt-3' as |A|>
         <A.Title>Update</A.Title>

--- a/ui/packages/consul-ui/tests/integration/components/consul/role/form-test.js
+++ b/ui/packages/consul-ui/tests/integration/components/consul/role/form-test.js
@@ -20,6 +20,8 @@ module('Integration | Component | consul/role/form', function (hooks) {
     this.set('onCreate', () => {});
     this.set('onUpdate', () => {});
     this.set('onCancel', () => {});
+    this.set('onDelete', () => {});
+    this.set('onChange', () => {});
 
     // Helper function to render component with common args
     this.renderRoleForm = async (extraArgs = {}) => {
@@ -28,9 +30,11 @@ module('Integration | Component | consul/role/form', function (hooks) {
           @form={{this.form}}
           @item={{this.item}}
           @create={{this.create}}
+          @onChange={{this.onChange}}
           @onCreate={{this.onCreate}}
           @onUpdate={{this.onUpdate}}
           @onCancel={{this.onCancel}}
+          @onDelete={{this.onDelete}}
         />
       `);
     };

--- a/ui/packages/consul-ui/tests/pages/dc/acls/roles/edit.js
+++ b/ui/packages/consul-ui/tests/pages/dc/acls/roles/edit.js
@@ -6,9 +6,9 @@
 export default function (visitable, submitable, deletable, cancelable, policySelector, tokenList) {
   return {
     visit: visitable(['/:dc/acls/roles/:role', '/:dc/acls/roles/create']),
-    ...submitable({}, 'main form > div'),
-    ...cancelable({}, 'main form > div'),
-    ...deletable({}, 'main form > div'),
+    ...submitable({}, 'main form .consul-role-form__actions'),
+    ...cancelable({}, 'main form .consul-role-form__actions'),
+    ...deletable({}, 'main form .consul-role-form__actions'),
     policies: policySelector(''),
     tokens: tokenList(),
   };


### PR DESCRIPTION
## Summary

Migrates the ACL Roles UI components to the HashiCorp Design System (HDS).

## Changes

- `app/components/consul/role/form/index.hbs` — updated role form to use HDS components
- `app/components/consul/role/form/index.scss` — new scoped styles for the role form
- `app/components/consul/role/fieldsets/` — new fieldsets component (index.hbs, README.mdx)
- `app/components/token-list/index.hbs` — updated token list template
- `app/components/token-list/pageobject.js` — updated page object for token list
- `app/controllers/dc/acls/roles/edit.js` — updated edit controller
- `app/styles/components.scss` — component style updates
- `app/styles/routes/dc/acls/index.scss` — ACL route style updates
- `app/templates/dc/acls/roles/edit.hbs` — updated edit template
- `tests/integration/components/consul/role/form-test.js` — updated integration tests
- `tests/pages/dc/acls/roles/edit.js` — updated page object for roles edit

## Related

Part of the broader HDS migration work, targeting the roles section of ACLs.
