### PR TITLE
feat: migrate policies UI to HDS components

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/policy/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/policy/fieldsets/index.hbs
@@ -1,0 +1,203 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<fieldset
+  disabled={{if (not (can "write policy" item=@item)) "disabled"}}
+>
+  {{! Policy ID — read-only, edit mode only }}
+  {{#unless @create}}
+    <Hds::Form::MaskedInput::Field
+      readonly
+      @isContentMasked={{false}}
+      @hasCopyButton={{true}}
+      @value={{@item.ID}}
+      as |F|
+    >
+      <F.Label>Policy ID</F.Label>
+    </Hds::Form::MaskedInput::Field>
+  {{/unless}}
+
+  {{! Name }}
+  <Hds::Form::TextInput::Field
+    @value={{@item.Name}}
+    name="policy[Name]"
+    @isInvalid={{if (and @item.error.Name (not @item.isPristine)) true false}}
+    {{on "input" this.handleChange}}
+    as |F|
+  >
+    <F.Label>Name</F.Label>
+    <F.HelperText>
+      Maximum 128 characters. May only include letters (uppercase and/or lowercase) and/or numbers.
+      Must be unique.
+    </F.HelperText>
+    {{#if (and @item.error.Name (not @item.isPristine))}}
+      <F.Error>{{@item.error.Name.validation}}</F.Error>
+    {{/if}}
+  </Hds::Form::TextInput::Field>
+
+  {{! Description — only for regular (non-identity) policies }}
+  {{#if (eq @item.template "")}}
+    <Hds::Form::Textarea::Field
+      @value={{@item.Description}}
+      name="policy[Description]"
+      @isOptional={{true}}
+      {{on "input" this.handleChange}}
+      as |F|
+    >
+      <F.Label>Description</F.Label>
+    </Hds::Form::Textarea::Field>
+  {{/if}}
+
+  {{! Rules / Code section }}
+  {{#if (eq @item.template "service-identity")}}
+    <Hds::CodeBlock
+      @language="hcl"
+      @ariaLabel="policy[Rules]"
+      @value={{service-identity-template
+        @item.Name
+        nspace=@nspace
+        partition=@partition
+        canUsePartitions=(can "use partitions")
+        canUseNspaces=(can "use nspaces")
+      }}
+      as |CB|
+    >
+      <CB.Title @tag="span">
+        Rules
+        <a
+          href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
+          rel="help noopener noreferrer"
+          target="_blank"
+          style="color: inherit;"
+        >(HCL Format)</a>
+      </CB.Title>
+    </Hds::CodeBlock>
+  {{else if (eq @item.template "node-identity")}}
+    <Hds::CodeBlock
+      @language="hcl"
+      @ariaLabel="policy[Rules]"
+      @value={{node-identity-template
+        @item.Name
+        partition=@partition
+        canUsePartitions=(can "use partitions")
+        canUseNspaces=(can "use nspaces")
+      }}
+      as |CB|
+    >
+      <CB.Title @tag="span">
+        Rules
+        <a
+          href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
+          rel="help noopener noreferrer"
+          target="_blank"
+          style="color: inherit;"
+        >(HCL Format)</a>
+      </CB.Title>
+    </Hds::CodeBlock>
+  {{else}}
+    <Hds::CodeEditor
+      @value={{@item.Rules}}
+      @ariaLabel="policy[Rules]"
+      @syntax="hcl"
+      @onInput={{fn this.handleChange "policy[Rules]"}}
+      as |CE|
+    >
+      <CE.Title @tag="span">
+        Rules
+        <a
+          href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
+          rel="help noopener noreferrer"
+          target="_blank"
+          style="color: inherit;"
+        >(HCL Format)</a>
+      </CE.Title>
+    </Hds::CodeEditor>
+    {{#if @item.error.Rules}}
+      <Hds::Form::Error>{{@item.error.Rules.validation}}</Hds::Form::Error>
+    {{/if}}
+  {{/if}}
+</fieldset>
+
+<Hds::Separator />
+
+{{! Valid Datacenters — only for node-identity: Datacenter dropdown }}
+{{#if (eq @item.template "node-identity")}}
+  <fieldset>
+    <DataSource
+      @src={{uri "/*/*/*/datacenters"}}
+      @onchange={{this.setDatacenters}}
+    />
+    <Hds::Form::SuperSelect::Single::Field
+      @options={{map-by "Name" this.datacenters}}
+      @selected={{or @item.Datacenter @dc}}
+      @searchField="Name"
+      @searchPlaceholder="Type a datacenter name"
+      @onChange={{fn this.handleChange "Datacenter"}}
+      @searchEnabled={{true}}
+      @label="Datacenter"
+      @listboxAriaLabel="Available datacenters"
+      @isOptional={{false}}
+      id="datacenter-select"
+      name="policy[Datacenter]"
+    as |F|>
+      <F.Options>{{F.options}}</F.Options>
+    </Hds::Form::SuperSelect::Single::Field>
+  </fieldset>
+{{else}}
+  {{! Valid Datacenters section — only for the default partition }}
+  {{#if (eq (or @partition "default") "default")}}
+    <fieldset>
+      <Hds::Text::Display @size="300" @tag="h2">Valid datacenters</Hds::Text::Display>
+
+      <Hds::Form::Toggle::Field
+        name="policy[isScoped]"
+        checked={{if (not this.isScoped) true false}}
+        {{on "change" this.handleChange}}
+        as |F|
+      >
+        <F.Label>All datacenters</F.Label>
+      </Hds::Form::Toggle::Field>
+
+      {{! Always load the datacenter list so checkboxes render in both states }}
+      <DataSource
+        @src={{uri "/*/*/*/datacenters"}}
+        @onchange={{this.setDatacenters}}
+      />
+
+      {{! Always render checkboxes.
+          When "All datacenters" is on (isScoped=false): checked + disabled.
+          When scoped (isScoped=true): interactive, reflecting current selection. }}
+      <div class="consul-policy-fieldsets__datacenter-checkboxes" role="group">
+        {{#each this.datacenters as |dc|}}
+          <Hds::Form::Checkbox::Field
+            @value={{dc.Name}}
+            name="policy[Datacenters]"
+            checked={{if (not this.isScoped) true (if (includes dc.Name @item.Datacenters) true false)}}
+            disabled={{if (not this.isScoped) true false}}
+            {{on "change" this.handleChange}}
+            as |F|
+          >
+            <F.Label>{{dc.Name}}</F.Label>
+          </Hds::Form::Checkbox::Field>
+        {{/each}}
+        {{! Render any selected datacenters that are no longer returned by the API }}
+        {{#each @item.Datacenters as |dc|}}
+          {{#if (not (find-by "Name" dc this.datacenters))}}
+            <Hds::Form::Checkbox::Field
+              @value={{dc}}
+              name="policy[Datacenters]"
+              checked={{true}}
+              disabled={{if (not this.isScoped) true false}}
+              {{on "change" this.handleChange}}
+              as |F|
+            >
+              <F.Label>{{dc}}</F.Label>
+            </Hds::Form::Checkbox::Field>
+          {{/if}}
+        {{/each}}
+      </div>
+    </fieldset>
+  {{/if}}
+{{/if}}

--- a/ui/packages/consul-ui/app/components/consul/policy/fieldsets/index.js
+++ b/ui/packages/consul-ui/app/components/consul/policy/fieldsets/index.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { set } from '@ember/object';
+
+/**
+ * Consul::Policy::Fieldsets
+ *
+ * Owns the `isScoped` toggle state that controls whether the datacenter
+ * checkbox list is shown, and the `datacenters` list loaded via DataSource.
+ * All field-change events are forwarded to the parent form via `@onChange`.
+ */
+export default class ConsulPolicyFieldsets extends Component {
+  // true when the user has scoped the policy to specific datacenters
+  @tracked isScoped = (this.args.item?.Datacenters?.length ?? 0) > 0;
+
+  // datacenter list populated by <DataSource>
+  @tracked datacenters = [];
+
+  // saved datacenter selection while toggled to "All datacenters"
+  previousDatacenters = null;
+
+  @action
+  setDatacenters(e) {
+    this.datacenters = e?.data ?? [];
+  }
+
+  @action
+  handleChange(e, value) {
+    const name = e?.target?.name ?? '';
+
+    if (name === 'policy[isScoped]') {
+      if (this.isScoped) {
+        // switching to "All datacenters" — save and clear the selection
+        this.previousDatacenters = this.args.item.Datacenters;
+        set(this.args.item, 'Datacenters', null);
+      } else {
+        // switching back to scoped — restore previous selection
+        set(this.args.item, 'Datacenters', this.previousDatacenters);
+        this.previousDatacenters = null;
+      }
+      this.isScoped = !this.isScoped;
+      // notify parent that the form data has changed
+      this.args.onChange?.(e, value);
+      return;
+    }
+
+    this.args.onChange?.(e, value);
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/policy/form/README.mdx
+++ b/ui/packages/consul-ui/app/components/consul/policy/form/README.mdx
@@ -1,24 +1,27 @@
 # Consul::Policy::Form
 
-A presentational component that renders the Policy edit/create form and the action buttons (Save / Cancel / Delete). It wraps the existing PolicyForm fieldset, conditionally loads tokens that use the policy, and delegates create/update/cancel/delete behavior to closure actions supplied by caller.
+A presentational component that renders the Policy create/edit form and the
+action buttons (Save / Cancel / Delete). It wraps `Consul::Policy::Fieldsets`,
+conditionally loads tokens that use the policy, and delegates create/update/
+cancel/delete behaviour to closure actions supplied by the caller.
 
 ## Usage
 
 ```hbs
 <Consul::Policy::Form
-  @form={{form}}
-  @partition={{partition}}
-  @nspace={{nspace}}
   @item={{item}}
   @create={{create}}
   @dc={{dc}}
+  @partition={{partition}}
+  @nspace={{nspace}}
   @id={{id}}
   @items={{items}}
-  @onCreate={{route-action 'create' item}}
-  @onUpdate={{route-action 'update' item}}
-  @onCancel={{route-action 'cancel' item}}
-  @onDelete={{route-action 'delete'}}
+  @onCreate={{fn this.onCreate item}}
+  @onUpdate={{fn this.onUpdate item}}
+  @onCancel={{fn this.onCancel item}}
+  @onDelete={{fn this.onDelete item}}
   @onItemsChange={{action (mut items) value="data"}}
+  @onChange={{action "change"}}
 />
 ```
 
@@ -26,37 +29,46 @@ A presentational component that renders the Policy edit/create form and the acti
 
 | Argument | Type | Required | Description |
 |---|---:|:---:|---|
-| `@form` | object | yes | Form builder / changeset used by PolicyForm. |
-| `@partition` | string | yes | Current partition. |
-| `@nspace` | string | yes | Current namespace. |
 | `@item` | object | yes | Policy model / changeset. |
-| `@create` | boolean | no | True when rendering the "create" flow. |
+| `@create` | boolean | no | True when rendering the create flow. |
 | `@dc` | string | no | Datacenter identifier used to build DataSource URIs. |
-| `@id` | string | no | Policy id (used to fetch tokens for the policy). |
-| `@items` | array | no | Tokens currently associated with the policy (passed from caller). |
-| `@onCreate` | function | no | Closure invoked to create the policy (caller typically passes `route-action 'create' item`). |
-| `@onUpdate` | function | no | Closure invoked to update the policy (caller typically passes `route-action 'update' item`). |
-| `@onCancel` | function | no | Closure invoked when Cancel is clicked (caller typically passes `route-action 'cancel' item` or a transition). |
-| `@onDelete` | function | no | Closure invoked to delete the policy (caller typically passes `route-action 'delete'`). |
-| `@onItemsChange` | function | no | Handler for DataSource `onchange`; recommended: `action (mut items) value="data"`. |
+| `@partition` | string | no | Current partition. |
+| `@nspace` | string | no | Current namespace. |
+| `@id` | string | no | Policy ID (used to fetch associated tokens). |
+| `@items` | array | no | Tokens currently associated with the policy (kept in sync via `@onItemsChange`). |
+| `@onCreate` | function | no | Invoked when Save is clicked in create mode. |
+| `@onUpdate` | function | no | Invoked when Save is clicked in edit mode. |
+| `@onCancel` | function | no | Invoked when Cancel is clicked. |
+| `@onDelete` | function | no | Invoked after the user confirms deletion. |
+| `@onItemsChange` | function | no | Handler for the DataSource `onchange` event; recommended: `action (mut items) value="data"`. |
+| `@onChange` | function | no | Forwarded to `Consul::Policy::Fieldsets` for all field input events. |
 
-## Behavior / Notes
+## Behaviour / Notes
 
-- When not in create mode and the policy has an ID, the component loads related tokens via the DataSource:
-  /{partition}/{nspace}/{dc}/tokens/for-policy/{id}. The caller should provide `@onItemsChange` to keep caller state in sync.
-- Save button:
-  - If `@create` is true and caller has permission → invokes `@onCreate`.
-  - Otherwise → invokes `@onUpdate` if provided.
-- Cancel button calls `@onCancel`. Pass a route-action (preferred) so route-level handlers (e.g. WithBlockingActions) are used, or pass a controller action if desired.
-- Delete button opens a confirmation dialog; actual delete is triggered by calling the provided `@onDelete` closure (confirmed via the dialog).
-- Keep argument names and usage consistent with existing callers. Pass route-action closures when the route/mixin provides the action (create/update/delete/cancel).
+- `Consul::Policy::Form` owns only the **delete modal** state
+  (`showDeleteModal`). Field state, `isScoped` toggle, and datacenter list are
+  owned by `Consul::Policy::Fieldsets`.
+- When not in create mode and the policy has an ID, the component loads related
+  tokens via DataSource `/${partition}/${nspace}/${dc}/tokens/for-policy/${id}`.
+  Pass `@onItemsChange` to keep caller state in sync.
+- **Save button**:
+  - `@create` is true and caller has `create tokens` permission → invokes `@onCreate`.
+  - Otherwise → invokes `@onUpdate` if the caller has `write policy` permission.
+- **Delete button** opens an `Hds::Modal` confirmation:
+  - If the policy has associated tokens the modal lists them before confirming.
+  - Actual delete is triggered by calling `@onDelete` (via `this.confirmDelete`).
+- **Action layout**: Save / Cancel (`Hds::ButtonSet`) are on the left; Delete
+  (`Hds::Button @color="critical"`) is on the right, matching the Figma design.
+
+## Sub-components
+
+- `Consul::Policy::Fieldsets` — HDS form fields (Policy ID, Name, Description,
+  Rules / CodeEditor, Valid Datacenters toggle + checkbox list).
 
 ## See
 
-- Component template: ./index.hbs  
-- Component class: ./index.js
-
-## Implementation hints
-
-- Invoke closure args directly inside the component (use `{{on 'click' @onCreate}}`, `{{on 'click' @onCancel}}`, `{{on 'click' (fn confirm @onDelete @item)}}`) so the calling context (route or controller) receives the event.
-- Avoid reserved/uppercase argument names (e.g. use `@local` not `@Local`).
+- Component template: [`./index.hbs`](./index.hbs)
+- Component class: [`./index.js`](./index.js)
+- Form layout styles: [`./index.scss`](./index.scss)
+- Fieldsets template: [`../fieldsets/index.hbs`](../fieldsets/index.hbs)
+- Fieldsets class: [`../fieldsets/index.js`](../fieldsets/index.js)

--- a/ui/packages/consul-ui/app/components/consul/policy/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/policy/form/index.hbs
@@ -3,116 +3,140 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<form>
-  <PolicyForm
-    @form={{@form}}
+<form class="consul-policy-form">
+  {{! Core fields: Policy ID, Name, Description, Rules, Valid Datacenters }}
+  <Consul::Policy::Fieldsets
+    @item={{@item}}
+    @create={{@create}}
+    @dc={{@dc}}
     @partition={{@partition}}
     @nspace={{@nspace}}
-    @item={{@item}}
-  >
-    {{!don't show template selection here, i.e. Service Identity}}
-    <:template></:template>
-  </PolicyForm>
-{{#if (and (not @create) @item @item.ID)}}
+    @onChange={{@onChange}}
+  />
+
+  {{! Applied to the following tokens — edit mode only }}
+  {{#if (and (not @create) @item @item.ID)}}
     <DataSource
-      @src={{uri '/${partition}/${nspace}/${dc}/tokens/for-policy/${id}'
+      @src={{uri "/${partition}/${nspace}/${dc}/tokens/for-policy/${id}"
         (hash
           partition=@partition
           nspace=@nspace
           dc=@dc
-          id=(or @id '')
+          id=(or @id "")
         )
       }}
       @onchange={{@onItemsChange}}
     />
     {{#if (gt @items.length 0)}}
-      <TokenList
-        @caption="Applied to the following tokens:"
-        @items={{@items}}
+      <div class="consul-policy-form__used-by">
+        <Hds::Separator />
+        <div class="consul-policy-form__usage">
+          <Hds::Form::Label>Applied to the following tokens:</Hds::Form::Label>
+          <TokenList @caption="Applied to the following tokens:" @items={{@items}} />
+        </div>
+      </div>
+    {{/if}}
+  {{/if}}
+
+  {{! Action buttons: Save + Cancel left, Delete right }}
+  <div class="consul-policy-form__actions">
+    <Hds::ButtonSet>
+      {{#if (and @create (can "create tokens"))}}
+        <Hds::Button
+          @text="Save"
+          type="submit"
+          {{on "click" @onCreate}}
+          disabled={{if (or @item.isPristine @item.isInvalid (eq @item.Name "")) "disabled"}}
+        />
+      {{else}}
+        {{#if (can "write policy" item=@item)}}
+          <Hds::Button
+            @text="Save"
+            type="submit"
+            {{on "click" @onUpdate}}
+            disabled={{if @item.isInvalid "disabled"}}
+          />
+        {{/if}}
+      {{/if}}
+      <Hds::Button
+        @text="Cancel"
+        @color="secondary"
+        type="reset"
+        {{on "click" @onCancel}}
+      />
+    </Hds::ButtonSet>
+
+    {{#if (and (not @create) (can "delete policy" item=@item))}}
+      <Hds::Button
+        @text="Delete"
+        @color="critical"
+        {{on "click" this.openDeleteModal}}
+        data-test-delete
       />
     {{/if}}
-{{/if}}
-    <div>
-      <Hds::ButtonSet>
-        {{#if (and @create (can "create tokens")) }}
-        {{! we only need to check for an empty name here as ember munges autofocus, once we have autofocus back revisit this}}
-          <Hds::Button
-            @text='Save'
-            type='submit'
-            {{ on 'click' @onCreate}}
-            disabled={{if (or @item.isPristine @item.isInvalid (eq @item.Name '')) 'disabled'}}
-          />
-        {{ else }}
-          {{#if (can "write policy" item=@item)}}
+  </div>
+
+  {{! Delete confirmation modal }}
+  {{#if this.showDeleteModal}}
+    {{#if (gt @items.length 0)}}
+      <Hds::Modal
+        @color="critical"
+        @onClose={{this.closeDeleteModal}}
+        data-test-delete-modal
+        as |M|
+      >
+        <M.Header @icon="alert-diamond">Policy in Use</M.Header>
+        <M.Body>
+          <p>
+            This Policy is currently in use. If you choose to delete this Policy, it will be removed
+            from the following <strong>{{@items.length}} Tokens</strong>:
+          </p>
+          <TokenList @items={{@items}} @target="_blank" />
+          <p>This action cannot be undone.</p>
+        </M.Body>
+        <M.Footer as |F|>
+          <Hds::ButtonSet>
             <Hds::Button
-              @text='Save'
-              type='submit'
-              {{ on 'click' @onUpdate}}
-              disabled={{if @item.isInvalid 'disabled'}}
+              @text="Yes, Delete"
+              @color="critical"
+              data-test-delete
+              {{on "click" this.confirmDelete}}
             />
-          {{/if}}
-        {{/if}}
-        <Hds::Button
-          @text='Cancel'
-          @color='secondary'
-          type='reset'
-          {{ on 'click' @onCancel}}
-        />
-        {{# if (and (not @create) (can "delete policy" item=@item) ) }}
-          <ConfirmationDialog @message="Are you sure you want to delete this Policy?">
-            <:action as |confirm|>
-              <Hds::Button
-                @text='Delete'
-                @color='critical'
-                {{on 'click' confirm}}
-                data-test-delete
-              />
-            </:action>
-            <:dialog as |execute cancel message|>
-              {{#if (gt @items.length 0)}}
-                <ModalDialog
-                  data-test-delete-modal
-                  @onclose={{cancel}}
-                  @open={{true}}
-                  @aria={{hash
-                  label="Policy in Use"
-                }}
-                >
-                  <:header>
-                    <h2>Policy in Use</h2>
-                  </:header>
-                  <:body>
-                    <p>
-                      This Policy is currently in use. If you choose to delete this Policy, it will be removed from the
-                      following <strong>{{@items.length}} Tokens</strong>:
-                    </p>
-                    <TokenList @items={{@items}} @target="_blank" />
-                    <p>
-                      This action cannot be undone. {{message}}
-                    </p>
-                  </:body>
-                  <:actions as |close|>
-                    <Hds::ButtonSet>
-                      <Hds::Button
-                        @text='Yes, Delete'
-                        data-test-delete
-                        @color='critical'
-                        {{on 'click' (queue execute (fn @onDelete @item))}}
-                      />
-                      <Hds::Button
-                        @text='Cancel'
-                        @color='secondary'
-                        {{on 'click' close}}
-                      />
-                    </Hds::ButtonSet>
-                  </:actions>
-                </ModalDialog>
-              {{else}}
-                <DeleteConfirmation @message={{message}} @execute={{queue execute (fn @onDelete @item)}} @cancel={{cancel}} />
-              {{/if}}
-            </:dialog>
-          </ConfirmationDialog>
-        {{/if}}
-      </Hds::ButtonSet>
-    </div>
+            <Hds::Button
+              @text="Cancel"
+              @color="secondary"
+              {{on "click" F.close}}
+            />
+          </Hds::ButtonSet>
+        </M.Footer>
+      </Hds::Modal>
+    {{else}}
+      <Hds::Modal
+        @color="critical"
+        @onClose={{this.closeDeleteModal}}
+        data-test-delete-modal
+        as |M|
+      >
+        <M.Header @icon="trash">Confirm delete</M.Header>
+        <M.Body>
+          <p>Are you sure you want to delete this Policy?</p>
+        </M.Body>
+        <M.Footer as |F|>
+          <Hds::ButtonSet>
+            <Hds::Button
+              @text="Delete"
+              @color="critical"
+              data-test-delete
+              {{on "click" this.confirmDelete}}
+            />
+            <Hds::Button
+              @text="Cancel"
+              @color="secondary"
+              {{on "click" F.close}}
+            />
+          </Hds::ButtonSet>
+        </M.Footer>
+      </Hds::Modal>
+    {{/if}}
+  {{/if}}
 </form>

--- a/ui/packages/consul-ui/app/components/consul/policy/form/index.js
+++ b/ui/packages/consul-ui/app/components/consul/policy/form/index.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+/**
+ * Consul::Policy::Form
+ *
+ * Owns the Delete confirmation modal state.  All other actions (Save, Cancel,
+ * Delete invoke) are delegated to the parent via @onCreate / @onUpdate /
+ * @onCancel / @onDelete args.
+ */
+export default class ConsulPolicyForm extends Component {
+  // true while the delete-confirmation modal is open
+  @tracked showDeleteModal = false;
+
+  @action
+  openDeleteModal() {
+    this.showDeleteModal = true;
+  }
+
+  @action
+  closeDeleteModal() {
+    this.showDeleteModal = false;
+  }
+
+  @action
+  confirmDelete() {
+    this.showDeleteModal = false;
+    this.args.onDelete(this.args.item);
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/policy/form/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/policy/form/index.scss
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+// Policy create/edit form layout.
+// Mirrors the token and role form patterns: flex column with 32px gap between
+// each top-level child (fieldsets, separators, tokens section, action row).
+// Separators' built-in margins are reset to zero so the gap is the sole source
+// of vertical rhythm.
+.consul-policy-form {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+
+  // Reset HDS separator margins so the form gap is the sole source of spacing.
+  > .hds-separator {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  // All top-level fieldsets: flex column so HDS form fields stack with 24px gap.
+  > fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  // Wrapper that groups the separator + "Applied to tokens" block as one flex
+  // child so the form gap only fires once above this section.
+  &__used-by {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+
+    // Reset HDS separator margins inside the used-by block.
+    > .hds-separator {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  // "Applied to the following tokens" section: label + table stacked at 8px.
+  &__usage {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  // Actions row: Save/Cancel on the left, Delete on the right.
+  &__actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  // Datacenter checkbox list: wrap items in a row, consistent with the Figma
+  // horizontal arrangement.
+  .consul-policy-fieldsets__datacenter-checkboxes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+}

--- a/ui/packages/consul-ui/app/components/consul/policy/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/policy/list/index.hbs
@@ -70,8 +70,8 @@
   </Consul::DataTable>
 
   {{#if this.itemToDelete}}
-    <Hds::Modal id="confirm-modal" @color="warning" @onClose={{this.cancelDelete}} as |M|>
-      <M.Header @icon="alert-triangle">Confirm delete</M.Header>
+    <Hds::Modal id="confirm-modal" @color="critical" @onClose={{this.cancelDelete}} as |M|>
+      <M.Header @icon="trash">Confirm delete</M.Header>
       <M.Body>
         <p>Are you sure you want to delete this policy?</p>
       </M.Body>

--- a/ui/packages/consul-ui/app/components/consul/policy/list/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/policy/list/index.scss
@@ -4,8 +4,6 @@
  */
 
 .consul-policy-list {
-  margin-top: 16px;
-
   /* Keep multi-word column headers on a single line. */
   .hds-table__th {
     white-space: nowrap;

--- a/ui/packages/consul-ui/app/components/consul/policy/toolbar/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/policy/toolbar/index.scss
@@ -3,7 +3,17 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/* The toolbar is now a standalone element rendered directly above the table
+   card. It shares the same card chrome (border, radius) on three sides;
+   the bottom border is removed so the toolbar and the table card merge
+   into a single visual unit with no gap or doubled border between them. */
 .consul-policy-toolbar {
+  padding: 8px;
+  background-color: var(--token-color-surface-faint);
+  border: 1px solid var(--token-color-border-faint);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+
   /* the sorter sits at the right end of the toolbar row */
   .consul-policy-toolbar__sort {
     flex: 0 0 auto;
@@ -13,6 +23,12 @@
       min-height: 2.25rem;
     }
   }
+}
+
+/* Separator between the controls row and the applied-filters area below. */
+.consul-policy-toolbar .hds-filter-bar__actions {
+  border-bottom: 1px solid var(--token-color-border-faint);
+  padding-bottom: 8px;
 }
 
 /* The policies index uses the HDS Filter Bar for its toolbar, so drop the

--- a/ui/packages/consul-ui/app/controllers/dc/acls/policies/edit.js
+++ b/ui/packages/consul-ui/app/controllers/dc/acls/policies/edit.js
@@ -11,6 +11,9 @@ export default class EditController extends Controller {
   @service('form')
   builder;
 
+  @service('dom')
+  dom;
+
   items = [];
 
   constructor() {
@@ -30,6 +33,26 @@ export default class EditController extends Controller {
         return prev;
       }, model)
     );
+  }
+
+  @action
+  change(e, value, item) {
+    const event = this.dom.normalizeEvent(e, value);
+    const form = this.form;
+    try {
+      form.handleEvent(event);
+    } catch (err) {
+      const target = event.target;
+      switch (target.name) {
+        case 'policy[isScoped]':
+          // isScoped is a UI-only toggle — not a real model property.
+          // The fieldsets component owns this state, so we silently swallow
+          // the "unknown property" error that the form builder would throw.
+          break;
+        default:
+          throw err;
+      }
+    }
   }
 
   // Forwarders replacing route-action usage

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -116,6 +116,7 @@
 @import 'consul-ui/components/consul/token/ruleset/list';
 @import 'consul-ui/components/consul/token/list';
 @import 'consul-ui/components/consul/token/toolbar';
+@import 'consul-ui/components/consul/policy/form';
 @import 'consul-ui/components/consul/policy/list';
 @import 'consul-ui/components/consul/policy/toolbar';
 @import 'consul-ui/components/consul/role/list';

--- a/ui/packages/consul-ui/app/styles/routes/dc/acls/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/acls/index.scss
@@ -3,17 +3,26 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* The token and role create/edit forms use HDS::Separator for section dividers,
-   so the global app-view rules that add border-bottom, padding-bottom, and
-   margin-bottom on every fieldset are redundant and must be suppressed. */
+/* The token, role and policy create/edit forms use HDS::Separator for section
+   dividers, so the global app-view rules that add border-bottom, padding-bottom,
+   and margin-bottom on every fieldset are redundant and must be suppressed.
+   Additionally the global `.app-shell__main table th span::after` rule injects
+   an info-circle icon into every HDS Table header span; suppress it on the
+   policy form's token table. */
 html[data-route='dc.acls.tokens.create'],
 html[data-route='dc.acls.tokens.edit'],
 html[data-route='dc.acls.roles.create'],
-html[data-route='dc.acls.roles.edit'] {
+html[data-route='dc.acls.roles.edit'],
+html[data-route='dc.acls.policies.create'],
+html[data-route='dc.acls.policies.edit'] {
   .app-view form:not(.filter-bar) fieldset {
     border-bottom: none;
     padding-bottom: 0;
     margin-bottom: 0;
+  }
+
+  .consul-policy-form table th span::after {
+    content: none;
   }
 }
 

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/edit.hbs
@@ -56,19 +56,6 @@ as |dc partition nspace id item create|}}
           </h1>
       </:header>
       <:content>
-  {{#if (not create) }}
-        <div class="definition-table">
-            <dl>
-              <dt>Policy ID</dt>
-              <dd>
-                <CopyableCode
-                  @value={{item.ID}}
-                  @name="Policy ID"
-                />
-              </dd>
-            </dl>
-        </div>
-  {{/if}}
   {{#if (or (eq (policy/typeof item) 'policy-management') (eq (policy/typeof item) 'read-only'))}}
     <Hds::Alert @type="inline" @icon="star-fill" class="mb-3 mt-2" as |A|>
       <A.Title>Built-in policy</A.Title>
@@ -105,7 +92,6 @@ as |dc partition nspace id item create|}}
     </DataSource>
   {{else}}
         <Consul::Policy::Form
-          @form={{this.form}}
           @partition={{partition}}
           @nspace={{nspace}}
           @item={{item}}
@@ -118,6 +104,7 @@ as |dc partition nspace id item create|}}
           @onCancel={{fn this.onCancel item}}
           @onDelete={{fn this.onDelete item}}
           @onItemsChange={{action (mut this.items) value="data"}}
+          @onChange={{action "change"}}
         />
   {{/if}}
       </:content>


### PR DESCRIPTION
## Summary

Migrates the Consul UI ACL Policies views to use HashiCorp Design System (HDS) components.

## Changes

- **`policy/form`** – Refactored form template and added backing JS + SCSS; extracted fieldsets into a dedicated `fieldsets` component
- **`policy/fieldsets`** – New component encapsulating policy-specific form fields
- **`policy/list`** – Updated list template to use HDS components
- **`dc/acls/policies/edit`** – Updated edit route template and controller
- **`styles/components.scss`** / **`routes/dc/acls/index.scss`** – Style updates to align with HDS tokens

## Notes

- `config/environment.js` changes are intentionally excluded from this PR and will follow in a separate commit.
