### PR TITLE
ui: migrate auth-methods components to HDS

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/auth-method/binding-list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/binding-list/index.hbs
@@ -5,34 +5,40 @@
 
 <div class="consul-auth-method-binding-list">
   <h2>{{@item.BindName}}</h2>
-  <dl>
-    <dt class="type">{{t "models.binding-rule.BindType"}}</dt>
-    <dd>
-      {{@item.BindType}}
-      {{#let
-        (if
-          (eq @item.BindType 'service')
-          (t "components.consul.auth-method.binding-list.bind-type.service")
+  <Hds::Card::Container
+    @level="base"
+    @hasBorder={{true}}
+    class="consul-auth-method-binding-list__card"
+  >
+    <dl class="consul-auth-method-binding-list__dl">
+      <dt class="type">{{t "models.binding-rule.BindType"}}</dt>
+      <dd>
+        {{@item.BindType}}
+        {{#let
           (if
-            (eq @item.BindType 'node')
-            (t "components.consul.auth-method.binding-list.bind-type.node")
+            (eq @item.BindType 'service')
+            (t "components.consul.auth-method.binding-list.bind-type.service")
             (if
-              (eq @item.BindType 'role')
-              (t "components.consul.auth-method.binding-list.bind-type.role")
-              ''
+              (eq @item.BindType 'node')
+              (t "components.consul.auth-method.binding-list.bind-type.node")
+              (if
+                (eq @item.BindType 'role')
+                (t "components.consul.auth-method.binding-list.bind-type.role")
+                ''
+              )
             )
           )
-        )
-        as |bindTypeTooltip|
-      }}
-        {{#if bindTypeTooltip}}
-          <span {{hds-tooltip bindTypeTooltip options=(detached-tooltip-options)}}></span>
-        {{/if}}
-      {{/let}}
-    </dd>
-    <dt>{{t "models.binding-rule.Selector"}}</dt>
-    <dd><code>{{@item.Selector}}</code></dd>
-    <dt>{{t "models.binding-rule.Description"}}</dt>
-    <dd>{{@item.Description}}</dd>
-  </dl>
+          as |bindTypeTooltip|
+        }}
+          {{#if bindTypeTooltip}}
+            <span {{hds-tooltip bindTypeTooltip options=(detached-tooltip-options)}}></span>
+          {{/if}}
+        {{/let}}
+      </dd>
+      <dt>{{t "models.binding-rule.Selector"}}</dt>
+      <dd><code>{{@item.Selector}}</code></dd>
+      <dt>{{t "models.binding-rule.Description"}}</dt>
+      <dd>{{@item.Description}}</dd>
+    </dl>
+  </Hds::Card::Container>
 </div>

--- a/ui/packages/consul-ui/app/components/consul/auth-method/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/index.scss
@@ -12,6 +12,10 @@
 // View
 .consul-auth-method-view {
   margin-bottom: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
   section {
     @extend %body-200-regular;
     width: 100%;
@@ -21,40 +25,62 @@
       @extend %display-400-semibold;
       padding-bottom: 12px;
     }
-    table {
-      table-layout: fixed;
-      thead td {
-        @extend %body-200-semibold;
-        color: var(--token-color-foreground-faint);
-      }
-      tbody {
-        td {
-          color: var(--token-color-hashicorp-brand);
-          word-break: break-word;
-        }
-        tr {
-          cursor: default;
-        }
-        tr:hover {
-          box-shadow: none;
-        }
-      }
-    }
   }
-  dl,
-  section dl {
-    @extend %tabular-dl;
+}
+
+.consul-auth-method-view__card {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+// Key/value definition list inside the card (and type-specific config lists)
+.consul-auth-method-view__dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 32px;
+  row-gap: 16px;
+  margin: 0;
+
+  dt {
+    @extend %body-200-semibold;
+    color: var(--token-color-foreground-primary);
+    white-space: nowrap;
   }
-  section dt {
-    width: 30%;
+
+  dd {
+    @extend %body-200-regular;
+    color: var(--token-color-foreground-primary);
+    margin: 0;
+    word-break: break-word;
   }
-  section dd {
-    width: 70%;
+
+  dt.check + dd {
+    display: flex;
+    align-items: center;
+  }
+}
+
+// Standalone copyable/masked fields (Hds::Form::MaskedInput::Field) rendered
+// full-width between the dl groups above
+.consul-auth-method-view__field {
+  width: 100%;
+}
+
+// Unbulleted stacked values (e.g. bound audiences, OIDC scopes, ARNs)
+.consul-auth-method-view__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  li:not(:last-of-type) {
+    padding-bottom: 8px;
   }
 }
 
 // Binding List
 .consul-auth-method-binding-list {
+  margin-bottom: 24px;
   p {
     margin-bottom: 4px !important;
   }
@@ -62,32 +88,38 @@
     @extend %display-400-semibold;
     padding-bottom: 12px;
   }
-  dl {
-    @extend %tabular-dl;
-  }
   code {
     background-color: var(--token-color-surface-strong);
     padding: 0 12px;
   }
 }
 
+.consul-auth-method-binding-list__card {
+  padding: 16px;
+}
+
+.consul-auth-method-binding-list__dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 32px;
+  row-gap: 16px;
+  margin: 0;
+
+  dt {
+    @extend %body-200-semibold;
+    color: var(--token-color-foreground-primary);
+    white-space: nowrap;
+  }
+
+  dd {
+    @extend %body-200-regular;
+    color: var(--token-color-foreground-primary);
+    margin: 0;
+    word-break: break-word;
+  }
+}
+
 // Nspace List
 .consul-auth-method-nspace-list {
-  thead {
-    td {
-      @extend %body-200-semibold;
-      color: var(--token-color-foreground-faint) !important;
-    }
-  }
-  tbody {
-    td {
-      color: var(--token-color-hashicorp-brand);
-    }
-    tr {
-      cursor: default;
-    }
-    tr:hover {
-      box-shadow: none;
-    }
-  }
+  margin-top: 16px;
 }

--- a/ui/packages/consul-ui/app/components/consul/auth-method/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/list/index.hbs
@@ -8,6 +8,7 @@
     @items={{@items}}
     @columns={{this.columns}}
     @ariaLabel="Auth Methods"
+    @card={{true}}
   >
     <:row as |item B|>
       {{! ---- Name (DisplayName, or Name when no DisplayName) ---- }}
@@ -24,7 +25,7 @@
               badge next to the name. }}
           {{#if (eq item.TokenLocality 'global')}}
             <span {{hds-tooltip "Creates global tokens" options=(detached-tooltip-options)}}>
-              <Hds::Badge @text="Global tokens" @color="highlight" @size="small" data-test-locality-global />
+              <Hds::Badge @text="Global Tokens" @color="highlight" @size="medium" data-test-locality-global />
             </span>
           {{/if}}
         </span>

--- a/ui/packages/consul-ui/app/components/consul/auth-method/list/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/list/index.scss
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-.consul-auth-method-list {
-  margin-top: 16px;
+/* When the toolbar lives above the table card (as a sibling, not inside it),
+   square off the card's top corners so the two elements form one visual unit. */
+.consul-auth-method-toolbar + .consul-auth-method-list .consul-data-table__card {
+  border-radius: 0 0 6px 6px;
+}
 
+.consul-auth-method-list {
   /* Keep multi-word column headers on a single line. */
   .hds-table__th {
     white-space: nowrap;

--- a/ui/packages/consul-ui/app/components/consul/auth-method/nspace-list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/nspace-list/index.hbs
@@ -4,21 +4,20 @@
 }}
 
 <div class="consul-auth-method-nspace-list">
-  <table>
-    <thead>
-      <tr>
-        <td>{{t "models.auth-method.Selector"}}</td>
-        <td>{{t "models.auth-method.BindNamespace"}}</td>
-      </tr>
-    </thead>
-    <tbody>
+  <Hds::Table>
+    <:head as |H|>
+      <H.Tr>
+        <H.Th>{{t "models.auth-method.Selector"}}</H.Th>
+        <H.Th>{{t "models.auth-method.BindNamespace"}}</H.Th>
+      </H.Tr>
+    </:head>
+    <:body as |B|>
       {{#each @items as |item|}}
-      <tr>
-        <td>{{item.Selector}}</td>
-        <td>{{item.BindNamespace}}</td>
-      </tr>
+      <B.Tr>
+        <B.Td>{{item.Selector}}</B.Td>
+        <B.Td>{{item.BindNamespace}}</B.Td>
+      </B.Tr>
       {{/each}}
-    </tbody>
-  </table>
+    </:body>
+  </Hds::Table>
 </div>
-

--- a/ui/packages/consul-ui/app/components/consul/auth-method/toolbar/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/toolbar/index.scss
@@ -3,7 +3,17 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/* The toolbar is a standalone element rendered directly above the table card.
+   It shares the same card chrome (border, radius) on three sides; the bottom
+   border is removed so the toolbar and the table card merge into a single
+   visual unit with no gap or doubled border between them. */
 .consul-auth-method-toolbar {
+  padding: 8px;
+  background-color: var(--token-color-surface-faint);
+  border: 1px solid var(--token-color-border-faint);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+
   /* the sorter sits at the right end of the toolbar row */
   .consul-auth-method-toolbar__sort {
     flex: 0 0 auto;
@@ -13,6 +23,12 @@
       min-height: 2.25rem;
     }
   }
+}
+
+/* Separator between the controls row and the applied-filters area below. */
+.consul-auth-method-toolbar .hds-filter-bar__actions {
+  border-bottom: 1px solid var(--token-color-border-faint);
+  padding-bottom: 8px;
 }
 
 /* The auth-methods index uses the HDS Filter Bar for its toolbar, so drop the

--- a/ui/packages/consul-ui/app/components/consul/auth-method/type/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/type/index.hbs
@@ -10,7 +10,7 @@
       @icon={{flightIcon}}
       @color="neutral"
       @type="filled"
-      @size="small"
+      @size="large"
     />
   </span>
 {{/let}}

--- a/ui/packages/consul-ui/app/components/consul/auth-method/view/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/view/index.hbs
@@ -3,151 +3,185 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-  <div class="consul-auth-method-view">
+<div class="consul-auth-method-view">
   {{#if (eq @item.Type 'kubernetes')}}
-    <dl>
-      <dt>{{t 'models.auth-method.Type'}}</dt>
-      <dd><Consul::AuthMethod::Type @item={{@item}} /></dd>
+    <Hds::Card::Container
+      @level="base"
+      @hasBorder={{true}}
+      class="consul-auth-method-view__card"
+    >
+      <dl class="consul-auth-method-view__dl">
+        <dt>{{t 'models.auth-method.Type'}}</dt>
+        <dd><Consul::AuthMethod::Type @item={{@item}} /></dd>
 
-    {{#each (array "DisplayName" "Description" "MaxTokenTTL" "TokenLocality" "TokenNameFormat") as |value|}}
-      {{#if (get @item value)}}
-      <dt>{{t (concat "models.auth-method." value)}}</dt>
-      <dd>{{get @item value}}</dd>
-      {{/if}}
-    {{/each}}
-      {{#if @item.Config.Host}}
-      <dt>{{t 'models.auth-method.Config.Host'}}</dt>
-      <dd>
-        <CopyableCode
-          @value={{@item.Config.Host}}
-          @name={{t 'models.auth-method.Config.Host'}}
-        />
-      </dd>
-      {{/if}}
-      {{#if @item.Config.CACert}}
-      <dt>{{t 'models.auth-method.Config.CACert'}}</dt>
-      <dd>
-        <CopyableCode
-          @obfuscated={{true}}
-          @value={{@item.Config.CACert}}
-          @name={{t 'models.auth-method.Config.CACert'}}
-        />
-      </dd>
-      {{/if}}
-      {{#if @item.Config.ServiceAccountJWT}}
-      <dt>{{t 'models.auth-method.Config.ServiceAccountJWT'}}</dt>
-      <dd>
-        <CopyableCode
-          @value={{@item.Config.ServiceAccountJWT}}
-          @name={{t 'models.auth-method.Config.ServiceAccountJWT'}}
-        />
-      </dd>
-      {{/if}}
-    </dl>
-  {{else}}
-    <section class="meta">
-      <dl>
-        <dt>Type</dt>
-        <dd>
-          <Consul::AuthMethod::Type @item={{@item}} />
-        </dd>
-
-{{#each (array "DisplayName" "Description" "MaxTokenTTL" "TokenLocality" "TokenNameFormat") as |value|}}
-  {{#if (get @item value)}}
-
+      {{#each (array "DisplayName" "Description" "MaxTokenTTL" "TokenLocality" "TokenNameFormat") as |value|}}
+        {{#if (get @item value)}}
         <dt>{{t (concat "models.auth-method." value)}}</dt>
         <dd>{{get @item value}}</dd>
+        {{/if}}
+      {{/each}}
+      </dl>
 
-  {{/if}}
-{{/each}}
+      {{#if @item.Config.Host}}
+      <div class="consul-auth-method-view__field">
+        <Hds::Form::MaskedInput::Field
+          readonly
+          @isContentMasked={{false}}
+          @hasCopyButton={{true}}
+          @value={{@item.Config.Host}}
+          as |F|
+        >
+          <F.Label>{{t 'models.auth-method.Config.Host'}}</F.Label>
+        </Hds::Form::MaskedInput::Field>
+      </div>
+      {{/if}}
+
+      {{#if @item.Config.CACert}}
+      <div class="consul-auth-method-view__field">
+        <Hds::Form::MaskedInput::Field
+          readonly
+          @isMultiline={{true}}
+          @hasCopyButton={{true}}
+          @value={{@item.Config.CACert}}
+          as |F|
+        >
+          <F.Label>{{t 'models.auth-method.Config.CACert'}}</F.Label>
+        </Hds::Form::MaskedInput::Field>
+      </div>
+      {{/if}}
+
+      {{#if @item.Config.ServiceAccountJWT}}
+      <div class="consul-auth-method-view__field">
+        <Hds::Form::MaskedInput::Field
+          readonly
+          @isContentMasked={{false}}
+          @isMultiline={{true}}
+          @hasCopyButton={{true}}
+          @value={{@item.Config.ServiceAccountJWT}}
+          as |F|
+        >
+          <F.Label>{{t 'models.auth-method.Config.ServiceAccountJWT'}}</F.Label>
+        </Hds::Form::MaskedInput::Field>
+      </div>
+      {{/if}}
+    </Hds::Card::Container>
+  {{else}}
+    <Hds::Card::Container
+      @level="base"
+      @hasBorder={{true}}
+      class="consul-auth-method-view__card"
+    >
+      <dl class="consul-auth-method-view__dl">
+        <dt>{{t 'models.auth-method.Type'}}</dt>
+        <dd><Consul::AuthMethod::Type @item={{@item}} /></dd>
+
+      {{#each (array "DisplayName" "Description" "MaxTokenTTL" "TokenLocality" "TokenNameFormat") as |value|}}
+        {{#if (get @item value)}}
+        <dt>{{t (concat "models.auth-method." value)}}</dt>
+        <dd>{{get @item value}}</dd>
+        {{/if}}
+      {{/each}}
+      </dl>
 
       {{#if (eq @item.Type 'aws-iam')}}
 
-{{#let
-  @item.Config
-as |config|}}
-  {{#each (array
-    "BoundIAMPrincipalARNs"
-    "EnableIAMEntityDetails"
-    "IAMEntityTags"
-    "IAMEndpoint"
-    "MaxRetries"
-    "STSEndpoint"
-    "STSRegion"
-    "AllowedSTSHeaderValues"
-    "ServerIDHeaderValue"
-  ) as |value|}}
-    {{#if (get config value)}}
-
-        <dt>{{t (concat "models.auth-method." value)}}</dt>
-        <dd>
-{{#let
-  (get config value)
-as |item|}}
-  {{#if (array-is-array item)}}
-          <ul>
-    {{#each item as |jtem|}}
+      <dl class="consul-auth-method-view__dl">
+      {{#let @item.Config as |config|}}
+        {{#each (array
+          "BoundIAMPrincipalARNs"
+          "EnableIAMEntityDetails"
+          "IAMEntityTags"
+          "IAMEndpoint"
+          "MaxRetries"
+          "STSEndpoint"
+          "STSRegion"
+          "AllowedSTSHeaderValues"
+          "ServerIDHeaderValue"
+        ) as |value|}}
+          {{#if (get config value)}}
+          <dt>{{t (concat "models.auth-method." value)}}</dt>
+          <dd>
+          {{#let (get config value) as |item|}}
+            {{#if (array-is-array item)}}
+            <ul class="consul-auth-method-view__list">
+              {{#each item as |jtem|}}
               <li>
                 <span>{{jtem}}</span>
               </li>
-    {{/each}}
-          </ul>
-  {{else}}
-          {{item}}
-  {{/if}}
-{{/let}}
-        </dd>
-
-    {{/if}}
-  {{/each}}
-
-{{/let}}
+              {{/each}}
+            </ul>
+            {{else}}
+            {{item}}
+            {{/if}}
+          {{/let}}
+          </dd>
+          {{/if}}
+        {{/each}}
+      {{/let}}
+      </dl>
 
       {{else if (eq @item.Type 'jwt')}}
+
         {{#if @item.Config.JWKSURL}}
-        <dt>{{t 'models.auth-method.Config.JWKSURL'}}</dt>
-        <dd>
-          <CopyableCode
+        <div class="consul-auth-method-view__field">
+          <Hds::Form::MaskedInput::Field
+            readonly
+            @isContentMasked={{false}}
+            @hasCopyButton={{true}}
             @value={{@item.Config.JWKSURL}}
-            @name={{t 'models.auth-method.Config.JWKSURL'}}
-          />
-        </dd>
-        <dt>{{t 'models.auth-method.Config.JWKSCACert'}}</dt>
-        <dd>
-          <CopyableCode
-            @obfuscated={{true}}
+            as |F|
+          >
+            <F.Label>{{t 'models.auth-method.Config.JWKSURL'}}</F.Label>
+          </Hds::Form::MaskedInput::Field>
+        </div>
+        <div class="consul-auth-method-view__field">
+          <Hds::Form::MaskedInput::Field
+            readonly
+            @isMultiline={{true}}
+            @hasCopyButton={{true}}
             @value={{@item.Config.JWKSCACert}}
-            @name={{t 'models.auth-method.Config.JWKSCACert'}}
-          />
-        </dd>
+            as |F|
+          >
+            <F.Label>{{t 'models.auth-method.Config.JWKSCACert'}}</F.Label>
+          </Hds::Form::MaskedInput::Field>
+        </div>
         {{/if}}
         {{#if @item.Config.JWTValidationPubKeys}}
-        <dt>{{t 'models.auth-method.Config.JWTValidationPubKeys'}}</dt>
-        <dd>
-          <CopyableCode
-            @obfuscated={{true}}
+        <div class="consul-auth-method-view__field">
+          <Hds::Form::MaskedInput::Field
+            readonly
+            @isMultiline={{true}}
+            @hasCopyButton={{true}}
             @value={{@item.Config.JWTValidationPubKeys}}
-            @name={{t 'models.auth-method.Config.JWTValidationPubKeys'}}
-          />
-        </dd>
+            as |F|
+          >
+            <F.Label>{{t 'models.auth-method.Config.JWTValidationPubKeys'}}</F.Label>
+          </Hds::Form::MaskedInput::Field>
+        </div>
         {{/if}}
         {{#if @item.Config.OIDCDiscoveryURL}}
-        <dt>{{t 'models.auth-method.Config.OIDCDiscoveryURL'}}</dt>
-        <dd>
-          <CopyableCode
+        <div class="consul-auth-method-view__field">
+          <Hds::Form::MaskedInput::Field
+            readonly
+            @isContentMasked={{false}}
+            @hasCopyButton={{true}}
             @value={{@item.Config.OIDCDiscoveryURL}}
-            @name={{t 'models.auth-method.Config.OIDCDiscoveryURL'}}
-          />
-        </dd>
+            as |F|
+          >
+            <F.Label>{{t 'models.auth-method.Config.OIDCDiscoveryURL'}}</F.Label>
+          </Hds::Form::MaskedInput::Field>
+        </div>
         {{/if}}
+
+        <dl class="consul-auth-method-view__dl">
         {{#if @item.Config.JWTSupportedAlgs}}
-        <dt>{{t 'models.auth-method.Config.JWTSupportedAlgs'}}</dt>
-        <dd>{{join ', ' @item.Config.JWTSupportedAlgs}}</dd>
+          <dt>{{t 'models.auth-method.Config.JWTSupportedAlgs'}}</dt>
+          <dd>{{join ', ' @item.Config.JWTSupportedAlgs}}</dd>
         {{/if}}
         {{#if @item.Config.BoundAudiences}}
           <dt>{{t 'models.auth-method.Config.BoundAudiences'}}</dt>
           <dd>
-            <ul>
+            <ul class="consul-auth-method-view__list">
               {{#each @item.Config.BoundAudiences as |bond|}}
               <li>
                 <span>{{bond}}</span>
@@ -162,26 +196,38 @@ as |item|}}
           <dd>{{get @item.Config value}}</dd>
           {{/if}}
         {{/each}}
+        </dl>
+
       {{else if (eq @item.Type 'oidc')}}
+
         {{#if @item.Config.OIDCDiscoveryURL}}
-        <dt>{{t 'models.auth-method.Config.OIDCDiscoveryURL'}}</dt>
-        <dd>
-          <CopyableCode
+        <div class="consul-auth-method-view__field">
+          <Hds::Form::MaskedInput::Field
+            readonly
+            @isContentMasked={{false}}
+            @hasCopyButton={{true}}
             @value={{@item.Config.OIDCDiscoveryURL}}
-            @name={{t 'models.auth-method.Config.OIDCDiscoveryURL'}}
-          />
-        </dd>
+            as |F|
+          >
+            <F.Label>{{t 'models.auth-method.Config.OIDCDiscoveryURL'}}</F.Label>
+          </Hds::Form::MaskedInput::Field>
+        </div>
         {{/if}}
         {{#if @item.Config.OIDCDiscoveryCACert}}
-        <dt>{{t 'models.auth-method.Config.OIDCDiscoveryCACert'}}</dt>
-        <dd>
-          <CopyableCode
-            @obfuscated={{true}}
+        <div class="consul-auth-method-view__field">
+          <Hds::Form::MaskedInput::Field
+            readonly
+            @isMultiline={{true}}
+            @hasCopyButton={{true}}
             @value={{@item.Config.OIDCDiscoveryCACert}}
-            @name={{t 'models.auth-method.Config.OIDCDiscoveryCACert'}}
-          />
-        </dd>
+            as |F|
+          >
+            <F.Label>{{t 'models.auth-method.Config.OIDCDiscoveryCACert'}}</F.Label>
+          </Hds::Form::MaskedInput::Field>
+        </div>
         {{/if}}
+
+        <dl class="consul-auth-method-view__dl">
         {{#if @item.Config.OIDCClientID}}
           <dt>{{t 'models.auth-method.Config.OIDCClientID'}}</dt>
           <dd>{{@item.Config.OIDCClientID}}</dd>
@@ -194,25 +240,29 @@ as |item|}}
           <dt>{{t 'models.auth-method.Config.OIDCClientAssertionPrivateKey'}}</dt>
           <dd>{{@item.Config.OIDCClientAssertion.PrivateKey.PemKey}}</dd>
         {{/if}}
+        </dl>
+
         {{#if @item.Config.AllowedRedirectURIs}}
-          <dt>{{t 'models.auth-method.Config.AllowedRedirectURIs'}}</dt>
-          <dd>
-            <ul>
-              {{#each @item.Config.AllowedRedirectURIs as |uri|}}
-              <li>
-                <CopyableCode
-                  @value={{uri}}
-                  @name="Redirect URI"
-                />
-              </li>
-              {{/each}}
-            </ul>
-          </dd>
+        {{#each @item.Config.AllowedRedirectURIs as |uri|}}
+        <div class="consul-auth-method-view__field">
+          <Hds::Form::MaskedInput::Field
+            readonly
+            @isContentMasked={{false}}
+            @hasCopyButton={{true}}
+            @value={{uri}}
+            as |F|
+          >
+            <F.Label>{{t 'models.auth-method.Config.AllowedRedirectURIs'}}</F.Label>
+          </Hds::Form::MaskedInput::Field>
+        </div>
+        {{/each}}
         {{/if}}
+
+        <dl class="consul-auth-method-view__dl">
         {{#if @item.Config.BoundAudiences}}
           <dt>{{t 'models.auth-method.Config.BoundAudiences'}}</dt>
           <dd>
-            <ul>
+            <ul class="consul-auth-method-view__list">
               {{#each @item.Config.BoundAudiences as |bond|}}
               <li>
                 <span>{{bond}}</span>
@@ -224,7 +274,7 @@ as |item|}}
         {{#if @item.Config.OIDCScopes}}
           <dt>{{t 'models.auth-method.Config.OIDCScopes'}}</dt>
           <dd>
-            <ul>
+            <ul class="consul-auth-method-view__list">
               {{#each @item.Config.OIDCScopes as |scope|}}
               <li>
                 <span>{{scope}}</span>
@@ -234,40 +284,40 @@ as |item|}}
           </dd>
         {{/if}}
         {{#if @item.Config.JWTSupportedAlgs}}
-        <dt>{{t 'models.auth-method.Config.JWTSupportedAlgs'}}</dt>
-        <dd>{{join ', ' @item.Config.JWTSupportedAlgs}}</dd>
+          <dt>{{t 'models.auth-method.Config.JWTSupportedAlgs'}}</dt>
+          <dd>{{join ', ' @item.Config.JWTSupportedAlgs}}</dd>
         {{/if}}
         {{#if @item.Config.VerboseOIDCLogging}}
-        <dt class="check">{{t 'models.auth-method.Config.VerboseOIDCLogging'}}</dt>
-        <dd><label><input type="checkbox" disabled="disabled" checked={{@item.Config.VerboseOIDCLogging}}> {{t 'models.auth-method.Config.VerboseOIDCLogging'}}</label></dd>
+          <dt class="check">{{t 'models.auth-method.Config.VerboseOIDCLogging'}}</dt>
+          <dd><label><input type="checkbox" disabled="disabled" checked={{@item.Config.VerboseOIDCLogging}}> {{t 'models.auth-method.Config.VerboseOIDCLogging'}}</label></dd>
         {{/if}}
+        </dl>
+
       {{/if}}
-      </dl>
-    </section>
+    </Hds::Card::Container>
 
     {{#if (not (eq @item.Type 'aws-iam'))}}
-    <hr />
 
     <section class="claim-mappings">
       <h2>Claim Mappings</h2>
     {{#if @item.Config.ClaimMappings}}
       <p>Use this if the claim you are capturing is singular. When mapped, the values can be any of a number, string, or boolean and will all be stringified when returned.</p>
-      <table>
-        <thead>
-          <tr>
-            <td>Key</td>
-            <td>Value</td>
-          </tr>
-        </thead>
-        <tbody>
+      <Hds::Table>
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Key</H.Th>
+            <H.Th>Value</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
           {{#each (entries @item.Config.ClaimMappings) as |entry|}}
-          <tr>
-            <td>{{get entry 0}}</td>
-            <td>{{get entry 1}}</td>
-          </tr>
+          <B.Tr>
+            <B.Td>{{get entry 0}}</B.Td>
+            <B.Td>{{get entry 1}}</B.Td>
+          </B.Tr>
           {{/each}}
-        </tbody>
-      </table>
+        </:body>
+      </Hds::Table>
     {{else}}
       <EmptyState>
         <:header>
@@ -289,28 +339,26 @@ as |item|}}
     {{/if}}
     </section>
 
-    <hr />
-
     <section class="list-claim-mappings">
       <h2>List Claim Mappings</h2>
     {{#if @item.Config.ListClaimMappings}}
       <p>Use this if the claim you are capturing is list-like (such as groups). When mapped, the values can be any of a number, string, or boolean and will all be stringified when returned.</p>
-      <table>
-        <thead>
-          <tr>
-            <td>Key</td>
-            <td>Value</td>
-          </tr>
-        </thead>
-        <tbody>
+      <Hds::Table>
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>Key</H.Th>
+            <H.Th>Value</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
           {{#each (entries @item.Config.ListClaimMappings) as |entry|}}
-          <tr>
-            <td>{{get entry 0}}</td>
-            <td>{{get entry 1}}</td>
-          </tr>
+          <B.Tr>
+            <B.Td>{{get entry 0}}</B.Td>
+            <B.Td>{{get entry 1}}</B.Td>
+          </B.Tr>
           {{/each}}
-        </tbody>
-      </table>
+        </:body>
+      </Hds::Table>
     {{else}}
       <EmptyState>
         <:header>
@@ -331,6 +379,7 @@ as |item|}}
       </EmptyState>
     {{/if}}
     </section>
+
+    {{/if}}
   {{/if}}
-{{/if}}
-  </div>
+</div>

--- a/ui/packages/consul-ui/app/templates/dc/acls/auth-methods/show/binding-rules.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/auth-methods/show/binding-rules.hbs
@@ -38,10 +38,8 @@ as |items|}}
     <p>
       Successful authentication with an auth method returns a set of trusted identity attributes corresponding to the authenticated identity. Those attributes are matched against all configured binding rules for that auth method to determine what privileges to grant the Consul ACL token it will ultimately create.
     </p>
-    <hr />
     {{#each items as |item|}}
       <Consul::AuthMethod::BindingList @item={{item}} />
-      <hr />
     {{/each}}
   {{else}}
     <EmptyState>


### PR DESCRIPTION
## Summary

Migrates the auth-methods ACL components from legacy UI patterns to Helios Design System (HDS) components.

## Changes

- `binding-list/index.hbs` — migrated binding list to HDS components
- `index.scss` — updated styles to align with HDS
- `nspace-list/index.hbs` — migrated namespace list to HDS components
- `view/index.hbs` — migrated auth-method view to HDS components
- `binding-rules.hbs` — cleaned up binding rules template

## Type of change

- [x] UI / Frontend
- [x] HDS migration
