### PR TITLE
fix(consul): use stable log keys for proxy config error

### DIFF
--- a/connect/proxy/config.go
+++ b/connect/proxy/config.go
@@ -279,7 +279,7 @@ func (w *AgentConfigWatcher) handler(blockVal watch.BlockingParamVal,
 	cfg.PublicListener.BindAddress = resp.Address
 	cfg.PublicListener.BindPort = resp.Port
 	if resp.Proxy.LocalServiceSocketPath != "" {
-		w.logger.Error("Unhandled unix domain socket config %+v %+v", resp.Proxy, cfg.PublicListener)
+		w.logger.Error("Unhandled unix domain socket config", "proxy", resp.Proxy, "public_listener", cfg.PublicListener)
 	}
 	cfg.PublicListener.LocalServiceAddress = ipaddr.FormatAddressPort(
 		resp.Proxy.LocalServiceAddress, resp.Proxy.LocalServicePort)


### PR DESCRIPTION
### Description

The error call at connect/proxy/config.go:282 formats two runtime structs into the message with printf style `%+v %+v`. That puts ad hoc values into the message string and breaks the log schema for structured log consumers. This change moves the values into stable key/value pairs, `proxy` and `public_listener`.

Before:

```go
w.logger.Error("Unhandled unix domain socket config %+v %+v", resp.Proxy, cfg.PublicListener)
```

After:

```go
w.logger.Error("Unhandled unix domain socket config", "proxy", resp.Proxy, "public_listener", cfg.PublicListener)
```

### Testing & Reproduction steps

* `go test ./connect/proxy` passes before and after the change.
* `gofmt -l` and `go vet ./connect/proxy` are clean.
* The change is a single line.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.
