### PR TITLE
ui: migrate linked-services (gateway) list to HDS components

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/service/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/table/index.hbs
@@ -120,20 +120,22 @@
         </B.Td>
 
         {{! ---- Service mesh ---- }}
-        <B.Td>
-          {{#if (or item.ConnectedWithProxy item.ConnectedWithGateway)}}
-            <span class="consul-service-table__mesh" data-test-mesh>
-              <span class="consul-service-table__mesh-icon" aria-hidden="true"></span>
-              {{#if (and item.ConnectedWithProxy item.ConnectedWithGateway)}}
-                <span>in service mesh with proxy and gateway</span>
-              {{else if item.ConnectedWithProxy}}
-                <span>in service mesh with proxy</span>
-              {{else}}
-                <span>in service mesh with gateway</span>
-              {{/if}}
-            </span>
-          {{/if}}
-        </B.Td>
+        {{#if this.showMesh}}
+          <B.Td>
+            {{#if (or item.ConnectedWithProxy item.ConnectedWithGateway)}}
+              <span class="consul-service-table__mesh" data-test-mesh>
+                <span class="consul-service-table__mesh-icon" aria-hidden="true"></span>
+                {{#if (and item.ConnectedWithProxy item.ConnectedWithGateway)}}
+                  <span>in service mesh with proxy and gateway</span>
+                {{else if item.ConnectedWithProxy}}
+                  <span>in service mesh with proxy</span>
+                {{else}}
+                  <span>in service mesh with gateway</span>
+                {{/if}}
+              </span>
+            {{/if}}
+          </B.Td>
+        {{/if}}
 
         {{! ---- Service type ---- }}
         <B.Td>

--- a/ui/packages/consul-ui/app/components/consul/service/table/index.js
+++ b/ui/packages/consul-ui/app/components/consul/service/table/index.js
@@ -54,9 +54,28 @@ const COLUMNS = [
  *
  * It does not perform any data fetching itself; it receives the already
  * fetched / filtered / searched `@items` from the data layer.
+ *
+ * @argument {boolean} [showMesh] - whether to render the "Service mesh"
+ *   column. Defaults to true. The gateway "linked services" tab's endpoint
+ *   (`/gateways/for-service`) never returns `ConnectedWithProxy` /
+ *   `ConnectedWithGateway`, so that column can never have real data there —
+ *   callers on that tab pass `@showMesh={{false}}` to omit it entirely rather
+ *   than show a column that's always empty.
  */
 export default class ConsulServiceTable extends Component {
-  columns = COLUMNS;
+  // Whether the "Service mesh" column is included, both in the header and in
+  // each row. Filtering it out of `columns` (rather than just hiding the cell)
+  // keeps the header/row cell counts in sync.
+  get showMesh() {
+    return this.args.showMesh !== false;
+  }
+
+  get columns() {
+    if (this.showMesh) {
+      return COLUMNS;
+    }
+    return COLUMNS.filter((column) => column.sortKey !== 'mesh');
+  }
 
   // Mirrors the link param logic from Consul::Service::List so that
   // cross-partition / cross-namespace / peered links keep working.

--- a/ui/packages/consul-ui/app/components/consul/service/toolbar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/toolbar/index.hbs
@@ -18,11 +18,57 @@
   @filterGroups={{this.filterGroups}}
   @searchPlaceholder="Search"
 >
-  <:quickFilters as |t|>
+  <:quickFilters as |api|>
     {{!
       Health quick filters: mirrors (and stays in sync with) the "Health"
-      multi-select group inside the Filter Bar above.
+      multi-select group inside the Filter Bar above. The linked-services tab
+      has no Health filter group to stay in sync with, so it gets a grouped
+      sort dropdown (Health status / Service name) in this slot instead,
+      mirroring Consul::HealthCheck::Toolbar's grouped sort control.
+
+      The block param is named `api` (not `t`) because this block also calls
+      the global translation helper (t) — a param named `t` would shadow it
+      and silently break every translation call inside this block.
     }}
-    <Consul::ListToolbar::HealthFilter @filters={{this.healthQuickFilters}} @api={{t}} />
+    {{#if @linked}}
+      {{#if @sort}}
+        <Hds::Dropdown
+          class="consul-service-toolbar__sort"
+          @listPosition="bottom-right"
+          @preserveContentInDom={{true}}
+          data-test-sort-control
+          as |dd|
+        >
+          <dd.ToggleButton
+            @icon="swap-vertical"
+            @text={{this.sortLabel}}
+            @color="secondary"
+            data-test-sort-toggle
+          />
+
+          <dd.Title @text={{t "common.consul.status"}} />
+          <dd.Interactive
+            data-test-sort-option="Status:asc"
+            {{on "click" (fn @sort.change (hash target=(hash selected="Status:asc")))}}
+          >{{t "common.sort.status.asc"}}</dd.Interactive>
+          <dd.Interactive
+            data-test-sort-option="Status:desc"
+            {{on "click" (fn @sort.change (hash target=(hash selected="Status:desc")))}}
+          >{{t "common.sort.status.desc"}}</dd.Interactive>
+
+          <dd.Title @text={{t "common.consul.service-name"}} />
+          <dd.Interactive
+            data-test-sort-option="Name:asc"
+            {{on "click" (fn @sort.change (hash target=(hash selected="Name:asc")))}}
+          >{{t "common.sort.alpha.asc"}}</dd.Interactive>
+          <dd.Interactive
+            data-test-sort-option="Name:desc"
+            {{on "click" (fn @sort.change (hash target=(hash selected="Name:desc")))}}
+          >{{t "common.sort.alpha.desc"}}</dd.Interactive>
+        </Hds::Dropdown>
+      {{/if}}
+    {{else}}
+      <Consul::ListToolbar::HealthFilter @filters={{this.healthQuickFilters}} @api={{api}} />
+    {{/if}}
   </:quickFilters>
 </Consul::ListToolbar>

--- a/ui/packages/consul-ui/app/components/consul/service/toolbar/index.js
+++ b/ui/packages/consul-ui/app/components/consul/service/toolbar/index.js
@@ -37,6 +37,29 @@ const KIND_OPTIONS = [
   { value: 'not-in-mesh', label: 'Not in service mesh' },
 ];
 
+// The gateway "linked services" tab only ever offered a single "Registered /
+// Not registered" filter (the `instance` predicate in
+// app/filter/predicates/service.js) — it has no Health/Service type/External
+// source data to filter on, so `@linked={{true}}` swaps in just this group
+// instead of the full services-index filter set.
+const INSTANCE_OPTIONS = [
+  { value: 'registered', label: 'Registered' },
+  { value: 'not-registered', label: 'Not Registered' },
+];
+
+// The linked-services tab has no health quick-filter buttons (see
+// `filterGroups`), so its `:quickFilters` slot renders a grouped sort
+// dropdown instead (Health status / Service name — mirrors
+// Consul::HealthCheck::Toolbar's grouped sort control). Maps a
+// `<Field>:<direction>` sort value to the translation key for its
+// toggle-button label.
+const SORT_LABEL_KEYS = {
+  'Status:asc': 'common.sort.status.asc',
+  'Status:desc': 'common.sort.status.desc',
+  'Name:asc': 'common.sort.alpha.asc',
+  'Name:desc': 'common.sort.alpha.desc',
+};
+
 /**
  * Consul::Service::Toolbar
  *
@@ -44,11 +67,25 @@ const KIND_OPTIONS = [
  * It supplies the concrete filter groups (Health / Service type / External
  * source) and the health quick-filter buttons, but owns no Filter Bar wiring
  * itself — that all lives in the generic toolbar.
+ *
+ * @argument {boolean} [linked] - render the reduced filter set used by the
+ *   gateway "linked services" tab (a single Instance/Registered filter, no
+ *   health quick-filters) instead of the full services-index filter set, and
+ *   a grouped sort dropdown (Health status / Service name) in its place.
+ * @argument {object} [sort] - `{ value, change }` sort state, as built by the
+ *   route template. Only used (and only rendered) in `@linked` mode.
  */
 export default class ConsulServiceToolbar extends Component {
   @service intl;
 
   healthQuickFilters = HEALTH_QUICK_FILTERS;
+
+  // Label shown on the linked-services sort dropdown's toggle button for the
+  // currently active sort value.
+  get sortLabel() {
+    const key = SORT_LABEL_KEYS[this.args.sort?.value];
+    return key ? this.intl.t(key) : '';
+  }
 
   // Display label for an external-source value, using its brand name when one
   // exists (e.g. "kubernetes" -> "Kubernetes") and falling back to the raw
@@ -73,6 +110,10 @@ export default class ConsulServiceToolbar extends Component {
   // source is only included when there are real external sources to choose
   // from (the synthetic "consul" option alone doesn't warrant the group).
   get filterGroups() {
+    if (this.args.linked) {
+      return [{ key: 'instance', text: 'Instance', options: INSTANCE_OPTIONS }];
+    }
+
     // On peer detail pages services can be "unknown", so offer that extra
     // Health option (matching the old search bar's peer-aware health states).
     const healthOptions = this.args.peer

--- a/ui/packages/consul-ui/app/templates/dc/services/show/services.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/services.hbs
@@ -50,14 +50,28 @@ as |route|>
     loader.data
 
   as |sort filters items|}}
+  {{! The intro alert and toolbar are rendered outside DataCollection so they
+      persist when filters/search reduce the visible rows to zero. They only
+      appear when there are actual linked services on this gateway. }}
   {{#if (gt items.length 0)}}
-      <input type="checkbox" id="toolbar-toggle" />
-      <Consul::Upstream::SearchBar
+      <Hds::Alert @type="inline" class="mb-3" as |A|>
+        <A.Title>{{t "routes.dc.services.show.services.intro.header"}}</A.Title>
+        <A.Description>
+          {{t "routes.dc.services.show.services.intro.body"}}
+        </A.Description>
+        <A.Link::Standalone
+          @text={{t "routes.dc.services.show.services.intro.footer.text"}}
+          @href="{{concat (env 'CONSUL_DOCS_URL') (t 'routes.dc.services.show.services.intro.footer.link')}}"
+          @icon="docs-link"
+          @iconPosition="trailing"
+          @size="small"
+        />
+      </Hds::Alert>
+      <Consul::Service::Toolbar
+        @linked={{true}}
+        @sort={{sort}}
         @search={{this.search}}
         @onsearch={{action (mut this.search) value="target.value"}}
-
-        @sort={{sort}}
-
         @filter={{filters}}
         />
   {{/if}}
@@ -69,15 +83,13 @@ as |route|>
         @items={{items}}
       as |collection|>
         <collection.Collection>
-          {{t "routes.dc.services.show.services.intro"
-            htmlSafe=true
-          }}
-          <Consul::Service::List
+          <Consul::Service::Table
             @nspace={{or route.params.nspace route.model.user.token.Namespace 'default'}}
             @partition={{or route.params.partition route.model.user.token.Partition 'default'}}
             @items={{collection.items}}
-          >
-          </Consul::Service::List>
+            @showMesh={{false}}
+            @card={{true}}
+          />
         </collection.Collection>
         <collection.Empty>
           <EmptyState>

--- a/ui/packages/consul-ui/tests/pages/dc/services/show.js
+++ b/ui/packages/consul-ui/tests/pages/dc/services/show.js
@@ -70,7 +70,7 @@ export default function (
     }),
   };
   page.tabs.linkedServicesTab = {
-    services: collection('.consul-service-list > ul > li:not(:first-child)', {
+    services: collection('.consul-service-table tbody tr', {
       name: text('[data-test-service-name]'),
     }),
   };

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -343,10 +343,12 @@ dc:
             }.
           </p>
       services:
-        intro: |
-          <p>
-            The following services may receive traffic from external services through this gateway. Learn more about configuring gateways in our <a href="{CONSUL_DOCS_URL}/connect/terminating-gateway" target="_blank" rel="noopener noreferrer">step-by-step guide</a>.
-          </p>
+        intro:
+          header: Linked services
+          body: The following services may receive traffic from external services through this gateway.
+          footer:
+            text: Learn more about configuring gateways
+            link: /connect/terminating-gateway
         empty: |
           <p>
             There are no Services{items, select,


### PR DESCRIPTION
## What

Migrates the terminating-gateway "Linked Services" tab (`dc.services.show.services`) off the legacy `Consul::Upstream::SearchBar` / `Consul::Service::List` onto the same HDS building blocks already used by the main Services list and the peers Imported Services tab: `Consul::Service::Toolbar` (HDS Filter Bar) and `Consul::Service::Table` (HDS Table).

## Changes

- `Consul::Service::Table` gains `@showMesh` (default `true`) to omit the Service mesh column/header together. The `gateway-services-nodes` endpoint this tab reads from never returns `ConnectedWithProxy`/`ConnectedWithGateway`, so that column could never have real data here — verified against the live endpoint response.
- `Consul::Service::Toolbar` gains a `@linked` mode:
  - swaps the Health/Service type/External source filter groups for the tab's original single Instance (Registered/Not Registered) filter
  - renders a grouped sort dropdown (Health status / Service name) in place of the health quick-filter buttons, mirroring the pattern already used by `Consul::HealthCheck::Toolbar` and `Consul::Peer::Toolbar`
- The intro copy is reskinned from a bare `<p>` into an `Hds::Alert`, rendered above the toolbar.
- Updates the `linkedServicesTab` test page object selector for the new table markup.

## Testing

- Verified live against a running Consul agent: toolbar, alert, table, sort dropdown, filters, and pagination all render and function correctly.
- `ember test --filter="dc / services / show / services"`: all 6 scenarios pass.