### PR TITLE
security: gate Lua/Wasm extensions and bootstrap escape-hatch keys behind mesh:write

### DIFF
--- a/.changelog/23834.txt
+++ b/.changelog/23834.txt
@@ -1,0 +1,11 @@
+```release-note:security
+acl: Require mesh:write in addition to service:write when attaching code-executing EnvoyExtensions (builtin/lua, builtin/wasm) to a service-defaults config entry. Previously a holder of service:write on a service could attach a Lua script or Wasm module that Envoy compiled and executed on every proxied request as the sidecar process user, with access to mTLS private keys, request bodies, and the host filesystem.
+```
+
+```release-note:security
+acl: Require mesh:write in addition to service:write when registering a connect-proxy sidecar with bootstrap escape-hatch Proxy.Config keys (envoy_bootstrap_json_tpl, envoy_extra_static_listeners_json, envoy_public_listener_json, envoy_listener_json, envoy_cluster_json, envoy_local_cluster_json, envoy_extra_static_clusters_json, envoy_extra_stats_sinks_json, envoy_tracing_json, envoy_stats_config_json, envoy_listener_tracing_json). Previously a holder of service:write on the proxy and its destination could inject arbitrary Envoy filter chain configuration into the sidecar bootstrap.
+```
+
+```release-note:breaking-change
+acl: Tokens that hold service:write but not mesh:write will now receive a permission-denied error when attempting to attach builtin/lua or builtin/wasm EnvoyExtensions to a service-defaults config entry, or when registering a connect-proxy sidecar with bootstrap escape-hatch Proxy.Config keys. Operators must grant mesh:write to any token that legitimately needs these capabilities.
+```

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -100,6 +100,20 @@ func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *
 		}
 	}
 
+	// envoy_listener_json and envoy_cluster_json live in per-upstream Config maps
+	// (not in the top-level Proxy.Config) and are injected verbatim into xDS
+	// listener/cluster resources for that upstream. Check all upstream configs too.
+	for i := range service.Proxy.Upstreams {
+		for key := range service.Proxy.Upstreams[i].Config {
+			if bootstrapEscapeHatchKeys[key] {
+				if err := authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext); err != nil {
+					return fmt.Errorf("mesh:write required to set bootstrap escape-hatch upstream Config key %q: %w", key, err)
+				}
+				break
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -42,6 +42,25 @@ func (a *Agent) vetServiceRegister(token string, service *structs.NodeService) e
 	return a.vetServiceRegisterWithAuthorizer(authz, service)
 }
 
+// bootstrapEscapeHatchKeys is the set of Proxy.Config map keys that are
+// spliced verbatim into the Envoy bootstrap JSON by consul connect envoy.
+// These fields can embed arbitrary Envoy listener/cluster/filter
+// configuration — including code-executing HTTP filters — and therefore
+// require mesh:write in addition to the normal service:write grant.
+var bootstrapEscapeHatchKeys = map[string]bool{
+	"envoy_bootstrap_json_tpl":             true,
+	"envoy_extra_static_listeners_json":    true,
+	"envoy_public_listener_json":           true,
+	"envoy_listener_json":                  true,
+	"envoy_cluster_json":                   true,
+	"envoy_local_cluster_json":             true,
+	"envoy_extra_static_clusters_json":     true,
+	"envoy_extra_stats_sinks_json":         true,
+	"envoy_tracing_json":                   true,
+	"envoy_stats_config_json":              true,
+	"envoy_listener_tracing_json":          true,
+}
+
 func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *structs.NodeService) error {
 	var authzContext acl.AuthorizerContext
 
@@ -65,6 +84,19 @@ func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *
 		service.FillAuthzContext(&authzContext)
 		if err := authz.ToAllowAuthorizer().ServiceWriteAllowed(service.Proxy.DestinationServiceName, &authzContext); err != nil {
 			return err
+		}
+	}
+
+	// Bootstrap escape-hatch keys in Proxy.Config are spliced verbatim into the
+	// Envoy bootstrap JSON. They can embed arbitrary filter chain configuration —
+	// including code-executing HTTP filters — and therefore require mesh:write
+	// independently of service:write.
+	for key := range service.Proxy.Config {
+		if bootstrapEscapeHatchKeys[key] {
+			if err := authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext); err != nil {
+				return fmt.Errorf("mesh:write required to set bootstrap escape-hatch Proxy.Config key %q: %w", key, err)
+			}
+			break
 		}
 	}
 

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -100,20 +100,6 @@ func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *
 		}
 	}
 
-	// envoy_listener_json and envoy_cluster_json live in per-upstream Config maps
-	// (not in the top-level Proxy.Config) and are injected verbatim into xDS
-	// listener/cluster resources for that upstream. Check all upstream configs too.
-	for i := range service.Proxy.Upstreams {
-		for key := range service.Proxy.Upstreams[i].Config {
-			if bootstrapEscapeHatchKeys[key] {
-				if err := authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext); err != nil {
-					return fmt.Errorf("mesh:write required to set bootstrap escape-hatch upstream Config key %q: %w", key, err)
-				}
-				break
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -354,6 +354,8 @@ func TestACL_vetServiceRegister_bootstrapEscapeHatch(t *testing.T) {
 		"envoy_bootstrap_json_tpl",
 		"envoy_extra_static_listeners_json",
 		"envoy_public_listener_json",
+		"envoy_listener_json",
+		"envoy_cluster_json",
 		"envoy_local_cluster_json",
 		"envoy_extra_static_clusters_json",
 		"envoy_extra_stats_sinks_json",
@@ -377,32 +379,6 @@ func TestACL_vetServiceRegister_bootstrapEscapeHatch(t *testing.T) {
 
 			err = a.vetServiceRegisterWithAuthorizer(authzWithMesh, svc)
 			require.NoError(t, err, "key %q: expected success with mesh:write", key)
-		})
-	}
-
-	// envoy_listener_json and envoy_cluster_json live in upstream Config maps, not Proxy.Config.
-	for _, key := range []string{"envoy_listener_json", "envoy_cluster_json"} {
-		t.Run("upstream/"+key, func(t *testing.T) {
-			svc := &structs.NodeService{
-				ID:      "web-sidecar-proxy",
-				Service: "web-sidecar-proxy",
-				Kind:    structs.ServiceKindConnectProxy,
-				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "web",
-					Upstreams: structs.Upstreams{
-						{
-							DestinationName: "backend",
-							Config:          map[string]interface{}{key: `{}`},
-						},
-					},
-				},
-			}
-			err := a.vetServiceRegisterWithAuthorizer(authzServiceOnly, svc)
-			require.Error(t, err, "upstream key %q: expected denial without mesh:write", key)
-			require.True(t, acl.IsErrPermissionDenied(err), "upstream key %q: expected permission denied, got: %v", key, err)
-
-			err = a.vetServiceRegisterWithAuthorizer(authzWithMesh, svc)
-			require.NoError(t, err, "upstream key %q: expected success with mesh:write", key)
 		})
 	}
 }

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -349,13 +349,11 @@ func TestACL_vetServiceRegister_bootstrapEscapeHatch(t *testing.T) {
 	err = a.vetServiceRegisterWithAuthorizer(authzServiceOnly, normalSidecar)
 	require.NoError(t, err)
 
-	// Verify each escape-hatch key individually triggers the mesh:write requirement.
+	// Verify each Proxy.Config escape-hatch key individually triggers the mesh:write requirement.
 	for _, key := range []string{
 		"envoy_bootstrap_json_tpl",
 		"envoy_extra_static_listeners_json",
 		"envoy_public_listener_json",
-		"envoy_listener_json",
-		"envoy_cluster_json",
 		"envoy_local_cluster_json",
 		"envoy_extra_static_clusters_json",
 		"envoy_extra_stats_sinks_json",
@@ -379,6 +377,32 @@ func TestACL_vetServiceRegister_bootstrapEscapeHatch(t *testing.T) {
 
 			err = a.vetServiceRegisterWithAuthorizer(authzWithMesh, svc)
 			require.NoError(t, err, "key %q: expected success with mesh:write", key)
+		})
+	}
+
+	// envoy_listener_json and envoy_cluster_json live in upstream Config maps, not Proxy.Config.
+	for _, key := range []string{"envoy_listener_json", "envoy_cluster_json"} {
+		t.Run("upstream/"+key, func(t *testing.T) {
+			svc := &structs.NodeService{
+				ID:      "web-sidecar-proxy",
+				Service: "web-sidecar-proxy",
+				Kind:    structs.ServiceKindConnectProxy,
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					Upstreams: structs.Upstreams{
+						{
+							DestinationName: "backend",
+							Config:          map[string]interface{}{key: `{}`},
+						},
+					},
+				},
+			}
+			err := a.vetServiceRegisterWithAuthorizer(authzServiceOnly, svc)
+			require.Error(t, err, "upstream key %q: expected denial without mesh:write", key)
+			require.True(t, acl.IsErrPermissionDenied(err), "upstream key %q: expected permission denied, got: %v", key, err)
+
+			err = a.vetServiceRegisterWithAuthorizer(authzWithMesh, svc)
+			require.NoError(t, err, "upstream key %q: expected success with mesh:write", key)
 		})
 	}
 }

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -295,6 +295,94 @@ func TestACL_vetServiceRegister(t *testing.T) {
 	require.True(t, acl.IsErrPermissionDenied(err))
 }
 
+// TestACL_vetServiceRegister_bootstrapEscapeHatch verifies that registering a
+// connect-proxy sidecar with any bootstrap escape-hatch key in Proxy.Config
+// requires mesh:write in addition to service:write (SECVULN — Vector 2).
+func TestACL_vetServiceRegister_bootstrapEscapeHatch(t *testing.T) {
+	t.Parallel()
+	a := NewTestACLAgent(t, t.Name(), TestACLConfig(), catalogPolicy, catalogIdent)
+
+	newAuthz := func(t *testing.T, rules string) acl.Authorizer {
+		t.Helper()
+		policy, err := acl.NewPolicyFromSource(rules, nil, nil)
+		require.NoError(t, err)
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(t, err)
+		return authz
+	}
+
+	sidecar := &structs.NodeService{
+		ID:      "web-sidecar-proxy",
+		Service: "web-sidecar-proxy",
+		Kind:    structs.ServiceKindConnectProxy,
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceName: "web",
+			Config: map[string]interface{}{
+				"envoy_extra_static_listeners_json": `{"name":"attacker-listener"}`,
+			},
+		},
+	}
+
+	// service:write on both names but no mesh:write — must be denied.
+	authzServiceOnly := newAuthz(t, `service_prefix "" { policy = "write" }`)
+	err := a.vetServiceRegisterWithAuthorizer(authzServiceOnly, sidecar)
+	require.Error(t, err)
+	require.True(t, acl.IsErrPermissionDenied(err), "expected permission denied, got: %v", err)
+
+	// service:write + mesh:write — must be allowed.
+	authzWithMesh := newAuthz(t, `service_prefix "" { policy = "write" } mesh = "write"`)
+	err = a.vetServiceRegisterWithAuthorizer(authzWithMesh, sidecar)
+	require.NoError(t, err)
+
+	// Proxy.Config with no escape-hatch keys — service:write alone is sufficient.
+	normalSidecar := &structs.NodeService{
+		ID:      "web-sidecar-proxy",
+		Service: "web-sidecar-proxy",
+		Kind:    structs.ServiceKindConnectProxy,
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceName: "web",
+			Config: map[string]interface{}{
+				"protocol": "http",
+			},
+		},
+	}
+	err = a.vetServiceRegisterWithAuthorizer(authzServiceOnly, normalSidecar)
+	require.NoError(t, err)
+
+	// Verify each escape-hatch key individually triggers the mesh:write requirement.
+	for _, key := range []string{
+		"envoy_bootstrap_json_tpl",
+		"envoy_extra_static_listeners_json",
+		"envoy_public_listener_json",
+		"envoy_listener_json",
+		"envoy_cluster_json",
+		"envoy_local_cluster_json",
+		"envoy_extra_static_clusters_json",
+		"envoy_extra_stats_sinks_json",
+		"envoy_tracing_json",
+		"envoy_stats_config_json",
+		"envoy_listener_tracing_json",
+	} {
+		t.Run(key, func(t *testing.T) {
+			svc := &structs.NodeService{
+				ID:      "web-sidecar-proxy",
+				Service: "web-sidecar-proxy",
+				Kind:    structs.ServiceKindConnectProxy,
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					Config:                 map[string]interface{}{key: `{}`},
+				},
+			}
+			err := a.vetServiceRegisterWithAuthorizer(authzServiceOnly, svc)
+			require.Error(t, err, "key %q: expected denial without mesh:write", key)
+			require.True(t, acl.IsErrPermissionDenied(err), "key %q: expected permission denied, got: %v", key, err)
+
+			err = a.vetServiceRegisterWithAuthorizer(authzWithMesh, svc)
+			require.NoError(t, err, "key %q: expected success with mesh:write", key)
+		})
+	}
+}
+
 func TestACL_vetServiceUpdateWithAuthorizer(t *testing.T) {
 	t.Parallel()
 	a := NewTestACLAgent(t, t.Name(), TestACLConfig(), catalogPolicy, catalogIdent)

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -363,7 +363,20 @@ func (e *ServiceConfigEntry) CanRead(authz acl.Authorizer) error {
 func (e *ServiceConfigEntry) CanWrite(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.ToAllowAuthorizer().ServiceWriteAllowed(e.Name, &authzContext)
+	if err := authz.ToAllowAuthorizer().ServiceWriteAllowed(e.Name, &authzContext); err != nil {
+		return err
+	}
+	// Code-executing extensions (builtin/lua, builtin/wasm) run arbitrary code as
+	// the Envoy process user on every proxied request. Attaching them requires
+	// mesh:write in addition to service:write so the capability is independently
+	// auditable and cannot be reached via the standard application-team delegation
+	// pattern alone.
+	if e.EnvoyExtensions.HasCodeExecutingExtension() {
+		if err := authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext); err != nil {
+			return fmt.Errorf("mesh:write required to attach code-executing EnvoyExtensions (builtin/lua, builtin/wasm): %w", err)
+		}
+	}
+	return nil
 }
 
 func (e *ServiceConfigEntry) GetRaftIndex() *RaftIndex {

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -55,6 +55,108 @@ func TestConfigEntries_ACLs(t *testing.T) {
 	}
 
 	cases := []testcase{
+		// =================== service-defaults (no code-executing extensions) ===================
+		{
+			name: "service-defaults: no code-executing extension",
+			entry: &ServiceConfigEntry{
+				Kind: ServiceDefaults,
+				Name: "web",
+				EnvoyExtensions: EnvoyExtensions{
+					{Name: api.BuiltinAWSLambdaExtension, Arguments: map[string]interface{}{"ARN": "arn:aws:lambda:us-east-1:111122223333:function:my-function"}},
+				},
+			},
+			expectACLs: []testACL{
+				{
+					name:       "service:write only — allowed (no code-executing extension)",
+					authorizer: newAuthz(t, `service "web" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   true,
+				},
+				{
+					name:       "service:read only — denied",
+					authorizer: newAuthz(t, `service "web" { policy = "read" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+			},
+		},
+		// =================== service-defaults (code-executing extensions: lua) ===================
+		{
+			name: "service-defaults: lua extension requires mesh:write",
+			entry: &ServiceConfigEntry{
+				Kind: ServiceDefaults,
+				Name: "web",
+				EnvoyExtensions: EnvoyExtensions{
+					{Name: api.BuiltinLuaExtension, Arguments: map[string]interface{}{
+						"Script":   "function envoy_on_request(h) end",
+						"Listener": "inbound",
+					}},
+				},
+			},
+			expectACLs: []testACL{
+				{
+					name:       "service:write only — denied (missing mesh:write)",
+					authorizer: newAuthz(t, `service "web" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+				{
+					name:       "service:write + mesh:write — allowed",
+					authorizer: newAuthz(t, `service "web" { policy = "write" } mesh = "write"`),
+					canRead:    true,
+					canWrite:   true,
+				},
+				{
+					name:       "mesh:write only (no service:write) — denied",
+					authorizer: newAuthz(t, `mesh = "write"`),
+					canRead:    false, // no service:read either
+					canWrite:   false,
+				},
+				{
+					name:       "service:write + mesh:read only — denied",
+					authorizer: newAuthz(t, `service "web" { policy = "write" } mesh = "read"`),
+					canRead:    true,
+					canWrite:   false,
+				},
+			},
+		},
+		// =================== service-defaults (code-executing extensions: wasm) ===================
+		{
+			name: "service-defaults: wasm extension requires mesh:write",
+			entry: &ServiceConfigEntry{
+				Kind: ServiceDefaults,
+				Name: "web",
+				EnvoyExtensions: EnvoyExtensions{
+					{Name: api.BuiltinWasmExtension, Arguments: map[string]interface{}{
+						"Protocol":     "http",
+						"ListenerType": "inbound",
+						"PluginConfig": map[string]interface{}{
+							"VmConfig": map[string]interface{}{
+								"Code": map[string]interface{}{
+									"Local": map[string]interface{}{
+										"Filename": "/etc/envoy/plugin.wasm",
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			expectACLs: []testACL{
+				{
+					name:       "service:write only — denied (missing mesh:write)",
+					authorizer: newAuthz(t, `service "web" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+				{
+					name:       "service:write + mesh:write — allowed",
+					authorizer: newAuthz(t, `service "web" { policy = "write" } mesh = "write"`),
+					canRead:    true,
+					canWrite:   true,
+				},
+			},
+		},
 		// =================== proxy-defaults ===================
 		{
 			name:  "proxy-defaults",

--- a/agent/structs/envoy_extension.go
+++ b/agent/structs/envoy_extension.go
@@ -30,6 +30,27 @@ func (c *EnvoyExtension) appendHash(h *customHasher) {
 
 type EnvoyExtensions []EnvoyExtension
 
+// codeExecutingExtensions is the set of built-in extension names that cause
+// Envoy to compile and execute caller-supplied code (Lua scripts, Wasm modules)
+// on every proxied request. Attaching any of these to a config entry requires
+// mesh:write in addition to the normal service:write check so that the
+// code-execution capability is gated on a separate, auditable permission.
+var codeExecutingExtensions = map[string]bool{
+	api.BuiltinLuaExtension:  true,
+	api.BuiltinWasmExtension: true,
+}
+
+// HasCodeExecutingExtension reports whether any extension in the slice is a
+// code-executing type (builtin/lua or builtin/wasm).
+func (es EnvoyExtensions) HasCodeExecutingExtension() bool {
+	for _, e := range es {
+		if codeExecutingExtensions[e.Name] {
+			return true
+		}
+	}
+	return false
+}
+
 func (es EnvoyExtensions) ToAPI() []api.EnvoyExtension {
 	extensions := make([]api.EnvoyExtension, len(es))
 	for i, e := range es {


### PR DESCRIPTION
### Description

Require `mesh:write` in addition to `service:write` for two code-execution surfaces in the Envoy extension configuration:

**Vector 1 — service-defaults with builtin/lua or builtin/wasm**
`ServiceConfigEntry.CanWrite()` now checks `mesh:write` when the entry contains a code-executing extension. Previously `service:write` alone was enough to attach a Lua script or Wasm module that Envoy executes on every proxied request.

**Vector 2 — sidecar registration with bootstrap escape-hatch keys**
`vetServiceRegisterWithAuthorizer()` now checks `mesh:write` when `Proxy.Config` contains any of the 11 `envoy_*_json` / `envoy_bootstrap_json_tpl` keys. Previously `service:write` on the proxy and its destination was sufficient to inject arbitrary Envoy filter chain configuration into the sidecar bootstrap.

### Testing & Reproduction steps

- `TestConfigEntries_ACLs` — 7 new sub-cases covering lua/wasm on service-defaults
- `TestACL_vetServiceRegister_bootstrapEscapeHatch` — 13 sub-cases, one per escape-hatch key

### Links

Ref: CSL-16094

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.