### PR TITLE
state: do not treat short hex node names as UUID prefixes

### DIFF
--- a/.changelog/23865.txt
+++ b/.changelog/23865.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+state: do not treat short hex node names as UUID prefixes
+```

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -36,10 +36,11 @@ const (
 )
 
 const (
-	// minUUIDLookupLen is used as a minimum length of a node name required before
-	// we test to see if the name is actually a UUID and perform an ID-based node
-	// lookup.
-	minUUIDLookupLen = 2
+	// minUUIDLookupLen is the minimum UUID prefix length after
+	// resizeNodeLookupKey before we do an ID-based node lookup.
+	// A floor of 2 let odd-length names like "ba1" shrink to "ba"
+	// and match unrelated node IDs.
+	minUUIDLookupLen = 8
 )
 
 var (
@@ -1882,14 +1883,15 @@ func (s *Store) nodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *ac
 	if n != nil {
 		ws.Add(watchCh)
 	} else {
-		if len(nodeNameOrID) < minUUIDLookupLen {
+		uuidPrefix := resizeNodeLookupKey(nodeNameOrID)
+		if len(uuidPrefix) < minUUIDLookupLen {
 			ws.Add(watchCh)
 			return true, 0, nil, nil, nil
 		}
 
 		// Attempt to lookup the node by its node ID
 		iter, err := tx.Get(tableNodes, indexUUID+"_prefix", Query{
-			Value:          resizeNodeLookupKey(nodeNameOrID),
+			Value:          uuidPrefix,
 			EnterpriseMeta: *entMeta,
 			PeerName:       peerName,
 		})

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1746,6 +1746,33 @@ func TestStateStore_NodeServices(t *testing.T) {
 		require.NotNil(t, ns)
 		require.Equal(t, "node2", ns.Node.Node)
 	})
+
+	// Missing "ba1" must not match a node whose ID starts with ba… (GH-23724).
+	t.Run("Missing short hex name does not match UUID prefix", func(t *testing.T) {
+		req := &structs.RegisterRequest{
+			ID:      types.NodeID("ba1e4a74-2192-161a-0510-cccccccccccc"),
+			Node:    "other-host",
+			Address: "9.10.11.12",
+		}
+		require.NoError(t, s.EnsureRegistration(3, req))
+
+		{
+			_, ns, err := s.NodeServices(nil, "other-host", nil, "")
+			require.NoError(t, err)
+			require.NotNil(t, ns)
+			require.Equal(t, "other-host", ns.Node.Node)
+		}
+		{
+			_, ns, err := s.NodeServices(nil, "ba1e4a74-2192-161a-0510-cccccccccccc", nil, "")
+			require.NoError(t, err)
+			require.NotNil(t, ns)
+			require.Equal(t, "other-host", ns.Node.Node)
+		}
+
+		_, ns, err := s.NodeServices(nil, "ba1", nil, "")
+		require.NoError(t, err)
+		require.Nil(t, ns)
+	})
 }
 
 func TestStateStore_DeleteNode(t *testing.T) {


### PR DESCRIPTION
## Description

`NodeServices("ba1")` can return an unrelated node.

## Root Cause

On a name miss the catalog does a UUID prefix lookup. `minUUIDLookupLen` is 2, and `resizeNodeLookupKey("ba1")` is `ba`, so any node whose ID starts `BA…` matches.

## Fix

Require 8 hex characters after resize before treating the query as a UUID prefix. A missing short hex name returns nothing. Existing UUID and prefix lookups are unchanged.

## Testing

`go test ./agent/consul/state -run 'TestStateStore_NodeServices' -count=1`

Fixes #23724