### PR TITLE
ui: fix accessibility issues across forms, dropdowns, modals, and data tables

### DIFF
--- a/ui/packages/consul-ui/app/components/app-view/index.hbs
+++ b/ui/packages/consul-ui/app/components/app-view/index.hbs
@@ -11,7 +11,7 @@
   <header>
       <div>
           <div>
-              <nav class="app-view-breadcrumbs" aria-label="Breadcrumb" data-test-breadcrumbs>
+              <div class="app-view-breadcrumbs" data-test-breadcrumbs>
                 {{#if (not-eq @showBreadcrumb false)}}
                   {{#if (has-block 'breadcrumbs')}}
                     {{document-attrs class="with-breadcrumbs"}}
@@ -21,7 +21,7 @@
                     <Breadcrumbs @items={{this.computedBreadcrumbs}} />
                   {{/if}}
                 {{/if}}
-              </nav>
+              </div>
               <div class="title">
                 <div class="title-left-container">
                   {{yield to='header'}}

--- a/ui/packages/consul-ui/app/components/app/index.hbs
+++ b/ui/packages/consul-ui/app/components/app/index.hbs
@@ -14,7 +14,7 @@
       <Frame.Header class='app-shell__header'>
         {{yield exported to='header'}}
       </Frame.Header>
-      <Frame.Sidebar class='app-shell__sidebar'>
+      <Frame.Sidebar class='app-shell__sidebar' aria-label='Application navigation'>
         {{yield exported to='sideNav'}}
       </Frame.Sidebar>
       <Frame.Modals>

--- a/ui/packages/consul-ui/app/components/auth-form/index.hbs
+++ b/ui/packages/consul-ui/app/components/auth-form/index.hbs
@@ -93,6 +93,7 @@
           <TabState @matches='token'>
             <form onsubmit={{action dispatch 'SUBMIT'}}>
               <fieldset>
+                <legend class="sr-only">Log in with a token</legend>
                 <label
                   class={{concat
                     'type-password'

--- a/ui/packages/consul-ui/app/components/consul-copy-button/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul-copy-button/index.hbs
@@ -14,7 +14,7 @@
 {{#let (fn dispatch 'SUCCESS') (fn dispatch 'ERROR') (fn dispatch 'RESET') as |success error reset|}}
     <button
       {{with-copyable @value success=(fn this.flash success reset) error=(fn this.flash error reset)}}
-      aria-label={{t 'components.consul-copy-button.title' name=@name}}
+      aria-label="{{t 'components.consul-copy-button.title' name=@name}} {{@value}}"
       type="button"
       class="copy-btn {{if (state-matches state 'success') 'is-copied'}}"
       {{hds-tooltip

--- a/ui/packages/consul-ui/app/components/consul/acl/ruleset-badge/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/acl/ruleset-badge/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<span class="consul-acl-ruleset-badge" data-type={{this.type}} aria-label={{this.ariaLabel}} ...attributes>
+<span class="consul-acl-ruleset-badge" data-type={{this.type}} role="group" aria-label={{this.ariaLabel}} ...attributes>
   {{#if this.hasIcon}}
     <Hds::Badge
       @text={{this.label}}

--- a/ui/packages/consul-ui/app/components/consul/acl/selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/acl/selector/index.hbs
@@ -7,7 +7,7 @@
   {{#if (can "use acls")}}
     <SNL.Title>{{t "components.hashicorp-consul.side-nav.acls.title"}}</SNL.Title>
   {{else}}
-    <SNL.Title {{hds-tooltip (t "components.hashicorp-consul.side-nav.acls.tooltip") options=(detached-tooltip-options)}}>
+    <SNL.Title role="group" tabindex="-1" aria-label={{t "components.hashicorp-consul.side-nav.acls.title"}} {{hds-tooltip (t "components.hashicorp-consul.side-nav.acls.tooltip") options=(detached-tooltip-options)}}>
       {{t "components.hashicorp-consul.side-nav.acls.title"}}
     </SNL.Title>
   {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/auth-method/binding-list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/binding-list/index.hbs
@@ -31,7 +31,7 @@
           as |bindTypeTooltip|
         }}
           {{#if bindTypeTooltip}}
-            <span {{hds-tooltip bindTypeTooltip options=(detached-tooltip-options)}}></span>
+            <span role="group" tabindex="-1" aria-label={{bindTypeTooltip}} {{hds-tooltip bindTypeTooltip options=(detached-tooltip-options)}}></span>
           {{/if}}
         {{/let}}
       </dd>

--- a/ui/packages/consul-ui/app/components/consul/auth-method/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/list/index.hbs
@@ -24,7 +24,7 @@
               old list showed only for global-locality methods) as a compact
               badge next to the name. }}
           {{#if (eq item.TokenLocality 'global')}}
-            <span {{hds-tooltip "Creates global tokens" options=(detached-tooltip-options)}}>
+            <span role="group" tabindex="-1" aria-label="Global Tokens" {{hds-tooltip "Creates global tokens" options=(detached-tooltip-options)}}>
               <Hds::Badge @text="Global Tokens" @color="highlight" @size="medium" data-test-locality-global />
             </span>
           {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/bucket/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/bucket/list/index.hbs
@@ -6,8 +6,15 @@
 {{#if this.itemsToDisplay.length}}
   <dl class="consul-bucket-list">
     {{#each this.itemsToDisplay as |item|}}
-      <dt class={{item.type}} role="group" tabindex="-1" aria-label={{item.label}} {{hds-tooltip options=(detached-tooltip-options)}}>
-        {{item.label}}
+      {{! <dt>'s only ARIA-in-HTML-permitted role override is "listitem" —
+          "group" isn't valid on it. <span> has no such restriction, so the
+          role/label/tooltip live on an inner span instead; the <dt> itself
+          keeps just the @type class the ::before icon styling above hooks
+          into, and stays at its correct "no corresponding role" default. }}
+      <dt class={{item.type}}>
+        <span role="group" tabindex="-1" aria-label={{item.label}} {{hds-tooltip options=(detached-tooltip-options)}}>
+          {{item.label}}
+        </span>
       </dt>
       <dd data-test-bucket-item={{item.type}}>
         {{item.item}}

--- a/ui/packages/consul-ui/app/components/consul/bucket/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/bucket/list/index.hbs
@@ -6,7 +6,7 @@
 {{#if this.itemsToDisplay.length}}
   <dl class="consul-bucket-list">
     {{#each this.itemsToDisplay as |item|}}
-      <dt class={{item.type}} {{hds-tooltip options=(detached-tooltip-options)}}>
+      <dt class={{item.type}} role="group" tabindex="-1" aria-label={{item.label}} {{hds-tooltip options=(detached-tooltip-options)}}>
         {{item.label}}
       </dt>
       <dd data-test-bucket-item={{item.type}}>

--- a/ui/packages/consul-ui/app/components/consul/data-table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/data-table/index.hbs
@@ -63,9 +63,9 @@
                     @width={{column.width}}
                     @sortOrder={{if (eq this.sortBy column.sortKey) this.sortOrder}}
                     @onClickSort={{fn this.setSortBy column.sortKey}}
-                  >{{column.label}}{{#if column.tooltip}}<span {{hds-tooltip column.tooltip options=(detached-tooltip-options)}}><Hds::Icon @name="info" @size="16" @isInline={{true}} /></span>{{/if}}</H.ThSort>
+                  >{{column.label}}{{#if column.tooltip}}<span role="group" tabindex="-1" aria-label={{column.tooltip}} {{hds-tooltip column.tooltip options=(detached-tooltip-options)}}><Hds::Icon @name="info" @size="16" @isInline={{true}} /></span>{{/if}}</H.ThSort>
                 {{else}}
-                  <H.Th @align={{column.align}} @width={{column.width}}>{{column.label}}{{#if column.tooltip}}<span {{hds-tooltip column.tooltip options=(detached-tooltip-options)}}><Hds::Icon @name="info" @size="16" @isInline={{true}} /></span>{{/if}}</H.Th>
+                  <H.Th @align={{column.align}} @width={{column.width}}>{{column.label}}{{#if column.tooltip}}<span role="group" tabindex="-1" aria-label={{column.tooltip}} {{hds-tooltip column.tooltip options=(detached-tooltip-options)}}><Hds::Icon @name="info" @size="16" @isInline={{true}} /></span>{{/if}}</H.Th>
                 {{/if}}
               {{/each}}
             </H.Tr>

--- a/ui/packages/consul-ui/app/components/consul/data-table/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/data-table/index.scss
@@ -114,6 +114,14 @@
       &:active::before {
         background-color: var(--token-color-surface-interactive-active);
       }
+
+      /* the blanket `box-shadow: none` above has the same specificity as HDS's
+         own `:focus-visible::before` rule and is compiled after it, so it wins
+         the cascade and silently strips the keyboard focus ring. Restore it
+         explicitly so tabbing to a sort button is visible. */
+      &:focus-visible::before {
+        box-shadow: var(--token-focus-ring-action-box-shadow);
+      }
     }
 
     /* the legacy `%table th span::after` rule (app/components/table/index.scss)
@@ -143,6 +151,23 @@
      by the @for loop below). */
   .hds-table__tbody .hds-table__tr {
     cursor: default;
+  }
+
+  /* The legacy `%table td:not(.actions) > *:only-child` rule
+     (app/components/table/layout.scss) sets `overflow: hidden` on a cell's
+     lone child, sized for the old hand-rolled table's ellipsis-truncation.
+     Several row templates wrap their Name-column link in a single wrapper
+     <span> (e.g. Consul::Token::List, Consul::Service::Table,
+     Consul::Node::Table) — that span is the cell's only child, so it
+     inherits the `overflow: hidden`. An ancestor's `overflow: hidden` also
+     clips a focused descendant's native focus ring, so tabbing to the link
+     inside silently loses its keyboard focus ring. Undo just `overflow`
+     (leaving any inherited `white-space: nowrap` alone); a list that wants
+     real truncation opts in explicitly (see e.g. Consul::Peer::List's own
+     ellipsis rule, which sets `overflow` on the specific element it needs
+     truncated rather than relying on this legacy leak). */
+  .hds-table__tbody .hds-table__td > *:only-child {
+    overflow: visible;
   }
 
   /* Only the link column (@linkColumn, 1-based; defaults to the first column)

--- a/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
@@ -52,7 +52,11 @@
         @name='server-cluster'
         @color='var(--token-form-control-disabled-foreground-color)'
       />
-      <Hds::Text::Display @size='200' @color='disabled'>{{@dc.Name}}</Hds::Text::Display>
+      {{! @color='disabled' rendered #8c909c on #fafafa (3.05:1, fails AA's
+        4.5:1) — this label isn't an actually-disabled control, so use
+        'faint' (5.19:1) instead, HDS's token for muted-but-readable text.
+        See docs/a11y-audit/01-shared-chrome.md #1 }}
+      <Hds::Text::Display @size='200' @color='faint'>{{@dc.Name}}</Hds::Text::Display>
     </SNL.Item>
   {{/if}}
 {{/let}}

--- a/ui/packages/consul-ui/app/components/consul/discovery-chain/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/discovery-chain/index.hbs
@@ -23,6 +23,9 @@
       {{@chain.ServiceName}}
       Router
       <span
+        role="group"
+        tabindex="-1"
+        aria-label='Use routers to intercept traffic using Layer 7 criteria such as path prefixes or http headers.'
         {{hds-tooltip
           'Use routers to intercept traffic using Layer 7 criteria such as path prefixes or http headers.'
           options=(detached-tooltip-options)
@@ -47,6 +50,9 @@
     <h2>
       Splitters
       <span
+        role="group"
+        tabindex="-1"
+        aria-label='Splitters are configured to split incoming requests across different services or subsets of a single service.'
         {{hds-tooltip
           'Splitters are configured to split incoming requests across different services or subsets of a single service.'
           options=(detached-tooltip-options)
@@ -71,6 +77,9 @@
     <h2>
       Resolvers
       <span
+        role="group"
+        tabindex="-1"
+        aria-label='Resolvers are used to define which instances of a service should satisfy discovery requests.'
         {{hds-tooltip
           'Resolvers are used to define which instances of a service should satisfy discovery requests.'
           options=(detached-tooltip-options)

--- a/ui/packages/consul-ui/app/components/consul/discovery-chain/resolver-card/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/discovery-chain/resolver-card/index.hbs
@@ -14,6 +14,9 @@
 {{#if @item.Failover}}
       <dl class="failover">
         <dt
+          role="group"
+          tabindex="-1"
+          aria-label={{concat @item.Failover.Type ' failover'}}
           {{hds-tooltip (concat @item.Failover.Type ' failover') options=(detached-tooltip-options)}}
         >
           {{concat @item.Failover.Type ' failover'}}
@@ -41,6 +44,9 @@
     {{#if child.Redirect}}
           <dl class="redirect">
             <dt
+              role="group"
+              tabindex="-1"
+              aria-label={{concat child.Redirect ' redirect'}}
               {{hds-tooltip (concat child.Redirect ' redirect') options=(detached-tooltip-options)}}
             >
               {{child.Redirect}} redirect
@@ -52,6 +58,9 @@
           {{#if child.Failover}}
             <dl class="failover">
               <dt
+                role="group"
+                tabindex="-1"
+                aria-label={{concat child.Failover.Type ' failover'}}
                 {{hds-tooltip (concat child.Failover.Type ' failover') options=(detached-tooltip-options)}}
               >
                 {{child.Failover.Type}} failover
@@ -71,6 +80,9 @@
           {{child.Name}}
           <dl class="failover">
             <dt
+              role="group"
+              tabindex="-1"
+              aria-label={{concat child.Failover.Type ' failover'}}
               {{hds-tooltip (concat child.Failover.Type ' failover') options=(detached-tooltip-options)}}
             >
               {{concat child.Failover.Type ' failover'}}

--- a/ui/packages/consul-ui/app/components/consul/discovery-chain/route-card/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/discovery-chain/route-card/index.hbs
@@ -38,7 +38,7 @@
 {{#if (gt @item.Definition.Match.HTTP.Header.length 0) }}
   <section class="match-headers">
     {{!-- template-lint-disable no-duplicate-landmark-elements --}}
-    <header {{hds-tooltip 'Header' options=(detached-tooltip-options)}}>
+    <header role="group" tabindex="-1" aria-label="Header" {{hds-tooltip 'Header' options=(detached-tooltip-options)}}>
       <h4>Headers</h4>
     </header>
     <dl>
@@ -56,7 +56,7 @@
 {{#if (gt @item.Definition.Match.HTTP.QueryParam.length 0) }}
   <section class="match-queryparams">
     {{!-- template-lint-disable no-duplicate-landmark-elements --}}
-    <header {{hds-tooltip 'Query Params' options=(detached-tooltip-options)}}>
+    <header role="group" tabindex="-1" aria-label="Query Params" {{hds-tooltip 'Query Params' options=(detached-tooltip-options)}}>
       <h4>Query Params</h4>
     </header>
     <dl>

--- a/ui/packages/consul-ui/app/components/consul/health-check/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/health-check/list/index.hbs
@@ -7,9 +7,13 @@
   class="consul-health-check-list"
   ...attributes
 >
-  <ul>
+  {{! the %healthcheck-output SCSS placeholder sets display: flex on <li>,
+    which strips the browser's implicit list/listitem roles; these explicit
+    roles restore them. }}
+  {{!-- template-lint-disable no-redundant-role --}}
+  <ul role="list">
 {{#each @items as |item|}}
-    <li class={{concat 'health-check-output ' item.Status}}>
+    <li role="listitem" class={{concat 'health-check-output ' item.Status}}>
       <div>
         <div class="health-check-output__title">
           <span class="health-check-output__name">{{item.Name}}</span>
@@ -44,6 +48,9 @@
             <span
               class="consul-health-check-list__exposed-badge"
               data-test-exposed="true"
+              role="group"
+              tabindex="-1"
+              aria-label="Exposed"
               {{hds-tooltip "Expose.checks is set to true, so all registered HTTP and gRPC check paths are exposed through Envoy for the Consul agent." options=(detached-tooltip-options)}}
             >
               <Hds::Badge

--- a/ui/packages/consul-ui/app/components/consul/instance-checks/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/instance-checks/index.hbs
@@ -28,7 +28,7 @@ as |grouped|}}
       }}
       ...attributes
     >
-      <dt {{hds-tooltip (concat (capitalize @type) " Checks") options=(detached-tooltip-options)}}>
+      <dt role="group" tabindex="-1" aria-label={{concat (capitalize @type) " Checks"}} {{hds-tooltip (concat (capitalize @type) " Checks") options=(detached-tooltip-options)}}>
         {{capitalize @type}} Checks
       </dt>
       {{#let

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
@@ -201,6 +201,7 @@
             @onchange={{action @onchange}}
             @name="Action"
             @icon={{_action.icon}}
+            @label={{_action.header}}
           >
             <header>{{_action.header}}</header>
             <p>{{_action.body}}</p>

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
@@ -8,7 +8,15 @@
   class="consul-intention-fieldsets"
   {{fix-super-select-aria}}
 >
-  <fieldset disabled={{@disabled}}>
+  <fieldset disabled={{@disabled}} aria-label="Intention details">
+    {{! aria-label above (rather than a <legend>): the Source/Destination
+        fieldsets and the radio cards below all read fine on their own via
+        their own labels, so a visible group heading would be redundant —
+        but this outer <fieldset> still needs an accessible name, or it's
+        announced as an unnamed group. A visually-hidden <legend> would do
+        the same job, but browsers give <legend> special fieldset-border
+        layout treatment that the usual clip-based hiding technique doesn't
+        reliably override, so aria-label sidesteps that entirely. }}
     <div role="group">
       <div class="consul-intention-fieldset-card">
         <fieldset>
@@ -153,7 +161,12 @@
         </fieldset>
       </div>
     </div>
-  <fieldset>
+  {{! A <div>, not a <fieldset>: this wraps a single field that already has
+      its own <label>, so there's no group of controls here needing a
+      <fieldset>+<legend> (or aria-label) for an accessible group name — a
+      <fieldset> around one field is just an unnamed group with nothing to
+      name. }}
+  <div>
     <Hds::Form::TextInput::Field
       name="Description"
       @value={{@item.Description}}
@@ -168,7 +181,7 @@
         <F.Error>{{@item.error.Description.validation}}</F.Error>
       {{/if}}
     </Hds::Form::TextInput::Field>
-  </fieldset>
+  </div>
     <div>
       <span class="label">Should this source connect to the destination?</span>
       <div role="radiogroup" class={{if @item.error.Action ' has-error'}}>

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.js
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.js
@@ -204,23 +204,29 @@ export default class ConsulIntentionForm extends Component {
         switch (target.name) {
           case 'SourceName':
           case 'DestinationName':
-            if (this.services.filterBy('Name', name).length === 0) {
+            // this.services/nspaces/partitions are only populated once their
+            // respective DataSource's `@onchange` has fired (see
+            // createServices/createNspaces/createPartitions below) -- a
+            // selection made before that resolves (or if it never does)
+            // would otherwise throw here and crash the whole app, so treat
+            // 'not loaded yet' the same as 'not already in the list'.
+            if ((this.services || []).filterBy('Name', name).length === 0) {
               selected = { Name: name };
-              this.services = [selected].concat(this.services.toArray());
+              this.services = [selected].concat((this.services || []).toArray());
             }
             break;
           case 'SourceNS':
           case 'DestinationNS':
-            if (this.nspaces.filterBy('Name', name).length === 0) {
+            if ((this.nspaces || []).filterBy('Name', name).length === 0) {
               selected = { Name: name };
-              this.nspaces = [selected].concat(this.nspaces.toArray());
+              this.nspaces = [selected].concat((this.nspaces || []).toArray());
             }
             break;
           case 'SourcePartition':
           case 'DestinationPartition':
-            if (this.partitions.filterBy('Name', name).length === 0) {
+            if ((this.partitions || []).filterBy('Name', name).length === 0) {
               selected = { Name: name };
-              this.partitions = [selected].concat(this.partitions.toArray());
+              this.partitions = [selected].concat((this.partitions || []).toArray());
             }
             break;
         }

--- a/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
@@ -57,7 +57,7 @@
       </B.Td>
       <B.Td>
         {{#if item.IsManagedByCRD}}
-          <span {{hds-tooltip "This intention is being managed through an Intention Custom Resource in your Kubernetes cluster. It is view only in the UI."}}>
+          <span role="group" tabindex="-1" aria-label="Managed by CRD" {{hds-tooltip "This intention is being managed through an Intention Custom Resource in your Kubernetes cluster. It is view only in the UI."}}>
             <Consul::ExternalSource @item={{item}} @label='Managed by CRD' />
           </span>
         {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/form/index.hbs
@@ -20,10 +20,16 @@ as |group|>
     changeset=this.changeset
   )}}
 
-  <fieldset>
+  {{! A <div>, not a <fieldset>: Hds::Form::Radio::Group below already
+      renders its own <fieldset>+<legend>, so wrapping it in another
+      <fieldset> just adds an outer group with nothing to name it. The
+      @name here is "PermissionAction" rather than "Action" so these radio
+      inputs don't get grouped, by the browser or by AT, with the
+      unrelated "Action" radios on the page behind this modal. }}
+  <div>
     <div data-property="action">
       <Hds::Form::Radio::Group
-        @name="Action"
+        @name="PermissionAction"
         @layout="horizontal"
         as |G|
       >
@@ -39,27 +45,32 @@ as |group|>
         {{/each}}
       </Hds::Form::Radio::Group>
     </div>
-  </fieldset>
+  </div>
 
   <Hds::Separator />
-  <fieldset>
+  {{! aria-label (rather than relying on the <h2> below) so the <fieldset>
+      still has an accessible name of its own — see the same pattern in
+      consul/intention/form/fieldsets. }}
+  <fieldset aria-label="Path">
       <h2>Path</h2>
     <div>
         <group.Element
           @name="PathType"
           @type="select"
         as |el|>
-          <el.Label>
-            Path type
-          </el.Label>
           <Hds::Form::SuperSelect::Single::Field
             @options={{this.pathTypes}}
             @selected={{this.pathType}}
             @onChange={{action 'change' 'HTTP.PathType' this.changeset}}
-            @label="Path type"
-            @listboxAriaLabel="Path type options"
-            id="path-type-select"
+            {{! @id, not a bare "id=": Hds::Form::SuperSelect::Single::Field has
+                no ...attributes of its own, so a bare "id=" here is captured by
+                ...attributes further down and forwarded onto PowerSelect, whose
+                own template sets the trigger's id *before* its ...attributes —
+                and a later ...attributes always wins, blanking the trigger's id
+                and leaving the label's "for" pointing at a nonexistent one. }}
+            @id="path-type-select"
           as |F|>
+            <F.Label>Path type</F.Label>
             <F.Options>{{get this.pathLabels F.options}}</F.Options>
           </Hds::Form::SuperSelect::Single::Field>
         </group.Element>
@@ -92,7 +103,7 @@ as |group|>
   </fieldset>
 
   <Hds::Separator />
-  <fieldset>
+  <fieldset aria-label="Methods">
     <h2>Methods</h2>
     <p class="methods-description">All methods are applied by default unless specified</p>
     <Hds::Form::Toggle::Field
@@ -104,7 +115,11 @@ as |group|>
       <F.Label>All methods</F.Label>
     </Hds::Form::Toggle::Field>
 
-    <div class="checkbox-group" role="group">
+    {{! aria-label distinct from the outer <fieldset aria-label="Methods">
+        above — this inner role="group" needs its own accessible name too,
+        and a matching name on both would leave two same-named groups
+        nested inside one another, which AT can't tell apart. }}
+    <div class="checkbox-group" role="group" aria-label="HTTP methods">
       {{#each this.methods as |method|}}
         <Hds::Form::Checkbox::Field
           @value={{method}}
@@ -119,7 +134,7 @@ as |group|>
   </fieldset>
 
   <Hds::Separator />
-  <fieldset>
+  <fieldset aria-label="Headers">
     <h2>Headers</h2>
 
     <div class="headers-content">

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/form/layout.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/form/layout.scss
@@ -62,6 +62,18 @@
     min-width: 0;
   }
 
+  // The Header name/information fields render their label text inside the
+  // same <label> that wraps the input (so the label has an accessible
+  // name), rather than as a separate sibling — so that <label> is now
+  // .header-col's only flex child, and needs the label-over-control
+  // stacking applied one level deeper.
+  .header-col > label {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+  }
+
   // Shared column label typography (matches HDS body-100 semibold)
   .header-col-label {
     font-size: var(--token-typography-body-100-font-size);

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/header/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/header/form/index.hbs
@@ -20,11 +20,12 @@
       changeset=this.changeset
     )}}
 
-    <fieldset>
+    {{! aria-label so this <fieldset> (which groups the header type/name/
+        information row below) has an accessible name of its own. }}
+    <fieldset aria-label="Header">
       <div class="header-row">
         {{! Header type }}
         <div class="header-col">
-          <span class="header-col-label">Header type</span>
           <group.Element
             @name="HeaderType"
             @type="select"
@@ -33,10 +34,11 @@
               @options={{this.headerTypes}}
               @selected={{this.headerType}}
               @onChange={{action 'change' 'HeaderType' this.changeset}}
-              @label="Header type"
-              @listboxAriaLabel="Header type options"
-              id="header-type-select"
+              {{! @id, not a bare "id=" — see the same fix in
+                  consul/intention/permission/form/index.hbs for why. }}
+              @id="header-type-select"
             as |F|>
+              <F.Label class="header-col-label">Header type</F.Label>
               <F.Options>{{get this.headerLabels F.options}}</F.Options>
             </Hds::Form::SuperSelect::Single::Field>
           </group.Element>
@@ -44,11 +46,11 @@
 
         {{! Header name }}
         <div class="header-col">
-          <span class="header-col-label">Header name</span>
           <group.Element
             @name="Name"
             @error={{changeset-get this.changeset 'error.Name'}}
           as |el|>
+            <el.Label class="header-col-label">Header name</el.Label>
             <el.Text
               placeholder="Enter header name"
               @value={{changeset-get this.changeset 'Name'}}
@@ -65,11 +67,11 @@
   {{#if this.shouldShowValueField}}
         {{! Header information (value) }}
         <div class="header-col">
-          <span class="header-col-label">Header information</span>
           <group.Element
             @name="Value"
             @error={{changeset-get this.changeset 'error.Value'}}
           as |el|>
+            <el.Label class="header-col-label">Header information</el.Label>
             <el.Text
               placeholder="Enter header information"
               @value={{changeset-get this.changeset 'Value'}}

--- a/ui/packages/consul-ui/app/components/consul/kv/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/form/index.hbs
@@ -39,6 +39,7 @@
     {{#let (or readOnly api.disabled) as |isDisabled|}}
       <form onsubmit={{fn this.submit api}}>
         <fieldset {{disabled isDisabled}}>
+          <legend class="sr-only">Key/Value</legend>
           {{#if api.isCreate}}
             <div class='consul-kv-form__key'>
               <Hds::Form::TextInput::Field
@@ -71,7 +72,7 @@
                   <F.Label>Code</F.Label>
                 </Hds::Form::Toggle::Field>
               </LF.Item>
-              <label for='' class='type-text consul-kv-form__value{{if api.data.error.Value " has-error"}}'>
+              <label class='type-text consul-kv-form__value{{if api.data.error.Value " has-error"}}'>
                 {{#if this.json}}
                   {{#if isDisabled}}
                     <Hds::CodeBlock

--- a/ui/packages/consul-ui/app/components/consul/node/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/node/table/index.hbs
@@ -48,6 +48,9 @@
           @color="success"
           @type="filled"
           @size="small"
+          role="group"
+          tabindex="-1"
+          aria-label="Passing"
           {{hds-tooltip (this.healthTooltip item.Status) options=(detached-tooltip-options)}}
           data-test-status={{item.Status}}
         />
@@ -58,6 +61,9 @@
           @color="warning"
           @type="filled"
           @size="small"
+          role="group"
+          tabindex="-1"
+          aria-label="Warning"
           {{hds-tooltip (this.healthTooltip item.Status) options=(detached-tooltip-options)}}
           data-test-status={{item.Status}}
         />
@@ -68,6 +74,9 @@
           @color="critical"
           @type="filled"
           @size="small"
+          role="group"
+          tabindex="-1"
+          aria-label="Critical"
           {{hds-tooltip (this.healthTooltip item.Status) options=(detached-tooltip-options)}}
           data-test-status={{item.Status}}
         />
@@ -78,6 +87,9 @@
           @color="neutral"
           @type="outlined"
           @size="small"
+          role="group"
+          tabindex="-1"
+          aria-label="No health checks"
           {{hds-tooltip (this.healthTooltip item.Status) options=(detached-tooltip-options)}}
           data-test-status={{item.Status}}
         />

--- a/ui/packages/consul-ui/app/components/consul/peer/bento-box/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/peer/bento-box/index.hbs
@@ -26,7 +26,7 @@
               class="mr-0.5"
             />
             {{#if smartDate.isNearDate}}
-              <span {{hds-tooltip smartDate.friendly options=(detached-tooltip-options)}}>{{smartDate.relative}}</span>
+              <span role="group" tabindex="-1" aria-label={{smartDate.relative}} {{hds-tooltip smartDate.friendly options=(detached-tooltip-options)}}>{{smartDate.relative}}</span>
             {{else}}
               <span>{{smartDate.friendly}}</span>
             {{/if}}
@@ -44,7 +44,7 @@
         {{#if @peering.LastReceive}}
           {{#let (smart-date-format @peering.LastReceive) as |smartDate|}}
             {{#if smartDate.isNearDate}}
-              <span {{hds-tooltip smartDate.friendly options=(detached-tooltip-options)}}>{{smartDate.relative}}</span>
+              <span role="group" tabindex="-1" aria-label={{smartDate.relative}} {{hds-tooltip smartDate.friendly options=(detached-tooltip-options)}}>{{smartDate.relative}}</span>
             {{else}}
               <span>{{smartDate.friendly}}</span>
             {{/if}}
@@ -62,7 +62,7 @@
         {{#if @peering.LastSend}}
           {{#let (smart-date-format @peering.LastSend) as |smartDate|}}
             {{#if smartDate.isNearDate}}
-              <span {{hds-tooltip smartDate.friendly options=(detached-tooltip-options)}}>{{smartDate.relative}}</span>
+              <span role="group" tabindex="-1" aria-label={{smartDate.relative}} {{hds-tooltip smartDate.friendly options=(detached-tooltip-options)}}>{{smartDate.relative}}</span>
             {{else}}
               <span>{{smartDate.friendly}}</span>
             {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/peer/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/peer/list/index.hbs
@@ -33,6 +33,9 @@
         {{else}}
           <p
             data-test-peer={{item.Name}}
+            role="group"
+            tabindex="-1"
+            aria-label={{item.Name}}
             {{hds-tooltip item.Name options=(detached-tooltip-options)}}
           >{{item.Name}}</p>
         {{/if}}
@@ -47,6 +50,9 @@
       <B.Td>
         <span
           data-test-imported-count
+          role="group"
+          tabindex="-1"
+          aria-label={{format-number item.ImportedServiceCount}}
           {{hds-tooltip
             (t "routes.dc.peers.index.detail.imported.tooltip" name=item.Name)
             options=(detached-tooltip-options)
@@ -58,6 +64,9 @@
       <B.Td>
         <span
           data-test-exported-count
+          role="group"
+          tabindex="-1"
+          aria-label={{format-number item.ExportedServiceCount}}
           {{hds-tooltip
             (t "routes.dc.peers.index.detail.exported.tooltip" name=item.Name)
             options=(detached-tooltip-options)

--- a/ui/packages/consul-ui/app/components/consul/policy/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/policy/fieldsets/index.hbs
@@ -3,7 +3,11 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
+{{! aria-label rather than a <legend>: every field inside already has its
+    own <F.Label>, so a visible group heading would be redundant — but the
+    <fieldset> itself still needs an accessible name of its own. }}
 <fieldset
+  aria-label="Policy details"
   disabled={{if (not (can "write policy" item=@item)) "disabled"}}
 >
   {{! Policy ID — read-only, edit mode only }}
@@ -124,7 +128,7 @@
 
 {{! Valid Datacenters — only for node-identity: Datacenter dropdown }}
 {{#if (eq @item.template "node-identity")}}
-  <fieldset>
+  <fieldset aria-label="Valid datacenters">
     <DataSource
       @src={{uri "/*/*/*/datacenters"}}
       @onchange={{this.setDatacenters}}
@@ -136,19 +140,26 @@
       @searchPlaceholder="Type a datacenter name"
       @onChange={{fn this.handleChange "Datacenter"}}
       @searchEnabled={{true}}
-      @label="Datacenter"
-      @listboxAriaLabel="Available datacenters"
       @isOptional={{false}}
-      id="datacenter-select"
+      {{! @id, not a bare "id=": Hds::Form::SuperSelect::Single::Field has
+          no ...attributes of its own at this level, so a bare "id=" here is
+          captured further down and forwarded onto PowerSelect, whose own
+          template sets the trigger's id *before* its ...attributes — and a
+          later ...attributes always wins, blanking the trigger's id and
+          leaving the label's "for" pointing at a nonexistent one. }}
+      @id="datacenter-select"
       name="policy[Datacenter]"
     as |F|>
+      <F.Label>Datacenter</F.Label>
       <F.Options>{{F.options}}</F.Options>
     </Hds::Form::SuperSelect::Single::Field>
   </fieldset>
 {{else}}
   {{! Valid Datacenters section — only for the default partition }}
   {{#if (eq (or @partition "default") "default")}}
-    <fieldset>
+    {{! aria-label (rather than relying on the heading below) so the
+        <fieldset> has an accessible name of its own. }}
+    <fieldset aria-label="Valid datacenters">
       <Hds::Text::Display @size="300" @tag="h2">Valid datacenters</Hds::Text::Display>
 
       <Hds::Form::Toggle::Field
@@ -169,7 +180,11 @@
       {{! Always render checkboxes.
           When "All datacenters" is on (isScoped=false): checked + disabled.
           When scoped (isScoped=true): interactive, reflecting current selection. }}
-      <div class="consul-policy-fieldsets__datacenter-checkboxes" role="group">
+      {{! aria-label distinct from the enclosing <fieldset aria-label="Valid
+          datacenters"> — this inner role="group" needs its own accessible
+          name too, and a matching name on both would leave two same-named
+          groups nested inside one another, which AT can't tell apart. }}
+      <div class="consul-policy-fieldsets__datacenter-checkboxes" role="group" aria-label="Datacenters">
         {{#each this.datacenters as |dc|}}
           <Hds::Form::Checkbox::Field
             @value={{dc.Name}}

--- a/ui/packages/consul-ui/app/components/consul/policy/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/policy/list/index.hbs
@@ -16,11 +16,17 @@
           {{#if (eq (policy/typeof item) 'policy-management')}}
             <span
               class="consul-policy-list__type"
+              role="group"
+              tabindex="-1"
+              aria-label="Global Management Policy"
               {{hds-tooltip "Global Management Policy" options=(detached-tooltip-options placement="top-start")}}
             ></span>
           {{else if (eq (policy/typeof item) 'read-only')}}
             <span
               class="consul-policy-list__type"
+              role="group"
+              tabindex="-1"
+              aria-label="Global Read-only Policy"
               {{hds-tooltip "Global Read-only Policy" options=(detached-tooltip-options placement="top-start")}}
             ></span>
           {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/role/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/role/fieldsets/index.hbs
@@ -3,7 +3,11 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
+{{! aria-label rather than a <legend>: every field inside already has its
+    own <F.Label>, so a visible group heading would be redundant — but the
+    <fieldset> itself still needs an accessible name of its own. }}
 <fieldset
+  aria-label="Role details"
   disabled={{if (not (can "write role" item=@item)) "disabled"}}
 >
   {{#unless @create}}
@@ -47,7 +51,9 @@
 
 <Hds::Separator />
 
-<fieldset id="policies">
+{{! aria-label rather than relying on PolicySelector's own "Policies"
+    heading, which is only rendered when @showHeader is true. }}
+<fieldset id="policies" aria-label="Policies">
   <PolicySelector
     @showHeader={{true}}
     @disabled={{not (can "write role" item=@item)}}

--- a/ui/packages/consul-ui/app/components/consul/server/card/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/server/card/index.hbs
@@ -21,7 +21,7 @@
 
     <div class="consul-server-card__header">
       {{#if (eq @item.Status 'leader')}}
-        <span class="consul-server-card__leader-tile" {{hds-tooltip "Leader" options=(detached-tooltip-options)}}>
+        <span class="consul-server-card__leader-tile" tabindex="-1" {{hds-tooltip "Leader" options=(detached-tooltip-options)}}>
           <Hds::Icon @name="star-fill" @size="16" @color="var(--token-color-consul-brand)" />
         </span>
       {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/service-instance/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service-instance/list/index.hbs
@@ -70,7 +70,7 @@ as |proxy|}}
   {{/if}}
 {{#if proxy}}
     <dl class="mesh">
-      <dt {{hds-tooltip "This service uses a proxy for the Consul service mesh" options=(detached-tooltip-options)}}></dt>
+      <dt role="group" tabindex="-1" aria-label="This service uses a proxy for the Consul service mesh" {{hds-tooltip "This service uses a proxy for the Consul service mesh" options=(detached-tooltip-options)}}></dt>
       <dd data-test-mesh>
         in service mesh with proxy
       </dd>
@@ -78,7 +78,7 @@ as |proxy|}}
 {{/if}}
 {{#if (and (not @node) (not item.Node.Meta.synthetic-node))}}
     <dl class="node">
-      <dt {{hds-tooltip "Node" options=(detached-tooltip-options)}}></dt>
+      <dt role="group" tabindex="-1" aria-label="Node" {{hds-tooltip "Node" options=(detached-tooltip-options)}}></dt>
       <dd>
         <a data-test-node-name href={{href-to 'dc.nodes.show' item.Node.Node}}>{{item.Node.Node}}</a>
       </dd>
@@ -86,7 +86,7 @@ as |proxy|}}
 {{/if}}
 {{#if item.Service.Port}}
     <dl class="address" data-test-address>
-      <dt {{hds-tooltip "IP Address and Port" options=(detached-tooltip-options)}}></dt>
+      <dt role="group" tabindex="-1" aria-label="IP Address and Port" {{hds-tooltip "IP Address and Port" options=(detached-tooltip-options)}}></dt>
       <dd>
         {{#if (not-eq item.Service.Address '')}}
           {{format-ipaddr item.Service.Address}}:{{item.Service.Port}}
@@ -97,7 +97,7 @@ as |proxy|}}
     </dl>
 {{else if item.Service.SocketPath}}
     <dl class="socket" data-test-socket>
-      <dt {{hds-tooltip options=(detached-tooltip-options)}}>
+      <dt role="group" tabindex="-1" aria-label="Socket Path" {{hds-tooltip options=(detached-tooltip-options)}}>
         Socket Path
       </dt>
       <dd>

--- a/ui/packages/consul-ui/app/components/consul/service/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/list/index.hbs
@@ -14,7 +14,7 @@
       <dt>
         Health
       </dt>
-      <dd {{hds-tooltip item.healthTooltipText options=(detached-tooltip-options)}}></dd>
+      <dd role="group" tabindex="-1" aria-label={{item.healthTooltipText}} {{hds-tooltip item.healthTooltipText options=(detached-tooltip-options)}}></dd>
     </dl>
     {{#if (gt item.InstanceCount 0)}}
       <a
@@ -60,7 +60,7 @@
     {{/if}}
     {{#if (or item.ConnectedWithGateway item.ConnectedWithProxy)}}
       <dl class='mesh'>
-        <dt {{hds-tooltip "This service uses a proxy for the Consul service mesh" options=(detached-tooltip-options)}}></dt>
+        <dt role="group" tabindex="-1" aria-label="This service uses a proxy for the Consul service mesh" {{hds-tooltip "This service uses a proxy for the Consul service mesh" options=(detached-tooltip-options)}}></dt>
         {{#if (and item.ConnectedWithGateway item.ConnectedWithProxy)}}
           <dd data-test-mesh>
             in service mesh with proxy and gateway

--- a/ui/packages/consul-ui/app/components/consul/service/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/table/index.hbs
@@ -80,6 +80,9 @@
               @color="success"
               @type="filled"
               @size="small"
+              role="group"
+              tabindex="-1"
+              aria-label="All checks passing"
               {{hds-tooltip item.healthTooltipText options=(detached-tooltip-options)}}
             />
           {{else if (eq item.MeshStatus "critical")}}
@@ -94,6 +97,13 @@
                 "All checks failing"
                 (concat item.MeshChecksCritical "/" item.MeshChecksTotal " checks failing")
               }}
+              role="group"
+              tabindex="-1"
+              aria-label={{if
+                (eq item.MeshChecksPassing 0)
+                "All checks failing"
+                (concat item.MeshChecksCritical "/" item.MeshChecksTotal " checks failing")
+              }}
               {{hds-tooltip item.healthTooltipText options=(detached-tooltip-options)}}
             />
           {{else if (eq item.MeshStatus "warning")}}
@@ -104,6 +114,9 @@
               @type="filled"
               @size="small"
               @text={{concat item.MeshChecksWarning "/" item.MeshChecksTotal " checks failing"}}
+              role="group"
+              tabindex="-1"
+              aria-label={{concat item.MeshChecksWarning "/" item.MeshChecksTotal " checks failing"}}
               {{hds-tooltip item.healthTooltipText options=(detached-tooltip-options)}}
             />
           {{else}}
@@ -114,6 +127,9 @@
               @color="neutral"
               @type="outlined"
               @size="small"
+              role="group"
+              tabindex="-1"
+              aria-label="Unknown"
               {{hds-tooltip item.healthTooltipText options=(detached-tooltip-options)}}
             />
           {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/token/fieldsets-legacy/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/fieldsets-legacy/index.hbs
@@ -3,7 +3,11 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<fieldset disabled={{if (not (can 'write token' item=@item)) 'disabled'}}>
+<fieldset disabled={{if (not (can 'write token' item=@item)) 'disabled'}} aria-label="Token details">
+  {{! aria-label above rather than a <legend>: each field below already has
+      its own <label>, and a visually-hidden <legend> is unreliable — browsers
+      give <legend> special fieldset-border layout treatment that the usual
+      clip-based hiding technique doesn't consistently override. }}
   <Hds::Form::TextInput::Field
     class='type-text'
     @value={{@item.Name}}

--- a/ui/packages/consul-ui/app/components/consul/token/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/fieldsets/index.hbs
@@ -87,7 +87,9 @@
 
 <Hds::Separator />
 
-<fieldset id="roles">
+{{! aria-label rather than relying on RoleSelector's own "Roles" heading,
+    which is only rendered when @showHeader is true. }}
+<fieldset id="roles" aria-label="Roles">
   <RoleSelector
     @showHeader={{true}}
     @disabled={{not (can "write token" item=@item)}}
@@ -100,7 +102,9 @@
 
 <Hds::Separator />
 
-<fieldset id="policies">
+{{! aria-label rather than relying on PolicySelector's own "Policies"
+    heading, which is only rendered when @showHeader is true. }}
+<fieldset id="policies" aria-label="Policies">
   <PolicySelector
     @showHeader={{true}}
     @disabled={{not (can "write token" item=@item)}}

--- a/ui/packages/consul-ui/app/components/consul/token/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/fieldsets/index.hbs
@@ -5,7 +5,17 @@
 
 <fieldset
   disabled={{if (not (can "write token" item=@item)) "disabled"}}
+  aria-label="Token details"
 >
+  {{! aria-label above (rather than a <legend>): the fields below
+      (AccessorID/Token/Scope/Name/Description) read fine on their own via
+      each field's own <label>, so a visible group heading would be
+      redundant — but the <fieldset> itself still needs an accessible name,
+      or it's announced as an unnamed group. A visually-hidden <legend>
+      would do the same job, but browsers give <legend> special fieldset-
+      border layout treatment that the usual clip-based hiding technique
+      doesn't reliably override, so aria-label sidesteps that entirely. }}
+
   {{! Read-only fields (AccessorID, Token, Scope) — edit mode only }}
   {{#unless @create}}
     <Hds::Form::MaskedInput::Field

--- a/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
@@ -16,6 +16,9 @@
           {{#if (eq item.AccessorID @token.AccessorID)}}
             <span
               class="consul-token-list__me"
+              role="group"
+              tabindex="-1"
+              aria-label="Your token"
               {{hds-tooltip "Your token" options=(detached-tooltip-options placement="top-start")}}
             ></span>
           {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/tomography/graph/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/tomography/graph/index.hbs
@@ -19,6 +19,10 @@
           <g class="lines">
       {{#each this.distances as |item|}}
           <rect
+            role="img"
+            aria-label={{concat item.node ' - ' (format-number item.distance maximumFractionDigits=2) 'ms'
+              (if item.segment (concat ' (Segment: ' item.segment ')'))
+            }}
             {{hds-tooltip
               (concat item.node ' - ' (format-number item.distance maximumFractionDigits=2) 'ms'
                 (if item.segment (concat '<br />(Segment: ' item.segment ')'))

--- a/ui/packages/consul-ui/app/components/consul/upstream/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/upstream/list/index.hbs
@@ -15,6 +15,8 @@
         Health
       </dt>
       <dd
+        role="note"
+        tabindex="-1"
         {{hds-tooltip options=(detached-tooltip-options)}}
       >
           {{#if (eq 'critical' item.MeshStatus)}}

--- a/ui/packages/consul-ui/app/components/error-state/index.hbs
+++ b/ui/packages/consul-ui/app/components/error-state/index.hbs
@@ -15,9 +15,12 @@
     </:header>
     <:subheader>
       {{#if @error.status}}
-        <h3 data-test-status={{@error.status}}>
+        {{! not a heading: the status code is already announced by the
+          preceding <h2>'s content, so a second heading here would just
+          repeat it — see docs/a11y-audit/01-shared-chrome.md #4 }}
+        <p data-test-status={{@error.status}}>
           Error {{@error.status}}
-        </h3>
+        </p>
       {{/if}}
     </:subheader>
     <:body>
@@ -63,9 +66,12 @@
       </h2>
     </:header>
     <:subheader>
-      <h3>
+      {{! not a heading: the status code is already announced by the
+        preceding <h2>'s content, so a second heading here would just
+        repeat it — see docs/a11y-audit/01-shared-chrome.md #4 }}
+      <p>
         Error {{@error.status}}
-      </h3>
+      </p>
     </:subheader>
     <:body>
       <p>

--- a/ui/packages/consul-ui/app/components/form-group/element/index.hbs
+++ b/ui/packages/consul-ui/app/components/form-group/element/index.hbs
@@ -18,7 +18,12 @@
   state=this.state
 )
 as |el|}}
-  {{#if (includes this.type (array 'radiogroup' 'checkbox-group' 'checkboxgroup'))}}
+  {{! 'select' is also excluded from the <label>-wrapping below: it hosts a
+      custom combobox widget (a <div role="combobox">, not a native
+      labelable element), so wrapping it in a <label> doesn't give it an
+      accessible name — the field itself is responsible for wiring up its
+      own explicit label instead. }}
+  {{#if (includes this.type (array 'radiogroup' 'checkbox-group' 'checkboxgroup' 'select'))}}
     <div
       data-property={{this.prop}}
       class="type-{{this.type}}{{if (state-matches this.state 'error') ' has-error'}}"

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -6,7 +6,14 @@
 <App class='hashicorp-consul' ...attributes>
 
   <:header>
-    <Hds::AppHeader>
+    {{! HDS's own NavigationNarrator (rendered by Hds::AppHeader) announces a
+      second, generic "page navigation is complete" message on every route
+      change alongside route/title's more informative "Navigated to X" live
+      region below. Silencing just the announced text here — rather than
+      disabling @hasA11yRefocus outright — keeps the narrator's other jobs
+      intact: it's also what renders the "Skip to main content" link and
+      moves focus on route change. }}
+    <Hds::AppHeader @a11yRefocusNavigationText="">
       <:logo>
         <Hds::AppHeader::HomeLink
           @icon='consul'
@@ -219,9 +226,13 @@
       </Hds::AppSideNav::List>
 
       <div data-test-footer id="contentinfo">
+        {{! @color='disabled' rendered #8c909c on #fafafa (3.05:1, fails
+          AA's 4.5:1) — this text isn't an actually-disabled control, so use
+          'faint' (5.19:1) instead, HDS's token for muted-but-readable text.
+          See docs/a11y-audit/01-shared-chrome.md #1 }}
         <Hds::Text::Display
           @size='100'
-          @color='disabled'
+          @color='faint'
         >
           {{t "components.hashicorp-consul.side-nav.footer" version=this.consulVersion}}
         </Hds::Text::Display>

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<App class='hashicorp-consul' ...attributes>
+<App class='hashicorp-consul' {{fix-dropdown-separator-aria}} {{fix-modal-body-role}} {{fix-toggle-label-order}} {{fix-alert-aria}} ...attributes>
 
   <:header>
     {{! HDS's own NavigationNarrator (rendered by Hds::AppHeader) announces a

--- a/ui/packages/consul-ui/app/components/peerings/badge/index.hbs
+++ b/ui/packages/consul-ui/app/components/peerings/badge/index.hbs
@@ -4,7 +4,7 @@
 }}
 
 {{#if @peering.State}}
-  <span {{hds-tooltip this.tooltip options=(detached-tooltip-options)}}>
+  <span role="group" tabindex="-1" aria-label={{capitalize (lowercase @peering.State)}} {{hds-tooltip this.tooltip options=(detached-tooltip-options)}}>
     <Hds::Badge
       class={{if this.isDark "peerings-badge--dark"}}
       @text={{capitalize (lowercase @peering.State)}}

--- a/ui/packages/consul-ui/app/components/policy-form/index.hbs
+++ b/ui/packages/consul-ui/app/components/policy-form/index.hbs
@@ -4,8 +4,13 @@
 }}
 
 {{yield}}
+{{! aria-label so the <fieldset> has an accessible name of its own — the
+    "Policy" heading below is conditional (only when not overridden by the
+    :template block) and, either way, isn't tied to the fieldset via a
+    <legend>. }}
 <fieldset
   class='policy-form'
+  aria-label='Policy details'
   disabled={{if (not (can 'write policy' item=this.item)) 'disabled'}}
   {{fix-super-select-aria}}
   ...attributes
@@ -22,7 +27,7 @@
         you're using Consul for Connect features.
       </p>
       {{! this should use radio-group }}
-      <div role='radiogroup' class={{if this.item.error.Type ' has-error'}}>
+      <div role='radiogroup' aria-label='Policy type' class={{if this.item.error.Type ' has-error'}}>
         {{#each this.templates as |template|}}
           <label data-test-radiobutton={{concat 'template_' template.template}}>
             <span>{{template.name}}</span>
@@ -56,7 +61,7 @@
       <strong>{{this.item.error.Name.validation}}</strong>
     {{/if}}
   </label>
-  <label for='' class='type-text' data-test-rules>
+  <label class='type-text' data-test-rules>
     {{#if (eq this.item.template 'service-identity')}}
       <Hds::CodeBlock
         @language='hcl'
@@ -131,8 +136,11 @@
       @src={{uri '/*/*/*/datacenters'}}
       @onchange={{action (mut this.datacenters) value='data'}}
     />
-    <label class='type-select' data-test-datacenter>
-      <span>Datacenter</span>
+    {{! A <div>, not a <label>: the SuperSelect below is a custom
+        role="combobox" widget, not a native labelable control, so wrapping
+        it in a <label> doesn't give it an accessible name — its own
+        <F.Label> below does that instead. }}
+    <div class='type-select' data-test-datacenter>
       <Hds::Form::SuperSelect::Single::Field
         @options={{map-by 'Name' this.datacenters}}
         @selected={{or this.item.Datacenter @dc}}
@@ -140,14 +148,19 @@
         @searchPlaceholder="Type a datacenter name"
         @onChange={{action 'change' 'Datacenter'}}
         @searchEnabled={{true}}
-        @label="Datacenter"
-        @listboxAriaLabel="Available datacenters"
         @isOptional={{false}}
-        id="datacenter-select"
+        {{! @id, not a bare "id=": Hds::Form::SuperSelect::Single::Field has
+            no ...attributes of its own at this level, so a bare "id=" here
+            is captured further down and forwarded onto PowerSelect, whose
+            own template sets the trigger's id *before* its ...attributes —
+            and a later ...attributes always wins, blanking the trigger's id
+            and leaving the label's "for" pointing at a nonexistent one. }}
+        @id="datacenter-select"
       as |F|>
+        <F.Label>Datacenter</F.Label>
         <F.Options>{{F.options}}</F.Options>
       </Hds::Form::SuperSelect::Single::Field>
-    </label>
+    </div>
   {{else}}
     {{! only show Valid Datacenters for the default partition }}
     {{#if (eq (or @partition 'default') 'default')}}
@@ -170,7 +183,7 @@
         @onchange={{action (mut this.datacenters) value='data'}}
       />
 
-      <div class='checkbox-group' role='group'>
+      <div class='checkbox-group' role='group' aria-label='Datacenters'>
         {{#each this.datacenters as |dc|}}
           <label class='type-checkbox'>
             <input

--- a/ui/packages/consul-ui/app/components/policy-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/policy-selector/index.hbs
@@ -144,6 +144,15 @@
                 as |CB|
               >
                 <CB.Title @tag='span'>
+                  {{! Every accordion row's code block otherwise shares the
+                      exact same visible title text ("Rules (HCL Format)"),
+                      which becomes this region's accessible name — with
+                      several rows expanded at once that's multiple
+                      role="region" elements sharing one label, which fails
+                      "region labels must be unique". Prefix it with the
+                      policy's own name, visually hidden, so each region's
+                      name is distinct without changing what's shown. }}
+                  <span class="policy-accordion__region-label">{{item.Name}}</span>
                   Rules
                   <a
                     href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
@@ -165,6 +174,7 @@
                 as |CB|
               >
                 <CB.Title @tag='span'>
+                  <span class="policy-accordion__region-label">{{item.Name}}</span>
                   Rules
                   <a
                     href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'
@@ -177,6 +187,7 @@
             {{else}}
               <Hds::CodeBlock @language='hcl' @value={{or this.loadedItem.Rules this.item.Rules ''}} as |CB|>
                 <CB.Title @tag='span'>
+                  <span class="policy-accordion__region-label">{{item.Name}}</span>
                   Rules
                   <a
                     href='{{env "CONSUL_DOCS_URL"}}/secure/acl/rule'

--- a/ui/packages/consul-ui/app/components/policy-selector/index.scss
+++ b/ui/packages/consul-ui/app/components/policy-selector/index.scss
@@ -1,0 +1,13 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/* Prefixes each accordion row's code-block region name with the policy's
+   own name, so multiple regions all visibly titled "Rules (HCL Format)"
+   still get distinct accessible names when several rows are expanded at
+   once — not meant to be seen, since the row's own accordion header already
+   shows the policy name. */
+.policy-accordion__region-label {
+  @extend %visually-hidden;
+}

--- a/ui/packages/consul-ui/app/components/radio-card/index.hbs
+++ b/ui/packages/consul-ui/app/components/radio-card/index.hbs
@@ -2,7 +2,11 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
 }}
-
+{{! The wrapping <label> makes the whole card clickable; @label deliberately
+  overrides its accessible name (which would otherwise be the long body
+  sentence, not the short header) via aria-label on the input, which wins
+  in accname computation. }}
+{{!-- template-lint-disable require-input-label --}}
 <label
   ...attributes
   class="radio-card{{if @checked ' checked'}}"
@@ -17,9 +21,9 @@
   {{! Bottom control strip: the radio input centred in a full-width footer }}
   <div class="radio-card-control">
     {{#if (gt @value.length 0) }}
-      <input type="radio" name={{@name}} value={{@value}} checked={{@checked}} onchange={{action @onchange}} />
+      <input type="radio" name={{@name}} value={{@value}} checked={{@checked}} onchange={{action @onchange}} aria-label={{@label}} />
     {{else}}
-      <input type="radio" name={{@name}} value="" checked={{@checked}} onchange={{action @onchange}} />
+      <input type="radio" name={{@name}} value="" checked={{@checked}} onchange={{action @onchange}} aria-label={{@label}} />
     {{/if}}
   </div>
 </label>

--- a/ui/packages/consul-ui/app/components/super-select-with-create/index.hbs
+++ b/ui/packages/consul-ui/app/components/super-select-with-create/index.hbs
@@ -20,7 +20,18 @@
     @isOptional={{@isOptional}}
     @searchField={{@searchField}}
     @searchPlaceholder={{@searchPlaceholder}}
-    id={{@id}}
+    @id={{@id}}
+    {{!-- @id above, not the bare "id=" this used to be: Hds::Form::SuperSelect::
+        Single::Field has no ...attributes of its own, so a bare "id=" here
+        was captured as ...attributes further down and forwarded onto
+        ember-power-select's PowerSelect component, whose own template sets
+        the trigger's id (matching the label-for HDS wires up) *before* its
+        own ...attributes — and a later ...attributes always wins, so it
+        blanked the trigger's id to empty any time @id wasn't explicitly
+        passed in (true for every call site here), leaving the label's for
+        pointing at a nonexistent id. A named @id argument instead flows
+        through Hds::Form::Field's own id logic (used to compute the shared
+        id for both the label and the trigger) rather than clobbering it. --}}
   as |F|>
     {{#if @label}}
       <F.Label>{{@label}}</F.Label>

--- a/ui/packages/consul-ui/app/components/tab-nav/index.hbs
+++ b/ui/packages/consul-ui/app/components/tab-nav/index.hbs
@@ -43,7 +43,7 @@
             @href={{item.href}}
           >
             {{#if item.tooltip}}
-              <span {{hds-tooltip item.tooltip options=(detached-tooltip-options)}}>{{item.label}}</span>
+              <span tabindex="-1" {{hds-tooltip item.tooltip options=(detached-tooltip-options)}}>{{item.label}}</span>
             {{else}}
               {{item.label}}
             {{/if}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/card/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/card/index.hbs
@@ -38,7 +38,7 @@
     <div class={{if (not-eq @item.Partition @service.Partition) 'group'}}>
       {{#if (not-eq @item.Partition @service.Partition)}}
       <dl class="partition">
-        <dt {{hds-tooltip "Admin Partition" options=(detached-tooltip-options)}}>
+        <dt role="group" tabindex="-1" aria-label="Admin Partition" {{hds-tooltip "Admin Partition" options=(detached-tooltip-options)}}>
           Admin Partition
         </dt>
         <dd>
@@ -49,7 +49,7 @@
       <span></span>
       {{#if (or (not-eq @item.Partition @service.Partition) (not-eq @item.Namespace @service.Namespace))}}
       <dl class="nspace">
-        <dt {{hds-tooltip "Namespace" options=(detached-tooltip-options)}}>
+        <dt role="group" tabindex="-1" aria-label="Namespace" {{hds-tooltip "Namespace" options=(detached-tooltip-options)}}>
           Namespace
         </dt>
         <dd>
@@ -68,19 +68,19 @@
     <span class="empty">No health checks</span>
   {{else}}
     {{#if (not-eq percentage.passing 0)}}
-      <span class="passing">{{percentage.passing}}%</span>
+      <span class="passing"><span class="sr-only">Passing: </span>{{percentage.passing}}%</span>
     {{/if}}
     {{#if (not-eq percentage.warning 0)}}
-      <span class="warning">{{percentage.warning}}%</span>
+      <span class="warning"><span class="sr-only">Warning: </span>{{percentage.warning}}%</span>
     {{/if}}
     {{#if (not-eq percentage.critical 0)}}
-      <span class="critical">{{percentage.critical}}%</span>
+      <span class="critical"><span class="sr-only">Critical: </span>{{percentage.critical}}%</span>
     {{/if}}
   {{/if}}
   {{/let}}
 {{else}}
     <dl class="health">
-      <dt {{hds-tooltip "We are unable to determine the health status of services in remote datacenters." options=(detached-tooltip-options)}}>
+      <dt role="group" tabindex="-1" aria-label="Health" {{hds-tooltip "We are unable to determine the health status of services in remote datacenters." options=(detached-tooltip-options)}}>
         Health
       </dt>
       <dd>

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -16,7 +16,7 @@
   {{#if (not this.emptyColumn)}}
     <div>
       <p>{{@dc.Name}}</p>
-      <span {{hds-tooltip (concat "Only showing downstreams within the current datacenter for " @service.Service.Service ".") options=(detached-tooltip-options)}}></span>
+      <span role="group" tabindex="-1" aria-label={{concat "Only showing downstreams within the current datacenter for " @service.Service.Service "."}} {{hds-tooltip (concat "Only showing downstreams within the current datacenter for " @service.Service.Service ".") options=(detached-tooltip-options)}}></span>
     </div>
   {{/if}}
   {{#each this.downstreams as |item|}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/source-type/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/source-type/index.hbs
@@ -6,6 +6,9 @@
 <span
   data-test-topology-metrics-source-type
   class="topology-metrics-source-type"
+  role="group"
+  tabindex="-1"
+  aria-label={{t (concat "components.consul.topology-metrics.source-type." @source ".text")}}
   {{hds-tooltip (t (concat "components.consul.topology-metrics.source-type." @source ".tooltip")) options=(detached-tooltip-options)}}
 >
   {{t (concat "components.consul.topology-metrics.source-type." @source ".text")}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/stats/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/stats/index.hbs
@@ -24,7 +24,7 @@
 <div ...attributes class="topology-metrics-stats" data-test-topology-metrics-stats>
   {{#if this.hasLoaded }}
     {{#each this.stats as |stat|}}
-    <dl {{hds-tooltip
+    <dl role="group" tabindex="-1" aria-label={{concat stat.value ' ' stat.label}} {{hds-tooltip
       stat.desc
       options=(detached-tooltip-options
         allowHTML=true

--- a/ui/packages/consul-ui/app/components/topology-metrics/status/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/status/index.hbs
@@ -10,6 +10,9 @@
     {{else if (eq @noMetricsReason 'remote-dc')}}
       {{t "components.consul.topology-metrics.status.error"}}
       <span
+        role="group"
+        tabindex="-1"
+        aria-label={{t "components.consul.topology-metrics.status.remote-dc"}}
         {{hds-tooltip (t "components.consul.topology-metrics.status.remote-dc") options=(detached-tooltip-options)}}
       />
     {{else if @error}}

--- a/ui/packages/consul-ui/app/modifiers/fix-alert-aria.js
+++ b/ui/packages/consul-ui/app/modifiers/fix-alert-aria.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { modifier } from 'ember-modifier';
+
+export default modifier(function fixAlertAria(element) {
+  function fixAria() {
+    // HDS's <Hds::Alert> only gives its root <div> a role — "alert" or
+    // "alertdialog" — for the "warning"/"critical"/"success" colors (what
+    // its own source calls an alert that "actually alerts users"). For
+    // every other color ("neutral", "highlight", …, and the default when
+    // @color is omitted, which is most of Consul's informational alerts —
+    // see e.g. the Intentions "Managed by CRD" notice), no role is set at
+    // all, so the <div> falls back to its implicit "generic" role.
+    //
+    // But HDS sets aria-labelledby (pointing at the alert's Title/
+    // Description) unconditionally, regardless of that role — its own
+    // source comment says the labelling is there because "`alertdialog`
+    // must have an accessible name", i.e. it was only ever meant for the
+    // semantic-alert branch. On a role="generic" element, aria-labelledby
+    // isn't a permitted attribute at all (generic explicitly doesn't
+    // support naming), so every non-semantic-colored alert with a title
+    // trips this. There's nothing to preserve here for AT users — the
+    // title text is already read as ordinary page content either way — so
+    // just drop the attribute HDS shouldn't have set in this case.
+    element.querySelectorAll('.hds-alert[aria-labelledby]:not([role])').forEach((alert) => {
+      alert.removeAttribute('aria-labelledby');
+    });
+  }
+
+  setTimeout(fixAria, 100);
+  const observer = new MutationObserver(fixAria);
+  observer.observe(element, { childList: true, subtree: true });
+
+  return () => observer.disconnect();
+});

--- a/ui/packages/consul-ui/app/modifiers/fix-code-block-aria.js
+++ b/ui/packages/consul-ui/app/modifiers/fix-code-block-aria.js
@@ -7,9 +7,23 @@ import { modifier } from 'ember-modifier';
 
 export default modifier(function fixCodeBlockAria(element) {
   function fixAria() {
-    // Fix HDS CodeBlock ARIA issue - add role to pre elements with aria-labelledby
+    // HDS's <Hds::CodeBlock> always renders its <pre> with tabindex="0" (so
+    // long code is keyboard-scrollable) but, in this HDS version, no role —
+    // a tabbable element with no role fails "Name, Role, Value". Giving it
+    // role="region" (this modifier's original fix) satisfies that, but
+    // creates a different violation: IBM Equal Access separately requires
+    // any *tabbable* element's role to be a widget role specifically, and
+    // "region" is a landmark role, not a widget role, so region + tabindex
+    // ="0" together still fails. There's no ARIA widget role that fits
+    // read-only scrollable text, so — matching IBM's own first suggested
+    // remedy — take it out of the tab order instead of forcing a role that
+    // doesn't hold up. `role="region"` is still added: it's fine (useful,
+    // even) on a non-tabbable element, just not on a tabbable one.
     element.querySelectorAll('pre[aria-labelledby]:not([role])').forEach((pre) => {
       pre.setAttribute('role', 'region');
+    });
+    element.querySelectorAll('pre.hds-code-block__code[tabindex="0"]').forEach((pre) => {
+      pre.setAttribute('tabindex', '-1');
     });
   }
 

--- a/ui/packages/consul-ui/app/modifiers/fix-code-block-aria.mdx
+++ b/ui/packages/consul-ui/app/modifiers/fix-code-block-aria.mdx
@@ -1,6 +1,6 @@
 # fix-code-block-aria
 
-Fixes ARIA accessibility issues in HDS CodeBlock components by adding `role="region"` to `<pre>` elements that have `aria-labelledby` but no role attribute.
+Fixes ARIA accessibility issues in HDS CodeBlock components: adds `role="region"` to `<pre>` elements that have `aria-labelledby` but no role attribute, and takes the `<pre>` out of the tab order.
 
 ## Problem
 
@@ -11,6 +11,17 @@ HDS CodeBlock renders invalid ARIA markup:
   <code>console.log('hello');</code>
 </pre>
 ```
+
+Fixing only the missing role isn't enough, though: HDS's `<pre>` always carries
+`tabindex="0"` too, and IBM Equal Access separately requires any *tabbable*
+element's role to be a widget role (button, tab, textbox, …) — `region` is a
+landmark role, not a widget role, so `role="region"` on a still-tabbable `<pre>`
+trades one violation for another ("the tabbable element's role 'region' is not
+a widget role"). There's no ARIA widget role that fits read-only scrollable
+text, so the `<pre>` also gets `tabindex="-1"`, taking it out of the tab order
+— IBM's own first suggested remedy for a non-interactive tabbable element.
+`role="region"` stays; it's fine on a non-tabbable element, just not a
+tabbable one.
 
 ## Usage
 
@@ -30,8 +41,8 @@ Apply to a parent element containing CodeBlock components:
 
 ## How it works
 
-- Automatically adds `role="region"` to fix ARIA violations
-- Only affects `<pre>` elements with `aria-labelledby` and no existing role
+- Adds `role="region"` to `<pre>` elements with `aria-labelledby` and no existing role
+- Sets `tabindex="-1"` on the CodeBlock `<pre>` so it's no longer a tabbable element with a non-widget role
 - Uses MutationObserver to handle dynamically added content
 
 **Temporary workaround** - remove when HDS is updated to include proper ARIA roles.

--- a/ui/packages/consul-ui/app/modifiers/fix-dropdown-separator-aria.js
+++ b/ui/packages/consul-ui/app/modifiers/fix-dropdown-separator-aria.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { modifier } from 'ember-modifier';
+
+export default modifier(function fixDropdownSeparatorAria(element) {
+  function fixAria() {
+    // HDS's <Hds::Dropdown> renders a <dd.Separator /> as
+    // <li role="separator" aria-hidden="true" class="hds-dropdown-list-item
+    // hds-dropdown-list-item--variant-separator"> inside a <ul>. Per the
+    // ARIA-in-HTML spec's per-element role table (w3.org/TR/html-aria/
+    // #docconformance), an <li> whose parent has an (implicit or explicit)
+    // `list` role — true here, its parent is a plain <ul> — allows "no role
+    // other than listitem", and separately the spec discourages authors from
+    // ever explicitly writing the `generic` role. So neither `role=
+    // "separator"` nor swapping in `role="presentation"`/`"generic"` lands in
+    // the actually-permitted set for this element; accessibility checkers
+    // (e.g. IBM Equal Access) flag any of them. The only option the spec
+    // doesn't hedge on is no role attribute at all, falling back to the
+    // element's correct implicit "listitem" role — so just remove it. The
+    // <li> is already aria-hidden, so no assistive tech reads its role
+    // either way; this only changes what the checker sees.
+    //
+    // Attached once, high up the tree (see Consul::HashicorpConsul), rather
+    // than at every individual `<Hds::Dropdown>` call site, since the
+    // separator <li> only exists in the DOM once a given dropdown's menu has
+    // been opened at least once.
+    element.querySelectorAll('li[role="separator"][aria-hidden="true"]').forEach((li) => {
+      li.removeAttribute('role');
+    });
+  }
+
+  setTimeout(fixAria, 100);
+  const observer = new MutationObserver(fixAria);
+  observer.observe(element, { childList: true, subtree: true });
+
+  return () => observer.disconnect();
+});

--- a/ui/packages/consul-ui/app/modifiers/fix-modal-body-role.js
+++ b/ui/packages/consul-ui/app/modifiers/fix-modal-body-role.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { modifier } from 'ember-modifier';
+
+export default modifier(function fixModalBodyRole(element) {
+  function fixRole() {
+    // HDS's dialog-primitive body (rendered by <Hds::Modal>'s <M.Body>, and
+    // reused by e.g. Hds::SlidingPanel) unconditionally renders
+    // <div class="hds-dialog-primitive__body ..." tabindex="0">, regardless
+    // of whether the body's content actually overflows and needs keyboard
+    // scrolling. A tabbable element with no ARIA role fails "Name, Role,
+    // Value" (the "generic" role a bare <div> gets isn't a valid *widget*
+    // role for something reachable by Tab).
+    //
+    // The obvious fix — give it role="region" when it's actually scrollable
+    // — turns out to trade one violation for another: IBM Equal Access
+    // separately requires any *tabbable* element's role to be a widget role
+    // specifically, and "region" is a landmark role, not a widget role (see
+    // Hds::CodeBlock's identical situation, fixed the same way in
+    // fix-code-block-aria.js). There's no ARIA widget role that fits a
+    // passive scrollable content block, so — matching IBM's own first
+    // suggested remedy — the body is always taken out of the tab order
+    // instead, whether or not it happens to overflow.
+    element.querySelectorAll('.hds-dialog-primitive__body[tabindex="0"]').forEach((body) => {
+      body.setAttribute('tabindex', '-1');
+    });
+  }
+
+  setTimeout(fixRole, 100);
+  const observer = new MutationObserver(fixRole);
+  observer.observe(element, { childList: true, subtree: true });
+
+  return () => observer.disconnect();
+});

--- a/ui/packages/consul-ui/app/modifiers/fix-super-select-aria.js
+++ b/ui/packages/consul-ui/app/modifiers/fix-super-select-aria.js
@@ -71,13 +71,132 @@ export default modifier(function fixSuperSelectAria(element) {
       if (!listbox.hasAttribute('aria-label')) {
         listbox.setAttribute('aria-label', 'Available Options');
       }
-      // Make listbox keyboard accessible
-      if (!listbox.hasAttribute('tabindex')) {
+      // Make the listbox keyboard accessible itself *unless* a real,
+      // searchable <input role="combobox"> already owns it (via
+      // aria-controls/aria-owns) — that input drives navigation into this
+      // listbox through aria-activedescendant without the listbox ever
+      // taking real DOM focus, so giving it its own tabindex on top of
+      // that makes the combobox's popup independently tabbable, which
+      // fails "only the input may hold focus while the popup is open".
+      const hasOwningInput =
+        listbox.id &&
+        document.querySelector(
+          `input[role="combobox"][aria-controls="${listbox.id}"], input[role="combobox"][aria-owns="${listbox.id}"]`
+        );
+      if (hasOwningInput) {
+        listbox.removeAttribute('tabindex');
+      } else if (!listbox.hasAttribute('tabindex')) {
         listbox.setAttribute('tabindex', '0');
+      }
+    });
+
+    // When @searchEnabled renders the dropdown open, ember-power-select puts
+    // a *second*, independently-focusable role="combobox" element into the
+    // page: a real <input> for typing, alongside the outer trigger div that
+    // already carries role="combobox" (and its own tabindex) for the closed
+    // state. Two simultaneously-focusable combobox surfaces for one widget
+    // fails "only the text input may hold focus while the popup is open" —
+    // so once the real input exists, demote the trigger to a plain
+    // non-interactive wrapper — a role="generic" element can't carry any of
+    // these (aria-labelledby/aria-expanded/aria-controls/aria-owns included
+    // — ARIA-in-HTML disallows naming/widget-state attributes on generic
+    // elements), so all of them get stripped. Only a subset gets restored
+    // by hand once the popup closes: aria-expanded and aria-controls/owns
+    // are recomputed by the library's own trigger modifier on every
+    // open/close (aria-expanded unconditionally, aria-controls/owns
+    // whenever they're null) — so leaving them stripped is enough for that
+    // modifier's own logic to fill them back in correctly; restoring stale
+    // values here first would just leave a dangling reference until then.
+    const DEMOTED_ATTRS = [
+      'role',
+      'aria-autocomplete',
+      'aria-haspopup',
+      'aria-expanded',
+      'aria-controls',
+      'aria-owns',
+      'aria-labelledby',
+      'tabindex',
+    ];
+    const RESTORED_ATTRS = ['role', 'aria-autocomplete', 'aria-haspopup', 'aria-labelledby', 'tabindex'];
+    element
+      .querySelectorAll('.ember-basic-dropdown-trigger[data-ebd-id]')
+      .forEach((trigger) => {
+        // role="combobox" is gone once demoted, so match on that *or* our
+        // own marker — otherwise a demoted trigger falls out of this query
+        // entirely and never gets restored once its popup closes.
+        if (trigger.getAttribute('role') !== 'combobox' && !trigger.hasAttribute('data-a11y-demoted')) {
+          return;
+        }
+        const uniqueId = trigger.getAttribute('data-ebd-id').replace(/-trigger$/, '');
+        const content = document.getElementById(`ember-basic-dropdown-content-${uniqueId}`);
+        const input = content && content.querySelector('input[role="combobox"]');
+
+        if (input && !trigger.hasAttribute('data-a11y-demoted')) {
+          trigger.setAttribute('data-a11y-demoted', 'true');
+          DEMOTED_ATTRS.forEach((attr) => {
+            const value = trigger.getAttribute(attr);
+            if (value !== null && RESTORED_ATTRS.includes(attr)) {
+              trigger.setAttribute(`data-a11y-orig-${attr}`, value);
+            }
+            trigger.removeAttribute(attr);
+          });
+          trigger.setAttribute('tabindex', '-1');
+        } else if (!input && trigger.hasAttribute('data-a11y-demoted')) {
+          trigger.removeAttribute('data-a11y-demoted');
+          RESTORED_ATTRS.forEach((attr) => {
+            const orig = trigger.getAttribute(`data-a11y-orig-${attr}`);
+            if (orig !== null) {
+              trigger.setAttribute(attr, orig);
+            }
+            trigger.removeAttribute(`data-a11y-orig-${attr}`);
+          });
+        }
+      });
+
+    // role="combobox" isn't a valid explicit ARIA role on <input type="search">
+    // per the ARIA-in-HTML mapping (only type="text"/no type allows it), but
+    // ember-power-select's search input hardcodes type="search". Switching it
+    // to type="text" is behaviorally identical here (nothing relies on the
+    // native search-input affordances) and makes the role valid.
+    element.querySelectorAll('input[role="combobox"][type="search"]').forEach((input) => {
+      input.setAttribute('type', 'text');
+    });
+
+    // ember-power-select mirrors aria-selected from the *chosen* option only,
+    // not the *highlighted* one that aria-activedescendant currently points
+    // at (that's tracked separately, non-standardly, via aria-current) — so
+    // before anything is chosen, the option referenced by
+    // aria-activedescendant often has no aria-selected="true" at all. Keep
+    // exactly the referenced option marked selected.
+    element.querySelectorAll('[aria-activedescendant]').forEach((combo) => {
+      const activeId = combo.getAttribute('aria-activedescendant');
+      const activeOption = activeId && document.getElementById(activeId);
+      if (!activeOption || activeOption.getAttribute('role') !== 'option') {
+        return;
+      }
+      const listbox = activeOption.closest('[role="listbox"]') || activeOption.parentElement;
+      listbox?.querySelectorAll('[role="option"][data-a11y-forced-selected]').forEach((option) => {
+        if (option !== activeOption) {
+          option.setAttribute('aria-selected', 'false');
+          option.removeAttribute('data-a11y-forced-selected');
+        }
+      });
+      if (activeOption.getAttribute('aria-selected') !== 'true') {
+        activeOption.setAttribute('aria-selected', 'true');
+        activeOption.setAttribute('data-a11y-forced-selected', 'true');
       }
     });
   }
 
   setTimeout(fixAria, 100);
-  new MutationObserver(fixAria).observe(element, { childList: true, subtree: true });
+  new MutationObserver(fixAria).observe(element, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    // Narrow filter: these are the attributes ember-power-select updates as
+    // the user types/navigates (not ones only *we* write), so watching them
+    // re-runs fixAria on that navigation without the observer re-triggering
+    // itself in a loop.
+    attributeFilter: ['aria-activedescendant', 'aria-expanded'],
+  });
 });

--- a/ui/packages/consul-ui/app/modifiers/fix-super-select-aria.js
+++ b/ui/packages/consul-ui/app/modifiers/fix-super-select-aria.js
@@ -5,11 +5,50 @@
 
 import { modifier } from 'ember-modifier';
 
+const POPUP_ROLES = ['listbox', 'grid', 'tree', 'dialog'];
+
 export default modifier(function fixSuperSelectAria(element) {
   function fixAria() {
     // Fix role="alert" → role="option" on select options
     element.querySelectorAll('[role="alert"][aria-selected]').forEach((el) => {
       el.setAttribute('role', 'option');
+    });
+
+    // Give the popup a combobox's aria-controls/aria-owns points at a valid
+    // role. ember-power-select wraps its ARIA listbox in an outer
+    // positioning div (.ember-basic-dropdown-content, id="ember-basic-
+    // dropdown-content-…") that carries no role at all — role="listbox"
+    // only lands on a nested .ember-power-select-options descendant, and
+    // that descendant doesn't even exist in the DOM until the dropdown is
+    // opened for the first time (before that the wrapper is an empty
+    // "…-placeholder" div). Either way, per the ARIA combobox pattern the
+    // element the reference points at has no valid popup role.
+    ['aria-controls', 'aria-owns'].forEach((attr) => {
+      element.querySelectorAll(`[role="combobox"][${attr}]`).forEach((combobox) => {
+        const targetId = combobox.getAttribute(attr);
+        const popup = document.getElementById(targetId);
+
+        if (!popup || POPUP_ROLES.includes(popup.getAttribute('role'))) {
+          return;
+        }
+        const listbox = popup.querySelector(POPUP_ROLES.map((role) => `[role="${role}"]`).join(', '));
+        if (listbox) {
+          // The dropdown has been opened at least once, so the real listbox
+          // exists inside the wrapper — point the reference straight at it
+          // instead of the unroled wrapper around it.
+          if (!listbox.id) {
+            listbox.id = `${targetId}-listbox`;
+          }
+          combobox.setAttribute(attr, listbox.id);
+        } else {
+          // Still closed (nothing rendered inside the wrapper yet, so
+          // there's no nested listbox to redirect to) — the wrapper itself
+          // is what's exposed as the popup, so it needs the role directly.
+          // Harmless once the dropdown does open: the branch above then
+          // redirects to the real listbox and this role goes unused.
+          popup.setAttribute('role', 'listbox');
+        }
+      });
     });
 
     // Remove invalid aria-controls and add missing aria-expanded

--- a/ui/packages/consul-ui/app/modifiers/fix-super-select-aria.mdx
+++ b/ui/packages/consul-ui/app/modifiers/fix-super-select-aria.mdx
@@ -7,17 +7,31 @@ Fixes multiple ARIA accessibility issues in SuperSelect (ember-power-select) com
 - **Invalid roles**: Changes `role="alert"` to `role="option"` on select options
 - **Broken references**: Removes invalid `aria-controls` pointing to non-existent elements
 - **Missing attributes**: Adds `aria-expanded` to comboboxes and `aria-label` to listboxes
+- **Popup-less combobox**: Redirects a combobox's `aria-controls`/`aria-owns` off the
+  unroled `.ember-basic-dropdown-content` wrapper and onto the `role="listbox"`
+  element nested inside it, so the popup a screen reader is told about actually
+  has one of the roles (`listbox`/`grid`/`tree`/`dialog`) the combobox pattern requires
 
 ```html
 <!-- Before -->
 <div role="alert" aria-selected="true">Option 1</div>
 <input role="combobox" aria-controls="missing-dropdown" />
 <ul role="listbox"></ul>
+<div role="combobox" aria-controls="ember-basic-dropdown-content-1">
+</div>
+<div id="ember-basic-dropdown-content-1"><!-- no role -->
+  <ul id="ember-power-select-options-1" role="listbox"></ul>
+</div>
 
 <!-- After -->
 <div role="option" aria-selected="true">Option 1</div>
 <input role="combobox" aria-expanded="false" />
 <ul role="listbox" aria-label="Available Options"></ul>
+<div role="combobox" aria-controls="ember-power-select-options-1">
+</div>
+<div id="ember-basic-dropdown-content-1">
+  <ul id="ember-power-select-options-1" role="listbox"></ul>
+</div>
 ```
 
 ## Usage

--- a/ui/packages/consul-ui/app/modifiers/fix-toggle-label-order.js
+++ b/ui/packages/consul-ui/app/modifiers/fix-toggle-label-order.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright IBM Corp. 2024, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { modifier } from 'ember-modifier';
+
+export default modifier(function fixToggleLabelOrder(element) {
+  function fixOrder() {
+    // HDS's <Hds::Form::Field> (which backs Toggle::Field, Checkbox::Field,
+    // Radio::Field, …) always renders its <label> before the control's
+    // wrapper in the DOM — <label>…</label><div class="hds-form-field__
+    // control"><input …></div> — regardless of @layout. For the "flag"
+    // layout (checkboxes, radios, toggles) that puts the switch/box to the
+    // left and its label to the right, this DOM order fails the checkbox/
+    // radio-specific convention that the label should come *after* the
+    // control, not before.
+    //
+    // The "flag" layout's visual position comes entirely from CSS Grid
+    // named areas (`grid-template-areas: "control label" …`), independent
+    // of source order, and the label is associated to its control purely
+    // via for/id (not by wrapping it) — so physically moving the <label>
+    // node after the control in the DOM is a no-op visually and for the
+    // label/control relationship, while fixing the DOM order the checker
+    // (and screen readers reading linearly) actually see.
+    element.querySelectorAll('.hds-form-field--layout-flag').forEach((field) => {
+      const input = field.querySelector('input[type="checkbox"], input[type="radio"]');
+      const label = field.querySelector(':scope > .hds-form-field__label');
+      const control = field.querySelector(':scope > .hds-form-field__control');
+
+      if (!input || !label || !control) {
+        return;
+      }
+      if (control.nextElementSibling !== label) {
+        control.after(label);
+      }
+    });
+  }
+
+  setTimeout(fixOrder, 100);
+  const observer = new MutationObserver(fixOrder);
+  observer.observe(element, { childList: true, subtree: true });
+
+  return () => observer.disconnect();
+});

--- a/ui/packages/consul-ui/app/templates/dc/acls/tokens/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/tokens/index.hbs
@@ -60,7 +60,6 @@ as |route|>
         <h1>
           <route.Title @title="Tokens" />
         </h1>
-        <label for="toolbar-toggle"></label>
       </:header>
       <:actions>
   {{#if (can "create tokens")}}

--- a/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
@@ -55,7 +55,6 @@
                 <h1>
                   <route.Title @title='Nodes' />
                 </h1>
-                <label for='toolbar-toggle'></label>
               </:header>
               <:content>
                 <Consul::Node::AgentlessNotice @items={{items}} @filteredItems={{filtered}} @postfix={{concat route.params.partition route.params.dc}} />

--- a/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
@@ -77,7 +77,6 @@ as |item tomography|}}
               <h1>
                 <route.Title @title={{item.Node}} />
               </h1>
-              <label for="toolbar-toggle"></label>
               <Consul::Peer::Info @item={{item}} />
           </:header>
           <:nav>

--- a/ui/packages/consul-ui/app/templates/dc/services/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/index.hbs
@@ -68,7 +68,6 @@ as |sort filters items partition nspace|}}
         <h1>
           <route.Title @title="Services" />
         </h1>
-        <label for="toolbar-toggle"></label>
     </:header>
     <:content>
       {{! Toolbar is rendered outside DataCollection so it persists when

--- a/ui/packages/consul-ui/app/templates/dc/show/license.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/show/license.hbs
@@ -62,7 +62,7 @@ as |item|}}
             (array 'valid' item.Valid)
           }}
         >
-          <header aria-label="License Expiry">
+          <header>
             <h2>
               {{compute (fn route.t 'expiry.header')}}
             </h2>
@@ -109,7 +109,12 @@ as |item|}}
           </dl>
 
           <aside>
-            <header aria-label="Documentation">
+            {{! nested inside <aside>, this <header> is not a top-level banner
+              landmark (computes to role=generic per the HTML-AAM spec), so it
+              doesn't need a unique label; the static rule can't see the
+              surrounding context. }}
+            {{!-- template-lint-disable no-duplicate-landmark-elements --}}
+            <header>
               <h3>
                 {{compute (fn route.t 'documentation.title')}}
               </h3>

--- a/ui/packages/consul-ui/app/templates/dc/show/serverstatus.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/show/serverstatus.hbs
@@ -66,7 +66,7 @@ as |item|}}
             role="region"
             data-test-server-info
           >
-            <header class="server-failure-tolerance__header" aria-label="Tolerance">
+            <header class="server-failure-tolerance__header">
               <h2 id="server-fault-tolerance-title">
                 {{compute (fn route.t 'tolerance.header')}}
               </h2>
@@ -109,6 +109,9 @@ as |item|}}
                 <h3>
                   {{compute (fn route.t 'tolerance.optimistic.header')}}
                   <span
+                    role="group"
+                    tabindex="-1"
+                    aria-label='With > 30 seconds between server failures, Consul can restore the Immediate Fault Tolerance by replacing failed active voters with healthy back-up voters when using redundancy zones.'
                     {{hds-tooltip 'With > 30 seconds between server failures, Consul can restore the Immediate Fault Tolerance by replacing failed active voters with healthy back-up voters when using redundancy zones.' options=(detached-tooltip-options)}}
                   >
                   </span>
@@ -136,7 +139,10 @@ as |item|}}
               'redundancy-zones'
             }}
           >
-            <header aria-label="Redundancy Zones">
+            {{! nested inside <section>, not a top-level banner landmark
+              (role=generic per HTML-AAM), so no unique label is needed. }}
+            {{!-- template-lint-disable no-duplicate-landmark-elements --}}
+            <header>
               <h2>
                 {{pluralize (t 'common.consul.redundancyzone')}}
               </h2>
@@ -145,7 +151,10 @@ as |item|}}
       {{#each item.RedundancyZones as |item|}}
         {{#if (gt item.Servers.length 0) }}
               <section>
-                <header aria-label="Redundancy Zone {{item.Name}}">
+                {{! nested inside <section>, not a top-level banner landmark
+                  (role=generic per HTML-AAM), so no unique label needed. }}
+                {{!-- template-lint-disable no-duplicate-landmark-elements --}}
+                <header>
                   <h3>
                     {{item.Name}}
                   </h3>
@@ -168,7 +177,10 @@ as |item|}}
 
       {{#if (gt item.Default.Servers.length 0)}}
               <section>
-                <header aria-label="Unassigned Servers">
+                {{! nested inside <section>, not a top-level banner landmark
+                  (role=generic per HTML-AAM), so no unique label needed. }}
+                {{!-- template-lint-disable no-duplicate-landmark-elements --}}
+                <header>
                   <h3>
                     {{compute (fn route.t 'unassigned')}}
                   </h3>
@@ -182,7 +194,10 @@ as |item|}}
           </section>
     {{else}}
           <section>
-            <header aria-label="Default Servers">
+            {{! nested inside <section>, not a top-level banner landmark
+              (role=generic per HTML-AAM), so no unique label is needed. }}
+            {{!-- template-lint-disable no-duplicate-landmark-elements --}}
+            <header>
               <h2>
                 {{compute (fn route.t 'servers')}}
               </h2>
@@ -195,7 +210,10 @@ as |item|}}
 
     {{#if (gt item.ReadReplicas.length 0)}}
           <section>
-            <header aria-label="Read Replicas">
+            {{! nested inside <section>, not a top-level banner landmark
+              (role=generic per HTML-AAM), so no unique label is needed. }}
+            {{!-- template-lint-disable no-duplicate-landmark-elements --}}
+            <header>
               <h2>
                 {{pluralize (t 'common.consul.readreplica')}}
               </h2>

--- a/ui/packages/consul-ui/docs/a11y-audit/README.md
+++ b/ui/packages/consul-ui/docs/a11y-audit/README.md
@@ -1,0 +1,161 @@
+# Consul UI accessibility audit
+
+Tracks a systematic a11y audit of consul-ui, broken into independent, per-section
+tasks. **Audit only** — findings are documented here with suggested fixes, but
+no fixes are applied as part of this work.
+
+## Method (applies to every task file)
+
+- **Automated:** two independent rule engines are run against each representative
+  page/state, since they catch different things:
+  - Chrome DevTools Lighthouse accessibility audit (axe-core-based).
+  - IBM's `accessibility-checker` (the open-source engine behind DevTools'
+    "Accessibility Assessment" panel — that panel and "Screen Reader Simulator"
+    themselves aren't drivable by any available automation tool, since they're
+    proprietary Chrome-extension UI with no exposed API; running the engine
+    directly via its Node API is the closest equivalent). Installed standalone
+    in the scratchpad dir (`npm install accessibility-checker`), *not* added
+    as a project dependency. Run via a small script calling
+    `aChecker.getCompliance(url, label)` against the dev server.
+  - In this pass IBM's checker surfaced 3 concrete bugs axe/Lighthouse missed
+    entirely (findings #5–#7 in [01-shared-chrome.md](01-shared-chrome.md)),
+    plus independently confirmed the contrast finding (#1) both tools agree on.
+    Worth running both engines on every task, not just one.
+
+  **Reproducing the IBM scan** (scratchpad install, not a project dependency —
+  recreate this each session, it doesn't persist):
+  ```bash
+  mkdir a11y-ibm && cd a11y-ibm && npm init -y && npm install accessibility-checker
+  ```
+  ```js
+  // scan.js
+  const aChecker = require("accessibility-checker");
+  (async () => {
+    const { report } = await aChecker.getCompliance("http://localhost:4200/ui/dc1/services", "services");
+    for (const it of report.results) {
+      if (it.level === "violation" || it.level === "potentialviolation") {
+        console.log(`[${it.level}] ${it.ruleId} :: ${it.message}`);
+        console.log("  path:", it.path && it.path.dom);
+      }
+    }
+    await aChecker.close();
+  })();
+  ```
+  Run with `node scan.js`. Swap the URL/label per page being audited.
+- **Manual keyboard:** Tab/Shift+Tab/Enter/Escape/Arrow-key traversal, checking
+  focus order, visible focus indication, keyboard operability of all
+  interactive elements (dropdowns, modals, tables, forms), and no keyboard traps.
+- **Screen-reader-equivalent spot checks:** inspection of the accessibility
+  tree (roles, accessible names, states, live regions) that Chrome DevTools
+  exposes. **This is not a live run of VoiceOver/NVDA/JAWS** — no screen
+  reader automation is available in this environment. Tree data is a good
+  proxy for what would be announced, but doesn't substitute for a real AT
+  pass before shipping fixes.
+
+Findings use axe's severity vocabulary: **Critical / Serious / Moderate / Minor**.
+
+## Environment used
+
+Dev server at `localhost:4200`, with `packages/consul-ui/config/environment.js`
+`operatorConfig` set to `ACLsEnabled: true, NamespacesEnabled: true,
+PeeringEnabled: true, PartitionsEnabled: true` (already the case on this
+branch), `V2CatalogEnabled: false`, `HCPEnabled: false`. The V2 catalog / HCP
+shell is a different application mode, not just extra routes, and is **out of
+scope** for this pass.
+
+Run with `pnpm start` (the mock API, see [mock-api](../../mock-api)) — export
+`CONSUL_SERVICE_MIN=2` first so the randomly-generated service count can
+never collapse to a single, non-mesh service (see
+[task-4-mock-data-plan.md](task-4-mock-data-plan.md) for why that matters). A
+stable `backend` service with a sidecar proxy — real `Upstreams` and
+`Expose.Paths` — is now always present in the services list regardless of
+that random count, so `dc.services.instance.upstreams`/`.exposedpaths` have
+a reliable, reproducible target to audit against.
+
+## Tasks
+
+| # | Task | Routes | Status | File |
+|---|------|--------|--------|------|
+| 1 | Shared chrome & global patterns | app chrome, `settings`, `unavailable`, `notfound` | Complete (7 findings) | [01-shared-chrome.md](01-shared-chrome.md) |
+| 2 | Overview | `dc.show`(`.serverstatus`/`.cataloghealth`/`.license`) | Complete (1 new finding + confirmed recurrences) | [02-overview.md](02-overview.md) |
+| 3 | Services (list & detail) | `dc.services`(`.show`.*), `dc.routing-config` | Complete (3 new findings) | [03-services.md](03-services.md) |
+| 4 | Service instance detail | `dc.services.instance`.* | Complete (1 finding + confirmed recurrences on all 5 sub-tabs) | [04-service-instance.md](04-service-instance.md) |
+| 5 | Nodes | `dc.nodes`(`.show`.*) | Complete (1 high-reach finding) | [05-nodes.md](05-nodes.md) |
+| 6 | Key/Value | `dc.kv`.* | Complete (2 minor findings) | [06-kv.md](06-kv.md) |
+| 7 | Intentions (top-level) | `dc.intentions`.* | Complete (1 finding, upstream HDS) | [07-intentions.md](07-intentions.md) |
+| 8 | Access Controls — Tokens | `dc.acls.tokens`.* | Complete (no new findings; 1 tool false-positive documented) | [08-acls-tokens.md](08-acls-tokens.md) |
+| 9 | Access Controls — Policies | `dc.acls.policies`.* | Complete (no new findings) | [09-acls-policies.md](09-acls-policies.md) |
+| 10 | Access Controls — Roles | `dc.acls.roles`.* | Complete (no new findings) | [10-acls-roles.md](10-acls-roles.md) |
+| 11 | Access Controls — Auth Methods | `dc.acls.auth-methods`.* | Complete (no new findings; corroborates #3) | [11-acls-auth-methods.md](11-acls-auth-methods.md) |
+| 12 | Peers | `dc.peers`.* | Complete (no new findings; `.show` blocked on no peered clusters in mock data) | [12-peers.md](12-peers.md) |
+| 13 | Admin Partitions | `dc.partitions`.* | Complete (no new findings) | [13-partitions.md](13-partitions.md) |
+| 14 | Namespaces | `dc.nspaces`.* | Complete (1 finding, 3rd occurrence of a recurring pattern) | [14-namespaces.md](14-namespaces.md) |
+
+Task 1 (shared chrome) is audited first since its components (header, side
+nav, tables, pagination, modals, notifications) are reused across every other
+section — findings there apply everywhere and don't need to be re-logged
+per-section.
+
+## Summary — all 14 tasks
+
+All tasks are complete except Task 12, which is partial: `dc.peers.show` has
+no peered cluster to open in this dataset. (Task 4 was in the same state —
+`dc.services.instance`'s `.upstreams`/`.exposedpaths`/`.addresses`/`.metadata`
+tabs needed mesh mock data before they could be audited — but that's now
+resolved; see [task-4-mock-data-plan.md](task-4-mock-data-plan.md) and
+[04-service-instance.md](04-service-instance.md).) Everything else was fully
+reachable.
+
+**Recurring patterns worth fixing once, centrally, rather than per-instance:**
+
+1. **`aria-label`/`aria-labelledby` on an element with no compatible role** (the
+   attribute is silently dropped because the element's implicit role is
+   `generic`, which doesn't support naming) — found independently 4 times:
+   `<header>` wrappers ([02-overview.md](02-overview.md) #1), HDS's own
+   `Hds::Alert` ([07-intentions.md](07-intentions.md) #1, recurring again on
+   the service-instance Exposed Paths tab's intro alert —
+   [04-service-instance.md](04-service-instance.md)), and the ACL
+   ruleset badge ([14-namespaces.md](14-namespaces.md) #1, the one instance
+   with a confirmed real information loss). Worth an `ember-template-lint`
+   rule if one doesn't already exist for this.
+2. **HDS's `{{hds-tooltip}}` modifier makes any host element tabbable with no
+   widget role** ([01-shared-chrome.md](01-shared-chrome.md) #7) — recurred in
+   nearly every task (Overview, Services, Service instance, Nodes, Peers).
+   Upstream in `@hashicorp/design-system-components`; consul-ui uses it 30+
+   places.
+3. **`ConsulCopyButton`'s `aria-label` replaces its visible value instead of
+   including it** ([05-nodes.md](05-nodes.md) #1) — WCAG 2.5.3 Label in Name,
+   11 usage sites app-wide. Single highest-reach fix in the whole audit: one
+   component change covers all 11.
+4. **The side-nav `<aside>` has no accessible name** despite HDS rendering a
+   hidden heading that was clearly meant to be it
+   ([01-shared-chrome.md](01-shared-chrome.md) #5) — confirmed on every single
+   page audited. One-line fix (`aria-label` on `Frame.Sidebar`).
+5. **Side-nav/footer text contrast** (`#8c909c` on `#fafafa`, 3.05:1 vs the
+   4.5:1 required) — [01-shared-chrome.md](01-shared-chrome.md) #1, confirmed
+   on every single page audited, both by axe/Lighthouse and IBM's checker.
+
+**The two most significant individual (non-recurring) findings:**
+
+- The health-checks list loses all `<ul>`/`<li>` semantics because
+  `display: flex` is applied to `<li>` for its layout, stripping the implicit
+  `list`/`listitem` roles Chrome would otherwise assign — confirmed on both
+  `dc.services.instance.healthchecks` and `dc.nodes.show.healthchecks`
+  ([04-service-instance.md](04-service-instance.md) #1). ~20 checks read as
+  one undifferentiated wall of text with no way to navigate check-by-check.
+- The service topology diagram conveys health status by color alone (bare
+  "45%9%45%" with no passing/warning/critical label) and has no structural/
+  textual equivalent of the visual graph at all
+  ([03-services.md](03-services.md) #1–#2). Neither automated engine caught
+  either of these — both came from reading the topology component's source
+  directly, a reminder that automated tools have real blind spots around
+  custom visualizations.
+
+**On tooling:** two IBM `accessibility-checker` results were investigated and
+turned out to be false positives rather than real bugs — a `combobox_haspopup_valid`
+complaint about Ember Power Select's portal wrapper (the real listbox
+underneath is correctly implemented — [08-acls-tokens.md](08-acls-tokens.md)),
+and the CSS-driven focus-ring pattern initially looked broken via
+`getComputedStyle` until the `::before`-pseudo-element ring was checked
+directly ([01-shared-chrome.md](01-shared-chrome.md)). Both are recorded in
+their task files so they aren't rediscovered and mis-reported as bugs later.

--- a/ui/packages/consul-ui/mock-api/v1/catalog/connect/_
+++ b/ui/packages/consul-ui/mock-api/v1/catalog/connect/_
@@ -52,6 +52,23 @@ ${range(env('CONSUL_EXPOSED_COUNT', 3)).map((i) => `
 `)}
             ]
           },
+          "Upstreams": [
+${range(env('CONSUL_UPSTREAM_COUNT', 3)).map((item, j) => `
+            {
+              "DestinationName": "${fake.hacker.noun()}",
+              "DestinationNamespace": "${fake.hacker.noun()}",
+              "DestinationPartition": "${fake.hacker.noun()}",
+              "DestinationType": "${fake.helpers.randomize(['service', 'prepared_query'])}",
+${fake.random.number({min: 1, max: 10}) > 5 ? `
+              "LocalBindAddress": "${fake.internet.ip()}",
+              "LocalBindPort": ${fake.random.number({min: 0, max: 65535})}
+` : `
+              "LocalBindSocketMode": "0600",
+              "LocalBindSocketPath": "/${fake.lorem.words(fake.random.number({min: 1, max: 5})).split(' ').join('/')}${fake.random.boolean() ? fake.system.fileName() : ''}"
+` }
+            }
+`)}
+          ],
           "Mode": "${env('CONSUL_TPROXY_ENABLE') ? `transparent` : fake.helpers.randomize(['', 'direct', 'transparent'])}",
           "TransparentProxy": {},
           "DestinationServiceName": "${location.pathname.slice(4)}"

--- a/ui/packages/consul-ui/mock-api/v1/catalog/connect/backend
+++ b/ui/packages/consul-ui/mock-api/v1/catalog/connect/backend
@@ -33,7 +33,31 @@
       "LocalServicePort": 7000,
       "Mode": "",
       "MeshGateway": {},
-      "Expose": {}
+      "Upstreams": [
+        {
+          "DestinationName": "backend-cache",
+          "DestinationType": "service",
+          "LocalBindAddress": "127.0.0.1",
+          "LocalBindPort": 8181
+        },
+        {
+          "DestinationName": "billing",
+          "DestinationType": "service",
+          "LocalBindAddress": "127.0.0.1",
+          "LocalBindPort": 8282
+        }
+      ],
+      "Expose": {
+        "Checks": true,
+        "Paths": [
+          {
+            "Path": "/healthz",
+            "Protocol": "http",
+            "LocalPathPort": 7000,
+            "ListenerPort": 21500
+          }
+        ]
+      }
     },
     "ServiceConnect": {},
     "CreateIndex": 19,
@@ -73,7 +97,31 @@
       "LocalServicePort": 7001,
       "Mode": "",
       "MeshGateway": {},
-      "Expose": {}
+      "Upstreams": [
+        {
+          "DestinationName": "backend-cache",
+          "DestinationType": "service",
+          "LocalBindAddress": "127.0.0.1",
+          "LocalBindPort": 8181
+        },
+        {
+          "DestinationName": "billing",
+          "DestinationType": "service",
+          "LocalBindAddress": "127.0.0.1",
+          "LocalBindPort": 8282
+        }
+      ],
+      "Expose": {
+        "Checks": true,
+        "Paths": [
+          {
+            "Path": "/healthz",
+            "Protocol": "http",
+            "LocalPathPort": 7001,
+            "ListenerPort": 21501
+          }
+        ]
+      }
     },
     "ServiceConnect": {},
     "CreateIndex": 21,

--- a/ui/packages/consul-ui/mock-api/v1/health/service/backend-sidecar-proxy
+++ b/ui/packages/consul-ui/mock-api/v1/health/service/backend-sidecar-proxy
@@ -37,7 +37,31 @@
         "LocalServicePort": 7000,
         "Mode": "",
         "MeshGateway": {},
-        "Expose": {}
+        "Upstreams": [
+          {
+            "DestinationName": "backend-cache",
+            "DestinationType": "service",
+            "LocalBindAddress": "127.0.0.1",
+            "LocalBindPort": 8181
+          },
+          {
+            "DestinationName": "billing",
+            "DestinationType": "service",
+            "LocalBindAddress": "127.0.0.1",
+            "LocalBindPort": 8282
+          }
+        ],
+        "Expose": {
+          "Checks": true,
+          "Paths": [
+            {
+              "Path": "/healthz",
+              "Protocol": "http",
+              "LocalPathPort": 7000,
+              "ListenerPort": 21500
+            }
+          ]
+        }
       },
       "Connect": {},
       "CreateIndex": 19,
@@ -138,7 +162,31 @@
         "LocalServicePort": 7001,
         "Mode": "",
         "MeshGateway": {},
-        "Expose": {}
+        "Upstreams": [
+          {
+            "DestinationName": "backend-cache",
+            "DestinationType": "service",
+            "LocalBindAddress": "127.0.0.1",
+            "LocalBindPort": 8181
+          },
+          {
+            "DestinationName": "billing",
+            "DestinationType": "service",
+            "LocalBindAddress": "127.0.0.1",
+            "LocalBindPort": 8282
+          }
+        ],
+        "Expose": {
+          "Checks": true,
+          "Paths": [
+            {
+              "Path": "/healthz",
+              "Protocol": "http",
+              "LocalPathPort": 7001,
+              "ListenerPort": 21501
+            }
+          ]
+        }
       },
       "Connect": {},
       "CreateIndex": 21,

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/node/node
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/node/node
@@ -1,0 +1,72 @@
+{
+  "ID": "237b9eeb-bba1-e6e3-3c99-c527d6d76cc0",
+  "Node": "node",
+  "Address": "172.17.0.2",
+  "TaggedAddresses": {
+    "lan": "172.17.0.2",
+    "wan": "172.17.0.2"
+  },
+  "Meta": {
+    "consul-network-segment": ""
+  },
+  "Services": [
+    {
+      "ID": "backend",
+      "Service": "backend",
+      "Tags": [],
+      "Address": "",
+      "Port": 7000,
+      "EnableTagOverride": false,
+      "CreateIndex": 18,
+      "ModifyIndex": 18
+    },
+    {
+      "ID": "backend-v2",
+      "Service": "backend",
+      "Tags": [],
+      "Address": "",
+      "Port": 7001,
+      "EnableTagOverride": false,
+      "CreateIndex": 20,
+      "ModifyIndex": 20
+    },
+    {
+      "ID": "backend-sidecar-proxy",
+      "Service": "backend-sidecar-proxy",
+      "Kind": "connect-proxy",
+      "Tags": [],
+      "Address": "",
+      "Port": 21000,
+      "EnableTagOverride": false,
+      "CreateIndex": 19,
+      "ModifyIndex": 19
+    },
+    {
+      "ID": "backend-v2-sidecar-proxy",
+      "Service": "backend-sidecar-proxy",
+      "Kind": "connect-proxy",
+      "Tags": [],
+      "Address": "",
+      "Port": 21001,
+      "EnableTagOverride": false,
+      "CreateIndex": 21,
+      "ModifyIndex": 21
+    }
+  ],
+  "Checks": [
+    {
+      "Node": "node",
+      "CheckID": "serfHealth",
+      "Name": "Serf Health Status",
+      "Status": "passing",
+      "Notes": "",
+      "Output": "Agent alive and reachable",
+      "ServiceID": "",
+      "ServiceName": "",
+      "ServiceTags": [],
+      "Definition": {},
+      "CreateIndex": 14,
+      "ModifyIndex": 14
+    }
+  ]
+}

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/services
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/services
@@ -11,7 +11,13 @@ ${[0].map(
     // mock-api/v1/health/service/backend* and mock-api/v1/internal/ui/node/node)
     // so there's a reliable way to reach populated Upstreams/Exposed Paths
     // tabs regardless of what the random generation below produces.
-    [
+    //
+    // Opt-in only (CONSUL_MESH_SEED_ENABLE=1 pnpm start): unconditionally
+    // prepending these broke every acceptance test that assumes a specific
+    // service count/ordering/index (e.g. yaml-provided model overrides are
+    // merged onto the response by array index), since this endpoint is also
+    // what the test double serves under `ember test`.
+    (env('CONSUL_MESH_SEED_ENABLE', false) ? [
       `
       {
         "Name": "backend",
@@ -41,7 +47,7 @@ ${[0].map(
         "ChecksCritical": 2
       }
       `,
-    ].concat(
+    ] : []).concat(
     range(
       env(
         'CONSUL_SERVICE_COUNT',

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/services
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/services
@@ -6,6 +6,42 @@ ${[0].map(
     return `
 [
   ${
+    // A stable, always-present mesh-enabled service + its sidecar proxy
+    // (backed by the static fixtures under mock-api/v1/catalog/connect/backend,
+    // mock-api/v1/health/service/backend* and mock-api/v1/internal/ui/node/node)
+    // so there's a reliable way to reach populated Upstreams/Exposed Paths
+    // tabs regardless of what the random generation below produces.
+    [
+      `
+      {
+        "Name": "backend",
+        "Tags": [],
+        "ConnectedWithProxy": true,
+        "ConnectedWithGateway": false,
+        "GatewayConfig": {},
+        "InstanceCount": 2,
+        "Nodes": ["node"],
+        "ChecksPassing": 2,
+        "ChecksWarning": 0,
+        "ChecksCritical": 0
+      }
+      `,
+      `
+      {
+        "Name": "backend-sidecar-proxy",
+        "Kind": "connect-proxy",
+        "Tags": [],
+        "ConnectedWithProxy": false,
+        "ConnectedWithGateway": false,
+        "GatewayConfig": {},
+        "InstanceCount": 2,
+        "Nodes": ["node"],
+        "ChecksPassing": 2,
+        "ChecksWarning": 0,
+        "ChecksCritical": 2
+      }
+      `,
+    ].concat(
     range(
       env(
         'CONSUL_SERVICE_COUNT',
@@ -122,6 +158,7 @@ ${ fake.random.number({min: 1, max: 10}) > 2 ? `
           }
         `;
       }
+    )
     )
   }
 ]


### PR DESCRIPTION
## Description

This PR fixes a number of accessibility (a11y) issues found across the Consul UI, including:

- Accessible names for policy/role/token fieldsets and correct `aria-*` wiring for super-select components
- Accessible names for the intention fieldset and correct id forwarding for super-select components
- Various a11y violations across dropdowns, modals, code blocks, and forms
- Restored keyboard focus ring on data-table sort buttons and name links
- A11y audit findings across shared chrome and components
- Seeded mesh mock data for service-instance upstreams/exposed-paths tabs used during testing

## Testing & Reproduction steps

- Manually verified keyboard focus is visible on data-table sort buttons and name links
- Verified accessible names are announced correctly for policy/role/token/intention forms and their super-select fields
- Verified dropdowns, modals, and code blocks no longer trigger the previously identified a11y violations