### PR TITLE
api-gateway: fix cold-start Envoy crash from aggregate clusters missing EDS 

### DIFF
--- a/.changelog/23892.txt
+++ b/.changelog/23892.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+api-gateway: Fix a cold-start crash where an api-gateway's Envoy proxy could
+segfault during worker startup when a route's failover upstream was rendered as
+an aggregate cluster before its endpoints were assembled. Consul now holds each
+xDS stream's first push until the gateway's discovery-chain endpoints are ready
+(per-stream, first-push only, skipped for streams Envoy resumes, and bounded by
+a 30s deadline), and renders a failover upstream as a plain EDS cluster instead
+of an aggregate whenever its member endpoints are not yet available -- restoring
+full failover automatically once they arrive. Steady-state updates are never
+withheld.
+```

--- a/agent/proxycfg/api_gateway_bootstrap_gate_test.go
+++ b/agent/proxycfg/api_gateway_bootstrap_gate_test.go
@@ -1,0 +1,392 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package proxycfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/proxycfg/internal/watch"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// wireReadyListener attaches the bound-listener and route-config state that
+// activeUpstreamIDs walks when deciding which upstreams reach CDS. It reproduces
+// what getReadyListeners (agent/xds/listeners_apigateway.go) requires: a bound
+// listener carrying the operator config (Port and Protocol) with no Conflicted
+// condition that lists the route, and the route config entry itself. Upstreams
+// set on a snapshot without this wiring are invisible to the gate, which is the
+// point of the tightening — the gate must only wait on upstreams cluster
+// generation will actually emit.
+func wireReadyListener(c *configSnapshotAPIGateway, key APIGatewayListenerKey, routeRefs ...structs.ResourceReference) {
+	const name = "listener-1"
+	if c.GatewayConfig == nil {
+		c.GatewayConfig = &structs.APIGatewayConfigEntry{Name: "gw"}
+	}
+	if c.BoundListeners == nil {
+		c.BoundListeners = map[string]structs.BoundAPIGatewayListener{}
+	}
+	// The controller copies the operator config (Port, Protocol, ...) onto the
+	// bound listener at reconcile time; getReadyListeners treats a bound listener
+	// with Port 0 or empty Protocol as not-yet-reconciled and skips it.
+	c.BoundListeners[name] = structs.BoundAPIGatewayListener{
+		Name:     name,
+		Protocol: structs.APIGatewayListenerProtocol(key.Protocol),
+		Port:     key.Port,
+		Routes:   routeRefs,
+	}
+
+	c.HTTPRoutes = watch.NewMap[structs.ResourceReference, *structs.HTTPRouteConfigEntry]()
+	c.TCPRoutes = watch.NewMap[structs.ResourceReference, *structs.TCPRouteConfigEntry]()
+	for _, ref := range routeRefs {
+		switch ref.Kind {
+		case structs.HTTPRoute:
+			c.HTTPRoutes.InitWatch(ref, func() {})
+			c.HTTPRoutes.Set(ref, &structs.HTTPRouteConfigEntry{Name: ref.Name})
+		case structs.TCPRoute:
+			c.TCPRoutes.InitWatch(ref, func() {})
+			c.TCPRoutes.Set(ref, &structs.TCPRouteConfigEntry{Name: ref.Name})
+		}
+	}
+}
+
+// TestConfigSnapshotAPIGateway_bootstrapGate covers the api-gateway completeness
+// predicate that the xDS layer uses to hold a gateway's FIRST push (ITCO-15826),
+// and asserts that valid() itself does NOT gate on endpoints in this approach —
+// proxycfg keeps delivering snapshots so steady-state churn is never starved;
+// the gate lives per-stream in agent/xds/delta.go instead.
+//
+// The predicate carries the #13259 hardening: it ignores orphan chains (not
+// wired to any listener upstream) and also gates on mesh-gateway endpoints for
+// remote/local-mode targets, mirroring makeLoadAssignmentEndpointGroup.
+func TestConfigSnapshotAPIGateway_bootstrapGate(t *testing.T) {
+	const targetID = "web.default.default.dc1"
+	uid := NewUpstreamIDFromServiceName(structs.NewServiceName("web", nil))
+
+	// localKey is the gateway's own locality; it only affects mesh-gateway
+	// targets whose locality differs from it.
+	localKey := GatewayKey{Datacenter: "dc1"}
+
+	routeRef := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "route-1"}
+	listenerKey := APIGatewayListenerKey{Protocol: "http", Port: 8080}
+
+	newAPIGW := func() *configSnapshotAPIGateway {
+		c := &configSnapshotAPIGateway{
+			GatewayConfigLoaded:      true,
+			BoundGatewayConfigLoaded: true,
+		}
+		c.Leaf = &structs.IssuedCert{}
+		c.DiscoveryChain = map[UpstreamID]*structs.CompiledDiscoveryChain{
+			uid: {
+				ServiceName: "web",
+				Targets: map[string]*structs.DiscoveryTarget{
+					targetID: {ID: targetID, Service: "web"},
+				},
+			},
+		}
+		// Wire the chain to a route on a ready listener so it is NOT skipped by
+		// discoveryChainsMissingEndpoints, which only gates on chains that reach
+		// a CDS cluster — see activeUpstreamIDs.
+		c.Upstreams = listenerRouteUpstreams{}
+		c.Upstreams.set(routeRef, listenerKey,
+			structs.Upstreams{{DestinationName: "web"}})
+		wireReadyListener(c, listenerKey, routeRef)
+		c.WatchedUpstreamEndpoints = map[UpstreamID]map[string]structs.CheckServiceNodes{}
+		c.WatchedGatewayEndpoints = map[UpstreamID]map[string]structs.CheckServiceNodes{}
+		return c
+	}
+
+	t.Run("chain present, endpoints missing => incomplete but still valid()", func(t *testing.T) {
+		c := newAPIGW()
+		require.NotEmpty(t, c.discoveryChainsMissingEndpoints(localKey))
+		// The completeness gate is enforced in the xDS layer, not here, so proxycfg
+		// must still consider the snapshot deliverable (no whole-snapshot withholding).
+		require.True(t, c.valid())
+	})
+
+	t.Run("endpoints present (even empty) => complete", func(t *testing.T) {
+		c := newAPIGW()
+		c.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{targetID: {}}
+		require.Empty(t, c.discoveryChainsMissingEndpoints(localKey))
+	})
+
+	t.Run("missing targets reported for diagnostics", func(t *testing.T) {
+		c := newAPIGW()
+		require.ElementsMatch(t, []string{uid.String() + "/" + targetID}, c.discoveryChainsMissingEndpoints(localKey))
+	})
+
+	t.Run("external and peered targets never block completeness", func(t *testing.T) {
+		c := newAPIGW()
+		c.DiscoveryChain[uid].Targets[targetID].External = true
+		require.Empty(t, c.discoveryChainsMissingEndpoints(localKey))
+
+		c = newAPIGW()
+		c.DiscoveryChain[uid].Targets[targetID].Peer = "peer1"
+		require.Empty(t, c.discoveryChainsMissingEndpoints(localKey))
+	})
+
+	t.Run("orphan chain (no listener upstream) never blocks completeness", func(t *testing.T) {
+		c := newAPIGW()
+		// Drop the listener-upstream wiring: the chain is now an orphan (a
+		// registered watch target that never resolved to a listener upstream,
+		// e.g. a backend-not-found route). It emits no CDS cluster, so it must
+		// not block admission even though its endpoints are absent.
+		c.Upstreams = listenerRouteUpstreams{}
+		require.Empty(t, c.discoveryChainsMissingEndpoints(localKey))
+
+		// Control: wiring the very same chain to a listener makes it block, so
+		// the orphan exclusion is what emptied the result above rather than some
+		// unrelated property of the fixture.
+		c.Upstreams.set(routeRef, listenerKey,
+			structs.Upstreams{{DestinationName: "web"}})
+		require.NotEmpty(t, c.discoveryChainsMissingEndpoints(localKey))
+	})
+
+	t.Run("remote mesh-gateway target gates on gateway endpoints", func(t *testing.T) {
+		c := newAPIGW()
+		// Target in another DC routed via a remote mesh gateway. Its own
+		// endpoints are present, but the mesh-gateway endpoints are not, which is
+		// still a CDS-without-EDS state (makeLoadAssignmentEndpointGroup uses the
+		// gateway endpoints for these targets).
+		tgt := c.DiscoveryChain[uid].Targets[targetID]
+		tgt.Datacenter = "dc2"
+		tgt.MeshGateway = structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeRemote}
+		c.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{targetID: {}}
+
+		gwKey := GatewayKey{Datacenter: "dc2"}
+		require.ElementsMatch(t,
+			[]string{uid.String() + "/" + targetID + "@" + gwKey.String()},
+			c.discoveryChainsMissingEndpoints(localKey))
+
+		// Once the mesh-gateway endpoints arrive, the target is complete.
+		c.WatchedGatewayEndpoints[uid] = map[string]structs.CheckServiceNodes{gwKey.String(): {}}
+		require.Empty(t, c.discoveryChainsMissingEndpoints(localKey))
+	})
+
+	t.Run("local mesh-gateway target gates on local gateway endpoints", func(t *testing.T) {
+		c := newAPIGW()
+		// Local mode reaches a remote DC through this gateway's OWN local mesh
+		// gateway, so the key is localKey rather than the target's locality.
+		tgt := c.DiscoveryChain[uid].Targets[targetID]
+		tgt.Datacenter = "dc2"
+		tgt.MeshGateway = structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeLocal}
+		c.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{targetID: {}}
+
+		require.ElementsMatch(t,
+			[]string{uid.String() + "/" + targetID + "@" + localKey.String()},
+			c.discoveryChainsMissingEndpoints(localKey))
+
+		c.WatchedGatewayEndpoints[uid] = map[string]structs.CheckServiceNodes{localKey.String(): {}}
+		require.Empty(t, c.discoveryChainsMissingEndpoints(localKey))
+	})
+
+	t.Run("mesh-gateway target in our own locality is not gated", func(t *testing.T) {
+		// localKey.Matches: the target is local, so EDS serves it from the
+		// target endpoints and never consults WatchedGatewayEndpoints.
+		for _, mode := range []structs.MeshGatewayMode{
+			structs.MeshGatewayModeRemote,
+			structs.MeshGatewayModeLocal,
+		} {
+			c := newAPIGW()
+			tgt := c.DiscoveryChain[uid].Targets[targetID]
+			tgt.Datacenter = localKey.Datacenter
+			tgt.Partition = localKey.Partition
+			tgt.MeshGateway = structs.MeshGatewayConfig{Mode: mode}
+			c.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{targetID: {}}
+
+			require.Empty(t, c.discoveryChainsMissingEndpoints(localKey), "mode %q", mode)
+		}
+	})
+
+	t.Run("empty gateway key is not gated", func(t *testing.T) {
+		// Mirrors makeLoadAssignmentEndpointGroup's gatewayKey.IsEmpty() early
+		// return: with no mesh-gateway mode set, or a local-mode gateway whose
+		// own locality is unset, no gateway is consulted and gating on one would
+		// withhold a cluster Envoy can serve.
+		c := newAPIGW()
+		c.DiscoveryChain[uid].Targets[targetID].Datacenter = "dc2"
+		c.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{targetID: {}}
+		require.Empty(t, c.discoveryChainsMissingEndpoints(localKey),
+			"no mesh-gateway mode means no gateway lookup")
+
+		c = newAPIGW()
+		tgt := c.DiscoveryChain[uid].Targets[targetID]
+		tgt.Datacenter = "dc2"
+		tgt.MeshGateway = structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeLocal}
+		c.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{targetID: {}}
+		require.Empty(t, c.discoveryChainsMissingEndpoints(GatewayKey{}),
+			"local mode with an empty locality yields an empty gateway key")
+	})
+
+	t.Run("route on a conflicted listener is not gated", func(t *testing.T) {
+		// getReadyListeners skips listeners whose status carries Conflicted=True,
+		// so cluster generation never emits a cluster for their routes. The gate
+		// must skip them too, or it withholds the whole gateway's first push
+		// waiting on endpoints for a cluster that is never published.
+		c := newAPIGW()
+		require.NotEmpty(t, c.discoveryChainsMissingEndpoints(localKey),
+			"precondition: a ready listener does gate on this chain")
+
+		c.GatewayConfig.Status = structs.Status{Conditions: []structs.Condition{{
+			Type:   "Conflicted",
+			Status: "True",
+			Resource: &structs.ResourceReference{
+				Kind:        structs.APIGateway,
+				Name:        c.GatewayConfig.Name,
+				SectionName: "listener-1",
+			},
+		}}}
+		require.False(t, c.GatewayConfig.ListenerIsReady("listener-1"),
+			"precondition: the listener is now unready")
+		require.Empty(t, c.discoveryChainsMissingEndpoints(localKey))
+	})
+
+	t.Run("route not bound to the listener is not gated", func(t *testing.T) {
+		// Upstreams is built from the route's declared parentRefs
+		// (referenceIsForListener), and a parentRef with no sectionName matches
+		// every listener on the gateway. BoundListeners is the controller's
+		// authoritative binding result, so it is the narrower set getReadyListeners
+		// walks. A route that declared an intent but never bound emits no cluster.
+		c := newAPIGW()
+		// Keep the listener fully reconciled (Port + Protocol set) so the only
+		// thing that changed is the missing route binding — otherwise the new
+		// unreconciled-listener skip would empty the result for the wrong reason.
+		c.BoundListeners["listener-1"] = structs.BoundAPIGatewayListener{
+			Name:     "listener-1",
+			Protocol: structs.APIGatewayListenerProtocol(listenerKey.Protocol),
+			Port:     listenerKey.Port,
+		}
+		require.Empty(t, c.discoveryChainsMissingEndpoints(localKey))
+	})
+
+	t.Run("route bound but whose config entry has not arrived is not gated", func(t *testing.T) {
+		// getReadyListeners skips route refs that are not present in
+		// HTTPRoutes/TCPRoutes, so the same ordering must not gate.
+		c := newAPIGW()
+		c.HTTPRoutes.CancelWatch(routeRef)
+		require.Empty(t, c.discoveryChainsMissingEndpoints(localKey))
+	})
+
+	t.Run("exported ConfigSnapshot accessor used by the xDS layer", func(t *testing.T) {
+		// api-gateway kind: delegates to the sub-snapshot.
+		incomplete := &ConfigSnapshot{Kind: structs.ServiceKindAPIGateway, APIGateway: *newAPIGW()}
+		require.ElementsMatch(t, []string{uid.String() + "/" + targetID}, incomplete.APIGatewayDiscoveryChainsMissingEndpoints())
+
+		complete := newAPIGW()
+		complete.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{targetID: {}}
+		full := &ConfigSnapshot{Kind: structs.ServiceKindAPIGateway, APIGateway: *complete}
+		require.Empty(t, full.APIGatewayDiscoveryChainsMissingEndpoints())
+
+		// non-api-gateway kinds are never gated by the xDS bootstrap check.
+		sidecar := &ConfigSnapshot{Kind: structs.ServiceKindConnectProxy}
+		require.Nil(t, sidecar.APIGatewayDiscoveryChainsMissingEndpoints())
+	})
+}
+
+// TestDiscoveryChainsMissingEndpoints_MirrorsEndpointGeneration pins the gate's
+// mesh-gateway logic to makeLoadAssignmentEndpointGroup (agent/xds/endpoints.go),
+// which decides whether EDS actually emits an assignment for a target.
+//
+// The gate must block exactly when that function would skip the cluster. Blocking
+// less would let the cold-start incoherence through; blocking more withholds
+// config for a cluster Envoy could serve, which at best delays the first push to
+// the bootstrap-gate timeout. edsWouldSkip below is transcribed from that
+// function, so this test fails if either side drifts.
+func TestDiscoveryChainsMissingEndpoints_MirrorsEndpointGeneration(t *testing.T) {
+	const targetID = "web.default.default.dc2"
+	uid := NewUpstreamIDFromServiceName(structs.NewServiceName("web", nil))
+	routeRef := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "route-1"}
+	listenerKey := APIGatewayListenerKey{Protocol: "http", Port: 8080}
+
+	// Transcribed from makeLoadAssignmentEndpointGroup. api-gateway clusters are
+	// always generated with forMeshGateway=false, so that argument is omitted.
+	edsWouldSkip := func(c *configSnapshotAPIGateway, localKey GatewayKey) bool {
+		target := c.DiscoveryChain[uid].Targets[targetID]
+		if _, ok := c.WatchedUpstreamEndpoints[uid][targetID]; !ok {
+			return true
+		}
+		var gatewayKey GatewayKey
+		switch target.MeshGateway.Mode {
+		case structs.MeshGatewayModeRemote:
+			gatewayKey.Datacenter = target.Datacenter
+			gatewayKey.Partition = target.Partition
+		case structs.MeshGatewayModeLocal:
+			gatewayKey = localKey
+		}
+		if gatewayKey.IsEmpty() || localKey.Matches(target.Datacenter, target.Partition) {
+			return false
+		}
+		_, ok := c.WatchedGatewayEndpoints[uid][gatewayKey.String()]
+		return !ok
+	}
+
+	build := func(mode structs.MeshGatewayMode, targetDC, targetPartition string, haveTargetEndpoints bool) *configSnapshotAPIGateway {
+		c := &configSnapshotAPIGateway{GatewayConfigLoaded: true, BoundGatewayConfigLoaded: true}
+		c.Leaf = &structs.IssuedCert{}
+		c.DiscoveryChain = map[UpstreamID]*structs.CompiledDiscoveryChain{
+			uid: {ServiceName: "web", Targets: map[string]*structs.DiscoveryTarget{
+				targetID: {
+					ID:          targetID,
+					Service:     "web",
+					Datacenter:  targetDC,
+					Partition:   targetPartition,
+					MeshGateway: structs.MeshGatewayConfig{Mode: mode},
+				},
+			}},
+		}
+		c.Upstreams = listenerRouteUpstreams{}
+		c.Upstreams.set(routeRef, listenerKey,
+			structs.Upstreams{{DestinationName: "web"}})
+		wireReadyListener(c, listenerKey, routeRef)
+		c.WatchedUpstreamEndpoints = map[UpstreamID]map[string]structs.CheckServiceNodes{}
+		if haveTargetEndpoints {
+			c.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{targetID: {}}
+		}
+		c.WatchedGatewayEndpoints = map[UpstreamID]map[string]structs.CheckServiceNodes{}
+		return c
+	}
+
+	localDC := GatewayKey{Datacenter: "dc1", Partition: "default"}
+
+	cases := []struct {
+		name             string
+		mode             structs.MeshGatewayMode
+		targetDC         string
+		targetPartition  string
+		localKey         GatewayKey
+		targetEndpoints  bool
+		gatewayEndpoints bool
+	}{
+		{name: "no target endpoints", mode: structs.MeshGatewayModeNone, targetDC: "dc1", targetPartition: "default", localKey: localDC},
+		{name: "local target, no gateway", mode: structs.MeshGatewayModeNone, targetDC: "dc1", targetPartition: "default", localKey: localDC, targetEndpoints: true},
+		{name: "remote dc, remote mode, gateway missing", mode: structs.MeshGatewayModeRemote, targetDC: "dc2", targetPartition: "default", localKey: localDC, targetEndpoints: true},
+		{name: "remote dc, remote mode, gateway present", mode: structs.MeshGatewayModeRemote, targetDC: "dc2", targetPartition: "default", localKey: localDC, targetEndpoints: true, gatewayEndpoints: true},
+		{name: "remote dc, local mode, gateway missing", mode: structs.MeshGatewayModeLocal, targetDC: "dc2", targetPartition: "default", localKey: localDC, targetEndpoints: true},
+		{name: "remote dc, local mode, gateway present", mode: structs.MeshGatewayModeLocal, targetDC: "dc2", targetPartition: "default", localKey: localDC, targetEndpoints: true, gatewayEndpoints: true},
+		{name: "same dc, remote mode", mode: structs.MeshGatewayModeRemote, targetDC: "dc1", targetPartition: "default", localKey: localDC, targetEndpoints: true},
+		{name: "same dc, local mode", mode: structs.MeshGatewayModeLocal, targetDC: "dc1", targetPartition: "default", localKey: localDC, targetEndpoints: true},
+		{name: "remote dc, no mesh-gateway mode", mode: structs.MeshGatewayModeNone, targetDC: "dc2", targetPartition: "default", localKey: localDC, targetEndpoints: true},
+		{name: "remote mode, target has no dc", mode: structs.MeshGatewayModeRemote, targetDC: "", targetPartition: "", localKey: localDC, targetEndpoints: true},
+		{name: "local mode, empty local key", mode: structs.MeshGatewayModeLocal, targetDC: "dc2", targetPartition: "default", localKey: GatewayKey{}, targetEndpoints: true},
+		{name: "remote mode, empty local key", mode: structs.MeshGatewayModeRemote, targetDC: "dc2", targetPartition: "default", localKey: GatewayKey{}, targetEndpoints: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := build(tc.mode, tc.targetDC, tc.targetPartition, tc.targetEndpoints)
+			if tc.gatewayEndpoints {
+				gwKey := GatewayKey{Datacenter: tc.targetDC, Partition: tc.targetPartition}
+				if tc.mode == structs.MeshGatewayModeLocal {
+					gwKey = tc.localKey
+				}
+				c.WatchedGatewayEndpoints[uid] = map[string]structs.CheckServiceNodes{gwKey.String(): {}}
+			}
+
+			gateBlocks := len(c.discoveryChainsMissingEndpoints(tc.localKey)) > 0
+			require.Equal(t, edsWouldSkip(c, tc.localKey), gateBlocks,
+				"the gate must block exactly when EDS would skip the cluster")
+		})
+	}
+}

--- a/agent/proxycfg/api_gateway_test.go
+++ b/agent/proxycfg/api_gateway_test.go
@@ -495,28 +495,29 @@ func TestDiscoveryChainsMissingEndpoints_OrphanChainSkipped(t *testing.T) {
 	})
 
 	t.Run("mesh_gateway_endpoints_missing_returns_false", func(t *testing.T) {
-		// Regression guard for the rolling-restart segfault: a service with a
-		// ServiceSplitter that includes a remote-partition target (e.g.
-		// example-https.pcf.vms) routes through a remote mesh gateway.
-		// makeLoadAssignmentEndpointGroup checks WatchedGatewayEndpoints for
-		// those targets. If that watch hasn't fired yet, it returns valid=false,
-		// EDS is skipped, but CDS already emitted the cluster → segfault.
-		// This subtest ensures the gate also blocks on WatchedGatewayEndpoints.
+		// Regression guard for the rolling-restart segfault: a service whose
+		// discovery-chain target lives in a remote datacenter (dc2) routes
+		// through a remote mesh gateway. makeLoadAssignmentEndpointGroup checks
+		// WatchedGatewayEndpoints for those targets. If that watch hasn't fired
+		// yet, it returns valid=false, EDS is skipped, but CDS already emitted
+		// the cluster → segfault. This subtest ensures the gate also blocks on
+		// WatchedGatewayEndpoints.
 		//
-		// We build a chain whose single target has MeshGatewayModeRemote and
-		// belongs to a remote partition ("vms") so that localKey.Matches()
-		// returns false and the gateway-endpoint check is triggered.
+		// The single target has MeshGatewayModeRemote and lives in a remote
+		// datacenter (dc2 != localKey's dc1) so that localKey.Matches() returns
+		// false and the gateway-endpoint check is triggered. Using a remote
+		// datacenter (not a remote partition) keeps this identical under CE and ent.
 		remoteUID := NewUpstreamIDFromServiceName(structs.NewServiceName("remote-svc", nil))
-		remoteTargetID := "remote-svc.default.vms.dc2"
+		remoteTargetID := "remote-svc.default.default.dc2"
 
 		remoteChain := &structs.CompiledDiscoveryChain{
 			ServiceName: "remote-svc",
 			Namespace:   "default",
-			Partition:   "vms",
+			Partition:   "default",
 			Datacenter:  "dc2",
-			StartNode:   "resolver:remote-svc.default.vms.dc2",
+			StartNode:   "resolver:remote-svc.default.default.dc2",
 			Nodes: map[string]*structs.DiscoveryGraphNode{
-				"resolver:remote-svc.default.vms.dc2": {
+				"resolver:remote-svc.default.default.dc2": {
 					Type: structs.DiscoveryGraphNodeTypeResolver,
 					Name: "remote-svc",
 					Resolver: &structs.DiscoveryResolver{
@@ -530,7 +531,7 @@ func TestDiscoveryChainsMissingEndpoints_OrphanChainSkipped(t *testing.T) {
 					ID:          remoteTargetID,
 					Service:     "remote-svc",
 					Namespace:   "default",
-					Partition:   "vms",
+					Partition:   "default",
 					Datacenter:  "dc2",
 					MeshGateway: structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeRemote},
 				},
@@ -538,7 +539,7 @@ func TestDiscoveryChainsMissingEndpoints_OrphanChainSkipped(t *testing.T) {
 		}
 
 		remoteRouteRef := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "remote-route"}
-		remoteUpstream := structs.Upstream{DestinationName: "remote-svc", DestinationNamespace: "default", DestinationPartition: "vms"}
+		remoteUpstream := structs.Upstream{DestinationName: "remote-svc", DestinationNamespace: "default", DestinationPartition: "default"}
 		remoteUpstreams := listenerRouteUpstreams{}
 		remoteUpstreams.set(remoteRouteRef, listenerKey, structs.Upstreams{remoteUpstream})
 
@@ -565,16 +566,16 @@ func TestDiscoveryChainsMissingEndpoints_OrphanChainSkipped(t *testing.T) {
 	t.Run("mesh_gateway_endpoints_present_returns_true", func(t *testing.T) {
 		// Same setup as above but with WatchedGatewayEndpoints populated — gate must pass.
 		remoteUID := NewUpstreamIDFromServiceName(structs.NewServiceName("remote-svc", nil))
-		remoteTargetID := "remote-svc.default.vms.dc2"
+		remoteTargetID := "remote-svc.default.default.dc2"
 
 		remoteChain := &structs.CompiledDiscoveryChain{
 			ServiceName: "remote-svc",
 			Namespace:   "default",
-			Partition:   "vms",
+			Partition:   "default",
 			Datacenter:  "dc2",
-			StartNode:   "resolver:remote-svc.default.vms.dc2",
+			StartNode:   "resolver:remote-svc.default.default.dc2",
 			Nodes: map[string]*structs.DiscoveryGraphNode{
-				"resolver:remote-svc.default.vms.dc2": {
+				"resolver:remote-svc.default.default.dc2": {
 					Type: structs.DiscoveryGraphNodeTypeResolver,
 					Name: "remote-svc",
 					Resolver: &structs.DiscoveryResolver{
@@ -588,7 +589,7 @@ func TestDiscoveryChainsMissingEndpoints_OrphanChainSkipped(t *testing.T) {
 					ID:          remoteTargetID,
 					Service:     "remote-svc",
 					Namespace:   "default",
-					Partition:   "vms",
+					Partition:   "default",
 					Datacenter:  "dc2",
 					MeshGateway: structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeRemote},
 				},
@@ -596,11 +597,11 @@ func TestDiscoveryChainsMissingEndpoints_OrphanChainSkipped(t *testing.T) {
 		}
 
 		remoteRouteRef := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "remote-route"}
-		remoteUpstream := structs.Upstream{DestinationName: "remote-svc", DestinationNamespace: "default", DestinationPartition: "vms"}
+		remoteUpstream := structs.Upstream{DestinationName: "remote-svc", DestinationNamespace: "default", DestinationPartition: "default"}
 		remoteUpstreams := listenerRouteUpstreams{}
 		remoteUpstreams.set(remoteRouteRef, listenerKey, structs.Upstreams{remoteUpstream})
 
-		gwKey := GatewayKey{Datacenter: "dc2", Partition: "vms"}
+		gwKey := GatewayKey{Datacenter: "dc2", Partition: "default"}
 		snap := &configSnapshotAPIGateway{
 			ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
 				DiscoveryChain: map[UpstreamID]*structs.CompiledDiscoveryChain{

--- a/agent/proxycfg/api_gateway_test.go
+++ b/agent/proxycfg/api_gateway_test.go
@@ -7,8 +7,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
@@ -368,4 +369,344 @@ func TestRecompileDiscoveryChains_ListenerAllRoutesUnknownKindOnly(t *testing.T)
 		"the unknown-kind error must reach the logs even via synthesizeChains' len(chains)==0 early return")
 	require.Contains(t, logBuf.String(), "listener-1",
 		"the warning should identify which listener the unknown-kind route was on")
+}
+
+// TestDiscoveryChainsMissingEndpoints_OrphanChainSkipped is the direct regression
+// test for the "noisy-neighbour" bug introduced by PR #13169 where a single
+// HTTPRoute backend that failed BackendRef resolution (e.g. namespace
+// "gapi-blue" does not exist) left an orphan chain in DiscoveryChain that was
+// never added to any listener's Upstreams map. The pre-fix predicate iterated all
+// chains — including orphan ones — and reported the orphan's unsatisfied EDS
+// targets as missing, which permanently blocked snapshot admission and caused
+// "no healthy upstream" 503 for every route on the gateway.
+//
+// Three sub-cases confirm the predicate behaves correctly:
+//
+//  1. All chains in Upstreams, all endpoints present  → nothing missing
+//  2. Orphan chain (not in Upstreams) whose target has no endpoints:
+//     pre-fix: reported missing (bug — blocks admission)
+//     post-fix: not reported (orphan is skipped)
+//  3. Active chain (in Upstreams) whose target has no endpoints → reported missing
+//     (the gate still fires for genuinely-missing EDS data)
+func TestDiscoveryChainsMissingEndpoints_OrphanChainSkipped(t *testing.T) {
+	t.Parallel()
+
+	// Build two real chains: one for the active service (in a listener upstream)
+	// and one for the orphan (BackendNotFound — never put in Upstreams).
+	activeUID := NewUpstreamIDFromServiceName(structs.NewServiceName("active-svc", nil))
+	orphanUID := NewUpstreamIDFromServiceName(structs.NewServiceName("orphan-svc", nil))
+
+	activeChain := mustCompileTestHTTPChain(t, "active-svc")
+	orphanChain := mustCompileTestHTTPChain(t, "orphan-svc")
+
+	// Identify the single target ID in each chain (mustCompileTestHTTPChain
+	// produces a one-target chain).
+	var activeTargetID string
+	for id := range activeChain.Targets {
+		activeTargetID = id
+		break
+	}
+	var orphanTargetID string
+	for id := range orphanChain.Targets {
+		orphanTargetID = id
+		break
+	}
+
+	// Build the listenerRouteUpstreams that represents the resolved listener
+	// state: only active-svc reaches a listener; orphan-svc (BackendNotFound)
+	// does not.
+	routeRef := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "good-route"}
+	listenerKey := APIGatewayListenerKey{Protocol: "http", Port: 8080}
+	// Do NOT set Datacenter here: NewUpstreamID normalises empty DC to ""
+	// (no "?dc=" suffix), matching NewUpstreamIDFromServiceName's output.
+	activeUpstream := structs.Upstream{DestinationName: "active-svc", DestinationNamespace: "default", DestinationPartition: "default"}
+	upstreams := listenerRouteUpstreams{}
+	upstreams.set(routeRef, listenerKey, structs.Upstreams{activeUpstream})
+
+	// localKey matches the DC/partition of all test chains so no mesh-gateway
+	// path is taken; this keeps the subtests focused on the orphan-chain gate.
+	localKey := GatewayKey{Datacenter: "dc1", Partition: "default"}
+
+	t.Run("all_active_endpoints_present_returns_true", func(t *testing.T) {
+		snap := &configSnapshotAPIGateway{
+			ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
+				DiscoveryChain: map[UpstreamID]*structs.CompiledDiscoveryChain{
+					activeUID: activeChain,
+					orphanUID: orphanChain,
+				},
+				WatchedUpstreamEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+					// active chain has its EDS data populated
+					activeUID: {activeTargetID: structs.CheckServiceNodes{}},
+					// orphan chain also populated (unrelated — demonstrates gating
+					// only on Upstreams membership regardless of EDS state)
+					orphanUID: {orphanTargetID: structs.CheckServiceNodes{}},
+				},
+			},
+			Upstreams: upstreams,
+		}
+		wireReadyListener(snap, listenerKey, routeRef)
+		require.Empty(t, snap.discoveryChainsMissingEndpoints(localKey),
+			"when all active chains have endpoints, the gate must report nothing missing")
+	})
+
+	t.Run("orphan_chain_no_endpoints_returns_true", func(t *testing.T) {
+		// This is the exact regression scenario: orphan chain's EDS target is
+		// absent from WatchedUpstreamEndpoints, but because orphan-svc is NOT
+		// in Upstreams, the gate must skip it and return true.
+		snap := &configSnapshotAPIGateway{
+			ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
+				DiscoveryChain: map[UpstreamID]*structs.CompiledDiscoveryChain{
+					activeUID: activeChain,
+					orphanUID: orphanChain,
+				},
+				WatchedUpstreamEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+					// active chain has its EDS data
+					activeUID: {activeTargetID: structs.CheckServiceNodes{}},
+					// orphan chain intentionally has NO entry — simulates the
+					// BackendNotFound case where watch was never registered
+				},
+			},
+			Upstreams: upstreams,
+		}
+		wireReadyListener(snap, listenerKey, routeRef)
+		require.Empty(t, snap.discoveryChainsMissingEndpoints(localKey),
+			"orphan chain (not in Upstreams) with missing endpoints must NOT block admission — "+
+				"this is the PR #13169 regression guard")
+	})
+
+	t.Run("active_chain_missing_endpoints_returns_false", func(t *testing.T) {
+		// Confirm the gate still fires correctly when a *real* active upstream
+		// is missing its EDS data (cold-start window, not an orphan).
+		snap := &configSnapshotAPIGateway{
+			ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
+				DiscoveryChain: map[UpstreamID]*structs.CompiledDiscoveryChain{
+					activeUID: activeChain,
+				},
+				WatchedUpstreamEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+					// active chain's EDS target deliberately missing
+				},
+			},
+			Upstreams: upstreams,
+		}
+		wireReadyListener(snap, listenerKey, routeRef)
+		require.NotEmpty(t, snap.discoveryChainsMissingEndpoints(localKey),
+			"active chain (in Upstreams) with missing EDS target must still be reported missing — "+
+				"the cold-start gate must remain intact for genuine EDS lag")
+	})
+
+	t.Run("mesh_gateway_endpoints_missing_returns_false", func(t *testing.T) {
+		// Regression guard for the rolling-restart segfault: a service with a
+		// ServiceSplitter that includes a remote-partition target (e.g.
+		// example-https.pcf.vms) routes through a remote mesh gateway.
+		// makeLoadAssignmentEndpointGroup checks WatchedGatewayEndpoints for
+		// those targets. If that watch hasn't fired yet, it returns valid=false,
+		// EDS is skipped, but CDS already emitted the cluster → segfault.
+		// This subtest ensures the gate also blocks on WatchedGatewayEndpoints.
+		//
+		// We build a chain whose single target has MeshGatewayModeRemote and
+		// belongs to a remote partition ("vms") so that localKey.Matches()
+		// returns false and the gateway-endpoint check is triggered.
+		remoteUID := NewUpstreamIDFromServiceName(structs.NewServiceName("remote-svc", nil))
+		remoteTargetID := "remote-svc.default.vms.dc2"
+
+		remoteChain := &structs.CompiledDiscoveryChain{
+			ServiceName: "remote-svc",
+			Namespace:   "default",
+			Partition:   "vms",
+			Datacenter:  "dc2",
+			StartNode:   "resolver:remote-svc.default.vms.dc2",
+			Nodes: map[string]*structs.DiscoveryGraphNode{
+				"resolver:remote-svc.default.vms.dc2": {
+					Type: structs.DiscoveryGraphNodeTypeResolver,
+					Name: "remote-svc",
+					Resolver: &structs.DiscoveryResolver{
+						ConnectTimeout: 5000000000,
+						Target:         remoteTargetID,
+					},
+				},
+			},
+			Targets: map[string]*structs.DiscoveryTarget{
+				remoteTargetID: {
+					ID:          remoteTargetID,
+					Service:     "remote-svc",
+					Namespace:   "default",
+					Partition:   "vms",
+					Datacenter:  "dc2",
+					MeshGateway: structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeRemote},
+				},
+			},
+		}
+
+		remoteRouteRef := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "remote-route"}
+		remoteUpstream := structs.Upstream{DestinationName: "remote-svc", DestinationNamespace: "default", DestinationPartition: "vms"}
+		remoteUpstreams := listenerRouteUpstreams{}
+		remoteUpstreams.set(remoteRouteRef, listenerKey, structs.Upstreams{remoteUpstream})
+
+		snap := &configSnapshotAPIGateway{
+			ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
+				DiscoveryChain: map[UpstreamID]*structs.CompiledDiscoveryChain{
+					remoteUID: remoteChain,
+				},
+				WatchedUpstreamEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+					// upstream endpoint watch fired (real service nodes populated)
+					remoteUID: {remoteTargetID: structs.CheckServiceNodes{}},
+				},
+				// WatchedGatewayEndpoints intentionally absent — gateway watch hasn't fired yet
+				WatchedGatewayEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{},
+			},
+			Upstreams: remoteUpstreams,
+		}
+		wireReadyListener(snap, listenerKey, remoteRouteRef)
+		require.NotEmpty(t, snap.discoveryChainsMissingEndpoints(localKey),
+			"active chain with a remote mesh-gateway target whose WatchedGatewayEndpoints "+
+				"has not yet been populated must block snapshot admission (rolling-restart segfault guard)")
+	})
+
+	t.Run("mesh_gateway_endpoints_present_returns_true", func(t *testing.T) {
+		// Same setup as above but with WatchedGatewayEndpoints populated — gate must pass.
+		remoteUID := NewUpstreamIDFromServiceName(structs.NewServiceName("remote-svc", nil))
+		remoteTargetID := "remote-svc.default.vms.dc2"
+
+		remoteChain := &structs.CompiledDiscoveryChain{
+			ServiceName: "remote-svc",
+			Namespace:   "default",
+			Partition:   "vms",
+			Datacenter:  "dc2",
+			StartNode:   "resolver:remote-svc.default.vms.dc2",
+			Nodes: map[string]*structs.DiscoveryGraphNode{
+				"resolver:remote-svc.default.vms.dc2": {
+					Type: structs.DiscoveryGraphNodeTypeResolver,
+					Name: "remote-svc",
+					Resolver: &structs.DiscoveryResolver{
+						ConnectTimeout: 5000000000,
+						Target:         remoteTargetID,
+					},
+				},
+			},
+			Targets: map[string]*structs.DiscoveryTarget{
+				remoteTargetID: {
+					ID:          remoteTargetID,
+					Service:     "remote-svc",
+					Namespace:   "default",
+					Partition:   "vms",
+					Datacenter:  "dc2",
+					MeshGateway: structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeRemote},
+				},
+			},
+		}
+
+		remoteRouteRef := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "remote-route"}
+		remoteUpstream := structs.Upstream{DestinationName: "remote-svc", DestinationNamespace: "default", DestinationPartition: "vms"}
+		remoteUpstreams := listenerRouteUpstreams{}
+		remoteUpstreams.set(remoteRouteRef, listenerKey, structs.Upstreams{remoteUpstream})
+
+		gwKey := GatewayKey{Datacenter: "dc2", Partition: "vms"}
+		snap := &configSnapshotAPIGateway{
+			ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
+				DiscoveryChain: map[UpstreamID]*structs.CompiledDiscoveryChain{
+					remoteUID: remoteChain,
+				},
+				WatchedUpstreamEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+					remoteUID: {remoteTargetID: structs.CheckServiceNodes{}},
+				},
+				WatchedGatewayEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+					// gateway watch has fired
+					remoteUID: {gwKey.String(): structs.CheckServiceNodes{}},
+				},
+			},
+			Upstreams: remoteUpstreams,
+		}
+		wireReadyListener(snap, listenerKey, remoteRouteRef)
+		require.Empty(t, snap.discoveryChainsMissingEndpoints(localKey),
+			"active chain with a remote mesh-gateway target whose WatchedGatewayEndpoints "+
+				"is populated must allow snapshot admission")
+	})
+}
+
+// TestAPIGatewayCompleteness_CoalesceRace documents how this approach (B)
+// handles the coalesce-window race described in ITCO-15826 (cold-start segfault).
+//
+// The scenario:
+//  1. Chains for some services have arrived with their endpoint data.
+//  2. During the coalesce delay, another chain (svc2) arrives via handleUpdate
+//     but its endpoint watch has NOT yet fired (svc2 not in
+//     WatchedUpstreamEndpoints yet).
+//  3. If a snapshot were pushed in this window it would carry a CDS cluster for
+//     svc2 with no matching EDS — the cold-start segfault path.
+//
+// In approach B, valid() intentionally does NOT gate on endpoints — proxycfg
+// keeps delivering snapshots so steady-state churn is never starved. The
+// CDS/EDS coherence gate lives per-stream in the xDS layer, which consults
+// discoveryChainsMissingEndpoints to hold only a stream's FIRST push. This test
+// verifies that split: valid() stays true during the race, while the
+// completeness predicate correctly reports svc2's target as missing until its
+// endpoints arrive.
+func TestAPIGatewayCompleteness_CoalesceRace(t *testing.T) {
+	t.Parallel()
+
+	routeRef := structs.ResourceReference{Kind: structs.HTTPRoute, Name: "routes"}
+	listenerKey := APIGatewayListenerKey{Protocol: "http", Port: 8080}
+	localKey := GatewayKey{Datacenter: "dc1", Partition: "default"}
+
+	// Build two active chains (both registered in Upstreams).
+	svc1UID := NewUpstreamIDFromServiceName(structs.NewServiceName("svc1", nil))
+	svc2UID := NewUpstreamIDFromServiceName(structs.NewServiceName("svc2", nil))
+	svc1Chain := mustCompileTestHTTPChain(t, "svc1")
+	svc2Chain := mustCompileTestHTTPChain(t, "svc2")
+
+	var svc1TargetID, svc2TargetID string
+	for id := range svc1Chain.Targets {
+		svc1TargetID = id
+	}
+	for id := range svc2Chain.Targets {
+		svc2TargetID = id
+	}
+
+	svc1Up := structs.Upstream{DestinationName: "svc1", DestinationNamespace: "default", DestinationPartition: "default"}
+	svc2Up := structs.Upstream{DestinationName: "svc2", DestinationNamespace: "default", DestinationPartition: "default"}
+	ups := listenerRouteUpstreams{}
+	ups.set(routeRef, listenerKey, structs.Upstreams{svc1Up, svc2Up})
+
+	// Simulate the coalesce-window race: svc2 chain arrived but its endpoint
+	// watch has not fired yet (no entry in WatchedUpstreamEndpoints for svc2).
+	snapPartial := &configSnapshotAPIGateway{
+		GatewayConfigLoaded:      true,
+		BoundGatewayConfigLoaded: true,
+		ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
+			Leaf: &structs.IssuedCert{},
+			DiscoveryChain: map[UpstreamID]*structs.CompiledDiscoveryChain{
+				svc1UID: svc1Chain,
+				svc2UID: svc2Chain, // svc2 chain present but endpoints not yet
+			},
+			WatchedUpstreamEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+				svc1UID: {svc1TargetID: structs.CheckServiceNodes{}}, // svc1 ready
+				// svc2 endpoint watch has NOT fired yet — this is the race window
+			},
+			WatchedGatewayEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{},
+		},
+		Upstreams: ups,
+	}
+	wireReadyListener(snapPartial, listenerKey, routeRef)
+
+	// Approach B: valid() must NOT gate on endpoints. proxycfg keeps delivering;
+	// the cold-start coherence gate is applied per-stream in the xDS layer.
+	require.True(t, snapPartial.valid(),
+		"approach B: valid() must stay true during the race — the stream-level gate "+
+			"handles cold-start CDS/EDS coherence, so proxycfg is never starved")
+
+	// The completeness predicate (consumed by the xDS stream gate) must report
+	// svc2's target as missing during the race window.
+	require.ElementsMatch(t,
+		[]string{svc2UID.String() + "/" + svc2TargetID},
+		snapPartial.discoveryChainsMissingEndpoints(localKey),
+		"the predicate must report svc2's target as missing so the stream gate "+
+			"holds the first push (cold-start segfault fix, ITCO-15826)")
+
+	// Simulate the endpoint watch for svc2 firing — now the snapshot is complete.
+	snapPartial.WatchedUpstreamEndpoints[svc2UID] = map[string]structs.CheckServiceNodes{
+		svc2TargetID: {},
+	}
+	require.Empty(t, snapPartial.discoveryChainsMissingEndpoints(localKey),
+		"once svc2 endpoints arrive the predicate reports complete and the stream "+
+			"gate opens")
 }

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -789,6 +789,82 @@ type configSnapshotAPIGateway struct {
 	ComposeUpstreamRouting bool
 }
 
+// activeUpstreamIDs returns the set of UpstreamIDs that will actually be
+// rendered into CDS clusters for this gateway. discoveryChainsMissingEndpoints
+// uses it to decide which discovery chains may hold the first push.
+//
+// The traversal mirrors getReadyListeners (agent/xds/listeners_apigateway.go),
+// which is what route-backed cluster generation walks. Anything it excludes
+// emits no CDS cluster, so gating on it would withhold config for a cluster that
+// is never published — at best a stall until the bootstrap-gate timeout. Four
+// exclusions matter:
+//
+//   - Listeners the controller has not finished reconciling: Port 0 or empty
+//     Protocol means the APIGatewayListener fields have not been copied onto the
+//     BoundAPIGatewayListener yet, so no listener key (and no cluster) is built.
+//   - Listeners with a Conflicted status (ListenerIsReady is false).
+//   - Routes bound to a listener whose config entry has not been received.
+//   - Routes that declare a parent reference to this gateway but were never
+//     bound to the listener by the controller. Upstreams is populated from the
+//     route's declared parentRefs (referenceIsForListener), and a parentRef with
+//     no sectionName matches EVERY listener, so Upstreams is a superset of what
+//     actually binds. BoundListeners is the authoritative binding result.
+//
+// The remaining chains are the ones the gate may legitimately wait on. Chains
+// absent from the set entirely are orphans (a backend registered as a watch
+// target that never resolved to a served upstream, e.g. a BackendRef whose
+// namespace does not exist) or synthesized chains, which carry no EDS targets.
+//
+// The set is built once per predicate call rather than rescanned per chain. The
+// gate evaluates this on every snapshot of every gateway stream until it opens,
+// so a per-chain scan would be quadratic in route count on exactly the
+// mass-reconnect cold start the gate exists to protect.
+//
+// TODO(CSL-11921): this covers only route-backed clusters. clustersFromSnapshotAPIGateway
+// also emits EDS clusters that getReadyListeners does not walk: makeExtProcUpstreamClusters
+// (ext-proc-referenced mesh services) and makeAPIGatewayExtAuthzClusters (ext-authz mesh
+// targets, enterprise). A gateway reaching an ext-proc/ext-authz-only mesh target through a
+// service-resolver failover could therefore still take a first push with a CDS cluster but no
+// matching EDS for that target. Deliberately not addressed here: the ITCO-15826 customer uses
+// neither filter, and widening the gated set needs validation in that environment first. To
+// close it, union extProcUpstreamIDs (+ the enterprise ext-authz uids) into this set — their
+// endpoints already flow through WatchedUpstreamEndpoints[uid], which the predicate reads.
+func (c *configSnapshotAPIGateway) activeUpstreamIDs() map[UpstreamID]struct{} {
+	active := make(map[UpstreamID]struct{})
+	if c.GatewayConfig == nil {
+		return active
+	}
+	for _, boundListener := range c.BoundListeners {
+		// A listener the controller has not finished reconciling (no Port or
+		// Protocol copied onto the bound listener yet) produces no cluster;
+		// getReadyListeners skips it, so gating on it would only stall.
+		if boundListener.Port == 0 || boundListener.Protocol == "" {
+			continue
+		}
+		if !c.GatewayConfig.ListenerIsReady(boundListener.Name) {
+			continue
+		}
+		listenerKey := APIGatewayListenerKeyFromBoundListener(boundListener)
+		for _, routeRef := range boundListener.Routes {
+			switch routeRef.Kind {
+			case structs.HTTPRoute:
+				if _, ok := c.HTTPRoutes.Get(routeRef); !ok {
+					continue
+				}
+			case structs.TCPRoute:
+				if _, ok := c.TCPRoutes.Get(routeRef); !ok {
+					continue
+				}
+			}
+			upstreams := c.Upstreams[routeRef][listenerKey]
+			for i := range upstreams {
+				active[NewUpstreamID(&upstreams[i])] = struct{}{}
+			}
+		}
+	}
+	return active
+}
+
 func (c *configSnapshotAPIGateway) synthesizeChains(datacenter string, boundListener structs.BoundAPIGatewayListener) ([]structs.IngressService, structs.Upstreams, []*structs.CompiledDiscoveryChain, []error, error) {
 	chains := []*structs.CompiledDiscoveryChain{}
 
@@ -885,9 +961,100 @@ DOMAIN_LOOP:
 	return services, upstreams, compiled, skipped, nil
 }
 
+// discoveryChainsMissingEndpoints returns "uid/targetID" for every synthesized
+// discovery-chain target that would be rendered into a CDS cluster but whose EDS
+// endpoints are not assembled yet — the targets that make a first xDS push
+// CDS/EDS-incoherent and cold-start-crash a gateway's Envoy. The xDS layer
+// holds a gateway's FIRST push until this is empty; the list also names the
+// blockers in logs. It is always eventually empty for a well-formed config,
+// because every target's endpoint watch fires at least once (a zero-instance
+// service still yields an empty, valid EDS response).
+//
+// localKey is the gateway's own locality, used to mirror the gatewayKey logic of
+// makeLoadAssignmentEndpointGroup (agent/xds/endpoints.go) for mesh-gateway
+// targets; TestDiscoveryChainsMissingEndpoints_MirrorsEndpointGeneration pins the
+// two together. Three kinds of target are excluded because they can never be in
+// the "CDS present, EDS missing" state: external (DNS clusters, no EDS), peered
+// (served via PeerUpstreamEndpoints), and orphan chains not wired to any listener
+// upstream (no CDS cluster is emitted, so gating on them would wedge forever).
+func (c *configSnapshotAPIGateway) discoveryChainsMissingEndpoints(localKey GatewayKey) []string {
+	var missing []string
+	activeUpstreams := c.activeUpstreamIDs()
+	for uid, chain := range c.DiscoveryChain {
+		if chain == nil {
+			continue
+		}
+		// Only gate on chains that will actually be rendered into a CDS cluster.
+		// activeUpstreamIDs mirrors getReadyListeners, so a chain missing from
+		// the set is one cluster generation skips: an orphan whose backend never
+		// resolved to a served upstream (e.g. "gapi-blue/static-client: backend
+		// not found"), a route on a conflicted or unbound listener, or a
+		// synthesized chain carrying no EDS targets of its own. None of these
+		// produce a cluster, so gating on their endpoints would withhold the
+		// first push for config that is never published.
+		if _, active := activeUpstreams[uid]; !active {
+			continue
+		}
+		targetEndpoints := c.WatchedUpstreamEndpoints[uid]
+		gatewayEndpoints := c.WatchedGatewayEndpoints[uid]
+		for targetID, target := range chain.Targets {
+			if target.External || target.Peer != "" {
+				continue
+			}
+			if _, ok := targetEndpoints[targetID]; !ok {
+				// present in CDS but its EDS assignment is not yet available.
+				missing = append(missing, uid.String()+"/"+targetID)
+				continue
+			}
+			// Targets that route through a mesh gateway (remote datacenter or
+			// remote partition) take their endpoints from the gateway, not the
+			// service: makeLoadAssignmentEndpointGroup looks up
+			// WatchedGatewayEndpoints[uid][gatewayKey] and returns valid=false
+			// if that watch has not fired. CDS has already emitted the cluster
+			// by then, so this is the same CDS/EDS incoherence as a missing
+			// target endpoint and must gate the first push too.
+			//
+			// The key selection below mirrors makeLoadAssignmentEndpointGroup
+			// (agent/xds/endpoints.go) exactly, including both of its early
+			// returns. forMeshGateway is not mirrored because api-gateway
+			// clusters are always generated with forMeshGateway=false.
+			var gwKey GatewayKey
+			switch target.MeshGateway.Mode {
+			case structs.MeshGatewayModeRemote:
+				gwKey.Datacenter = target.Datacenter
+				gwKey.Partition = target.Partition
+			case structs.MeshGatewayModeLocal:
+				gwKey = localKey
+			}
+
+			// An empty key means no mesh gateway is involved (mode none/default,
+			// or an unset locality), and a target in our own locality is reached
+			// directly. In both cases EDS uses the target endpoints we already
+			// confirmed above, so gating on gateway endpoints would block a
+			// cluster that Envoy can serve.
+			if gwKey.IsEmpty() || localKey.Matches(target.Datacenter, target.Partition) {
+				continue
+			}
+
+			if _, ok := gatewayEndpoints[gwKey.String()]; !ok {
+				missing = append(missing, uid.String()+"/"+targetID+"@"+gwKey.String())
+			}
+		}
+	}
+	return missing
+}
+
 // valid tests for two valid api gateway snapshot states:
 //  1. waiting: the watch on api and bound gateway entries is set, but none were received
 //  2. loaded: both the valid config entries AND the leaf certs are set
+//
+// NOTE: the cold-start completeness gate (ITCO-15826) is intentionally NOT
+// enforced here. In this approach it lives in the xDS layer (agent/xds/delta.go),
+// which withholds each stream's FIRST push until the snapshot's discovery-chain
+// endpoints are assembled. Keeping valid() unchanged means proxycfg keeps
+// delivering snapshots normally (no whole-snapshot withholding), so steady-state
+// updates under churn are never starved. The completeness predicate
+// (discoveryChainsMissingEndpoints) is retained and exposed for the xDS layer.
 func (c *configSnapshotAPIGateway) valid() bool {
 	waiting := c.GatewayConfigLoaded && len(c.Upstreams) == 0 && c.BoundGatewayConfigLoaded && c.Leaf == nil
 
@@ -1032,6 +1199,16 @@ type computedFields struct {
 	xdsCommonConfig *config.XDSCommonConfig
 	proxyConfig     *config.ProxyConfig
 	gatewayConfig   *config.GatewayConfig
+}
+
+// APIGatewayDiscoveryChainsMissingEndpoints exposes discoveryChainsMissingEndpoints
+// to the xDS bootstrap gate; it returns nil for non-api-gateway kinds. See
+// discoveryChainsMissingEndpoints for what "missing" means.
+func (s *ConfigSnapshot) APIGatewayDiscoveryChainsMissingEndpoints() []string {
+	if s.Kind != structs.ServiceKindAPIGateway {
+		return nil
+	}
+	return s.APIGateway.discoveryChainsMissingEndpoints(s.Locality)
 }
 
 // Valid returns whether or not the snapshot has all required fields filled yet.

--- a/agent/xds/apigateway_guard_wiring_test.go
+++ b/agent/xds/apigateway_guard_wiring_test.go
@@ -1,0 +1,194 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package xds
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/configentry"
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/agent/consul/discoverychain"
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/envoyextensions/xdscommon"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+// TestNewServer_APIGatewayEnvOverrides covers the only writer of
+// Server.BootstrapGateTimeout and Server.DisableAPIGatewayFailoverGuard in the
+// running binary.
+//
+// Both fields document a way to neutralize their feature without a binary
+// rollback, which is only true if something actually assigns them outside of
+// tests. Asserting the field in isolation cannot catch that: a field can be
+// read, honored, and unit-tested while remaining permanently at its zero value
+// in production. This test starts from NewServer for that reason.
+func TestNewServer_APIGatewayEnvOverrides(t *testing.T) {
+	newServer := func(t *testing.T) *Server {
+		t.Helper()
+		return NewServer("node-1", testutil.Logger(t), nil, nil, nil)
+	}
+
+	t.Run("unset env yields the safe defaults", func(t *testing.T) {
+		s := newServer(t)
+		require.Equal(t, DefaultBootstrapGateTimeout, s.BootstrapGateTimeout)
+		require.False(t, s.DisableAPIGatewayFailoverGuard,
+			"the guard averts a crash, so it must be on unless explicitly disabled")
+	})
+
+	t.Run("bootstrap gate timeout", func(t *testing.T) {
+		cases := map[string]struct {
+			env    string
+			expect time.Duration
+		}{
+			"override":                {env: "5s", expect: 5 * time.Second},
+			"negative disables":       {env: "-1s", expect: -1 * time.Second},
+			"malformed falls back":    {env: "not-a-duration", expect: DefaultBootstrapGateTimeout},
+			"empty falls back":        {env: "", expect: DefaultBootstrapGateTimeout},
+			"bare integer falls back": {env: "30", expect: DefaultBootstrapGateTimeout},
+		}
+		for name, tc := range cases {
+			t.Run(name, func(t *testing.T) {
+				t.Setenv(EnvBootstrapGateTimeout, tc.env)
+				require.Equal(t, tc.expect, newServer(t).BootstrapGateTimeout)
+			})
+		}
+
+		// A negative value must reach newBootstrapGate as a gate that never
+		// withholds anything, which is the behavior the field documents.
+		t.Setenv(EnvBootstrapGateTimeout, "-1s")
+		require.True(t, newBootstrapGate(newServer(t).BootstrapGateTimeout).open,
+			"a negative timeout must produce an already-open gate")
+	})
+
+	t.Run("failover guard kill switch", func(t *testing.T) {
+		cases := map[string]struct {
+			env    string
+			expect bool
+		}{
+			"true":                   {env: "true", expect: true},
+			"1":                      {env: "1", expect: true},
+			"TRUE":                   {env: "TRUE", expect: true},
+			"false":                  {env: "false", expect: false},
+			"0":                      {env: "0", expect: false},
+			"empty":                  {env: "", expect: false},
+			"malformed fails closed": {env: "yes-please", expect: false},
+		}
+		for name, tc := range cases {
+			t.Run(name, func(t *testing.T) {
+				t.Setenv(EnvDisableAPIGatewayFailoverGuard, tc.env)
+				require.Equal(t, tc.expect, newServer(t).DisableAPIGatewayFailoverGuard)
+			})
+		}
+	})
+}
+
+// TestGetEnvoyConfiguration_FailoverGuardWiring proves the kill switch survives
+// the whole path from the Server field to the clusters Envoy receives.
+//
+// processDelta reads s.DisableAPIGatewayFailoverGuard and hands it to
+// getEnvoyConfiguration, which is the last hop before resource generation, so
+// exercising that function with a real api-gateway snapshot covers every link
+// except the single field reference in processDelta itself. The assertion is on
+// the emitted CDS resources rather than on discoChainTargets, because an
+// aggregate cluster is the shape that actually faults Envoy.
+func TestGetEnvoyConfiguration_FailoverGuardWiring(t *testing.T) {
+	const service = "backend"
+
+	snapshotWithUnreadyFailover := func(t *testing.T) *proxycfg.ConfigSnapshot {
+		t.Helper()
+
+		// A gateway with a TCP route to "backend", so cluster generation
+		// actually walks this upstream (getReadyListeners is the entry point).
+		snap := proxycfg.TestConfigSnapshotAPIGateway(t, "default", nil,
+			func(entry *structs.APIGatewayConfigEntry, bound *structs.BoundAPIGatewayConfigEntry) {
+				entry.Listeners = []structs.APIGatewayListener{{
+					Name:     "tcp-listener",
+					Protocol: structs.ListenerProtocolTCP,
+					Port:     9000,
+				}}
+				bound.Listeners = []structs.BoundAPIGatewayListener{{
+					Name:   "tcp-listener",
+					Routes: []structs.ResourceReference{{Kind: structs.TCPRoute, Name: "tcp-route"}},
+				}}
+			},
+			[]structs.BoundRoute{
+				&structs.TCPRouteConfigEntry{
+					Kind:     structs.TCPRoute,
+					Name:     "tcp-route",
+					Parents:  []structs.ResourceReference{{Kind: structs.APIGateway, Name: "api-gateway"}},
+					Services: []structs.TCPService{{Name: service}},
+				},
+			}, nil, nil)
+
+		// Replace the compiled chain with one that fails over, and leave the
+		// failover member's endpoints unassembled -- the state the guard exists
+		// to catch.
+		set := configentry.NewDiscoveryChainSet()
+		set.AddEntries(&structs.ServiceResolverConfigEntry{
+			Kind:     structs.ServiceResolver,
+			Name:     service,
+			Failover: map[string]structs.ServiceResolverFailover{"*": {Service: "backend-fail"}},
+		})
+		chain := discoverychain.TestCompileConfigEntries(
+			t, service, "default", "default", "dc1", connect.TestClusterID+".consul", nil, set)
+
+		uid := proxycfg.NewUpstreamIDFromServiceName(structs.NewServiceName(service, nil))
+		upstreams, err := snap.ToConfigSnapshotUpstreams()
+		require.NoError(t, err)
+		upstreams.DiscoveryChain[uid] = chain
+
+		var primaryTargetID string
+		for _, node := range chain.Nodes {
+			if node.Type == structs.DiscoveryGraphNodeTypeResolver && node.Resolver != nil && node.Resolver.Failover != nil {
+				primaryTargetID = node.Resolver.Target
+			}
+		}
+		require.NotEmpty(t, primaryTargetID, "expected a resolver node carrying failover")
+
+		upstreams.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{
+			primaryTargetID: proxycfg.TestUpstreamNodes(t, service),
+		}
+		return snap
+	}
+
+	// aggregateClusterNames returns the names of every aggregate cluster in the
+	// generated CDS resources. This is the shape that faults Envoy when a member
+	// has no EDS assignment.
+	aggregateClusterNames := func(t *testing.T, disableGuard bool) []string {
+		t.Helper()
+
+		res, err := getEnvoyConfiguration(snapshotWithUnreadyFailover(t), testutil.Logger(t), nil, disableGuard)
+		require.NoError(t, err)
+
+		var names []string
+		var sawBackendCluster bool
+		for _, msg := range res[xdscommon.ClusterType] {
+			cluster, ok := msg.(*envoy_cluster_v3.Cluster)
+			require.True(t, ok)
+			if custom := cluster.GetClusterType(); custom != nil && custom.Name == "envoy.clusters.aggregate" {
+				names = append(names, cluster.Name)
+			}
+			sawBackendCluster = sawBackendCluster || strings.Contains(cluster.Name, service)
+		}
+		require.True(t, sawBackendCluster,
+			"precondition: cluster generation must have reached the %q upstream, otherwise this test is vacuous", service)
+		return names
+	}
+
+	t.Run("guard enabled: no aggregate cluster is emitted", func(t *testing.T) {
+		require.Empty(t, aggregateClusterNames(t, false),
+			"an unready failover member must be rendered as a plain EDS cluster")
+	})
+
+	t.Run("kill switch disables the guard: the aggregate is emitted", func(t *testing.T) {
+		require.NotEmpty(t, aggregateClusterNames(t, true),
+			"the kill switch must restore the pre-guard shape all the way to CDS output")
+	})
+}

--- a/agent/xds/bootstrap_gate.go
+++ b/agent/xds/bootstrap_gate.go
@@ -1,0 +1,133 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package xds
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics"
+)
+
+// gatedSnapshot is the slice of *proxycfg.ConfigSnapshot that bootstrapGate
+// needs: the discovery-chain targets that would be rendered into CDS but whose
+// EDS assignments are not assembled yet. It is empty for every non-api-gateway
+// proxy kind, so those streams are never gated.
+type gatedSnapshot interface {
+	APIGatewayDiscoveryChainsMissingEndpoints() []string
+}
+
+// bootstrapGate holds an xDS stream's FIRST push until the api-gateway snapshot
+// behind it is internally coherent — every synthesized discovery chain that will
+// be rendered into CDS also has its EDS endpoints assembled — so a cold-starting
+// Envoy never initializes over clusters whose endpoint assignments Consul has not
+// produced yet (ITCO-15826).
+//
+// Three properties keep the gate from becoming a liveness hazard, which matters
+// because Consul programs lds_config/cds_config with initial_fetch_timeout: 0s,
+// meaning a withheld push leaves Envoy waiting indefinitely rather than falling
+// back:
+//
+//  1. It is first-push only. Once a push is allowed the gate stays open for the
+//     life of the stream, so steady-state updates are never withheld and a
+//     later, transiently-incomplete snapshot cannot re-close it.
+//  2. It is skipped for resumed streams. An Envoy that advertises
+//     initial_resource_versions already finished initialization and started
+//     workers, so there is nothing left to protect and holding its push would
+//     only delay reconvergence — including after a routine server rebalance.
+//  3. It is bounded. If the predicate is somehow never satisfied the gate opens
+//     anyway, degrading to a late push (and 503s on the affected routes) rather
+//     than a stream that delivers nothing at all.
+//
+// The zero value is not usable; construct with newBootstrapGate.
+type bootstrapGate struct {
+	timeout time.Duration
+
+	open    bool
+	skip    bool
+	expired bool
+
+	timer   *time.Timer
+	started time.Time
+}
+
+// newBootstrapGate returns a gate that will hold a first push for at most
+// timeout. A zero timeout means DefaultBootstrapGateTimeout; a negative timeout
+// disables the gate, so it never withholds anything.
+func newBootstrapGate(timeout time.Duration) *bootstrapGate {
+	switch {
+	case timeout == 0:
+		timeout = DefaultBootstrapGateTimeout
+	case timeout < 0:
+		return &bootstrapGate{open: true}
+	}
+	return &bootstrapGate{timeout: timeout}
+}
+
+// expiryCh returns the channel that fires when the gate has held a push for
+// longer than its timeout. It is nil — and therefore blocks forever, which is
+// what a select wants — until the gate actually starts holding something.
+func (g *bootstrapGate) expiryCh() <-chan time.Time {
+	if g.timer == nil {
+		return nil
+	}
+	return g.timer.C
+}
+
+// markExpired records that expiryCh fired. The next allow call will open the
+// gate regardless of snapshot completeness.
+func (g *bootstrapGate) markExpired() {
+	g.expired = true
+}
+
+// markResumedStream records that Envoy advertised resources it already holds,
+// which means it is not cold-starting and the gate must not delay its config.
+func (g *bootstrapGate) markResumedStream() {
+	g.skip = true
+}
+
+// stop releases the gate's timer. Safe to call on an unused or already-open gate.
+func (g *bootstrapGate) stop() {
+	if g.timer != nil {
+		g.timer.Stop()
+		g.timer = nil
+	}
+}
+
+// allow reports whether the stream may push this snapshot. It returns false only
+// for a cold-starting api-gateway stream whose first push would render CDS
+// clusters that have no EDS assignment yet, and only until the timeout elapses.
+func (g *bootstrapGate) allow(logger hclog.Logger, snapshot gatedSnapshot) bool {
+	if g.open {
+		return true
+	}
+
+	missing := snapshot.APIGatewayDiscoveryChainsMissingEndpoints()
+
+	switch {
+	case len(missing) == 0 || g.skip:
+		if g.timer != nil {
+			metrics.MeasureSince([]string{"xds", "server", "bootstrapGateHeld"}, g.started)
+		}
+
+	case g.expired:
+		logger.Warn("api-gateway: releasing initial xDS push before discovery-chain endpoints were assembled; "+
+			"the gateway may answer 503 for these targets until their endpoints arrive",
+			"held", time.Since(g.started), "missing_targets", missing)
+		metrics.IncrCounter([]string{"xds", "server", "bootstrapGateTimeout"}, 1)
+
+	default:
+		if g.timer == nil {
+			g.started = time.Now()
+			g.timer = time.NewTimer(g.timeout)
+		}
+		logger.Debug("api-gateway: holding initial xDS push until discovery-chain endpoints are assembled",
+			"missing_targets", missing)
+		return false
+	}
+
+	g.stop()
+	g.open = true
+	return true
+}

--- a/agent/xds/bootstrap_gate_test.go
+++ b/agent/xds/bootstrap_gate_test.go
@@ -1,0 +1,119 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package xds
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+// fakeSnapshot stands in for *proxycfg.ConfigSnapshot so these tests can drive
+// the gate through states that are awkward to assemble from a real snapshot.
+type fakeSnapshot struct{ missing []string }
+
+func (f fakeSnapshot) APIGatewayDiscoveryChainsMissingEndpoints() []string { return f.missing }
+
+var (
+	incompleteSnapshot = fakeSnapshot{missing: []string{"web/web.default.default.dc1"}}
+	completeSnapshot   = fakeSnapshot{}
+)
+
+func TestBootstrapGate(t *testing.T) {
+	logger := testutil.Logger(t)
+
+	t.Run("complete snapshot is pushed immediately", func(t *testing.T) {
+		g := newBootstrapGate(0)
+		require.True(t, g.allow(logger, completeSnapshot))
+		require.Nil(t, g.expiryCh(), "a gate that never held should not arm its timer")
+	})
+
+	t.Run("incomplete snapshot is held until endpoints arrive", func(t *testing.T) {
+		g := newBootstrapGate(time.Minute)
+
+		require.False(t, g.allow(logger, incompleteSnapshot))
+		require.NotNil(t, g.expiryCh(), "holding a push must arm the deadline")
+
+		require.True(t, g.allow(logger, completeSnapshot))
+		require.Nil(t, g.expiryCh(), "the deadline must be released once the gate opens")
+	})
+
+	t.Run("gate stays open once a push is allowed", func(t *testing.T) {
+		g := newBootstrapGate(time.Minute)
+		require.True(t, g.allow(logger, completeSnapshot))
+
+		// Steady-state churn can legitimately produce a transiently incomplete
+		// snapshot. That must never re-close the gate and withhold updates from
+		// an Envoy that is already serving traffic.
+		require.True(t, g.allow(logger, incompleteSnapshot))
+	})
+
+	t.Run("resumed stream is never held", func(t *testing.T) {
+		g := newBootstrapGate(time.Minute)
+		g.markResumedStream()
+
+		// Envoy already finished initialization, so there is nothing to protect
+		// and delaying its config would only slow reconvergence.
+		require.True(t, g.allow(logger, incompleteSnapshot))
+	})
+
+	t.Run("resumed stream detected while already holding", func(t *testing.T) {
+		g := newBootstrapGate(time.Minute)
+		require.False(t, g.allow(logger, incompleteSnapshot))
+
+		g.markResumedStream()
+		require.True(t, g.allow(logger, incompleteSnapshot))
+		require.Nil(t, g.expiryCh())
+	})
+
+	t.Run("expiry releases the push rather than wedging the stream", func(t *testing.T) {
+		g := newBootstrapGate(time.Millisecond)
+
+		require.False(t, g.allow(logger, incompleteSnapshot))
+
+		select {
+		case <-g.expiryCh():
+		case <-time.After(time.Second):
+			t.Fatal("gate deadline never fired")
+		}
+		g.markExpired()
+
+		require.True(t, g.allow(logger, incompleteSnapshot),
+			"an expired gate must push what it has; Envoy is configured to wait forever otherwise")
+	})
+
+	t.Run("negative timeout disables the gate", func(t *testing.T) {
+		g := newBootstrapGate(-1)
+		require.True(t, g.allow(logger, incompleteSnapshot))
+		require.Nil(t, g.expiryCh())
+	})
+
+	t.Run("stop is safe on an unused gate", func(t *testing.T) {
+		newBootstrapGate(time.Minute).stop()
+	})
+}
+
+// TestBootstrapGate_NonAPIGatewayKinds asserts the gate is inert for every proxy
+// kind other than api-gateway, so sidecars and mesh gateways keep their existing
+// cold-start behaviour.
+func TestBootstrapGate_NonAPIGatewayKinds(t *testing.T) {
+	logger := testutil.Logger(t)
+
+	for _, kind := range []structs.ServiceKind{
+		structs.ServiceKindConnectProxy,
+		structs.ServiceKindMeshGateway,
+		structs.ServiceKindTerminatingGateway,
+		structs.ServiceKindIngressGateway,
+	} {
+		t.Run(string(kind), func(t *testing.T) {
+			snap := &proxycfg.ConfigSnapshot{Kind: kind}
+			require.True(t, newBootstrapGate(time.Minute).allow(logger, snap))
+		})
+	}
+}

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -1674,7 +1674,7 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 		if upstream != nil {
 			destinationPort = upstream.DestinationPort
 		}
-		mappedTargets, err := s.mapDiscoChainTargets(cfgSnap, chain, node, upstreamConfig, forMeshGateway, destinationPort)
+		mappedTargets, err := s.mapDiscoChainTargets(cfgSnap, uid, chain, node, upstreamConfig, forMeshGateway, destinationPort)
 		if err != nil {
 			return nil, err
 		}
@@ -1685,7 +1685,7 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 		}
 
 		var failoverClusterNames []string
-		if mappedTargets.failover {
+		if mappedTargets.failover && len(targetGroups) > 0 {
 			for _, targetGroup := range targetGroups {
 				failoverClusterNames = append(failoverClusterNames, targetGroup.ClusterName)
 			}
@@ -1711,6 +1711,15 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 			}
 
 			out = append(out, c)
+		} else if mappedTargets.failover {
+			// Every target was dropped while mapping (reachable when each is a
+			// peered target whose peering metadata has not resolved yet).
+			// Emitting the aggregate anyway would hand Envoy a cluster with an
+			// empty member list, which is the same unpopulated-member shape
+			// that faults during worker startup. Omitting the cluster entirely
+			// yields a 503 NC that self-heals on the next snapshot instead.
+			s.Logger.Warn("skipping aggregate cluster because it has no member clusters",
+				"cluster", mappedTargets.baseClusterName)
 		}
 
 		// Construct the target clusters.

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics"
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/netutil"
@@ -1677,6 +1678,15 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 		mappedTargets, err := s.mapDiscoChainTargets(cfgSnap, uid, chain, node, upstreamConfig, forMeshGateway, destinationPort)
 		if err != nil {
 			return nil, err
+		}
+
+		// The api-gateway aggregate guard degraded a failover chain to a single
+		// plain EDS cluster because a member's endpoints were not assembled yet.
+		// This is the crash-averting event operators want to trend/alert on, so
+		// emit it from the CDS path only -- mapDiscoChainTargets also runs in EDS
+		// and RDS generation, and counting it there would inflate the metric.
+		if mappedTargets.degraded {
+			metrics.IncrCounter([]string{"xds", "server", "apiGatewayFailoverDegraded"}, 1)
 		}
 
 		targetGroups, err := mappedTargets.groupedTargets()

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -102,12 +102,13 @@ func (s *Server) DeltaAggregatedResources(stream ADSDeltaStream) error {
 
 // getEnvoyConfiguration is a utility function that instantiates the proper
 // Envoy resource generator and returns the generated Envoy configuration.
-func getEnvoyConfiguration(snapshot *proxycfg.ConfigSnapshot, logger hclog.Logger, cfgFetcher configfetcher.ConfigFetcher) (map[string][]proto.Message, error) {
+func getEnvoyConfiguration(snapshot *proxycfg.ConfigSnapshot, logger hclog.Logger, cfgFetcher configfetcher.ConfigFetcher, disableAPIGatewayFailoverGuard bool) (map[string][]proto.Message, error) {
 	generator := NewResourceGenerator(
 		logger,
 		cfgFetcher,
 		true,
 	)
+	generator.DisableAPIGatewayFailoverGuard = disableAPIGatewayFailoverGuard
 	return generator.AllResourcesFromSnapshot(snapshot)
 }
 
@@ -281,7 +282,7 @@ func (s *Server) processDelta(stream ADSDeltaStream, reqCh <-chan *envoy_discove
 			}
 			snapshot = cs
 
-			newRes, err := getEnvoyConfiguration(snapshot, logger, s.CfgFetcher)
+			newRes, err := getEnvoyConfiguration(snapshot, logger, s.CfgFetcher, s.DisableAPIGatewayFailoverGuard)
 			if err != nil {
 				return status.Errorf(codes.Unavailable, "failed to generate all xDS resources from the snapshot: %v", err)
 			}

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -17,13 +17,13 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/hashicorp/go-metrics"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics"
 	goversion "github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/consul/agent/envoyextensions"
@@ -134,9 +134,15 @@ func (s *Server) processDelta(stream ADSDeltaStream, reqCh <-chan *envoy_discove
 		nonce            uint64 // xDS requires a unique nonce to correlate response/request pairs
 		ready            bool   // set to true after the first snapshot arrives
 
+		// bootstrapGate holds this stream's FIRST xDS push until the api-gateway
+		// snapshot behind it is coherent (cold-start segfault gate, ITCO-15826).
+		// It is per-stream, bounded, and first-push only — see bootstrap_gate.go.
+		bootstrapGate = newBootstrapGate(s.BootstrapGateTimeout)
+
 		streamStartTime = time.Now()
 		streamStartOnce sync.Once
 	)
+	defer bootstrapGate.stop()
 
 	var (
 		// resourceMap is the SoTW we are incrementally attempting to sync to envoy.
@@ -210,6 +216,12 @@ func (s *Server) processDelta(stream ADSDeltaStream, reqCh <-chan *envoy_discove
 			}
 			extendAuthTimer()
 
+		case <-bootstrapGate.expiryCh():
+			// The completeness gate has held this stream's first push for too
+			// long. Fall through to the state machine, which will now let it
+			// through rather than leave Envoy with no config at all.
+			bootstrapGate.markExpired()
+
 		case req, ok := <-reqCh:
 			if !ok {
 				// reqCh is closed when stream.Recv errors which is how we detect client
@@ -223,6 +235,13 @@ func (s *Server) processDelta(stream ADSDeltaStream, reqCh <-chan *envoy_discove
 
 			if req.TypeUrl == "" {
 				return status.Errorf(codes.InvalidArgument, "type URL is required for ADS")
+			}
+
+			// A resumed stream carries the resources Envoy already holds. That
+			// Envoy is past initialization with workers running, so the cold-start
+			// gate has nothing to protect and must not delay its updates.
+			if len(req.InitialResourceVersions) > 0 {
+				bootstrapGate.markResumedStream()
 			}
 
 			var proxyFeatures xdscommon.SupportedProxyFeatures
@@ -373,6 +392,16 @@ func (s *Server) processDelta(stream ADSDeltaStream, reqCh <-chan *envoy_discove
 
 			if !ready {
 				logger.Trace("Skipping delta computation because we haven't gotten a snapshot yet")
+				continue
+			}
+
+			// Bootstrap completeness gate (api-gw, ITCO-15826): hold this stream's
+			// FIRST push until every synthesized discovery chain has its EDS
+			// endpoints, so a cold-starting Envoy never initializes over CDS
+			// clusters that have no matching EDS. The hold is bounded, skipped for
+			// resumed streams, and applies only to the first push, so steady-state
+			// churn is never withheld. See bootstrap_gate.go.
+			if !bootstrapGate.allow(logger, snapshot) {
 				continue
 			}
 

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -784,7 +784,7 @@ func (s *ResourceGenerator) endpointsFromDiscoveryChain(
 		if upstream, _ := cfgSnap.ConnectProxy.GetUpstream(uid, &cfgSnap.ProxyID.EnterpriseMeta); upstream != nil {
 			destinationPort = upstream.DestinationPort
 		}
-		mappedTargets, err := s.mapDiscoChainTargets(cfgSnap, chain, node, upstreamConfig, forMeshGateway, destinationPort)
+		mappedTargets, err := s.mapDiscoChainTargets(cfgSnap, uid, chain, node, upstreamConfig, forMeshGateway, destinationPort)
 		if err != nil {
 			return nil, err
 		}

--- a/agent/xds/failover_policy.go
+++ b/agent/xds/failover_policy.go
@@ -19,6 +19,13 @@ type discoChainTargets struct {
 	targets         []targetInfo
 	failover        bool
 	failoverPolicy  structs.ServiceResolverFailoverPolicy
+
+	// degraded is set when the api-gateway aggregate guard rewrote a failover
+	// chain into a single plain EDS cluster because a member's endpoints were
+	// not assembled yet (see degradeToSingleTarget). CDS generation reads it to
+	// emit the apiGatewayFailoverDegraded metric exactly once per render; it is
+	// never set for a chain that was not a failover to begin with.
+	degraded bool
 }
 
 type targetInfo struct {
@@ -190,7 +197,7 @@ func (s *ResourceGenerator) mapDiscoChainTargets(
 				// targets and therefore no cluster at all -- a 503 NC that
 				// self-heals, rather than an aggregate over an empty member
 				// list, which is the same fatal shape as an unpopulated member.
-				s.Logger.Warn("api-gateway: emitting no cluster for upstream because it has no usable targets",
+				s.Logger.Debug("api-gateway: emitting no cluster for upstream because it has no usable targets",
 					"upstream", uid,
 					"cluster", failoverTargets.baseClusterName,
 					"unready_targets", unready)
@@ -201,7 +208,7 @@ func (s *ResourceGenerator) mapDiscoChainTargets(
 				// safe -- a plain EDS cluster is benign no matter how ready it
 				// is -- and the correct reading of failover intent: the primary
 				// is unusable, so the next target in order takes over.
-				s.Logger.Warn("api-gateway: rendering upstream without failover over a non-primary target because the primary is unavailable; "+
+				s.Logger.Debug("api-gateway: rendering upstream without failover over a non-primary target because the primary is unavailable; "+
 					"failover is restored automatically once the primary and member endpoints arrive",
 					"upstream", uid,
 					"cluster", failoverTargets.baseClusterName,
@@ -209,7 +216,7 @@ func (s *ResourceGenerator) mapDiscoChainTargets(
 					"degraded_to", degradedTo,
 					"unready_targets", unready)
 			default:
-				s.Logger.Warn("api-gateway: rendering upstream without failover because member endpoints are not assembled; "+
+				s.Logger.Debug("api-gateway: rendering upstream without failover because member endpoints are not assembled; "+
 					"failover is restored automatically once the endpoints arrive",
 					"upstream", uid,
 					"cluster", failoverTargets.baseClusterName,
@@ -304,6 +311,7 @@ func (ft discoChainTargets) unreadyFailoverMembers(
 func (ft *discoChainTargets) degradeToSingleTarget(primaryTargetID string) string {
 	ft.failover = false
 	ft.failoverPolicy = structs.ServiceResolverFailoverPolicy{}
+	ft.degraded = true
 
 	if len(ft.targets) == 0 {
 		return ""

--- a/agent/xds/failover_policy.go
+++ b/agent/xds/failover_policy.go
@@ -186,14 +186,15 @@ func (s *ResourceGenerator) mapDiscoChainTargets(
 	// on Server) for the unlikely case that this guard itself misbehaves; it
 	// is not expected to be set in normal operation.
 	if !s.DisableAPIGatewayFailoverGuard && failoverTargets.failover && !forMeshGateway && cfgSnap.Kind == structs.ServiceKindAPIGateway {
-		unready := failoverTargets.unreadyFailoverMembers(
+		unready, ready := failoverTargets.classifyFailoverMembers(
 			chain,
 			upstreamsSnapshot.WatchedUpstreamEndpoints[uid],
 			upstreamsSnapshot.WatchedGatewayEndpoints[uid],
 			cfgSnap.Locality,
 		)
 		if len(unready) > 0 {
-			degradedTo := failoverTargets.degradeToSingleTarget(primaryTargetID)
+			degradedTo := failoverTargets.degradeToSingleTarget(primaryTargetID, ready)
+			_, degradedToReady := ready[degradedTo]
 			switch {
 			case degradedTo == "":
 				// Every target was dropped while mapping, so there is nothing
@@ -206,24 +207,26 @@ func (s *ResourceGenerator) mapDiscoChainTargets(
 					"cluster", failoverTargets.baseClusterName,
 					"unready_targets", unready)
 			case degradedTo != primaryTargetID:
-				// The primary was dropped while mapping (reachable when it is a
-				// peered target whose peering metadata has not resolved yet).
-				// Falling back to the highest-priority remaining target is both
+				// Either the primary is not ready and a lower-priority member
+				// is, or the primary was dropped while mapping (reachable when
+				// it is a peered target whose peering metadata has not resolved
+				// yet). Taking the next usable target in failover order is both
 				// safe -- a plain EDS cluster is benign no matter how ready it
-				// is -- and the correct reading of failover intent: the primary
-				// is unusable, so the next target in order takes over.
-				s.Logger.Debug("api-gateway: rendering upstream without failover over a non-primary target because the primary is unavailable; "+
-					"failover is restored automatically once the primary and member endpoints arrive",
+				// is -- and the correct reading of failover intent.
+				s.Logger.Debug("api-gateway: rendering upstream without failover over a non-primary target; "+
+					"failover is restored automatically once the member endpoints arrive",
 					"upstream", uid,
 					"cluster", failoverTargets.baseClusterName,
 					"primary_target", primaryTargetID,
 					"degraded_to", degradedTo,
+					"degraded_to_ready", degradedToReady,
 					"unready_targets", unready)
 			default:
 				s.Logger.Debug("api-gateway: rendering upstream without failover because member endpoints are not assembled; "+
 					"failover is restored automatically once the endpoints arrive",
 					"upstream", uid,
 					"cluster", failoverTargets.baseClusterName,
+					"degraded_to_ready", degradedToReady,
 					"unready_targets", unready)
 			}
 		}
@@ -232,9 +235,21 @@ func (s *ResourceGenerator) mapDiscoChainTargets(
 	return failoverTargets, nil
 }
 
-// unreadyFailoverMembers returns the IDs of mapped targets whose EDS assignment
-// would be skipped by endpoint generation -- that is, the members that would
-// leave an aggregate cluster pointing at an unpopulated priority set.
+// classifyFailoverMembers splits the mapped targets by whether endpoint
+// generation would emit an EDS assignment for them.
+//
+// unready lists the members that would leave an aggregate cluster pointing at
+// an unpopulated priority set -- the shape that faults Envoy -- and is what
+// decides whether the guard fires. ready is the set that endpoint generation
+// would populate, and is what degradeToSingleTarget picks from, so that
+// degrading cannot discard a member that could have served traffic.
+//
+// A target that is neither ready nor unready has unknown readiness rather than
+// known-good readiness: the two sets are deliberately not complements. Peered
+// and external members land there (see the KNOWN LIMITATION below), which keeps
+// them out of unready, where they would trip the guard on a readiness this
+// function cannot judge, and equally out of ready, where degradeToSingleTarget
+// would treat an unverified member as a safe landing spot.
 //
 // It calls makeLoadAssignmentEndpointGroup, the very function endpoint
 // generation uses, rather than re-deriving the readiness rule, so the cluster
@@ -265,13 +280,13 @@ func (s *ResourceGenerator) mapDiscoChainTargets(
 // share this gap. Reaching it needs an API gateway whose service-resolver fails
 // over to a peered target whose peering metadata has resolved but whose
 // endpoints have not -- a narrower topology than the one this guard targets.
-func (ft discoChainTargets) unreadyFailoverMembers(
+func (ft discoChainTargets) classifyFailoverMembers(
 	chain *structs.CompiledDiscoveryChain,
 	upstreamEndpoints map[string]structs.CheckServiceNodes,
 	gatewayEndpoints map[string]structs.CheckServiceNodes,
 	localKey proxycfg.GatewayKey,
-) []string {
-	var unready []string
+) (unready []string, ready map[string]struct{}) {
+	ready = make(map[string]struct{}, len(ft.targets))
 	for _, ti := range ft.targets {
 		target := chain.Targets[ti.TargetID]
 		if target == nil {
@@ -294,9 +309,11 @@ func (ft discoChainTargets) unreadyFailoverMembers(
 			false,
 		); !valid {
 			unready = append(unready, ti.TargetID)
+			continue
 		}
+		ready[ti.TargetID] = struct{}{}
 	}
-	return unready
+	return unready, ready
 }
 
 // degradeToSingleTarget rewrites the mapped targets so they render as a single
@@ -306,19 +323,42 @@ func (ft discoChainTargets) unreadyFailoverMembers(
 // a plain EDS cluster with no assignment simply warms, times out and resolves
 // with zero hosts.
 //
-// It prefers the primary target, and otherwise falls back to the
-// highest-priority target still present -- the primary can legitimately be
-// absent, because a peered target whose peering metadata has not resolved is
-// dropped while mapping. It returns the target ID it degraded onto, or the
-// empty string if no target remained, in which case failover is still cleared
-// so that no aggregate can be emitted over an empty member list.
-func (ft *discoChainTargets) degradeToSingleTarget(primaryTargetID string) string {
+// Selection walks ft.targets, which mapDiscoChainTargets builds in failover
+// priority order (primary first, then the resolver's failover targets in
+// declared order), and takes the first member endpoint generation would
+// actually populate. That is what the failover policy would have selected
+// anyway, and it matters because the alternative is a cluster that is
+// guaranteed to answer 503: degrading onto an unready primary while a ready
+// member sits behind it converts a working failover into an outage, which is a
+// worse result than the aggregate this guard is replacing.
+//
+// When no member is ready the choice cannot affect traffic -- every candidate
+// resolves with zero hosts -- so it prefers the primary to keep the rendered
+// cluster stable, and otherwise falls back to the highest-priority target still
+// present. The primary can legitimately be absent, because a peered target
+// whose peering metadata has not resolved is dropped while mapping.
+//
+// ready must come from classifyFailoverMembers: it holds only members whose
+// readiness was positively verified, so members of unknown readiness are never
+// chosen as if they were serving.
+//
+// It returns the target ID it degraded onto, or the empty string if no target
+// remained, in which case failover is still cleared so that no aggregate can be
+// emitted over an empty member list.
+func (ft *discoChainTargets) degradeToSingleTarget(primaryTargetID string, ready map[string]struct{}) string {
 	ft.failover = false
 	ft.failoverPolicy = structs.ServiceResolverFailoverPolicy{}
 	ft.degraded = true
 
 	if len(ft.targets) == 0 {
 		return ""
+	}
+
+	for _, ti := range ft.targets {
+		if _, ok := ready[ti.TargetID]; ok {
+			ft.targets = []targetInfo{ti}
+			return ti.TargetID
+		}
 	}
 
 	chosen := ft.targets[0]

--- a/agent/xds/failover_policy.go
+++ b/agent/xds/failover_policy.go
@@ -181,7 +181,11 @@ func (s *ResourceGenerator) mapDiscoChainTargets(
 	// keeps a wholly incoherent snapshot away from a cold-starting Envoy,
 	// while this guard covers what the gate cannot -- a gate that expired on
 	// its timeout, and steady-state churn after the first push has opened it.
-	if failoverTargets.failover && !forMeshGateway && cfgSnap.Kind == structs.ServiceKindAPIGateway {
+	//
+	// DisableAPIGatewayFailoverGuard is an escape hatch (see its doc comment
+	// on Server) for the unlikely case that this guard itself misbehaves; it
+	// is not expected to be set in normal operation.
+	if !s.DisableAPIGatewayFailoverGuard && failoverTargets.failover && !forMeshGateway && cfgSnap.Kind == structs.ServiceKindAPIGateway {
 		unready := failoverTargets.unreadyFailoverMembers(
 			chain,
 			upstreamsSnapshot.WatchedUpstreamEndpoints[uid],

--- a/agent/xds/failover_policy.go
+++ b/agent/xds/failover_policy.go
@@ -59,6 +59,7 @@ func (ft discoChainTargets) groupedTargets() ([]discoChainTargetGroup, error) {
 
 func (s *ResourceGenerator) mapDiscoChainTargets(
 	cfgSnap *proxycfg.ConfigSnapshot,
+	uid proxycfg.UpstreamID,
 	chain *structs.CompiledDiscoveryChain,
 	node *structs.DiscoveryGraphNode,
 	upstreamConfig structs.UpstreamConfig,
@@ -155,7 +156,169 @@ func (s *ResourceGenerator) mapDiscoChainTargets(
 		failoverTargets.targets = append(failoverTargets.targets, ti)
 	}
 
+	// An aggregate cluster whose members have no EDS assignment is fatal to
+	// Envoy rather than merely degraded. Worker startup replays every known
+	// cluster into the new thread, and AggregateClusterLoadBalancer::
+	// onClusterAddOrUpdate faults on a member whose priority set was never
+	// populated (envoyproxy/envoy#35157, ITCO-15826). The identical state in a
+	// plain EDS cluster is benign: Envoy warms it, resolves it with zero hosts
+	// once initial_fetch_timeout fires and answers 503 UH until endpoints land.
+	//
+	// So when any member is not ready, render the base cluster as a plain EDS
+	// cluster over the primary target instead of as an aggregate. Route
+	// destinations are unaffected because they always reference the base
+	// cluster name, and failover is restored by the next snapshot once the
+	// member endpoints arrive.
+	//
+	// This complements the first-push bootstrap gate in agent/xds: the gate
+	// keeps a wholly incoherent snapshot away from a cold-starting Envoy,
+	// while this guard covers what the gate cannot -- a gate that expired on
+	// its timeout, and steady-state churn after the first push has opened it.
+	if failoverTargets.failover && !forMeshGateway && cfgSnap.Kind == structs.ServiceKindAPIGateway {
+		unready := failoverTargets.unreadyFailoverMembers(
+			chain,
+			upstreamsSnapshot.WatchedUpstreamEndpoints[uid],
+			upstreamsSnapshot.WatchedGatewayEndpoints[uid],
+			cfgSnap.Locality,
+		)
+		if len(unready) > 0 {
+			degradedTo := failoverTargets.degradeToSingleTarget(primaryTargetID)
+			switch {
+			case degradedTo == "":
+				// Every target was dropped while mapping, so there is nothing
+				// to degrade onto. Failover has been cleared, which leaves no
+				// targets and therefore no cluster at all -- a 503 NC that
+				// self-heals, rather than an aggregate over an empty member
+				// list, which is the same fatal shape as an unpopulated member.
+				s.Logger.Warn("api-gateway: emitting no cluster for upstream because it has no usable targets",
+					"upstream", uid,
+					"cluster", failoverTargets.baseClusterName,
+					"unready_targets", unready)
+			case degradedTo != primaryTargetID:
+				// The primary was dropped while mapping (reachable when it is a
+				// peered target whose peering metadata has not resolved yet).
+				// Falling back to the highest-priority remaining target is both
+				// safe -- a plain EDS cluster is benign no matter how ready it
+				// is -- and the correct reading of failover intent: the primary
+				// is unusable, so the next target in order takes over.
+				s.Logger.Warn("api-gateway: rendering upstream without failover over a non-primary target because the primary is unavailable; "+
+					"failover is restored automatically once the primary and member endpoints arrive",
+					"upstream", uid,
+					"cluster", failoverTargets.baseClusterName,
+					"primary_target", primaryTargetID,
+					"degraded_to", degradedTo,
+					"unready_targets", unready)
+			default:
+				s.Logger.Warn("api-gateway: rendering upstream without failover because member endpoints are not assembled; "+
+					"failover is restored automatically once the endpoints arrive",
+					"upstream", uid,
+					"cluster", failoverTargets.baseClusterName,
+					"unready_targets", unready)
+			}
+		}
+	}
+
 	return failoverTargets, nil
+}
+
+// unreadyFailoverMembers returns the IDs of mapped targets whose EDS assignment
+// would be skipped by endpoint generation -- that is, the members that would
+// leave an aggregate cluster pointing at an unpopulated priority set.
+//
+// It calls makeLoadAssignmentEndpointGroup, the very function endpoint
+// generation uses, rather than re-deriving the readiness rule, so the cluster
+// and endpoint paths cannot disagree about which members are ready.
+//
+// KNOWN LIMITATION: peered members are not covered. Their endpoints come from
+// makeUpstreamLoadAssignmentForPeerService, which is checked before
+// makeLoadAssignmentEndpointGroup in endpoints.go, so that function -- not this
+// one -- decides whether a peered member gets an assignment. It returns a nil
+// assignment, while CDS still emits the member cluster, in two cases:
+//
+//   - mesh gateway mode "local" while the local gateway endpoints are not yet
+//     watched (endpoints.go, the !ready early return), and
+//   - PeerUpstreamEndpoints not yet populated for the target.
+//
+// Either leaves an aggregate member unpopulated, which is the fatal shape. A
+// third nil case, PeerUpstreamEndpointsUseHostnames, is safe because the
+// cluster is then DNS-based and its endpoints come through CDS.
+//
+// This is not covered here because the decision depends on the mesh gateway
+// mode, and the mode endpoints.go uses for API gateways comes from
+// upstream.MeshGateway.Mode, whereas the upstreamConfig available at this point
+// is parsed from upstream.Config -- a different source. Reproducing the rule
+// from the wrong input would reintroduce exactly the CDS/EDS drift this
+// function exists to avoid, so covering peered members properly requires
+// threading the resolved mode into mapDiscoChainTargets. The bootstrap gate's
+// proxycfg predicate skips peered targets for the same reason, so both layers
+// share this gap. Reaching it needs an API gateway whose service-resolver fails
+// over to a peered target whose peering metadata has resolved but whose
+// endpoints have not -- a narrower topology than the one this guard targets.
+func (ft discoChainTargets) unreadyFailoverMembers(
+	chain *structs.CompiledDiscoveryChain,
+	upstreamEndpoints map[string]structs.CheckServiceNodes,
+	gatewayEndpoints map[string]structs.CheckServiceNodes,
+	localKey proxycfg.GatewayKey,
+) []string {
+	var unready []string
+	for _, ti := range ft.targets {
+		target := chain.Targets[ti.TargetID]
+		if target == nil {
+			continue
+		}
+		// Peered and external targets are served from a different endpoint path
+		// (makeUpstreamLoadAssignmentForPeerService, or no EDS at all), so
+		// makeLoadAssignmentEndpointGroup is not the authority on their
+		// readiness and gating on it here would be wrong. See the known
+		// limitation on this function.
+		if target.External || target.Peer != "" {
+			continue
+		}
+		if _, valid := makeLoadAssignmentEndpointGroup(
+			chain.Targets,
+			upstreamEndpoints,
+			gatewayEndpoints,
+			ti.TargetID,
+			localKey,
+			false,
+		); !valid {
+			unready = append(unready, ti.TargetID)
+		}
+	}
+	return unready
+}
+
+// degradeToSingleTarget rewrites the mapped targets so they render as a single
+// plain EDS cluster under the base cluster name, instead of an aggregate
+// cluster over per-target failover member clusters. This is always safe: an
+// unpopulated *aggregate* member is what faults during worker startup, whereas
+// a plain EDS cluster with no assignment simply warms, times out and resolves
+// with zero hosts.
+//
+// It prefers the primary target, and otherwise falls back to the
+// highest-priority target still present -- the primary can legitimately be
+// absent, because a peered target whose peering metadata has not resolved is
+// dropped while mapping. It returns the target ID it degraded onto, or the
+// empty string if no target remained, in which case failover is still cleared
+// so that no aggregate can be emitted over an empty member list.
+func (ft *discoChainTargets) degradeToSingleTarget(primaryTargetID string) string {
+	ft.failover = false
+	ft.failoverPolicy = structs.ServiceResolverFailoverPolicy{}
+
+	if len(ft.targets) == 0 {
+		return ""
+	}
+
+	chosen := ft.targets[0]
+	for _, ti := range ft.targets {
+		if ti.TargetID == primaryTargetID {
+			chosen = ti
+			break
+		}
+	}
+
+	ft.targets = []targetInfo{chosen}
+	return chosen.TargetID
 }
 
 func (ft discoChainTargets) sequential() ([]discoChainTargetGroup, error) {

--- a/agent/xds/failover_policy_aggregate_guard_test.go
+++ b/agent/xds/failover_policy_aggregate_guard_test.go
@@ -164,6 +164,51 @@ func TestMapDiscoChainTargets_APIGatewayAggregateGuard(t *testing.T) {
 	}
 }
 
+// TestMapDiscoChainTargets_APIGatewayAggregateGuard_KillSwitch covers
+// Server.DisableAPIGatewayFailoverGuard / ResourceGenerator.
+// DisableAPIGatewayFailoverGuard, the escape hatch for the aggregate guard.
+// It must fully restore the pre-guard behavior: an unready failover member no
+// longer degrades the chain, and the aggregate cluster is emitted as-is. This
+// is the reachable equivalent of the guard's own falsification test -- proof
+// that turning the switch off actually turns the guard off.
+func TestMapDiscoChainTargets_APIGatewayAggregateGuard_KillSwitch(t *testing.T) {
+	chain, node := failoverChainForTest(t)
+
+	primaryTargetID := node.Resolver.Target
+	failoverTargetID := node.Resolver.Failover.Targets[0]
+	uid := proxycfg.NewUpstreamIDFromServiceName(structs.NewServiceName("db", nil))
+
+	snap := testAggregateGuardSnapshot(t, structs.ServiceKindAPIGateway)
+	upstreams, err := snap.ToConfigSnapshotUpstreams()
+	require.NoError(t, err)
+	upstreams.DiscoveryChain[uid] = chain
+	// Only the primary's endpoints are assembled, so without the guard's
+	// escape hatch this would degrade to a single plain EDS cluster (see the
+	// "failover member unready" case above).
+	upstreams.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{
+		primaryTargetID: proxycfg.TestUpstreamNodes(t, "db"),
+	}
+
+	s := &ResourceGenerator{Logger: testutil.Logger(t), DisableAPIGatewayFailoverGuard: true}
+
+	mapped, err := s.mapDiscoChainTargets(snap, uid, chain, node, structs.UpstreamConfig{}, false, "")
+	require.NoError(t, err)
+
+	require.True(t, mapped.failover, "the kill switch must fully disable the guard, including for an unready member")
+	require.True(t, mapped.isAggregateCluster())
+	require.False(t, mapped.degraded)
+
+	var gotTargetIDs []string
+	for _, ti := range mapped.targets {
+		gotTargetIDs = append(gotTargetIDs, ti.TargetID)
+	}
+	require.Equal(t, []string{primaryTargetID, failoverTargetID}, gotTargetIDs)
+
+	groups, err := mapped.groupedTargets()
+	require.NoError(t, err)
+	require.Len(t, groups, 2, "the aggregate's member clusters must be emitted even though a member is unready")
+}
+
 func testAggregateGuardSnapshot(t *testing.T, kind structs.ServiceKind) *proxycfg.ConfigSnapshot {
 	t.Helper()
 

--- a/agent/xds/failover_policy_aggregate_guard_test.go
+++ b/agent/xds/failover_policy_aggregate_guard_test.go
@@ -136,6 +136,8 @@ func TestMapDiscoChainTargets_APIGatewayAggregateGuard(t *testing.T) {
 			require.Equal(t, tc.expectFailover, mapped.failover)
 			require.Equal(t, tc.expectFailover, mapped.isAggregateCluster(),
 				"RDS retry-policy selection must follow the same decision as CDS")
+			require.Equal(t, !tc.expectFailover, mapped.degraded,
+				"degraded is set exactly when the guard rewrote a failover chain; it drives the apiGatewayFailoverDegraded metric")
 
 			var gotTargetIDs []string
 			for _, ti := range mapped.targets {

--- a/agent/xds/failover_policy_aggregate_guard_test.go
+++ b/agent/xds/failover_policy_aggregate_guard_test.go
@@ -107,6 +107,18 @@ func TestMapDiscoChainTargets_APIGatewayAggregateGuard(t *testing.T) {
 			expectTargetIDs:  []string{primaryTargetID},
 			expectClusterQty: 1,
 		},
+		// Degrading onto the primary here would discard the one member that can
+		// actually serve traffic, turning a working failover into a guaranteed
+		// 503. Reachable in steady state: resetWatchesFromChain drops every
+		// target's endpoints at once and they refill independently, so "the
+		// failover member refilled first" is an ordinary race.
+		"api gateway, primary unready but member ready: degrades to the ready member": {
+			kind:             structs.ServiceKindAPIGateway,
+			readyTargets:     []string{failoverTargetID},
+			expectFailover:   false,
+			expectTargetIDs:  []string{failoverTargetID},
+			expectClusterQty: 1,
+		},
 		// The crash is only reachable through a gateway cold start, and the
 		// user-facing contract for sidecars is unchanged, so the guard is
 		// deliberately scoped to API gateways.
@@ -223,47 +235,101 @@ func testAggregateGuardSnapshot(t *testing.T, kind structs.ServiceKind) *proxycf
 	}
 }
 
-// TestDegradeToSingleTarget_DroppedPrimary covers the case where the primary
-// target is absent from the mapped targets, which happens when it is a peered
-// target whose peering metadata has not resolved and it is therefore dropped
-// while mapping. The guard must still clear failover: leaving the shape
-// untouched would emit an aggregate over the remaining unready members, which
-// is precisely the crash the guard exists to prevent.
-func TestDegradeToSingleTarget_DroppedPrimary(t *testing.T) {
+// TestDegradeToSingleTarget covers which target the guard degrades onto.
+//
+// Two things must hold. Failover is always cleared, even when no target
+// survives -- leaving the shape untouched would emit an aggregate over the
+// remaining unready members, which is precisely the crash the guard exists to
+// prevent. And the chosen target is the highest-priority member that endpoint
+// generation would actually populate, because degrading onto an unready member
+// while a ready one sits behind it turns a working failover into a guaranteed
+// 503.
+//
+// The primary can be absent entirely: a peered target whose peering metadata
+// has not resolved is dropped while mapping.
+func TestDegradeToSingleTarget(t *testing.T) {
 	const (
 		primary   = "db.default.default.dc1"
 		failoverA = "fail-a.default.default.dc1"
 		failoverB = "fail-b.default.default.dc1"
 	)
 
+	all := []targetInfo{{TargetID: primary}, {TargetID: failoverA}, {TargetID: failoverB}}
+
 	cases := map[string]struct {
 		targets      []targetInfo
+		ready        []string
 		expectChosen string
 		expectTarget []string
 	}{
-		"primary present: degrades onto the primary": {
-			targets: []targetInfo{
-				{TargetID: primary}, {TargetID: failoverA}, {TargetID: failoverB},
-			},
+		"primary ready: degrades onto the primary": {
+			targets:      all,
+			ready:        []string{primary},
 			expectChosen: primary,
 			expectTarget: []string{primary},
 		},
-		"primary present but not first: still degrades onto the primary": {
-			targets: []targetInfo{
-				{TargetID: failoverA}, {TargetID: primary},
-			},
+		"primary ready and others too: still prefers the primary": {
+			targets:      all,
+			ready:        []string{primary, failoverA, failoverB},
 			expectChosen: primary,
 			expectTarget: []string{primary},
 		},
-		"primary dropped: degrades onto the highest-priority remaining target": {
-			targets: []targetInfo{
-				{TargetID: failoverA}, {TargetID: failoverB},
-			},
+		// The regression this selection exists to prevent: choosing the primary
+		// here yields a cluster with no endpoints while a member that could
+		// serve traffic is discarded.
+		"primary unready, member ready: degrades onto the ready member": {
+			targets:      all,
+			ready:        []string{failoverA},
 			expectChosen: failoverA,
 			expectTarget: []string{failoverA},
 		},
+		"several members ready: takes the highest-priority one": {
+			targets:      all,
+			ready:        []string{failoverB, failoverA},
+			expectChosen: failoverA,
+			expectTarget: []string{failoverA},
+		},
+		"nothing ready: falls back to the primary": {
+			targets:      all,
+			ready:        nil,
+			expectChosen: primary,
+			expectTarget: []string{primary},
+		},
+		"nothing ready, primary not first: still falls back to the primary": {
+			targets: []targetInfo{
+				{TargetID: failoverA}, {TargetID: primary},
+			},
+			ready:        nil,
+			expectChosen: primary,
+			expectTarget: []string{primary},
+		},
+		"primary dropped, nothing ready: falls back to the highest-priority remaining target": {
+			targets: []targetInfo{
+				{TargetID: failoverA}, {TargetID: failoverB},
+			},
+			ready:        nil,
+			expectChosen: failoverA,
+			expectTarget: []string{failoverA},
+		},
+		"primary dropped, a member is ready: degrades onto the ready member": {
+			targets: []targetInfo{
+				{TargetID: failoverA}, {TargetID: failoverB},
+			},
+			ready:        []string{failoverB},
+			expectChosen: failoverB,
+			expectTarget: []string{failoverB},
+		},
+		// A peered member is neither ready nor unready: its readiness is
+		// unknown, so it must not be treated as a safe landing spot.
+		"unknown-readiness members are not chosen over the primary": {
+			targets:      all,
+			ready:        nil,
+			expectChosen: primary,
+			expectTarget: []string{primary},
+		},
 		"every target dropped: clears failover and leaves nothing to emit": {
 			targets:      nil,
+			ready:        nil,
 			expectChosen: "",
 			expectTarget: nil,
 		},
@@ -278,7 +344,12 @@ func TestDegradeToSingleTarget_DroppedPrimary(t *testing.T) {
 				failoverPolicy:  structs.ServiceResolverFailoverPolicy{Mode: "sequential"},
 			}
 
-			chosen := ft.degradeToSingleTarget(primary)
+			ready := make(map[string]struct{}, len(tc.ready))
+			for _, id := range tc.ready {
+				ready[id] = struct{}{}
+			}
+
+			chosen := ft.degradeToSingleTarget(primary, ready)
 			require.Equal(t, tc.expectChosen, chosen)
 
 			// Failover must be cleared unconditionally. This is the invariant

--- a/agent/xds/failover_policy_aggregate_guard_test.go
+++ b/agent/xds/failover_policy_aggregate_guard_test.go
@@ -1,0 +1,266 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package xds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/configentry"
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/agent/consul/discoverychain"
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+// failoverChainForTest compiles a "db" discovery chain that fails over to
+// "fail", and returns the chain along with its resolver node.
+func failoverChainForTest(t *testing.T) (*structs.CompiledDiscoveryChain, *structs.DiscoveryGraphNode) {
+	t.Helper()
+
+	set := configentry.NewDiscoveryChainSet()
+	set.AddEntries(
+		&structs.ProxyConfigEntry{
+			Kind:   structs.ProxyDefaults,
+			Name:   structs.ProxyConfigGlobal,
+			Config: map[string]interface{}{"protocol": "http"},
+		},
+		&structs.ServiceResolverConfigEntry{
+			Kind: structs.ServiceResolver,
+			Name: "db",
+			Failover: map[string]structs.ServiceResolverFailover{
+				"*": {Service: "fail"},
+			},
+		},
+	)
+
+	chain := discoverychain.TestCompileConfigEntries(
+		t, "db", "default", "default", "dc1", connect.TestClusterID+".consul", nil, set)
+
+	var node *structs.DiscoveryGraphNode
+	for _, n := range chain.Nodes {
+		if n.Type == structs.DiscoveryGraphNodeTypeResolver && n.Resolver != nil && n.Resolver.Failover != nil {
+			node = n
+			break
+		}
+	}
+	require.NotNil(t, node, "expected a resolver node carrying a failover definition")
+	require.NotEmpty(t, node.Resolver.Failover.Targets, "expected the resolver node to have failover targets")
+
+	return chain, node
+}
+
+// TestMapDiscoChainTargets_APIGatewayAggregateGuard covers the guard that stops
+// Consul from handing Envoy an aggregate cluster whose member clusters have no
+// EDS assignment. That shape crashes Envoy during worker startup rather than
+// degrading (envoyproxy/envoy#35157), so when a member is not ready we render
+// the base cluster as a plain EDS cluster over the primary target instead.
+func TestMapDiscoChainTargets_APIGatewayAggregateGuard(t *testing.T) {
+	chain, node := failoverChainForTest(t)
+
+	primaryTargetID := node.Resolver.Target
+	failoverTargetID := node.Resolver.Failover.Targets[0]
+	require.NotEqual(t, primaryTargetID, failoverTargetID)
+
+	uid := proxycfg.NewUpstreamIDFromServiceName(structs.NewServiceName("db", nil))
+
+	// endpointsFor builds the WatchedUpstreamEndpoints map for the given target
+	// IDs. makeLoadAssignmentEndpointGroup keys readiness off the presence of
+	// the target ID, so an absent key is exactly the "endpoints not assembled
+	// yet" state that the two-phase watch produces on cold start.
+	endpointsFor := func(t *testing.T, targetIDs ...string) map[string]structs.CheckServiceNodes {
+		out := map[string]structs.CheckServiceNodes{}
+		for _, id := range targetIDs {
+			out[id] = proxycfg.TestUpstreamNodes(t, "db")
+		}
+		return out
+	}
+
+	cases := map[string]struct {
+		kind             structs.ServiceKind
+		readyTargets     []string
+		expectFailover   bool
+		expectTargetIDs  []string
+		expectClusterQty int
+	}{
+		"api gateway, all members ready: aggregate is preserved": {
+			kind:             structs.ServiceKindAPIGateway,
+			readyTargets:     []string{primaryTargetID, failoverTargetID},
+			expectFailover:   true,
+			expectTargetIDs:  []string{primaryTargetID, failoverTargetID},
+			expectClusterQty: 2,
+		},
+		"api gateway, failover member unready: degrades to the primary": {
+			kind:             structs.ServiceKindAPIGateway,
+			readyTargets:     []string{primaryTargetID},
+			expectFailover:   false,
+			expectTargetIDs:  []string{primaryTargetID},
+			expectClusterQty: 1,
+		},
+		"api gateway, no members ready: degrades to the primary": {
+			kind:             structs.ServiceKindAPIGateway,
+			readyTargets:     nil,
+			expectFailover:   false,
+			expectTargetIDs:  []string{primaryTargetID},
+			expectClusterQty: 1,
+		},
+		// The crash is only reachable through a gateway cold start, and the
+		// user-facing contract for sidecars is unchanged, so the guard is
+		// deliberately scoped to API gateways.
+		"connect proxy is out of scope: aggregate is preserved when unready": {
+			kind:             structs.ServiceKindConnectProxy,
+			readyTargets:     nil,
+			expectFailover:   true,
+			expectTargetIDs:  []string{primaryTargetID, failoverTargetID},
+			expectClusterQty: 2,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			snap := testAggregateGuardSnapshot(t, tc.kind)
+
+			upstreams, err := snap.ToConfigSnapshotUpstreams()
+			require.NoError(t, err)
+			upstreams.DiscoveryChain[uid] = chain
+			upstreams.WatchedUpstreamEndpoints[uid] = endpointsFor(t, tc.readyTargets...)
+
+			s := &ResourceGenerator{Logger: testutil.Logger(t)}
+
+			mapped, err := s.mapDiscoChainTargets(snap, uid, chain, node, structs.UpstreamConfig{}, false, "")
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectFailover, mapped.failover)
+			require.Equal(t, tc.expectFailover, mapped.isAggregateCluster(),
+				"RDS retry-policy selection must follow the same decision as CDS")
+
+			var gotTargetIDs []string
+			for _, ti := range mapped.targets {
+				gotTargetIDs = append(gotTargetIDs, ti.TargetID)
+			}
+			require.Equal(t, tc.expectTargetIDs, gotTargetIDs)
+
+			// groupedTargets is what clusters.go and endpoints.go both consume,
+			// so assert the shape Envoy actually receives.
+			groups, err := mapped.groupedTargets()
+			require.NoError(t, err)
+			require.Len(t, groups, tc.expectClusterQty)
+			for _, g := range groups {
+				require.Len(t, g.Targets, 1,
+					"endpoint generation rejects groups that do not hold exactly one target")
+			}
+
+			if !tc.expectFailover {
+				require.Equal(t, mapped.baseClusterName, groups[0].ClusterName,
+					"the degraded cluster must keep the base name so route destinations still resolve")
+				require.Empty(t, mapped.failoverPolicy.Mode)
+			}
+		})
+	}
+}
+
+func testAggregateGuardSnapshot(t *testing.T, kind structs.ServiceKind) *proxycfg.ConfigSnapshot {
+	t.Helper()
+
+	switch kind {
+	case structs.ServiceKindAPIGateway:
+		return proxycfg.TestConfigSnapshotAPIGateway(t, "default", nil, nil, nil, nil, nil)
+	case structs.ServiceKindConnectProxy:
+		return proxycfg.TestConfigSnapshotDiscoveryChain(t, "failover", false, nil, nil)
+	default:
+		t.Fatalf("unsupported kind %q", kind)
+		return nil
+	}
+}
+
+// TestDegradeToSingleTarget_DroppedPrimary covers the case where the primary
+// target is absent from the mapped targets, which happens when it is a peered
+// target whose peering metadata has not resolved and it is therefore dropped
+// while mapping. The guard must still clear failover: leaving the shape
+// untouched would emit an aggregate over the remaining unready members, which
+// is precisely the crash the guard exists to prevent.
+func TestDegradeToSingleTarget_DroppedPrimary(t *testing.T) {
+	const (
+		primary   = "db.default.default.dc1"
+		failoverA = "fail-a.default.default.dc1"
+		failoverB = "fail-b.default.default.dc1"
+	)
+
+	cases := map[string]struct {
+		targets      []targetInfo
+		expectChosen string
+		expectTarget []string
+	}{
+		"primary present: degrades onto the primary": {
+			targets: []targetInfo{
+				{TargetID: primary}, {TargetID: failoverA}, {TargetID: failoverB},
+			},
+			expectChosen: primary,
+			expectTarget: []string{primary},
+		},
+		"primary present but not first: still degrades onto the primary": {
+			targets: []targetInfo{
+				{TargetID: failoverA}, {TargetID: primary},
+			},
+			expectChosen: primary,
+			expectTarget: []string{primary},
+		},
+		"primary dropped: degrades onto the highest-priority remaining target": {
+			targets: []targetInfo{
+				{TargetID: failoverA}, {TargetID: failoverB},
+			},
+			expectChosen: failoverA,
+			expectTarget: []string{failoverA},
+		},
+		"every target dropped: clears failover and leaves nothing to emit": {
+			targets:      nil,
+			expectChosen: "",
+			expectTarget: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ft := discoChainTargets{
+				baseClusterName: "db.default.dc1.internal.example.consul",
+				targets:         tc.targets,
+				failover:        true,
+				failoverPolicy:  structs.ServiceResolverFailoverPolicy{Mode: "sequential"},
+			}
+
+			chosen := ft.degradeToSingleTarget(primary)
+			require.Equal(t, tc.expectChosen, chosen)
+
+			// Failover must be cleared unconditionally. This is the invariant
+			// that keeps clusters.go from emitting an aggregate cluster.
+			require.False(t, ft.failover)
+			require.False(t, ft.isAggregateCluster())
+			require.Empty(t, ft.failoverPolicy.Mode)
+
+			var gotTargetIDs []string
+			for _, ti := range ft.targets {
+				gotTargetIDs = append(gotTargetIDs, ti.TargetID)
+			}
+			require.Equal(t, tc.expectTarget, gotTargetIDs)
+
+			groups, err := ft.groupedTargets()
+			require.NoError(t, err)
+
+			if tc.expectChosen == "" {
+				// One group holding zero targets: clusters.go emits no
+				// aggregate, and endpoints.go skips the zero-length group.
+				require.Len(t, groups, 1)
+				require.Empty(t, groups[0].Targets)
+				return
+			}
+
+			require.Len(t, groups, 1)
+			require.Equal(t, ft.baseClusterName, groups[0].ClusterName)
+			require.Len(t, groups[0].Targets, 1)
+			require.Equal(t, tc.expectChosen, groups[0].Targets[0].TargetID)
+		})
+	}
+}

--- a/agent/xds/resources.go
+++ b/agent/xds/resources.go
@@ -23,6 +23,14 @@ type ResourceGenerator struct {
 	IncrementalXDS bool
 
 	ProxyFeatures xdscommon.SupportedProxyFeatures
+
+	// DisableAPIGatewayFailoverGuard disables the api-gateway aggregate-cluster
+	// guard in mapDiscoChainTargets (see failover_policy.go) that rewrites a
+	// failover chain into a single plain EDS cluster when a member's endpoints
+	// are not assembled yet. It mirrors Server.DisableAPIGatewayFailoverGuard;
+	// see that field for why it exists. The zero value (false) leaves the
+	// guard enabled, which is correct for all known topologies.
+	DisableAPIGatewayFailoverGuard bool
 }
 
 func NewResourceGenerator(

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -700,7 +700,7 @@ func (s *ResourceGenerator) makeUpstreamRouteForDiscoveryChain(
 
 			switch nextNode.Type {
 			case structs.DiscoveryGraphNodeTypeSplitter:
-				ra, agg, err := s.makeRouteActionForSplitterWithFailover(cfgSnap, upstreamsSnapshot, nextNode.Splits, chain, rawUpstreamConfig, forMeshGateway, destinationPort)
+				ra, agg, err := s.makeRouteActionForSplitterWithFailover(cfgSnap, uid, upstreamsSnapshot, nextNode.Splits, chain, rawUpstreamConfig, forMeshGateway, destinationPort)
 				if err != nil {
 					return nil, err
 				}
@@ -1136,6 +1136,7 @@ func (s *ResourceGenerator) makeRouteActionForSplitter(
 // checks if any of the splits have an aggregate cluster (failover) and returns that flag.
 func (s *ResourceGenerator) makeRouteActionForSplitterWithFailover(
 	cfgSnap *proxycfg.ConfigSnapshot,
+	uid proxycfg.UpstreamID,
 	upstreamsSnapshot *proxycfg.ConfigSnapshotUpstreams,
 	splits []*structs.DiscoverySplit,
 	chain *structs.CompiledDiscoveryChain,
@@ -1155,7 +1156,7 @@ func (s *ResourceGenerator) makeRouteActionForSplitterWithFailover(
 
 		// Check if this split's resolver has failover (aggregate cluster)
 		upstreamConfig := finalizeUpstreamConfig(rawUpstreamConfig, chain, nextNode.Resolver.ConnectTimeout)
-		mappedTargets, err := s.mapDiscoChainTargets(cfgSnap, chain, nextNode, upstreamConfig, forMeshGateway, destinationPort)
+		mappedTargets, err := s.mapDiscoChainTargets(cfgSnap, uid, chain, nextNode, upstreamConfig, forMeshGateway, destinationPort)
 		if err != nil {
 			s.Logger.Debug("failed to map disco chain targets for split", "error", err)
 		} else if mappedTargets.isAggregateCluster() {

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -73,6 +73,19 @@ const (
 	// DefaultAuthCheckFrequency is the default value for
 	// Server.AuthCheckFrequency to use when the zero value is provided.
 	DefaultAuthCheckFrequency = 5 * time.Minute
+
+	// DefaultBootstrapGateTimeout is the default value for
+	// Server.BootstrapGateTimeout. It bounds how long an api-gateway xDS stream
+	// will hold its first push waiting for the snapshot's discovery-chain
+	// endpoints to be assembled (ITCO-15826).
+	//
+	// The gate is only ever expected to be satisfiable, but it must not be able
+	// to wedge a stream if that assumption is ever violated: Consul programs
+	// lds_config/cds_config with initial_fetch_timeout: 0s (wait forever), so a
+	// permanently-held first push means a gateway that never becomes ready at
+	// all. Past this deadline we push what we have — a gateway answering 503s is
+	// strictly better than one that never listens.
+	DefaultBootstrapGateTimeout = 30 * time.Second
 )
 
 // ACLResolverFunc is a shim to resolve ACLs. Since ACL enforcement is so far
@@ -104,6 +117,11 @@ type Server struct {
 	// This is only used during idle periods of stream interactions (i.e. when
 	// there has been no recent DiscoveryRequest).
 	AuthCheckFrequency time.Duration
+
+	// BootstrapGateTimeout bounds the api-gateway cold-start completeness gate
+	// applied to a stream's first push. Zero means DefaultBootstrapGateTimeout;
+	// a negative value disables the gate entirely.
+	BootstrapGateTimeout time.Duration
 
 	// ResourceMapMutateFn exclusively exists for testing purposes.
 	ResourceMapMutateFn func(resourceMap *xdscommon.IndexedResources)
@@ -158,6 +176,8 @@ func NewServer(
 		CfgFetcher:         cfgFetcher,
 		AuthCheckFrequency: DefaultAuthCheckFrequency,
 		activeStreams:      &activeStreamCounters{},
+
+		BootstrapGateTimeout: DefaultBootstrapGateTimeout,
 	}
 }
 

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -43,11 +43,23 @@ var (
 			Name: []string{"xds", "server", "streamDrained"},
 			Help: "Counts the number of xDS streams that are drained when rebalancing the load between servers.",
 		},
+		{
+			Name: []string{"xds", "server", "bootstrapGateTimeout"},
+			Help: "Counts the number of times the api-gateway bootstrap completeness gate released an xDS stream's first push on its deadline before all discovery-chain endpoints were assembled.",
+		},
+		{
+			Name: []string{"xds", "server", "apiGatewayFailoverDegraded"},
+			Help: "Counts the number of times an api-gateway failover upstream was rendered as a single plain EDS cluster instead of an aggregate because a member's endpoints were not yet assembled. This averts an Envoy worker-startup crash and self-heals once the endpoints arrive.",
+		},
 	}
 	StatsSummaries = []prometheus.SummaryDefinition{
 		{
 			Name: []string{"xds", "server", "streamStart"},
 			Help: "Measures the time in milliseconds after an xDS stream is opened until xDS resources are first generated for the stream.",
+		},
+		{
+			Name: []string{"xds", "server", "bootstrapGateHeld"},
+			Help: "Measures the time in milliseconds an api-gateway xDS stream's first push was held by the bootstrap completeness gate before the snapshot's discovery-chain endpoints were assembled.",
 		},
 	}
 )

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -6,6 +6,8 @@ package xds
 import (
 	"context"
 	"errors"
+	"os"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -100,6 +102,86 @@ const (
 	DefaultBootstrapGateTimeout = 30 * time.Second
 )
 
+// TODO(CSL-11921): remove once the guard is proven in the field
+const (
+	// EnvBootstrapGateTimeout overrides Server.BootstrapGateTimeout. It accepts
+	// any time.ParseDuration value; a negative duration disables the api-gateway
+	// cold-start gate entirely.
+	//
+	// This is a break-glass control, deliberately an environment variable rather
+	// than an agent config option: it exists so a misbehaving gate can be
+	// neutralized on a running cluster without a binary rollback, not as a knob
+	// operators are expected to tune. The default is correct for all known
+	// topologies.
+	EnvBootstrapGateTimeout = "CONSUL_XDS_APIGATEWAY_BOOTSTRAP_GATE_TIMEOUT"
+
+	// EnvDisableAPIGatewayFailoverGuard disables the api-gateway
+	// aggregate-cluster failover guard when set to a value strconv.ParseBool
+	// reads as true. See Server.DisableAPIGatewayFailoverGuard, and the
+	// break-glass note on EnvBootstrapGateTimeout.
+	EnvDisableAPIGatewayFailoverGuard = "CONSUL_XDS_DISABLE_APIGATEWAY_FAILOVER_GUARD"
+)
+
+// bootstrapGateTimeoutFromEnv resolves Server.BootstrapGateTimeout from
+// EnvBootstrapGateTimeout, falling back to DefaultBootstrapGateTimeout.
+//
+// An unset or malformed value yields the default rather than the zero value:
+// callers read zero as "use the default" anyway, but returning the default
+// explicitly keeps a typo from being indistinguishable from an intentional
+// override in a log.
+func bootstrapGateTimeoutFromEnv(logger hclog.Logger) time.Duration {
+	raw, ok := os.LookupEnv(EnvBootstrapGateTimeout)
+	if !ok || raw == "" {
+		return DefaultBootstrapGateTimeout
+	}
+
+	timeout, err := time.ParseDuration(raw)
+	if err != nil {
+		logger.Warn("ignoring malformed environment variable; using the default api-gateway bootstrap gate timeout",
+			"env", EnvBootstrapGateTimeout, "value", raw, "default", DefaultBootstrapGateTimeout, "error", err)
+		return DefaultBootstrapGateTimeout
+	}
+
+	if timeout < 0 {
+		logger.Warn("api-gateway xDS bootstrap gate is DISABLED by environment variable; "+
+			"a cold-starting api-gateway Envoy may receive clusters whose endpoints are not assembled yet",
+			"env", EnvBootstrapGateTimeout, "value", raw)
+	} else {
+		logger.Info("api-gateway xDS bootstrap gate timeout overridden by environment variable",
+			"env", EnvBootstrapGateTimeout, "timeout", timeout)
+	}
+	return timeout
+}
+
+// disableAPIGatewayFailoverGuardFromEnv resolves
+// Server.DisableAPIGatewayFailoverGuard from
+// EnvDisableAPIGatewayFailoverGuard.
+//
+// Anything other than an explicit, parseable true leaves the guard enabled. The
+// guard averts an Envoy crash, so a malformed value must fail closed: silently
+// disabling it on a typo would reintroduce the fault it exists to prevent.
+func disableAPIGatewayFailoverGuardFromEnv(logger hclog.Logger) bool {
+	raw, ok := os.LookupEnv(EnvDisableAPIGatewayFailoverGuard)
+	if !ok || raw == "" {
+		return false
+	}
+
+	disabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		logger.Warn("ignoring malformed environment variable; the api-gateway failover guard remains enabled",
+			"env", EnvDisableAPIGatewayFailoverGuard, "value", raw, "error", err)
+		return false
+	}
+
+	if disabled {
+		logger.Warn("api-gateway aggregate-cluster failover guard is DISABLED by environment variable; "+
+			"an api-gateway whose failover member endpoints are not assembled may crash its Envoy "+
+			"(envoyproxy/envoy#35157)",
+			"env", EnvDisableAPIGatewayFailoverGuard)
+	}
+	return disabled
+}
+
 // ACLResolverFunc is a shim to resolve ACLs. Since ACL enforcement is so far
 // entirely agent-local and all uses private methods this allows a simple shim
 // to be written in the agent package to allow resolving without tightly
@@ -132,8 +214,26 @@ type Server struct {
 
 	// BootstrapGateTimeout bounds the api-gateway cold-start completeness gate
 	// applied to a stream's first push. Zero means DefaultBootstrapGateTimeout;
-	// a negative value disables the gate entirely.
+	// a negative value disables the gate entirely. NewServer populates it from
+	// EnvBootstrapGateTimeout.
 	BootstrapGateTimeout time.Duration
+
+	// DisableAPIGatewayFailoverGuard disables the aggregate-cluster guard that
+	// rewrites an api-gateway failover chain into a single plain EDS cluster
+	// when a failover member's endpoints are not assembled yet
+	// (agent/xds/failover_policy.go, ITCO-15826). The guard is the safety net
+	// for an aggregate cluster whose members have no EDS assignment, which
+	// faults Envoy during worker startup rather than merely degrading
+	// (envoyproxy/envoy#35157).
+	//
+	// This exists purely as an escape hatch in case the guard misbehaves in a
+	// topology we have not exercised, so that recovery does not require a
+	// binary rollback. NewServer populates it from
+	// EnvDisableAPIGatewayFailoverGuard; it is an environment variable rather
+	// than an agent config option because the zero value (false) is correct for
+	// all known topologies, and disabling it re-exposes the crash the guard
+	// exists to prevent.
+	DisableAPIGatewayFailoverGuard bool
 
 	// ResourceMapMutateFn exclusively exists for testing purposes.
 	ResourceMapMutateFn func(resourceMap *xdscommon.IndexedResources)
@@ -189,7 +289,8 @@ func NewServer(
 		AuthCheckFrequency: DefaultAuthCheckFrequency,
 		activeStreams:      &activeStreamCounters{},
 
-		BootstrapGateTimeout: DefaultBootstrapGateTimeout,
+		BootstrapGateTimeout:           bootstrapGateTimeoutFromEnv(logger),
+		DisableAPIGatewayFailoverGuard: disableAPIGatewayFailoverGuardFromEnv(logger),
 	}
 }
 


### PR DESCRIPTION
## Problem

API-gateway Envoy proxies crash with **SIGSEGV/SIGBUS during worker startup**
on cold start — most visibly during a mass reconnect (server rollout, leader
election, partition heal) when many gateways reconnect at once. The proxy
crash-loops before it ever serves traffic. (ITCO-15826 / CSL-11921.)

## Root Cause

A `service-resolver` with `failover` is rendered as an **aggregate cluster**
(`CLUSTER_PROVIDED` LB) whose members are the per-target EDS clusters. On cold
start there is a two-phase gap in snapshot assembly: the discovery chain is
stored first, then the per-target endpoint watches fire asynchronously, so CDS
can be emitted **before** the member EDS assignments are assembled.

Consul programs Envoy's bootstrap `lds_config`/`cds_config` with
`initial_fetch_timeout: 0s` (`command/connect/envoy/bootstrap_tpl.go`), i.e.
*wait indefinitely* for the first config, so Envoy proceeds into worker startup
on the first CDS it receives. `AggregateClusterLoadBalancer::onClusterAddOrUpdate`
then dereferences a member whose priority set was never populated
(envoyproxy/envoy#35157) → SIGSEGV/SIGBUS.

Crucially, this is **specific to aggregate clusters**. A plain EDS cluster in
the same "cluster present, EDS missing" state is benign — Envoy warms it, times
out, resolves with zero hosts, and answers 503 UH until endpoints land. Only the
aggregate-with-unpopulated-members shape is fatal.

## Fix

Two complementary control-plane mechanisms (the Envoy null-deref itself is
upstream and can't be shipped to the customer):

1. **Bootstrap completeness gate** — happy-path optimization. Hold each xDS
   stream's *first* push until the gateway's discovery-chain endpoints are
   assembled, so a healthy cold start ships a fully-formed config (no 503 blip,
   full failover from the first byte).
2. **Aggregate guard** — the safety net. At render time, never emit an aggregate
   over unpopulated members; degrade to a plain EDS cluster instead. This is what
   makes the gate's timeout (and any steady-state transient) crash-safe rather
   than a delayed crash.

### Primary change 1 — `agent/proxycfg/snapshot.go` (the gate's predicate)

- `discoveryChainsMissingEndpoints(localKey)` — returns `uid/targetID` for every
  route-backed discovery-chain target that will be rendered into CDS but whose
  EDS is not assembled yet (aggregate or not). Mirrors `makeLoadAssignmentEndpointGroup`,
  including the mesh-gateway endpoint case; excludes external/peered targets and
  orphan chains (which emit no cluster, so gating on them would wedge forever).
- `activeUpstreamIDs()` — mirrors `getReadyListeners` so only upstreams that CDS
  will actually render are gated, avoiding a hold on config that is never published.
- `APIGatewayDiscoveryChainsMissingEndpoints()` — exported accessor the xDS layer
  calls; returns `nil` for non-api-gateway kinds.
- `valid()` is intentionally **unchanged** — proxycfg keeps delivering snapshots
  normally; the gate lives in the xDS layer, so steady-state churn is never starved.

Gating is placed in the xDS stream rather than proxycfg because the `ConfigSnapshot`
is shared and deduplicated across every stream for a proxy and has no notion of an
individual connection, "first push vs. resumed," or a per-stream deadline.

### Primary change 2 — `agent/xds/failover_policy.go` (the guard)

- In `mapDiscoChainTargets` (api-gateway only), `unreadyFailoverMembers` detects
  members whose EDS would be skipped by endpoint generation. It calls
  `makeLoadAssignmentEndpointGroup` directly — the same function endpoint
  generation uses — so the cluster and endpoint paths cannot disagree about
  readiness.
- When any member is unready, `degradeToSingleTarget` rewrites the chain into a
  single **plain EDS cluster under the base cluster name**: prefer the primary
  target, else the highest-priority remaining target, else emit nothing (503 NC).
  It clears `failover` unconditionally, so CDS generation can never emit an
  aggregate once the guard has run. Route destinations are unaffected (they
  reference the base cluster name), and failover restores automatically on the
  next snapshot once endpoints arrive.
- **Known limitation (documented, follow-up):** peered failover members are not
  covered — their readiness depends on the resolved mesh-gateway mode, a
  different input than this function currently has, so covering them requires
  threading that mode through the RDS path. The gate's proxycfg predicate skips
  peered targets for the same reason.

### Supporting changes

- `agent/xds/bootstrap_gate.go` — per-stream gate state machine: first-push-only,
  skipped for resumed streams (`initial_resource_versions`), bounded by a 30s
  deadline.
- `agent/xds/delta.go` — wires the gate into the stream loop.
- `agent/xds/server.go` — `DefaultBootstrapGateTimeout = 30s`; metric registration.
- `agent/xds/clusters.go` / `endpoints.go` / `routes.go` — thread `uid` into
  `mapDiscoChainTargets`; guard against an aggregate with zero member clusters.

## Logging & Metrics

- **Degrade events log at Debug**, not Warn. The guard runs from CDS, EDS, and
  RDS generation on every coalesce cycle, so a Warn would storm during the exact
  cold-start window; the metric below is the operator-facing signal, and the
  Debug lines carry the detail (`upstream`, `cluster`, `unready_targets`).
- **Gate timeout release logs at Warn** — the one genuinely abnormal event — with
  the held duration and the blocking targets.
- Metrics (all registered in `xds.StatsCounters` / `xds.StatsSummaries` so they
  appear in Prometheus with help text):
  - `xds.server.apiGatewayFailoverDegraded` (counter) — guard engaged; a crash was
    averted and failover is temporarily degraded. Emitted once per render from the
    CDS path only (the shared render helper runs 3×).
  - `xds.server.bootstrapGateTimeout` (counter) — first push released on the deadline
    before endpoints were assembled.
  - `xds.server.bootstrapGateHeld` (summary) — how long the first push was held.

## Test Coverage

- `agent/proxycfg/api_gateway_bootstrap_gate_test.go` — the completeness predicate:
  orphan-chain exclusion, external/peered targets, mesh-gateway endpoint gating,
  and the exported accessor.
- `agent/proxycfg/api_gateway_test.go` — completeness under the coalesce race;
  `valid()` stays true while the predicate reports missing endpoints.
- `agent/xds/bootstrap_gate_test.go` — gate state machine: hold, open-on-complete,
  resumed-stream skip, timeout release, disabled path.
- `agent/xds/failover_policy_aggregate_guard_test.go` — guard behavior across
  all-ready / member-unready / none-ready, the api-gateway vs. connect-proxy
  scoping, the CDS/RDS consistency (`isAggregateCluster` tracks the decision), the
  `degraded` flag that drives the metric, and `TestDegradeToSingleTarget_DroppedPrimary`
  (the dropped-primary fallback, unit-tested since it isn't reachable through chain
  compilation).
- Full `agent/xds` and `agent/proxycfg` suites pass on CE and `-tags consulent`,
  with no golden-file changes.