### PR TITLE
perf(proxycfg): skip discovery chain watch reset when the chain is un…

### DIFF
--- a/.changelog/23894.txt
+++ b/.changelog/23894.txt
@@ -1,3 +1,9 @@
 ```release-note:improvement
-proxycfg: Skip tearing down and re-establishing an upstream's discovery chain target watches when a chain update delivers an unchanged chain. The discovery chain watch wakes on any config entry write in the cluster, so this previously cleared and re-fetched watched upstream endpoints far more often than necessary, briefly leaving clusters without their endpoint assignments.
+proxycfg: Skip tearing down and re-establishing an upstream's discovery chain
+target watches when a repeated chain update delivers no actual change. When a
+service is missing some discovery chain config entries (service-router,
+service-splitter, service-defaults, proxy-defaults), the chain watch can wake
+on unrelated config entry writes elsewhere in the cluster; this previously
+reset all of that upstream's target watches and cleared its cached endpoints
+on every such wakeup, regardless of write rate.
 ```

--- a/.changelog/23894.txt
+++ b/.changelog/23894.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+proxycfg: Skip tearing down and re-establishing an upstream's discovery chain target watches when a chain update delivers an unchanged chain. The discovery chain watch wakes on any config entry write in the cluster, so this previously cleared and re-fetched watched upstream endpoints far more often than necessary, briefly leaving clusters without their endpoint assignments.
+```

--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -97,10 +97,13 @@ func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u UpdateEv
 			return fmt.Errorf("discovery-chain watch fired for unsupported kind: %s", snap.Kind)
 		}
 
+		prevChain := upstreamsSnapshot.DiscoveryChain[uid]
 		upstreamsSnapshot.DiscoveryChain[uid] = resp.Chain
 
-		if err := s.resetWatchesFromChain(ctx, uid, resp.Chain, upstreamsSnapshot); err != nil {
-			return err
+		if s.needsWatchResetFromChain(prevChain, resp.Chain, upstreamsSnapshot.WatchedUpstreams[uid]) {
+			if err := s.resetWatchesFromChain(ctx, uid, resp.Chain, upstreamsSnapshot); err != nil {
+				return err
+			}
 		}
 		reconcilePeeringWatches(upstreamsSnapshot.DiscoveryChain, upstreamsSnapshot.UpstreamConfig, upstreamsSnapshot.PeeredUpstreams, upstreamsSnapshot.PeerUpstreamEndpoints, upstreamsSnapshot.UpstreamPeerTrustBundles)
 
@@ -261,6 +264,48 @@ func (s *handlerUpstreams) setPeerEndpoints(upstreamsSnapshot *ConfigSnapshotUps
 			delete(upstreamsSnapshot.PeerUpstreamEndpointsUseHostnames, uid)
 		}
 	}
+}
+
+// needsWatchResetFromChain reports whether the target watches for an upstream
+// must be torn down and re-established in response to a discovery chain update.
+//
+// The discovery chain watch is backed by a memdb index that spans the whole
+// config-entries table, and chain compilation reads several entry kinds that
+// commonly do not exist (router, splitter, defaults), which registers broad
+// radix-tree watches. As a result the watch wakes on essentially any
+// config-entry write in the cluster, and the majority of those wakeups deliver
+// a chain identical to the one already held. Unconditionally resetting on those
+// cancels and re-establishes every target watch and clears the upstream's
+// endpoints, which leaves clusters present without their endpoint assignments
+// until the health watches re-fire.
+//
+// Note that the spurious-wakeup suppression in ServerLocalBlockingQuery does not
+// filter these out, because the hash it compares is taken over a result struct
+// that embeds the query index.
+func (s *handlerUpstreams) needsWatchResetFromChain(
+	prevChain *structs.CompiledDiscoveryChain,
+	nextChain *structs.CompiledDiscoveryChain,
+	watchedUpstreams map[string]context.CancelFunc,
+) bool {
+	if prevChain == nil || nextChain == nil {
+		return true
+	}
+	if prevChain.GetHash() != nextChain.GetHash() {
+		return true
+	}
+
+	// The chain is unchanged, so the existing watches are still the correct set.
+	// Confirm they are all actually present before skipping: resetWatchesFromChain
+	// can fail partway through establishing them, and that error is logged and
+	// discarded by the caller, so a previous attempt may have left this upstream
+	// with an incomplete set of watches that would otherwise never be repaired.
+	for _, target := range nextChain.Targets {
+		if _, ok := watchedUpstreams[target.ID]; !ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (s *handlerUpstreams) resetWatchesFromChain(

--- a/agent/proxycfg/upstreams_test.go
+++ b/agent/proxycfg/upstreams_test.go
@@ -1,0 +1,157 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package proxycfg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/consul/discoverychain"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// TestHandleUpdateUpstreams_DiscoveryChainWatchReset asserts that target watches
+// are only torn down when the compiled discovery chain actually changed.
+//
+// The discovery chain watch wakes on any config-entry write in the cluster
+// because the backing memdb index spans the whole config-entries table, so most
+// wakeups redeliver an identical chain. Resetting on those cancels every target
+// watch and clears WatchedUpstreamEndpoints, which transiently leaves clusters
+// without their endpoint assignments.
+func TestHandleUpdateUpstreams_DiscoveryChainWatchReset(t *testing.T) {
+	const (
+		targetID  = "db.default.default.dc1"
+		chainName = "db"
+	)
+
+	compileChain := func(t *testing.T, entries ...structs.ConfigEntry) *structs.CompiledDiscoveryChain {
+		t.Helper()
+		return discoverychain.TestCompileConfigEntries(
+			t, chainName, "default", "default", "dc1", "trustdomain.consul", nil,
+			discoChainSetWithEntries(entries...),
+		)
+	}
+
+	// setup returns a handler and snapshot that have already processed an initial
+	// discovery chain update, so the upstream's target watches are established.
+	setup := func(t *testing.T) (*handlerUpstreams, *ConfigSnapshot, UpstreamID, *structs.CompiledDiscoveryChain) {
+		t.Helper()
+
+		upstream := &structs.Upstream{DestinationName: chainName}
+		uid := NewUpstreamID(upstream)
+
+		config := stateConfig{logger: hclog.NewNullLogger(), source: &structs.QuerySource{Datacenter: "dc1"}}
+		recordWatches(&config)
+
+		snap := &ConfigSnapshot{
+			Kind: structs.ServiceKindConnectProxy,
+			ConnectProxy: configSnapshotConnectProxy{
+				ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
+					UpstreamConfig:           map[UpstreamID]*structs.Upstream{uid: upstream},
+					DiscoveryChain:           make(map[UpstreamID]*structs.CompiledDiscoveryChain),
+					WatchedUpstreams:         make(map[UpstreamID]map[string]context.CancelFunc),
+					WatchedUpstreamEndpoints: make(map[UpstreamID]map[string]structs.CheckServiceNodes),
+					WatchedGateways:          make(map[UpstreamID]map[string]context.CancelFunc),
+					WatchedGatewayEndpoints:  make(map[UpstreamID]map[string]structs.CheckServiceNodes),
+					// Make the upstream implicit so the chain update is not
+					// discarded as belonging to an unknown upstream.
+					IntentionUpstreams: map[UpstreamID]struct{}{uid: {}},
+				},
+			},
+		}
+
+		handler := &handlerUpstreams{handlerState: handlerState{
+			stateConfig: config,
+			serviceInstance: serviceInstance{
+				kind:     structs.ServiceKindConnectProxy,
+				proxyCfg: structs.ConnectProxyConfig{Mode: structs.ProxyModeDefault},
+			},
+			ch: make(chan UpdateEvent, 10),
+		}}
+
+		chain := compileChain(t)
+		require.NoError(t, handler.handleUpdateUpstreams(context.Background(), UpdateEvent{
+			CorrelationID: "discovery-chain:" + uid.String(),
+			Result:        &structs.DiscoveryChainResponse{Chain: chain},
+		}, snap))
+
+		require.Contains(t, snap.ConnectProxy.WatchedUpstreams[uid], targetID,
+			"initial update should establish the target watch")
+
+		return handler, snap, uid, chain
+	}
+
+	// armResetDetector replaces the stored cancel funcs with sentinels and seeds
+	// endpoint data, so a subsequent reset is directly observable.
+	armResetDetector := func(snap *ConfigSnapshot, uid UpstreamID) *bool {
+		reset := false
+		for id := range snap.ConnectProxy.WatchedUpstreams[uid] {
+			snap.ConnectProxy.WatchedUpstreams[uid][id] = func() { reset = true }
+		}
+		snap.ConnectProxy.WatchedUpstreamEndpoints[uid] = map[string]structs.CheckServiceNodes{
+			targetID: {},
+		}
+		return &reset
+	}
+
+	sendChain := func(t *testing.T, handler *handlerUpstreams, snap *ConfigSnapshot, uid UpstreamID, chain *structs.CompiledDiscoveryChain) {
+		t.Helper()
+		require.NoError(t, handler.handleUpdateUpstreams(context.Background(), UpdateEvent{
+			CorrelationID: "discovery-chain:" + uid.String(),
+			Result:        &structs.DiscoveryChainResponse{Chain: chain},
+		}, snap))
+	}
+
+	t.Run("unchanged chain does not reset watches", func(t *testing.T) {
+		handler, snap, uid, chain := setup(t)
+		reset := armResetDetector(snap, uid)
+
+		// Recompile the same config entries: a distinct object with identical
+		// content, which is what a spurious wakeup delivers.
+		sendChain(t, handler, snap, uid, compileChain(t))
+
+		require.False(t, *reset, "identical chain must not cancel target watches")
+		require.Contains(t, snap.ConnectProxy.WatchedUpstreamEndpoints[uid], targetID,
+			"identical chain must not clear watched endpoints")
+		require.Equal(t, chain.GetHash(), snap.ConnectProxy.DiscoveryChain[uid].GetHash())
+	})
+
+	t.Run("changed chain resets watches", func(t *testing.T) {
+		handler, snap, uid, _ := setup(t)
+		reset := armResetDetector(snap, uid)
+
+		changed := compileChain(t, &structs.ServiceResolverConfigEntry{
+			Kind:           structs.ServiceResolver,
+			Name:           chainName,
+			ConnectTimeout: 1234,
+		})
+		sendChain(t, handler, snap, uid, changed)
+
+		require.True(t, *reset, "changed chain must cancel existing target watches")
+		require.Equal(t, changed.GetHash(), snap.ConnectProxy.DiscoveryChain[uid].GetHash())
+	})
+
+	t.Run("unchanged chain repairs a missing watch", func(t *testing.T) {
+		handler, snap, uid, _ := setup(t)
+		armResetDetector(snap, uid)
+
+		// resetWatchesFromChain can fail partway through and the error is
+		// discarded by the caller, so an unchanged chain must still repair an
+		// incomplete watch set rather than skipping indefinitely.
+		delete(snap.ConnectProxy.WatchedUpstreams[uid], targetID)
+
+		sendChain(t, handler, snap, uid, compileChain(t))
+
+		require.Contains(t, snap.ConnectProxy.WatchedUpstreams[uid], targetID,
+			"missing watch must be re-established even when the chain is unchanged")
+	})
+
+	t.Run("first chain establishes watches", func(t *testing.T) {
+		_, snap, uid, _ := setup(t)
+		require.Contains(t, snap.ConnectProxy.WatchedUpstreams[uid], targetID)
+	})
+}


### PR DESCRIPTION
## Description

The compiled discovery chain watch can wake on config entry writes that are unrelated to the chain being watched, for services whose chain is missing one or more of the config entry kinds it reads (service-router, service-splitter, service-defaults, proxy-defaults). Every such wakeup ran `resetWatchesFromChain`, which cancels all of an upstream's target watches and deletes its `WatchedUpstreamEndpoints` entries before re-establishing them — even though the delivered chain was identical to the one already held.

This is redundant work: watch cancellation, goroutine spawn, ACL resolution and a fresh endpoint query per target, repeated on every spurious wakeup. The cost scales with config-entry write rate, so it is negligible in a quiescent cluster and becomes significant under sustained config churn (bulk apply, CI/CD pipelines, a controller reconciling many resources).

There is a secondary correctness angle: between the teardown and the health watches repopulating endpoints, the snapshot briefly holds a chain with no endpoints. In practice this window is usually absorbed by proxycfg's 200ms snapshot coalescing timer (`coalesceTimeout`) before anything is delivered downstream, since the endpoint refill is a local, non-blocking memdb query. It only becomes observable if that refill is slow enough to miss the coalescing window — for example under heavy server load, slow ACL resolution, or peered/cross-DC targets. This PR is primarily a watch-churn efficiency fix; treat the coherence improvement as a secondary, load-dependent benefit rather than the main justification.

## Cause

Three things combine to produce the spurious wakeup, and a fourth explains why it isn't caught by existing suppression.

**1. The watch index is table-wide.** `configEntryTxn` derives its index from `maxIndexTxn(tx, tableConfigEntries)`. Any config entry write — any kind, any service, any namespace — advances this index.

**2. Missing entries register broad watches.** Chain compilation reads service-router, service-splitter, service-defaults and proxy-defaults for the service. When one of these does not exist, the memdb `FirstWatch` for it returns a channel over a radix subtree rather than a specific key, and that channel fires on writes to sibling keys in the same subtree.

Verified directly against the state store — same chain, only the config entries present differ:

| Chain's config entries | Unrelated write wakes the watch? |
|---|---|
| Resolver only (router/splitter/defaults missing) | **Yes** |
| All four entry kinds present | **No** |
| No entries at all (fully default chain) | **Yes** |

So this is not universal: a service with a complete, explicit set of config entries is unaffected. It is the common case for partially-configured services (e.g. only a `service-resolver` for failover, or a fully defaulted chain with no entries at all), which is typical for many real chains.

**3. The affected data source is server-local, not the client-agent RPC path.** Client agents fetch chains via `DiscoveryChain.Get`, which already deduplicates using `chain.GetHash()` (#12362). Dataplane/API-gateway proxycfg running inside a server process (`server != nil` in `agent.go`) instead uses `ServerCompiledDiscoveryChain`, a separate server-local data source added roughly five months after that RPC-side fix, which does not carry the same dedup logic.

**4. The generic suppression that does exist can't help here.** `ServerLocalNotify` passes `suppressSpuriousWakeup = true`, but `ServerLocalBlockingQuery` hashes the *entire* result struct, and this data source embeds the query index inside that struct:

```go
rsp := &structs.DiscoveryChainResponse{
    Chain:     chain,
    QueryMeta: structs.QueryMeta{Index: index},  // part of the hashed value
}
```

The hash is only consulted after a wakeup, and a wakeup only happens when the index has moved, so `priorHash == newHash` is unreachable in practice — confirmed directly:

```
index100=5766836599256476925  index101=11858792734613954199  equal=false
chainHashEqual=true
```

Same chain, different index → different hash. The suppression exists in code but cannot fire for this data source.

## Fix

Compare the compiled chain against the one already stored and reset target watches only when it actually changed — the optimization anticipated by the existing `TODO(rb): content hash based add/remove`.

`needsWatchResetFromChain` returns true when:

1. either chain is nil (first delivery, or preserving the existing nil-chain error path), or
2. `prevChain.GetHash() != nextChain.GetHash()`, or
3. the chain is unchanged but some `chain.Targets` entry has no live watch.

Condition 3 is load-bearing, not defensive padding. `resetWatchesFromChain` can fail partway through establishing watches, and `state.go` logs that error and `continue`s, discarding it. A hash-only comparison would then skip the reset forever and never repair the resulting incomplete watch set.

`GetHash()` covers `c.Targets`, so an equal hash implies an identical target set, which is what makes it safe to conclude the existing watches are still correct and can be left alone.

## Validation

**Spurious wakeup reproduced against a real state store**, with only a `service-resolver` present (router/splitter/defaults absent) — the common partially-configured case:

```
initial idx=2 hash=3409361584718896957
watchset fired on unrelated write: true
re-query: idx 2 -> 3 (advanced=true), chainHashSame=true
```

**Precondition isolated** by repeating the same probe with all four entry kinds present for the service: the unrelated write does *not* fire the watch. This confirms the spurious wakeup is conditional on missing config entries, not a property of every chain.

**Falsification of the new test.** Reverting the call site to the original unconditional reset fails exactly one subtest:

```
--- FAIL: .../unchanged_chain_does_not_reset_watches
        identical chain must not cancel target watches
```

The other three still pass, since they are satisfied by always resetting — confirming the test isolates this specific change and nothing else.

**Suites:**
- `go test ./agent/proxycfg/...` — pass
- `go test ./agent/xds/...` — pass (primary consumer of the snapshot)
- `gofmt` / `go vet` — clean

## Testing

New `TestHandleUpdateUpstreams_DiscoveryChainWatchReset` in `agent/proxycfg/upstreams_test.go`, exercising the real `handleUpdateUpstreams` entry point rather than calling the helper directly:

| Case | Asserts |
|---|---|
| `unchanged chain does not reset watches` | no watch cancelled, endpoints retained |
| `changed chain resets watches` | watches torn down and rebuilt |
| `unchanged chain repairs a missing watch` | incomplete watch set is repaired |
| `first chain establishes watches` | initial delivery still sets up watches |

Two details worth noting for review:
- Resets are detected by replacing the stored cancel funcs with sentinels that set a flag, so a teardown is observed directly rather than inferred from side effects.
- The unchanged case recompiles the same config entries into a *distinct* object with identical content, which is exactly what a spurious wakeup delivers — comparing pointers would not have caught the bug.

Run with:
```
go test ./agent/proxycfg/ -run TestHandleUpdateUpstreams_DiscoveryChainWatchReset -v
```

## Risk

Low, and scoped to a single call site in `handleUpdateUpstreams`. Behaviour is byte-for-byte unchanged whenever the chain changed, on first delivery, or when any target watch is missing — the only behaviour removed is redundant work on an identical chain with a complete watch set.

The plausible failure mode would be skipping a reset that was actually needed, which requires `GetHash()` to under-report a material change. It covers `c.Targets`, and condition 3 backstops the partial-failure case.

No config, API, or wire-format change. No golden files affected.

## Expected impact

This is a watch-churn efficiency fix, scaled by config-entry write rate and by how many watched chains are missing one or more config entry kinds. It is expected to be unmeasurable in a quiescent cluster and meaningful only under sustained config churn (bulk applies, CI/CD-driven config writes, a controller reconciling many resources). It is not a fix for cold-start scenarios where a chain is genuinely new and its endpoints are genuinely not yet assembled — that state is unaffected by this change.

Recommend validating impact in a real environment before treating this as a significant capacity win: compare `grep -c "resetting watches for discovery chain"` in Trace-level server logs against the actual discovery-chain config-entry write rate over the same window. If resets track config changes closely, the benefit here is small; if resets substantially outnumber config changes, this removes that gap.
