### PR TITLE
security: reject non-default PeerName in Catalog.Deregister

### DIFF
--- a/.changelog/23897.txt
+++ b/.changelog/23897.txt
@@ -1,0 +1,11 @@
+```release-note:security
+catalog: Fixed an incorrect authorization vulnerability where a local
+ACL token with `service:write` or `node:write` could delete peer-imported catalog
+objects by supplying a non-default `PeerName` in a `Catalog.Deregister` request.
+Authorization was checked only against the local service or node name, not the peer
+origin, allowing deletion of objects in a peer-scoped catalog namespace the caller
+does not control. `Catalog.Deregister` now rejects any request whose `PeerName` is
+not the default, mirroring the existing guard on `Catalog.Register` and
+`Catalog.ListServices`. Legitimate peer-state deletion continues through the internal
+`PeeringBackend.CatalogDeregister` path.
+```

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -426,6 +426,10 @@ func vetRegisterWithACL(
 // If a ServiceID or CheckID is not provided in the request, the entire
 // node is deregistered.
 func (c *Catalog) Deregister(args *structs.DeregisterRequest, reply *struct{}) error {
+	if args.PeerName != structs.DefaultPeerKeyword {
+		return errors.New("deregistering peer-imported catalog objects is not supported")
+	}
+
 	if done, err := c.srv.ForwardRPC("Catalog.Deregister", args, reply); done {
 		return err
 	}

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -598,6 +598,56 @@ func TestCatalog_Deregister(t *testing.T) {
 	}
 }
 
+// TestCatalog_Deregister_PeerName verifies that Catalog.Deregister rejects any
+// request that carries a non-default PeerName, preventing a local token from
+// deleting peer-imported catalog objects.
+func TestCatalog_Deregister_PeerName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	tests := map[string]struct {
+		peerName string
+		wantErr  string
+	}{
+		"non-empty peer name rejected": {
+			peerName: "peer1",
+			wantErr:  "deregistering peer-imported catalog objects is not supported",
+		},
+		"default peer name allowed": {
+			peerName: structs.DefaultPeerKeyword,
+			wantErr:  "",
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			arg := structs.DeregisterRequest{
+				Datacenter: "dc1",
+				Node:       "foo",
+				PeerName:   tc.peerName,
+			}
+			var out struct{}
+			err := msgpackrpc.CallWithCodec(codec, "Catalog.Deregister", &arg, &out)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestCatalog_Deregister_ACLDeny(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")


### PR DESCRIPTION
## Summary

A local ACL token with `service:write` or `node:write` could delete peer-imported catalog objects by supplying a non-default `PeerName` in a `Catalog.Deregister` request. Authorization was checked only against the local object name, not the peer origin, allowing the caller to target a different catalog namespace than the one they are authorized for.

Mirrors the guard already present on `Catalog.Register` and `Catalog.ListServices`: reject any request where `PeerName` is not the default (empty string). Legitimate peer-state deletion continues through the internal `PeeringBackend.CatalogDeregister` path.
