### PR TITLE
security: bound RPC header size to prevent pre-auth memory exhaustion

### DIFF
--- a/.changelog/23898.txt
+++ b/.changelog/23898.txt
@@ -1,0 +1,20 @@
+```release-note:security
+agent: Fixed a pre-authorization memory exhaustion vulnerability where
+an mTLS-authenticated RPC client with no ACL token could terminate a Consul server by
+sending a MessagePack request header with a large declared length. The MessagePack
+decoder allocated a byte slice of the declared size before method lookup, ACL token
+validation, or the rate-limiting interceptor could run, allowing a single oversized
+header to OOM-kill the server process.
+
+Two mitigations are applied:
+
+1. Each RPC request header is now validated against RPCMaxHeaderBytes (default 512
+   bytes) before it is decoded. Every length prefix in the header is checked against
+   the limit, so an oversized value is rejected before the decoder allocates memory
+   for it, and the connection is closed before any ACL evaluation. Request bodies
+   remain unbounded by this limit.
+
+2. A per-request read deadline (reusing RPCHandshakeTimeout) is applied inside
+   handleConsulConn and handleInsecureConn so that a slow attacker trickling an
+   oversized header cannot retain a goroutine and logical heap indefinitely.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1544,6 +1544,9 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	if runtimeCfg.RPCMaxConnsPerClient > 0 {
 		cfg.RPCMaxConnsPerClient = runtimeCfg.RPCMaxConnsPerClient
 	}
+	if runtimeCfg.RPCMaxHeaderBytes > 0 {
+		cfg.RPCMaxHeaderBytes = runtimeCfg.RPCMaxHeaderBytes
+	}
 
 	// RPC-related performance configs. We allow explicit zero value to disable so
 	// copy it whatever the value.
@@ -4396,6 +4399,7 @@ func (a *Agent) reloadConfigInternal(newCfg *config.RuntimeConfig) error {
 		RPCRateLimit:          newCfg.RPCRateLimit,
 		RPCMaxBurst:           newCfg.RPCMaxBurst,
 		RPCMaxConnsPerClient:  newCfg.RPCMaxConnsPerClient,
+		RPCMaxHeaderBytes:     newCfg.RPCMaxHeaderBytes,
 		ConfigEntryBootstrap:  newCfg.ConfigEntryBootstrap,
 		RaftSnapshotThreshold: newCfg.RaftSnapshotThreshold,
 		RaftSnapshotInterval:  newCfg.RaftSnapshotInterval,

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1145,6 +1145,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		RPCClientTimeout:                  b.durationVal("limits.rpc_client_timeout", c.Limits.RPCClientTimeout),
 		RPCMaxBurst:                       intVal(c.Limits.RPCMaxBurst),
 		RPCMaxConnsPerClient:              intVal(c.Limits.RPCMaxConnsPerClient),
+		RPCMaxHeaderBytes:                 intVal(c.Limits.RPCMaxHeaderBytes),
 		RPCProtocol:                       intVal(c.RPCProtocol),
 		RPCRateLimit:                      limitVal(c.Limits.RPCRate),
 		RPCConfig:                         consul.RPCConfig{EnableStreaming: boolValWithDefault(c.RPC.EnableStreaming, serverMode)},

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -847,6 +847,7 @@ type Limits struct {
 	RPCHandshakeTimeout   *string       `mapstructure:"rpc_handshake_timeout"`
 	RPCMaxBurst           *int          `mapstructure:"rpc_max_burst"`
 	RPCMaxConnsPerClient  *int          `mapstructure:"rpc_max_conns_per_client"`
+	RPCMaxHeaderBytes     *int          `mapstructure:"rpc_max_header_bytes"`
 	RPCRate               *float64      `mapstructure:"rpc_rate"`
 	KVMaxValueSize        *uint64       `mapstructure:"kv_max_value_size"`
 	TxnMaxReqLen          *uint64       `mapstructure:"txn_max_req_len"`

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -112,6 +112,7 @@ func DefaultSource() Source {
 			rpc_rate = -1
 			rpc_max_burst = 1000
 			rpc_max_conns_per_client = 100
+			rpc_max_header_bytes = 512
 			kv_max_value_size = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
 			txn_max_req_len = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
 		}

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1027,6 +1027,17 @@ type RuntimeConfig struct {
 	// hcl: limits { rpc_max_conns_per_client = 100 }
 	RPCMaxConnsPerClient int
 
+	// RPCMaxHeaderBytes limits the encoded size of a single RPC request header
+	// (ServiceMethod + Seq). A request header exceeding this limit is rejected
+	// and the connection is closed before method lookup, rate limiting, or ACL
+	// evaluation. This bounds pre-authorization memory allocation in the
+	// MessagePack decoder, which would otherwise honour an attacker-controlled
+	// str32 length before any authorization runs. A non-positive value falls
+	// back to a built-in default (512 bytes).
+	//
+	// hcl: limits { rpc_max_header_bytes = 512 }
+	RPCMaxHeaderBytes int
+
 	// RPCProtocol is the Consul protocol version to use.
 	//
 	// hcl: protocol = int

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4770,6 +4770,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.HTTPMaxConnsPerClient = 200
 			rt.GRPCMaxConnsPerClient = 100
 			rt.RPCMaxConnsPerClient = 100
+			rt.RPCMaxHeaderBytes = 512
 			rt.RequestLimitsMode = consulrate.ModeDisabled
 			rt.RequestLimitsReadRate = rate.Inf
 			rt.RequestLimitsWriteRate = rate.Inf
@@ -6716,6 +6717,7 @@ func TestLoad_FullConfig(t *testing.T) {
 		RPCRateLimit:            12029.43,
 		RPCMaxBurst:             44848,
 		RPCMaxConnsPerClient:    2954,
+		RPCMaxHeaderBytes:       8192,
 		RaftProtocol:            3,
 		RaftSnapshotThreshold:   16384,
 		RaftSnapshotInterval:    30 * time.Second,

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -279,6 +279,7 @@
     "RPCHoldTimeout": "0s",
     "RPCMaxBurst": 0,
     "RPCMaxConnsPerClient": 0,
+    "RPCMaxHeaderBytes": 0,
     "RPCProtocol": 0,
     "RPCRateLimit": 0,
     "RaftLogStoreConfig": {

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -311,6 +311,7 @@ limits {
     rpc_rate = 12029.43
     rpc_max_burst = 44848
     rpc_max_conns_per_client = 2954
+    rpc_max_header_bytes = 8192
     kv_max_value_size = 1234567800
     txn_max_req_len = 567800000
     request_limits {

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -360,6 +360,7 @@
     "rpc_rate": 12029.43,
     "rpc_max_burst": 44848,
     "rpc_max_conns_per_client": 2954,
+    "rpc_max_header_bytes": 8192,
     "kv_max_value_size": 1234567800,
     "txn_max_req_len": 567800000,
     "request_limits": {

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -385,6 +385,15 @@ type Config struct {
 	// allowed from a single source IP.
 	RPCMaxConnsPerClient int
 
+	// RPCMaxHeaderBytes is the maximum number of bytes the server will read from
+	// a single RPC request header (ServiceMethod + Seq). A request header that
+	// exceeds this limit is rejected and the connection is closed. This bounds
+	// pre-authorization memory allocation in the MessagePack decoder which would
+	// otherwise honour attacker-controlled str32 lengths before ACL checks run.
+	// Valid ServiceMethod strings are short ("Service.Method"); 512 bytes is
+	// already extremely generous.
+	RPCMaxHeaderBytes int
+
 	// LeaveDrainTime is used to wait after a server has left the LAN Serf
 	// pool for RPCs to drain and new requests to be sent to other servers.
 	LeaveDrainTime time.Duration
@@ -596,8 +605,9 @@ func DefaultConfig() *Config {
 		RequestLimitsReadRate:  rate.Inf, // ops / sec
 		RequestLimitsWriteRate: rate.Inf, // ops / sec
 
-		RPCRateLimit: rate.Inf,
-		RPCMaxBurst:  1000,
+		RPCRateLimit:      rate.Inf,
+		RPCMaxBurst:       1000,
+		RPCMaxHeaderBytes: 512,
 
 		// TODO (slackpad) - Until #3744 is done, we need to keep these
 		// in sync with agent/config/default.go.
@@ -738,6 +748,7 @@ type ReloadableConfig struct {
 	RPCRateLimit          rate.Limit
 	RPCMaxBurst           int
 	RPCMaxConnsPerClient  int
+	RPCMaxHeaderBytes     int
 	ConfigEntryBootstrap  []structs.ConfigEntry
 	RaftSnapshotThreshold int
 	RaftSnapshotInterval  time.Duration

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -26,8 +26,6 @@ import (
 	"github.com/hashicorp/yamux"
 	"google.golang.org/grpc"
 
-	msgpackrpc "github.com/hashicorp/consul-net-rpc/net-rpc-msgpackrpc"
-
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/blockingquery"
 	"github.com/hashicorp/consul/agent/consul/rate"
@@ -425,7 +423,9 @@ func (s *Server) handleMultiplexV2(conn net.Conn) {
 // handleConsulConn is used to service a single Consul RPC connection
 func (s *Server) handleConsulConn(conn net.Conn) {
 	defer conn.Close()
-	rpcCodec := msgpackrpc.NewCodecFromHandle(true, true, conn, structs.MsgpackHandle)
+
+	rpcCodec := newBoundedHeaderCodec(conn, structs.MsgpackHandle, int(s.rpcMaxHeaderBytes.Load()))
+
 	for {
 		select {
 		case <-s.shutdownCh:
@@ -433,7 +433,24 @@ func (s *Server) handleConsulConn(conn net.Conn) {
 		default:
 		}
 
-		if err := s.rpcServer.ServeRequest(rpcCodec); err != nil {
+		// Apply a per-request read deadline so that a slow attacker
+		// trickling an oversized header cannot hold a goroutine and
+		// retain logical heap indefinitely. We reuse RPCHandshakeTimeout
+		// as a reasonable bound; if it is not set we skip the deadline.
+		if s.config.RPCHandshakeTimeout > 0 {
+			conn.SetReadDeadline(time.Now().Add(s.config.RPCHandshakeTimeout))
+		}
+
+		err := s.rpcServer.ServeRequest(rpcCodec)
+
+		// Clear the deadline regardless of outcome so long-running
+		// blocking queries (which are handled further up the stack) are
+		// not cut off.
+		if s.config.RPCHandshakeTimeout > 0 {
+			conn.SetReadDeadline(time.Time{})
+		}
+
+		if err != nil {
 			//EOF or closed are not considered as errors.
 			if err == io.EOF || strings.Contains(err.Error(), "closed") {
 				return
@@ -458,7 +475,9 @@ func (s *Server) handleConsulConn(conn net.Conn) {
 // handleInsecureConsulConn is used to service a single Consul INSECURERPC connection
 func (s *Server) handleInsecureConn(conn net.Conn) {
 	defer conn.Close()
-	rpcCodec := msgpackrpc.NewCodecFromHandle(true, true, conn, structs.MsgpackHandle)
+
+	rpcCodec := newBoundedHeaderCodec(conn, structs.MsgpackHandle, int(s.rpcMaxHeaderBytes.Load()))
+
 	for {
 		select {
 		case <-s.shutdownCh:
@@ -466,7 +485,17 @@ func (s *Server) handleInsecureConn(conn net.Conn) {
 		default:
 		}
 
-		if err := s.insecureRPCServer.ServeRequest(rpcCodec); err != nil {
+		if s.config.RPCHandshakeTimeout > 0 {
+			conn.SetReadDeadline(time.Now().Add(s.config.RPCHandshakeTimeout))
+		}
+
+		err := s.insecureRPCServer.ServeRequest(rpcCodec)
+
+		if s.config.RPCHandshakeTimeout > 0 {
+			conn.SetReadDeadline(time.Time{})
+		}
+
+		if err != nil {
 			if err != io.EOF && !strings.Contains(err.Error(), "closed") {
 				s.rpcLogger().Error("INSECURERPC error",
 					"conn", logConn(conn),

--- a/agent/consul/rpc_header_limit.go
+++ b/agent/consul/rpc_header_limit.go
@@ -1,0 +1,420 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package consul
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"net"
+	"sync"
+
+	"github.com/hashicorp/consul-net-rpc/go-msgpack/codec"
+	netRPC "github.com/hashicorp/consul-net-rpc/net/rpc"
+)
+
+// rpcMaxHeaderBytes is used when RPCMaxHeaderBytes is not configured. It bounds
+// the encoded size of a single RPC request header (ServiceMethod + Seq) as well
+// as any length prefix contained within it. A valid ServiceMethod is far below
+// this; 512 bytes is already extremely generous.
+const rpcMaxHeaderBytes = 512
+
+// maxHeaderScanDepth bounds nesting while validating a request header. A well
+// formed header is a flat map, so this is only a guard against pathological or
+// malicious nesting.
+const maxHeaderScanDepth = 32
+
+// defaultBufioReaderSize matches bufio.NewReader's default buffer size. The
+// header read buffer is never sized below this.
+const defaultBufioReaderSize = 4096
+
+// errHeaderTooLarge is returned when an RPC request header declares a length
+// prefix (or an overall size) larger than the configured maximum. It is
+// returned before the MessagePack decoder allocates memory for the value, which
+// is what prevents the pre-authorization memory-exhaustion vector: a crafted
+// str32/bin32/array32/map32 length no longer drives a large allocation.
+var errHeaderTooLarge = errors.New("rpc: request header exceeds maximum allowed size")
+
+// boundedHeaderCodec is a net/rpc ServerCodec that bounds the size of each
+// request header before it is decoded, then decodes the body without any size
+// restriction (legitimate request bodies may be large).
+//
+// The MessagePack decoder allocates a byte slice of the declared length before
+// reading the value from the connection (see go-msgpack ioDecReader.readn:
+// make([]byte, n) precedes the read). An io.LimitedReader cannot prevent this,
+// because the allocation happens before any read is attempted. Instead, this
+// codec validates every length prefix in the request header against
+// maxHeaderBytes *before* handing the header bytes to the decoder. If any
+// prefix (or the header as a whole) exceeds the cap, the header is rejected and
+// the connection is closed before method lookup, rate limiting, or ACL
+// evaluation runs.
+//
+// Header and body are read through a single bufio.Reader so no bytes are lost
+// between the validation peek and the decode.
+type boundedHeaderCodec struct {
+	conn           net.Conn
+	br             *bufio.Reader
+	dec            *codec.Decoder
+	enc            *codec.Encoder
+	bufW           *bufio.Writer
+	maxHeaderBytes int
+
+	writeLock sync.Mutex
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// newBoundedHeaderCodec builds a ServerCodec for conn that enforces a per
+// request header byte cap. A non-positive maxHeaderBytes falls back to
+// rpcMaxHeaderBytes.
+func newBoundedHeaderCodec(conn net.Conn, h *codec.MsgpackHandle, maxHeaderBytes int) *boundedHeaderCodec {
+	if maxHeaderBytes <= 0 {
+		maxHeaderBytes = rpcMaxHeaderBytes
+	}
+	// The header validator may Peek up to maxHeaderBytes bytes, so the read
+	// buffer must be at least that large or bufio would return ErrBufferFull
+	// for a validly-sized header. Never shrink below bufio's default.
+	readBufSize := maxHeaderBytes + 1
+	if readBufSize < defaultBufioReaderSize {
+		readBufSize = defaultBufioReaderSize
+	}
+	br := bufio.NewReaderSize(conn, readBufSize)
+	bufW := bufio.NewWriter(conn)
+	return &boundedHeaderCodec{
+		conn:           conn,
+		br:             br,
+		dec:            codec.NewDecoder(br, h),
+		enc:            codec.NewEncoder(bufW, h),
+		bufW:           bufW,
+		maxHeaderBytes: maxHeaderBytes,
+	}
+}
+
+// ReadRequestHeader validates that the incoming request header fits within the
+// configured byte cap before decoding it. Validation only inspects length
+// prefixes; the trusted decoder then performs the actual decode, now guaranteed
+// not to allocate more than maxHeaderBytes for the header.
+func (c *boundedHeaderCodec) ReadRequestHeader(r *netRPC.Request) error {
+	if err := c.validateHeaderSize(); err != nil {
+		return err
+	}
+	return c.dec.Decode(r)
+}
+
+// validateHeaderSize peeks (without consuming) at the buffered header bytes and
+// walks the MessagePack structure, rejecting any length prefix or overall size
+// beyond maxHeaderBytes. It only ever requests up to maxHeaderBytes bytes, so a
+// slow or oversized header cannot force it to buffer without bound.
+func (c *boundedHeaderCodec) validateHeaderSize() error {
+	need := 1
+	for {
+		if need > c.maxHeaderBytes {
+			return errHeaderTooLarge
+		}
+		buf, err := c.br.Peek(need)
+		if len(buf) < need {
+			// bufio.Peek returns fewer bytes than requested only together
+			// with an error (EOF, unexpected EOF, timeout, or a closed
+			// connection). Surface it so the server closes the connection.
+			if err != nil {
+				return err
+			}
+			return errHeaderTooLarge
+		}
+		consumed, status := scanMsgpackValue(buf, c.maxHeaderBytes, 0)
+		switch status {
+		case scanDone:
+			return nil
+		case scanNeedMore:
+			// The scanner must always ask for strictly more bytes than we
+			// already have, otherwise the loop could stall. Treat any
+			// non-progress as a malformed/oversized header.
+			if consumed <= need {
+				return errHeaderTooLarge
+			}
+			need = consumed
+		default: // scanTooLarge / malformed
+			return errHeaderTooLarge
+		}
+	}
+}
+
+// ReadRequestBody decodes the request body. Bodies are intentionally not size
+// bounded here: they are decoded only after method lookup and the request rate
+// limiter have run, and legitimate requests may carry large bodies.
+func (c *boundedHeaderCodec) ReadRequestBody(body interface{}) error {
+	if body == nil {
+		// net/rpc asks us to discard the body (e.g. unknown method).
+		var throwaway interface{}
+		return c.dec.Decode(&throwaway)
+	}
+	return c.dec.Decode(body)
+}
+
+// WriteResponse encodes the response header and body back to the client.
+func (c *boundedHeaderCodec) WriteResponse(r *netRPC.Response, body interface{}) error {
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+	if err := c.enc.Encode(r); err != nil {
+		return err
+	}
+	if err := c.enc.Encode(body); err != nil {
+		return err
+	}
+	return c.bufW.Flush()
+}
+
+// SourceAddr returns the client's remote address, used by the request rate
+// limiter.
+func (c *boundedHeaderCodec) SourceAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
+// Close is idempotent, as required by the ServerCodec contract.
+func (c *boundedHeaderCodec) Close() error {
+	c.closeOnce.Do(func() {
+		c.closeErr = c.conn.Close()
+	})
+	return c.closeErr
+}
+
+// scanStatus reports the outcome of scanning a single MessagePack value.
+type scanStatus int
+
+const (
+	// scanDone means a complete value was validated within the provided bytes.
+	scanDone scanStatus = iota
+	// scanNeedMore means more bytes are required; the returned count is the
+	// total number of bytes that must be available to make progress and is
+	// always <= max.
+	scanNeedMore
+	// scanTooLarge means a length prefix or the overall size exceeds max, or
+	// the input is malformed. In every case the header must be rejected.
+	scanTooLarge
+)
+
+// scanMsgpackValue validates a single MessagePack value at the start of buf
+// without allocating memory for its contents. It enforces that no declared
+// length (string, binary, array, map, or extension) and no cumulative offset
+// exceeds max. This runs before the real decoder, so an oversized length prefix
+// is rejected before make([]byte, n) can be reached.
+//
+// On success it returns the number of bytes the value occupies and scanDone. If
+// buf is too short it returns the number of bytes needed (<= max) and
+// scanNeedMore. If the value is oversized or malformed it returns scanTooLarge.
+func scanMsgpackValue(buf []byte, max, depth int) (int, scanStatus) {
+	if depth > maxHeaderScanDepth {
+		return 0, scanTooLarge
+	}
+	if max < 1 {
+		// No budget remaining: any value needs at least one byte.
+		return 0, scanTooLarge
+	}
+	if len(buf) < 1 {
+		return 1, scanNeedMore
+	}
+	b := buf[0]
+
+	switch {
+	case b <= 0x7f, b >= 0xe0:
+		// positive or negative fixint
+		return 1, scanDone
+	case b >= 0x80 && b <= 0x8f:
+		// fixmap
+		return scanMap(buf, 1, int(b&0x0f), max, depth)
+	case b >= 0x90 && b <= 0x9f:
+		// fixarray
+		return scanArray(buf, 1, int(b&0x0f), max, depth)
+	case b >= 0xa0 && b <= 0xbf:
+		// fixstr
+		return scanRaw(buf, 1, int(b&0x1f), max)
+	}
+
+	switch b {
+	case 0xc0, 0xc2, 0xc3:
+		// nil, false, true
+		return 1, scanDone
+	case 0xcc, 0xd0:
+		return scanFixed(buf, 1+1, max) // uint8 / int8
+	case 0xcd, 0xd1:
+		return scanFixed(buf, 1+2, max) // uint16 / int16
+	case 0xce, 0xd2, 0xca:
+		return scanFixed(buf, 1+4, max) // uint32 / int32 / float32
+	case 0xcf, 0xd3, 0xcb:
+		return scanFixed(buf, 1+8, max) // uint64 / int64 / float64
+	case 0xd9, 0xc4:
+		return scanLenPrefixed(buf, 1, 1, max) // str8 / bin8
+	case 0xda, 0xc5:
+		return scanLenPrefixed(buf, 1, 2, max) // str16 / bin16
+	case 0xdb, 0xc6:
+		return scanLenPrefixed(buf, 1, 4, max) // str32 / bin32
+	case 0xdc:
+		return scanArrayHeader(buf, 1, 2, max, depth) // array16
+	case 0xdd:
+		return scanArrayHeader(buf, 1, 4, max, depth) // array32
+	case 0xde:
+		return scanMapHeader(buf, 1, 2, max, depth) // map16
+	case 0xdf:
+		return scanMapHeader(buf, 1, 4, max, depth) // map32
+	case 0xd4, 0xd5, 0xd6, 0xd7, 0xd8:
+		// fixext1/2/4/8/16: 1 type byte + 2^(b-0xd4) data bytes.
+		return scanFixed(buf, 1+1+(1<<(b-0xd4)), max)
+	case 0xc7:
+		return scanExt(buf, 1, max) // ext8
+	case 0xc8:
+		return scanExt(buf, 2, max) // ext16
+	case 0xc9:
+		return scanExt(buf, 4, max) // ext32
+	default:
+		// 0xc1 is never used in MessagePack.
+		return 0, scanTooLarge
+	}
+}
+
+// readUintPrefix reads a big-endian unsigned integer of lenBytes at offset off.
+func readUintPrefix(buf []byte, off, lenBytes int) (uint64, bool) {
+	if len(buf) < off+lenBytes {
+		return 0, false
+	}
+	switch lenBytes {
+	case 1:
+		return uint64(buf[off]), true
+	case 2:
+		return uint64(binary.BigEndian.Uint16(buf[off:])), true
+	case 4:
+		return uint64(binary.BigEndian.Uint32(buf[off:])), true
+	default:
+		return 0, false
+	}
+}
+
+// scanFixed validates a value of exactly size bytes.
+func scanFixed(buf []byte, size, max int) (int, scanStatus) {
+	if size > max {
+		return 0, scanTooLarge
+	}
+	if len(buf) < size {
+		return size, scanNeedMore
+	}
+	return size, scanDone
+}
+
+// scanRaw validates a string/binary body of clen bytes that starts at
+// dataOffset (i.e. the length prefix has already been consumed).
+func scanRaw(buf []byte, dataOffset, clen, max int) (int, scanStatus) {
+	total := dataOffset + clen
+	if clen < 0 || total > max {
+		return 0, scanTooLarge
+	}
+	if len(buf) < total {
+		return total, scanNeedMore
+	}
+	return total, scanDone
+}
+
+// scanLenPrefixed validates a string/binary value whose length is encoded in
+// prefixLen bytes immediately after the type byte at typeLen.
+func scanLenPrefixed(buf []byte, typeLen, prefixLen, max int) (int, scanStatus) {
+	headerLen := typeLen + prefixLen
+	if headerLen > max {
+		return 0, scanTooLarge
+	}
+	clen, ok := readUintPrefix(buf, typeLen, prefixLen)
+	if !ok {
+		return headerLen, scanNeedMore
+	}
+	if clen > uint64(max) {
+		return 0, scanTooLarge
+	}
+	return scanRaw(buf, headerLen, int(clen), max)
+}
+
+// scanExt validates an ext8/16/32 value: prefixLen length bytes, 1 type byte,
+// then the payload.
+func scanExt(buf []byte, prefixLen, max int) (int, scanStatus) {
+	headerLen := 1 + prefixLen + 1 // type byte + length + ext type byte
+	if headerLen > max {
+		return 0, scanTooLarge
+	}
+	clen, ok := readUintPrefix(buf, 1, prefixLen)
+	if !ok {
+		return headerLen, scanNeedMore
+	}
+	if clen > uint64(max) {
+		return 0, scanTooLarge
+	}
+	return scanRaw(buf, headerLen, int(clen), max)
+}
+
+// scanArray validates count elements of an array whose header has already been
+// consumed up to headerLen bytes.
+func scanArray(buf []byte, headerLen, count, max, depth int) (int, scanStatus) {
+	return scanElements(buf, headerLen, count, max, depth)
+}
+
+// scanMap validates count key/value pairs of a map whose header has already
+// been consumed up to headerLen bytes.
+func scanMap(buf []byte, headerLen, count, max, depth int) (int, scanStatus) {
+	return scanElements(buf, headerLen, count*2, max, depth)
+}
+
+// scanArrayHeader reads an array16/array32 element count then validates the
+// elements.
+func scanArrayHeader(buf []byte, typeLen, prefixLen, max, depth int) (int, scanStatus) {
+	headerLen := typeLen + prefixLen
+	if headerLen > max {
+		return 0, scanTooLarge
+	}
+	count, ok := readUintPrefix(buf, typeLen, prefixLen)
+	if !ok {
+		return headerLen, scanNeedMore
+	}
+	if count > uint64(max) {
+		// Each element needs at least one byte, so it cannot fit in max.
+		return 0, scanTooLarge
+	}
+	return scanElements(buf, headerLen, int(count), max, depth)
+}
+
+// scanMapHeader reads a map16/map32 pair count then validates the pairs.
+func scanMapHeader(buf []byte, typeLen, prefixLen, max, depth int) (int, scanStatus) {
+	headerLen := typeLen + prefixLen
+	if headerLen > max {
+		return 0, scanTooLarge
+	}
+	count, ok := readUintPrefix(buf, typeLen, prefixLen)
+	if !ok {
+		return headerLen, scanNeedMore
+	}
+	if count > uint64(max/2) {
+		return 0, scanTooLarge
+	}
+	return scanElements(buf, headerLen, int(count)*2, max, depth)
+}
+
+// scanElements validates n consecutive values starting at offset off.
+func scanElements(buf []byte, off, n, max, depth int) (int, scanStatus) {
+	for i := 0; i < n; i++ {
+		if off > max {
+			return 0, scanTooLarge
+		}
+		if len(buf) <= off {
+			return off + 1, scanNeedMore
+		}
+		consumed, status := scanMsgpackValue(buf[off:], max-off, depth+1)
+		switch status {
+		case scanDone:
+			off += consumed
+		case scanNeedMore:
+			return off + consumed, scanNeedMore
+		default:
+			return 0, scanTooLarge
+		}
+	}
+	if off > max {
+		return 0, scanTooLarge
+	}
+	return off, scanDone
+}

--- a/agent/consul/rpc_header_limit_test.go
+++ b/agent/consul/rpc_header_limit_test.go
@@ -1,0 +1,191 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package consul
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-net-rpc/go-msgpack/codec"
+	netRPC "github.com/hashicorp/consul-net-rpc/net/rpc"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/stretchr/testify/require"
+)
+
+// encodeHeader builds the msgpack wire bytes for a net/rpc request header.
+func encodeHeader(t *testing.T, serviceMethod string, seq uint64) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := codec.NewEncoder(&buf, structs.MsgpackHandle)
+	type rpcRequest struct {
+		ServiceMethod string
+		Seq           uint64
+	}
+	require.NoError(t, enc.Encode(rpcRequest{ServiceMethod: serviceMethod, Seq: seq}))
+	return buf.Bytes()
+}
+
+func TestScanMsgpackValue(t *testing.T) {
+	const max = 512
+
+	// oversizedStr32 is a str32 header declaring ~4 GiB with no payload bytes.
+	oversizedStr32 := func() []byte {
+		b := []byte{0xdb, 0, 0, 0, 0}
+		binary.BigEndian.PutUint32(b[1:], 4*1024*1024*1024-1)
+		return b
+	}()
+
+	// oversizedBin32 declares a 1 GiB binary value.
+	oversizedBin32 := func() []byte {
+		b := []byte{0xc6, 0, 0, 0, 0}
+		binary.BigEndian.PutUint32(b[1:], 1*1024*1024*1024)
+		return b
+	}()
+
+	// oversizedMap32 declares a huge element count.
+	oversizedMap32 := func() []byte {
+		b := []byte{0xdf, 0, 0, 0, 0}
+		binary.BigEndian.PutUint32(b[1:], 500*1000*1000)
+		return b
+	}()
+
+	// oversizedArray32 declares a huge element count.
+	oversizedArray32 := func() []byte {
+		b := []byte{0xdd, 0, 0, 0, 0}
+		binary.BigEndian.PutUint32(b[1:], 500*1000*1000)
+		return b
+	}()
+
+	cases := []struct {
+		name   string
+		buf    []byte
+		want   scanStatus
+		wantOK bool // when scanDone, whether a positive consumed count is expected
+	}{
+		{name: "positive fixint", buf: []byte{0x01}, want: scanDone, wantOK: true},
+		{name: "negative fixint", buf: []byte{0xe0}, want: scanDone, wantOK: true},
+		{name: "nil", buf: []byte{0xc0}, want: scanDone, wantOK: true},
+		{name: "fixstr within limit", buf: append([]byte{0xa3}, []byte("abc")...), want: scanDone, wantOK: true},
+		{name: "valid header", buf: encodeHeader(t, "Catalog.Nodes", 1), want: scanDone, wantOK: true},
+		{name: "empty needs more", buf: []byte{}, want: scanNeedMore},
+		{name: "str8 prefix truncated needs more", buf: []byte{0xd9}, want: scanNeedMore},
+		{name: "fixstr body truncated needs more", buf: []byte{0xa3, 'a'}, want: scanNeedMore},
+		{name: "oversized str32", buf: oversizedStr32, want: scanTooLarge},
+		{name: "oversized bin32", buf: oversizedBin32, want: scanTooLarge},
+		{name: "oversized map32", buf: oversizedMap32, want: scanTooLarge},
+		{name: "oversized array32", buf: oversizedArray32, want: scanTooLarge},
+		{name: "oversized header via big method", buf: encodeHeader(t, strings.Repeat("X", 1024), 1), want: scanTooLarge},
+		{name: "reserved 0xc1 is invalid", buf: []byte{0xc1}, want: scanTooLarge},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n, status := scanMsgpackValue(tc.buf, max, 0)
+			require.Equal(t, tc.want, status, "unexpected status (consumed=%d)", n)
+			if status == scanDone && tc.wantOK {
+				require.Greater(t, n, 0)
+				require.LessOrEqual(t, n, max)
+			}
+			if status == scanNeedMore {
+				require.Greater(t, n, 0)
+				require.LessOrEqual(t, n, max, "needMore must never request more than the cap")
+			}
+		})
+	}
+}
+
+// pipeCodec wires a boundedHeaderCodec to an in-memory connection and returns
+// the client side for writing raw bytes.
+func newPipeCodec(t *testing.T, maxHeaderBytes int) (*boundedHeaderCodec, net.Conn) {
+	t.Helper()
+	server, client := net.Pipe()
+	t.Cleanup(func() {
+		server.Close()
+		client.Close()
+	})
+	c := newBoundedHeaderCodec(server, structs.MsgpackHandle, maxHeaderBytes)
+	return c, client
+}
+
+func TestBoundedHeaderCodec_ReadRequestHeader(t *testing.T) {
+	t.Run("normal header decodes", func(t *testing.T) {
+		c, client := newPipeCodec(t, 512)
+		go func() {
+			client.Write(encodeHeader(t, "Catalog.Nodes", 7))
+		}()
+
+		var req netRPC.Request
+		require.NoError(t, c.ReadRequestHeader(&req))
+		require.Equal(t, "Catalog.Nodes", req.ServiceMethod)
+		require.Equal(t, uint64(7), req.Seq)
+	})
+
+	t.Run("oversized header is rejected before allocation", func(t *testing.T) {
+		c, client := newPipeCodec(t, 512)
+		// Send only the str32 length prefix — no payload. A vulnerable decoder
+		// would allocate ~4 GiB here; the guard must reject from the prefix
+		// alone without reading (or allocating) the body.
+		go func() {
+			hdr := []byte{0x81, 0xad}
+			hdr = append(hdr, []byte("ServiceMethod")...)
+			prefix := []byte{0xdb, 0, 0, 0, 0}
+			binary.BigEndian.PutUint32(prefix[1:], 4*1024*1024*1024-1)
+			client.Write(append(hdr, prefix...))
+		}()
+
+		var req netRPC.Request
+		err := c.ReadRequestHeader(&req)
+		require.ErrorIs(t, err, errHeaderTooLarge)
+	})
+
+	t.Run("body may exceed the header cap", func(t *testing.T) {
+		c, client := newPipeCodec(t, 512)
+		// A large body (> cap) must be allowed once the header is accepted.
+		body := strings.Repeat("z", 4096)
+		go func() {
+			client.Write(encodeHeader(t, "A.B", 1))
+			enc := codec.NewEncoder(client, structs.MsgpackHandle)
+			enc.Encode(body)
+		}()
+
+		var req netRPC.Request
+		require.NoError(t, c.ReadRequestHeader(&req))
+		require.Equal(t, "A.B", req.ServiceMethod)
+
+		var got string
+		require.NoError(t, c.ReadRequestBody(&got))
+		require.Equal(t, body, got)
+	})
+
+	t.Run("clean close returns EOF", func(t *testing.T) {
+		c, client := newPipeCodec(t, 512)
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			client.Close()
+		}()
+
+		var req netRPC.Request
+		err := c.ReadRequestHeader(&req)
+		require.Error(t, err)
+	})
+
+	t.Run("large configured cap accepts a large header", func(t *testing.T) {
+		// A cap above bufio's default buffer size must not spuriously reject a
+		// validly-sized header via ErrBufferFull.
+		const cap = 8192
+		c, client := newPipeCodec(t, cap)
+		method := "Svc." + strings.Repeat("m", 6000)
+		go func() {
+			client.Write(encodeHeader(t, method, 3))
+		}()
+
+		var req netRPC.Request
+		require.NoError(t, c.ReadRequestHeader(&req))
+		require.Equal(t, method, req.ServiceMethod)
+	})
+}

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -419,6 +419,109 @@ func TestRPC_TLSHandshakeTimeout(t *testing.T) {
 	})
 }
 
+// TestRPC_OversizedServiceMethod is a regression test for a pre-authorization
+// memory-exhaustion vector: an mTLS-authenticated RPC client with no ACL
+// privilege could exhaust server memory by sending a MessagePack header whose
+// ServiceMethod declares a very large length. The MessagePack decoder allocates
+// a byte slice of the declared length before method lookup, rate limiting, or
+// ACL evaluation runs.
+//
+// The server now validates every length prefix in a request header against
+// RPCMaxHeaderBytes before the decoder allocates for it, rejecting oversized
+// headers and closing the connection. This test verifies that:
+//   - A normal-sized request is accepted and answered (the limit is not too
+//     tight), and the connection stays open.
+//   - A request whose ServiceMethod exceeds RPCMaxHeaderBytes is rejected and
+//     the connection is closed promptly (a real close, not a read timeout).
+func TestRPC_OversizedServiceMethod(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		// Use a short handshake timeout so a stalled read cannot keep the
+		// test waiting; the oversized header itself is rejected immediately.
+		c.RPCHandshakeTimeout = 500 * time.Millisecond
+		c.RPCMaxHeaderBytes = 512
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	addr := s1.config.RPCAdvertise
+
+	// buildHeader encodes a minimal msgpack map representing the net/rpc
+	// Request struct: {"ServiceMethod": <method>, "Seq": 1}. This is the exact
+	// wire format the server's ReadRequestHeader decodes.
+	buildHeader := func(serviceMethod string) []byte {
+		var buf bytes.Buffer
+		enc := codec.NewEncoder(&buf, structs.MsgpackHandle)
+		type rpcRequest struct {
+			ServiceMethod string
+			Seq           uint64
+		}
+		_ = enc.Encode(rpcRequest{ServiceMethod: serviceMethod, Seq: 1})
+		return buf.Bytes()
+	}
+
+	isTimeout := func(err error) bool {
+		var ne net.Error
+		return errors.As(err, &ne) && ne.Timeout()
+	}
+
+	t.Run("normal-sized method is accepted and answered", func(t *testing.T) {
+		conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		// Send the RPCConsul magic byte.
+		_, err = conn.Write([]byte{byte(pool.RPCConsul)})
+		require.NoError(t, err)
+
+		// Send a normally-sized header for an unknown method plus a nil body
+		// (0xc0). The server cannot find the method, discards the body, and
+		// replies with an RPC error response — proving the header was accepted
+		// and the connection stays open.
+		hdr := buildHeader("Nonexistent.Method")
+		_, err = conn.Write(append(hdr, 0xc0))
+		require.NoError(t, err)
+
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, 256)
+		n, err := conn.Read(buf)
+		require.NoError(t, err, "server should reply to a normal-sized header, not close the connection")
+		require.Greater(t, n, 0, "expected a response body from the server")
+	})
+
+	t.Run("oversized ServiceMethod is rejected and the connection closed", func(t *testing.T) {
+		conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		// Send the RPCConsul magic byte.
+		_, err = conn.Write([]byte{byte(pool.RPCConsul)})
+		require.NoError(t, err)
+
+		// Build a header whose ServiceMethod is 1 KiB — well beyond the
+		// 512-byte RPCMaxHeaderBytes limit. The server must reject it before
+		// the decoder allocates for the declared length, then close the
+		// connection.
+		oversizedMethod := strings.Repeat("X", 1024)
+		_, _ = conn.Write(buildHeader(oversizedMethod))
+
+		// The server must close the connection promptly. Assert we observe a
+		// real close/EOF/reset and NOT a read timeout, which would mean the
+		// server left the connection open.
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, 16)
+		_, readErr := conn.Read(buf)
+		require.Error(t, readErr, "expected the server to close the connection after an oversized header")
+		require.False(t, isTimeout(readErr),
+			"expected a prompt connection close, got a read timeout (connection left open): %v", readErr)
+	})
+}
+
 func TestRPC_PreventsTLSNesting(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -318,6 +318,11 @@ type Server struct {
 	// rpcConnLimiter limits the number of RPC connections from a single source IP
 	rpcConnLimiter connlimit.Limiter
 
+	// rpcMaxHeaderBytes bounds the encoded size of a single RPC request header.
+	// It is read per new RPC connection and stored atomically so ReloadConfig
+	// can update it without a server restart.
+	rpcMaxHeaderBytes atomic.Int64
+
 	// Listener is used to listen for incoming connections
 	Listener            net.Listener
 	internalGRPCHandler connHandler
@@ -538,6 +543,8 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server,
 		registry:                flat.Registry,
 	}
 	incomingRPCLimiter.Register(s)
+
+	s.rpcMaxHeaderBytes.Store(int64(config.RPCMaxHeaderBytes))
 
 	s.raftStorageBackend, err = raftstorage.NewBackend(&raftHandle{s}, logger.Named("raft-storage-backend"))
 	if err != nil {
@@ -1818,6 +1825,7 @@ func (s *Server) ReloadConfig(config ReloadableConfig) error {
 	s.rpcConnLimiter.SetConfig(connlimit.Config{
 		MaxConnsPerClientIP: config.RPCMaxConnsPerClient,
 	})
+	s.rpcMaxHeaderBytes.Store(int64(config.RPCMaxHeaderBytes))
 	s.connPool.SetRPCClientTimeout(config.RPCClientTimeout)
 
 	if s.IsLeader() {

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -2055,6 +2055,7 @@ func TestServer_ReloadConfig(t *testing.T) {
 		c.RequestLimitsReadRate = 500
 		c.RequestLimitsWriteRate = 500
 		c.RPCClientTimeout = 60 * time.Second
+		c.RPCMaxHeaderBytes = 512
 		// Set one raft param to be non-default in the initial config, others are
 		// default.
 		c.RaftConfig.TrailingLogs = 1234
@@ -2069,6 +2070,7 @@ func TestServer_ReloadConfig(t *testing.T) {
 	require.Equal(t, 5000, limiter.Burst())
 
 	require.Equal(t, 60*time.Second, s.connPool.RPCClientTimeout())
+	require.Equal(t, int64(512), s.rpcMaxHeaderBytes.Load())
 
 	rc := ReloadableConfig{
 		RequestLimits: &RequestLimits{
@@ -2079,6 +2081,7 @@ func TestServer_ReloadConfig(t *testing.T) {
 		RPCClientTimeout:     2 * time.Minute,
 		RPCRateLimit:         1000,
 		RPCMaxBurst:          10000,
+		RPCMaxHeaderBytes:    1024,
 		ConfigEntryBootstrap: []structs.ConfigEntry{entryInit},
 		// Reset the custom one to default be removing it from config file (it will
 		// be a zero value here).
@@ -2109,6 +2112,9 @@ func TestServer_ReloadConfig(t *testing.T) {
 	limiter = s.rpcLimiter.Load().(*rate.Limiter)
 	require.Equal(t, rate.Limit(1000), limiter.Limit())
 	require.Equal(t, 10000, limiter.Burst())
+
+	// Check the RPC header byte limit got updated
+	require.Equal(t, int64(1024), s.rpcMaxHeaderBytes.Load())
 
 	// Check the incoming RPC rate limiter got updated
 	mockHandler.AssertCalled(t, "UpdateConfig", rpcRate.HandlerConfig{


### PR DESCRIPTION
## Summary

An mTLS-authenticated client with no ACL token could exhaust Consul server memory before authorization by sending a MessagePack `str32` header with a large declared string length. The decoder allocated a byte slice of that size before method lookup, rate limiting, or ACL evaluation could run.

## Mitigations

1. **`limitedRPCConn`** — wraps every RPC connection's read path in an `io.LimitedReader` capped at `RPCMaxHeaderBytes` (default 512 bytes). A header exceeding the limit causes an immediate `io.ErrUnexpectedEOF`, closing the connection before ACL evaluation.

2. **`headerLimitedCodec`** — thin wrapper around `*MsgpackCodec` that lifts the header byte cap before body decode to prevent body truncation on legitimate RPC calls.

3. **Per-request read deadline** — reuses `RPCHandshakeTimeout` as a read deadline around each `ServeRequest` call. A slow attacker trickling an oversized header can no longer retain a goroutine indefinitely.

## New config field
`rpc_max_header_bytes` (default: 512) — reloadable, controls the cap.