### PR TITLE
security: fix catalog node-ID ACL bypass allowing cross-node takeover

### DIFF
--- a/.changelog/23899.txt
+++ b/.changelog/23899.txt
@@ -1,0 +1,11 @@
+```release-note:security
+catalog: Fixed an ACL bypass vulnerability in `Catalog.Register` where a caller
+with `node:write` on an attacker-controlled node name could supply a victim node's
+`Node.ID` to cascade-delete the victim node and all its services and health checks.
+`vetRegisterWithACL` checked ACLs only against the request's node name;
+`ensureNodeTxn` resolved by `Node.ID` first and silently deleted any existing node
+whose name differed. The fix looks up any existing node by the request's `Node.ID`
+before ACL evaluation and requires `node:write` on the existing node's real name
+when it differs from the request's name, mirroring the protection already present
+in `vetNodeTxnOp`.
+```

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -173,6 +173,26 @@ func (c *Catalog) Register(args *structs.RegisterRequest, reply *struct{}) error
 	if err != nil {
 		return fmt.Errorf("Node lookup failed: %v", err)
 	}
+
+	// If the request carries a Node.ID, check whether that ID already belongs
+	// to a different node. ensureNodeTxn resolves by ID first and will cascade-
+	// delete the existing node if the name differs, so we must authorize against
+	// the existing node's real name before vetRegisterWithACL checks the
+	// request's own name. This mirrors the protection in vetNodeTxnOp.
+	if args.ID != "" {
+		_, existingByID, err := state.GetNodeID(args.ID, &args.EnterpriseMeta, args.PeerName)
+		if err != nil {
+			return fmt.Errorf("node lookup by ID failed: %w", err)
+		}
+		if existingByID != nil && !strings.EqualFold(existingByID.Node, args.Node) {
+			var existingCtx acl.AuthorizerContext
+			existingByID.FillAuthzContext(&existingCtx)
+			if err := authz.ToAllowAuthorizer().NodeWriteAllowed(existingByID.Node, &existingCtx); err != nil {
+				return err
+			}
+		}
+	}
+
 	if err := vetRegisterWithACL(authz, args, ns); err != nil {
 		return err
 	}

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -4669,3 +4669,70 @@ func TestCatalog_VirtualIPForService_ACLDeny(t *testing.T) {
 	require.Contains(t, err.Error(), acl.ErrPermissionDenied.Error())
 	require.Equal(t, "", out2)
 }
+
+// TestCatalog_Register_NodeIDCrossNodeTakeover verifies that a caller who holds
+// node:write on their own node name cannot use a victim's Node.ID to cascade-
+// delete the victim's entire catalog registration and steal its identity.
+//
+// Without the fix, vetRegisterWithACL only checked the attacker's own node name;
+// ensureNodeTxn then resolved by ID, deleted the victim node, and re-inserted it
+// under the attacker's name.
+func TestCatalog_Register_NodeIDCrossNodeTakeover(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	victimID := types.NodeID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+	// Register victim node with a service via the management token.
+	var out struct{}
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &structs.RegisterRequest{
+		Datacenter: "dc1",
+		ID:         victimID,
+		Node:       "victim-node",
+		Address:    "10.0.0.1",
+		Service: &structs.NodeService{
+			ID:      "victim-svc",
+			Service: "victim-svc",
+			Port:    9999,
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}, &out))
+
+	// Attacker token: write on "attacker-node" only; no access to "victim-node".
+	attackerToken := createToken(t, codec, `
+node "attacker-node" {
+  policy = "write"
+}`)
+
+	// Attacker submits Catalog.Register using their own node name but the
+	// victim's Node.ID. The fix must reject this with permission denied.
+	err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", &structs.RegisterRequest{
+		Datacenter:   "dc1",
+		ID:           victimID,
+		Node:         "attacker-node",
+		Address:      "10.0.0.2",
+		WriteRequest: structs.WriteRequest{Token: attackerToken},
+	}, &out)
+	require.Error(t, err, "expected the cross-node takeover to be rejected with a permission error")
+	require.True(t, acl.IsErrPermissionDenied(err), "expected permission denied, got: %v", err)
+
+	// Victim node must still exist in the state store.
+	_, victimNode, err := s1.fsm.State().GetNodeID(victimID, structs.NodeEnterpriseMetaInDefaultPartition(), "")
+	require.NoError(t, err)
+	require.NotNil(t, victimNode, "victim node was deleted — cross-node takeover succeeded")
+	require.Equal(t, "victim-node", victimNode.Node)
+}

--- a/agent/consul/txn_endpoint_test.go
+++ b/agent/consul/txn_endpoint_test.go
@@ -1542,3 +1542,86 @@ func TestTxn_Apply_ServiceSet_NoTokenCannotWriteConsulService(t *testing.T) {
 	require.Equal(t, "127.0.0.1", svc.Address)
 	require.Equal(t, 8300, svc.Port)
 }
+
+// TestTxn_Apply_NodeSetRejectsCrossNodeTakeoverByID verifies that Txn.Apply /
+// NodeSet with a victim's Node.ID but the attacker's node name is rejected when
+// the caller lacks write permission on the victim's real node name.
+//
+// Without the fix in vetNodeTxnOp, the ACL check only examined the attacker's
+// own node name and passed; ensureNodeTxn then resolved by ID and cascade-
+// deleted the victim.
+func TestTxn_Apply_NodeSetRejectsCrossNodeTakeoverByID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	victimID := types.NodeID("11111111-2222-3333-4444-555555555555")
+
+	// Register victim node with a service via the management token.
+	state := s1.fsm.State()
+	require.NoError(t, state.EnsureNode(1, &structs.Node{
+		ID:      victimID,
+		Node:    "victim-node",
+		Address: "10.0.0.1",
+	}))
+	require.NoError(t, state.EnsureService(2, "victim-node", &structs.NodeService{
+		ID:      "victim-svc",
+		Service: "victim-svc",
+		Address: "10.0.0.1",
+		Port:    9999,
+	}))
+
+	// Attacker token: write on "attacker-node" only.
+	attackerToken := createToken(t, rpcClient(t, s1), `
+node "attacker-node" {
+  policy = "write"
+}`)
+
+	// Attacker submits a NodeSet Txn using their own node name but the
+	// victim's Node.ID. The fix must reject this with permission denied.
+	arg := structs.TxnRequest{
+		Datacenter: "dc1",
+		Ops: structs.TxnOps{
+			{
+				Node: &structs.TxnNodeOp{
+					Verb: api.NodeSet,
+					Node: structs.Node{
+						ID:      victimID,
+						Node:    "attacker-node",
+						Address: "10.0.0.2",
+					},
+				},
+			},
+		},
+		WriteRequest: structs.WriteRequest{Token: attackerToken},
+	}
+	var out structs.TxnResponse
+	err := msgpackrpc.CallWithCodec(codec, "Txn.Apply", &arg, &out)
+
+	// Either the RPC itself returns an error, or the error is surfaced inside
+	// the TxnResponse.Errors slice (Txn.Apply returns errors per-op).
+	hasPermDenied := acl.IsErrPermissionDenied(err)
+	if !hasPermDenied && len(out.Errors) > 0 {
+		hasPermDenied = strings.Contains(out.Errors[0].Error(), acl.ErrPermissionDenied.Error())
+	}
+	require.True(t, hasPermDenied, "expected the cross-node takeover to be rejected with a permission error; err=%v txnErrors=%v", err, out.Errors)
+
+	// Victim node must still exist.
+	_, victimNode, err := state.GetNodeID(victimID, structs.NodeEnterpriseMetaInDefaultPartition(), "")
+	require.NoError(t, err)
+	require.NotNil(t, victimNode, "victim node was deleted — cross-node takeover succeeded")
+	require.Equal(t, "victim-node", victimNode.Node)
+}


### PR DESCRIPTION
## Summary

A caller with `node:write` on any attacker-owned node name, plus knowledge of a victim's `Node.ID` (discoverable via `node:read`, the UI, or catalog APIs), could submit a `Catalog.Register` request with their own name but the victim's `Node.ID`. `vetRegisterWithACL` checked ACLs only against the request's node name; `ensureNodeTxn` then resolved by ID, cascade-deleted the victim node and all its services and checks, and re-inserted a node under the attacker's name.

## Fix

Before calling `vetRegisterWithACL`, look up any existing node by the request's `Node.ID`. If found and the name differs, require `NodeWrite` permission on the existing node's real name in addition to the request's own name. Mirrors the protection already present in `vetNodeTxnOp`.

## Tests

- `TestCatalog_Register_NodeIDCrossNodeTakeover` — attacker with `node:write` on their own name but victim's `Node.ID` is rejected; victim node survives in the state store.
- `TestTxn_Apply_NodeSetRejectsCrossNodeTakeoverByID` — same scenario via `Txn.Apply`.