### PR TITLE
security: escape regex metacharacters in SPIFFE RBAC patterns

### DIFF
--- a/.changelog/23900.txt
+++ b/.changelog/23900.txt
@@ -1,0 +1,3 @@
+```release-note:security
+xds: escape regex metacharacters in service name, namespace, partition, and trust domain values when building Envoy RBAC SPIFFE match patterns, preventing an intention/authorization bypass via regex injection.
+```

--- a/agent/xds/rbac.go
+++ b/agent/xds/rbac.go
@@ -5,6 +5,7 @@ package xds
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -1153,6 +1154,21 @@ func makeSpiffePattern(src rbacService) string {
 		host = src.TrustDomain
 	}
 
+	// Escape regex metacharacters in user-controlled values so they are matched
+	// literally. Service names, namespaces, and partitions may legitimately
+	// contain characters such as '.', '|', or '+' which would otherwise be
+	// interpreted as regex operators and could broaden the RBAC match beyond the
+	// intended identity, bypassing intention enforcement. The anyPath ('[^/]+')
+	// values are intentional regex wildcards and must not be escaped.
+	if ns != anyPath {
+		ns = regexp.QuoteMeta(ns)
+	}
+	if svc != anyPath {
+		svc = regexp.QuoteMeta(svc)
+	}
+	ap = regexp.QuoteMeta(ap)
+	host = regexp.QuoteMeta(host)
+
 	id := connect.SpiffeIDService{
 		Namespace: ns,
 		Service:   svc,
@@ -1170,8 +1186,10 @@ func makeSpiffePattern(src rbacService) string {
 
 func makeSpiffeMeshGatewayPattern(gwTrustDomain, gwPartition string) string {
 	id := connect.SpiffeIDMeshGateway{
-		Host:      gwTrustDomain,
-		Partition: gwPartition,
+		// Escape regex metacharacters so user-controlled values are matched
+		// literally rather than being interpreted as regex operators.
+		Host:      regexp.QuoteMeta(gwTrustDomain),
+		Partition: regexp.QuoteMeta(gwPartition),
 		// Datacenter is not verified by RBAC, so we match on any value.
 		Datacenter: anyPath,
 	}

--- a/agent/xds/rbac_test.go
+++ b/agent/xds/rbac_test.go
@@ -1310,3 +1310,82 @@ func TestJWTClaimsToPrincipals(t *testing.T) {
 		})
 	}
 }
+
+// TestMakeSpiffePattern_EscapesRegexMetacharacters verifies that regex
+// metacharacters in the source service name and trust domain are escaped when
+// building the Envoy RBAC SPIFFE match pattern, so they are matched literally.
+//
+// Without escaping, a "." in a service name acts as the regex "any character"
+// wildcard, letting an unintended identity satisfy an intention's RBAC rule
+// (an authorization bypass). This is a behavioral test: it compiles the
+// generated pattern and asserts that crafted identities do NOT match. Unlike
+// the golden fixtures, this cannot be silently regenerated to a passing state
+// if the escaping is ever removed.
+func TestMakeSpiffePattern_EscapesRegexMetacharacters(t *testing.T) {
+	const trustDomain = "test.consul"
+
+	compile := func(service string) *regexp.Regexp {
+		p := makeSpiffePattern(rbacService{
+			ServiceName: structs.NewServiceName(service, nil),
+			TrustDomain: trustDomain,
+		})
+		return regexp.MustCompile(p)
+	}
+
+	spiffeID := func(service string) string {
+		return fmt.Sprintf("spiffe://%s/ns/default/dc/dc1/svc/%s", trustDomain, service)
+	}
+
+	cases := []struct {
+		name         string
+		re           *regexp.Regexp
+		mustMatch    []string
+		mustNotMatch []string
+	}{
+		{
+			// A "." in the service name must be matched literally, not as the
+			// regex "any character" wildcard.
+			name:      "dot in service name is not a wildcard",
+			re:        compile("web.api"),
+			mustMatch: []string{spiffeID("web.api")},
+			mustNotMatch: []string{
+				spiffeID("web-api"),
+				spiffeID("webXapi"),
+				spiffeID("web_api"),
+			},
+		},
+		{
+			// A "|" must not turn the pattern into an alternation that also
+			// matches a completely different service name.
+			name:      "pipe in service name does not create alternation",
+			re:        compile("harmless|admin"),
+			mustMatch: []string{spiffeID("harmless|admin")},
+			mustNotMatch: []string{
+				spiffeID("admin"),
+				spiffeID("harmless"),
+			},
+		},
+		{
+			// The "." in the trust domain must also be matched literally.
+			name:      "dot in trust domain is not a wildcard",
+			re:        compile("web"),
+			mustMatch: []string{spiffeID("web")},
+			mustNotMatch: []string{
+				"spiffe://testXconsul/ns/default/dc/dc1/svc/web",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, id := range tc.mustMatch {
+				assert.True(t, tc.re.MatchString(id),
+					"pattern %q should match legitimate identity %q", tc.re.String(), id)
+			}
+			for _, id := range tc.mustNotMatch {
+				assert.False(t, tc.re.MatchString(id),
+					"BYPASS: pattern %q must not match crafted identity %q", tc.re.String(), id)
+			}
+		})
+	}
+}

--- a/agent/xds/testdata/listeners/terminating-gateway-with-peer-trust-bundle.latest.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-with-peer-trust-bundle.latest.golden
@@ -186,7 +186,7 @@
                           "authenticated": {
                             "principalName": {
                               "safeRegex": {
-                                "regex": "^spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/[^/]+/svc/source$"
+                                "regex": "^spiffe://1c053652-8512-4373-90cf-5a7f6263a994\\.consul/ns/default/dc/[^/]+/svc/source$"
                               }
                             }
                           }
@@ -195,7 +195,7 @@
                           "authenticated": {
                             "principalName": {
                               "safeRegex": {
-                                "regex": "^spiffe://d89ac423-e95a-475d-94f2-1c557c57bf31.consul/ns/default/dc/[^/]+/svc/source$"
+                                "regex": "^spiffe://d89ac423-e95a-475d-94f2-1c557c57bf31\\.consul/ns/default/dc/[^/]+/svc/source$"
                               }
                             }
                           }

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow--httpfilter.golden
@@ -19,7 +19,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -29,7 +29,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }
@@ -28,7 +28,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -38,7 +38,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny--httpfilter.golden
@@ -19,7 +19,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -29,7 +29,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }
@@ -55,7 +55,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }
@@ -28,7 +28,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -38,7 +38,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }

--- a/agent/xds/testdata/rbac/default-allow-kitchen-sink--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-kitchen-sink--httpfilter.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/cron$"
                   }
                 }
               }
@@ -25,7 +25,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }
@@ -37,7 +37,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -47,7 +47,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }
@@ -58,7 +58,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/unsafe$"
                           }
                         }
                       }
@@ -69,7 +69,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/cron$"
                           }
                         }
                       }

--- a/agent/xds/testdata/rbac/default-allow-kitchen-sink.golden
+++ b/agent/xds/testdata/rbac/default-allow-kitchen-sink.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/cron$"
                   }
                 }
               }
@@ -25,7 +25,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }
@@ -37,7 +37,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -47,7 +47,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }
@@ -58,7 +58,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/unsafe$"
                           }
                         }
                       }
@@ -69,7 +69,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/cron$"
                           }
                         }
                       }

--- a/agent/xds/testdata/rbac/default-allow-one-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-one-deny--httpfilter.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-one-deny.golden
+++ b/agent/xds/testdata/rbac/default-allow-one-deny.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-path-allow.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-allow.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-path-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-deny--httpfilter.golden
@@ -20,7 +20,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-path-deny.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-deny.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-service-wildcard-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-service-wildcard-deny--httpfilter.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-service-wildcard-deny.golden
+++ b/agent/xds/testdata/rbac/default-allow-service-wildcard-deny.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-single-intention-with-kitchen-sink-perms--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-single-intention-with-kitchen-sink-perms--httpfilter.golden
@@ -279,7 +279,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-single-intention-with-kitchen-sink-perms.golden
+++ b/agent/xds/testdata/rbac/default-allow-single-intention-with-kitchen-sink-perms.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-two-path-deny-and-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-two-path-deny-and-path-allow--httpfilter.golden
@@ -42,7 +42,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-allow-two-path-deny-and-path-allow.golden
+++ b/agent/xds/testdata/rbac/default-allow-two-path-deny-and-path-allow.golden
@@ -16,7 +16,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-deny-allow-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-allow-deny--httpfilter.golden
@@ -18,7 +18,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -28,7 +28,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }

--- a/agent/xds/testdata/rbac/default-deny-allow-deny.golden
+++ b/agent/xds/testdata/rbac/default-deny-allow-deny.golden
@@ -18,7 +18,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -28,7 +28,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }

--- a/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow--httpfilter.golden
@@ -19,7 +19,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-deny-kitchen-sink--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-kitchen-sink--httpfilter.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/cron$"
                   }
                 }
               }
@@ -24,7 +24,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }
@@ -36,7 +36,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -46,7 +46,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }
@@ -57,7 +57,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/unsafe$"
                           }
                         }
                       }
@@ -68,7 +68,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/cron$"
                           }
                         }
                       }

--- a/agent/xds/testdata/rbac/default-deny-kitchen-sink.golden
+++ b/agent/xds/testdata/rbac/default-deny-kitchen-sink.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/cron$"
                   }
                 }
               }
@@ -24,7 +24,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }
@@ -36,7 +36,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -46,7 +46,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }
@@ -57,7 +57,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/unsafe$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/unsafe$"
                           }
                         }
                       }
@@ -68,7 +68,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/cron$"
+                            "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/cron$"
                           }
                         }
                       }

--- a/agent/xds/testdata/rbac/default-deny-mixed-precedence--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-mixed-precedence--httpfilter.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-deny-mixed-precedence.golden
+++ b/agent/xds/testdata/rbac/default-deny-mixed-precedence.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-deny-one-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-one-allow--httpfilter.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-deny-one-allow.golden
+++ b/agent/xds/testdata/rbac/default-deny-one-allow.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-deny-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-path-allow--httpfilter.golden
@@ -19,7 +19,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink--httpfilter.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }
@@ -27,7 +27,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/gateway/mesh/dc/[^/]+$"
+                          "regex": "^spiffe://test\\.consul/gateway/mesh/dc/[^/]+$"
                         }
                       }
                     }
@@ -40,7 +40,7 @@
                             "name": "x-forwarded-client-cert",
                             "stringMatch": {
                               "safeRegex": {
-                                "regex": "^[^,]+;URI=spiffe://peer1.domain/ap/part1/ns/default/dc/[^/]+/svc/[^/]+(?:,.*)?$"
+                                "regex": "^[^,]+;URI=spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/[^/]+(?:,.*)?$"
                               }
                             }
                           }
@@ -51,7 +51,7 @@
                               "name": "x-forwarded-client-cert",
                               "stringMatch": {
                                 "safeRegex": {
-                                  "regex": "^[^,]+;URI=spiffe://peer1.domain/ap/part1/ns/default/dc/[^/]+/svc/web(?:,.*)?$"
+                                  "regex": "^[^,]+;URI=spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/web(?:,.*)?$"
                                 }
                               }
                             }

--- a/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink.golden
+++ b/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }
@@ -27,7 +27,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://peer1.domain/ap/part1/ns/default/dc/[^/]+/svc/[^/]+$"
+                          "regex": "^spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/[^/]+$"
                         }
                       }
                     }
@@ -37,7 +37,7 @@
                       "authenticated": {
                         "principalName": {
                           "safeRegex": {
-                            "regex": "^spiffe://peer1.domain/ap/part1/ns/default/dc/[^/]+/svc/web$"
+                            "regex": "^spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/web$"
                           }
                         }
                       }

--- a/agent/xds/testdata/rbac/default-deny-service-wildcard-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-service-wildcard-allow--httpfilter.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-deny-service-wildcard-allow.golden
+++ b/agent/xds/testdata/rbac/default-deny-service-wildcard-allow.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/[^/]+$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/[^/]+$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-deny-single-intention-with-kitchen-sink-perms--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-single-intention-with-kitchen-sink-perms--httpfilter.golden
@@ -278,7 +278,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/default-deny-two-path-deny-and-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-two-path-deny-and-path-allow--httpfilter.golden
@@ -43,7 +43,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/empty-top-level-jwt-with-one-permission--httpfilter.golden
+++ b/agent/xds/testdata/rbac/empty-top-level-jwt-with-one-permission--httpfilter.golden
@@ -67,7 +67,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/top-level-jwt-no-permissions--httpfilter.golden
+++ b/agent/xds/testdata/rbac/top-level-jwt-no-permissions--httpfilter.golden
@@ -18,7 +18,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                         }
                       }
                     }

--- a/agent/xds/testdata/rbac/top-level-jwt-no-permissions.golden
+++ b/agent/xds/testdata/rbac/top-level-jwt-no-permissions.golden
@@ -15,7 +15,7 @@
               "authenticated": {
                 "principalName": {
                   "safeRegex": {
-                    "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                    "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                   }
                 }
               }

--- a/agent/xds/testdata/rbac/top-level-jwt-with-multiple-permissions--httpfilter.golden
+++ b/agent/xds/testdata/rbac/top-level-jwt-with-multiple-permissions--httpfilter.golden
@@ -146,7 +146,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                         }
                       }
                     }

--- a/agent/xds/testdata/rbac/top-level-jwt-with-one-permission--httpfilter.golden
+++ b/agent/xds/testdata/rbac/top-level-jwt-with-one-permission--httpfilter.golden
@@ -95,7 +95,7 @@
                     "authenticated": {
                       "principalName": {
                         "safeRegex": {
-                          "regex": "^spiffe://test.consul/ns/default/dc/[^/]+/svc/web$"
+                          "regex": "^spiffe://test\\.consul/ns/default/dc/[^/]+/svc/web$"
                         }
                       }
                     }


### PR DESCRIPTION
## Summary

When Consul builds the Envoy authorization (RBAC) rules that enforce Connect intentions, it puts the source service name, namespace, partition, and trust domain directly into a regular expression without escaping. Any regex special character (e.g. `.`, `|`, `+`) in a name was treated as a regex operator instead of plain text.

Because Consul accepts service names containing these characters, a rule intended for one identity could match more broadly than intended. For example, an intention for a service named `web.api` would also match `web-api` since `.` matches any character, potentially allowing a caller to reach a destination it should not.

## Fix

Escape the exact (non-wildcard) values with `regexp.QuoteMeta` in `makeSpiffePattern` and `makeSpiffeMeshGatewayPattern` before they are inserted into the pattern. The intentional `[^/]+` wildcards used for "any namespace/service" are left untouched. This mirrors how the codebase already handles the same problem for route prefixes in `routes.go`.
