### PR TITLE
security: gate Lua/Wasm extensions and bootstrap escape-hatch keys behind mesh:write

### DIFF
--- a/.changelog/23901.txt
+++ b/.changelog/23901.txt
@@ -1,0 +1,11 @@
+```release-note:security
+acl: Require mesh:write in addition to service:write when attaching code-executing EnvoyExtensions (builtin/lua, builtin/wasm) or upstream escape-hatch overrides (envoy_listener_json, envoy_cluster_json in UpstreamConfig defaults or overrides) to a service-defaults config entry. Previously a holder of service:write on a service could attach a Lua script or Wasm module, or an upstream escape-hatch override, that Envoy compiled and executed on every proxied request as the sidecar process user, with access to mTLS private keys, request bodies, and the host filesystem.
+```
+
+```release-note:security
+acl: Require mesh:write in addition to service:write when registering a connect-proxy sidecar with bootstrap or xDS escape-hatch keys, whether set in the top-level Proxy.Config map or per-upstream in Proxy.Upstreams[*].Config (envoy_bootstrap_json_tpl, envoy_extra_static_listeners_json, envoy_public_listener_json, envoy_listener_json, envoy_cluster_json, envoy_local_cluster_json, envoy_extra_static_clusters_json, envoy_extra_stats_sinks_json, envoy_tracing_json, envoy_stats_config_json, envoy_listener_tracing_json). Key matching is case-insensitive to match the mapstructure decoding used downstream. Previously a holder of service:write on the proxy and its destination could inject arbitrary Envoy filter chain configuration into the sidecar bootstrap or xDS resources, including via a per-upstream override or a mixed-case key.
+```
+
+```release-note:breaking-change
+acl: Tokens that hold service:write but not mesh:write will now receive a permission-denied error when attempting to attach builtin/lua or builtin/wasm EnvoyExtensions (or upstream envoy_listener_json/envoy_cluster_json escape-hatch overrides) to a service-defaults config entry, or when registering a connect-proxy sidecar with bootstrap or xDS escape-hatch keys set in the top-level Proxy.Config map or per-upstream in Proxy.Upstreams[*].Config. Operators must grant mesh:write to any token that legitimately needs these capabilities.
+```

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -68,6 +68,16 @@ func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *
 		}
 	}
 
+	// Escape-hatch keys in Proxy.Config or Proxy.Upstreams[*].Config embed
+	// arbitrary Envoy JSON into the sidecar's bootstrap configuration or xDS
+	// listener/cluster resources. They can introduce code-executing HTTP
+	// filters and therefore require mesh:write independently of service:write.
+	if service.Proxy.HasEnvoyEscapeHatchOverride() {
+		if err := authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext); err != nil {
+			return fmt.Errorf("mesh:write required to set an Envoy escape-hatch key in Proxy.Config or Proxy.Upstreams[*].Config: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -295,6 +295,167 @@ func TestACL_vetServiceRegister(t *testing.T) {
 	require.True(t, acl.IsErrPermissionDenied(err))
 }
 
+// TestACL_vetServiceRegister_bootstrapEscapeHatch verifies that registering a
+// connect-proxy sidecar with any bootstrap escape-hatch key in Proxy.Config
+// requires mesh:write in addition to service:write (SECVULN — Vector 2).
+func TestACL_vetServiceRegister_bootstrapEscapeHatch(t *testing.T) {
+	t.Parallel()
+	a := NewTestACLAgent(t, t.Name(), TestACLConfig(), catalogPolicy, catalogIdent)
+
+	newAuthz := func(t *testing.T, rules string) acl.Authorizer {
+		t.Helper()
+		policy, err := acl.NewPolicyFromSource(rules, nil, nil)
+		require.NoError(t, err)
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(t, err)
+		return authz
+	}
+
+	sidecar := &structs.NodeService{
+		ID:      "web-sidecar-proxy",
+		Service: "web-sidecar-proxy",
+		Kind:    structs.ServiceKindConnectProxy,
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceName: "web",
+			Config: map[string]interface{}{
+				"envoy_extra_static_listeners_json": `{"name":"attacker-listener"}`,
+			},
+		},
+	}
+
+	// service:write on both names but no mesh:write — must be denied.
+	authzServiceOnly := newAuthz(t, `service_prefix "" { policy = "write" }`)
+	err := a.vetServiceRegisterWithAuthorizer(authzServiceOnly, sidecar)
+	require.Error(t, err)
+	require.True(t, acl.IsErrPermissionDenied(err), "expected permission denied, got: %v", err)
+
+	// service:write + mesh:write — must be allowed.
+	authzWithMesh := newAuthz(t, `service_prefix "" { policy = "write" } mesh = "write"`)
+	err = a.vetServiceRegisterWithAuthorizer(authzWithMesh, sidecar)
+	require.NoError(t, err)
+
+	// Proxy.Config with no escape-hatch keys — service:write alone is sufficient.
+	normalSidecar := &structs.NodeService{
+		ID:      "web-sidecar-proxy",
+		Service: "web-sidecar-proxy",
+		Kind:    structs.ServiceKindConnectProxy,
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceName: "web",
+			Config: map[string]interface{}{
+				"protocol": "http",
+			},
+		},
+	}
+	err = a.vetServiceRegisterWithAuthorizer(authzServiceOnly, normalSidecar)
+	require.NoError(t, err)
+
+	// Verify every escape-hatch key triggers the mesh:write requirement.
+	for _, key := range structs.EnvoyEscapeHatchKeyNames() {
+		t.Run(key, func(t *testing.T) {
+			svc := &structs.NodeService{
+				ID:      "web-sidecar-proxy",
+				Service: "web-sidecar-proxy",
+				Kind:    structs.ServiceKindConnectProxy,
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					Config:                 map[string]interface{}{key: `{}`},
+				},
+			}
+			err := a.vetServiceRegisterWithAuthorizer(authzServiceOnly, svc)
+			require.Error(t, err, "key %q: expected denial without mesh:write", key)
+			require.True(t, acl.IsErrPermissionDenied(err), "key %q: expected permission denied, got: %v", key, err)
+
+			err = a.vetServiceRegisterWithAuthorizer(authzWithMesh, svc)
+			require.NoError(t, err, "key %q: expected success with mesh:write", key)
+		})
+	}
+}
+
+// TestACL_vetServiceRegister_bootstrapEscapeHatch_Upstream verifies that
+// escape-hatch keys (envoy_listener_json, envoy_cluster_json) set on a
+// per-upstream Config map — not just the top-level Proxy.Config — also
+// require mesh:write. These keys are only ever consumed from
+// Proxy.Upstreams[*].Config (see agent/xds/listeners.go), so a check that
+// only inspects Proxy.Config would miss them entirely (SECVULN — Vector 2).
+func TestACL_vetServiceRegister_bootstrapEscapeHatch_Upstream(t *testing.T) {
+	t.Parallel()
+	a := NewTestACLAgent(t, t.Name(), TestACLConfig(), catalogPolicy, catalogIdent)
+
+	newAuthz := func(t *testing.T, rules string) acl.Authorizer {
+		t.Helper()
+		policy, err := acl.NewPolicyFromSource(rules, nil, nil)
+		require.NoError(t, err)
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(t, err)
+		return authz
+	}
+
+	authzServiceOnly := newAuthz(t, `service_prefix "" { policy = "write" }`)
+	authzWithMesh := newAuthz(t, `service_prefix "" { policy = "write" } mesh = "write"`)
+
+	for _, key := range []string{"envoy_listener_json", "envoy_cluster_json"} {
+		key := key
+		t.Run(key, func(t *testing.T) {
+			svc := &structs.NodeService{
+				ID:      "web-sidecar-proxy",
+				Service: "web-sidecar-proxy",
+				Kind:    structs.ServiceKindConnectProxy,
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					Upstreams: structs.Upstreams{
+						{
+							DestinationName: "db",
+							Config:          map[string]interface{}{key: `{"name":"attacker-listener"}`},
+						},
+					},
+				},
+			}
+			err := a.vetServiceRegisterWithAuthorizer(authzServiceOnly, svc)
+			require.Error(t, err, "upstream key %q: expected denial without mesh:write", key)
+			require.True(t, acl.IsErrPermissionDenied(err), "upstream key %q: expected permission denied, got: %v", key, err)
+
+			err = a.vetServiceRegisterWithAuthorizer(authzWithMesh, svc)
+			require.NoError(t, err, "upstream key %q: expected success with mesh:write", key)
+		})
+	}
+}
+
+// TestACL_vetServiceRegister_bootstrapEscapeHatch_CaseInsensitive verifies
+// that escape-hatch key matching is case-insensitive, matching the
+// case-insensitive mapstructure decoding used downstream by the bootstrap
+// and xDS config decoders. A mixed-case key must not bypass the mesh:write
+// requirement.
+func TestACL_vetServiceRegister_bootstrapEscapeHatch_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	a := NewTestACLAgent(t, t.Name(), TestACLConfig(), catalogPolicy, catalogIdent)
+
+	newAuthz := func(t *testing.T, rules string) acl.Authorizer {
+		t.Helper()
+		policy, err := acl.NewPolicyFromSource(rules, nil, nil)
+		require.NoError(t, err)
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(t, err)
+		return authz
+	}
+
+	authzServiceOnly := newAuthz(t, `service_prefix "" { policy = "write" }`)
+
+	svc := &structs.NodeService{
+		ID:      "web-sidecar-proxy",
+		Service: "web-sidecar-proxy",
+		Kind:    structs.ServiceKindConnectProxy,
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceName: "web",
+			Config: map[string]interface{}{
+				"Envoy_Extra_Static_Listeners_JSON": `{"name":"attacker-listener"}`,
+			},
+		},
+	}
+	err := a.vetServiceRegisterWithAuthorizer(authzServiceOnly, svc)
+	require.Error(t, err, "expected denial for mixed-case escape-hatch key without mesh:write")
+	require.True(t, acl.IsErrPermissionDenied(err), "expected permission denied, got: %v", err)
+}
+
 func TestACL_vetServiceUpdateWithAuthorizer(t *testing.T) {
 	t.Parallel()
 	a := NewTestACLAgent(t, t.Name(), TestACLConfig(), catalogPolicy, catalogIdent)

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -288,6 +288,16 @@ func serviceACLCheckWithConsulExemption(
 		}
 	}
 
+	// Escape-hatch keys in Proxy.Config or Proxy.Upstreams[*].Config embed
+	// arbitrary Envoy JSON into the sidecar's bootstrap configuration or xDS
+	// listener/cluster resources. They can introduce code-executing HTTP
+	// filters and therefore require mesh:write independently of service:write.
+	if service.Proxy.HasEnvoyEscapeHatchOverride() {
+		if err := authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext); err != nil {
+			return fmt.Errorf("mesh:write required to set an Envoy escape-hatch key in Proxy.Config or Proxy.Upstreams[*].Config: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -479,7 +479,160 @@ func TestCatalog_Register_ConnectProxy_invalid(t *testing.T) {
 	assert.Contains(t, err.Error(), "DestinationServiceName")
 }
 
-// Test that write is required for the proxy destination to register a proxy.
+// TestCatalog_Register_ConnectProxy_EscapeHatchKeyRequiresMeshWrite verifies
+// that registering a connect-proxy via Catalog.Register with any escape-hatch
+// key in Proxy.Config requires mesh:write in addition to service:write
+// (SECVULN — Vector 2, catalog path).
+func TestCatalog_Register_ConnectProxy_EscapeHatchKeyRequiresMeshWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	// Token with service:write on both names but no mesh:write.
+	serviceOnlyToken := createTokenWithPolicyNameFull(t, codec, "escape-hatch-service-only", `
+service_prefix "" { policy = "write" }
+node_prefix "" { policy = "write" }
+`, "root").SecretID
+
+	// Token with service:write + mesh:write.
+	meshToken := createTokenWithPolicyNameFull(t, codec, "escape-hatch-mesh-write", `
+service_prefix "" { policy = "write" }
+node_prefix "" { policy = "write" }
+mesh = "write"
+`, "root").SecretID
+
+	for _, key := range structs.EnvoyEscapeHatchKeyNames() {
+		key := key
+		t.Run(key, func(t *testing.T) {
+			arg := structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "foo",
+				Address:    "127.0.0.1",
+				Service: &structs.NodeService{
+					ID:      "web-sidecar-proxy",
+					Service: "web-sidecar-proxy",
+					Kind:    structs.ServiceKindConnectProxy,
+					Port:    20000,
+					Proxy: structs.ConnectProxyConfig{
+						DestinationServiceName: "web",
+						Config:                 map[string]interface{}{key: `{}`},
+					},
+				},
+			}
+
+			var out struct{}
+
+			// service:write only — must be denied.
+			arg.Token = serviceOnlyToken
+			err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out)
+			require.Error(t, err, "key %q: expected denial without mesh:write", key)
+			require.True(t, acl.IsErrPermissionDenied(err), "key %q: expected permission denied, got: %v", key, err)
+
+			// service:write + mesh:write — ACL check must pass. The registration
+			// may still fail with a virtual-IP error in environments where no
+			// agent HTTP listener is running (pre-existing limitation of
+			// testServerWithConfig); that is not caused by our ACL gate.
+			arg.Token = meshToken
+			err = msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out)
+			if err != nil {
+				require.False(t, acl.IsErrPermissionDenied(err),
+					"key %q: mesh:write token must not be ACL-denied, got: %v", key, err)
+			}
+		})
+	}
+}
+
+// TestCatalog_Register_ConnectProxy_UpstreamEscapeHatchKeyRequiresMeshWrite
+// verifies that escape-hatch keys (envoy_listener_json, envoy_cluster_json)
+// set on a per-upstream Config map — not just the top-level Proxy.Config —
+// also require mesh:write via Catalog.Register (SECVULN — Vector 2, catalog
+// path, per-upstream placement).
+func TestCatalog_Register_ConnectProxy_UpstreamEscapeHatchKeyRequiresMeshWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLInitialManagementToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	serviceOnlyToken := createTokenWithPolicyNameFull(t, codec, "upstream-escape-hatch-service-only", `
+service_prefix "" { policy = "write" }
+node_prefix "" { policy = "write" }
+`, "root").SecretID
+
+	meshToken := createTokenWithPolicyNameFull(t, codec, "upstream-escape-hatch-mesh-write", `
+service_prefix "" { policy = "write" }
+node_prefix "" { policy = "write" }
+mesh = "write"
+`, "root").SecretID
+
+	for _, key := range []string{"envoy_listener_json", "envoy_cluster_json"} {
+		key := key
+		t.Run(key, func(t *testing.T) {
+			arg := structs.RegisterRequest{
+				Datacenter: "dc1",
+				Node:       "foo",
+				Address:    "127.0.0.1",
+				Service: &structs.NodeService{
+					ID:      "web-sidecar-proxy",
+					Service: "web-sidecar-proxy",
+					Kind:    structs.ServiceKindConnectProxy,
+					Port:    20000,
+					Proxy: structs.ConnectProxyConfig{
+						DestinationServiceName: "web",
+						Upstreams: structs.Upstreams{
+							{
+								DestinationName: "db",
+								LocalBindPort:   9191,
+								Config:          map[string]interface{}{key: `{}`},
+							},
+						},
+					},
+				},
+			}
+
+			var out struct{}
+
+			// service:write only — must be denied.
+			arg.Token = serviceOnlyToken
+			err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out)
+			require.Error(t, err, "upstream key %q: expected denial without mesh:write", key)
+			require.True(t, acl.IsErrPermissionDenied(err), "upstream key %q: expected permission denied, got: %v", key, err)
+
+			// service:write + mesh:write — ACL check must pass.
+			arg.Token = meshToken
+			err = msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out)
+			if err != nil {
+				require.False(t, acl.IsErrPermissionDenied(err),
+					"upstream key %q: mesh:write token must not be ACL-denied, got: %v", key, err)
+			}
+		})
+	}
+}
+
 func TestCatalog_Register_ConnectProxy_ACLDestinationServiceName(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -363,7 +363,20 @@ func (e *ServiceConfigEntry) CanRead(authz acl.Authorizer) error {
 func (e *ServiceConfigEntry) CanWrite(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.ToAllowAuthorizer().ServiceWriteAllowed(e.Name, &authzContext)
+	if err := authz.ToAllowAuthorizer().ServiceWriteAllowed(e.Name, &authzContext); err != nil {
+		return err
+	}
+	// Code-executing extensions (builtin/lua, builtin/wasm) and upstream escape-hatch
+	// overrides (envoy_listener_json, envoy_cluster_json) run or embed arbitrary Envoy
+	// JSON as the sidecar process user on every proxied request. Both require mesh:write
+	// in addition to service:write so the capability is independently auditable and
+	// cannot be reached via the standard application-team delegation pattern alone.
+	if e.EnvoyExtensions.HasCodeExecutingExtension() || e.UpstreamConfig.HasEscapeHatchOverride() {
+		if err := authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext); err != nil {
+			return fmt.Errorf("mesh:write required to attach code-executing EnvoyExtensions or upstream escape-hatch overrides (envoy_listener_json, envoy_cluster_json): %w", err)
+		}
+	}
+	return nil
 }
 
 func (e *ServiceConfigEntry) GetRaftIndex() *RaftIndex {
@@ -412,6 +425,26 @@ func (c *UpstreamConfiguration) Clone() *UpstreamConfiguration {
 	}
 
 	return &c2
+}
+
+// HasEscapeHatchOverride reports whether any upstream in the configuration
+// carries an envoy_listener_json or envoy_cluster_json escape-hatch override.
+// These fields embed arbitrary Envoy JSON that is delivered verbatim to the
+// sidecar, can introduce code-executing HTTP filters, and therefore require
+// mesh:write in addition to service:write.
+func (c *UpstreamConfiguration) HasEscapeHatchOverride() bool {
+	if c == nil {
+		return false
+	}
+	if c.Defaults != nil && (c.Defaults.EnvoyListenerJSON != "" || c.Defaults.EnvoyClusterJSON != "") {
+		return true
+	}
+	for _, o := range c.Overrides {
+		if o != nil && (o.EnvoyListenerJSON != "" || o.EnvoyClusterJSON != "") {
+			return true
+		}
+	}
+	return false
 }
 
 // DestinationConfig represents a virtual service, i.e. one that is external to Consul

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -55,6 +55,183 @@ func TestConfigEntries_ACLs(t *testing.T) {
 	}
 
 	cases := []testcase{
+		// =================== service-defaults (no code-executing extensions) ===================
+		{
+			name: "service-defaults: no code-executing extension",
+			entry: &ServiceConfigEntry{
+				Kind: ServiceDefaults,
+				Name: "web",
+				EnvoyExtensions: EnvoyExtensions{
+					{Name: api.BuiltinAWSLambdaExtension, Arguments: map[string]interface{}{"ARN": "arn:aws:lambda:us-east-1:111122223333:function:my-function"}},
+				},
+			},
+			expectACLs: []testACL{
+				{
+					name:       "service:write only — allowed (no code-executing extension)",
+					authorizer: newAuthz(t, `service "web" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   true,
+				},
+				{
+					name:       "service:read only — denied",
+					authorizer: newAuthz(t, `service "web" { policy = "read" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+			},
+		},
+		// =================== service-defaults (code-executing extensions: lua) ===================
+		{
+			name: "service-defaults: lua extension requires mesh:write",
+			entry: &ServiceConfigEntry{
+				Kind: ServiceDefaults,
+				Name: "web",
+				EnvoyExtensions: EnvoyExtensions{
+					{Name: api.BuiltinLuaExtension, Arguments: map[string]interface{}{
+						"Script":   "function envoy_on_request(h) end",
+						"Listener": "inbound",
+					}},
+				},
+			},
+			expectACLs: []testACL{
+				{
+					name:       "service:write only — denied (missing mesh:write)",
+					authorizer: newAuthz(t, `service "web" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+				{
+					name:       "service:write + mesh:write — allowed",
+					authorizer: newAuthz(t, `service "web" { policy = "write" } mesh = "write"`),
+					canRead:    true,
+					canWrite:   true,
+				},
+				{
+					name:       "mesh:write only (no service:write) — denied",
+					authorizer: newAuthz(t, `mesh = "write"`),
+					canRead:    false, // no service:read either
+					canWrite:   false,
+				},
+				{
+					name:       "service:write + mesh:read only — denied",
+					authorizer: newAuthz(t, `service "web" { policy = "write" } mesh = "read"`),
+					canRead:    true,
+					canWrite:   false,
+				},
+			},
+		},
+		// =================== service-defaults (code-executing extensions: wasm) ===================
+		{
+			name: "service-defaults: wasm extension requires mesh:write",
+			entry: &ServiceConfigEntry{
+				Kind: ServiceDefaults,
+				Name: "web",
+				EnvoyExtensions: EnvoyExtensions{
+					{Name: api.BuiltinWasmExtension, Arguments: map[string]interface{}{
+						"Protocol":     "http",
+						"ListenerType": "inbound",
+						"PluginConfig": map[string]interface{}{
+							"VmConfig": map[string]interface{}{
+								"Code": map[string]interface{}{
+									"Local": map[string]interface{}{
+										"Filename": "/etc/envoy/plugin.wasm",
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			expectACLs: []testACL{
+				{
+					name:       "service:write only — denied (missing mesh:write)",
+					authorizer: newAuthz(t, `service "web" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+				{
+					name:       "service:write + mesh:write — allowed",
+					authorizer: newAuthz(t, `service "web" { policy = "write" } mesh = "write"`),
+					canRead:    true,
+					canWrite:   true,
+				},
+			},
+		},
+		// =================== service-defaults (upstream escape-hatch overrides) ===================
+		{
+			name: "service-defaults: upstream defaults envoy_listener_json requires mesh:write",
+			entry: &ServiceConfigEntry{
+				Kind: ServiceDefaults,
+				Name: "web",
+				UpstreamConfig: &UpstreamConfiguration{
+					Defaults: &UpstreamConfig{
+						EnvoyListenerJSON: `{"name":"custom-listener"}`,
+					},
+				},
+			},
+			expectACLs: []testACL{
+				{
+					name:       "service:write only — denied (missing mesh:write)",
+					authorizer: newAuthz(t, `service "web" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+				{
+					name:       "service:write + mesh:write — allowed",
+					authorizer: newAuthz(t, `service "web" { policy = "write" } mesh = "write"`),
+					canRead:    true,
+					canWrite:   true,
+				},
+			},
+		},
+		{
+			name: "service-defaults: upstream override envoy_cluster_json requires mesh:write",
+			entry: &ServiceConfigEntry{
+				Kind: ServiceDefaults,
+				Name: "web",
+				UpstreamConfig: &UpstreamConfiguration{
+					Overrides: []*UpstreamConfig{
+						{
+							Name:             "db",
+							EnvoyClusterJSON: `{"name":"custom-cluster"}`,
+						},
+					},
+				},
+			},
+			expectACLs: []testACL{
+				{
+					name:       "service:write only — denied (missing mesh:write)",
+					authorizer: newAuthz(t, `service "web" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   false,
+				},
+				{
+					name:       "service:write + mesh:write — allowed",
+					authorizer: newAuthz(t, `service "web" { policy = "write" } mesh = "write"`),
+					canRead:    true,
+					canWrite:   true,
+				},
+			},
+		},
+		{
+			name: "service-defaults: upstream config without escape-hatch — service:write sufficient",
+			entry: &ServiceConfigEntry{
+				Kind: ServiceDefaults,
+				Name: "web",
+				UpstreamConfig: &UpstreamConfiguration{
+					Defaults: &UpstreamConfig{
+						Protocol: "http",
+					},
+				},
+			},
+			expectACLs: []testACL{
+				{
+					authorizer: newAuthz(t, `service "web" { policy = "write" }`),
+					canRead:    true,
+					canWrite:   true,
+				},
+			},
+		},
 		// =================== proxy-defaults ===================
 		{
 			name:  "proxy-defaults",

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -333,6 +333,27 @@ type ConnectProxyConfig struct {
 	AccessLogs AccessLogsConfig `json:",omitempty" alias:"access_logs"`
 }
 
+// HasEnvoyEscapeHatchOverride reports whether the proxy's own opaque Config,
+// or any of its Upstreams[*].Config maps, sets an Envoy escape-hatch key (see
+// EnvoyEscapeHatchKeyNames). These keys embed arbitrary Envoy JSON that is
+// delivered verbatim to the sidecar and can introduce code-executing HTTP
+// filters (e.g. envoy_listener_json/envoy_cluster_json set per-upstream), so
+// callers must independently require mesh:write before honoring them.
+func (c *ConnectProxyConfig) HasEnvoyEscapeHatchOverride() bool {
+	if c == nil {
+		return false
+	}
+	if HasEnvoyEscapeHatchKey(c.Config) {
+		return true
+	}
+	for _, u := range c.Upstreams {
+		if HasEnvoyEscapeHatchKey(u.Config) {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *ConnectProxyConfig) UnmarshalJSON(data []byte) (err error) {
 	type Alias ConnectProxyConfig
 	aux := &struct {

--- a/agent/structs/envoy_extension.go
+++ b/agent/structs/envoy_extension.go
@@ -4,6 +4,8 @@
 package structs
 
 import (
+	"strings"
+
 	"github.com/hashicorp/consul/api"
 )
 
@@ -29,6 +31,98 @@ func (c *EnvoyExtension) appendHash(h *customHasher) {
 }
 
 type EnvoyExtensions []EnvoyExtension
+
+// codeExecutingExtensions is the set of built-in extension names that cause
+// Envoy to compile and execute caller-supplied code (Lua scripts, Wasm modules)
+// on every proxied request. Attaching any of these to a config entry requires
+// mesh:write in addition to the normal service:write check so that the
+// code-execution capability is gated on a separate, auditable permission.
+var codeExecutingExtensions = map[string]bool{
+	api.BuiltinLuaExtension:  true,
+	api.BuiltinWasmExtension: true,
+}
+
+// HasCodeExecutingExtension reports whether any extension in the slice is a
+// code-executing type (builtin/lua or builtin/wasm).
+func (es EnvoyExtensions) HasCodeExecutingExtension() bool {
+	for _, e := range es {
+		if codeExecutingExtensions[e.Name] {
+			return true
+		}
+	}
+	return false
+}
+
+// envoyEscapeHatchKeys is the set of Proxy.Config map keys that embed
+// arbitrary Envoy JSON into the sidecar's bootstrap configuration or xDS
+// listener/cluster resources. Any of these keys can introduce code-executing
+// HTTP filters and therefore require mesh:write in addition to service:write.
+//
+// It is unexported and accessed only through IsEnvoyEscapeHatchKey,
+// HasEnvoyEscapeHatchKey, and EnvoyEscapeHatchKeyNames so that no importing
+// package (or test) can mutate the set at runtime and silently weaken the
+// security gate.
+//
+// Bootstrap-time keys (command/connect/envoy/bootstrap_config.go):
+//
+//	envoy_bootstrap_json_tpl, envoy_extra_static_listeners_json,
+//	envoy_extra_static_clusters_json, envoy_extra_stats_sinks_json,
+//	envoy_stats_config_json, envoy_tracing_json
+//
+// xDS runtime keys (agent/xds/config/config.go):
+//
+//	envoy_public_listener_json, envoy_listener_tracing_json,
+//	envoy_local_cluster_json
+//
+// Per-upstream keys (agent/structs/config_entry.go UpstreamConfig):
+//
+//	envoy_listener_json, envoy_cluster_json
+var envoyEscapeHatchKeys = map[string]bool{
+	"envoy_bootstrap_json_tpl":          true,
+	"envoy_extra_static_listeners_json": true,
+	"envoy_public_listener_json":        true,
+	"envoy_listener_json":               true,
+	"envoy_cluster_json":                true,
+	"envoy_local_cluster_json":          true,
+	"envoy_extra_static_clusters_json":  true,
+	"envoy_extra_stats_sinks_json":      true,
+	"envoy_tracing_json":                true,
+	"envoy_stats_config_json":           true,
+	"envoy_listener_tracing_json":       true,
+}
+
+// IsEnvoyEscapeHatchKey reports whether the given config map key is an Envoy
+// escape-hatch key. Comparison is case-insensitive: the mapstructure decoders
+// that ultimately consume these maps (command/connect/envoy/bootstrap_config.go,
+// agent/xds/config/config.go) match struct tags against map keys
+// case-insensitively by default, so an exact-case comparison here could be
+// bypassed by a caller-supplied key that only differs in case.
+func IsEnvoyEscapeHatchKey(key string) bool {
+	return envoyEscapeHatchKeys[strings.ToLower(key)]
+}
+
+// EnvoyEscapeHatchKeyNames returns a copy of the Envoy escape-hatch key names.
+// A fresh slice is returned on each call so callers cannot mutate the
+// underlying set.
+func EnvoyEscapeHatchKeyNames() []string {
+	names := make([]string, 0, len(envoyEscapeHatchKeys))
+	for key := range envoyEscapeHatchKeys {
+		names = append(names, key)
+	}
+	return names
+}
+
+// HasEnvoyEscapeHatchKey reports whether the given opaque config map (e.g. a
+// ConnectProxyConfig.Config or Upstream.Config value) sets any Envoy
+// escape-hatch key.
+func HasEnvoyEscapeHatchKey(cfg map[string]interface{}) bool {
+	for key := range cfg {
+		if IsEnvoyEscapeHatchKey(key) {
+			return true
+		}
+	}
+	return false
+}
 
 func (es EnvoyExtensions) ToAPI() []api.EnvoyExtension {
 	extensions := make([]api.EnvoyExtension, len(es))


### PR DESCRIPTION
## Summary

Requires `mesh:write` in addition to `service:write` for code-executing Envoy extension surfaces.

**Vector 1** — Attaching `builtin/lua` or `builtin/wasm`, or an upstream escape-hatch override (`envoy_listener_json`/`envoy_cluster_json` in `UpstreamConfig` defaults or overrides), to a `service-defaults` config entry now requires `mesh:write` in addition to `service:write`.

**Vector 2** — Registering a connect-proxy with bootstrap or xDS escape-hatch keys, whether in the top-level `Proxy.Config` map or per-upstream in `Proxy.Upstreams[*].Config` (both agent API and catalog API paths), now requires `mesh:write` in addition to `service:write`. Key matching is case-insensitive to match the downstream mapstructure decoding.

**Vector 3** — `proxy-defaults` already requires `mesh:write` via `ProxyConfigEntry.CanWrite`. No change needed.

## Files changed

| File | Change |
|---|---|
| `agent/structs/envoy_extension.go` | `HasCodeExecutingExtension()` + unexported `envoyEscapeHatchKeys` map with `IsEnvoyEscapeHatchKey()` / `EnvoyEscapeHatchKeyNames()` / `HasEnvoyEscapeHatchKey()` helpers |
| `agent/structs/connect_proxy_config.go` | `HasEnvoyEscapeHatchOverride()` checks top-level and per-upstream config |
| `agent/structs/config_entry.go` | `ServiceConfigEntry.CanWrite` requires `mesh:write` for Lua/Wasm extensions and upstream escape-hatch overrides |
| `agent/acl.go` | `vetServiceRegisterWithAuthorizer` requires `mesh:write` for escape-hatch keys |
| `agent/consul/catalog_endpoint.go` | `serviceACLCheckWithConsulExemption` requires `mesh:write` for escape-hatch keys |
| `agent/acl_test.go` | Agent path tests for all 11 escape-hatch keys |
| `agent/consul/catalog_endpoint_test.go` | Catalog path integration tests for all 11 escape-hatch keys |
| `agent/structs/config_entry_test.go` | ACL matrix tests for Lua, Wasm, non-code-executing extensions, and upstream overrides |
