### PR TITLE
fix: update debian docker images from bullseye to bookworm (#23909)

### DIFF
--- a/.github/scripts/verify_artifact.sh
+++ b/.github/scripts/verify_artifact.sh
@@ -118,19 +118,19 @@ function verify_deb {
   case "${artifact_path}" in
     *_i386.deb)
       docker_platform="linux/386"
-      docker_image="i386/debian:bullseye"
+      docker_image="i386/debian:bookworm"
       ;;
     *_amd64.deb)
       docker_platform="linux/amd64"
-      docker_image="amd64/debian:bullseye"
+      docker_image="amd64/debian:bookworm"
       ;;
     *_armhf.deb)
       docker_platform="linux/arm/v7"
-      docker_image="arm32v7/debian:bullseye"
+      docker_image="arm32v7/debian:bookworm"
       ;;
     *_arm64.deb)
       docker_platform="linux/arm64"
-      docker_image="arm64v8/debian:bullseye"
+      docker_image="arm64v8/debian:bookworm"
       ;;
     *)
       echo "${artifact_path} did not match known patterns for debs"
@@ -191,7 +191,7 @@ function verify_zip {
           -v $(pwd):/workdir \
           -v ${SCRIPT_DIR}:/scripts \
           -w /workdir  \
-        amd64/debian \
+        amd64/debian:bookworm \
         /scripts/verify_bin.sh \
         ./consul \
         "${expect_version}"
@@ -209,7 +209,7 @@ function verify_zip {
           -v $(pwd):/workdir \
           -v ${SCRIPT_DIR}:/scripts \
           -w /workdir  \
-        arm32v7/debian \
+        arm32v7/debian:bookworm \
         /scripts/verify_bin.sh \
         ./consul \
         "${expect_version}"
@@ -227,7 +227,7 @@ function verify_zip {
           -v $(pwd):/workdir \
           -v ${SCRIPT_DIR}:/scripts \
           -w /workdir  \
-        arm64v8/debian \
+        arm64v8/debian:bookworm \
         /scripts/verify_bin.sh \
         ./consul \
         "${expect_version}"


### PR DESCRIPTION
### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
