### PR TITLE
agent/xds: allow trailing semicolon-separated fields in XFCC rbac principal

### DIFF
--- a/.changelog/23920.txt
+++ b/.changelog/23920.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent/xds: Fixed an issue where cross-cluster and peered requests originating from an API Gateway were rejected with HTTP 403 Forbidden by downstream service RBAC intentions. Trailing semicolon-separated fields in the client certificate component of the `x-forwarded-client-cert` (XFCC) header (such as auto-registered DNS SANs) are now properly accepted by the RBAC principal regular expression.
+```

--- a/agent/xds/rbac.go
+++ b/agent/xds/rbac.go
@@ -1010,8 +1010,8 @@ func xfccPrincipal(src rbacService) *envoy_rbac_v3.Principal {
 	idPattern = idPattern[1 : len(idPattern)-1]
 
 	// Anchor to the first XFCC component, allowing subsequent semicolon-separated
-	// fields (such as ;DNS=... or ;Subject=...) before any comma or end of string.
-	pattern := `^[^,]+;URI=` + idPattern + `(?:;[^,]*)?(?:,.*)?$`
+	// fields (such as ;DNS=... or ;Subject=...) or comma-separated hops.
+	pattern := `^[^,]+;URI=` + idPattern + `(?:[;,].*)?$`
 
 	// By=spiffe://8c7db6d3-e4ee-aa8c-488c-dbedd3772b78.consul/gateway/mesh/dc/dc2;
 	// Hash=2a2db78ac351a05854a0abd350631bf98cc0eb827d21f4ed5935ccd287779eb6;

--- a/agent/xds/rbac.go
+++ b/agent/xds/rbac.go
@@ -1009,8 +1009,9 @@ func xfccPrincipal(src rbacService) *envoy_rbac_v3.Principal {
 	// Remove the leading ^ and trailing $.
 	idPattern = idPattern[1 : len(idPattern)-1]
 
-	// Anchor to the first XFCC component
-	pattern := `^[^,]+;URI=` + idPattern + `(?:,.*)?$`
+	// Anchor to the first XFCC component, allowing subsequent semicolon-separated
+	// fields (such as ;DNS=... or ;Subject=...) before any comma or end of string.
+	pattern := `^[^,]+;URI=` + idPattern + `(?:;[^,]*)?(?:,.*)?$`
 
 	// By=spiffe://8c7db6d3-e4ee-aa8c-488c-dbedd3772b78.consul/gateway/mesh/dc/dc2;
 	// Hash=2a2db78ac351a05854a0abd350631bf98cc0eb827d21f4ed5935ccd287779eb6;

--- a/agent/xds/rbac_test.go
+++ b/agent/xds/rbac_test.go
@@ -1434,8 +1434,23 @@ func TestXFCCPrincipal(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "api gateway - with trailing Subject field",
+			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;Hash=abc;URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway;Subject="CN=gateway.default"`,
+			expected: true,
+		},
+		{
+			name:     "api gateway - with trailing Subject and multiple hops",
+			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;Hash=abc;URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway;Subject="CN=gateway.default",By=spiffe://server.consul/gateway/mesh/dc/server`,
+			expected: true,
+		},
+		{
 			name:     "negative: service name prefix spoofing (gateway2)",
 			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway2`,
+			expected: false,
+		},
+		{
+			name:     "negative: hyphenated prefix spoofing (gateway-evil)",
+			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway-evil`,
 			expected: false,
 		},
 		{

--- a/agent/xds/rbac_test.go
+++ b/agent/xds/rbac_test.go
@@ -1389,3 +1389,71 @@ func TestMakeSpiffePattern_EscapesRegexMetacharacters(t *testing.T) {
 		})
 	}
 }
+
+func TestXFCCPrincipal(t *testing.T) {
+	src := rbacService{
+		ServiceName: structs.ServiceName{
+			Name: "gateway",
+		},
+		TrustDomain: "2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul",
+		Peer:        "client",
+	}
+
+	principal := xfccPrincipal(src)
+	headerMatcher := principal.GetHeader()
+	require.NotNil(t, headerMatcher)
+	require.Equal(t, "x-forwarded-client-cert", headerMatcher.Name)
+
+	regex := headerMatcher.GetStringMatch().GetSafeRegex().Regex
+	re, err := regexp.Compile(regex)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		xfcc     string
+		expected bool
+	}{
+		{
+			name:     "standard sidecar - single hop without DNS SANs",
+			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway`,
+			expected: true,
+		},
+		{
+			name:     "standard sidecar - multi-hop without DNS SANs",
+			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway,By=gateway`,
+			expected: true,
+		},
+		{
+			name:     "api gateway - multi-hop with auto-registered DNS SANs",
+			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;Hash=abc;Subject="";URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway;DNS=gateway.default.svc;DNS=gateway.default.svc.cluster.local,By=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway`,
+			expected: true,
+		},
+		{
+			name:     "api gateway - single hop with auto-registered DNS SANs",
+			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;Hash=abc;Subject="";URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway;DNS=gateway.default.svc;DNS=gateway.default.svc.cluster.local`,
+			expected: true,
+		},
+		{
+			name:     "negative: service name prefix spoofing (gateway2)",
+			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway2`,
+			expected: false,
+		},
+		{
+			name:     "negative: different service",
+			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/other`,
+			expected: false,
+		},
+		{
+			name:     "negative: matched cert is in second hop not first hop",
+			xfcc:     `By=spiffe://server.consul/gateway/mesh/dc/server;URI=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/attacker,By=spiffe://2f6cbc1e-8ff2-dd37-0d90-12156d7d2795.consul/ns/default/dc/client/svc/gateway`,
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched := re.MatchString(tc.xfcc)
+			require.Equal(t, tc.expected, matched, "expected match=%v for xfcc %q with regex %s", tc.expected, tc.xfcc, regex)
+		})
+	}
+}

--- a/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink--httpfilter.golden
@@ -40,7 +40,7 @@
                             "name": "x-forwarded-client-cert",
                             "stringMatch": {
                               "safeRegex": {
-                                "regex": "^[^,]+;URI=spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/[^/]+(?:,.*)?$"
+                                "regex": "^[^,]+;URI=spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/[^/]+(?:;[^,]*)?(?:,.*)?$"
                               }
                             }
                           }
@@ -51,7 +51,7 @@
                               "name": "x-forwarded-client-cert",
                               "stringMatch": {
                                 "safeRegex": {
-                                  "regex": "^[^,]+;URI=spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/web(?:,.*)?$"
+                                  "regex": "^[^,]+;URI=spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/web(?:;[^,]*)?(?:,.*)?$"
                                 }
                               }
                             }

--- a/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-peered-kitchen-sink--httpfilter.golden
@@ -40,7 +40,7 @@
                             "name": "x-forwarded-client-cert",
                             "stringMatch": {
                               "safeRegex": {
-                                "regex": "^[^,]+;URI=spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/[^/]+(?:;[^,]*)?(?:,.*)?$"
+                                "regex": "^[^,]+;URI=spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/[^/]+(?:[;,].*)?$"
                               }
                             }
                           }
@@ -51,7 +51,7 @@
                               "name": "x-forwarded-client-cert",
                               "stringMatch": {
                                 "safeRegex": {
-                                  "regex": "^[^,]+;URI=spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/web(?:;[^,]*)?(?:,.*)?$"
+                                  "regex": "^[^,]+;URI=spiffe://peer1\\.domain/ap/part1/ns/default/dc/[^/]+/svc/web(?:[;,].*)?$"
                                 }
                               }
                             }


### PR DESCRIPTION

### Description

Fixes an authorization failure (`HTTP 403 Forbidden` / `RBAC: access denied`) when an API Gateway proxies cross-cluster or peered traffic to services with service intentions.

#### Root Cause
PR #23647 introduced automatic DNS SAN registration (`DNS:*.api-gateway.consul`, etc.) into API Gateway leaf certificates. When an API Gateway establishes an mTLS connection across a cluster peering (via mesh gateway or direct peer resolver), Envoy populates the `x-forwarded-client-cert` (XFCC) header with the client certificate details:
```text
By=spiffe://...;Hash=...;Subject="";URI=spiffe://<trust-domain>/ns/<ns>/dc/<dc>/svc/<svc>;DNS=gateway.default.svc;DNS=gateway.default.svc.cluster.local,By=...
```

In `agent/xds/rbac.go:xfccPrincipal`, the Envoy RBAC regex pattern used to validate the caller's SPIFFE ID in the first XFCC hop was:
```regex
^[^,]+;URI=<idPattern>(?:,.*)?$
```
This regex assumed that `;URI=<idPattern>` is either immediately followed by a comma (for subsequent hops) or ends the string. Because PR #23647 added `;DNS=...` fields immediately following `;URI=...`, the regex failed to match. Consequently, the destination service proxy's Envoy RBAC filter denied incoming requests with `rbac_access_denied_matched_policy[none]`.

#### Solution
Relax the pattern in `agent/xds/rbac.go` to permit subsequent semicolon-separated key-value fields (such as `;DNS=...` or `;Subject=...`) in the first XFCC component before comma-separated subsequent hops or end-of-string:
```diff
- pattern := `^[^,]+;URI=` + idPattern + `(?:,.*)?$`
+ pattern := `^[^,]+;URI=` + idPattern + `(?:;[^,]*)?(?:,.*)?$`
```

---

### Testing & Reproduction steps

#### 1. Unit Tests
- Added `TestXFCCPrincipal` in `agent/xds/rbac_test.go` asserting regex matching behavior across:
  - Standard sidecar proxy: single-hop and multi-hop without DNS SANs
  - API Gateway: single-hop and multi-hop with auto-registered DNS SANs
  - Negative security assertions: ensuring service name prefix spoofing (e.g. `gateway2` matching `gateway`), mismatched service identities, and identities appearing only in subsequent hops are rejected.
- Updated golden fixture `agent/xds/testdata/rbac/default-deny-peered-kitchen-sink--httpfilter.golden`.

#### 2. Acceptance Test Reproduction & Verification
- **Reproduction**: Set up dual-cluster KinD environment (`kind-dc1`, `kind-dc2`) and ran `TestPeering_Gateway` with an unfixed build. Reproduced the exact failure:
  ```text
  < HTTP/1.1 403 Forbidden
  curl: (22) The requested URL returned error: 403
  [debug] envoy.rbac enforced denied, matched policy none
  [debug] envoy.http Preparing local reply with details rbac_access_denied_matched_policy[none]
  ```
- **Verification**: Applied this fix and verified live curl immediately returned `HTTP/1.1 200 OK` (`"hello world"`). Ran the full end-to-end `TestPeering_Gateway` test suite from scratch on fresh clusters:
  ```text
  --- PASS: TestPeering_Gateway (337.67s)
  PASS
  ok   github.com/hashicorp/consul-k8s/acceptance/tests/peering 338.139s
  ```

---

### Links

* Related PR: https://github.com/hashicorp/consul/pull/23647
* Failing CI Run: https://github.com/hashicorp/consul-k8s-workflows/actions/runs/34382416380

---

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] appropriate backport labels added
* [x] not a security concern

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.